### PR TITLE
fix: remove toolbar logo border and update analytics subdomain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,4 +299,4 @@ git push && git push --tags  # Triggers: Docker build → push to ghcr.io → VP
 3. Test on dev environment
 4. Tag release → auto-deploys to app.racku.la
 
-**Analytics:** Umami (self-hosted at `analytics.racku.la`) - privacy-focused, no cookies. Separate tracking for dev and prod environments. Configure via `VITE_UMAMI_*` env vars. Analytics utility at `src/lib/utils/analytics.ts`.
+**Analytics:** Umami (self-hosted at `t.racku.la`) - privacy-focused, no cookies. Separate tracking for dev and prod environments. Configure via `VITE_UMAMI_*` env vars. Analytics utility at `src/lib/utils/analytics.ts`.

--- a/deploy/.env.production
+++ b/deploy/.env.production
@@ -1,5 +1,5 @@
 # Production environment - analytics enabled
 # Actual VITE_UMAMI_WEBSITE_ID is set via GitHub Actions secret UMAMI_PROD_WEBSITE_ID
 VITE_UMAMI_ENABLED=true
-VITE_UMAMI_SCRIPT_URL=https://analytics.racku.la/script.js
+VITE_UMAMI_SCRIPT_URL=https://t.racku.la/script.js
 VITE_UMAMI_WEBSITE_ID=your-website-id-here

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -35,5 +35,5 @@ server {
     # - font-src 'self': Only allow fonts from same origin
     # - connect-src: Allow XHR/fetch to same origin and analytics endpoints
     # - frame-ancestors 'self': Prevent framing by other sites (reinforces X-Frame-Options)
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://analytics.racku.la https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://analytics.racku.la https://static.cloudflareinsights.com; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://t.racku.la https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://t.racku.la https://static.cloudflareinsights.com; frame-ancestors 'self';" always;
 }

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -1190,11 +1190,11 @@ Production (nginx) includes these security headers:
 
 ```
 default-src 'self';
-script-src 'self' 'unsafe-inline' https://analytics.racku.la https://static.cloudflareinsights.com;
+script-src 'self' 'unsafe-inline' https://t.racku.la https://static.cloudflareinsights.com;
 style-src 'self' 'unsafe-inline';
 img-src 'self' data: blob:;
 font-src 'self';
-connect-src 'self' https://analytics.racku.la https://static.cloudflareinsights.com;
+connect-src 'self' https://t.racku.la https://static.cloudflareinsights.com;
 frame-ancestors 'self';
 ```
 
@@ -1202,7 +1202,7 @@ Notes:
 
 - `'unsafe-inline'` for styles required for Svelte scoped styles
 - `'unsafe-inline'` for scripts required for Cloudflare Web Analytics
-- Analytics domains whitelisted: Umami (analytics.racku.la) and Cloudflare Web Analytics
+- Analytics domains whitelisted: Umami (t.racku.la) and Cloudflare Web Analytics
 - `data:` and `blob:` for images support export previews and device images
 - GitHub Pages (dev) does not support custom headers
 
@@ -2210,7 +2210,7 @@ Session properties are set via `umami.identify()` on script load:
 
 ### 20.7 Production Deployment
 
-The hosted app at `app.racku.la` uses a self-hosted Umami instance at `analytics.racku.la`.
+The hosted app at `app.racku.la` uses a self-hosted Umami instance at `t.racku.la`.
 
 ---
 

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -405,17 +405,14 @@
 	/* Clickable brand (opens About in non-hamburger mode) */
 	.toolbar-brand--clickable {
 		cursor: pointer;
-		border: 1px solid var(--colour-border);
-		padding: 0 var(--space-2); /* Tight vertical, modest horizontal for button-like appearance */
+		padding: 0 var(--space-2);
 		transition:
 			background-color var(--duration-fast) var(--ease-out),
-			border-color var(--duration-fast) var(--ease-out),
 			transform var(--duration-fast) var(--ease-out);
 	}
 
 	.toolbar-brand--clickable:hover {
 		background: var(--colour-surface-hover);
-		border-color: var(--colour-border-hover, var(--colour-border));
 		transform: scale(1.02);
 	}
 
@@ -522,8 +519,6 @@
 	.toolbar-brand.hamburger-mode {
 		cursor: pointer;
 		padding: var(--space-2);
-		border: 1px solid var(--colour-border);
-		border-radius: var(--radius-md);
 		background: transparent;
 		width: 100%;
 		justify-content: space-between;
@@ -535,7 +530,6 @@
 
 	.toolbar-brand.hamburger-mode:hover {
 		background: var(--colour-surface-hover);
-		border-color: var(--colour-border-hover, var(--colour-border));
 	}
 
 	.toolbar-brand.hamburger-mode:focus-visible {


### PR DESCRIPTION
## Summary
- Remove button-like border styling from lockup logo in toolbar (both desktop and hamburger modes)
- Keep hover, focus, and click behavior intact
- Update analytics subdomain from `analytics.racku.la` to `t.racku.la` in CSP headers, env config, and documentation

## Test plan
- [ ] Verify logo no longer has visible border in desktop mode
- [ ] Verify logo no longer has visible border in hamburger mode (< 1024px)
- [ ] Verify hover/focus/click behavior still works
- [ ] Verify production deployment loads analytics script from t.racku.la

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed border styling and border-color hover transitions from the toolbar brand element in both desktop and mobile layouts.

* **Chores**
  * Updated analytics service endpoints across configuration files and documentation references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->