### PR TITLE
feat: add toggle to disable rear view on canvas (#207)

### DIFF
--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -542,6 +542,22 @@
       </div>
 
       <div class="form-group">
+        <label for="show-rear-view">Show Rear View</label>
+        <SegmentedControl
+          options={[
+            { value: "show", label: "Show" },
+            { value: "hide", label: "Hide" },
+          ]}
+          value={selectedRack.show_rear ? "show" : "hide"}
+          onchange={(value) =>
+            layoutStore.updateRack(RACK_ID, {
+              show_rear: value === "show",
+            })}
+          ariaLabel="Show rear view on canvas"
+        />
+      </div>
+
+      <div class="form-group">
         <label for="rack-notes">Notes</label>
         <textarea
           id="rack-notes"

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -120,15 +120,15 @@
   tabindex="0"
   role="option"
   aria-selected={selected}
-  aria-label="{rack.name}, {rack.height}U rack, front and rear view{selected
-    ? ', selected'
-    : ''}"
+  aria-label="{rack.name}, {rack.height}U rack, {rack.show_rear
+    ? 'front and rear view'
+    : 'front view only'}{selected ? ', selected' : ''}"
   onkeydown={handleKeyDown}
 >
   <!-- Rack name centered above both views -->
   <div class="rack-dual-view-name">{rack.name}</div>
 
-  <div class="rack-dual-view-container">
+  <div class="rack-dual-view-container" class:single-view={!rack.show_rear}>
     <!-- Front view -->
     <div class="rack-front" role="presentation">
       <Rack
@@ -141,7 +141,7 @@
         {partyMode}
         faceFilter="front"
         hideRackName={true}
-        viewLabel="FRONT"
+        viewLabel={rack.show_rear ? "FRONT" : undefined}
         onselect={() => handleSelect()}
         {ondeviceselect}
         ondevicedrop={handleFrontDeviceDrop}
@@ -151,27 +151,29 @@
       />
     </div>
 
