### PR TITLE
fix: respect U numbering direction in export (#217)

### DIFF
--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -617,8 +617,12 @@ export function generateExportSVG(
     }
 
     // U labels on left rail
+    // Respect desc_units and starting_unit settings (mirrors Rack.svelte logic)
+    const startUnit = rack.starting_unit ?? 1;
     for (let i = 0; i < rack.height; i++) {
-      const uNumber = rack.height - i;
+      const uNumber = rack.desc_units
+        ? startUnit + i // Descending: lowest number at top
+        : startUnit + (rack.height - 1) - i; // Ascending: highest number at top
       const labelY = i * U_HEIGHT + U_HEIGHT / 2 + RACK_PADDING + RAIL_WIDTH;
 
       const label = document.createElementNS(

--- a/src/tests/export.test.ts
+++ b/src/tests/export.test.ts
@@ -368,6 +368,96 @@ describe("Export Utilities", () => {
         }
       });
     });
+
+    describe("U Numbering Direction (#217)", () => {
+      it("renders U numbers ascending (U1 at bottom) when desc_units is false", () => {
+        const rack: Rack = {
+          name: "Test Rack",
+          height: 4,
+          width: 19,
+          position: 0,
+          desc_units: false,
+          form_factor: "4-post",
+          starting_unit: 1,
+          devices: [],
+        };
+
+        const svg = generateExportSVG([rack], [], defaultOptions);
+        const textElements = svg.querySelectorAll("text");
+        const uLabels = Array.from(textElements)
+          .filter((el) => /^[0-9]+$/.test(el.textContent || ""))
+          .map((el) => el.textContent);
+
+        // With desc_units=false, U4 should be at top (first), U1 at bottom (last)
+        expect(uLabels).toEqual(["4", "3", "2", "1"]);
+      });
+
+      it("renders U numbers descending (U1 at top) when desc_units is true", () => {
+        const rack: Rack = {
+          name: "Test Rack",
+          height: 4,
+          width: 19,
+          position: 0,
+          desc_units: true,
+          form_factor: "4-post",
+          starting_unit: 1,
+          devices: [],
+        };
+
+        const svg = generateExportSVG([rack], [], defaultOptions);
+        const textElements = svg.querySelectorAll("text");
+        const uLabels = Array.from(textElements)
+          .filter((el) => /^[0-9]+$/.test(el.textContent || ""))
+          .map((el) => el.textContent);
+
+        // With desc_units=true, U1 should be at top (first), U4 at bottom (last)
+        expect(uLabels).toEqual(["1", "2", "3", "4"]);
+      });
+
+      it("respects starting_unit offset", () => {
+        const rack: Rack = {
+          name: "Test Rack",
+          height: 4,
+          width: 19,
+          position: 0,
+          desc_units: false,
+          form_factor: "4-post",
+          starting_unit: 10,
+          devices: [],
+        };
+
+        const svg = generateExportSVG([rack], [], defaultOptions);
+        const textElements = svg.querySelectorAll("text");
+        const uLabels = Array.from(textElements)
+          .filter((el) => /^[0-9]+$/.test(el.textContent || ""))
+          .map((el) => el.textContent);
+
+        // Starting at U10, ascending: U13 at top, U10 at bottom
+        expect(uLabels).toEqual(["13", "12", "11", "10"]);
+      });
+
+      it("combines desc_units and starting_unit correctly", () => {
+        const rack: Rack = {
+          name: "Test Rack",
+          height: 4,
+          width: 19,
+          position: 0,
+          desc_units: true,
+          form_factor: "4-post",
+          starting_unit: 10,
+          devices: [],
+        };
+
+        const svg = generateExportSVG([rack], [], defaultOptions);
+        const textElements = svg.querySelectorAll("text");
+        const uLabels = Array.from(textElements)
+          .filter((el) => /^[0-9]+$/.test(el.textContent || ""))
+          .map((el) => el.textContent);
+
+        // Descending with starting_unit=10: U10 at top, U13 at bottom
+        expect(uLabels).toEqual(["10", "11", "12", "13"]);
+      });
+    });
   });
 
   describe("exportAsSVG", () => {


### PR DESCRIPTION
## Summary
- Fixed export SVG ignoring `desc_units` and `starting_unit` rack settings
- U labels now match canvas display in all export formats (PNG, PDF, SVG)

## Root Cause
Export code at `src/lib/utils/export.ts:621` was hardcoded to `rack.height - i`, ignoring the rack's U numbering configuration.

## Changes
- Apply same logic as `Rack.svelte` for U label generation
- Added 4 unit tests covering all combinations of `desc_units` and `starting_unit`

## Test plan
- [x] Lint passes
- [x] 85 export tests pass (4 new)
- [ ] Manual: Create rack with "U1 at top", export PNG, verify U1 appears at top

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rack U-label rendering now supports both ascending and descending numbering directions
  * Added customizable starting unit configuration for flexible rack labelling across different hardware layouts and standards

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->