### PR TITLE
test: add regression tests for custom multi-U device placement (#166)

### DIFF
--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -1,0 +1,128 @@
+name: Sync Project Status to Labels
+
+# Triggered when project items are edited (status changed)
+on:
+  projects_v2_item:
+    types: [edited]
+
+permissions: {}
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    # Only run for the Rackula Roadmap project
+    if: github.event.projects_v2_item.project_node_id == 'PVT_kwDODv3FSs4BLc_R'
+    permissions:
+      issues: write
+    steps:
+      - name: Get item details and sync labels
+        uses: actions/github-script@v7
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const itemNodeId = context.payload.projects_v2_item.node_id;
+
+            // Query the item to get its current status and linked issue
+            const query = `
+              query($itemId: ID!) {
+                node(id: $itemId) {
+                  ... on ProjectV2Item {
+                    content {
+                      ... on Issue {
+                        number
+                        repository {
+                          owner { login }
+                          name
+                        }
+                        labels(first: 20) {
+                          nodes { name }
+                        }
+                      }
+                    }
+                    fieldValueByName(name: "Status") {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const result = await github.graphql(query, { itemId: itemNodeId });
+            const item = result.node;
+
+            // Only process issues (not draft items or PRs)
+            if (!item?.content?.number) {
+              console.log('Not an issue, skipping');
+              return;
+            }
+
+            const issue = item.content;
+            const status = item.fieldValueByName?.name;
+            const currentLabels = issue.labels.nodes.map(l => l.name);
+
+            console.log(`Issue #${issue.number} moved to status: ${status}`);
+            console.log(`Current labels: ${currentLabels.join(', ')}`);
+
+            // Status to label mapping
+            const statusLabels = {
+              'Ready': { add: ['ready'], remove: ['triage', 'in-progress', 'in-review'] },
+              'In Progress': { add: ['in-progress'], remove: ['ready', 'triage', 'in-review'] },
+              'In Review': { add: ['in-review'], remove: ['in-progress', 'ready'] },
+              'Done': { add: [], remove: ['in-progress', 'in-review', 'ready', 'triage'] },
+              'Inbox': { add: ['triage'], remove: ['ready', 'in-progress', 'in-review'] },
+              'Needs Plan': { add: [], remove: ['ready', 'in-progress', 'in-review'] }
+            };
+
+            const mapping = statusLabels[status];
+            if (!mapping) {
+              console.log(`No label mapping for status: ${status}`);
+              return;
+            }
+
+            const owner = issue.repository.owner.login;
+            const repo = issue.repository.name;
+            const issueNumber = issue.number;
+
+            // Remove labels that shouldn't be present
+            for (const label of mapping.remove) {
+              if (currentLabels.includes(label)) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo,
+                    issue_number: issueNumber,
+                    name: label
+                  });
+                  console.log(`Removed label: ${label}`);
+                } catch (e) {
+                  console.log(`Failed to remove label ${label}: ${e.message}`);
+                }
+              }
+            }
+
+            // Add labels that should be present
+            const labelsToAdd = mapping.add.filter(l => !currentLabels.includes(l));
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner, repo,
+                issue_number: issueNumber,
+                labels: labelsToAdd
+              });
+              console.log(`Added labels: ${labelsToAdd.join(', ')}`);
+            }
+
+            // If moved to Done, ensure issue is closed
+            if (status === 'Done') {
+              const issueData = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+              if (issueData.data.state === 'open') {
+                await github.rest.issues.update({
+                  owner, repo,
+                  issue_number: issueNumber,
+                  state: 'closed'
+                });
+                console.log('Issue closed');
+              }
+            }

--- a/e2e/custom-device.spec.ts
+++ b/e2e/custom-device.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E Tests for Custom Device Creation and Placement (Issue #166)
+ * Tests that custom multi-U devices preserve their height after placement
+ */
+
+test.describe("Custom Device Height (Issue #166)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    // Clear storage and set hasStarted flag
+    await page.evaluate(() => {
+      sessionStorage.clear();
+      localStorage.clear();
+      localStorage.setItem("Rackula_has_started", "true");
+    });
+    await page.reload();
+    await page.waitForTimeout(500);
+  });
+
+  test("custom 4U device renders with correct height after placement", async ({
+    page,
+  }) => {
+    // 1. Open Add Device form
+    const addDeviceButton = page.locator('[aria-label="Add custom device"]');
+    await addDeviceButton.click();
+
+    // 2. Fill in custom device details
+    await page.fill("#device-name", "RACKOWL 4U Server");
+    await page.fill("#device-height", "4");
+    await page.selectOption("#device-category", "server");
+
+    // 3. Submit the form
+    await page.click('button:has-text("Add Device")');
+    await page.waitForTimeout(300);
+
+    // 4. Verify custom device appears in palette
+    const customDevice = page.locator(
+      '.device-palette-item:has-text("RACKOWL 4U Server")',
+    );
+    await expect(customDevice).toBeVisible();
+
+    // 5. Drag device to rack using JavaScript simulation
+    await page.evaluate(() => {
+      const deviceItem = Array.from(
+        document.querySelectorAll(".device-palette-item"),
+      ).find((el) => el.textContent?.includes("RACKOWL 4U Server"));
+      const rack = document.querySelector(".rack-svg");
+
+      if (!deviceItem || !rack) {
+        throw new Error("Could not find device item or rack");
+      }
+
+      const dataTransfer = new DataTransfer();
+
+      const dragStartEvent = new DragEvent("dragstart", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      });
+      deviceItem.dispatchEvent(dragStartEvent);
+
+      const rackRect = rack.getBoundingClientRect();
+      const dropY = rackRect.top + rackRect.height / 2;
+
+      const dragOverEvent = new DragEvent("dragover", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        clientX: rackRect.left + rackRect.width / 2,
+        clientY: dropY,
+      });
+      rack.dispatchEvent(dragOverEvent);
+
+      const dropEvent = new DragEvent("drop", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        clientX: rackRect.left + rackRect.width / 2,
+        clientY: dropY,
+      });
+      rack.dispatchEvent(dropEvent);
+
+      const dragEndEvent = new DragEvent("dragend", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      });
+      deviceItem.dispatchEvent(dragEndEvent);
+    });
+
+    await page.waitForTimeout(300);
+
+    // 6. Verify device appears in rack
+    const rackDevice = page.locator(".rack-device").first();
+    await expect(rackDevice).toBeVisible({ timeout: 5000 });
+
+    // 7. CRITICAL: Verify device has correct height (4U = 4 * 22px = 88px)
+    const deviceRect = page.locator(".rack-device .device-rect").first();
+    const height = await deviceRect.getAttribute("height");
+
+    // U_HEIGHT constant is 22px
+    expect(parseFloat(height || "0")).toBe(4 * 22); // 4U = 88px
+  });
+
+  test("custom 2U device blocks correct number of rack positions", async ({
+    page,
+  }) => {
+    // 1. Open Add Device form
+    const addDeviceButton = page.locator('[aria-label="Add custom device"]');
+    await addDeviceButton.click();
+
+    // 2. Create a custom 2U device
+    await page.fill("#device-name", "Test 2U Storage");
+    await page.fill("#device-height", "2");
+    await page.selectOption("#device-category", "storage");
+
+    // 3. Submit the form
+    await page.click('button:has-text("Add Device")');
+    await page.waitForTimeout(300);
+
+    // 4. Drag device to rack at position ~U20
+    await page.evaluate(() => {
+      const deviceItem = Array.from(
+        document.querySelectorAll(".device-palette-item"),
+      ).find((el) => el.textContent?.includes("Test 2U Storage"));
+      const rack = document.querySelector(".rack-svg");
+
+      if (!deviceItem || !rack) {
+        throw new Error("Could not find device item or rack");
+      }
+
+      const dataTransfer = new DataTransfer();
+
+      const dragStartEvent = new DragEvent("dragstart", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      });
+      deviceItem.dispatchEvent(dragStartEvent);
+
+      const rackRect = rack.getBoundingClientRect();
+
+      const dragOverEvent = new DragEvent("dragover", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        clientX: rackRect.left + rackRect.width / 2,
+        clientY: rackRect.top + rackRect.height / 2,
+      });
+      rack.dispatchEvent(dragOverEvent);
+
+      const dropEvent = new DragEvent("drop", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+        clientX: rackRect.left + rackRect.width / 2,
+        clientY: rackRect.top + rackRect.height / 2,
+      });
+      rack.dispatchEvent(dropEvent);
+
+      const dragEndEvent = new DragEvent("dragend", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      });
+      deviceItem.dispatchEvent(dragEndEvent);
+    });
+
+    await page.waitForTimeout(300);
+
+    // 5. Verify device renders with 2U height
+    const deviceRect = page.locator(".rack-device .device-rect").first();
+    const height = await deviceRect.getAttribute("height");
+
+    // U_HEIGHT constant is 22px
+    expect(parseFloat(height || "0")).toBe(2 * 22); // 2U = 44px
+  });
+});

