### PR TITLE
feat: show warning modal for mobile users

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,6 +21,7 @@
   import HelpPanel from "$lib/components/HelpPanel.svelte";
   import BottomSheet from "$lib/components/BottomSheet.svelte";
   import DeviceDetails from "$lib/components/DeviceDetails.svelte";
+  import MobileWarningModal from "$lib/components/MobileWarningModal.svelte";
   import {
     getShareParam,
     clearShareParam,
@@ -788,6 +789,8 @@
   <HelpPanel open={helpPanelOpen} onclose={handleHelpClose} />
 
   <ToastContainer />
+
+  <MobileWarningModal />
 
   <KeyboardHandler
     onsave={handleSave}

--- a/src/lib/components/MobileWarningModal.svelte
+++ b/src/lib/components/MobileWarningModal.svelte
@@ -1,0 +1,184 @@
+<!--
+  MobileWarningModal Component
+  Shows a warning to users on small viewports that Rackula is designed for desktop.
+  Dismissible and remembers dismissal for the session.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { trapFocus, focusFirst, createFocusManager } from "$lib/utils/focus";
+
+  const STORAGE_KEY = "rackula-mobile-warning-dismissed";
+  const BREAKPOINT = 1024;
+
+  let open = $state(false);
+  let dialogElement: HTMLDivElement | null = $state(null);
+  const focusManager = createFocusManager();
+
+  onMount(() => {
+    // Only show on small viewports that haven't dismissed
+    const isMobile = window.innerWidth < BREAKPOINT;
+    const isDismissed = sessionStorage.getItem(STORAGE_KEY) === "true";
+
+    if (isMobile && !isDismissed) {
+      open = true;
+    }
+  });
+
+  function handleContinue() {
+    sessionStorage.setItem(STORAGE_KEY, "true");
+    open = false;
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.key === "Escape" && open) {
+      handleContinue();
+    }
+  }
+
+  // Focus management
+  $effect(() => {
+    if (open) {
+      focusManager.save();
+      setTimeout(() => {
+        if (dialogElement) {
+          focusFirst(dialogElement);
+        }
+      }, 0);
+    } else {
+      focusManager.restore();
+    }
+  });
+
+  onMount(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  });
+</script>
+
+{#if open}
+  <div class="modal-backdrop" role="presentation">
+    <div
+      bind:this={dialogElement}
+      class="modal"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="mobile-warning-title"
+      aria-describedby="mobile-warning-desc"
+      use:trapFocus
+    >
+      <div class="modal-icon" aria-hidden="true">
+        <svg
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+        >
+          <rect x="5" y="2" width="14" height="20" rx="2" ry="2" />
+          <line
+            x1="12"
+            y1="18"
+            x2="12"
+            y2="18.01"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
+      </div>
+
+      <h2 id="mobile-warning-title" class="modal-title">
+        Rackula works best on desktop
+      </h2>
+
+      <p id="mobile-warning-desc" class="modal-description">
+        This app is designed for screens 1024px or wider. For the best
+        experience, please visit on a desktop or laptop computer.
+      </p>
+
+      <p class="modal-note">Mobile support is coming soon!</p>
+
+      <button type="button" class="continue-button" onclick={handleContinue}>
+        Continue anyway
+      </button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--colour-backdrop, rgba(0, 0, 0, 0.8));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: var(--z-modal, 200);
+    padding: var(--space-4);
+  }
+
+  .modal {
+    background: var(--colour-dialog-bg, var(--colour-bg));
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    max-width: 400px;
+    width: 100%;
+    padding: var(--space-6);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .modal-icon {
+    color: var(--colour-primary);
+    opacity: 0.8;
+  }
+
+  .modal-title {
+    margin: 0;
+    font-size: var(--font-size-xl, 1.25rem);
+    font-weight: 600;
+    color: var(--colour-text);
+  }
+
+  .modal-description {
+    margin: 0;
+    font-size: var(--font-size-base, 1rem);
+    color: var(--colour-text-muted);
+    line-height: 1.5;
+  }
+
+  .modal-note {
+    margin: 0;
+    font-size: var(--font-size-sm, 0.875rem);
+    color: var(--colour-primary);
+    font-weight: 500;
+  }
+
+  .continue-button {
+    margin-top: var(--space-2);
+    padding: var(--space-3) var(--space-6);
+    background: var(--colour-primary);
+    color: var(--colour-primary-contrast, white);
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-base, 1rem);
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--duration-fast);
+  }
+
+  .continue-button:hover {
+    background: var(--colour-primary-hover);
+  }
+
+  .continue-button:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: 2px;
+  }
+</style>

