### PR TITLE
test: add regression tests for blank panel depth detection

### DIFF
--- a/src/tests/EditPanel.test.ts
+++ b/src/tests/EditPanel.test.ts
@@ -1,616 +1,692 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/svelte';
-import EditPanel from '$lib/components/EditPanel.svelte';
-import ColourSwatch from '$lib/components/ColourSwatch.svelte';
-import { resetLayoutStore, getLayoutStore } from '$lib/stores/layout.svelte';
-import { resetSelectionStore, getSelectionStore } from '$lib/stores/selection.svelte';
-import { resetUIStore } from '$lib/stores/ui.svelte';
-
-describe('EditPanel Component', () => {
-	beforeEach(() => {
-		resetLayoutStore();
-		resetSelectionStore();
-		resetUIStore();
-	});
-
-	describe('Visibility', () => {
-		it('is hidden when nothing is selected', () => {
-			render(EditPanel);
-			// Use hidden: true to find elements with aria-hidden="true"
-			const panel = screen.queryByRole('complementary', { hidden: true });
-			// When no selection, right drawer should not have 'open' class
-			expect(panel).not.toHaveClass('open');
-			expect(panel).toHaveAttribute('aria-hidden', 'true');
-		});
-
-		it('shows when a rack is selected', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			// Add a rack
-			const rack = layoutStore.addRack('Test Rack', 42);
-			expect(rack).not.toBeNull();
-
-			// Select it
-			selectionStore.selectRack(RACK_ID);
-
-			render(EditPanel);
-			// The panel should be open
-			const panel = screen.getByRole('complementary');
-			expect(panel).toHaveClass('open');
-		});
-
-		it('shows when a device is selected', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			// Add a rack
-			const rack = layoutStore.addRack('Test Rack', 42);
-			expect(rack).not.toBeNull();
-
-			// Add a device to library and place it
-			const device = layoutStore.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-
-			// Select the device by ID
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-			const panel = screen.getByRole('complementary');
-			expect(panel).toHaveClass('open');
-		});
-	});
-
-	describe('Rack Editing', () => {
-		it('shows rack fields when rack is selected', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			selectionStore.selectRack(RACK_ID);
-
-			render(EditPanel);
-
-			// Should show name field
-			expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
-			// Should show height field
-			expect(screen.getByLabelText(/height/i)).toBeInTheDocument();
-		});
-
-		it('rack name field is editable', async () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			selectionStore.selectRack(RACK_ID);
-
-			render(EditPanel);
-
-			const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
-			expect(nameInput.value).toBe('My Rack');
-
-			await fireEvent.input(nameInput, { target: { value: 'New Name' } });
-			await fireEvent.blur(nameInput);
-
-			// Check store was updated
-			expect(layoutStore.rack?.name).toBe('New Name');
-		});
-
-		it('rack height is editable when no devices present', async () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			selectionStore.selectRack(RACK_ID);
-
-			render(EditPanel);
-
-			const heightInput = screen.getByLabelText(/height/i) as HTMLInputElement;
-			expect(heightInput).not.toBeDisabled();
-		});
-
-		it('rack height input is enabled when devices present (smart validation)', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			selectionStore.selectRack(RACK_ID);
-
-			render(EditPanel);
-
-			// Input should be enabled even with devices (smart validation allows growing)
-			const heightInput = screen.getByLabelText(/height/i) as HTMLInputElement;
-			expect(heightInput).not.toBeDisabled();
-		});
-
-		it('name change updates layout store', async () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			selectionStore.selectRack(RACK_ID);
-
-			render(EditPanel);
-
-			const nameInput = screen.getByLabelText(/name/i);
-			await fireEvent.input(nameInput, { target: { value: 'Updated Rack' } });
-			await fireEvent.blur(nameInput);
-
-			expect(layoutStore.rack?.name).toBe('Updated Rack');
-		});
-
-		it('delete button is present for rack', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			selectionStore.selectRack(RACK_ID);
-
-			render(EditPanel);
-
-			expect(screen.getByRole('button', { name: /delete rack/i })).toBeInTheDocument();
-		});
-
-	});
-
-	describe('Device Display', () => {
-		it('shows device fields when device is selected', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9',
-				comments: 'Some notes'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 5);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			// Should show device name (may appear multiple times with display name field)
-			const deviceNames = screen.getAllByText('Test Server');
-			expect(deviceNames.length).toBeGreaterThan(0);
-			// Should show height
-			expect(screen.getByText('2U')).toBeInTheDocument();
-			// Should show category (uses getCategoryDisplayName)
-			expect(screen.getByText('Servers')).toBeInTheDocument();
-			// Should show position
-			expect(screen.getByText('U5')).toBeInTheDocument();
-		});
-
-		it('shows notes when present', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9',
-				// Schema v1.0.0: Uses 'notes' field
-				notes: 'Important server notes'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			expect(screen.getByText('Important server notes')).toBeInTheDocument();
-		});
-
-		it('remove button is present for device', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			expect(screen.getByRole('button', { name: /remove from rack/i })).toBeInTheDocument();
-		});
-
-		it('shows brand label for device with manufacturer', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'ProLiant DL380',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9',
-				manufacturer: 'HPE'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			// Should show Brand label
-			expect(screen.getByText('Brand')).toBeInTheDocument();
-			// Should show manufacturer name
-			expect(screen.getByText('HPE')).toBeInTheDocument();
-		});
-
-		it('shows Generic brand for device without manufacturer', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Custom Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-				// No manufacturer field
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			// Should show Brand label
-			expect(screen.getByText('Brand')).toBeInTheDocument();
-			// Should show Generic as fallback
-			expect(screen.getByText('Generic')).toBeInTheDocument();
-		});
-	});
-
-	describe('Device colour picker', () => {
-		it('shows colour row with device type colour', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			// Should show Colour label
-			expect(screen.getByText('Colour')).toBeInTheDocument();
-			// Should show the colour value
-			expect(screen.getByText('#4A90D9')).toBeInTheDocument();
-		});
-
-		it('toggles colour picker when colour row is clicked', async () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			// Colour picker should not be visible initially
-			expect(screen.queryByLabelText(/custom hex colour/i)).not.toBeInTheDocument();
-
-			// Click the colour row button
-			const colourButton = screen.getByRole('button', { name: /edit device colour/i });
-			await fireEvent.click(colourButton);
-
-			// Colour picker should now be visible
-			expect(screen.getByLabelText(/custom hex colour/i)).toBeInTheDocument();
-		});
-
-		it('shows custom badge when colour override is set', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-
-			// Set a colour override on the placed device
-			layoutStore.updateDeviceColour(RACK_ID, 0, '#FF5555');
-
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			// Should show the override colour
-			expect(screen.getByText('#FF5555')).toBeInTheDocument();
-			// Should show custom badge
-			expect(screen.getByText('custom')).toBeInTheDocument();
-		});
-	});
-
-	describe('Power device properties', () => {
-		it('does not show power section for non-power devices', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const device = layoutStore.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			layoutStore.placeDevice(RACK_ID, device.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			expect(screen.queryByText(/outlets/i)).not.toBeInTheDocument();
-			expect(screen.queryByText(/va rating/i)).not.toBeInTheDocument();
-		});
-
-		it('shows power section for power devices with outlet_count', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			// Manually add a power device type with outlet_count
-			const deviceType = {
-				slug: 'test-pdu',
-				u_height: 1,
-				model: 'Test PDU',
-				outlet_count: 8,
-				colour: '#F5A623',
-				category: 'power' as const
-			};
-			layoutStore.layout.device_types.push(deviceType);
-			layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			expect(screen.getByText(/outlets/i)).toBeInTheDocument();
-			expect(screen.getByText('8')).toBeInTheDocument();
-		});
-
-		it('shows power section for power devices with va_rating', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			// Manually add a power device type with va_rating
-			const deviceType = {
-				slug: 'test-ups',
-				u_height: 2,
-				model: 'Test UPS',
-				outlet_count: 6,
-				va_rating: 1500,
-				colour: '#F5A623',
-				category: 'power' as const
-			};
-			layoutStore.layout.device_types.push(deviceType);
-			layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			expect(screen.getByText(/va rating/i)).toBeInTheDocument();
-			expect(screen.getByText('1500')).toBeInTheDocument();
-		});
-
-		it('shows both outlet_count and va_rating when present', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			const deviceType = {
-				slug: 'full-ups',
-				u_height: 4,
-				model: 'Full UPS',
-				outlet_count: 8,
-				va_rating: 3000,
-				colour: '#F5A623',
-				category: 'power' as const
-			};
-			layoutStore.layout.device_types.push(deviceType);
-			layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			expect(screen.getByText(/outlets/i)).toBeInTheDocument();
-			expect(screen.getByText('8')).toBeInTheDocument();
-			expect(screen.getByText(/va rating/i)).toBeInTheDocument();
-			expect(screen.getByText('3000')).toBeInTheDocument();
-		});
-
-		it('does not show undefined for missing power values', () => {
-			const layoutStore = getLayoutStore();
-			const selectionStore = getSelectionStore();
-			const RACK_ID = 'rack-0';
-
-			layoutStore.addRack('My Rack', 24);
-			// Power device without outlet_count or va_rating
-			const deviceType = {
-				slug: 'basic-power',
-				u_height: 1,
-				model: 'Basic Power',
-				colour: '#F5A623',
-				category: 'power' as const
-			};
-			layoutStore.layout.device_types.push(deviceType);
-			layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
-			const deviceId = layoutStore.rack!.devices[0]!.id;
-			selectionStore.selectDevice(RACK_ID, deviceId);
-
-			render(EditPanel);
-
-			// Should not display "undefined" anywhere
-			expect(screen.queryByText('undefined')).not.toBeInTheDocument();
-			// Should not show outlet or VA labels if no values
-			expect(screen.queryByText(/outlets/i)).not.toBeInTheDocument();
-			expect(screen.queryByText(/va rating/i)).not.toBeInTheDocument();
-		});
-	});
-
-	describe('Device face assignment', () => {
-	it('shows face selector when device selected', () => {
-		const layoutStore = getLayoutStore();
-		const selectionStore = getSelectionStore();
-		const RACK_ID = 'rack-0';
-
-		layoutStore.addRack('My Rack', 24);
-		const device = layoutStore.addDeviceType({
-			name: 'Test Server',
-			u_height: 2,
-			category: 'server',
-			colour: '#4A90D9'
-		});
-		layoutStore.placeDevice(RACK_ID, device.slug, 1);
-		const deviceId = layoutStore.rack!.devices[0]!.id;
-		selectionStore.selectDevice(RACK_ID, deviceId);
-
-		const { getByLabelText } = render(EditPanel);
-		expect(getByLabelText(/mounted face/i)).toBeTruthy();
-	});
-
-	it('has three select options', () => {
-		const layoutStore = getLayoutStore();
-		const selectionStore = getSelectionStore();
-		const RACK_ID = 'rack-0';
-
-		layoutStore.addRack('My Rack', 24);
-		const device = layoutStore.addDeviceType({
-			name: 'Test Server',
-			u_height: 2,
-			category: 'server',
-			colour: '#4A90D9'
-		});
-		layoutStore.placeDevice(RACK_ID, device.slug, 1);
-		const deviceId = layoutStore.rack!.devices[0]!.id;
-		selectionStore.selectDevice(RACK_ID, deviceId);
-
-		const { getByRole } = render(EditPanel);
-		const select = getByRole('combobox', { name: /mounted face/i });
-		expect(select).toBeTruthy();
-		// Check for three options
-		const options = select.querySelectorAll('option');
-		expect(options.length).toBe(3);
-		expect(options[0]?.textContent).toBe('Front');
-		expect(options[1]?.textContent).toBe('Rear');
-		expect(options[2]?.textContent).toBe('Both (full-depth)');
-	});
-
-	it('does not show face selector for rack selection', () => {
-		const layoutStore = getLayoutStore();
-		const selectionStore = getSelectionStore();
-		const RACK_ID = 'rack-0';
-
-		layoutStore.addRack('My Rack', 24);
-		selectionStore.selectRack(RACK_ID);
-
-		const { queryByLabelText } = render(EditPanel);
-		expect(queryByLabelText(/mounted face/i)).toBeNull();
-	});
-	});
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import EditPanel from "$lib/components/EditPanel.svelte";
+import ColourSwatch from "$lib/components/ColourSwatch.svelte";
+import { resetLayoutStore, getLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  resetSelectionStore,
+  getSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { resetUIStore } from "$lib/stores/ui.svelte";
+
+describe("EditPanel Component", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetUIStore();
+  });
+
+  describe("Visibility", () => {
+    it("is hidden when nothing is selected", () => {
+      render(EditPanel);
+      // Use hidden: true to find elements with aria-hidden="true"
+      const panel = screen.queryByRole("complementary", { hidden: true });
+      // When no selection, right drawer should not have 'open' class
+      expect(panel).not.toHaveClass("open");
+      expect(panel).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("shows when a rack is selected", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      // Add a rack
+      const rack = layoutStore.addRack("Test Rack", 42);
+      expect(rack).not.toBeNull();
+
+      // Select it
+      selectionStore.selectRack(RACK_ID);
+
+      render(EditPanel);
+      // The panel should be open
+      const panel = screen.getByRole("complementary");
+      expect(panel).toHaveClass("open");
+    });
+
+    it("shows when a device is selected", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      // Add a rack
+      const rack = layoutStore.addRack("Test Rack", 42);
+      expect(rack).not.toBeNull();
+
+      // Add a device to library and place it
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+
+      // Select the device by ID
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+      const panel = screen.getByRole("complementary");
+      expect(panel).toHaveClass("open");
+    });
+  });
+
+  describe("Rack Editing", () => {
+    it("shows rack fields when rack is selected", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      selectionStore.selectRack(RACK_ID);
+
+      render(EditPanel);
+
+      // Should show name field
+      expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      // Should show height field
+      expect(screen.getByLabelText(/height/i)).toBeInTheDocument();
+    });
+
+    it("rack name field is editable", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      selectionStore.selectRack(RACK_ID);
+
+      render(EditPanel);
+
+      const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+      expect(nameInput.value).toBe("My Rack");
+
+      await fireEvent.input(nameInput, { target: { value: "New Name" } });
+      await fireEvent.blur(nameInput);
+
+      // Check store was updated
+      expect(layoutStore.rack?.name).toBe("New Name");
+    });
+
+    it("rack height is editable when no devices present", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      selectionStore.selectRack(RACK_ID);
+
+      render(EditPanel);
+
+      const heightInput = screen.getByLabelText(/height/i) as HTMLInputElement;
+      expect(heightInput).not.toBeDisabled();
+    });
+
+    it("rack height input is enabled when devices present (smart validation)", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      selectionStore.selectRack(RACK_ID);
+
+      render(EditPanel);
+
+      // Input should be enabled even with devices (smart validation allows growing)
+      const heightInput = screen.getByLabelText(/height/i) as HTMLInputElement;
+      expect(heightInput).not.toBeDisabled();
+    });
+
+    it("name change updates layout store", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      selectionStore.selectRack(RACK_ID);
+
+      render(EditPanel);
+
+      const nameInput = screen.getByLabelText(/name/i);
+      await fireEvent.input(nameInput, { target: { value: "Updated Rack" } });
+      await fireEvent.blur(nameInput);
+
+      expect(layoutStore.rack?.name).toBe("Updated Rack");
+    });
+
+    it("delete button is present for rack", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      selectionStore.selectRack(RACK_ID);
+
+      render(EditPanel);
+
+      expect(
+        screen.getByRole("button", { name: /delete rack/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Device Display", () => {
+    it("shows device fields when device is selected", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+        comments: "Some notes",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 5);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      // Should show device name (may appear multiple times with display name field)
+      const deviceNames = screen.getAllByText("Test Server");
+      expect(deviceNames.length).toBeGreaterThan(0);
+      // Should show height
+      expect(screen.getByText("2U")).toBeInTheDocument();
+      // Should show category (uses getCategoryDisplayName)
+      expect(screen.getByText("Servers")).toBeInTheDocument();
+      // Should show position
+      expect(screen.getByText("U5")).toBeInTheDocument();
+    });
+
+    it("shows notes when present", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+        // Schema v1.0.0: Uses 'notes' field
+        notes: "Important server notes",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      expect(screen.getByText("Important server notes")).toBeInTheDocument();
+    });
+
+    it("remove button is present for device", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      expect(
+        screen.getByRole("button", { name: /remove from rack/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows brand label for device with manufacturer", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "ProLiant DL380",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+        manufacturer: "HPE",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      // Should show Brand label
+      expect(screen.getByText("Brand")).toBeInTheDocument();
+      // Should show manufacturer name
+      expect(screen.getByText("HPE")).toBeInTheDocument();
+    });
+
+    it("shows Generic brand for device without manufacturer", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Custom Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+        // No manufacturer field
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      // Should show Brand label
+      expect(screen.getByText("Brand")).toBeInTheDocument();
+      // Should show Generic as fallback
+      expect(screen.getByText("Generic")).toBeInTheDocument();
+    });
+  });
+
+  describe("Device colour picker", () => {
+    it("shows colour row with device type colour", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      // Should show Colour label
+      expect(screen.getByText("Colour")).toBeInTheDocument();
+      // Should show the colour value
+      expect(screen.getByText("#4A90D9")).toBeInTheDocument();
+    });
+
+    it("toggles colour picker when colour row is clicked", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      // Colour picker should not be visible initially
+      expect(
+        screen.queryByLabelText(/custom hex colour/i),
+      ).not.toBeInTheDocument();
+
+      // Click the colour row button
+      const colourButton = screen.getByRole("button", {
+        name: /edit device colour/i,
+      });
+      await fireEvent.click(colourButton);
+
+      // Colour picker should now be visible
+      expect(screen.getByLabelText(/custom hex colour/i)).toBeInTheDocument();
+    });
+
+    it("shows custom badge when colour override is set", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+
+      // Set a colour override on the placed device
+      layoutStore.updateDeviceColour(RACK_ID, 0, "#FF5555");
+
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      // Should show the override colour
+      expect(screen.getByText("#FF5555")).toBeInTheDocument();
+      // Should show custom badge
+      expect(screen.getByText("custom")).toBeInTheDocument();
+    });
+  });
+
+  describe("Power device properties", () => {
+    it("does not show power section for non-power devices", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      expect(screen.queryByText(/outlets/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/va rating/i)).not.toBeInTheDocument();
+    });
+
+    it("shows power section for power devices with outlet_count", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      // Manually add a power device type with outlet_count
+      const deviceType = {
+        slug: "test-pdu",
+        u_height: 1,
+        model: "Test PDU",
+        outlet_count: 8,
+        colour: "#F5A623",
+        category: "power" as const,
+      };
+      layoutStore.layout.device_types.push(deviceType);
+      layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      expect(screen.getByText(/outlets/i)).toBeInTheDocument();
+      expect(screen.getByText("8")).toBeInTheDocument();
+    });
+
+    it("shows power section for power devices with va_rating", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      // Manually add a power device type with va_rating
+      const deviceType = {
+        slug: "test-ups",
+        u_height: 2,
+        model: "Test UPS",
+        outlet_count: 6,
+        va_rating: 1500,
+        colour: "#F5A623",
+        category: "power" as const,
+      };
+      layoutStore.layout.device_types.push(deviceType);
+      layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      expect(screen.getByText(/va rating/i)).toBeInTheDocument();
+      expect(screen.getByText("1500")).toBeInTheDocument();
+    });
+
+    it("shows both outlet_count and va_rating when present", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const deviceType = {
+        slug: "full-ups",
+        u_height: 4,
+        model: "Full UPS",
+        outlet_count: 8,
+        va_rating: 3000,
+        colour: "#F5A623",
+        category: "power" as const,
+      };
+      layoutStore.layout.device_types.push(deviceType);
+      layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      expect(screen.getByText(/outlets/i)).toBeInTheDocument();
+      expect(screen.getByText("8")).toBeInTheDocument();
+      expect(screen.getByText(/va rating/i)).toBeInTheDocument();
+      expect(screen.getByText("3000")).toBeInTheDocument();
+    });
+
+    it("does not show undefined for missing power values", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      // Power device without outlet_count or va_rating
+      const deviceType = {
+        slug: "basic-power",
+        u_height: 1,
+        model: "Basic Power",
+        colour: "#F5A623",
+        category: "power" as const,
+      };
+      layoutStore.layout.device_types.push(deviceType);
+      layoutStore.placeDevice(RACK_ID, deviceType.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      render(EditPanel);
+
+      // Should not display "undefined" anywhere
+      expect(screen.queryByText("undefined")).not.toBeInTheDocument();
+      // Should not show outlet or VA labels if no values
+      expect(screen.queryByText(/outlets/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/va rating/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Device face assignment", () => {
+    it("shows face selector when device selected", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      const { getByLabelText } = render(EditPanel);
+      expect(getByLabelText(/mounted face/i)).toBeTruthy();
+    });
+
+    it("has three select options", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      const device = layoutStore.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      layoutStore.placeDevice(RACK_ID, device.slug, 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      const { getByRole } = render(EditPanel);
+      const select = getByRole("combobox", { name: /mounted face/i });
+      expect(select).toBeTruthy();
+      // Check for three options
+      const options = select.querySelectorAll("option");
+      expect(options.length).toBe(3);
+      expect(options[0]?.textContent).toBe("Front");
+      expect(options[1]?.textContent).toBe("Rear");
+      expect(options[2]?.textContent).toBe("Both (full-depth)");
+    });
+
+    it("does not show face selector for rack selection", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      selectionStore.selectRack(RACK_ID);
+
+      const { queryByLabelText } = render(EditPanel);
+      expect(queryByLabelText(/mounted face/i)).toBeNull();
+    });
+
+    it("face dropdown is enabled for blank panels (half-depth devices)", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      // Place a blank panel from the starter library (has is_full_depth: false)
+      layoutStore.placeDevice(RACK_ID, "1u-blank", 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      const { getByRole } = render(EditPanel);
+      const select = getByRole("combobox", { name: /mounted face/i });
+
+      // Face dropdown should be enabled for blank panels (half-depth devices)
+      expect(select).not.toBeDisabled();
+    });
+
+    it("face dropdown is enabled for PDUs (half-depth devices)", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      // Place a PDU from the starter library (has is_full_depth: false)
+      layoutStore.placeDevice(RACK_ID, "1u-pdu", 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      const { getByRole } = render(EditPanel);
+      const select = getByRole("combobox", { name: /mounted face/i });
+
+      // Face dropdown should be enabled for PDUs (half-depth devices)
+      expect(select).not.toBeDisabled();
+    });
+
+    it("face dropdown is disabled for full-depth servers", () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+      const RACK_ID = "rack-0";
+
+      layoutStore.addRack("My Rack", 24);
+      // Place a server from the starter library (is_full_depth undefined = full-depth)
+      layoutStore.placeDevice(RACK_ID, "1u-server", 1);
+      const deviceId = layoutStore.rack!.devices[0]!.id;
+      selectionStore.selectDevice(RACK_ID, deviceId);
+
+      const { getByRole } = render(EditPanel);
+      const select = getByRole("combobox", { name: /mounted face/i });
+
+      // Face dropdown should be disabled for full-depth devices
+      expect(select).toBeDisabled();
+    });
+  });
 });
 
