### PR TITLE
fix: export respects colour_override on placed devices (#171)

### DIFF
--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -727,7 +727,10 @@ export function generateExportSVG(
       deviceRect.setAttribute("y", String(deviceY + 1));
       deviceRect.setAttribute("width", String(deviceWidth));
       deviceRect.setAttribute("height", String(deviceHeight));
-      deviceRect.setAttribute("fill", device.colour);
+      deviceRect.setAttribute(
+        "fill",
+        placedDevice.colour_override ?? device.colour,
+      );
       deviceRect.setAttribute("rx", "2");
       deviceRect.setAttribute("ry", "2");
       rackGroup.appendChild(deviceRect);
@@ -795,7 +798,7 @@ export function generateExportSVG(
 
           // White icon with slight transparency for visibility on coloured backgrounds
           const iconColor = "rgba(255, 255, 255, 0.85)";
-          const iconBgColor = device.colour;
+          const iconBgColor = placedDevice.colour_override ?? device.colour;
           const iconElements = createCategoryIconElements(
             device.category,
             iconColor,


### PR DESCRIPTION
## Summary

Fixes exports (PNG, JPEG, SVG, PDF) to respect `colour_override` on placed devices.

- Device rectangles now use `placedDevice.colour_override ?? device.colour`
- Category icon backgrounds also respect the override
- Falls back to DeviceType's base colour when no override is set

## Files Changed

- `src/lib/utils/export.ts`: Use colour_override in SVG rendering (lines 730, 801)
- `src/tests/export.test.ts`: Add 4 tests for colour override in exports

## Test Plan

- [x] Test with colour_override set → uses custom colour
- [x] Test without colour_override → uses default colour  
- [x] Test with undefined colour_override → uses default colour
- [x] Test in dual-view export → respects override in both views

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SVG exports now support custom colour overrides for devices, with automatic fallback to default colours when not specified.

* **Tests**
  * Added comprehensive test coverage for colour override functionality in exports, including dual-view scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->