### PR TITLE
feat: add invert U numbering toggle to EditPanel (#204)

### DIFF
--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -9,6 +9,7 @@
   import BrandIcon from "./BrandIcon.svelte";
   import ImageUpload from "./ImageUpload.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
+  import SegmentedControl from "./SegmentedControl.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
@@ -458,6 +459,19 @@
       isFullDepth,
     );
   });
+
+  // Transform internal position to display position (matches ruler labels)
+  // Internal: position 1 = bottom of rack, position N = top
+  // Display with desc_units=false: U1 at bottom (same as internal)
+  // Display with desc_units=true: U1 at top (inverted)
+  const displayPosition = $derived.by(() => {
+    if (!selectedDeviceInfo) return null;
+    const { placedDevice, rack } = selectedDeviceInfo;
+    const pos = placedDevice.position;
+    return rack.desc_units
+      ? rack.height - pos + 1 // Inverted: bottom (pos=1) shows as highest U
+      : pos; // Normal: position = display
+  });
 </script>
 
 <Drawer
@@ -509,6 +523,22 @@
             </button>
           {/each}
         </div>
+      </div>
+
+      <div class="form-group">
+        <label for="rack-numbering">U Numbering</label>
+        <SegmentedControl
+          options={[
+            { value: "bottom", label: "U1 at bottom" },
+            { value: "top", label: "U1 at top" },
+          ]}
+          value={selectedRack.desc_units ? "top" : "bottom"}
+          onchange={(value) =>
+            layoutStore.updateRack(RACK_ID, {
+              desc_units: value === "top",
+            })}
+          ariaLabel="U numbering direction"
+        />
       </div>
 
       <div class="form-group">
@@ -619,9 +649,7 @@
         <div class="info-row position-row">
           <span class="info-label">Position</span>
           <div class="position-controls">
-            <span class="info-value position-value"
-              >U{selectedDeviceInfo.placedDevice.position}</span
-            >
+            <span class="info-value position-value">U{displayPosition}</span>
             <div class="position-buttons">
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- Adds SegmentedControl to toggle between "U1 at bottom" and "U1 at top" in rack edit panel
- Transforms device position display in EditPanel to match ruler labels when inverted
- Core `desc_units` logic already existed in codebase — this exposes it through UI

## Changes
- `EditPanel.svelte`: Add SegmentedControl after Height presets, add `displayPosition` derived helper
- `EditPanel.test.ts`: Add 8 new tests for U Numbering toggle and position display transformation

## Test plan
- [x] Toggle control appears after Height in rack edit panel
- [x] Default selection is "U1 at bottom"
- [x] Clicking "U1 at top" updates `desc_units` to true
- [x] Device position in EditPanel matches ruler label when inverted
- [x] Setting persists in saved layout (existing schema support)
- [x] All 85 unit tests pass
- [x] Lint and build pass

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added a U-numbering toggle control for racks, allowing users to select between bottom and top numbering orientations.
- Device position displays are now dynamically updated to accurately reflect the selected U-numbering direction.
- Position values throughout the interface now correctly adapt based on the chosen numbering orientation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->