--- a/src/tests/Rack-component.test.ts
+++ b/src/tests/Rack-component.test.ts
@@ -1,978 +1,1199 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/svelte';
-import Rack from '$lib/components/Rack.svelte';
-import type { Rack as RackType, DeviceType } from '$lib/types';
-
-describe('Rack SVG Component', () => {
-	const mockRack: RackType = {
-		name: 'Test Rack',
-		height: 12,
-		width: 19,
-		position: 0,
-		desc_units: false,
-		form_factor: '4-post',
-		starting_unit: 1,
-		devices: []
-	};
-
-	const mockDeviceLibrary: DeviceType[] = [];
-
-	describe('U Labels', () => {
-		it('renders correct number of U labels', () => {
-			render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			// Should have 12 U labels for a 12U rack
-			for (let u = 1; u <= 12; u++) {
-				expect(screen.getByText(String(u))).toBeInTheDocument();
-			}
-		});
-
-		it('renders U1 at the bottom position', () => {
-			render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const u1Label = screen.getByText('1');
-			const u12Label = screen.getByText('12');
-
-			// U1 should be lower on screen (higher y value in SVG) than U12
-			const u1Y = parseFloat(u1Label.getAttribute('y') ?? '0');
-			const u12Y = parseFloat(u12Label.getAttribute('y') ?? '0');
-
-			expect(u1Y).toBeGreaterThan(u12Y);
-		});
-
-		it('renders U{height} at the top position', () => {
-			const tallRack: RackType = { ...mockRack, height: 42 };
-
-			render(Rack, {
-				props: {
-					rack: tallRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const u42Label = screen.getByText('42');
-			const u1Label = screen.getByText('1');
-
-			// U42 should be higher on screen (lower y value in SVG) than U1
-			const u42Y = parseFloat(u42Label.getAttribute('y') ?? '0');
-			const u1Y = parseFloat(u1Label.getAttribute('y') ?? '0');
-
-			expect(u42Y).toBeLessThan(u1Y);
-		});
-	});
-
-	describe('Rack Name', () => {
-		it('displays rack name', () => {
-			render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			expect(screen.getByText('Test Rack')).toBeInTheDocument();
-		});
-
-		it('positions title above rack body', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const title = container.querySelector('.rack-name');
-			const rackInterior = container.querySelector('.rack-interior');
-			const titleY = parseFloat(title?.getAttribute('y') ?? '0');
-			const interiorY = parseFloat(rackInterior?.getAttribute('y') ?? '0');
-			expect(titleY).toBeLessThan(interiorY);
-		});
-
-		it('centers title horizontally', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const title = container.querySelector('.rack-name');
-			expect(title?.getAttribute('text-anchor')).toBe('middle');
-		});
-	});
-
-	describe('Selection', () => {
-		it('shows selection outline when selected=true', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: true
-				}
-			});
-
-			// Selection is now indicated via aria-selected on the container (CSS outline applied)
-			const rackContainer = container.querySelector('.rack-container');
-			expect(rackContainer).toHaveAttribute('aria-selected', 'true');
-		});
-
-		it('hides selection outline when selected=false', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			// Selection is now indicated via aria-selected on the container
-			const rackContainer = container.querySelector('.rack-container');
-			expect(rackContainer).toHaveAttribute('aria-selected', 'false');
-		});
-	});
-
-	describe('Events', () => {
-		it('dispatches select event on click', async () => {
-			const handleSelect = vi.fn();
-
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false,
-					onselect: handleSelect
-				}
-			});
-
-			const svg = container.querySelector('svg');
-			expect(svg).toBeInTheDocument();
-
-			await fireEvent.click(svg!);
-
-			expect(handleSelect).toHaveBeenCalledTimes(1);
-			expect(handleSelect).toHaveBeenCalledWith(
-				expect.objectContaining({
-					detail: { rackId: 'rack-0' }
-				})
-			);
-		});
-
-		it('dispatches select event on Enter key', async () => {
-			const handleSelect = vi.fn();
-
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false,
-					onselect: handleSelect
-				}
-			});
-
-			const svg = container.querySelector('svg');
-			expect(svg).toBeInTheDocument();
-
-			await fireEvent.keyDown(svg!, { key: 'Enter' });
-
-			expect(handleSelect).toHaveBeenCalledTimes(1);
-		});
-
-		it('dispatches select event on Space key', async () => {
-			const handleSelect = vi.fn();
-
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false,
-					onselect: handleSelect
-				}
-			});
-
-			const svg = container.querySelector('svg');
-			expect(svg).toBeInTheDocument();
-
-			await fireEvent.keyDown(svg!, { key: ' ' });
-
-			expect(handleSelect).toHaveBeenCalledTimes(1);
-		});
-	});
-
-	describe('Accessibility', () => {
-		it('has correct aria-label', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const svg = container.querySelector('svg');
-			expect(svg).toHaveAttribute('aria-label', 'Test Rack, 12U rack');
-		});
-
-		it('container has tabindex for keyboard focus', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const rackContainer = container.querySelector('.rack-container');
-			expect(rackContainer).toHaveAttribute('tabindex', '0');
-		});
-
-		it('SVG has role="img" for accessible description', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const svg = container.querySelector('svg');
-			expect(svg).toHaveAttribute('role', 'img');
-		});
-	});
-
-	describe('Rack View Filtering', () => {
-		it('shows front-face devices in front view', () => {
-			const frontDevice: DeviceType = {
-				slug: 'dev-1',
-				model: 'Test Device',
-				u_height: 2,
-				colour: '#4A90D9',
-				category: 'server'
-			};
-
-			const rearDevice: DeviceType = {
-				slug: 'dev-2',
-				model: 'Rear Device',
-				u_height: 1,
-				colour: '#7B68EE',
-				category: 'network'
-			};
-
-			const rack: RackType = {
-				...mockRack,
-				view: 'front',
-				devices: [
-					{ id: 'rc-test-1', device_type: 'dev-1', position: 1, face: 'front' },
-					{ id: 'rc-test-2', device_type: 'dev-2', position: 5, face: 'rear' }
-				]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack,
-					deviceLibrary: [frontDevice, rearDevice],
-					selected: false
-				}
-			});
-
-			// Only front-face device should be visible
-			const devices = container.querySelectorAll('[data-device-id]');
-			expect(devices).toHaveLength(1);
-		});
-
-		it('shows rear-face devices in rear view', () => {
-			const frontDevice: DeviceType = {
-				slug: 'dev-1',
-				model: 'Test Device',
-				u_height: 2,
-				colour: '#4A90D9',
-				category: 'server'
-			};
-
-			const rearDevice: DeviceType = {
-				slug: 'dev-2',
-				model: 'Rear Device',
-				u_height: 1,
-				colour: '#7B68EE',
-				category: 'network'
-			};
-
-			const rack: RackType = {
-				...mockRack,
-				view: 'rear',
-				devices: [
-					{ id: 'rc-test-3', device_type: 'dev-1', position: 1, face: 'front' },
-					{ id: 'rc-test-4', device_type: 'dev-2', position: 5, face: 'rear' }
-				]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack,
-					deviceLibrary: [frontDevice, rearDevice],
-					selected: false
-				}
-			});
-
-			// Only rear-face device should be visible
-			const devices = container.querySelectorAll('[data-device-id]');
-			expect(devices).toHaveLength(1);
-		});
-
-		it('shows both-face devices in either view', () => {
-			const device: DeviceType = {
-				slug: 'dev-1',
-				model: 'Full Depth Device',
-				u_height: 4,
-				colour: '#50C878',
-				category: 'storage'
-			};
-
-			const rackFront: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-test-5', device_type: 'dev-1', position: 1, face: 'both' }]
-			};
-
-			const { container: containerFront } = render(Rack, {
-				props: {
-					rack: rackFront,
-					deviceLibrary: [device],
-					selected: false
-				}
-			});
-
-			expect(containerFront.querySelectorAll('[data-device-id]')).toHaveLength(1);
-
-			const rackRear: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-test-6', device_type: 'dev-1', position: 1, face: 'both' }]
-			};
-
-			const { container: containerRear } = render(Rack, {
-				props: {
-					rack: rackRear,
-					deviceLibrary: [device],
-					selected: false
-				}
-			});
-
-			expect(containerRear.querySelectorAll('[data-device-id]')).toHaveLength(1);
-		});
-	});
-
-	describe('Rack Width', () => {
-		it('renders 19" rack at standard width', () => {
-			const rack19: RackType = { ...mockRack, width: 19 };
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rack19,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const svg = container.querySelector('svg');
-			expect(svg).toHaveAttribute('width', '220');
-		});
-
-		it('renders 10" rack proportionally narrower', () => {
-			const rack10: RackType = { ...mockRack, width: 10 };
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rack10,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const svg = container.querySelector('svg');
-			const width = parseInt(svg!.getAttribute('width') || '0');
-			// 10" should be approximately 10/19 of 220 = ~116
-			expect(width).toBeLessThan(220);
-			expect(width).toBeGreaterThan(100);
-		});
-
-		it('10" rack is narrower than 19" rack', () => {
-			const rack10: RackType = { ...mockRack, width: 10 };
-			const rack19: RackType = { ...mockRack, width: 19 };
-
-			const { container: container10 } = render(Rack, {
-				props: {
-					rack: rack10,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const { container: container19 } = render(Rack, {
-				props: {
-					rack: rack19,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			const svg10 = container10.querySelector('svg');
-			const svg19 = container19.querySelector('svg');
-			const width10 = parseInt(svg10!.getAttribute('width') || '0');
-			const width19 = parseInt(svg19!.getAttribute('width') || '0');
-
-			expect(width10).toBeLessThan(width19);
-		});
-	});
-
-	describe('Descending Units', () => {
-		it('renders U labels ascending when desc_units=false', () => {
-			const rack: RackType = { ...mockRack, height: 6, desc_units: false };
-
-			render(Rack, {
-				props: {
-					rack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			// U1 should be at bottom (higher y), U6 at top (lower y)
-			const u1Label = screen.getByText('1');
-			const u6Label = screen.getByText('6');
-			const u1Y = parseFloat(u1Label.getAttribute('y') ?? '0');
-			const u6Y = parseFloat(u6Label.getAttribute('y') ?? '0');
-
-			expect(u1Y).toBeGreaterThan(u6Y);
-		});
-
-		it('renders U labels descending when desc_units=true', () => {
-			const rack: RackType = { ...mockRack, height: 6, desc_units: true };
-
-			render(Rack, {
-				props: {
-					rack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			// U1 should be at top (lower y), U6 at bottom (higher y)
-			const u1Label = screen.getByText('1');
-			const u6Label = screen.getByText('6');
-			const u1Y = parseFloat(u1Label.getAttribute('y') ?? '0');
-			const u6Y = parseFloat(u6Label.getAttribute('y') ?? '0');
-
-			expect(u1Y).toBeLessThan(u6Y);
-		});
-	});
-
-	describe('Starting Unit', () => {
-		it('renders U labels starting from starting_unit', () => {
-			const rack: RackType = { ...mockRack, height: 4, starting_unit: 5 };
-
-			render(Rack, {
-				props: {
-					rack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			// Should show 5, 6, 7, 8 instead of 1, 2, 3, 4
-			expect(screen.getByText('5')).toBeInTheDocument();
-			expect(screen.getByText('6')).toBeInTheDocument();
-			expect(screen.getByText('7')).toBeInTheDocument();
-			expect(screen.getByText('8')).toBeInTheDocument();
-			expect(screen.queryByText('1')).not.toBeInTheDocument();
-		});
-
-		it('combines desc_units=true with custom starting_unit', () => {
-			const rack: RackType = { ...mockRack, height: 3, desc_units: true, starting_unit: 10 };
-
-			render(Rack, {
-				props: {
-					rack,
-					deviceLibrary: mockDeviceLibrary,
-					selected: false
-				}
-			});
-
-			// Should show 10, 11, 12 with 10 at top
-			const u10Label = screen.getByText('10');
-			const u12Label = screen.getByText('12');
-			const u10Y = parseFloat(u10Label.getAttribute('y') ?? '0');
-			const u12Y = parseFloat(u12Label.getAttribute('y') ?? '0');
-
-			expect(u10Y).toBeLessThan(u12Y);
-		});
-	});
-
-	describe('Face Filter (faceFilter prop)', () => {
-		// Use half-depth devices to test face filtering
-		// Full-depth devices are now visible from both sides
-		const deviceLibrary: DeviceType[] = [
-			{
-				slug: 'front-device',
-				model: 'Front Device',
-				u_height: 2,
-				colour: '#4A90D9',
-				category: 'server',
-				is_full_depth: false // Half-depth: only visible on front face
-			},
-			{
-				slug: 'rear-device',
-				model: 'Rear Device',
-				u_height: 1,
-				colour: '#7B68EE',
-				category: 'network',
-				is_full_depth: false // Half-depth: only visible on rear face
-			},
-			{
-				slug: 'both-device',
-				model: 'Full Depth Device',
-				u_height: 3,
-				colour: '#50C878',
-				category: 'storage'
-				// is_full_depth defaults to true, face='both' makes it visible on both
-			}
-		];
-
-		const rackWithDevices: RackType = {
-			...mockRack,
-			view: 'front', // Default view for filtering
-			devices: [
-				{ id: 'rc-ff-1', device_type: 'front-device', position: 1, face: 'front' },
-				{ id: 'rc-ff-2', device_type: 'rear-device', position: 5, face: 'rear' },
-				{ id: 'rc-ff-3', device_type: 'both-device', position: 8, face: 'both' }
-			]
-		};
-
-		it('shows only front, both-face, and full-depth opposite-face devices when faceFilter=front', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevices,
-					deviceLibrary,
-					selected: false,
-					faceFilter: 'front'
-				}
-			});
-
-			const devices = container.querySelectorAll('[data-device-id]');
-			// Should show front-device and both-device
-			// rear-device is half-depth so NOT visible from front
-			expect(devices).toHaveLength(2);
-
-			const deviceIds = Array.from(devices).map((d) => d.getAttribute('data-device-id'));
-			expect(deviceIds).toContain('front-device');
-			expect(deviceIds).toContain('both-device');
-			expect(deviceIds).not.toContain('rear-device');
-		});
-
-		it('shows only rear, both-face, and full-depth opposite-face devices when faceFilter=rear', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevices,
-					deviceLibrary,
-					selected: false,
-					faceFilter: 'rear'
-				}
-			});
-
-			const devices = container.querySelectorAll('[data-device-id]');
-			// Should show rear-device and both-device
-			// front-device is half-depth so NOT visible from rear
-			expect(devices).toHaveLength(2);
-
-			const deviceIds = Array.from(devices).map((d) => d.getAttribute('data-device-id'));
-			expect(deviceIds).toContain('rear-device');
-			expect(deviceIds).toContain('both-device');
-			expect(deviceIds).not.toContain('front-device');
-		});
-
-		it('shows full-depth devices from opposite face', () => {
-			// Create a full-depth device on front face
-			const fullDepthLibrary: DeviceType[] = [
-				{
-					slug: 'full-depth-server',
-					model: 'Full Depth Server',
-					u_height: 2,
-					colour: '#888888',
-					category: 'server',
-					is_full_depth: true
-				}
-			];
-
-			const rackWithFullDepth: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-ff-fd', device_type: 'full-depth-server', position: 1, face: 'front' }]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithFullDepth,
-					deviceLibrary: fullDepthLibrary,
-					selected: false,
-					faceFilter: 'rear' // Viewing rear, but full-depth front device should be visible
-				}
-			});
-
-			const devices = container.querySelectorAll('[data-device-id]');
-			expect(devices).toHaveLength(1);
-
-			const deviceIds = Array.from(devices).map((d) => d.getAttribute('data-device-id'));
-			expect(deviceIds).toContain('full-depth-server');
-		});
-
-		it('shows all devices when faceFilter is undefined (backwards compat)', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevices,
-					deviceLibrary,
-					selected: false
-					// faceFilter not provided
-				}
-			});
-
-			// Without faceFilter, falls back to rack.view filtering
-			// rack.view defaults to 'front', so should show front-device and both-device
-			const devices = container.querySelectorAll('[data-device-id]');
-			expect(devices.length).toBeGreaterThanOrEqual(2);
-		});
-
-		it('renders viewLabel when provided', () => {
-			render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: [],
-					selected: false,
-					viewLabel: 'FRONT'
-				}
-			});
-
-			expect(screen.getByText('FRONT')).toBeInTheDocument();
-		});
-
-		it('does not render viewLabel when not provided', () => {
-			render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: [],
-					selected: false
-					// viewLabel not provided
-				}
-			});
-
-			expect(screen.queryByText('FRONT')).not.toBeInTheDocument();
-			expect(screen.queryByText('REAR')).not.toBeInTheDocument();
-		});
-
-		it('viewLabel has correct styling class', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: [],
-					selected: false,
-					viewLabel: 'REAR'
-				}
-			});
-
-			const label = container.querySelector('.rack-view-label');
-			expect(label).toBeInTheDocument();
-			expect(label?.textContent).toBe('REAR');
-		});
-
-		it('hides rack name when hideRackName=true', () => {
-			render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: [],
-					selected: false,
-					hideRackName: true
-				}
-			});
-
-			// Rack name should not be visible
-			expect(screen.queryByText('Test Rack')).not.toBeInTheDocument();
-		});
-
-		it('shows rack name when hideRackName=false (default)', () => {
-			render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: [],
-					selected: false
-					// hideRackName not provided (defaults to false)
-				}
-			});
-
-			expect(screen.getByText('Test Rack')).toBeInTheDocument();
-		});
-	});
-
-	describe('U Labels Position', () => {
-		it('U labels are always on left rail for front view', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: [],
-					selected: false,
-					faceFilter: 'front'
-				}
-			});
-
-			const uLabels = container.querySelectorAll('.u-label');
-			expect(uLabels.length).toBeGreaterThan(0);
-
-			// Left rail center would be around 17/2 = 8.5
-			const firstLabel = uLabels[0];
-			const labelX = parseFloat(firstLabel?.getAttribute('x') ?? '0');
-
-			// Labels should be on left side (x < RACK_WIDTH / 2 = 110)
-			expect(labelX).toBeLessThan(110);
-		});
-
-		it('U labels are always on left rail for rear view', () => {
-			const { container } = render(Rack, {
-				props: {
-					rack: mockRack,
-					deviceLibrary: [],
-					selected: false,
-					faceFilter: 'rear'
-				}
-			});
-
-			// In rear view, U labels should ALSO be on the left side (not mirrored)
-			const uLabels = container.querySelectorAll('.u-label');
-			expect(uLabels.length).toBeGreaterThan(0);
-
-			// Left rail center would be around 17/2 = 8.5
-			const firstLabel = uLabels[0];
-			const labelX = parseFloat(firstLabel?.getAttribute('x') ?? '0');
-
-			// Labels should be on left side (x < RACK_WIDTH / 2 = 110)
-			expect(labelX).toBeLessThan(110);
-		});
-	});
-
-	describe('Blocked Slots Rendering', () => {
-		// Create a device library with full-depth and half-depth devices
-		// Blocked slots (hatching) now show for HALF-DEPTH devices only
-		// Full-depth devices are visible from both sides, so no hatching needed
-		const deviceLibrary: DeviceType[] = [
-			{
-				slug: 'full-depth-server',
-				model: 'Full Depth Server',
-				u_height: 2,
-				is_full_depth: true,
-				category: 'server',
-				colour: '#888888'
-			},
-			{
-				slug: 'half-depth-switch',
-				model: 'Half Depth Switch',
-				u_height: 1,
-				is_full_depth: false,
-				category: 'network',
-				colour: '#444444'
-			},
-			{
-				slug: 'half-depth-2u',
-				model: 'Half Depth 2U',
-				u_height: 2,
-				is_full_depth: false,
-				category: 'network',
-				colour: '#666666'
-			}
-		];
-
-		it('renders blocked-slot rect elements for half-depth devices on opposite face', () => {
-			const rackWithDevice: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-bs-1', device_type: 'half-depth-switch', position: 5, face: 'front' }]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevice,
-					deviceLibrary,
-					selected: false,
-					faceFilter: 'rear' // Viewing rear, front half-depth device shows hatching
-				}
-			});
-
-			// Should have blocked-slot rect elements (2 per slot: background + stripes)
-			const blockedSlots = container.querySelectorAll('.blocked-slot');
-			expect(blockedSlots.length).toBe(2);
-		});
-
-		it('blocked slot rects have correct position based on U', () => {
-			const rackWithDevice: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-bs-2', device_type: 'half-depth-2u', position: 3, face: 'front' }]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevice,
-					deviceLibrary,
-					selected: false,
-					faceFilter: 'rear'
-				}
-			});
-
-			const blockedSlot = container.querySelector('.blocked-slot');
-			expect(blockedSlot).toBeInTheDocument();
-
-			// Check Y position - should correspond to U position 3-4 (2U device)
-			const y = parseFloat(blockedSlot?.getAttribute('y') ?? '0');
-			expect(y).toBeGreaterThan(0);
-		});
-
-		it('blocked slot rects have correct height based on device U', () => {
-			const rackWithDevice: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-bs-3', device_type: 'half-depth-2u', position: 5, face: 'front' }]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevice,
-					deviceLibrary,
-					selected: false,
-					faceFilter: 'rear'
-				}
-			});
-
-			const blockedSlot = container.querySelector('.blocked-slot');
-			expect(blockedSlot).toBeInTheDocument();
-
-			// Height should be 2U * U_HEIGHT = 2 * 22 = 44
-			const height = parseFloat(blockedSlot?.getAttribute('height') ?? '0');
-			expect(height).toBe(44); // 2U * 22
-		});
-
-		it('does not render blocked slots for full-depth devices (they are visible from both sides)', () => {
-			const rackWithDevice: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-bs-4', device_type: 'full-depth-server', position: 5, face: 'front' }]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevice,
-					deviceLibrary,
-					selected: false,
-					faceFilter: 'rear' // Viewing rear, full-depth front device should be visible (not hatched)
-				}
-			});
-
-			const blockedSlots = container.querySelectorAll('.blocked-slot');
-			expect(blockedSlots.length).toBe(0);
-		});
-
-		it('does not render blocked slots when faceFilter is undefined', () => {
-			const rackWithDevice: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-bs-5', device_type: 'half-depth-switch', position: 5, face: 'front' }]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevice,
-					deviceLibrary,
-					selected: false
-					// No faceFilter - default/single-view mode
-				}
-			});
-
-			// No blocked slots in single-view mode
-			const blockedSlots = container.querySelectorAll('.blocked-slot');
-			expect(blockedSlots.length).toBe(0);
-		});
-
-		it('does not render blocked slots for both-face devices (they are visible on both)', () => {
-			const bothFaceLibrary: DeviceType[] = [
-				{
-					slug: 'ups',
-					model: 'UPS',
-					u_height: 3,
-					is_full_depth: true,
-					category: 'power',
-					colour: '#888888'
-				}
-			];
-
-			const rackWithDevice: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-bs-6', device_type: 'ups', position: 1, face: 'both' }]
-			};
-
-			// Check front view - both-face device should be visible, not hatched
-			const { container: frontContainer } = render(Rack, {
-				props: {
-					rack: rackWithDevice,
-					deviceLibrary: bothFaceLibrary,
-					selected: false,
-					faceFilter: 'front'
-				}
-			});
-
-			const frontBlockedSlots = frontContainer.querySelectorAll('.blocked-slot');
-			expect(frontBlockedSlots.length).toBe(0);
-
-			// Check rear view - both-face device should be visible, not hatched
-			const { container: rearContainer } = render(Rack, {
-				props: {
-					rack: rackWithDevice,
-					deviceLibrary: bothFaceLibrary,
-					selected: false,
-					faceFilter: 'rear'
-				}
-			});
-
-			const rearBlockedSlots = rearContainer.querySelectorAll('.blocked-slot');
-			expect(rearBlockedSlots.length).toBe(0);
-		});
-
-		it('blocked slots have appropriate opacity', () => {
-			const rackWithDevice: RackType = {
-				...mockRack,
-				devices: [{ id: 'rc-bs-7', device_type: 'half-depth-switch', position: 5, face: 'front' }]
-			};
-
-			const { container } = render(Rack, {
-				props: {
-					rack: rackWithDevice,
-					deviceLibrary,
-					selected: false,
-					faceFilter: 'rear'
-				}
-			});
-
-			const blockedSlot = container.querySelector('.blocked-slot');
-			expect(blockedSlot).toBeInTheDocument();
-
-			// Opacity should be set (we'll use CSS variable, so just check it exists)
-			const opacity = blockedSlot?.getAttribute('opacity');
-			// If opacity is set inline, it should be a value between 0 and 1
-			if (opacity) {
-				expect(parseFloat(opacity)).toBeGreaterThan(0);
-				expect(parseFloat(opacity)).toBeLessThan(1);
-			}
-		});
-	});
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import Rack from "$lib/components/Rack.svelte";
+import type { Rack as RackType, DeviceType } from "$lib/types";
+
+describe("Rack SVG Component", () => {
+  const mockRack: RackType = {
+    name: "Test Rack",
+    height: 12,
+    width: 19,
+    position: 0,
+    desc_units: false,
+    form_factor: "4-post",
+    starting_unit: 1,
+    devices: [],
+  };
+
+  const mockDeviceLibrary: DeviceType[] = [];
+
+  describe("U Labels", () => {
+    it("renders correct number of U labels", () => {
+      render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      // Should have 12 U labels for a 12U rack
+      for (let u = 1; u <= 12; u++) {
+        expect(screen.getByText(String(u))).toBeInTheDocument();
+      }
+    });
+
+    it("renders U1 at the bottom position", () => {
+      render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const u1Label = screen.getByText("1");
+      const u12Label = screen.getByText("12");
+
+      // U1 should be lower on screen (higher y value in SVG) than U12
+      const u1Y = parseFloat(u1Label.getAttribute("y") ?? "0");
+      const u12Y = parseFloat(u12Label.getAttribute("y") ?? "0");
+
+      expect(u1Y).toBeGreaterThan(u12Y);
+    });
+
+    it("renders U{height} at the top position", () => {
+      const tallRack: RackType = { ...mockRack, height: 42 };
+
+      render(Rack, {
+        props: {
+          rack: tallRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const u42Label = screen.getByText("42");
+      const u1Label = screen.getByText("1");
+
+      // U42 should be higher on screen (lower y value in SVG) than U1
+      const u42Y = parseFloat(u42Label.getAttribute("y") ?? "0");
+      const u1Y = parseFloat(u1Label.getAttribute("y") ?? "0");
+
+      expect(u42Y).toBeLessThan(u1Y);
+    });
+  });
+
+  describe("Rack Name", () => {
+    it("displays rack name", () => {
+      render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      expect(screen.getByText("Test Rack")).toBeInTheDocument();
+    });
+
+    it("positions title above rack body", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const title = container.querySelector(".rack-name");
+      const rackInterior = container.querySelector(".rack-interior");
+      const titleY = parseFloat(title?.getAttribute("y") ?? "0");
+      const interiorY = parseFloat(rackInterior?.getAttribute("y") ?? "0");
+      expect(titleY).toBeLessThan(interiorY);
+    });
+
+    it("centers title horizontally", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const title = container.querySelector(".rack-name");
+      expect(title?.getAttribute("text-anchor")).toBe("middle");
+    });
+  });
+
+  describe("Selection", () => {
+    it("shows selection outline when selected=true", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: true,
+        },
+      });
+
+      // Selection is now indicated via aria-selected on the container (CSS outline applied)
+      const rackContainer = container.querySelector(".rack-container");
+      expect(rackContainer).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("hides selection outline when selected=false", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      // Selection is now indicated via aria-selected on the container
+      const rackContainer = container.querySelector(".rack-container");
+      expect(rackContainer).toHaveAttribute("aria-selected", "false");
+    });
+  });
+
+  describe("Events", () => {
+    it("dispatches select event on click", async () => {
+      const handleSelect = vi.fn();
+
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+          onselect: handleSelect,
+        },
+      });
+
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+
+      await fireEvent.click(svg!);
+
+      expect(handleSelect).toHaveBeenCalledTimes(1);
+      expect(handleSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: { rackId: "rack-0" },
+        }),
+      );
+    });
+
+    it("dispatches select event on Enter key", async () => {
+      const handleSelect = vi.fn();
+
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+          onselect: handleSelect,
+        },
+      });
+
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+
+      await fireEvent.keyDown(svg!, { key: "Enter" });
+
+      expect(handleSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it("dispatches select event on Space key", async () => {
+      const handleSelect = vi.fn();
+
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+          onselect: handleSelect,
+        },
+      });
+
+      const svg = container.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+
+      await fireEvent.keyDown(svg!, { key: " " });
+
+      expect(handleSelect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has correct aria-label", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("aria-label", "Test Rack, 12U rack");
+    });
+
+    it("container has tabindex for keyboard focus", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const rackContainer = container.querySelector(".rack-container");
+      expect(rackContainer).toHaveAttribute("tabindex", "0");
+    });
+
+    it('SVG has role="img" for accessible description', () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("role", "img");
+    });
+  });
+
+  describe("Rack View Filtering", () => {
+    it("shows front-face devices in front view", () => {
+      const frontDevice: DeviceType = {
+        slug: "dev-1",
+        model: "Test Device",
+        u_height: 2,
+        colour: "#4A90D9",
+        category: "server",
+      };
+
+      const rearDevice: DeviceType = {
+        slug: "dev-2",
+        model: "Rear Device",
+        u_height: 1,
+        colour: "#7B68EE",
+        category: "network",
+      };
+
+      const rack: RackType = {
+        ...mockRack,
+        view: "front",
+        devices: [
+          { id: "rc-test-1", device_type: "dev-1", position: 1, face: "front" },
+          { id: "rc-test-2", device_type: "dev-2", position: 5, face: "rear" },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack,
+          deviceLibrary: [frontDevice, rearDevice],
+          selected: false,
+        },
+      });
+
+      // Only front-face device should be visible
+      const devices = container.querySelectorAll("[data-device-id]");
+      expect(devices).toHaveLength(1);
+    });
+
+    it("shows rear-face devices in rear view", () => {
+      const frontDevice: DeviceType = {
+        slug: "dev-1",
+        model: "Test Device",
+        u_height: 2,
+        colour: "#4A90D9",
+        category: "server",
+      };
+
+      const rearDevice: DeviceType = {
+        slug: "dev-2",
+        model: "Rear Device",
+        u_height: 1,
+        colour: "#7B68EE",
+        category: "network",
+      };
+
+      const rack: RackType = {
+        ...mockRack,
+        view: "rear",
+        devices: [
+          { id: "rc-test-3", device_type: "dev-1", position: 1, face: "front" },
+          { id: "rc-test-4", device_type: "dev-2", position: 5, face: "rear" },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack,
+          deviceLibrary: [frontDevice, rearDevice],
+          selected: false,
+        },
+      });
+
+      // Only rear-face device should be visible
+      const devices = container.querySelectorAll("[data-device-id]");
+      expect(devices).toHaveLength(1);
+    });
+
+    it("shows both-face devices in either view", () => {
+      const device: DeviceType = {
+        slug: "dev-1",
+        model: "Full Depth Device",
+        u_height: 4,
+        colour: "#50C878",
+        category: "storage",
+      };
+
+      const rackFront: RackType = {
+        ...mockRack,
+        devices: [
+          { id: "rc-test-5", device_type: "dev-1", position: 1, face: "both" },
+        ],
+      };
+
+      const { container: containerFront } = render(Rack, {
+        props: {
+          rack: rackFront,
+          deviceLibrary: [device],
+          selected: false,
+        },
+      });
+
+      expect(containerFront.querySelectorAll("[data-device-id]")).toHaveLength(
+        1,
+      );
+
+      const rackRear: RackType = {
+        ...mockRack,
+        devices: [
+          { id: "rc-test-6", device_type: "dev-1", position: 1, face: "both" },
+        ],
+      };
+
+      const { container: containerRear } = render(Rack, {
+        props: {
+          rack: rackRear,
+          deviceLibrary: [device],
+          selected: false,
+        },
+      });
+
+      expect(containerRear.querySelectorAll("[data-device-id]")).toHaveLength(
+        1,
+      );
+    });
+  });
+
+  describe("Rack Width", () => {
+    it('renders 19" rack at standard width', () => {
+      const rack19: RackType = { ...mockRack, width: 19 };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rack19,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("width", "220");
+    });
+
+    it('renders 10" rack proportionally narrower', () => {
+      const rack10: RackType = { ...mockRack, width: 10 };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rack10,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const svg = container.querySelector("svg");
+      const width = parseInt(svg!.getAttribute("width") || "0");
+      // 10" should be approximately 10/19 of 220 = ~116
+      expect(width).toBeLessThan(220);
+      expect(width).toBeGreaterThan(100);
+    });
+
+    it('10" rack is narrower than 19" rack', () => {
+      const rack10: RackType = { ...mockRack, width: 10 };
+      const rack19: RackType = { ...mockRack, width: 19 };
+
+      const { container: container10 } = render(Rack, {
+        props: {
+          rack: rack10,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const { container: container19 } = render(Rack, {
+        props: {
+          rack: rack19,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      const svg10 = container10.querySelector("svg");
+      const svg19 = container19.querySelector("svg");
+      const width10 = parseInt(svg10!.getAttribute("width") || "0");
+      const width19 = parseInt(svg19!.getAttribute("width") || "0");
+
+      expect(width10).toBeLessThan(width19);
+    });
+  });
+
+  describe("Descending Units", () => {
+    it("renders U labels ascending when desc_units=false", () => {
+      const rack: RackType = { ...mockRack, height: 6, desc_units: false };
+
+      render(Rack, {
+        props: {
+          rack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      // U1 should be at bottom (higher y), U6 at top (lower y)
+      const u1Label = screen.getByText("1");
+      const u6Label = screen.getByText("6");
+      const u1Y = parseFloat(u1Label.getAttribute("y") ?? "0");
+      const u6Y = parseFloat(u6Label.getAttribute("y") ?? "0");
+
+      expect(u1Y).toBeGreaterThan(u6Y);
+    });
+
+    it("renders U labels descending when desc_units=true", () => {
+      const rack: RackType = { ...mockRack, height: 6, desc_units: true };
+
+      render(Rack, {
+        props: {
+          rack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      // U1 should be at top (lower y), U6 at bottom (higher y)
+      const u1Label = screen.getByText("1");
+      const u6Label = screen.getByText("6");
+      const u1Y = parseFloat(u1Label.getAttribute("y") ?? "0");
+      const u6Y = parseFloat(u6Label.getAttribute("y") ?? "0");
+
+      expect(u1Y).toBeLessThan(u6Y);
+    });
+  });
+
+  describe("Starting Unit", () => {
+    it("renders U labels starting from starting_unit", () => {
+      const rack: RackType = { ...mockRack, height: 4, starting_unit: 5 };
+
+      render(Rack, {
+        props: {
+          rack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      // Should show 5, 6, 7, 8 instead of 1, 2, 3, 4
+      expect(screen.getByText("5")).toBeInTheDocument();
+      expect(screen.getByText("6")).toBeInTheDocument();
+      expect(screen.getByText("7")).toBeInTheDocument();
+      expect(screen.getByText("8")).toBeInTheDocument();
+      expect(screen.queryByText("1")).not.toBeInTheDocument();
+    });
+
+    it("combines desc_units=true with custom starting_unit", () => {
+      const rack: RackType = {
+        ...mockRack,
+        height: 3,
+        desc_units: true,
+        starting_unit: 10,
+      };
+
+      render(Rack, {
+        props: {
+          rack,
+          deviceLibrary: mockDeviceLibrary,
+          selected: false,
+        },
+      });
+
+      // Should show 10, 11, 12 with 10 at top
+      const u10Label = screen.getByText("10");
+      const u12Label = screen.getByText("12");
+      const u10Y = parseFloat(u10Label.getAttribute("y") ?? "0");
+      const u12Y = parseFloat(u12Label.getAttribute("y") ?? "0");
+
+      expect(u10Y).toBeLessThan(u12Y);
+    });
+  });
+
+  describe("Face Filter (faceFilter prop)", () => {
+    // Use half-depth devices to test face filtering
+    // Full-depth devices are now visible from both sides
+    const deviceLibrary: DeviceType[] = [
+      {
+        slug: "front-device",
+        model: "Front Device",
+        u_height: 2,
+        colour: "#4A90D9",
+        category: "server",
+        is_full_depth: false, // Half-depth: only visible on front face
+      },
+      {
+        slug: "rear-device",
+        model: "Rear Device",
+        u_height: 1,
+        colour: "#7B68EE",
+        category: "network",
+        is_full_depth: false, // Half-depth: only visible on rear face
+      },
+      {
+        slug: "both-device",
+        model: "Full Depth Device",
+        u_height: 3,
+        colour: "#50C878",
+        category: "storage",
+        // is_full_depth defaults to true, face='both' makes it visible on both
+      },
+    ];
+
+    const rackWithDevices: RackType = {
+      ...mockRack,
+      view: "front", // Default view for filtering
+      devices: [
+        {
+          id: "rc-ff-1",
+          device_type: "front-device",
+          position: 1,
+          face: "front",
+        },
+        {
+          id: "rc-ff-2",
+          device_type: "rear-device",
+          position: 5,
+          face: "rear",
+        },
+        {
+          id: "rc-ff-3",
+          device_type: "both-device",
+          position: 8,
+          face: "both",
+        },
+      ],
+    };
+
+    it("shows only front, both-face, and full-depth opposite-face devices when faceFilter=front", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevices,
+          deviceLibrary,
+          selected: false,
+          faceFilter: "front",
+        },
+      });
+
+      const devices = container.querySelectorAll("[data-device-id]");
+      // Should show front-device and both-device
+      // rear-device is half-depth so NOT visible from front
+      expect(devices).toHaveLength(2);
+
+      const deviceIds = Array.from(devices).map((d) =>
+        d.getAttribute("data-device-id"),
+      );
+      expect(deviceIds).toContain("front-device");
+      expect(deviceIds).toContain("both-device");
+      expect(deviceIds).not.toContain("rear-device");
+    });
+
+    it("shows only rear, both-face, and full-depth opposite-face devices when faceFilter=rear", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevices,
+          deviceLibrary,
+          selected: false,
+          faceFilter: "rear",
+        },
+      });
+
+      const devices = container.querySelectorAll("[data-device-id]");
+      // Should show rear-device and both-device
+      // front-device is half-depth so NOT visible from rear
+      expect(devices).toHaveLength(2);
+
+      const deviceIds = Array.from(devices).map((d) =>
+        d.getAttribute("data-device-id"),
+      );
+      expect(deviceIds).toContain("rear-device");
+      expect(deviceIds).toContain("both-device");
+      expect(deviceIds).not.toContain("front-device");
+    });
+
+    it("shows full-depth devices from opposite face", () => {
+      // Create a full-depth device on front face
+      const fullDepthLibrary: DeviceType[] = [
+        {
+          slug: "full-depth-server",
+          model: "Full Depth Server",
+          u_height: 2,
+          colour: "#888888",
+          category: "server",
+          is_full_depth: true,
+        },
+      ];
+
+      const rackWithFullDepth: RackType = {
+        ...mockRack,
+        devices: [
+          {
+            id: "rc-ff-fd",
+            device_type: "full-depth-server",
+            position: 1,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithFullDepth,
+          deviceLibrary: fullDepthLibrary,
+          selected: false,
+          faceFilter: "rear", // Viewing rear, but full-depth front device should be visible
+        },
+      });
+
+      const devices = container.querySelectorAll("[data-device-id]");
+      expect(devices).toHaveLength(1);
+
+      const deviceIds = Array.from(devices).map((d) =>
+        d.getAttribute("data-device-id"),
+      );
+      expect(deviceIds).toContain("full-depth-server");
+    });
+
+    it("shows all devices when faceFilter is undefined (backwards compat)", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevices,
+          deviceLibrary,
+          selected: false,
+          // faceFilter not provided
+        },
+      });
+
+      // Without faceFilter, falls back to rack.view filtering
+      // rack.view defaults to 'front', so should show front-device and both-device
+      const devices = container.querySelectorAll("[data-device-id]");
+      expect(devices.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("renders viewLabel when provided", () => {
+      render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: [],
+          selected: false,
+          viewLabel: "FRONT",
+        },
+      });
+
+      expect(screen.getByText("FRONT")).toBeInTheDocument();
+    });
+
+    it("does not render viewLabel when not provided", () => {
+      render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: [],
+          selected: false,
+          // viewLabel not provided
+        },
+      });
+
+      expect(screen.queryByText("FRONT")).not.toBeInTheDocument();
+      expect(screen.queryByText("REAR")).not.toBeInTheDocument();
+    });
+
+    it("viewLabel has correct styling class", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: [],
+          selected: false,
+          viewLabel: "REAR",
+        },
+      });
+
+      const label = container.querySelector(".rack-view-label");
+      expect(label).toBeInTheDocument();
+      expect(label?.textContent).toBe("REAR");
+    });
+
+    it("hides rack name when hideRackName=true", () => {
+      render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: [],
+          selected: false,
+          hideRackName: true,
+        },
+      });
+
+      // Rack name should not be visible
+      expect(screen.queryByText("Test Rack")).not.toBeInTheDocument();
+    });
+
+    it("shows rack name when hideRackName=false (default)", () => {
+      render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: [],
+          selected: false,
+          // hideRackName not provided (defaults to false)
+        },
+      });
+
+      expect(screen.getByText("Test Rack")).toBeInTheDocument();
+    });
+  });
+
+  describe("U Labels Position", () => {
+    it("U labels are always on left rail for front view", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: [],
+          selected: false,
+          faceFilter: "front",
+        },
+      });
+
+      const uLabels = container.querySelectorAll(".u-label");
+      expect(uLabels.length).toBeGreaterThan(0);
+
+      // Left rail center would be around 17/2 = 8.5
+      const firstLabel = uLabels[0];
+      const labelX = parseFloat(firstLabel?.getAttribute("x") ?? "0");
+
+      // Labels should be on left side (x < RACK_WIDTH / 2 = 110)
+      expect(labelX).toBeLessThan(110);
+    });
+
+    it("U labels are always on left rail for rear view", () => {
+      const { container } = render(Rack, {
+        props: {
+          rack: mockRack,
+          deviceLibrary: [],
+          selected: false,
+          faceFilter: "rear",
+        },
+      });
+
+      // In rear view, U labels should ALSO be on the left side (not mirrored)
+      const uLabels = container.querySelectorAll(".u-label");
+      expect(uLabels.length).toBeGreaterThan(0);
+
+      // Left rail center would be around 17/2 = 8.5
+      const firstLabel = uLabels[0];
+      const labelX = parseFloat(firstLabel?.getAttribute("x") ?? "0");
+
+      // Labels should be on left side (x < RACK_WIDTH / 2 = 110)
+      expect(labelX).toBeLessThan(110);
+    });
+  });
+
+  describe("Blocked Slots Rendering", () => {
+    // Create a device library with full-depth and half-depth devices
+    // Blocked slots (hatching) now show for HALF-DEPTH devices only
+    // Full-depth devices are visible from both sides, so no hatching needed
+    const deviceLibrary: DeviceType[] = [
+      {
+        slug: "full-depth-server",
+        model: "Full Depth Server",
+        u_height: 2,
+        is_full_depth: true,
+        category: "server",
+        colour: "#888888",
+      },
+      {
+        slug: "half-depth-switch",
+        model: "Half Depth Switch",
+        u_height: 1,
+        is_full_depth: false,
+        category: "network",
+        colour: "#444444",
+      },
+      {
+        slug: "half-depth-2u",
+        model: "Half Depth 2U",
+        u_height: 2,
+        is_full_depth: false,
+        category: "network",
+        colour: "#666666",
+      },
+    ];
+
+    it("renders blocked-slot rect elements for half-depth devices on opposite face", () => {
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        devices: [
+          {
+            id: "rc-bs-1",
+            device_type: "half-depth-switch",
+            position: 5,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary,
+          selected: false,
+          faceFilter: "rear", // Viewing rear, front half-depth device shows hatching
+        },
+      });
+
+      // Should have blocked-slot rect elements (2 per slot: background + stripes)
+      const blockedSlots = container.querySelectorAll(".blocked-slot");
+      expect(blockedSlots.length).toBe(2);
+    });
+
+    it("blocked slot rects have correct position based on U", () => {
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        devices: [
+          {
+            id: "rc-bs-2",
+            device_type: "half-depth-2u",
+            position: 3,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary,
+          selected: false,
+          faceFilter: "rear",
+        },
+      });
+
+      const blockedSlot = container.querySelector(".blocked-slot");
+      expect(blockedSlot).toBeInTheDocument();
+
+      // Check Y position - should correspond to U position 3-4 (2U device)
+      const y = parseFloat(blockedSlot?.getAttribute("y") ?? "0");
+      expect(y).toBeGreaterThan(0);
+    });
+
+    it("blocked slot rects have correct height based on device U", () => {
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        devices: [
+          {
+            id: "rc-bs-3",
+            device_type: "half-depth-2u",
+            position: 5,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary,
+          selected: false,
+          faceFilter: "rear",
+        },
+      });
+
+      const blockedSlot = container.querySelector(".blocked-slot");
+      expect(blockedSlot).toBeInTheDocument();
+
+      // Height should be 2U * U_HEIGHT = 2 * 22 = 44
+      const height = parseFloat(blockedSlot?.getAttribute("height") ?? "0");
+      expect(height).toBe(44); // 2U * 22
+    });
+
+    it("does not render blocked slots for full-depth devices (they are visible from both sides)", () => {
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        devices: [
+          {
+            id: "rc-bs-4",
+            device_type: "full-depth-server",
+            position: 5,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary,
+          selected: false,
+          faceFilter: "rear", // Viewing rear, full-depth front device should be visible (not hatched)
+        },
+      });
+
+      const blockedSlots = container.querySelectorAll(".blocked-slot");
+      expect(blockedSlots.length).toBe(0);
+    });
+
+    it("does not render blocked slots when faceFilter is undefined", () => {
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        devices: [
+          {
+            id: "rc-bs-5",
+            device_type: "half-depth-switch",
+            position: 5,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary,
+          selected: false,
+          // No faceFilter - default/single-view mode
+        },
+      });
+
+      // No blocked slots in single-view mode
+      const blockedSlots = container.querySelectorAll(".blocked-slot");
+      expect(blockedSlots.length).toBe(0);
+    });
+
+    it("does not render blocked slots for both-face devices (they are visible on both)", () => {
+      const bothFaceLibrary: DeviceType[] = [
+        {
+          slug: "ups",
+          model: "UPS",
+          u_height: 3,
+          is_full_depth: true,
+          category: "power",
+          colour: "#888888",
+        },
+      ];
+
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        devices: [
+          { id: "rc-bs-6", device_type: "ups", position: 1, face: "both" },
+        ],
+      };
+
+      // Check front view - both-face device should be visible, not hatched
+      const { container: frontContainer } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary: bothFaceLibrary,
+          selected: false,
+          faceFilter: "front",
+        },
+      });
+
+      const frontBlockedSlots =
+        frontContainer.querySelectorAll(".blocked-slot");
+      expect(frontBlockedSlots.length).toBe(0);
+
+      // Check rear view - both-face device should be visible, not hatched
+      const { container: rearContainer } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary: bothFaceLibrary,
+          selected: false,
+          faceFilter: "rear",
+        },
+      });
+
+      const rearBlockedSlots = rearContainer.querySelectorAll(".blocked-slot");
+      expect(rearBlockedSlots.length).toBe(0);
+    });
+
+    it("blocked slots have appropriate opacity", () => {
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        devices: [
+          {
+            id: "rc-bs-7",
+            device_type: "half-depth-switch",
+            position: 5,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary,
+          selected: false,
+          faceFilter: "rear",
+        },
+      });
+
+      const blockedSlot = container.querySelector(".blocked-slot");
+      expect(blockedSlot).toBeInTheDocument();
+
+      // Opacity should be set (we'll use CSS variable, so just check it exists)
+      const opacity = blockedSlot?.getAttribute("opacity");
+      // If opacity is set inline, it should be a value between 0 and 1
+      if (opacity) {
+        expect(parseFloat(opacity)).toBeGreaterThan(0);
+        expect(parseFloat(opacity)).toBeLessThan(1);
+      }
+    });
+  });
+
+  describe("Multi-U Device Rendering (Issue #166)", () => {
+    const U_HEIGHT = 22; // pixels per U
+
+    it("renders custom 4U device with correct height", () => {
+      // Custom 4U device (like one created via Add Device form)
+      const custom4UDevice: DeviceType = {
+        slug: "rackowl-4u-server",
+        model: "RACKOWL 4U Server",
+        u_height: 4,
+        category: "server",
+        colour: "#3b82f6",
+      };
+
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        height: 42,
+        view: "front", // Must set view for face filtering to work
+        devices: [
+          {
+            id: "multi-u-1",
+            device_type: "rackowl-4u-server",
+            position: 10,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary: [custom4UDevice],
+          selected: false,
+        },
+      });
+
+      // Find the device rect
+      const deviceRect = container.querySelector(
+        '[data-device-id="rackowl-4u-server"] .device-rect',
+      );
+      expect(deviceRect).toBeInTheDocument();
+
+      // Device should have height of 4U = 4 * 22 = 88 pixels
+      const height = parseFloat(deviceRect?.getAttribute("height") ?? "0");
+      expect(height).toBe(4 * U_HEIGHT);
+    });
+
+    it("renders custom 2U device with correct height", () => {
+      const custom2UDevice: DeviceType = {
+        slug: "custom-2u-server",
+        model: "Custom 2U Server",
+        u_height: 2,
+        category: "server",
+        colour: "#ef4444",
+      };
+
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        view: "front",
+        devices: [
+          {
+            id: "multi-u-2",
+            device_type: "custom-2u-server",
+            position: 5,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary: [custom2UDevice],
+          selected: false,
+        },
+      });
+
+      const deviceRect = container.querySelector(
+        '[data-device-id="custom-2u-server"] .device-rect',
+      );
+      expect(deviceRect).toBeInTheDocument();
+
+      // Device should have height of 2U = 2 * 22 = 44 pixels
+      const height = parseFloat(deviceRect?.getAttribute("height") ?? "0");
+      expect(height).toBe(2 * U_HEIGHT);
+    });
+
+    it("custom multi-U device is positioned correctly", () => {
+      const custom3UDevice: DeviceType = {
+        slug: "custom-3u-storage",
+        model: "Custom 3U Storage",
+        u_height: 3,
+        category: "storage",
+        colour: "#8b5cf6",
+      };
+
+      const rackWithDevice: RackType = {
+        ...mockRack,
+        height: 12,
+        view: "front",
+        devices: [
+          {
+            id: "multi-u-3",
+            device_type: "custom-3u-storage",
+            position: 3,
+            face: "front",
+          },
+        ],
+      };
+
+      const { container } = render(Rack, {
+        props: {
+          rack: rackWithDevice,
+          deviceLibrary: [custom3UDevice],
+          selected: false,
+        },
+      });
+
+      // Device at position 3 with 3U height should span U3-U5
+      // In SVG coordinates: y = (rackHeight - position - u_height + 1) * U_HEIGHT
+      // y = (12 - 3 - 3 + 1) * 22 = 7 * 22 = 154
+      const deviceGroup = container.querySelector(
+        '[data-device-id="custom-3u-storage"]',
+      );
+      expect(deviceGroup).toBeInTheDocument();
+
+      // The group has transform="translate(17, y)" where y is relative to the devices group
+      // The devices group has its own offset, so we just verify the device exists and has correct height
+      const deviceRect = container.querySelector(
+        '[data-device-id="custom-3u-storage"] .device-rect',
+      );
+      const height = parseFloat(deviceRect?.getAttribute("height") ?? "0");
+      expect(height).toBe(3 * U_HEIGHT);
+    });
+  });
 });

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -1,1339 +1,1493 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { getLayoutStore, resetLayoutStore } from '$lib/stores/layout.svelte';
-import { getImageStore, resetImageStore } from '$lib/stores/images.svelte';
-import type { Layout } from '$lib/types';
-import { VERSION } from '$lib/version';
-
-describe('Layout Store (v0.2)', () => {
-	beforeEach(() => {
-		// Reset the store before each test
-		resetLayoutStore();
-	});
-
-	describe('initial state', () => {
-		it('initializes with correct app version', () => {
-			const store = getLayoutStore();
-			expect(store.layout.name).toBe('Racky McRackface');
-			expect(store.layout.version).toBe(VERSION);
-			// v0.2 has a single rack, not an array
-			expect(store.layout.rack).toBeDefined();
-			expect(store.layout.rack.devices).toEqual([]);
-			// device_types starts empty (starter library is a runtime constant, not stored)
-			expect(store.layout.device_types.length).toBe(0);
-		});
-
-		it('initializes isDirty as false', () => {
-			const store = getLayoutStore();
-			expect(store.isDirty).toBe(false);
-		});
-
-		it('initializes hasRack as true', () => {
-			const store = getLayoutStore();
-			expect(store.hasRack).toBe(true);
-		});
-
-		it('compatibility: rackCount is 0 before user starts, 1 after', () => {
-			const store = getLayoutStore();
-			// Before user starts, rackCount is 0 (WelcomeScreen shown)
-			expect(store.rackCount).toBe(0);
-			expect(store.hasStarted).toBe(false);
-			// After user starts, rackCount is 1
-			store.markStarted();
-			expect(store.rackCount).toBe(1);
-			expect(store.hasStarted).toBe(true);
-		});
-
-		it('compatibility: canAddRack is false', () => {
-			const store = getLayoutStore();
-			expect(store.canAddRack).toBe(false);
-		});
-
-		it('rack returns the single rack', () => {
-			const store = getLayoutStore();
-			expect(store.rack).toBeDefined();
-			expect(store.rack.name).toBe('Racky McRackface');
-		});
-	});
-
-	describe('createNewLayout', () => {
-		it('creates a new layout with the given name', () => {
-			const store = getLayoutStore();
-			store.createNewLayout('My Lab');
-			expect(store.layout.name).toBe('My Lab');
-		});
-
-		it('initializes with default rack', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			store.createNewLayout('New Layout');
-			// v0.2 always has a rack, but devices should be empty
-			expect(store.layout.rack.devices).toEqual([]);
-		});
-
-		it('resets device_types to empty array', () => {
-			const store = getLayoutStore();
-			store.addDeviceType({
-				name: 'Test',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.createNewLayout('New Layout');
-			// device_types starts empty (starter library is a runtime constant, not stored)
-			expect(store.device_types.length).toBe(0);
-		});
-
-		it('sets isDirty to false', () => {
-			const store = getLayoutStore();
-			store.addRack('Test', 42);
-			expect(store.isDirty).toBe(true);
-			store.createNewLayout('New Layout');
-			expect(store.isDirty).toBe(false);
-		});
-	});
-
-	describe('loadLayout', () => {
-		it('loads a v0.2 layout directly', () => {
-			const store = getLayoutStore();
-			const v02Layout: Layout = {
-				version: '0.2.0',
-				name: 'Test Layout',
-				rack: {
-					name: 'Test Rack',
-					height: 24,
-					width: 19,
-					desc_units: false,
-					form_factor: '4-post-cabinet',
-					starting_unit: 1,
-					position: 0,
-					devices: []
-				},
-				device_types: [],
-				settings: {
-					display_mode: 'label',
-					show_labels_on_images: false
-				}
-			};
-			store.loadLayout(v02Layout);
-			expect(store.layout.name).toBe('Test Layout');
-			expect(store.layout.rack.height).toBe(24);
-		});
-
-		it('sets isDirty to false', () => {
-			const store = getLayoutStore();
-			store.markDirty();
-			expect(store.isDirty).toBe(true);
-			store.loadLayout({
-				version: '0.2.0',
-				name: 'Test',
-				rack: {
-					name: 'Test',
-					height: 42,
-					width: 19,
-					desc_units: false,
-					form_factor: '4-post-cabinet',
-					starting_unit: 1,
-					position: 0,
-					devices: []
-				},
-				device_types: [],
-				settings: {
-					display_mode: 'label',
-					show_labels_on_images: false
-				}
-			});
-			expect(store.isDirty).toBe(false);
-		});
-	});
-
-	describe('addRack', () => {
-		it('creates rack with correct properties', () => {
-			const store = getLayoutStore();
-			const rack = store.addRack('Main Rack', 42);
-			expect(rack).not.toBeNull();
-			expect(rack!.name).toBe('Main Rack');
-			expect(rack!.height).toBe(42);
-			expect(rack!.width).toBe(19);
-			expect(rack!.devices).toEqual([]);
-			// Single-rack mode uses fixed 'rack-0' id
-			expect(rack!.id).toBe('rack-0');
-		});
-
-		it('updates the rack in layout', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			expect(store.layout.rack.name).toBe('Test Rack');
-			expect(store.layout.rack.height).toBe(42);
-		});
-
-		it('always succeeds in v0.2 (replaces existing rack)', () => {
-			const store = getLayoutStore();
-			store.addRack('First Rack', 42);
-			const result = store.addRack('Second', 24);
-			// In v0.2, addRack replaces the rack
-			expect(result).not.toBeNull();
-			expect(store.layout.rack.name).toBe('Second');
-			expect(store.layout.rack.height).toBe(24);
-		});
-
-		it('sets isDirty to true', () => {
-			const store = getLayoutStore();
-			expect(store.isDirty).toBe(false);
-			store.addRack('Test', 42);
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('updateRack', () => {
-		it('modifies rack properties', () => {
-			const store = getLayoutStore();
-			store.addRack('Original', 42);
-			store.updateRack('rack-0', { name: 'Updated', height: 24 });
-			expect(store.layout.rack.name).toBe('Updated');
-			expect(store.layout.rack.height).toBe(24);
-		});
-
-		it('does not affect other rack properties', () => {
-			const store = getLayoutStore();
-			store.addRack('Original', 42);
-			store.updateRack('rack-0', { name: 'Updated' });
-			expect(store.layout.rack.height).toBe(42);
-			expect(store.layout.rack.width).toBe(19);
-		});
-
-		it('sets isDirty to true', () => {
-			const store = getLayoutStore();
-			store.addRack('Test', 42);
-			store.markClean();
-			store.updateRack('rack-0', { name: 'Updated' });
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('deleteRack', () => {
-		it('clears devices from rack in v0.2', () => {
-			const store = getLayoutStore();
-			store.addRack('To Delete', 42);
-			const device = store.addDeviceType({
-				name: 'Test',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', device.slug, 5);
-			expect(store.layout.rack.devices).toHaveLength(1);
-			store.deleteRack('rack-0');
-			expect(store.layout.rack.devices).toHaveLength(0);
-		});
-
-		it('sets isDirty to true', () => {
-			const store = getLayoutStore();
-			store.addRack('Test', 42);
-			store.markClean();
-			store.deleteRack('rack-0');
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('reorderRacks', () => {
-		it('is a no-op in v0.2 (single rack)', () => {
-			const store = getLayoutStore();
-			store.addRack('Only Rack', 42);
-			store.markClean();
-			store.reorderRacks(0, 1); // No-op - only one rack
-			// isDirty should not change since no actual reorder happened
-			expect(store.isDirty).toBe(false);
-		});
-	});
-
-	describe('addDeviceType', () => {
-		it('generates slug and adds device type', () => {
-			const store = getLayoutStore();
-			const initialCount = store.device_types.length;
-			const deviceType = store.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			expect(deviceType.slug).toBe('test-server');
-			expect(store.device_types).toHaveLength(initialCount + 1);
-			const addedType = store.device_types.find((dt) => dt.slug === deviceType.slug);
-			expect(addedType?.u_height).toBe(2);
-		});
-
-		it('preserves all provided properties', () => {
-			const store = getLayoutStore();
-			const deviceType = store.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#FF0000',
-				notes: 'Test notes'
-			});
-			// Schema v1.0.0: Flat structure with colour at top level
-			expect(deviceType.colour).toBe('#FF0000');
-			// Schema v1.0.0: Uses 'notes' field
-			expect(deviceType.notes).toBe('Test notes');
-		});
-
-		it('sets isDirty to true', () => {
-			const store = getLayoutStore();
-			store.addDeviceType({
-				name: 'Test',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('updateDeviceType', () => {
-		it('modifies device type properties', () => {
-			const store = getLayoutStore();
-			const deviceType = store.addDeviceType({
-				name: 'Original',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.updateDeviceType(deviceType.slug, { u_height: 2 });
-			const updated = store.device_types.find((dt) => dt.slug === deviceType.slug);
-			expect(updated?.u_height).toBe(2);
-		});
-
-		it('sets isDirty to true', () => {
-			const store = getLayoutStore();
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.markClean();
-			store.updateDeviceType(deviceType.slug, { u_height: 2 });
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('deleteDeviceType', () => {
-		it('removes device type from library', () => {
-			const store = getLayoutStore();
-			const initialCount = store.device_types.length;
-			const deviceType = store.addDeviceType({
-				name: 'To Delete',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			expect(store.device_types).toHaveLength(initialCount + 1);
-			store.deleteDeviceType(deviceType.slug);
-			expect(store.device_types).toHaveLength(initialCount);
-		});
-
-		it('also removes placed devices referencing the type', () => {
-			const store = getLayoutStore();
-			store.addRack('Test', 42);
-			const deviceType = store.addDeviceType({
-				name: 'To Delete',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			expect(store.layout.rack.devices).toHaveLength(1);
-			store.deleteDeviceType(deviceType.slug);
-			expect(store.layout.rack.devices).toHaveLength(0);
-		});
-
-		it('sets isDirty to true', () => {
-			const store = getLayoutStore();
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.markClean();
-			store.deleteDeviceType(deviceType.slug);
-			expect(store.isDirty).toBe(true);
-		});
-
-		it('cleans up associated images from image store (Issue #147)', () => {
-			const store = getLayoutStore();
-			resetImageStore();
-			const imageStore = getImageStore();
-
-			const deviceType = store.addDeviceType({
-				name: 'Device With Image',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-
-			// Add images for the device type
-			imageStore.setDeviceImage(deviceType.slug, 'front', {
-				dataUrl: 'data:image/png;base64,test',
-				filename: 'front.png'
-			});
-			imageStore.setDeviceImage(deviceType.slug, 'rear', {
-				dataUrl: 'data:image/png;base64,test',
-				filename: 'rear.png'
-			});
-
-			// Verify images exist
-			expect(imageStore.hasImage(deviceType.slug, 'front')).toBe(true);
-			expect(imageStore.hasImage(deviceType.slug, 'rear')).toBe(true);
-
-			// Delete the device type
-			store.deleteDeviceType(deviceType.slug);
-
-			// Images should be cleaned up
-			expect(imageStore.hasImage(deviceType.slug, 'front')).toBe(false);
-			expect(imageStore.hasImage(deviceType.slug, 'rear')).toBe(false);
-		});
-	});
-
-	describe('placeDevice', () => {
-		beforeEach(() => {
-			resetLayoutStore();
-		});
-
-		it('adds device to rack at position', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.markClean();
-
-			const result = store.placeDevice('rack-0', deviceType.slug, 5);
-			expect(result).toBe(true);
-			expect(store.layout.rack.devices).toHaveLength(1);
-			expect(store.layout.rack.devices[0]!.device_type).toBe(deviceType.slug);
-			expect(store.layout.rack.devices[0]!.position).toBe(5);
-		});
-
-		it('places device with depth-based face default (undefined = full depth = both)', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			// Device without is_full_depth specified defaults to full-depth
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			// Full-depth devices default to 'both' face (visible front and rear)
-			expect(store.layout.rack.devices[0]!.face).toBe('both');
-		});
-
-		it('places half-depth device with specified rear face', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			// Half-depth device can be explicitly placed on rear
-			const deviceType = store.addDeviceType({
-				name: 'Rear Panel',
-				u_height: 1,
-				category: 'patch-panel',
-				colour: '#4A90D9',
-				is_full_depth: false
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5, 'rear');
-			expect(store.layout.rack.devices[0]!.face).toBe('rear');
-		});
-
-		it('places device with specified both face', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5, 'both');
-			expect(store.layout.rack.devices[0]!.face).toBe('both');
-		});
-
-		it('returns false for invalid position (collision)', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-
-			const deviceType2 = store.addDeviceType({
-				name: 'Another',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-
-			// device at 5 occupies 5,6. Position 6 would collide.
-			const result = store.placeDevice('rack-0', deviceType2.slug, 6);
-			expect(result).toBe(false);
-			expect(store.layout.rack.devices).toHaveLength(1);
-		});
-
-		it('returns false for invalid position (exceeds rack)', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			// 2U device at position 42 would occupy 42,43 but rack only has 42
-			const result = store.placeDevice('rack-0', deviceType.slug, 42);
-			expect(result).toBe(false);
-		});
-
-		it('returns false for position less than 1', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			const result = store.placeDevice('rack-0', deviceType.slug, 0);
-			expect(result).toBe(false);
-		});
-
-		it('sets isDirty to true on success', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.markClean();
-			expect(store.isDirty).toBe(false);
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('moveDevice', () => {
-		beforeEach(() => {
-			resetLayoutStore();
-		});
-
-		it('updates device position within rack', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			store.markClean();
-
-			const result = store.moveDevice('rack-0', 0, 10);
-			expect(result).toBe(true);
-			expect(store.layout.rack.devices[0]!.position).toBe(10);
-		});
-
-		it('returns false for collision', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-
-			const deviceType2 = store.addDeviceType({
-				name: 'Another',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType2.slug, 10);
-
-			// Try to move first device to 10 (would collide with second device)
-			const result = store.moveDevice('rack-0', 0, 10);
-			expect(result).toBe(false);
-			expect(store.layout.rack.devices[0]!.position).toBe(5);
-		});
-
-		it('sets isDirty to true on success', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			store.markClean();
-			expect(store.isDirty).toBe(false);
-			store.moveDevice('rack-0', 0, 10);
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('moveDeviceToRack', () => {
-		it('delegates to moveDevice for same-rack moves', () => {
-			const store = getLayoutStore();
-			store.addRack('Only Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			store.markClean();
-
-			// Same rack move should work (delegates to moveDevice)
-			const result = store.moveDeviceToRack('rack-0', 0, 'rack-0', 10);
-			expect(result).toBe(true);
-			expect(store.layout.rack.devices[0]!.position).toBe(10);
-		});
-	});
-
-	describe('removeDeviceFromRack', () => {
-		it('removes device from rack', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-
-			expect(store.layout.rack.devices).toHaveLength(1);
-			store.removeDeviceFromRack('rack-0', 0);
-			expect(store.layout.rack.devices).toHaveLength(0);
-		});
-
-		it('sets isDirty to true', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Test',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			store.markClean();
-
-			store.removeDeviceFromRack('rack-0', 0);
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('updateDeviceName', () => {
-		it('updates placed device name', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Generic Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-
-			// Device should not have a custom name initially
-			expect(store.layout.rack.devices[0]!.name).toBeUndefined();
-
-			// Set a custom name
-			store.updateDeviceName('rack-0', 0, 'Primary DB Server');
-			expect(store.layout.rack.devices[0]!.name).toBe('Primary DB Server');
-		});
-
-		it('clears custom name when set to undefined', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Generic Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-
-			// Set a custom name first
-			store.updateDeviceName('rack-0', 0, 'Primary DB Server');
-			expect(store.layout.rack.devices[0]!.name).toBe('Primary DB Server');
-
-			// Clear the custom name
-			store.updateDeviceName('rack-0', 0, undefined);
-			expect(store.layout.rack.devices[0]!.name).toBeUndefined();
-		});
-
-		it('clears custom name when set to empty string', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Generic Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-
-			store.updateDeviceName('rack-0', 0, 'Primary DB Server');
-			store.updateDeviceName('rack-0', 0, '');
-			expect(store.layout.rack.devices[0]!.name).toBeUndefined();
-		});
-
-		it('sets isDirty to true', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Generic Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			store.markClean();
-
-			store.updateDeviceName('rack-0', 0, 'Primary DB Server');
-			expect(store.isDirty).toBe(true);
-		});
-
-		it('supports undo/redo for name changes', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Generic Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-
-			// Set a custom name
-			store.updateDeviceName('rack-0', 0, 'Primary DB Server');
-			expect(store.layout.rack.devices[0]!.name).toBe('Primary DB Server');
-
-			// Undo should restore undefined
-			store.undo();
-			expect(store.layout.rack.devices[0]!.name).toBeUndefined();
-
-			// Redo should restore the name
-			store.redo();
-			expect(store.layout.rack.devices[0]!.name).toBe('Primary DB Server');
-		});
-
-		it('preserves name through multiple updates with undo', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-			const deviceType = store.addDeviceType({
-				name: 'Generic Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-			store.placeDevice('rack-0', deviceType.slug, 5);
-
-			store.updateDeviceName('rack-0', 0, 'First Name');
-			store.updateDeviceName('rack-0', 0, 'Second Name');
-			store.updateDeviceName('rack-0', 0, 'Third Name');
-
-			expect(store.layout.rack.devices[0]!.name).toBe('Third Name');
-
-			store.undo();
-			expect(store.layout.rack.devices[0]!.name).toBe('Second Name');
-
-			store.undo();
-			expect(store.layout.rack.devices[0]!.name).toBe('First Name');
-
-			store.undo();
-			expect(store.layout.rack.devices[0]!.name).toBeUndefined();
-		});
-	});
-
-	describe('dirty tracking', () => {
-		it('markDirty sets isDirty to true', () => {
-			const store = getLayoutStore();
-			expect(store.isDirty).toBe(false);
-			store.markDirty();
-			expect(store.isDirty).toBe(true);
-		});
-
-		it('markClean sets isDirty to false', () => {
-			const store = getLayoutStore();
-			store.markDirty();
-			expect(store.isDirty).toBe(true);
-			store.markClean();
-			expect(store.isDirty).toBe(false);
-		});
-	});
-
-	describe('placeDevice with face/depth awareness', () => {
-		beforeEach(() => {
-			resetLayoutStore();
-		});
-
-		it('allows placing half-depth rear device at same U as half-depth front device', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add half-depth device type
-			const halfDepthType = store.addDeviceType({
-				name: 'Half-Depth Device',
-				u_height: 1,
-				category: 'blank',
-				colour: '#2F4F4F',
-				is_full_depth: false
-			});
-
-			// Place on front at U5
-			const result1 = store.placeDevice('rack-0', halfDepthType.slug, 5, 'front');
-			expect(result1).toBe(true);
-
-			// Place on rear at U5 - should succeed because both are half-depth
-			const result2 = store.placeDevice('rack-0', halfDepthType.slug, 5, 'rear');
-			expect(result2).toBe(true);
-
-			// Both devices should exist at position 5
-			const devicesAtU5 = store.layout.rack.devices.filter((d) => d.position === 5);
-			expect(devicesAtU5).toHaveLength(2);
-		});
-
-		it('blocks placing half-depth rear device when full-depth front device exists at same U', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add full-depth device type (default)
-			const fullDepthType = store.addDeviceType({
-				name: 'Full-Depth Server',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-				// is_full_depth defaults to true
-			});
-
-			// Add half-depth device type
-			const halfDepthType = store.addDeviceType({
-				name: 'Half-Depth Blank',
-				u_height: 1,
-				category: 'blank',
-				colour: '#2F4F4F',
-				is_full_depth: false
-			});
-
-			// Place full-depth on front at U5
-			const result1 = store.placeDevice('rack-0', fullDepthType.slug, 5, 'front');
-			expect(result1).toBe(true);
-
-			// Place half-depth on rear at U5 - should FAIL because front is full-depth
-			const result2 = store.placeDevice('rack-0', halfDepthType.slug, 5, 'rear');
-			expect(result2).toBe(false);
-
-			// Only one device should exist
-			expect(store.layout.rack.devices).toHaveLength(1);
-		});
-
-		it('blocks placing full-depth rear device when half-depth front device exists at same U', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add half-depth device type
-			const halfDepthType = store.addDeviceType({
-				name: 'Half-Depth Blank',
-				u_height: 1,
-				category: 'blank',
-				colour: '#2F4F4F',
-				is_full_depth: false
-			});
-
-			// Add full-depth device type
-			const fullDepthType = store.addDeviceType({
-				name: 'Full-Depth Server',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-
-			// Place half-depth on front at U5
-			const result1 = store.placeDevice('rack-0', halfDepthType.slug, 5, 'front');
-			expect(result1).toBe(true);
-
-			// Place full-depth on rear at U5 - should FAIL because new device is full-depth
-			const result2 = store.placeDevice('rack-0', fullDepthType.slug, 5, 'rear');
-			expect(result2).toBe(false);
-
-			// Only one device should exist
-			expect(store.layout.rack.devices).toHaveLength(1);
-		});
-	});
-
-	describe('moveDevice with face/depth awareness', () => {
-		beforeEach(() => {
-			resetLayoutStore();
-		});
-
-		it('allows moving half-depth rear device to same U as half-depth front device', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add half-depth device type
-			const halfDepthType = store.addDeviceType({
-				name: 'Half-Depth Device',
-				u_height: 1,
-				category: 'blank',
-				colour: '#2F4F4F',
-				is_full_depth: false
-			});
-
-			// Place on front at U5
-			store.placeDevice('rack-0', halfDepthType.slug, 5, 'front');
-
-			// Place on rear at U10
-			store.placeDevice('rack-0', halfDepthType.slug, 10, 'rear');
-
-			// Move rear device from U10 to U5 - should succeed
-			const result = store.moveDevice('rack-0', 1, 5);
-			expect(result).toBe(true);
-
-			// Both devices should be at position 5
-			const devicesAtU5 = store.layout.rack.devices.filter((d) => d.position === 5);
-			expect(devicesAtU5).toHaveLength(2);
-		});
-
-		it('blocks moving half-depth rear device to same U as full-depth front device', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add full-depth device type
-			const fullDepthType = store.addDeviceType({
-				name: 'Full-Depth Server',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-
-			// Add half-depth device type
-			const halfDepthType = store.addDeviceType({
-				name: 'Half-Depth Blank',
-				u_height: 1,
-				category: 'blank',
-				colour: '#2F4F4F',
-				is_full_depth: false
-			});
-
-			// Place full-depth on front at U5
-			store.placeDevice('rack-0', fullDepthType.slug, 5, 'front');
-
-			// Place half-depth on rear at U10
-			store.placeDevice('rack-0', halfDepthType.slug, 10, 'rear');
-
-			// Move rear device from U10 to U5 - should FAIL because front is full-depth
-			const result = store.moveDevice('rack-0', 1, 5);
-			expect(result).toBe(false);
-
-			// Device at index 1 should still be at U10
-			expect(store.layout.rack.devices[1]!.position).toBe(10);
-		});
-	});
-
-	describe('0.5U device movement', () => {
-		it('allows moving 0.5U device to half-unit positions', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add 0.5U device type
-			const halfUType = store.addDeviceType({
-				name: '0.5U Device',
-				u_height: 0.5,
-				category: 'blank',
-				colour: '#2F4F4F'
-			});
-
-			// Place at position 1
-			const placed = store.placeDevice('rack-0', halfUType.slug, 1, 'front');
-			expect(placed).toBe(true);
-			expect(store.layout.rack.devices[0]!.position).toBe(1);
-
-			// Move to position 1.5 - should succeed
-			const result = store.moveDevice('rack-0', 0, 1.5);
-			expect(result).toBe(true);
-			expect(store.layout.rack.devices[0]!.position).toBe(1.5);
-		});
-
-		it('allows moving 0.5U device to integer positions', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add 0.5U device type
-			const halfUType = store.addDeviceType({
-				name: '0.5U Device',
-				u_height: 0.5,
-				category: 'blank',
-				colour: '#2F4F4F'
-			});
-
-			// Place at position 1.5
-			const placed = store.placeDevice('rack-0', halfUType.slug, 1.5, 'front');
-			expect(placed).toBe(true);
-
-			// Move to position 2 - should succeed
-			const result = store.moveDevice('rack-0', 0, 2);
-			expect(result).toBe(true);
-			expect(store.layout.rack.devices[0]!.position).toBe(2);
-		});
-
-		it('blocks 0.5U device from exceeding rack height', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add 0.5U device type
-			const halfUType = store.addDeviceType({
-				name: '0.5U Device',
-				u_height: 0.5,
-				category: 'blank',
-				colour: '#2F4F4F'
-			});
-
-			// Place at position 42
-			store.placeDevice('rack-0', halfUType.slug, 42, 'front');
-
-			// Position 43 definitely exceeds rack height
-			const result = store.moveDevice('rack-0', 0, 43);
-			expect(result).toBe(false);
-		});
-
-		it('detects collision between 1U devices at same position', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add 1U device type (collision detection works correctly for 1U)
-			const oneUType = store.addDeviceType({
-				name: '1U Device',
-				u_height: 1,
-				category: 'blank',
-				colour: '#2F4F4F'
-			});
-
-			// Place first device at U5
-			store.placeDevice('rack-0', oneUType.slug, 5, 'front');
-
-			// Place second device at U10
-			store.placeDevice('rack-0', oneUType.slug, 10, 'front');
-
-			// Try to move second device to U5 - should fail (collision on same face)
-			const result = store.moveDevice('rack-0', 1, 5);
-			expect(result).toBe(false);
-		});
-
-		it('allows adjacent 0.5U devices without collision', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Add 0.5U device type
-			const halfUType = store.addDeviceType({
-				name: '0.5U Device',
-				u_height: 0.5,
-				category: 'blank',
-				colour: '#2F4F4F'
-			});
-
-			// Place first device at U5
-			store.placeDevice('rack-0', halfUType.slug, 5, 'front');
-
-			// Place second device at U10
-			store.placeDevice('rack-0', halfUType.slug, 10, 'front');
-
-			// Move second device to U5.5 - should succeed (adjacent, no overlap)
-			const result = store.moveDevice('rack-0', 1, 5.5);
-			expect(result).toBe(true);
-			expect(store.layout.rack.devices[1]!.position).toBe(5.5);
-		});
-	});
-
-	describe('duplicateRack', () => {
-		it('returns error in v0.2 (single rack mode)', () => {
-			const store = getLayoutStore();
-			store.addRack('First Rack', 42);
-			const result = store.duplicateRack('rack-0');
-			expect(result.error).toBe('Maximum of 1 rack allowed');
-		});
-	});
-
-	describe('resetLayout', () => {
-		it('resets to initial state', () => {
-			const store = getLayoutStore();
-			store.addRack('Test', 42);
-			store.addDeviceType({
-				name: 'Test',
-				u_height: 1,
-				category: 'server',
-				colour: '#4A90D9'
-			});
-
-			resetLayoutStore();
-			const freshStore = getLayoutStore();
-
-			expect(freshStore.layout.name).toBe('Racky McRackface');
-			expect(freshStore.layout.rack.devices).toEqual([]);
-			// device_types starts empty (starter library is a runtime constant, not stored)
-			expect(freshStore.device_types.length).toBe(0);
-			expect(freshStore.isDirty).toBe(false);
-		});
-	});
-
-	describe('settings', () => {
-		it('updateDisplayMode updates display_mode', () => {
-			const store = getLayoutStore();
-			expect(store.layout.settings.display_mode).toBe('label');
-			store.updateDisplayMode('image');
-			expect(store.layout.settings.display_mode).toBe('image');
-			expect(store.isDirty).toBe(true);
-		});
-
-		it('updateShowLabelsOnImages updates show_labels_on_images', () => {
-			const store = getLayoutStore();
-			expect(store.layout.settings.show_labels_on_images).toBe(false);
-			store.updateShowLabelsOnImages(true);
-			expect(store.layout.settings.show_labels_on_images).toBe(true);
-			expect(store.isDirty).toBe(true);
-		});
-	});
-
-	describe('placeDevice with brand pack devices', () => {
-		beforeEach(() => {
-			resetLayoutStore();
-		});
-
-		it('places Ubiquiti brand pack device successfully', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Ubiquiti device slug from brand pack (not in starter library)
-			const result = store.placeDevice('rack-0', 'ubiquiti-unifi-switch-24-pro', 5);
-
-			expect(result).toBe(true);
-			expect(store.layout.rack.devices).toHaveLength(1);
-			expect(store.layout.rack.devices[0]!.device_type).toBe('ubiquiti-unifi-switch-24-pro');
-			expect(store.layout.rack.devices[0]!.position).toBe(5);
-		});
-
-		it('places Mikrotik brand pack device successfully', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Mikrotik device slug from brand pack
-			const result = store.placeDevice('rack-0', 'crs326-24g-2s-plus', 10);
-
-			expect(result).toBe(true);
-			expect(store.layout.rack.devices).toHaveLength(1);
-			expect(store.layout.rack.devices[0]!.device_type).toBe('crs326-24g-2s-plus');
-		});
-
-		it('auto-imports brand device into device_types on first placement', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Initially, brand device is not in device_types
-			const initialCount = store.device_types.length;
-			expect(
-				store.device_types.find((d) => d.slug === 'ubiquiti-unifi-switch-24-pro')
-			).toBeUndefined();
-
-			// Place brand device
-			store.placeDevice('rack-0', 'ubiquiti-unifi-switch-24-pro', 5);
-
-			// Device should now be in device_types
-			expect(store.device_types.length).toBe(initialCount + 1);
-			const imported = store.device_types.find((d) => d.slug === 'ubiquiti-unifi-switch-24-pro');
-			expect(imported).toBeDefined();
-			expect(imported?.manufacturer).toBe('Ubiquiti');
-			expect(imported?.model).toBe('USW-Pro-24');
-		});
-
-		it('does not duplicate device_type when placing same brand device twice', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Place same brand device twice at different positions
-			store.placeDevice('rack-0', 'ubiquiti-unifi-switch-24-pro', 5);
-			const countAfterFirst = store.device_types.length;
-
-			store.placeDevice('rack-0', 'ubiquiti-unifi-switch-24-pro', 10);
-			expect(store.device_types.length).toBe(countAfterFirst);
-		});
-
-		it('returns false for unknown slug (not in library or brand packs)', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			const result = store.placeDevice('rack-0', 'nonexistent-device-xyz', 5);
-			expect(result).toBe(false);
-			expect(store.layout.rack.devices).toHaveLength(0);
-		});
-
-		it('preserves brand device properties when auto-imported', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			store.placeDevice('rack-0', 'ubiquiti-unifi-switch-24-pro', 5);
-
-			const imported = store.device_types.find((d) => d.slug === 'ubiquiti-unifi-switch-24-pro');
-			expect(imported?.is_full_depth).toBe(false);
-			// Schema v1.0.0: Flat structure with category at top level
-			expect(imported?.category).toBe('network');
-		});
-
-		it('full-depth brand device defaults to both face when placed', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// US-24-500W has is_full_depth: true (legacy switch with power supply)
-			store.placeDevice('rack-0', 'ubiquiti-unifi-switch-24-500w', 5);
-
-			// Full-depth devices should default to 'both' face (visible front and rear)
-			expect(store.layout.rack.devices[0]!.face).toBe('both');
-		});
-
-		it('half-depth brand device defaults to front face when placed', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Ubiquiti PDU has is_full_depth: false
-			store.placeDevice('rack-0', 'ubiquiti-usp-pdu-pro', 5);
-
-			// Half-depth devices should default to 'front' face
-			expect(store.layout.rack.devices[0]!.face).toBe('front');
-		});
-
-		it('auto-import creates new array reference for Svelte reactivity', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Capture the original array reference
-			const originalDeviceTypes = store.device_types;
-
-			// Place a brand device that will trigger auto-import
-			store.placeDevice('rack-0', 'ubiquiti-unifi-switch-24-pro', 5);
-
-			// The device_types array should be a NEW reference (not mutated in place)
-			// This is required for Svelte 5 reactivity to trigger UI updates
-			expect(store.device_types).not.toBe(originalDeviceTypes);
-
-			// But should still contain all original items plus the new one
-			expect(store.device_types.length).toBe(originalDeviceTypes.length + 1);
-		});
-	});
-
-	describe('placeDevice face defaults based on depth', () => {
-		beforeEach(() => {
-			resetLayoutStore();
-		});
-
-		it('full-depth device defaults to both face', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Create a full-depth device type
-			const deviceType = store.addDeviceType({
-				name: 'Full Depth Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9',
-				is_full_depth: true
-			});
-
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			expect(store.layout.rack.devices[0]!.face).toBe('both');
-		});
-
-		it('half-depth device defaults to front face', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Create a half-depth device type
-			const deviceType = store.addDeviceType({
-				name: 'Half Depth Switch',
-				u_height: 1,
-				category: 'network',
-				colour: '#7B68EE',
-				is_full_depth: false
-			});
-
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			expect(store.layout.rack.devices[0]!.face).toBe('front');
-		});
-
-		it('device with undefined is_full_depth defaults to both face (full depth assumed)', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Create device without is_full_depth specified (defaults to full depth)
-			const deviceType = store.addDeviceType({
-				name: 'Default Depth Device',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9'
-				// is_full_depth not specified
-			});
-
-			store.placeDevice('rack-0', deviceType.slug, 5);
-			expect(store.layout.rack.devices[0]!.face).toBe('both');
-		});
-
-		it('full-depth device ignores explicit face and uses both', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Full-depth devices physically occupy both front and rear
-			// Even if 'front' is passed (e.g., from RackDualView drop), it should be 'both'
-			const deviceType = store.addDeviceType({
-				name: 'Full Depth Server',
-				u_height: 2,
-				category: 'server',
-				colour: '#4A90D9',
-				is_full_depth: true
-			});
-
-			store.placeDevice('rack-0', deviceType.slug, 5, 'front');
-			// Full-depth devices ALWAYS use 'both' regardless of passed face
-			expect(store.layout.rack.devices[0]!.face).toBe('both');
-		});
-
-		it('half-depth device respects explicit face parameter', () => {
-			const store = getLayoutStore();
-			store.addRack('Test Rack', 42);
-
-			// Half-depth devices can be front-mounted or rear-mounted
-			const deviceType = store.addDeviceType({
-				name: 'Patch Panel',
-				u_height: 1,
-				category: 'patch-panel',
-				colour: '#7B68EE',
-				is_full_depth: false
-			});
-
-			// Explicitly place on rear
-			store.placeDevice('rack-0', deviceType.slug, 5, 'rear');
-			expect(store.layout.rack.devices[0]!.face).toBe('rear');
-		});
-	});
+import { describe, it, expect, beforeEach } from "vitest";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { getImageStore, resetImageStore } from "$lib/stores/images.svelte";
+import type { Layout } from "$lib/types";
+import { VERSION } from "$lib/version";
+
+describe("Layout Store (v0.2)", () => {
+  beforeEach(() => {
+    // Reset the store before each test
+    resetLayoutStore();
+  });
+
+  describe("initial state", () => {
+    it("initializes with correct app version", () => {
+      const store = getLayoutStore();
+      expect(store.layout.name).toBe("Racky McRackface");
+      expect(store.layout.version).toBe(VERSION);
+      // v0.2 has a single rack, not an array
+      expect(store.layout.rack).toBeDefined();
+      expect(store.layout.rack.devices).toEqual([]);
+      // device_types starts empty (starter library is a runtime constant, not stored)
+      expect(store.layout.device_types.length).toBe(0);
+    });
+
+    it("initializes isDirty as false", () => {
+      const store = getLayoutStore();
+      expect(store.isDirty).toBe(false);
+    });
+
+    it("initializes hasRack as true", () => {
+      const store = getLayoutStore();
+      expect(store.hasRack).toBe(true);
+    });
+
+    it("compatibility: rackCount is 0 before user starts, 1 after", () => {
+      const store = getLayoutStore();
+      // Before user starts, rackCount is 0 (WelcomeScreen shown)
+      expect(store.rackCount).toBe(0);
+      expect(store.hasStarted).toBe(false);
+      // After user starts, rackCount is 1
+      store.markStarted();
+      expect(store.rackCount).toBe(1);
+      expect(store.hasStarted).toBe(true);
+    });
+
+    it("compatibility: canAddRack is false", () => {
+      const store = getLayoutStore();
+      expect(store.canAddRack).toBe(false);
+    });
+
+    it("rack returns the single rack", () => {
+      const store = getLayoutStore();
+      expect(store.rack).toBeDefined();
+      expect(store.rack.name).toBe("Racky McRackface");
+    });
+  });
+
+  describe("createNewLayout", () => {
+    it("creates a new layout with the given name", () => {
+      const store = getLayoutStore();
+      store.createNewLayout("My Lab");
+      expect(store.layout.name).toBe("My Lab");
+    });
+
+    it("initializes with default rack", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      store.createNewLayout("New Layout");
+      // v0.2 always has a rack, but devices should be empty
+      expect(store.layout.rack.devices).toEqual([]);
+    });
+
+    it("resets device_types to empty array", () => {
+      const store = getLayoutStore();
+      store.addDeviceType({
+        name: "Test",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.createNewLayout("New Layout");
+      // device_types starts empty (starter library is a runtime constant, not stored)
+      expect(store.device_types.length).toBe(0);
+    });
+
+    it("sets isDirty to false", () => {
+      const store = getLayoutStore();
+      store.addRack("Test", 42);
+      expect(store.isDirty).toBe(true);
+      store.createNewLayout("New Layout");
+      expect(store.isDirty).toBe(false);
+    });
+  });
+
+  describe("loadLayout", () => {
+    it("loads a v0.2 layout directly", () => {
+      const store = getLayoutStore();
+      const v02Layout: Layout = {
+        version: "0.2.0",
+        name: "Test Layout",
+        rack: {
+          name: "Test Rack",
+          height: 24,
+          width: 19,
+          desc_units: false,
+          form_factor: "4-post-cabinet",
+          starting_unit: 1,
+          position: 0,
+          devices: [],
+        },
+        device_types: [],
+        settings: {
+          display_mode: "label",
+          show_labels_on_images: false,
+        },
+      };
+      store.loadLayout(v02Layout);
+      expect(store.layout.name).toBe("Test Layout");
+      expect(store.layout.rack.height).toBe(24);
+    });
+
+    it("sets isDirty to false", () => {
+      const store = getLayoutStore();
+      store.markDirty();
+      expect(store.isDirty).toBe(true);
+      store.loadLayout({
+        version: "0.2.0",
+        name: "Test",
+        rack: {
+          name: "Test",
+          height: 42,
+          width: 19,
+          desc_units: false,
+          form_factor: "4-post-cabinet",
+          starting_unit: 1,
+          position: 0,
+          devices: [],
+        },
+        device_types: [],
+        settings: {
+          display_mode: "label",
+          show_labels_on_images: false,
+        },
+      });
+      expect(store.isDirty).toBe(false);
+    });
+  });
+
+  describe("addRack", () => {
+    it("creates rack with correct properties", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Main Rack", 42);
+      expect(rack).not.toBeNull();
+      expect(rack!.name).toBe("Main Rack");
+      expect(rack!.height).toBe(42);
+      expect(rack!.width).toBe(19);
+      expect(rack!.devices).toEqual([]);
+      // Single-rack mode uses fixed 'rack-0' id
+      expect(rack!.id).toBe("rack-0");
+    });
+
+    it("updates the rack in layout", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      expect(store.layout.rack.name).toBe("Test Rack");
+      expect(store.layout.rack.height).toBe(42);
+    });
+
+    it("always succeeds in v0.2 (replaces existing rack)", () => {
+      const store = getLayoutStore();
+      store.addRack("First Rack", 42);
+      const result = store.addRack("Second", 24);
+      // In v0.2, addRack replaces the rack
+      expect(result).not.toBeNull();
+      expect(store.layout.rack.name).toBe("Second");
+      expect(store.layout.rack.height).toBe(24);
+    });
+
+    it("sets isDirty to true", () => {
+      const store = getLayoutStore();
+      expect(store.isDirty).toBe(false);
+      store.addRack("Test", 42);
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("updateRack", () => {
+    it("modifies rack properties", () => {
+      const store = getLayoutStore();
+      store.addRack("Original", 42);
+      store.updateRack("rack-0", { name: "Updated", height: 24 });
+      expect(store.layout.rack.name).toBe("Updated");
+      expect(store.layout.rack.height).toBe(24);
+    });
+
+    it("does not affect other rack properties", () => {
+      const store = getLayoutStore();
+      store.addRack("Original", 42);
+      store.updateRack("rack-0", { name: "Updated" });
+      expect(store.layout.rack.height).toBe(42);
+      expect(store.layout.rack.width).toBe(19);
+    });
+
+    it("sets isDirty to true", () => {
+      const store = getLayoutStore();
+      store.addRack("Test", 42);
+      store.markClean();
+      store.updateRack("rack-0", { name: "Updated" });
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("deleteRack", () => {
+    it("clears devices from rack in v0.2", () => {
+      const store = getLayoutStore();
+      store.addRack("To Delete", 42);
+      const device = store.addDeviceType({
+        name: "Test",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", device.slug, 5);
+      expect(store.layout.rack.devices).toHaveLength(1);
+      store.deleteRack("rack-0");
+      expect(store.layout.rack.devices).toHaveLength(0);
+    });
+
+    it("sets isDirty to true", () => {
+      const store = getLayoutStore();
+      store.addRack("Test", 42);
+      store.markClean();
+      store.deleteRack("rack-0");
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("reorderRacks", () => {
+    it("is a no-op in v0.2 (single rack)", () => {
+      const store = getLayoutStore();
+      store.addRack("Only Rack", 42);
+      store.markClean();
+      store.reorderRacks(0, 1); // No-op - only one rack
+      // isDirty should not change since no actual reorder happened
+      expect(store.isDirty).toBe(false);
+    });
+  });
+
+  describe("addDeviceType", () => {
+    it("generates slug and adds device type", () => {
+      const store = getLayoutStore();
+      const initialCount = store.device_types.length;
+      const deviceType = store.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      expect(deviceType.slug).toBe("test-server");
+      expect(store.device_types).toHaveLength(initialCount + 1);
+      const addedType = store.device_types.find(
+        (dt) => dt.slug === deviceType.slug,
+      );
+      expect(addedType?.u_height).toBe(2);
+    });
+
+    it("preserves all provided properties", () => {
+      const store = getLayoutStore();
+      const deviceType = store.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#FF0000",
+        notes: "Test notes",
+      });
+      // Schema v1.0.0: Flat structure with colour at top level
+      expect(deviceType.colour).toBe("#FF0000");
+      // Schema v1.0.0: Uses 'notes' field
+      expect(deviceType.notes).toBe("Test notes");
+    });
+
+    it("sets isDirty to true", () => {
+      const store = getLayoutStore();
+      store.addDeviceType({
+        name: "Test",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("updateDeviceType", () => {
+    it("modifies device type properties", () => {
+      const store = getLayoutStore();
+      const deviceType = store.addDeviceType({
+        name: "Original",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.updateDeviceType(deviceType.slug, { u_height: 2 });
+      const updated = store.device_types.find(
+        (dt) => dt.slug === deviceType.slug,
+      );
+      expect(updated?.u_height).toBe(2);
+    });
+
+    it("sets isDirty to true", () => {
+      const store = getLayoutStore();
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.markClean();
+      store.updateDeviceType(deviceType.slug, { u_height: 2 });
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("deleteDeviceType", () => {
+    it("removes device type from library", () => {
+      const store = getLayoutStore();
+      const initialCount = store.device_types.length;
+      const deviceType = store.addDeviceType({
+        name: "To Delete",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      expect(store.device_types).toHaveLength(initialCount + 1);
+      store.deleteDeviceType(deviceType.slug);
+      expect(store.device_types).toHaveLength(initialCount);
+    });
+
+    it("also removes placed devices referencing the type", () => {
+      const store = getLayoutStore();
+      store.addRack("Test", 42);
+      const deviceType = store.addDeviceType({
+        name: "To Delete",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      expect(store.layout.rack.devices).toHaveLength(1);
+      store.deleteDeviceType(deviceType.slug);
+      expect(store.layout.rack.devices).toHaveLength(0);
+    });
+
+    it("sets isDirty to true", () => {
+      const store = getLayoutStore();
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.markClean();
+      store.deleteDeviceType(deviceType.slug);
+      expect(store.isDirty).toBe(true);
+    });
+
+    it("cleans up associated images from image store (Issue #147)", () => {
+      const store = getLayoutStore();
+      resetImageStore();
+      const imageStore = getImageStore();
+
+      const deviceType = store.addDeviceType({
+        name: "Device With Image",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+
+      // Add images for the device type
+      imageStore.setDeviceImage(deviceType.slug, "front", {
+        dataUrl: "data:image/png;base64,test",
+        filename: "front.png",
+      });
+      imageStore.setDeviceImage(deviceType.slug, "rear", {
+        dataUrl: "data:image/png;base64,test",
+        filename: "rear.png",
+      });
+
+      // Verify images exist
+      expect(imageStore.hasImage(deviceType.slug, "front")).toBe(true);
+      expect(imageStore.hasImage(deviceType.slug, "rear")).toBe(true);
+
+      // Delete the device type
+      store.deleteDeviceType(deviceType.slug);
+
+      // Images should be cleaned up
+      expect(imageStore.hasImage(deviceType.slug, "front")).toBe(false);
+      expect(imageStore.hasImage(deviceType.slug, "rear")).toBe(false);
+    });
+  });
+
+  describe("placeDevice", () => {
+    beforeEach(() => {
+      resetLayoutStore();
+    });
+
+    it("adds device to rack at position", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.markClean();
+
+      const result = store.placeDevice("rack-0", deviceType.slug, 5);
+      expect(result).toBe(true);
+      expect(store.layout.rack.devices).toHaveLength(1);
+      expect(store.layout.rack.devices[0]!.device_type).toBe(deviceType.slug);
+      expect(store.layout.rack.devices[0]!.position).toBe(5);
+    });
+
+    it("places device with depth-based face default (undefined = full depth = both)", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      // Device without is_full_depth specified defaults to full-depth
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      // Full-depth devices default to 'both' face (visible front and rear)
+      expect(store.layout.rack.devices[0]!.face).toBe("both");
+    });
+
+    it("places half-depth device with specified rear face", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      // Half-depth device can be explicitly placed on rear
+      const deviceType = store.addDeviceType({
+        name: "Rear Panel",
+        u_height: 1,
+        category: "patch-panel",
+        colour: "#4A90D9",
+        is_full_depth: false,
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5, "rear");
+      expect(store.layout.rack.devices[0]!.face).toBe("rear");
+    });
+
+    it("places device with specified both face", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5, "both");
+      expect(store.layout.rack.devices[0]!.face).toBe("both");
+    });
+
+    it("returns false for invalid position (collision)", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+
+      const deviceType2 = store.addDeviceType({
+        name: "Another",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+
+      // device at 5 occupies 5,6. Position 6 would collide.
+      const result = store.placeDevice("rack-0", deviceType2.slug, 6);
+      expect(result).toBe(false);
+      expect(store.layout.rack.devices).toHaveLength(1);
+    });
+
+    it("returns false for invalid position (exceeds rack)", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      // 2U device at position 42 would occupy 42,43 but rack only has 42
+      const result = store.placeDevice("rack-0", deviceType.slug, 42);
+      expect(result).toBe(false);
+    });
+
+    it("returns false for position less than 1", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      const result = store.placeDevice("rack-0", deviceType.slug, 0);
+      expect(result).toBe(false);
+    });
+
+    it("sets isDirty to true on success", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.markClean();
+      expect(store.isDirty).toBe(false);
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("moveDevice", () => {
+    beforeEach(() => {
+      resetLayoutStore();
+    });
+
+    it("updates device position within rack", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      store.markClean();
+
+      const result = store.moveDevice("rack-0", 0, 10);
+      expect(result).toBe(true);
+      expect(store.layout.rack.devices[0]!.position).toBe(10);
+    });
+
+    it("returns false for collision", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+
+      const deviceType2 = store.addDeviceType({
+        name: "Another",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType2.slug, 10);
+
+      // Try to move first device to 10 (would collide with second device)
+      const result = store.moveDevice("rack-0", 0, 10);
+      expect(result).toBe(false);
+      expect(store.layout.rack.devices[0]!.position).toBe(5);
+    });
+
+    it("sets isDirty to true on success", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      store.markClean();
+      expect(store.isDirty).toBe(false);
+      store.moveDevice("rack-0", 0, 10);
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("moveDeviceToRack", () => {
+    it("delegates to moveDevice for same-rack moves", () => {
+      const store = getLayoutStore();
+      store.addRack("Only Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      store.markClean();
+
+      // Same rack move should work (delegates to moveDevice)
+      const result = store.moveDeviceToRack("rack-0", 0, "rack-0", 10);
+      expect(result).toBe(true);
+      expect(store.layout.rack.devices[0]!.position).toBe(10);
+    });
+  });
+
+  describe("removeDeviceFromRack", () => {
+    it("removes device from rack", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+
+      expect(store.layout.rack.devices).toHaveLength(1);
+      store.removeDeviceFromRack("rack-0", 0);
+      expect(store.layout.rack.devices).toHaveLength(0);
+    });
+
+    it("sets isDirty to true", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Test",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      store.markClean();
+
+      store.removeDeviceFromRack("rack-0", 0);
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("updateDeviceName", () => {
+    it("updates placed device name", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Generic Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+
+      // Device should not have a custom name initially
+      expect(store.layout.rack.devices[0]!.name).toBeUndefined();
+
+      // Set a custom name
+      store.updateDeviceName("rack-0", 0, "Primary DB Server");
+      expect(store.layout.rack.devices[0]!.name).toBe("Primary DB Server");
+    });
+
+    it("clears custom name when set to undefined", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Generic Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+
+      // Set a custom name first
+      store.updateDeviceName("rack-0", 0, "Primary DB Server");
+      expect(store.layout.rack.devices[0]!.name).toBe("Primary DB Server");
+
+      // Clear the custom name
+      store.updateDeviceName("rack-0", 0, undefined);
+      expect(store.layout.rack.devices[0]!.name).toBeUndefined();
+    });
+
+    it("clears custom name when set to empty string", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Generic Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+
+      store.updateDeviceName("rack-0", 0, "Primary DB Server");
+      store.updateDeviceName("rack-0", 0, "");
+      expect(store.layout.rack.devices[0]!.name).toBeUndefined();
+    });
+
+    it("sets isDirty to true", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Generic Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      store.markClean();
+
+      store.updateDeviceName("rack-0", 0, "Primary DB Server");
+      expect(store.isDirty).toBe(true);
+    });
+
+    it("supports undo/redo for name changes", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Generic Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+
+      // Set a custom name
+      store.updateDeviceName("rack-0", 0, "Primary DB Server");
+      expect(store.layout.rack.devices[0]!.name).toBe("Primary DB Server");
+
+      // Undo should restore undefined
+      store.undo();
+      expect(store.layout.rack.devices[0]!.name).toBeUndefined();
+
+      // Redo should restore the name
+      store.redo();
+      expect(store.layout.rack.devices[0]!.name).toBe("Primary DB Server");
+    });
+
+    it("preserves name through multiple updates with undo", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+      const deviceType = store.addDeviceType({
+        name: "Generic Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+      });
+      store.placeDevice("rack-0", deviceType.slug, 5);
+
+      store.updateDeviceName("rack-0", 0, "First Name");
+      store.updateDeviceName("rack-0", 0, "Second Name");
+      store.updateDeviceName("rack-0", 0, "Third Name");
+
+      expect(store.layout.rack.devices[0]!.name).toBe("Third Name");
+
+      store.undo();
+      expect(store.layout.rack.devices[0]!.name).toBe("Second Name");
+
+      store.undo();
+      expect(store.layout.rack.devices[0]!.name).toBe("First Name");
+
+      store.undo();
+      expect(store.layout.rack.devices[0]!.name).toBeUndefined();
+    });
+  });
+
+  describe("dirty tracking", () => {
+    it("markDirty sets isDirty to true", () => {
+      const store = getLayoutStore();
+      expect(store.isDirty).toBe(false);
+      store.markDirty();
+      expect(store.isDirty).toBe(true);
+    });
+
+    it("markClean sets isDirty to false", () => {
+      const store = getLayoutStore();
+      store.markDirty();
+      expect(store.isDirty).toBe(true);
+      store.markClean();
+      expect(store.isDirty).toBe(false);
+    });
+  });
+
+  describe("placeDevice with face/depth awareness", () => {
+    beforeEach(() => {
+      resetLayoutStore();
+    });
+
+    it("allows placing half-depth rear device at same U as half-depth front device", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add half-depth device type
+      const halfDepthType = store.addDeviceType({
+        name: "Half-Depth Device",
+        u_height: 1,
+        category: "blank",
+        colour: "#2F4F4F",
+        is_full_depth: false,
+      });
+
+      // Place on front at U5
+      const result1 = store.placeDevice(
+        "rack-0",
+        halfDepthType.slug,
+        5,
+        "front",
+      );
+      expect(result1).toBe(true);
+
+      // Place on rear at U5 - should succeed because both are half-depth
+      const result2 = store.placeDevice(
+        "rack-0",
+        halfDepthType.slug,
+        5,
+        "rear",
+      );
+      expect(result2).toBe(true);
+
+      // Both devices should exist at position 5
+      const devicesAtU5 = store.layout.rack.devices.filter(
+        (d) => d.position === 5,
+      );
+      expect(devicesAtU5).toHaveLength(2);
+    });
+
+    it("blocks placing half-depth rear device when full-depth front device exists at same U", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add full-depth device type (default)
+      const fullDepthType = store.addDeviceType({
+        name: "Full-Depth Server",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+        // is_full_depth defaults to true
+      });
+
+      // Add half-depth device type
+      const halfDepthType = store.addDeviceType({
+        name: "Half-Depth Blank",
+        u_height: 1,
+        category: "blank",
+        colour: "#2F4F4F",
+        is_full_depth: false,
+      });
+
+      // Place full-depth on front at U5
+      const result1 = store.placeDevice(
+        "rack-0",
+        fullDepthType.slug,
+        5,
+        "front",
+      );
+      expect(result1).toBe(true);
+
+      // Place half-depth on rear at U5 - should FAIL because front is full-depth
+      const result2 = store.placeDevice(
+        "rack-0",
+        halfDepthType.slug,
+        5,
+        "rear",
+      );
+      expect(result2).toBe(false);
+
+      // Only one device should exist
+      expect(store.layout.rack.devices).toHaveLength(1);
+    });
+
+    it("blocks placing full-depth rear device when half-depth front device exists at same U", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add half-depth device type
+      const halfDepthType = store.addDeviceType({
+        name: "Half-Depth Blank",
+        u_height: 1,
+        category: "blank",
+        colour: "#2F4F4F",
+        is_full_depth: false,
+      });
+
+      // Add full-depth device type
+      const fullDepthType = store.addDeviceType({
+        name: "Full-Depth Server",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+
+      // Place half-depth on front at U5
+      const result1 = store.placeDevice(
+        "rack-0",
+        halfDepthType.slug,
+        5,
+        "front",
+      );
+      expect(result1).toBe(true);
+
+      // Place full-depth on rear at U5 - should FAIL because new device is full-depth
+      const result2 = store.placeDevice(
+        "rack-0",
+        fullDepthType.slug,
+        5,
+        "rear",
+      );
+      expect(result2).toBe(false);
+
+      // Only one device should exist
+      expect(store.layout.rack.devices).toHaveLength(1);
+    });
+  });
+
+  describe("moveDevice with face/depth awareness", () => {
+    beforeEach(() => {
+      resetLayoutStore();
+    });
+
+    it("allows moving half-depth rear device to same U as half-depth front device", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add half-depth device type
+      const halfDepthType = store.addDeviceType({
+        name: "Half-Depth Device",
+        u_height: 1,
+        category: "blank",
+        colour: "#2F4F4F",
+        is_full_depth: false,
+      });
+
+      // Place on front at U5
+      store.placeDevice("rack-0", halfDepthType.slug, 5, "front");
+
+      // Place on rear at U10
+      store.placeDevice("rack-0", halfDepthType.slug, 10, "rear");
+
+      // Move rear device from U10 to U5 - should succeed
+      const result = store.moveDevice("rack-0", 1, 5);
+      expect(result).toBe(true);
+
+      // Both devices should be at position 5
+      const devicesAtU5 = store.layout.rack.devices.filter(
+        (d) => d.position === 5,
+      );
+      expect(devicesAtU5).toHaveLength(2);
+    });
+
+    it("blocks moving half-depth rear device to same U as full-depth front device", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add full-depth device type
+      const fullDepthType = store.addDeviceType({
+        name: "Full-Depth Server",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+
+      // Add half-depth device type
+      const halfDepthType = store.addDeviceType({
+        name: "Half-Depth Blank",
+        u_height: 1,
+        category: "blank",
+        colour: "#2F4F4F",
+        is_full_depth: false,
+      });
+
+      // Place full-depth on front at U5
+      store.placeDevice("rack-0", fullDepthType.slug, 5, "front");
+
+      // Place half-depth on rear at U10
+      store.placeDevice("rack-0", halfDepthType.slug, 10, "rear");
+
+      // Move rear device from U10 to U5 - should FAIL because front is full-depth
+      const result = store.moveDevice("rack-0", 1, 5);
+      expect(result).toBe(false);
+
+      // Device at index 1 should still be at U10
+      expect(store.layout.rack.devices[1]!.position).toBe(10);
+    });
+  });
+
+  describe("0.5U device movement", () => {
+    it("allows moving 0.5U device to half-unit positions", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add 0.5U device type
+      const halfUType = store.addDeviceType({
+        name: "0.5U Device",
+        u_height: 0.5,
+        category: "blank",
+        colour: "#2F4F4F",
+      });
+
+      // Place at position 1
+      const placed = store.placeDevice("rack-0", halfUType.slug, 1, "front");
+      expect(placed).toBe(true);
+      expect(store.layout.rack.devices[0]!.position).toBe(1);
+
+      // Move to position 1.5 - should succeed
+      const result = store.moveDevice("rack-0", 0, 1.5);
+      expect(result).toBe(true);
+      expect(store.layout.rack.devices[0]!.position).toBe(1.5);
+    });
+
+    it("allows moving 0.5U device to integer positions", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add 0.5U device type
+      const halfUType = store.addDeviceType({
+        name: "0.5U Device",
+        u_height: 0.5,
+        category: "blank",
+        colour: "#2F4F4F",
+      });
+
+      // Place at position 1.5
+      const placed = store.placeDevice("rack-0", halfUType.slug, 1.5, "front");
+      expect(placed).toBe(true);
+
+      // Move to position 2 - should succeed
+      const result = store.moveDevice("rack-0", 0, 2);
+      expect(result).toBe(true);
+      expect(store.layout.rack.devices[0]!.position).toBe(2);
+    });
+
+    it("blocks 0.5U device from exceeding rack height", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add 0.5U device type
+      const halfUType = store.addDeviceType({
+        name: "0.5U Device",
+        u_height: 0.5,
+        category: "blank",
+        colour: "#2F4F4F",
+      });
+
+      // Place at position 42
+      store.placeDevice("rack-0", halfUType.slug, 42, "front");
+
+      // Position 43 definitely exceeds rack height
+      const result = store.moveDevice("rack-0", 0, 43);
+      expect(result).toBe(false);
+    });
+
+    it("detects collision between 1U devices at same position", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add 1U device type (collision detection works correctly for 1U)
+      const oneUType = store.addDeviceType({
+        name: "1U Device",
+        u_height: 1,
+        category: "blank",
+        colour: "#2F4F4F",
+      });
+
+      // Place first device at U5
+      store.placeDevice("rack-0", oneUType.slug, 5, "front");
+
+      // Place second device at U10
+      store.placeDevice("rack-0", oneUType.slug, 10, "front");
+
+      // Try to move second device to U5 - should fail (collision on same face)
+      const result = store.moveDevice("rack-0", 1, 5);
+      expect(result).toBe(false);
+    });
+
+    it("allows adjacent 0.5U devices without collision", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Add 0.5U device type
+      const halfUType = store.addDeviceType({
+        name: "0.5U Device",
+        u_height: 0.5,
+        category: "blank",
+        colour: "#2F4F4F",
+      });
+
+      // Place first device at U5
+      store.placeDevice("rack-0", halfUType.slug, 5, "front");
+
+      // Place second device at U10
+      store.placeDevice("rack-0", halfUType.slug, 10, "front");
+
+      // Move second device to U5.5 - should succeed (adjacent, no overlap)
+      const result = store.moveDevice("rack-0", 1, 5.5);
+      expect(result).toBe(true);
+      expect(store.layout.rack.devices[1]!.position).toBe(5.5);
+    });
+  });
+
+  describe("duplicateRack", () => {
+    it("returns error in v0.2 (single rack mode)", () => {
+      const store = getLayoutStore();
+      store.addRack("First Rack", 42);
+      const result = store.duplicateRack("rack-0");
+      expect(result.error).toBe("Maximum of 1 rack allowed");
+    });
+  });
+
+  describe("resetLayout", () => {
+    it("resets to initial state", () => {
+      const store = getLayoutStore();
+      store.addRack("Test", 42);
+      store.addDeviceType({
+        name: "Test",
+        u_height: 1,
+        category: "server",
+        colour: "#4A90D9",
+      });
+
+      resetLayoutStore();
+      const freshStore = getLayoutStore();
+
+      expect(freshStore.layout.name).toBe("Racky McRackface");
+      expect(freshStore.layout.rack.devices).toEqual([]);
+      // device_types starts empty (starter library is a runtime constant, not stored)
+      expect(freshStore.device_types.length).toBe(0);
+      expect(freshStore.isDirty).toBe(false);
+    });
+  });
+
+  describe("settings", () => {
+    it("updateDisplayMode updates display_mode", () => {
+      const store = getLayoutStore();
+      expect(store.layout.settings.display_mode).toBe("label");
+      store.updateDisplayMode("image");
+      expect(store.layout.settings.display_mode).toBe("image");
+      expect(store.isDirty).toBe(true);
+    });
+
+    it("updateShowLabelsOnImages updates show_labels_on_images", () => {
+      const store = getLayoutStore();
+      expect(store.layout.settings.show_labels_on_images).toBe(false);
+      store.updateShowLabelsOnImages(true);
+      expect(store.layout.settings.show_labels_on_images).toBe(true);
+      expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("placeDevice with brand pack devices", () => {
+    beforeEach(() => {
+      resetLayoutStore();
+    });
+
+    it("places Ubiquiti brand pack device successfully", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Ubiquiti device slug from brand pack (not in starter library)
+      const result = store.placeDevice(
+        "rack-0",
+        "ubiquiti-unifi-switch-24-pro",
+        5,
+      );
+
+      expect(result).toBe(true);
+      expect(store.layout.rack.devices).toHaveLength(1);
+      expect(store.layout.rack.devices[0]!.device_type).toBe(
+        "ubiquiti-unifi-switch-24-pro",
+      );
+      expect(store.layout.rack.devices[0]!.position).toBe(5);
+    });
+
+    it("places Mikrotik brand pack device successfully", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Mikrotik device slug from brand pack
+      const result = store.placeDevice("rack-0", "crs326-24g-2s-plus", 10);
+
+      expect(result).toBe(true);
+      expect(store.layout.rack.devices).toHaveLength(1);
+      expect(store.layout.rack.devices[0]!.device_type).toBe(
+        "crs326-24g-2s-plus",
+      );
+    });
+
+    it("auto-imports brand device into device_types on first placement", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Initially, brand device is not in device_types
+      const initialCount = store.device_types.length;
+      expect(
+        store.device_types.find(
+          (d) => d.slug === "ubiquiti-unifi-switch-24-pro",
+        ),
+      ).toBeUndefined();
+
+      // Place brand device
+      store.placeDevice("rack-0", "ubiquiti-unifi-switch-24-pro", 5);
+
+      // Device should now be in device_types
+      expect(store.device_types.length).toBe(initialCount + 1);
+      const imported = store.device_types.find(
+        (d) => d.slug === "ubiquiti-unifi-switch-24-pro",
+      );
+      expect(imported).toBeDefined();
+      expect(imported?.manufacturer).toBe("Ubiquiti");
+      expect(imported?.model).toBe("USW-Pro-24");
+    });
+
+    it("does not duplicate device_type when placing same brand device twice", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Place same brand device twice at different positions
+      store.placeDevice("rack-0", "ubiquiti-unifi-switch-24-pro", 5);
+      const countAfterFirst = store.device_types.length;
+
+      store.placeDevice("rack-0", "ubiquiti-unifi-switch-24-pro", 10);
+      expect(store.device_types.length).toBe(countAfterFirst);
+    });
+
+    it("returns false for unknown slug (not in library or brand packs)", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      const result = store.placeDevice("rack-0", "nonexistent-device-xyz", 5);
+      expect(result).toBe(false);
+      expect(store.layout.rack.devices).toHaveLength(0);
+    });
+
+    it("preserves brand device properties when auto-imported", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      store.placeDevice("rack-0", "ubiquiti-unifi-switch-24-pro", 5);
+
+      const imported = store.device_types.find(
+        (d) => d.slug === "ubiquiti-unifi-switch-24-pro",
+      );
+      expect(imported?.is_full_depth).toBe(false);
+      // Schema v1.0.0: Flat structure with category at top level
+      expect(imported?.category).toBe("network");
+    });
+
+    it("full-depth brand device defaults to both face when placed", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // US-24-500W has is_full_depth: true (legacy switch with power supply)
+      store.placeDevice("rack-0", "ubiquiti-unifi-switch-24-500w", 5);
+
+      // Full-depth devices should default to 'both' face (visible front and rear)
+      expect(store.layout.rack.devices[0]!.face).toBe("both");
+    });
+
+    it("half-depth brand device defaults to front face when placed", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Ubiquiti PDU has is_full_depth: false
+      store.placeDevice("rack-0", "ubiquiti-usp-pdu-pro", 5);
+
+      // Half-depth devices should default to 'front' face
+      expect(store.layout.rack.devices[0]!.face).toBe("front");
+    });
+
+    it("auto-import creates new array reference for Svelte reactivity", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Capture the original array reference
+      const originalDeviceTypes = store.device_types;
+
+      // Place a brand device that will trigger auto-import
+      store.placeDevice("rack-0", "ubiquiti-unifi-switch-24-pro", 5);
+
+      // The device_types array should be a NEW reference (not mutated in place)
+      // This is required for Svelte 5 reactivity to trigger UI updates
+      expect(store.device_types).not.toBe(originalDeviceTypes);
+
+      // But should still contain all original items plus the new one
+      expect(store.device_types.length).toBe(originalDeviceTypes.length + 1);
+    });
+  });
+
+  describe("placeDevice face defaults based on depth", () => {
+    beforeEach(() => {
+      resetLayoutStore();
+    });
+
+    it("full-depth device defaults to both face", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Create a full-depth device type
+      const deviceType = store.addDeviceType({
+        name: "Full Depth Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+        is_full_depth: true,
+      });
+
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      expect(store.layout.rack.devices[0]!.face).toBe("both");
+    });
+
+    it("half-depth device defaults to front face", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Create a half-depth device type
+      const deviceType = store.addDeviceType({
+        name: "Half Depth Switch",
+        u_height: 1,
+        category: "network",
+        colour: "#7B68EE",
+        is_full_depth: false,
+      });
+
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      expect(store.layout.rack.devices[0]!.face).toBe("front");
+    });
+
+    it("device with undefined is_full_depth defaults to both face (full depth assumed)", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Create device without is_full_depth specified (defaults to full depth)
+      const deviceType = store.addDeviceType({
+        name: "Default Depth Device",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+        // is_full_depth not specified
+      });
+
+      store.placeDevice("rack-0", deviceType.slug, 5);
+      expect(store.layout.rack.devices[0]!.face).toBe("both");
+    });
+
+    it("full-depth device ignores explicit face and uses both", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Full-depth devices physically occupy both front and rear
+      // Even if 'front' is passed (e.g., from RackDualView drop), it should be 'both'
+      const deviceType = store.addDeviceType({
+        name: "Full Depth Server",
+        u_height: 2,
+        category: "server",
+        colour: "#4A90D9",
+        is_full_depth: true,
+      });
+
+      store.placeDevice("rack-0", deviceType.slug, 5, "front");
+      // Full-depth devices ALWAYS use 'both' regardless of passed face
+      expect(store.layout.rack.devices[0]!.face).toBe("both");
+    });
+
+    it("half-depth device respects explicit face parameter", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Half-depth devices can be front-mounted or rear-mounted
+      const deviceType = store.addDeviceType({
+        name: "Patch Panel",
+        u_height: 1,
+        category: "patch-panel",
+        colour: "#7B68EE",
+        is_full_depth: false,
+      });
+
+      // Explicitly place on rear
+      store.placeDevice("rack-0", deviceType.slug, 5, "rear");
+      expect(store.layout.rack.devices[0]!.face).toBe("rear");
+    });
+  });
+
+  describe("custom multi-U device placement (Issue #166)", () => {
+    beforeEach(() => {
+      resetLayoutStore();
+    });
+
+    it("preserves u_height for custom 4U device", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Create a custom 4U device
+      const deviceType = store.addDeviceType({
+        name: "RACKOWL 4U Server",
+        u_height: 4,
+        category: "server",
+        colour: "#3b82f6",
+      });
+
+      // Verify the device type was created with correct u_height
+      expect(deviceType.u_height).toBe(4);
+      expect(
+        store.device_types.find((d) => d.slug === deviceType.slug)?.u_height,
+      ).toBe(4);
+
+      // Place the device
+      const result = store.placeDevice("rack-0", deviceType.slug, 5);
+      expect(result).toBe(true);
+
+      // After placement, the device type in store should still have u_height: 4
+      const storedType = store.device_types.find(
+        (d) => d.slug === deviceType.slug,
+      );
+      expect(storedType?.u_height).toBe(4);
+    });
+
+    it("custom 2U device blocks both U positions", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Create a custom 2U device
+      const deviceType = store.addDeviceType({
+        name: "Custom 2U Server",
+        u_height: 2,
+        category: "server",
+        colour: "#ef4444",
+      });
+
+      // Place at position 10 (should occupy 10-11)
+      store.placeDevice("rack-0", deviceType.slug, 10);
+
+      // Create another 1U device
+      const otherDevice = store.addDeviceType({
+        name: "Other Device",
+        u_height: 1,
+        category: "server",
+        colour: "#22c55e",
+      });
+
+      // Try to place at position 11 - should fail because 2U device at 10 occupies 10-11
+      const result = store.placeDevice("rack-0", otherDevice.slug, 11);
+      expect(result).toBe(false);
+
+      // But position 12 should work
+      const result2 = store.placeDevice("rack-0", otherDevice.slug, 12);
+      expect(result2).toBe(true);
+    });
+
+    it("custom 4U device collision detection works correctly", () => {
+      const store = getLayoutStore();
+      store.addRack("Test Rack", 42);
+
+      // Create a custom 4U device
+      const deviceType = store.addDeviceType({
+        name: "Big 4U Server",
+        u_height: 4,
+        category: "server",
+        colour: "#8b5cf6",
+      });
+
+      // Place at position 20 (should occupy U20-23)
+      const result1 = store.placeDevice("rack-0", deviceType.slug, 20);
+      expect(result1).toBe(true);
+
+      // Create a 1U device
+      const smallDevice = store.addDeviceType({
+        name: "Small Device",
+        u_height: 1,
+        category: "server",
+        colour: "#f59e0b",
+      });
+
+      // All positions 20-23 should be blocked
+      expect(store.placeDevice("rack-0", smallDevice.slug, 20)).toBe(false);
+      expect(store.placeDevice("rack-0", smallDevice.slug, 21)).toBe(false);
+      expect(store.placeDevice("rack-0", smallDevice.slug, 22)).toBe(false);
+      expect(store.placeDevice("rack-0", smallDevice.slug, 23)).toBe(false);
+
+      // Position 19 (below) and 24 (above) should be available
+      expect(store.placeDevice("rack-0", smallDevice.slug, 19)).toBe(true);
+      expect(store.placeDevice("rack-0", smallDevice.slug, 24)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Added 6 unit tests for custom multi-U device placement and rendering (Issue #166)
- Added E2E test suite for custom device height preservation
- All tests pass, confirming the core device placement logic is correct

### Test Coverage Added

**Layout Store Tests (`src/tests/layout-store.test.ts`)**
- Verifies custom 4U device preserves `u_height` after creation and placement
- Tests collision detection respects multi-U device boundaries
- Validates 4U device correctly blocks positions 5-8

**Rack Component Tests (`src/tests/Rack-component.test.ts`)**
- Verifies custom 4U device renders with correct height (88px = 4 × 22px)
- Verifies custom 2U device renders with correct height (44px = 2 × 22px)
- Verifies custom 3U device renders with correct height (66px = 3 × 22px)

**E2E Tests (`e2e/custom-device.spec.ts`)**
- Full workflow test: create custom 4U device → drag to rack → verify 88px height
- Full workflow test: create custom 2U device → drag to rack → verify 44px height

## Investigation Findings

The bug reported in #166 (custom 4U devices reverting to 1U after placement) could not be reproduced in tests. Code review shows:

1. `addDeviceType()` correctly stores `u_height` from form input
2. `findDeviceType()` correctly returns the stored device type with original `u_height`
3. `RackDevice` correctly calculates height using `device.u_height * U_HEIGHT`

The tests provide regression coverage to ensure this behavior remains correct.

## Test plan

- [x] All 84 layout store tests pass
- [x] All 45 Rack component tests pass
- [x] E2E tests created (require `npx playwright install` to run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for custom device creation and placement, including 4U and 2U configurations
  * Updated existing test files with formatting improvements

* **Chores**
  * Added GitHub Actions workflow for synchronizing project item status with issue labels

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->