-    <!-- Rear view -->
-    <div class="rack-rear" role="presentation">
-      <Rack
-        {rack}
-        {deviceLibrary}
-        selected={false}
-        {selectedDeviceId}
-        {displayMode}
-        {showLabelsOnImages}
-        {partyMode}
-        faceFilter="rear"
-        hideRackName={true}
-        viewLabel="REAR"
-        onselect={() => handleSelect()}
-        {ondeviceselect}
-        ondevicedrop={handleRearDeviceDrop}
-        {ondevicemove}
-        {ondevicemoverack}
-        {onplacementtap}
-      />
-    </div>
+    <!-- Rear view (conditionally shown based on rack.show_rear) -->
+    {#if rack.show_rear}
+      <div class="rack-rear" role="presentation">
+        <Rack
+          {rack}
+          {deviceLibrary}
+          selected={false}
+          {selectedDeviceId}
+          {displayMode}
+          {showLabelsOnImages}
+          {partyMode}
+          faceFilter="rear"
+          hideRackName={true}
+          viewLabel="REAR"
+          onselect={() => handleSelect()}
+          {ondeviceselect}
+          ondevicedrop={handleRearDeviceDrop}
+          {ondevicemove}
+          {ondevicemoverack}
+          {onplacementtap}
+        />
+      </div>
+    {/if}
   </div>
 </div>
 

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -309,6 +309,7 @@ export const RackSchema = z
       .max(100, "Height cannot exceed 100U"),
     width: z.union([z.literal(10), z.literal(19), z.literal(23)]),
     desc_units: z.boolean(),
+    show_rear: z.boolean().default(true),
     form_factor: FormFactorSchema,
     starting_unit: z.number().int().min(1),
     position: z.number().int().min(0),

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -232,12 +232,13 @@ function createNewLayout(name: string): void {
  * @param layoutData - v0.2 layout to load
  */
 function loadLayout(layoutData: Layout): void {
-  // Ensure runtime view is set
+  // Ensure runtime view is set and show_rear defaults to true for older layouts
   layout = {
     ...layoutData,
     rack: {
       ...layoutData.rack,
       view: layoutData.rack.view ?? "front",
+      show_rear: layoutData.rack.show_rear ?? true,
     },
   };
   isDirty = false;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -291,6 +291,8 @@ export interface Rack {
   width: 10 | 19 | 23;
   /** Descending units - if true, U1 is at top (default: false) */
   desc_units: boolean;
+  /** Show rear view on canvas (default: true) */
+  show_rear: boolean;
   /** Rack form factor */
   form_factor: FormFactor;
   /** Starting unit number (default: 1) */

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -390,11 +390,18 @@ export function generateExportSVG(
 
   // Calculate dimensions
   const maxRackHeight = Math.max(...racks.map((r) => r.height), 0);
-  // For dual view: each rack takes 2x width + gap between front/rear
+  // For dual view: each rack takes 2x width + gap between front/rear (but respect show_rear)
   const singleRackWidth =
     racks.length * RACK_WIDTH + (racks.length - 1) * RACK_GAP;
+  // Count how many racks will actually show dual view (respecting show_rear setting)
+  const dualViewRackCount = isDualView
+    ? racks.filter((r) => r.show_rear !== false).length
+    : 0;
+  const singleViewRackCount = racks.length - dualViewRackCount;
   const totalRackWidth = isDualView
-    ? racks.length * (RACK_WIDTH * 2 + RACK_GAP) + (racks.length - 1) * RACK_GAP
+    ? dualViewRackCount * (RACK_WIDTH * 2 + RACK_GAP) +
+      singleViewRackCount * RACK_WIDTH +
+      (racks.length - 1) * RACK_GAP
     : singleRackWidth;
 
   // Calculate space needed above rack for names and labels
@@ -903,15 +910,22 @@ export function generateExportSVG(
   }
 
   // Render each rack (single or dual view)
-  racks.forEach((rack, index) => {
+  // Track cumulative X position to handle mixed single/dual racks properly
+  let currentX = EXPORT_PADDING;
+
+  racks.forEach((rack) => {
     // Position rack below header space (name/labels)
     const rackY =
       EXPORT_PADDING + headerSpace + (maxRackHeight - rack.height) * U_HEIGHT;
 
-    if (isDualView) {
+    // Respect rack's show_rear setting - if false, force front-only even when isDualView
+    const shouldShowRear = rack.show_rear !== false;
+    const effectiveDualView = isDualView && shouldShowRear;
+
+    if (effectiveDualView) {
       // Dual view: render front and rear side-by-side
       const dualRackWidth = RACK_WIDTH * 2 + RACK_GAP;
-      const baseX = EXPORT_PADDING + index * (dualRackWidth + RACK_GAP);
+      const baseX = currentX;
 
       // Render rack name centered above both views
       if (includeNames) {
@@ -940,10 +954,13 @@ export function generateExportSVG(
       const rearX = baseX + RACK_WIDTH + RACK_GAP;
       const rearGroup = renderRackView(rack, rearX, rackY, "rear", "REAR");
       svg.appendChild(rearGroup);
+
+      // Advance X position for next rack
+      currentX += dualRackWidth + RACK_GAP;
     } else {
       // Single view: render with optional face filter
       // Note: Rack name is handled inside renderRackView when no viewLabel is provided
-      const rackX = EXPORT_PADDING + index * (RACK_WIDTH + RACK_GAP);
+      const rackX = currentX;
       const faceFilter =
         exportView === "front" || exportView === "rear"
           ? exportView
@@ -951,6 +968,9 @@ export function generateExportSVG(
       const rackGroup = renderRackView(rack, rackX, rackY, faceFilter);
 
       svg.appendChild(rackGroup);
+
+      // Advance X position for next rack
+      currentX += RACK_WIDTH + RACK_GAP;
     }
   });
 

--- a/src/lib/utils/rack.ts
+++ b/src/lib/utils/rack.ts
@@ -3,73 +3,77 @@
  * Pure functions for rack operations
  */
 
-import type { DeviceType, FormFactor, Rack, RackView } from '$lib/types';
+import type { DeviceType, FormFactor, Rack, RackView } from "$lib/types";
 import {
-	MIN_RACK_HEIGHT,
-	MAX_RACK_HEIGHT,
-	STANDARD_RACK_WIDTH,
-	ALLOWED_RACK_WIDTHS,
-	DEFAULT_RACK_VIEW
-} from '$lib/types/constants';
+  MIN_RACK_HEIGHT,
+  MAX_RACK_HEIGHT,
+  STANDARD_RACK_WIDTH,
+  ALLOWED_RACK_WIDTHS,
+  DEFAULT_RACK_VIEW,
+} from "$lib/types/constants";
 
 /**
  * Create a new rack with sensible defaults
  */
 export function createRack(
-	name: string,
-	height: number,
-	view?: RackView,
-	width?: 10 | 19,
-	form_factor?: FormFactor,
-	desc_units?: boolean,
-	starting_unit?: number
+  name: string,
+  height: number,
+  view?: RackView,
+  width?: 10 | 19,
+  form_factor?: FormFactor,
+  desc_units?: boolean,
+  starting_unit?: number,
+  show_rear?: boolean,
 ): Rack {
-	return {
-		name,
-		height,
-		width: width ?? (STANDARD_RACK_WIDTH as 10 | 19),
-		position: 0,
-		view: view ?? DEFAULT_RACK_VIEW,
-		devices: [],
-		form_factor: form_factor ?? '4-post-cabinet',
-		desc_units: desc_units ?? false,
-		starting_unit: starting_unit ?? 1
-	};
+  return {
+    name,
+    height,
+    width: width ?? (STANDARD_RACK_WIDTH as 10 | 19),
+    position: 0,
+    view: view ?? DEFAULT_RACK_VIEW,
+    devices: [],
+    form_factor: form_factor ?? "4-post-cabinet",
+    desc_units: desc_units ?? false,
+    show_rear: show_rear ?? true,
+    starting_unit: starting_unit ?? 1,
+  };
 }
 
 /**
  * Validation result for a rack
  */
 export interface RackValidationResult {
-	valid: boolean;
-	errors: string[];
+  valid: boolean;
+  errors: string[];
 }
 
 /**
  * Validate a rack object
  */
 export function validateRack(rack: Rack): RackValidationResult {
-	const errors: string[] = [];
+  const errors: string[] = [];
 
-	// Validate name
-	if (!rack.name || rack.name.trim() === '') {
-		errors.push('Name is required');
-	}
+  // Validate name
+  if (!rack.name || rack.name.trim() === "") {
+    errors.push("Name is required");
+  }
 
-	// Validate height
-	if (rack.height < MIN_RACK_HEIGHT || rack.height > MAX_RACK_HEIGHT) {
-		errors.push(`Height must be between ${MIN_RACK_HEIGHT} and ${MAX_RACK_HEIGHT}`);
-	}
+  // Validate height
+  if (rack.height < MIN_RACK_HEIGHT || rack.height > MAX_RACK_HEIGHT) {
+    errors.push(
+      `Height must be between ${MIN_RACK_HEIGHT} and ${MAX_RACK_HEIGHT}`,
+    );
+  }
 
-	// Validate width (must be 10, 19, or 23 inches)
-	if (!ALLOWED_RACK_WIDTHS.includes(rack.width)) {
-		errors.push('Width must be 10, 19, or 23 inches');
-	}
+  // Validate width (must be 10, 19, or 23 inches)
+  if (!ALLOWED_RACK_WIDTHS.includes(rack.width)) {
+    errors.push("Width must be 10, 19, or 23 inches");
+  }
 
-	return {
-		valid: errors.length === 0,
-		errors
-	};
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
 }
 
 /**
@@ -78,20 +82,29 @@ export function validateRack(rack: Rack): RackValidationResult {
  * @param deviceLibrary - The device library to look up device heights
  * @returns Set of occupied U positions
  */
-export function getOccupiedUs(rack: Rack, deviceLibrary: DeviceType[]): Set<number> {
-	const occupied = new Set<number>();
+export function getOccupiedUs(
+  rack: Rack,
+  deviceLibrary: DeviceType[],
+): Set<number> {
+  const occupied = new Set<number>();
 
-	for (const placedDevice of rack.devices) {
-		const device = deviceLibrary.find((d) => d.slug === placedDevice.device_type);
-		if (device) {
-			// Device at position P with height H occupies Us P through P+H-1
-			for (let u = placedDevice.position; u < placedDevice.position + device.u_height; u++) {
-				occupied.add(u);
-			}
-		}
-	}
+  for (const placedDevice of rack.devices) {
+    const device = deviceLibrary.find(
+      (d) => d.slug === placedDevice.device_type,
+    );
+    if (device) {
+      // Device at position P with height H occupies Us P through P+H-1
+      for (
+        let u = placedDevice.position;
+        u < placedDevice.position + device.u_height;
+        u++
+      ) {
+        occupied.add(u);
+      }
+    }
+  }
 
-	return occupied;
+  return occupied;
 }
 
 /**
@@ -101,9 +114,13 @@ export function getOccupiedUs(rack: Rack, deviceLibrary: DeviceType[]): Set<numb
  * @param uPosition - The U position to check
  * @returns true if the position is available, false if occupied
  */
-export function isUAvailable(rack: Rack, deviceLibrary: DeviceType[], uPosition: number): boolean {
-	const occupied = getOccupiedUs(rack, deviceLibrary);
-	return !occupied.has(uPosition);
+export function isUAvailable(
+  rack: Rack,
+  deviceLibrary: DeviceType[],
+  uPosition: number,
+): boolean {
+  const occupied = getOccupiedUs(rack, deviceLibrary);
+  return !occupied.has(uPosition);
 }
 
 /**
@@ -112,10 +129,10 @@ export function isUAvailable(rack: Rack, deviceLibrary: DeviceType[], uPosition:
  * @returns A new rack with copied name and copied devices
  */
 export function duplicateRack(rack: Rack): Rack {
-	return {
-		...rack,
-		name: `${rack.name} (Copy)`,
-		position: rack.position + 1,
-		devices: rack.devices.map((device) => ({ ...device }))
-	};
+  return {
+    ...rack,
+    name: `${rack.name} (Copy)`,
+    position: rack.position + 1,
+    devices: rack.devices.map((device) => ({ ...device })),
+  };
 }

--- a/src/lib/utils/serialization.ts
+++ b/src/lib/utils/serialization.ts
@@ -2,25 +2,25 @@
  * Layout Serialization and Factory Functions
  */
 
-import type { Layout, Rack, FormFactor } from '$lib/types';
-import { VERSION } from '$lib/version';
+import type { Layout, Rack, FormFactor } from "$lib/types";
+import { VERSION } from "$lib/version";
 
 /**
  * Create a new empty layout
  * @param name - Layout name (default: "Racky McRackface")
  * @returns New Layout object with empty device_types (starter library is a runtime constant)
  */
-export function createLayout(name: string = 'Racky McRackface'): Layout {
-	return {
-		version: VERSION,
-		name,
-		rack: createDefaultRack(name),
-		device_types: [], // Starter library is a runtime constant, not stored in layout
-		settings: {
-			display_mode: 'label',
-			show_labels_on_images: false
-		}
-	};
+export function createLayout(name: string = "Racky McRackface"): Layout {
+  return {
+    version: VERSION,
+    name,
+    rack: createDefaultRack(name),
+    device_types: [], // Starter library is a runtime constant, not stored in layout
+    settings: {
+      display_mode: "label",
+      show_labels_on_images: false,
+    },
+  };
 }
 
 /**
@@ -29,17 +29,18 @@ export function createLayout(name: string = 'Racky McRackface'): Layout {
  * @returns A default Rack with empty devices
  */
 function createDefaultRack(name: string): Rack {
-	return {
-		name,
-		height: 42,
-		width: 19,
-		desc_units: false,
-		form_factor: '4-post-cabinet',
-		starting_unit: 1,
-		position: 0,
-		devices: [],
-		view: 'front' // Runtime only
-	};
+  return {
+    name,
+    height: 42,
+    width: 19,
+    desc_units: false,
+    show_rear: true,
+    form_factor: "4-post-cabinet",
+    starting_unit: 1,
+    position: 0,
+    devices: [],
+    view: "front", // Runtime only
+  };
 }
 
 /**
@@ -50,25 +51,28 @@ function createDefaultRack(name: string): Rack {
  * @param form_factor - Form factor
  * @param desc_units - Whether units are numbered top-down
  * @param starting_unit - First U number
+ * @param show_rear - Show rear view on canvas (default: true)
  * @returns A new Rack object
  */
 export function createRack(
-	name: string,
-	height: number,
-	width: 10 | 19 = 19,
-	form_factor: FormFactor = '4-post-cabinet',
-	desc_units: boolean = false,
-	starting_unit: number = 1
+  name: string,
+  height: number,
+  width: 10 | 19 = 19,
+  form_factor: FormFactor = "4-post-cabinet",
+  desc_units: boolean = false,
+  starting_unit: number = 1,
+  show_rear: boolean = true,
 ): Rack {
-	return {
-		name,
-		height,
-		width,
-		desc_units,
-		form_factor,
-		starting_unit,
-		position: 0,
-		devices: [],
-		view: 'front' // Runtime only
-	};
+  return {
+    name,
+    height,
+    width,
+    desc_units,
+    show_rear,
+    form_factor,
+    starting_unit,
+    position: 0,
+    devices: [],
+    view: "front", // Runtime only
+  };
 }

--- a/src/tests/RackDualView.test.ts
+++ b/src/tests/RackDualView.test.ts
@@ -15,6 +15,7 @@ function createTestRack(overrides: Partial<Rack> = {}): Rack {
     width: 19,
     position: 0,
     desc_units: false,
+    show_rear: true,
     form_factor: "4-post",
     starting_unit: 1,
     devices: [],

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -12,18 +12,18 @@
  * const device = createTestDevice({ position: 5 });
  */
 
-import { vi } from 'vitest';
+import { vi } from "vitest";
 import type {
-	Rack,
-	DeviceType,
-	PlacedDevice,
-	DeviceFace,
-	DeviceCategory,
-	Layout,
-	LayoutSettings,
-	Airflow
-} from '$lib/types';
-import type { Command, CommandType } from '$lib/stores/commands/types';
+  Rack,
+  DeviceType,
+  PlacedDevice,
+  DeviceFace,
+  DeviceCategory,
+  Layout,
+  LayoutSettings,
+  Airflow,
+} from "$lib/types";
+import type { Command, CommandType } from "$lib/stores/commands/types";
 
 // =============================================================================
 // Rack Factory
@@ -34,17 +34,18 @@ import type { Command, CommandType } from '$lib/stores/commands/types';
  * All properties can be overridden.
  */
 export function createTestRack(overrides: Partial<Rack> = {}): Rack {
-	return {
-		name: 'Test Rack',
-		height: 42,
-		width: 19,
-		position: 0,
-		desc_units: false,
-		form_factor: '4-post',
-		starting_unit: 1,
-		devices: [],
-		...overrides
-	};
+  return {
+    name: "Test Rack",
+    height: 42,
+    width: 19,
+    position: 0,
+    desc_units: false,
+    show_rear: true,
+    form_factor: "4-post",
+    starting_unit: 1,
+    devices: [],
+    ...overrides,
+  };
 }
 
 // =============================================================================
@@ -52,15 +53,15 @@ export function createTestRack(overrides: Partial<Rack> = {}): Rack {
 // =============================================================================
 
 export interface CreateTestDeviceTypeOptions {
-	slug?: string;
-	u_height?: number;
-	model?: string;
-	manufacturer?: string;
-	category?: DeviceCategory;
-	colour?: string;
-	is_full_depth?: boolean;
-	airflow?: Airflow;
-	face?: DeviceFace;
+  slug?: string;
+  u_height?: number;
+  model?: string;
+  manufacturer?: string;
+  category?: DeviceCategory;
+  colour?: string;
+  is_full_depth?: boolean;
+  airflow?: Airflow;
+  face?: DeviceFace;
 }
 
 /**
@@ -78,38 +79,39 @@ export interface CreateTestDeviceTypeOptions {
  * const switch = createTestDeviceType('my-switch', 1);
  */
 export function createTestDeviceType(
-	slugOrOptions?: string | CreateTestDeviceTypeOptions,
-	u_height?: number
+  slugOrOptions?: string | CreateTestDeviceTypeOptions,
+  u_height?: number,
 ): DeviceType {
-	// Handle shorthand: createTestDeviceType('slug', 2)
-	if (typeof slugOrOptions === 'string') {
-		return {
-			slug: slugOrOptions,
-			model: `Test Device ${slugOrOptions}`,
-			u_height: u_height ?? 1,
-			// Flat structure in v1.0.0
-			category: 'server',
-			colour: '#4A90D9'
-		};
-	}
+  // Handle shorthand: createTestDeviceType('slug', 2)
+  if (typeof slugOrOptions === "string") {
+    return {
+      slug: slugOrOptions,
+      model: `Test Device ${slugOrOptions}`,
+      u_height: u_height ?? 1,
+      // Flat structure in v1.0.0
+      category: "server",
+      colour: "#4A90D9",
+    };
+  }
 
-	// Handle options object
-	const options = slugOrOptions ?? {};
-	const result: DeviceType = {
-		slug: options.slug ?? 'test-device',
-		u_height: options.u_height ?? 1,
-		model: options.model ?? 'Test Device',
-		// Flat structure in v1.0.0
-		category: options.category ?? 'server',
-		colour: options.colour ?? '#336699'
-	};
+  // Handle options object
+  const options = slugOrOptions ?? {};
+  const result: DeviceType = {
+    slug: options.slug ?? "test-device",
+    u_height: options.u_height ?? 1,
+    model: options.model ?? "Test Device",
+    // Flat structure in v1.0.0
+    category: options.category ?? "server",
+    colour: options.colour ?? "#336699",
+  };
 
-	// Add optional properties only if specified
-	if (options.manufacturer) result.manufacturer = options.manufacturer;
-	if (options.is_full_depth !== undefined) result.is_full_depth = options.is_full_depth;
-	if (options.airflow) result.airflow = options.airflow;
+  // Add optional properties only if specified
+  if (options.manufacturer) result.manufacturer = options.manufacturer;
+  if (options.is_full_depth !== undefined)
+    result.is_full_depth = options.is_full_depth;
+  if (options.airflow) result.airflow = options.airflow;
 
-	return result;
+  return result;
 }
 
 // =============================================================================
@@ -120,14 +122,16 @@ export function createTestDeviceType(
  * Creates a test PlacedDevice with sensible defaults.
  * Schema v1.0.0: PlacedDevice now requires a UUID id field
  */
-export function createTestDevice(overrides: Partial<PlacedDevice> = {}): PlacedDevice {
-	return {
-		id: overrides.id ?? crypto.randomUUID(),
-		device_type: 'test-device',
-		position: 10,
-		face: 'front',
-		...overrides
-	};
+export function createTestDevice(
+  overrides: Partial<PlacedDevice> = {},
+): PlacedDevice {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    device_type: "test-device",
+    position: 10,
+    face: "front",
+    ...overrides,
+  };
 }
 
 // =============================================================================
@@ -139,16 +143,19 @@ export function createTestDevice(overrides: Partial<PlacedDevice> = {}): PlacedD
  * Execute and undo are vi.fn() mocks for assertion.
  */
 export function createMockCommand(
-	description: string,
-	type: CommandType = 'PLACE_DEVICE'
-): Command & { execute: ReturnType<typeof vi.fn>; undo: ReturnType<typeof vi.fn> } {
-	return {
-		type,
-		description,
-		timestamp: Date.now(),
-		execute: vi.fn(),
-		undo: vi.fn()
-	};
+  description: string,
+  type: CommandType = "PLACE_DEVICE",
+): Command & {
+  execute: ReturnType<typeof vi.fn>;
+  undo: ReturnType<typeof vi.fn>;
+} {
+  return {
+    type,
+    description,
+    timestamp: Date.now(),
+    execute: vi.fn(),
+    undo: vi.fn(),
+  };
 }
 
 // =============================================================================
@@ -158,26 +165,28 @@ export function createMockCommand(
 /**
  * Creates default LayoutSettings.
  */
-export function createTestLayoutSettings(overrides: Partial<LayoutSettings> = {}): LayoutSettings {
-	return {
-		display_mode: 'label',
-		show_labels_on_images: false,
-		...overrides
-	};
+export function createTestLayoutSettings(
+  overrides: Partial<LayoutSettings> = {},
+): LayoutSettings {
+  return {
+    display_mode: "label",
+    show_labels_on_images: false,
+    ...overrides,
+  };
 }
 
 /**
  * Creates a complete test Layout.
  */
 export function createTestLayout(overrides: Partial<Layout> = {}): Layout {
-	return {
-		version: '1.0',
-		name: 'Test Layout',
-		rack: createTestRack(),
-		device_types: [],
-		settings: createTestLayoutSettings(),
-		...overrides
-	};
+  return {
+    version: "1.0",
+    name: "Test Layout",
+    rack: createTestRack(),
+    device_types: [],
+    settings: createTestLayoutSettings(),
+    ...overrides,
+  };
 }
 
 // =============================================================================
@@ -189,27 +198,27 @@ export function createTestLayout(overrides: Partial<Layout> = {}): Layout {
  * Useful when you need multiple device types.
  */
 export function createTestDeviceLibrary(): DeviceType[] {
-	return [
-		createTestDeviceType({ slug: 'server-1', u_height: 2, category: 'server' }),
-		createTestDeviceType({
-			slug: 'switch-1',
-			u_height: 1,
-			category: 'network',
-			colour: '#50FA7B'
-		}),
-		createTestDeviceType({
-			slug: 'pdu-1',
-			u_height: 1,
-			category: 'power',
-			colour: '#FFB86C'
-		}),
-		createTestDeviceType({
-			slug: 'half-depth-device',
-			u_height: 1,
-			is_full_depth: false,
-			category: 'network'
-		})
-	];
+  return [
+    createTestDeviceType({ slug: "server-1", u_height: 2, category: "server" }),
+    createTestDeviceType({
+      slug: "switch-1",
+      u_height: 1,
+      category: "network",
+      colour: "#50FA7B",
+    }),
+    createTestDeviceType({
+      slug: "pdu-1",
+      u_height: 1,
+      category: "power",
+      colour: "#FFB86C",
+    }),
+    createTestDeviceType({
+      slug: "half-depth-device",
+      u_height: 1,
+      is_full_depth: false,
+      category: "network",
+    }),
+  ];
 }
 
 // =============================================================================
@@ -221,13 +230,13 @@ export function createTestDeviceLibrary(): DeviceType[] {
  * Import these instead of hardcoding values in tests.
  */
 export const TEST_CONSTANTS = {
-	/** Height of one rack unit in pixels */
-	U_HEIGHT: 22,
-	/** Padding around rack content */
-	RACK_PADDING: 4,
-	/** Width of mounting rails */
-	RAIL_WIDTH: 17,
-	/** Standard rack widths */
-	RACK_WIDTH_10: 110,
-	RACK_WIDTH_19: 220
+  /** Height of one rack unit in pixels */
+  U_HEIGHT: 22,
+  /** Padding around rack content */
+  RACK_PADDING: 4,
+  /** Width of mounting rails */
+  RAIL_WIDTH: 17,
+  /** Standard rack widths */
+  RACK_WIDTH_10: 110,
+  RACK_WIDTH_19: 220,
 } as const;

--- a/src/tests/yaml.test.ts
+++ b/src/tests/yaml.test.ts
@@ -121,6 +121,7 @@ describe("v0.2 Layout YAML Serialization", () => {
       height: 42,
       width: 19,
       desc_units: false,
+      show_rear: true,
       form_factor: "4-post-cabinet",
       starting_unit: 1,
       position: 0,


### PR DESCRIPTION
## Summary
- Add `show_rear` boolean property to Rack type (default: true)
- Add "Show Rear View" toggle in EditPanel when rack is selected
- RackDualView conditionally renders rear view based on `show_rear`
- PNG/PDF exports respect the per-rack `show_rear` setting
- Backward compatible: older layouts default to showing rear view

## Test plan
- [x] Verify toggle appears in EditPanel when rack is selected
- [x] Verify toggling "Hide" removes rear view from canvas
- [x] Verify toggling "Show" restores rear view on canvas
- [x] Verify PNG export respects show_rear setting
- [x] Verify PDF export respects show_rear setting
- [x] Verify older layouts without show_rear default to showing rear

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added per-rack "Show Rear View" toggle control to independently display or hide rear views for each rack on the canvas. Rear view is enabled by default. Rendering and export functionality now properly handle mixed configurations where some racks show both front and rear views while others display front-only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->