--- a/src/tests/MobileWarningModal.test.ts
+++ b/src/tests/MobileWarningModal.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import MobileWarningModal from "$lib/components/MobileWarningModal.svelte";
+
+describe("MobileWarningModal", () => {
+  beforeEach(() => {
+    // Clear sessionStorage before each test
+    sessionStorage.clear();
+    // Reset window.innerWidth mock
+    vi.restoreAllMocks();
+  });
+
+  function mockWindowWidth(width: number) {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: width,
+    });
+  }
+
+  describe("Visibility", () => {
+    it("shows modal on mobile viewport (< 1024px)", () => {
+      mockWindowWidth(768);
+      render(MobileWarningModal);
+
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+      expect(
+        screen.getByText("Rackula works best on desktop"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show modal on desktop viewport (>= 1024px)", () => {
+      mockWindowWidth(1024);
+      render(MobileWarningModal);
+
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+
+    it("does not show modal on large desktop viewport", () => {
+      mockWindowWidth(1920);
+      render(MobileWarningModal);
+
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+
+    it("does not show modal if previously dismissed in session", () => {
+      mockWindowWidth(768);
+      sessionStorage.setItem("rackula-mobile-warning-dismissed", "true");
+      render(MobileWarningModal);
+
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Content", () => {
+    beforeEach(() => {
+      mockWindowWidth(768);
+    });
+
+    it("shows title", () => {
+      render(MobileWarningModal);
+
+      expect(
+        screen.getByText("Rackula works best on desktop"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows description about screen size", () => {
+      render(MobileWarningModal);
+
+      expect(
+        screen.getByText(/designed for screens 1024px or wider/i),
+      ).toBeInTheDocument();
+    });
+
+    it("shows mobile support coming soon message", () => {
+      render(MobileWarningModal);
+
+      expect(
+        screen.getByText(/mobile support is coming soon/i),
+      ).toBeInTheDocument();
+    });
+
+    it("shows continue button", () => {
+      render(MobileWarningModal);
+
+      expect(
+        screen.getByRole("button", { name: /continue anyway/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Dismissal", () => {
+    beforeEach(() => {
+      mockWindowWidth(768);
+    });
+
+    it("closes modal when continue button is clicked", async () => {
+      render(MobileWarningModal);
+
+      const button = screen.getByRole("button", { name: /continue anyway/i });
+      await fireEvent.click(button);
+
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+
+    it("saves dismissal to sessionStorage when continue is clicked", async () => {
+      render(MobileWarningModal);
+
+      const button = screen.getByRole("button", { name: /continue anyway/i });
+      await fireEvent.click(button);
+
+      expect(sessionStorage.getItem("rackula-mobile-warning-dismissed")).toBe(
+        "true",
+      );
+    });
+
+    it("closes modal on Escape key", async () => {
+      render(MobileWarningModal);
+
+      await fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+
+    it("saves dismissal to sessionStorage on Escape key", async () => {
+      render(MobileWarningModal);
+
+      await fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(sessionStorage.getItem("rackula-mobile-warning-dismissed")).toBe(
+        "true",
+      );
+    });
+  });
+
+  describe("Accessibility", () => {
+    beforeEach(() => {
+      mockWindowWidth(768);
+    });
+
+    it("has correct ARIA role", () => {
+      render(MobileWarningModal);
+
+      const dialog = screen.getByRole("alertdialog");
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+    });
+
+    it("has aria-labelledby pointing to title", () => {
+      render(MobileWarningModal);
+
+      const dialog = screen.getByRole("alertdialog");
+      expect(dialog).toHaveAttribute("aria-labelledby", "mobile-warning-title");
+    });
+
+    it("has aria-describedby pointing to description", () => {
+      render(MobileWarningModal);
+
+      const dialog = screen.getByRole("alertdialog");
+      expect(dialog).toHaveAttribute("aria-describedby", "mobile-warning-desc");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Shows a dismissible modal to users on viewports < 1024px
- Explains that Rackula is designed for desktop browsers
- "Continue anyway" button allows brave souls to proceed
- Dismissal saved in sessionStorage (per browser session)
- Fully accessible with proper ARIA attributes and focus management

## Test plan

- [x] 15 unit tests covering visibility, content, dismissal, and accessibility
- [x] Lint passes
- [x] Build succeeds

## Screenshots

The modal appears centered with:
- Mobile phone icon
- "Rackula works best on desktop" title
- Description about 1024px minimum width
- "Mobile support is coming soon!" note
- "Continue anyway" button

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a mobile warning modal that appears on screens under 1024px width. Users can dismiss the modal, with dismissal state remembered for the session duration. The modal supports keyboard navigation and accessibility features.

* **Tests**
  * Implemented comprehensive test suite covering viewport behavior, dismissal persistence, keyboard interaction, and accessibility compliance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->