### PR TITLE
feat: allow face override on all device types

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,5 @@
+/** @type {import("prettier").Config} */
+export default {
+  plugins: ["prettier-plugin-svelte"],
+  overrides: [{ files: "*.svelte", options: { parser: "svelte" } }],
+};


### PR DESCRIPTION
## Summary

- Removes the `disabled` attribute from the "Mounted Face" dropdown, allowing users to override the face setting on any device including full-depth devices
- Updates the helper text to show "Overriding default full-depth setting" when a user changes a full-depth device to front-only or rear-only
- Adds `prettier.config.js` to fix Svelte file parsing in pre-commit hooks

## Test plan

- [x] Added 3 new tests for face override functionality:
  - `allows face override on full-depth devices`
  - `updates face when changed on full-depth device`
  - `allows face override on devices with is_full_depth undefined`
- [x] All existing tests pass
- [x] Build succeeds
- [x] Lint passes

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized code formatting across Svelte components and tests.

* **Tests**
  * Updated and added tests reflecting new face-control behavior for full-depth devices.

* **Bug Fixes**
  * Face selector is now enabled for full-depth devices, allowing users to override face selection.

* **Chores**
  * Added project code-formatting configuration with Svelte support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->