### PR TITLE
chore: Restore Dracula purple logo with white brand text (#233)

### DIFF
--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -1,10 +1,12 @@
 <!--
   LogoLockup Component
   Logo + title lockup for toolbar branding
-  White by default, rainbow gradient on hover, celebrate on success
-  Showcase mode: slow rainbow wave for About/Help display
+  Logo mark: Dracula purple by default, rainbow gradient on hover
+  Brand text: White by default, rainbow gradient on hover
+  Celebrate on success, Showcase mode: slow rainbow wave for About/Help
 
   v4: DRackula prefix for dev/local environments (blood-red D)
+  v5: Purple logo mark with white brand text (restoring Dracula theming)
 -->
 <script lang="ts">
   import SantaHat from "./SantaHat.svelte";
@@ -290,18 +292,20 @@
     z-index: 1;
   }
 
-  .logo-mark,
+  .logo-mark {
+    /* Dracula purple by default, gradient on hover/special states */
+    fill: var(--dracula-purple, #bd93f9);
+    transition: fill 0.3s ease;
+    flex-shrink: 0;
+    filter: drop-shadow(0 0 6px rgba(189, 147, 249, 0.2));
+    /* Align mark baseline with text baseline */
+    margin-bottom: -2px;
+  }
+
   .logo-title text {
     /* White by default, gradient on hover/special states */
     fill: var(--dracula-foreground, #f8f8f2);
     transition: fill 0.3s ease;
-  }
-
-  .logo-mark {
-    flex-shrink: 0;
-    filter: drop-shadow(0 0 6px rgba(248, 248, 242, 0.15));
-    /* Align mark baseline with text baseline */
-    margin-bottom: -2px;
   }
 
   .logo-title {
@@ -373,24 +377,31 @@
 
   /* Respect reduced motion preference */
   @media (prefers-reduced-motion: reduce) {
-    .logo-mark,
+    .logo-mark {
+      /* Purple by default (matches normal state) */
+      fill: var(--dracula-purple, #bd93f9);
+      filter: drop-shadow(0 0 6px rgba(189, 147, 249, 0.2));
+    }
+
     .logo-title text {
       /* White by default, static purple on hover/special states */
       fill: var(--dracula-foreground, #f8f8f2);
     }
 
-    .logo-mark,
     .logo-title {
       filter: drop-shadow(0 0 6px rgba(248, 248, 242, 0.15));
     }
 
-    /* Static purple for hover state (no animation) */
-    .logo-mark--hover,
+    /* Static purple for hover state (no animation) - logo stays purple, text goes purple */
+    .logo-mark--hover {
+      fill: var(--dracula-purple) !important;
+      filter: drop-shadow(0 0 8px rgba(189, 147, 249, 0.3));
+    }
+
     .logo-title--hover text {
       fill: var(--dracula-purple) !important;
     }
 
-    .logo-mark--hover,
     .logo-title--hover {
       filter: drop-shadow(0 0 8px rgba(189, 147, 249, 0.2));
     }


### PR DESCRIPTION
## Summary
- Restores Dracula purple (`#bd93f9`) for the logo mark by default
- Keeps brand text "Rackula" white by default
- Preserves rainbow gradient hover behavior for both elements

## Changes
- Logo mark: Dracula purple fill with purple glow
- Brand text: White fill with white glow  
- On hover: Both get rainbow gradient animation
- Updated reduced-motion styles for consistency

## Test Plan
- [x] LogoLockup tests pass (34/34)
- [x] Build succeeds
- [ ] Visual: logo mark appears purple on load
- [ ] Visual: brand text appears white on load
- [ ] Visual: hover triggers rainbow gradient on both elements

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed logo appearance with Dracula purple mark by default and white title text featuring gradient effects on interaction.
  * Improved reduced-motion accessibility with maintained visual consistency across all states.
  * Preserved all existing feature flags and environment-specific styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->