### PR TITLE
feat: add DeskPi brand pack for 10-inch rack accessories (#226)

### DIFF
--- a/src/lib/data/brandPacks/deskpi.ts
+++ b/src/lib/data/brandPacks/deskpi.ts
@@ -1,0 +1,100 @@
+/**
+ * DeskPi Brand Pack
+ * Pre-defined device types for DeskPi 10-inch rack accessories
+ * Popular homelab brand for Raspberry Pi rack mounting solutions
+ */
+
+import type { DeviceType } from "$lib/types";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
+
+/**
+ * DeskPi device definitions
+ * Primarily 10-inch rack compatible devices for Raspberry Pi and networking
+ */
+export const deskpiDevices: DeviceType[] = [
+  // ============================================
+  // Patch Panels
+  // ============================================
+  {
+    slug: "deskpi-12-port-patch-panel-0-5u",
+    u_height: 0.5,
+    manufacturer: "DeskPi",
+    model: "12-Port CAT6 Patch Panel",
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS["patch-panel"],
+    category: "patch-panel",
+  },
+  {
+    slug: "deskpi-12-port-keystone-patch-panel-1u",
+    u_height: 1,
+    manufacturer: "DeskPi",
+    model: "12-Port CAT6 Keystone Patch Panel",
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS["patch-panel"],
+    category: "patch-panel",
+  },
+  {
+    slug: "deskpi-d-type-patch-panel-1u",
+    u_height: 1,
+    manufacturer: "DeskPi",
+    model: "7D D-Type Patch Panel",
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS["patch-panel"],
+    category: "patch-panel",
+  },
+
+  // ============================================
+  // Raspberry Pi Rack Mounts
+  // ============================================
+  {
+    slug: "deskpi-rackmate-1u-2-pi",
+    u_height: 1,
+    manufacturer: "DeskPi",
+    model: "RackMate 1U (2x Raspberry Pi)",
+    is_full_depth: false,
+    airflow: "passive",
+    colour: CATEGORY_COLOURS.server,
+    category: "server",
+  },
+  {
+    slug: "deskpi-rackmate-2u-4-pi",
+    u_height: 2,
+    manufacturer: "DeskPi",
+    model: "RackMate 2U (4x Raspberry Pi)",
+    is_full_depth: false,
+    airflow: "passive",
+    colour: CATEGORY_COLOURS.server,
+    category: "server",
+  },
+
+  // ============================================
+  // Rack Accessories
+  // ============================================
+  {
+    slug: "deskpi-brush-panel-0-5u",
+    u_height: 0.5,
+    manufacturer: "DeskPi",
+    model: "Brush Cable Manager",
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS["cable-management"],
+    category: "cable-management",
+  },
+  {
+    slug: "deskpi-vented-shelf-0-5u",
+    u_height: 0.5,
+    manufacturer: "DeskPi",
+    model: "Vented Rack Shelf",
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS.shelf,
+    category: "shelf",
+  },
+  {
+    slug: "deskpi-rack-shelf-1u",
+    u_height: 1,
+    manufacturer: "DeskPi",
+    model: "Rack Shelf",
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS.shelf,
+    category: "shelf",
+  },
+];

--- a/src/lib/data/brandPacks/index.ts
+++ b/src/lib/data/brandPacks/index.ts
@@ -3,57 +3,59 @@
  * Exports all brand-specific device packs
  */
 
-import type { DeviceType } from '$lib/types';
-import { ubiquitiDevices } from './ubiquiti';
-import { mikrotikDevices } from './mikrotik';
-import { tplinkDevices } from './tp-link';
-import { synologyDevices } from './synology';
-import { apcDevices } from './apc';
-import { dellDevices } from './dell';
-import { supermicroDevices } from './supermicro';
-import { hpeDevices } from './hpe';
+import type { DeviceType } from "$lib/types";
+import { ubiquitiDevices } from "./ubiquiti";
+import { mikrotikDevices } from "./mikrotik";
+import { tplinkDevices } from "./tp-link";
+import { synologyDevices } from "./synology";
+import { apcDevices } from "./apc";
+import { dellDevices } from "./dell";
+import { supermicroDevices } from "./supermicro";
+import { hpeDevices } from "./hpe";
 // New brand packs
-import { fortinetDevices } from './fortinet';
-import { eatonDevices } from './eaton';
-import { netgearDevices } from './netgear';
-import { paloaltoDevices } from './palo-alto';
-import { qnapDevices } from './qnap';
-import { lenovoDevices } from './lenovo';
-import { cyberpowerDevices } from './cyberpower';
-import { netgateDevices } from './netgate';
-import { blackmagicdesignDevices } from './blackmagicdesign';
+import { fortinetDevices } from "./fortinet";
+import { eatonDevices } from "./eaton";
+import { netgearDevices } from "./netgear";
+import { paloaltoDevices } from "./palo-alto";
+import { qnapDevices } from "./qnap";
+import { lenovoDevices } from "./lenovo";
+import { cyberpowerDevices } from "./cyberpower";
+import { netgateDevices } from "./netgate";
+import { blackmagicdesignDevices } from "./blackmagicdesign";
+import { deskpiDevices } from "./deskpi";
 
 export {
-	ubiquitiDevices,
-	mikrotikDevices,
-	tplinkDevices,
-	synologyDevices,
-	apcDevices,
-	dellDevices,
-	supermicroDevices,
-	hpeDevices,
-	// New brand packs
-	fortinetDevices,
-	eatonDevices,
-	netgearDevices,
-	paloaltoDevices,
-	qnapDevices,
-	lenovoDevices,
-	cyberpowerDevices,
-	netgateDevices,
-	blackmagicdesignDevices
+  ubiquitiDevices,
+  mikrotikDevices,
+  tplinkDevices,
+  synologyDevices,
+  apcDevices,
+  dellDevices,
+  supermicroDevices,
+  hpeDevices,
+  // New brand packs
+  fortinetDevices,
+  eatonDevices,
+  netgearDevices,
+  paloaltoDevices,
+  qnapDevices,
+  lenovoDevices,
+  cyberpowerDevices,
+  netgateDevices,
+  blackmagicdesignDevices,
+  deskpiDevices,
 };
 
 /**
  * Brand section data structure
  */
 export interface BrandSection {
-	id: string;
-	title: string;
-	devices: DeviceType[];
-	defaultExpanded: boolean;
-	/** simple-icons slug for brand logo, undefined for fallback icon */
-	icon?: string;
+  id: string;
+  title: string;
+  devices: DeviceType[];
+  defaultExpanded: boolean;
+  /** simple-icons slug for brand logo, undefined for fallback icon */
+  icon?: string;
 }
 
 /**
@@ -61,174 +63,183 @@ export interface BrandSection {
  * Does not include the generic section (that comes from the layout store)
  */
 export function getBrandPacks(): BrandSection[] {
-	return [
-		// Network Equipment
-		{
-			id: 'ubiquiti',
-			title: 'Ubiquiti',
-			devices: ubiquitiDevices,
-			defaultExpanded: false,
-			icon: 'ubiquiti'
-		},
-		{
-			id: 'mikrotik',
-			title: 'MikroTik',
-			devices: mikrotikDevices,
-			defaultExpanded: false,
-			icon: 'mikrotik'
-		},
-		{
-			id: 'tp-link',
-			title: 'TP-Link',
-			devices: tplinkDevices,
-			defaultExpanded: false,
-			icon: 'tplink'
-		},
-		{
-			id: 'fortinet',
-			title: 'Fortinet',
-			devices: fortinetDevices,
-			defaultExpanded: false,
-			icon: 'fortinet'
-		},
-		{
-			id: 'netgear',
-			title: 'Netgear',
-			devices: netgearDevices,
-			defaultExpanded: false,
-			icon: 'netgear'
-		},
-		{
-			id: 'palo-alto',
-			title: 'Palo Alto',
-			devices: paloaltoDevices,
-			defaultExpanded: false,
-			icon: 'paloaltonetworks'
-		},
-		{
-			id: 'netgate',
-			title: 'Netgate',
-			devices: netgateDevices,
-			defaultExpanded: false
-		},
-		// Storage
-		{
-			id: 'synology',
-			title: 'Synology',
-			devices: synologyDevices,
-			defaultExpanded: false,
-			icon: 'synology'
-		},
-		{
-			id: 'qnap',
-			title: 'QNAP',
-			devices: qnapDevices,
-			defaultExpanded: false,
-			icon: 'qnap'
-		},
-		// Power
-		{
-			id: 'apc',
-			title: 'APC',
-			devices: apcDevices,
-			defaultExpanded: false,
-			icon: 'schneiderelectric'
-		},
-		{
-			id: 'eaton',
-			title: 'Eaton',
-			devices: eatonDevices,
-			defaultExpanded: false,
-			icon: 'eaton'
-		},
-		{
-			id: 'cyberpower',
-			title: 'CyberPower',
-			devices: cyberpowerDevices,
-			defaultExpanded: false
-		},
-		// Servers
-		{
-			id: 'dell',
-			title: 'Dell',
-			devices: dellDevices,
-			defaultExpanded: false,
-			icon: 'dell'
-		},
-		{
-			id: 'supermicro',
-			title: 'Supermicro',
-			devices: supermicroDevices,
-			defaultExpanded: false,
-			icon: 'supermicro'
-		},
-		{
-			id: 'hpe',
-			title: 'HPE',
-			devices: hpeDevices,
-			defaultExpanded: false,
-			icon: 'hp'
-		},
-		{
-			id: 'lenovo',
-			title: 'Lenovo',
-			devices: lenovoDevices,
-			defaultExpanded: false,
-			icon: 'lenovo'
-		},
-		// AV/Media
-		{
-			id: 'blackmagicdesign',
-			title: 'Blackmagic Design',
-			devices: blackmagicdesignDevices,
-			defaultExpanded: false,
-			icon: 'blackmagicdesign'
-		}
-	];
+  return [
+    // Network Equipment
+    {
+      id: "ubiquiti",
+      title: "Ubiquiti",
+      devices: ubiquitiDevices,
+      defaultExpanded: false,
+      icon: "ubiquiti",
+    },
+    {
+      id: "mikrotik",
+      title: "MikroTik",
+      devices: mikrotikDevices,
+      defaultExpanded: false,
+      icon: "mikrotik",
+    },
+    {
+      id: "tp-link",
+      title: "TP-Link",
+      devices: tplinkDevices,
+      defaultExpanded: false,
+      icon: "tplink",
+    },
+    {
+      id: "fortinet",
+      title: "Fortinet",
+      devices: fortinetDevices,
+      defaultExpanded: false,
+      icon: "fortinet",
+    },
+    {
+      id: "netgear",
+      title: "Netgear",
+      devices: netgearDevices,
+      defaultExpanded: false,
+      icon: "netgear",
+    },
+    {
+      id: "palo-alto",
+      title: "Palo Alto",
+      devices: paloaltoDevices,
+      defaultExpanded: false,
+      icon: "paloaltonetworks",
+    },
+    {
+      id: "netgate",
+      title: "Netgate",
+      devices: netgateDevices,
+      defaultExpanded: false,
+    },
+    // Storage
+    {
+      id: "synology",
+      title: "Synology",
+      devices: synologyDevices,
+      defaultExpanded: false,
+      icon: "synology",
+    },
+    {
+      id: "qnap",
+      title: "QNAP",
+      devices: qnapDevices,
+      defaultExpanded: false,
+      icon: "qnap",
+    },
+    // Power
+    {
+      id: "apc",
+      title: "APC",
+      devices: apcDevices,
+      defaultExpanded: false,
+      icon: "schneiderelectric",
+    },
+    {
+      id: "eaton",
+      title: "Eaton",
+      devices: eatonDevices,
+      defaultExpanded: false,
+      icon: "eaton",
+    },
+    {
+      id: "cyberpower",
+      title: "CyberPower",
+      devices: cyberpowerDevices,
+      defaultExpanded: false,
+    },
+    // Servers
+    {
+      id: "dell",
+      title: "Dell",
+      devices: dellDevices,
+      defaultExpanded: false,
+      icon: "dell",
+    },
+    {
+      id: "supermicro",
+      title: "Supermicro",
+      devices: supermicroDevices,
+      defaultExpanded: false,
+      icon: "supermicro",
+    },
+    {
+      id: "hpe",
+      title: "HPE",
+      devices: hpeDevices,
+      defaultExpanded: false,
+      icon: "hp",
+    },
+    {
+      id: "lenovo",
+      title: "Lenovo",
+      devices: lenovoDevices,
+      defaultExpanded: false,
+      icon: "lenovo",
+    },
+    // AV/Media
+    {
+      id: "blackmagicdesign",
+      title: "Blackmagic Design",
+      devices: blackmagicdesignDevices,
+      defaultExpanded: false,
+      icon: "blackmagicdesign",
+    },
+    // Homelab Accessories
+    {
+      id: "deskpi",
+      title: "DeskPi",
+      devices: deskpiDevices,
+      defaultExpanded: false,
+    },
+  ];
 }
 
 /**
  * Get devices for a specific brand
  */
 export function getBrandDevices(brandId: string): DeviceType[] {
-	switch (brandId) {
-		case 'ubiquiti':
-			return ubiquitiDevices;
-		case 'mikrotik':
-			return mikrotikDevices;
-		case 'tp-link':
-			return tplinkDevices;
-		case 'synology':
-			return synologyDevices;
-		case 'apc':
-			return apcDevices;
-		case 'dell':
-			return dellDevices;
-		case 'supermicro':
-			return supermicroDevices;
-		case 'hpe':
-			return hpeDevices;
-		case 'fortinet':
-			return fortinetDevices;
-		case 'eaton':
-			return eatonDevices;
-		case 'netgear':
-			return netgearDevices;
-		case 'palo-alto':
-			return paloaltoDevices;
-		case 'qnap':
-			return qnapDevices;
-		case 'lenovo':
-			return lenovoDevices;
-		case 'cyberpower':
-			return cyberpowerDevices;
-		case 'netgate':
-			return netgateDevices;
-		case 'blackmagicdesign':
-			return blackmagicdesignDevices;
-		default:
-			return [];
-	}
+  switch (brandId) {
+    case "ubiquiti":
+      return ubiquitiDevices;
+    case "mikrotik":
+      return mikrotikDevices;
+    case "tp-link":
+      return tplinkDevices;
+    case "synology":
+      return synologyDevices;
+    case "apc":
+      return apcDevices;
+    case "dell":
+      return dellDevices;
+    case "supermicro":
+      return supermicroDevices;
+    case "hpe":
+      return hpeDevices;
+    case "fortinet":
+      return fortinetDevices;
+    case "eaton":
+      return eatonDevices;
+    case "netgear":
+      return netgearDevices;
+    case "palo-alto":
+      return paloaltoDevices;
+    case "qnap":
+      return qnapDevices;
+    case "lenovo":
+      return lenovoDevices;
+    case "cyberpower":
+      return cyberpowerDevices;
+    case "netgate":
+      return netgateDevices;
+    case "blackmagicdesign":
+      return blackmagicdesignDevices;
+    case "deskpi":
+      return deskpiDevices;
+    default:
+      return [];
+  }
 }
 
 /**
@@ -236,28 +247,29 @@ export function getBrandDevices(brandId: string): DeviceType[] {
  * @returns The DeviceType if found, undefined otherwise
  */
 export function findBrandDevice(slug: string): DeviceType | undefined {
-	// Search all brand packs
-	const allDevices = [
-		...ubiquitiDevices,
-		...mikrotikDevices,
-		...tplinkDevices,
-		...synologyDevices,
-		...apcDevices,
-		...dellDevices,
-		...supermicroDevices,
-		...hpeDevices,
-		...fortinetDevices,
-		...eatonDevices,
-		...netgearDevices,
-		...paloaltoDevices,
-		...qnapDevices,
-		...lenovoDevices,
-		...cyberpowerDevices,
-		...netgateDevices,
-		...blackmagicdesignDevices
-	];
+  // Search all brand packs
+  const allDevices = [
+    ...ubiquitiDevices,
+    ...mikrotikDevices,
+    ...tplinkDevices,
+    ...synologyDevices,
+    ...apcDevices,
+    ...dellDevices,
+    ...supermicroDevices,
+    ...hpeDevices,
+    ...fortinetDevices,
+    ...eatonDevices,
+    ...netgearDevices,
+    ...paloaltoDevices,
+    ...qnapDevices,
+    ...lenovoDevices,
+    ...cyberpowerDevices,
+    ...netgateDevices,
+    ...blackmagicdesignDevices,
+    ...deskpiDevices,
+  ];
 
-	return allDevices.find((d) => d.slug === slug);
+  return allDevices.find((d) => d.slug === slug);
 }
 
 // Cached set of all brand device slugs
@@ -268,27 +280,28 @@ let brandSlugsCache: Set<string> | null = null;
  * Used to distinguish brand devices from custom devices
  */
 export function getBrandSlugs(): Set<string> {
-	if (!brandSlugsCache) {
-		const allDevices = [
-			...ubiquitiDevices,
-			...mikrotikDevices,
-			...tplinkDevices,
-			...synologyDevices,
-			...apcDevices,
-			...dellDevices,
-			...supermicroDevices,
-			...hpeDevices,
-			...fortinetDevices,
-			...eatonDevices,
-			...netgearDevices,
-			...paloaltoDevices,
-			...qnapDevices,
-			...lenovoDevices,
-			...cyberpowerDevices,
-			...netgateDevices,
-			...blackmagicdesignDevices
-		];
-		brandSlugsCache = new Set(allDevices.map((d) => d.slug));
-	}
-	return brandSlugsCache;
+  if (!brandSlugsCache) {
+    const allDevices = [
+      ...ubiquitiDevices,
+      ...mikrotikDevices,
+      ...tplinkDevices,
+      ...synologyDevices,
+      ...apcDevices,
+      ...dellDevices,
+      ...supermicroDevices,
+      ...hpeDevices,
+      ...fortinetDevices,
+      ...eatonDevices,
+      ...netgearDevices,
+      ...paloaltoDevices,
+      ...qnapDevices,
+      ...lenovoDevices,
+      ...cyberpowerDevices,
+      ...netgateDevices,
+      ...blackmagicdesignDevices,
+      ...deskpiDevices,
+    ];
+    brandSlugsCache = new Set(allDevices.map((d) => d.slug));
+  }
+  return brandSlugsCache;
 }


### PR DESCRIPTION
## Summary
- Add DeskPi brand pack with 8 devices for 10-inch rack homelab setups
- DeskPi is popular for Raspberry Pi rack mounting and 10-inch network accessories
- Mikrotik coverage was already comprehensive (57 devices) - no changes needed

## Devices Added
- 12-Port CAT6 Patch Panel (0.5U)
- 12-Port CAT6 Keystone Patch Panel (1U)
- 7D D-Type Patch Panel (1U)
- RackMate 1U (2x Raspberry Pi)
- RackMate 2U (4x Raspberry Pi)
- Brush Cable Manager (0.5U)
- Vented Rack Shelf (0.5U)
- Rack Shelf (1U)

## Files Changed
- `src/lib/data/brandPacks/deskpi.ts` - New DeskPi brand pack
- `src/lib/data/brandPacks/index.ts` - Register DeskPi in brand pack system

## Test Plan
- [x] Lint passes
- [x] Build succeeds
- [x] DeskPi devices load correctly (verified via tsx)
- [ ] Manual verification in dev environment

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeskPi brand pack to the system with pre-configured, rack-compatible device definitions. Includes patch panels in multiple form factors, Raspberry Pi rack mounts available in 1U and 2U configurations with varying capacity options, and complementary rack accessories including cable management and shelving solutions. All devices are now available throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->