-describe('ColourSwatch Component', () => {
-	it('renders a colour swatch', () => {
-		const { container } = render(ColourSwatch, { props: { colour: '#FF0000' } });
-		const swatch = container.querySelector('.colour-swatch');
-		expect(swatch).toBeInTheDocument();
-	});
+describe("ColourSwatch Component", () => {
+  it("renders a colour swatch", () => {
+    const { container } = render(ColourSwatch, {
+      props: { colour: "#FF0000" },
+    });
+    const swatch = container.querySelector(".colour-swatch");
+    expect(swatch).toBeInTheDocument();
+  });
 
-	it('applies the correct colour', () => {
-		const { container } = render(ColourSwatch, { props: { colour: '#4A90D9' } });
-		const swatch = container.querySelector('.colour-swatch') as HTMLElement;
-		// happy-dom keeps hex, jsdom converts to rgb
-		expect(['#4A90D9', 'rgb(74, 144, 217)']).toContain(swatch.style.backgroundColor);
-	});
+  it("applies the correct colour", () => {
+    const { container } = render(ColourSwatch, {
+      props: { colour: "#4A90D9" },
+    });
+    const swatch = container.querySelector(".colour-swatch") as HTMLElement;
+    // happy-dom keeps hex, jsdom converts to rgb
+    expect(["#4A90D9", "rgb(74, 144, 217)"]).toContain(
+      swatch.style.backgroundColor,
+    );
+  });
 
-	it('uses default size when not specified', () => {
-		const { container } = render(ColourSwatch, { props: { colour: '#FF0000' } });
-		const swatch = container.querySelector('.colour-swatch') as HTMLElement;
-		// Default size is 16px
-		expect(swatch.style.width).toBe('16px');
-		expect(swatch.style.height).toBe('16px');
-	});
+  it("uses default size when not specified", () => {
+    const { container } = render(ColourSwatch, {
+      props: { colour: "#FF0000" },
+    });
+    const swatch = container.querySelector(".colour-swatch") as HTMLElement;
+    // Default size is 16px
+    expect(swatch.style.width).toBe("16px");
+    expect(swatch.style.height).toBe("16px");
+  });
 
-	it('uses custom size when specified', () => {
-		const { container } = render(ColourSwatch, { props: { colour: '#FF0000', size: 24 } });
-		const swatch = container.querySelector('.colour-swatch') as HTMLElement;
-		expect(swatch.style.width).toBe('24px');
-		expect(swatch.style.height).toBe('24px');
-	});
+  it("uses custom size when specified", () => {
+    const { container } = render(ColourSwatch, {
+      props: { colour: "#FF0000", size: 24 },
+    });
+    const swatch = container.querySelector(".colour-swatch") as HTMLElement;
+    expect(swatch.style.width).toBe("24px");
+    expect(swatch.style.height).toBe("24px");
+  });
 
-	it('has a border for visibility', () => {
-		const { container } = render(ColourSwatch, { props: { colour: '#FFFFFF' } });
-		const swatch = container.querySelector('.colour-swatch');
-		expect(swatch).toHaveClass('colour-swatch');
-		// Border is applied via CSS, just verify the class is present
-	});
+  it("has a border for visibility", () => {
+    const { container } = render(ColourSwatch, {
+      props: { colour: "#FFFFFF" },
+    });
+    const swatch = container.querySelector(".colour-swatch");
+    expect(swatch).toHaveClass("colour-swatch");
+    // Border is applied via CSS, just verify the class is present
+  });
 });

--- a/src/tests/device-lookup.test.ts
+++ b/src/tests/device-lookup.test.ts
@@ -1,105 +1,151 @@
-import { describe, it, expect } from 'vitest';
-import { findDeviceType, findDeviceInLibrary } from '$lib/utils/device-lookup';
-import type { DeviceType } from '$lib/types';
+import { describe, it, expect } from "vitest";
+import { findDeviceType, findDeviceInLibrary } from "$lib/utils/device-lookup";
+import type { DeviceType } from "$lib/types";
 
-describe('Device Lookup Utility', () => {
-	// Mock devices for testing
-	const customDevice: DeviceType = {
-		slug: 'custom-server',
-		model: 'Custom Server',
-		u_height: 2,
-		colour: '#ff0000',
-		category: 'server'
-	};
+describe("Device Lookup Utility", () => {
+  // Mock devices for testing
+  const customDevice: DeviceType = {
+    slug: "custom-server",
+    model: "Custom Server",
+    u_height: 2,
+    colour: "#ff0000",
+    category: "server",
+  };
 
-	const layoutDeviceTypes: DeviceType[] = [customDevice];
+  const layoutDeviceTypes: DeviceType[] = [customDevice];
 
-	describe('findDeviceType', () => {
-		it('finds device in layout device_types first (priority 1)', () => {
-			const result = findDeviceType('custom-server', layoutDeviceTypes);
-			expect(result).toBe(customDevice);
-		});
+  describe("findDeviceType", () => {
+    it("finds device in layout device_types first (priority 1)", () => {
+      const result = findDeviceType("custom-server", layoutDeviceTypes);
+      expect(result).toBe(customDevice);
+    });
 
-		it('falls back to starter pack if not in layout (priority 2)', () => {
-			// '1u-server' is a known starter library device
-			const result = findDeviceType('1u-server', []);
-			expect(result).toBeDefined();
-			expect(result?.slug).toBe('1u-server');
-		});
+    it("falls back to starter pack if not in layout (priority 2)", () => {
+      // '1u-server' is a known starter library device
+      const result = findDeviceType("1u-server", []);
+      expect(result).toBeDefined();
+      expect(result?.slug).toBe("1u-server");
+    });
 
-		it('falls back to brand packs if not in layout or starter (priority 3)', () => {
-			// 'ubiquiti-unifi-dream-machine-pro' is a known Ubiquiti device
-			const result = findDeviceType('ubiquiti-unifi-dream-machine-pro', []);
-			expect(result).toBeDefined();
-			expect(result?.slug).toBe('ubiquiti-unifi-dream-machine-pro');
-		});
+    it("falls back to brand packs if not in layout or starter (priority 3)", () => {
+      // 'ubiquiti-unifi-dream-machine-pro' is a known Ubiquiti device
+      const result = findDeviceType("ubiquiti-unifi-dream-machine-pro", []);
+      expect(result).toBeDefined();
+      expect(result?.slug).toBe("ubiquiti-unifi-dream-machine-pro");
+    });
 
-		it('returns undefined if not found in any source', () => {
-			const result = findDeviceType('non-existent-device-xyz-123', []);
-			expect(result).toBeUndefined();
-		});
+    it("returns undefined if not found in any source", () => {
+      const result = findDeviceType("non-existent-device-xyz-123", []);
+      expect(result).toBeUndefined();
+    });
 
-		it('layout devices take priority over starter library', () => {
-			// Create a custom device with same slug as a starter device
-			const customOverride: DeviceType = {
-				slug: '1u-server',
-				model: 'My Custom 1U',
-				u_height: 1,
-				colour: '#0000ff',
-				category: 'server'
-			};
+    it("layout devices take priority over starter library", () => {
+      // Create a custom device with same slug as a starter device
+      const customOverride: DeviceType = {
+        slug: "1u-server",
+        model: "My Custom 1U",
+        u_height: 1,
+        colour: "#0000ff",
+        category: "server",
+      };
 
-			const result = findDeviceType('1u-server', [customOverride]);
-			expect(result).toBe(customOverride);
-			expect(result?.model).toBe('My Custom 1U');
-		});
+      const result = findDeviceType("1u-server", [customOverride]);
+      expect(result).toBe(customOverride);
+      expect(result?.model).toBe("My Custom 1U");
+    });
 
-		it('layout devices take priority over brand packs', () => {
-			// Create a custom device with same slug as a brand device
-			const customOverride: DeviceType = {
-				slug: 'ubiquiti-unifi-dream-machine-pro',
-				model: 'My Custom UDM',
-				u_height: 1,
-				colour: '#00ff00',
-				category: 'server'
-			};
+    it("layout devices take priority over brand packs", () => {
+      // Create a custom device with same slug as a brand device
+      const customOverride: DeviceType = {
+        slug: "ubiquiti-unifi-dream-machine-pro",
+        model: "My Custom UDM",
+        u_height: 1,
+        colour: "#00ff00",
+        category: "server",
+      };
 
-			const result = findDeviceType('ubiquiti-unifi-dream-machine-pro', [customOverride]);
-			expect(result).toBe(customOverride);
-			expect(result?.model).toBe('My Custom UDM');
-		});
+      const result = findDeviceType("ubiquiti-unifi-dream-machine-pro", [
+        customOverride,
+      ]);
+      expect(result).toBe(customOverride);
+      expect(result?.model).toBe("My Custom UDM");
+    });
 
-		it('works with empty layout device types array', () => {
-			const result = findDeviceType('1u-server', []);
-			expect(result).toBeDefined();
-		});
+    it("works with empty layout device types array", () => {
+      const result = findDeviceType("1u-server", []);
+      expect(result).toBeDefined();
+    });
 
-		it('works without layout device types parameter (defaults to empty)', () => {
-			const result = findDeviceType('1u-server');
-			expect(result).toBeDefined();
-		});
-	});
+    it("works without layout device types parameter (defaults to empty)", () => {
+      const result = findDeviceType("1u-server");
+      expect(result).toBeDefined();
+    });
+  });
 
-	describe('findDeviceInLibrary', () => {
-		const library: DeviceType[] = [
-			{ slug: 'device-a', model: 'A', u_height: 1, colour: '#000', category: 'server' },
-			{ slug: 'device-b', model: 'B', u_height: 2, colour: '#111', category: 'network' },
-			{ slug: 'device-c', model: 'C', u_height: 3, colour: '#222', category: 'storage' }
-		];
+  describe("is_full_depth property", () => {
+    it("blank panels have is_full_depth: false", () => {
+      const result = findDeviceType("1u-blank");
+      expect(result).toBeDefined();
+      expect(result?.is_full_depth).toBe(false);
+    });
 
-		it('finds device by slug', () => {
-			const result = findDeviceInLibrary(library, 'device-b');
-			expect(result?.model).toBe('B');
-		});
+    it("PDUs have is_full_depth: false", () => {
+      const result = findDeviceType("1u-pdu");
+      expect(result).toBeDefined();
+      expect(result?.is_full_depth).toBe(false);
+    });
 
-		it('returns undefined if not found', () => {
-			const result = findDeviceInLibrary(library, 'device-z');
-			expect(result).toBeUndefined();
-		});
+    it("servers have is_full_depth undefined (defaults to full-depth)", () => {
+      const result = findDeviceType("1u-server");
+      expect(result).toBeDefined();
+      expect(result?.is_full_depth).toBeUndefined();
+    });
 
-		it('works with empty library', () => {
-			const result = findDeviceInLibrary([], 'device-a');
-			expect(result).toBeUndefined();
-		});
-	});
+    it("patch panels have is_full_depth: false", () => {
+      const result = findDeviceType("24-port-patch-panel");
+      expect(result).toBeDefined();
+      expect(result?.is_full_depth).toBe(false);
+    });
+  });
+
+  describe("findDeviceInLibrary", () => {
+    const library: DeviceType[] = [
+      {
+        slug: "device-a",
+        model: "A",
+        u_height: 1,
+        colour: "#000",
+        category: "server",
+      },
+      {
+        slug: "device-b",
+        model: "B",
+        u_height: 2,
+        colour: "#111",
+        category: "network",
+      },
+      {
+        slug: "device-c",
+        model: "C",
+        u_height: 3,
+        colour: "#222",
+        category: "storage",
+      },
+    ];
+
+    it("finds device by slug", () => {
+      const result = findDeviceInLibrary(library, "device-b");
+      expect(result?.model).toBe("B");
+    });
+
+    it("returns undefined if not found", () => {
+      const result = findDeviceInLibrary(library, "device-z");
+      expect(result).toBeUndefined();
+    });
+
+    it("works with empty library", () => {
+      const result = findDeviceInLibrary([], "device-a");
+      expect(result).toBeUndefined();
+    });
+  });
 });

--- a/src/tests/starterLibrary.test.ts
+++ b/src/tests/starterLibrary.test.ts
@@ -1,481 +1,547 @@
-import { describe, it, expect } from 'vitest';
-import { getStarterLibrary } from '$lib/data/starterLibrary';
-import { CATEGORY_COLOURS } from '$lib/types/constants';
-import { createLayout } from '$lib/utils/serialization';
-
-describe('Starter Device Type Library', () => {
-	describe('getStarterLibrary', () => {
-		it('returns 43 generic device types', () => {
-			const deviceTypes = getStarterLibrary();
-			expect(deviceTypes).toHaveLength(43);
-		});
-
-		it('all categories have at least one starter device type', () => {
-			const deviceTypes = getStarterLibrary();
-			const categoriesWithDevices = new Set(deviceTypes.map((d) => d.category));
-
-			// All categories should be represented
-			expect(categoriesWithDevices.has('server')).toBe(true);
-			expect(categoriesWithDevices.has('network')).toBe(true);
-			expect(categoriesWithDevices.has('storage')).toBe(true);
-			expect(categoriesWithDevices.has('power')).toBe(true);
-			expect(categoriesWithDevices.has('patch-panel')).toBe(true);
-			expect(categoriesWithDevices.has('kvm')).toBe(true);
-			expect(categoriesWithDevices.has('av-media')).toBe(true);
-			expect(categoriesWithDevices.has('cooling')).toBe(true);
-			expect(categoriesWithDevices.has('shelf')).toBe(true);
-			expect(categoriesWithDevices.has('blank')).toBe(true);
-			expect(categoriesWithDevices.has('cable-management')).toBe(true);
-		});
-
-		it('all device types have valid properties', () => {
-			const deviceTypes = getStarterLibrary();
-
-			deviceTypes.forEach((deviceType) => {
-				expect(deviceType.slug).toBeTruthy();
-				expect(deviceType.u_height).toBeGreaterThanOrEqual(0.5);
-				expect(deviceType.u_height).toBeLessThanOrEqual(42);
-				expect(deviceType.colour).toBeTruthy();
-				expect(deviceType.category).toBeTruthy();
-			});
-		});
-
-		it('device type slugs are unique', () => {
-			const deviceTypes = getStarterLibrary();
-			const slugs = deviceTypes.map((d) => d.slug);
-			const uniqueSlugs = new Set(slugs);
-
-			expect(uniqueSlugs.size).toBe(slugs.length);
-		});
-
-		it('device types have correct category colours', () => {
-			const deviceTypes = getStarterLibrary();
-
-			deviceTypes.forEach((deviceType) => {
-				expect(deviceType.colour).toBe(CATEGORY_COLOURS[deviceType.category]);
-			});
-		});
-
-		it('device type slugs are kebab-case', () => {
-			const deviceTypes = getStarterLibrary();
-
-			deviceTypes.forEach((deviceType) => {
-				expect(deviceType.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
-			});
-		});
-
-		it('no devices have manufacturer (all generic)', () => {
-			const deviceTypes = getStarterLibrary();
-
-			deviceTypes.forEach((deviceType) => {
-				expect(deviceType.manufacturer).toBeUndefined();
-			});
-		});
-	});
-
-	describe('server category (4 items)', () => {
-		it('includes Server (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Server' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('server');
-		});
-
-		it('includes Server (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Server' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('server');
-		});
-
-		it('includes Server (3U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Server' && d.u_height === 3);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('server');
-		});
-
-		it('includes Server (4U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Server' && d.u_height === 4);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('server');
-		});
-	});
-
-	describe('network category (4 items)', () => {
-		it('includes Switch (24-Port)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Switch (24-Port)');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
-			expect(device?.category).toBe('network');
-		});
-
-		it('includes Switch (48-Port)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Switch (48-Port)');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
-			expect(device?.category).toBe('network');
-		});
-
-		it('includes Router/Firewall (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Router/Firewall' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('network');
-		});
-
-		it('includes Router/Firewall (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Router/Firewall' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('network');
-		});
-	});
-
-	describe('storage category (4 items)', () => {
-		it('includes Storage (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Storage' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('storage');
-		});
-
-		it('includes Storage (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Storage' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('storage');
-		});
-
-		it('includes Storage (3U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Storage' && d.u_height === 3);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('storage');
-		});
-
-		it('includes Storage (4U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Storage' && d.u_height === 4);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('storage');
-		});
-	});
-
-	describe('power category (4 items)', () => {
-		it('includes PDU (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'PDU' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('power');
-		});
-
-		it('includes PDU (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'PDU' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('power');
-		});
-
-		it('includes UPS (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'UPS' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('power');
-		});
-
-		it('includes UPS (4U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'UPS' && d.u_height === 4);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('power');
-		});
-	});
-
-	describe('patch-panel category (3 items)', () => {
-		it('includes Fiber Patch Panel', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Fiber Patch Panel');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
-			expect(device?.category).toBe('patch-panel');
-		});
-
-		it('includes Patch Panel (24-Port)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Patch Panel (24-Port)');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
-			expect(device?.category).toBe('patch-panel');
-		});
-
-		it('includes Patch Panel (48-Port)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Patch Panel (48-Port)');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(2);
-			expect(device?.category).toBe('patch-panel');
-		});
-	});
-
-	describe('kvm category (2 items)', () => {
-		it('includes KVM Switch', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'KVM Switch');
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('kvm');
-		});
-
-		it('includes Console Drawer', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Console Drawer');
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('kvm');
-		});
-	});
-
-	describe('av-media category (8 items)', () => {
-		it('includes Amplifier (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Amplifier' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('av-media');
-		});
-
-		it('includes Amplifier (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Amplifier' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('av-media');
-		});
-
-		it('includes AV Receiver (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'AV Receiver' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('av-media');
-		});
-
-		it('includes Power Amplifier (3U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Power Amplifier');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(3);
-			expect(device?.category).toBe('av-media');
-		});
-
-		it('has 8 av-media devices total', () => {
-			const library = getStarterLibrary();
-			const avDevices = library.filter((d) => d.category === 'av-media');
-			expect(avDevices).toHaveLength(8);
-		});
-	});
-
-	describe('cooling category (2 items)', () => {
-		it('includes Fan Panel (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Fan Panel' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('cooling');
-		});
-
-		it('includes Fan Panel (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Fan Panel' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('cooling');
-		});
-	});
-
-	describe('shelf category (4 items)', () => {
-		it('includes Cantilever Shelf', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Cantilever Shelf');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
-			expect(device?.category).toBe('shelf');
-		});
-
-		it('includes Shelf (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Shelf' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('shelf');
-		});
-
-		it('includes Shelf (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Shelf' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('shelf');
-		});
-
-		it('includes Vented Shelf', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Vented Shelf');
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('shelf');
-		});
-
-		it('shelf device types have Dracula comment colour', () => {
-			const library = getStarterLibrary();
-			const shelves = library.filter((d) => d.category === 'shelf');
-
-			shelves.forEach((shelf) => {
-				expect(shelf.colour).toBe('#6272A4');
-			});
-		});
-	});
-
-	describe('blank category (5 items)', () => {
-		it('includes Blank Panel (0.5U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 0.5);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('blank');
-		});
-
-		it('includes Blank Panel (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('blank');
-		});
-
-		it('includes Blank Panel (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('blank');
-		});
-
-		it('includes Blank Panel (3U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 3);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('blank');
-		});
-
-		it('includes Blank Panel (4U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 4);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('blank');
-		});
-	});
-
-	describe('cable-management category (3 items)', () => {
-		it('includes Brush Panel', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Brush Panel');
-			expect(device).toBeDefined();
-			expect(device?.u_height).toBe(1);
-			expect(device?.category).toBe('cable-management');
-		});
-
-		it('includes Cable Manager (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Cable Manager' && d.u_height === 1);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('cable-management');
-		});
-
-		it('includes Cable Manager (2U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Cable Manager' && d.u_height === 2);
-			expect(device).toBeDefined();
-			expect(device?.category).toBe('cable-management');
-		});
-
-		it('cable-management devices have Dracula comment colour', () => {
-			const library = getStarterLibrary();
-			const cableDevices = library.filter((d) => d.category === 'cable-management');
-
-			expect(cableDevices).toHaveLength(3);
-			cableDevices.forEach((device) => {
-				expect(device.colour).toBe('#6272A4');
-			});
-		});
-	});
-
-	describe('slug generation', () => {
-		it('generates correct slug for Router/Firewall (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Router/Firewall' && d.u_height === 1);
-			expect(device?.slug).toBe('1u-router-firewall');
-		});
-
-		it('generates correct slug for Switch (24-Port)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Switch (24-Port)');
-			expect(device?.slug).toBe('24-port-switch');
-		});
-
-		it('generates correct slug for Blank Panel (0.5U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Blank Panel' && d.u_height === 0.5);
-			expect(device?.slug).toBe('0-5u-blank');
-		});
-
-		it('generates correct slug for Cable Manager (1U)', () => {
-			const library = getStarterLibrary();
-			const device = library.find((d) => d.model === 'Cable Manager' && d.u_height === 1);
-			expect(device?.slug).toBe('1u-cable-manager');
-		});
-	});
-
-	describe('all devices have required properties', () => {
-		it('every device has a slug', () => {
-			const library = getStarterLibrary();
-			library.forEach((device) => {
-				expect(device.slug).toBeDefined();
-				expect(device.slug.length).toBeGreaterThan(0);
-			});
-		});
-
-		it('every device has u_height > 0', () => {
-			const library = getStarterLibrary();
-			library.forEach((device) => {
-				expect(device.u_height).toBeGreaterThan(0);
-			});
-		});
-
-		it('every device has a category color', () => {
-			const library = getStarterLibrary();
-			library.forEach((device) => {
-				expect(device.colour).toBeDefined();
-				expect(device.colour).toMatch(/^#[0-9A-Fa-f]{6}$/);
-			});
-		});
-	});
-
-	describe('Layout integration', () => {
-		it('new layout has empty device_types (starter library is runtime constant)', () => {
-			const layout = createLayout();
-
-			// device_types starts empty - starter library is a runtime constant
-			expect(layout.device_types.length).toBe(0);
-		});
-
-		it('starter library contains only generic devices', () => {
-			const starterLibrary = getStarterLibrary();
-
-			// Library should have 43 generic devices
-			expect(starterLibrary.length).toBe(43);
-			expect(starterLibrary[0]?.slug).toBeTruthy();
-		});
-
-		it('starter device types have valid structure', () => {
-			const starterLibrary = getStarterLibrary();
-			const starterDeviceType = starterLibrary[0];
-
-			expect(starterDeviceType).toBeDefined();
-			expect(starterDeviceType!.slug).toBeTruthy();
-			expect(starterDeviceType!.u_height).toBeGreaterThan(0);
-			expect(starterDeviceType!.category).toBeTruthy();
-		});
-	});
+import { describe, it, expect } from "vitest";
+import { getStarterLibrary } from "$lib/data/starterLibrary";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
+import { createLayout } from "$lib/utils/serialization";
+
+describe("Starter Device Type Library", () => {
+  describe("getStarterLibrary", () => {
+    it("returns 43 generic device types", () => {
+      const deviceTypes = getStarterLibrary();
+      expect(deviceTypes).toHaveLength(43);
+    });
+
+    it("all categories have at least one starter device type", () => {
+      const deviceTypes = getStarterLibrary();
+      const categoriesWithDevices = new Set(deviceTypes.map((d) => d.category));
+
+      // All categories should be represented
+      expect(categoriesWithDevices.has("server")).toBe(true);
+      expect(categoriesWithDevices.has("network")).toBe(true);
+      expect(categoriesWithDevices.has("storage")).toBe(true);
+      expect(categoriesWithDevices.has("power")).toBe(true);
+      expect(categoriesWithDevices.has("patch-panel")).toBe(true);
+      expect(categoriesWithDevices.has("kvm")).toBe(true);
+      expect(categoriesWithDevices.has("av-media")).toBe(true);
+      expect(categoriesWithDevices.has("cooling")).toBe(true);
+      expect(categoriesWithDevices.has("shelf")).toBe(true);
+      expect(categoriesWithDevices.has("blank")).toBe(true);
+      expect(categoriesWithDevices.has("cable-management")).toBe(true);
+    });
+
+    it("all device types have valid properties", () => {
+      const deviceTypes = getStarterLibrary();
+
+      deviceTypes.forEach((deviceType) => {
+        expect(deviceType.slug).toBeTruthy();
+        expect(deviceType.u_height).toBeGreaterThanOrEqual(0.5);
+        expect(deviceType.u_height).toBeLessThanOrEqual(42);
+        expect(deviceType.colour).toBeTruthy();
+        expect(deviceType.category).toBeTruthy();
+      });
+    });
+
+    it("device type slugs are unique", () => {
+      const deviceTypes = getStarterLibrary();
+      const slugs = deviceTypes.map((d) => d.slug);
+      const uniqueSlugs = new Set(slugs);
+
+      expect(uniqueSlugs.size).toBe(slugs.length);
+    });
+
+    it("device types have correct category colours", () => {
+      const deviceTypes = getStarterLibrary();
+
+      deviceTypes.forEach((deviceType) => {
+        expect(deviceType.colour).toBe(CATEGORY_COLOURS[deviceType.category]);
+      });
+    });
+
+    it("device type slugs are kebab-case", () => {
+      const deviceTypes = getStarterLibrary();
+
+      deviceTypes.forEach((deviceType) => {
+        expect(deviceType.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+      });
+    });
+
+    it("no devices have manufacturer (all generic)", () => {
+      const deviceTypes = getStarterLibrary();
+
+      deviceTypes.forEach((deviceType) => {
+        expect(deviceType.manufacturer).toBeUndefined();
+      });
+    });
+  });
+
+  describe("server category (4 items)", () => {
+    it("includes Server (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Server" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("server");
+    });
+
+    it("includes Server (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Server" && d.u_height === 2,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("server");
+    });
+
+    it("includes Server (3U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Server" && d.u_height === 3,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("server");
+    });
+
+    it("includes Server (4U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Server" && d.u_height === 4,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("server");
+    });
+  });
+
+  describe("network category (4 items)", () => {
+    it("includes Switch (24-Port)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Switch (24-Port)");
+      expect(device).toBeDefined();
+      expect(device?.u_height).toBe(1);
+      expect(device?.category).toBe("network");
+    });
+
+    it("includes Switch (48-Port)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Switch (48-Port)");
+      expect(device).toBeDefined();
+      expect(device?.u_height).toBe(1);
+      expect(device?.category).toBe("network");
+    });
+
+    it("includes Router/Firewall (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Router/Firewall" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("network");
+    });
+
+    it("includes Router/Firewall (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Router/Firewall" && d.u_height === 2,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("network");
+    });
+  });
+
+  describe("storage category (4 items)", () => {
+    it("includes Storage (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Storage" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("storage");
+    });
+
+    it("includes Storage (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Storage" && d.u_height === 2,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("storage");
+    });
+
+    it("includes Storage (3U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Storage" && d.u_height === 3,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("storage");
+    });
+
+    it("includes Storage (4U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Storage" && d.u_height === 4,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("storage");
+    });
+  });
+
+  describe("power category (4 items)", () => {
+    it("includes PDU (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "PDU" && d.u_height === 1);
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("power");
+    });
+
+    it("includes PDU (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "PDU" && d.u_height === 2);
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("power");
+    });
+
+    it("includes UPS (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "UPS" && d.u_height === 2);
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("power");
+    });
+
+    it("includes UPS (4U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "UPS" && d.u_height === 4);
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("power");
+    });
+  });
+
+  describe("patch-panel category (3 items)", () => {
+    it("includes Fiber Patch Panel", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Fiber Patch Panel");
+      expect(device).toBeDefined();
+      expect(device?.u_height).toBe(1);
+      expect(device?.category).toBe("patch-panel");
+    });
+
+    it("includes Patch Panel (24-Port)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Patch Panel (24-Port)");
+      expect(device).toBeDefined();
+      expect(device?.u_height).toBe(1);
+      expect(device?.category).toBe("patch-panel");
+    });
+
+    it("includes Patch Panel (48-Port)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Patch Panel (48-Port)");
+      expect(device).toBeDefined();
+      expect(device?.u_height).toBe(2);
+      expect(device?.category).toBe("patch-panel");
+    });
+  });
+
+  describe("kvm category (2 items)", () => {
+    it("includes KVM Switch", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "KVM Switch");
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("kvm");
+    });
+
+    it("includes Console Drawer", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Console Drawer");
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("kvm");
+    });
+  });
+
+  describe("av-media category (8 items)", () => {
+    it("includes Amplifier (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Amplifier" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("av-media");
+    });
+
+    it("includes Amplifier (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Amplifier" && d.u_height === 2,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("av-media");
+    });
+
+    it("includes AV Receiver (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "AV Receiver" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("av-media");
+    });
+
+    it("includes Power Amplifier (3U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Power Amplifier");
+      expect(device).toBeDefined();
+      expect(device?.u_height).toBe(3);
+      expect(device?.category).toBe("av-media");
+    });
+
+    it("has 8 av-media devices total", () => {
+      const library = getStarterLibrary();
+      const avDevices = library.filter((d) => d.category === "av-media");
+      expect(avDevices).toHaveLength(8);
+    });
+  });
+
+  describe("cooling category (2 items)", () => {
+    it("includes Fan Panel (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Fan Panel" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("cooling");
+    });
+
+    it("includes Fan Panel (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Fan Panel" && d.u_height === 2,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("cooling");
+    });
+  });
+
+  describe("shelf category (4 items)", () => {
+    it("includes Cantilever Shelf", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Cantilever Shelf");
+      expect(device).toBeDefined();
+      expect(device?.u_height).toBe(1);
+      expect(device?.category).toBe("shelf");
+    });
+
+    it("includes Shelf (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Shelf" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("shelf");
+    });
+
+    it("includes Shelf (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Shelf" && d.u_height === 2,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("shelf");
+    });
+
+    it("includes Vented Shelf", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Vented Shelf");
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("shelf");
+    });
+
+    it("shelf device types have Dracula comment colour", () => {
+      const library = getStarterLibrary();
+      const shelves = library.filter((d) => d.category === "shelf");
+
+      shelves.forEach((shelf) => {
+        expect(shelf.colour).toBe("#6272A4");
+      });
+    });
+  });
+
+  describe("blank category (5 items)", () => {
+    it("includes Blank Panel (0.5U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Blank Panel" && d.u_height === 0.5,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("blank");
+    });
+
+    it("includes Blank Panel (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Blank Panel" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("blank");
+    });
+
+    it("includes Blank Panel (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Blank Panel" && d.u_height === 2,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("blank");
+    });
+
+    it("includes Blank Panel (3U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Blank Panel" && d.u_height === 3,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("blank");
+    });
+
+    it("includes Blank Panel (4U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Blank Panel" && d.u_height === 4,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("blank");
+    });
+
+    it("blank panels are half-depth (is_full_depth: false)", () => {
+      const library = getStarterLibrary();
+      const blanks = library.filter((d) => d.category === "blank");
+
+      expect(blanks.length).toBe(5);
+      blanks.forEach((blank) => {
+        expect(blank.is_full_depth).toBe(false);
+      });
+    });
+  });
+
+  describe("cable-management category (3 items)", () => {
+    it("includes Brush Panel", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Brush Panel");
+      expect(device).toBeDefined();
+      expect(device?.u_height).toBe(1);
+      expect(device?.category).toBe("cable-management");
+    });
+
+    it("includes Cable Manager (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Cable Manager" && d.u_height === 1,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("cable-management");
+    });
+
+    it("includes Cable Manager (2U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Cable Manager" && d.u_height === 2,
+      );
+      expect(device).toBeDefined();
+      expect(device?.category).toBe("cable-management");
+    });
+
+    it("cable-management devices have Dracula comment colour", () => {
+      const library = getStarterLibrary();
+      const cableDevices = library.filter(
+        (d) => d.category === "cable-management",
+      );
+
+      expect(cableDevices).toHaveLength(3);
+      cableDevices.forEach((device) => {
+        expect(device.colour).toBe("#6272A4");
+      });
+    });
+  });
+
+  describe("slug generation", () => {
+    it("generates correct slug for Router/Firewall (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Router/Firewall" && d.u_height === 1,
+      );
+      expect(device?.slug).toBe("1u-router-firewall");
+    });
+
+    it("generates correct slug for Switch (24-Port)", () => {
+      const library = getStarterLibrary();
+      const device = library.find((d) => d.model === "Switch (24-Port)");
+      expect(device?.slug).toBe("24-port-switch");
+    });
+
+    it("generates correct slug for Blank Panel (0.5U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Blank Panel" && d.u_height === 0.5,
+      );
+      expect(device?.slug).toBe("0-5u-blank");
+    });
+
+    it("generates correct slug for Cable Manager (1U)", () => {
+      const library = getStarterLibrary();
+      const device = library.find(
+        (d) => d.model === "Cable Manager" && d.u_height === 1,
+      );
+      expect(device?.slug).toBe("1u-cable-manager");
+    });
+  });
+
+  describe("all devices have required properties", () => {
+    it("every device has a slug", () => {
+      const library = getStarterLibrary();
+      library.forEach((device) => {
+        expect(device.slug).toBeDefined();
+        expect(device.slug.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("every device has u_height > 0", () => {
+      const library = getStarterLibrary();
+      library.forEach((device) => {
+        expect(device.u_height).toBeGreaterThan(0);
+      });
+    });
+
+    it("every device has a category color", () => {
+      const library = getStarterLibrary();
+      library.forEach((device) => {
+        expect(device.colour).toBeDefined();
+        expect(device.colour).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      });
+    });
+  });
+
+  describe("Layout integration", () => {
+    it("new layout has empty device_types (starter library is runtime constant)", () => {
+      const layout = createLayout();
+
+      // device_types starts empty - starter library is a runtime constant
+      expect(layout.device_types.length).toBe(0);
+    });
+
+    it("starter library contains only generic devices", () => {
+      const starterLibrary = getStarterLibrary();
+
+      // Library should have 43 generic devices
+      expect(starterLibrary.length).toBe(43);
+      expect(starterLibrary[0]?.slug).toBeTruthy();
+    });
+
+    it("starter device types have valid structure", () => {
+      const starterLibrary = getStarterLibrary();
+      const starterDeviceType = starterLibrary[0];
+
+      expect(starterDeviceType).toBeDefined();
+      expect(starterDeviceType!.slug).toBeTruthy();
+      expect(starterDeviceType!.u_height).toBeGreaterThan(0);
+      expect(starterDeviceType!.category).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Added regression tests verifying blank panels have `is_full_depth: false`
- Added tests for `findDeviceType` returning correct depth values
- Added EditPanel tests verifying face dropdown is enabled for half-depth devices

## Investigation Results
After investigation, the behavior reported in the issue appears to be already working correctly:
- Blank panels in starterLibrary.ts have `is_full_depth: false` ✓
- `findDeviceType('1u-blank')` returns a device with `is_full_depth: false` ✓  
- The face dropdown IS enabled for blank panels (half-depth devices) ✓
- The face dropdown IS disabled for servers (full-depth devices) ✓

## Files Changed
- `src/tests/starterLibrary.test.ts`: Added test for blank panels having `is_full_depth: false`
- `src/tests/device-lookup.test.ts`: Added tests for `is_full_depth` property lookup
- `src/tests/EditPanel.test.ts`: Added tests for face dropdown enabled/disabled states

## Test Plan
- [x] All new tests pass
- [x] Existing tests continue to pass
- [x] Tests verify blank panels have enabled face dropdown
- [x] Tests verify servers have disabled face dropdown

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for device properties across multiple test suites
  * Improved test code consistency and formatting standards

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->