### PR TITLE
feat: show depth indicator on device library items (#240)

### DIFF
--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -106,6 +106,13 @@
     />
   {/if}
   <span class="device-height">{device.u_height}U</span>
+  {#if device.is_full_depth === false}
+    <span
+      class="depth-indicator"
+      title="Half-depth: Mounts on one face only"
+      aria-label="Half-depth device">½D</span
+    >
+  {/if}
 </div>
 
 <style>
@@ -190,5 +197,16 @@
     font-weight: var(--font-weight-semibold);
     color: var(--colour-text);
     flex-shrink: 0;
+  }
+
+  .depth-indicator {
+    background-color: var(--colour-surface-hover);
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-full);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    color: var(--colour-text-muted);
+    flex-shrink: 0;
+    cursor: help;
   }
 </style>

--- a/src/tests/DevicePaletteItem.test.ts
+++ b/src/tests/DevicePaletteItem.test.ts
@@ -3,316 +3,405 @@
  * Tests for device palette item rendering and interactions
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/svelte';
-import DevicePaletteItem from '$lib/components/DevicePaletteItem.svelte';
-import type { DeviceType } from '$lib/types';
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import DevicePaletteItem from "$lib/components/DevicePaletteItem.svelte";
+import type { DeviceType } from "$lib/types";
 
-describe('DevicePaletteItem', () => {
-	// Helper to create test device
-	function createTestDevice(overrides: Partial<DeviceType> = {}): DeviceType {
-		return {
-			slug: 'test-server',
-			u_height: 2,
-			model: 'Test Server',
-			colour: '#4A90D9',
-			category: 'server',
-			...overrides
-		};
-	}
+describe("DevicePaletteItem", () => {
+  // Helper to create test device
+  function createTestDevice(overrides: Partial<DeviceType> = {}): DeviceType {
+    return {
+      slug: "test-server",
+      u_height: 2,
+      model: "Test Server",
+      colour: "#4A90D9",
+      category: "server",
+      ...overrides,
+    };
+  }
 
-	describe('Rendering', () => {
-		it('renders without crashing', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			expect(document.querySelector('.device-palette-item')).toBeTruthy();
-		});
+  describe("Rendering", () => {
+    it("renders without crashing", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      expect(document.querySelector(".device-palette-item")).toBeTruthy();
+    });
 
-		it('displays the device model name', () => {
-			render(DevicePaletteItem, {
-				props: { device: createTestDevice({ model: 'Dell PowerEdge R740' }) }
-			});
-			expect(screen.getByText('Dell PowerEdge R740')).toBeTruthy();
-		});
+    it("displays the device model name", () => {
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice({ model: "Dell PowerEdge R740" }) },
+      });
+      expect(screen.getByText("Dell PowerEdge R740")).toBeTruthy();
+    });
 
-		it('displays slug when model is not provided', () => {
-			render(DevicePaletteItem, {
-				props: { device: createTestDevice({ model: undefined, slug: 'custom-device' }) }
-			});
-			expect(screen.getByText('custom-device')).toBeTruthy();
-		});
+    it("displays slug when model is not provided", () => {
+      render(DevicePaletteItem, {
+        props: {
+          device: createTestDevice({ model: undefined, slug: "custom-device" }),
+        },
+      });
+      expect(screen.getByText("custom-device")).toBeTruthy();
+    });
 
-		it('displays the device height in U', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice({ u_height: 4 }) } });
-			expect(screen.getByText('4U')).toBeTruthy();
-		});
+    it("displays the device height in U", () => {
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice({ u_height: 4 }) },
+      });
+      expect(screen.getByText("4U")).toBeTruthy();
+    });
 
-		it('displays 0.5U heights correctly', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice({ u_height: 0.5 }) } });
-			expect(screen.getByText('0.5U')).toBeTruthy();
-		});
+    it("displays 0.5U heights correctly", () => {
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice({ u_height: 0.5 }) },
+      });
+      expect(screen.getByText("0.5U")).toBeTruthy();
+    });
 
-		it('renders category icon', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const iconContainer = document.querySelector('.category-icon-indicator');
-			expect(iconContainer).toBeTruthy();
-			expect(iconContainer?.querySelector('.category-icon')).toBeTruthy();
-		});
+    it("renders category icon", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const iconContainer = document.querySelector(".category-icon-indicator");
+      expect(iconContainer).toBeTruthy();
+      expect(iconContainer?.querySelector(".category-icon")).toBeTruthy();
+    });
 
-		it('applies category colour to icon', () => {
-			render(DevicePaletteItem, {
-				props: { device: createTestDevice({ colour: '#FF5500', category: 'network' }) }
-			});
-			const iconContainer = document.querySelector('.category-icon-indicator') as HTMLElement;
-			// happy-dom keeps hex, jsdom converts to rgb
-			expect(['#FF5500', 'rgb(255, 85, 0)']).toContain(iconContainer?.style.color);
-		});
+    it("applies category colour to icon", () => {
+      render(DevicePaletteItem, {
+        props: {
+          device: createTestDevice({ colour: "#FF5500", category: "network" }),
+        },
+      });
+      const iconContainer = document.querySelector(
+        ".category-icon-indicator",
+      ) as HTMLElement;
+      // happy-dom keeps hex, jsdom converts to rgb
+      expect(["#FF5500", "rgb(255, 85, 0)"]).toContain(
+        iconContainer?.style.color,
+      );
+    });
 
-		it('renders drag handle', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			expect(document.querySelector('.drag-handle')).toBeTruthy();
-		});
-	});
+    it("renders drag handle", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      expect(document.querySelector(".drag-handle")).toBeTruthy();
+    });
+  });
 
-	describe('Accessibility', () => {
-		it('has role="listitem"', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const item = document.querySelector('.device-palette-item');
-			expect(item?.getAttribute('role')).toBe('listitem');
-		});
+  describe("Accessibility", () => {
+    it('has role="listitem"', () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const item = document.querySelector(".device-palette-item");
+      expect(item?.getAttribute("role")).toBe("listitem");
+    });
 
-		it('is focusable with tabindex="0"', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const item = document.querySelector('.device-palette-item');
-			expect(item?.getAttribute('tabindex')).toBe('0');
-		});
+    it('is focusable with tabindex="0"', () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const item = document.querySelector(".device-palette-item");
+      expect(item?.getAttribute("tabindex")).toBe("0");
+    });
 
-		it('has descriptive aria-label', () => {
-			render(DevicePaletteItem, {
-				props: { device: createTestDevice({ model: 'Dell R740', u_height: 2 }) }
-			});
-			const item = document.querySelector('.device-palette-item');
-			expect(item?.getAttribute('aria-label')).toBe('Dell R740, 2U server');
-		});
+    it("has descriptive aria-label", () => {
+      render(DevicePaletteItem, {
+        props: {
+          device: createTestDevice({ model: "Dell R740", u_height: 2 }),
+        },
+      });
+      const item = document.querySelector(".device-palette-item");
+      expect(item?.getAttribute("aria-label")).toBe("Dell R740, 2U server");
+    });
 
-		it('drag handle has aria-hidden', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const handle = document.querySelector('.drag-handle');
-			expect(handle?.getAttribute('aria-hidden')).toBe('true');
-		});
-	});
+    it("drag handle has aria-hidden", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const handle = document.querySelector(".drag-handle");
+      expect(handle?.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
 
-	describe('Selection', () => {
-		it('calls onselect when clicked', async () => {
-			const handleSelect = vi.fn();
-			render(DevicePaletteItem, { props: { device: createTestDevice(), onselect: handleSelect } });
+  describe("Selection", () => {
+    it("calls onselect when clicked", async () => {
+      const handleSelect = vi.fn();
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice(), onselect: handleSelect },
+      });
 
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
-			await fireEvent.click(item);
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
+      await fireEvent.click(item);
 
-			expect(handleSelect).toHaveBeenCalledTimes(1);
-		});
+      expect(handleSelect).toHaveBeenCalledTimes(1);
+    });
 
-		it('passes device in CustomEvent detail', async () => {
-			const handleSelect = vi.fn();
-			const device = createTestDevice({ slug: 'my-device' });
-			render(DevicePaletteItem, { props: { device, onselect: handleSelect } });
+    it("passes device in CustomEvent detail", async () => {
+      const handleSelect = vi.fn();
+      const device = createTestDevice({ slug: "my-device" });
+      render(DevicePaletteItem, { props: { device, onselect: handleSelect } });
 
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
-			await fireEvent.click(item);
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
+      await fireEvent.click(item);
 
-			expect(handleSelect).toHaveBeenCalled();
-			const event = handleSelect.mock.calls[0][0] as CustomEvent;
-			expect(event.detail.device.slug).toBe('my-device');
-		});
+      expect(handleSelect).toHaveBeenCalled();
+      const event = handleSelect.mock.calls[0][0] as CustomEvent;
+      expect(event.detail.device.slug).toBe("my-device");
+    });
 
-		it('does not throw when clicked without onselect', async () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
-			await expect(fireEvent.click(item)).resolves.toBe(true);
-		});
+    it("does not throw when clicked without onselect", async () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
+      await expect(fireEvent.click(item)).resolves.toBe(true);
+    });
 
-		it('shows selected state when librarySelected is true', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice(), librarySelected: true } });
-			const item = document.querySelector('.device-palette-item');
-			expect(item?.classList.contains('library-selected')).toBe(true);
-		});
+    it("shows selected state when librarySelected is true", () => {
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice(), librarySelected: true },
+      });
+      const item = document.querySelector(".device-palette-item");
+      expect(item?.classList.contains("library-selected")).toBe(true);
+    });
 
-		it('does not show selected state by default', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const item = document.querySelector('.device-palette-item');
-			expect(item?.classList.contains('library-selected')).toBe(false);
-		});
-	});
+    it("does not show selected state by default", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const item = document.querySelector(".device-palette-item");
+      expect(item?.classList.contains("library-selected")).toBe(false);
+    });
+  });
 
-	describe('Keyboard Navigation', () => {
-		it('triggers select on Enter key', async () => {
-			const handleSelect = vi.fn();
-			render(DevicePaletteItem, { props: { device: createTestDevice(), onselect: handleSelect } });
+  describe("Keyboard Navigation", () => {
+    it("triggers select on Enter key", async () => {
+      const handleSelect = vi.fn();
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice(), onselect: handleSelect },
+      });
 
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
-			await fireEvent.keyDown(item, { key: 'Enter' });
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
+      await fireEvent.keyDown(item, { key: "Enter" });
 
-			expect(handleSelect).toHaveBeenCalledTimes(1);
-		});
+      expect(handleSelect).toHaveBeenCalledTimes(1);
+    });
 
-		it('triggers select on Space key', async () => {
-			const handleSelect = vi.fn();
-			render(DevicePaletteItem, { props: { device: createTestDevice(), onselect: handleSelect } });
+    it("triggers select on Space key", async () => {
+      const handleSelect = vi.fn();
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice(), onselect: handleSelect },
+      });
 
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
-			await fireEvent.keyDown(item, { key: ' ' });
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
+      await fireEvent.keyDown(item, { key: " " });
 
-			expect(handleSelect).toHaveBeenCalledTimes(1);
-		});
+      expect(handleSelect).toHaveBeenCalledTimes(1);
+    });
 
-		it('does not trigger select on other keys', async () => {
-			const handleSelect = vi.fn();
-			render(DevicePaletteItem, { props: { device: createTestDevice(), onselect: handleSelect } });
+    it("does not trigger select on other keys", async () => {
+      const handleSelect = vi.fn();
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice(), onselect: handleSelect },
+      });
 
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
-			await fireEvent.keyDown(item, { key: 'Tab' });
-			await fireEvent.keyDown(item, { key: 'Escape' });
-			await fireEvent.keyDown(item, { key: 'a' });
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
+      await fireEvent.keyDown(item, { key: "Tab" });
+      await fireEvent.keyDown(item, { key: "Escape" });
+      await fireEvent.keyDown(item, { key: "a" });
 
-			expect(handleSelect).not.toHaveBeenCalled();
-		});
-	});
+      expect(handleSelect).not.toHaveBeenCalled();
+    });
+  });
 
-	describe('Drag and Drop', () => {
-		it('has draggable="true"', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const item = document.querySelector('.device-palette-item');
-			expect(item?.getAttribute('draggable')).toBe('true');
-		});
+  describe("Drag and Drop", () => {
+    it('has draggable="true"', () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const item = document.querySelector(".device-palette-item");
+      expect(item?.getAttribute("draggable")).toBe("true");
+    });
 
-		it('sets dragging class on dragstart', async () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
+    it("sets dragging class on dragstart", async () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
 
-			// Create a mock DataTransfer
-			const dataTransfer = {
-				setData: vi.fn(),
-				effectAllowed: ''
-			};
+      // Create a mock DataTransfer
+      const dataTransfer = {
+        setData: vi.fn(),
+        effectAllowed: "",
+      };
 
-			await fireEvent.dragStart(item, { dataTransfer });
+      await fireEvent.dragStart(item, { dataTransfer });
 
-			expect(item.classList.contains('dragging')).toBe(true);
-		});
+      expect(item.classList.contains("dragging")).toBe(true);
+    });
 
-		it('removes dragging class on dragend', async () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
+    it("removes dragging class on dragend", async () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
 
-			// Start drag
-			const dataTransfer = {
-				setData: vi.fn(),
-				effectAllowed: ''
-			};
-			await fireEvent.dragStart(item, { dataTransfer });
-			expect(item.classList.contains('dragging')).toBe(true);
+      // Start drag
+      const dataTransfer = {
+        setData: vi.fn(),
+        effectAllowed: "",
+      };
+      await fireEvent.dragStart(item, { dataTransfer });
+      expect(item.classList.contains("dragging")).toBe(true);
 
-			// End drag
-			await fireEvent.dragEnd(item);
-			expect(item.classList.contains('dragging')).toBe(false);
-		});
+      // End drag
+      await fireEvent.dragEnd(item);
+      expect(item.classList.contains("dragging")).toBe(false);
+    });
 
-		it('sets drag data in dataTransfer on dragstart', async () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice({ slug: 'drag-test' }) } });
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
+    it("sets drag data in dataTransfer on dragstart", async () => {
+      render(DevicePaletteItem, {
+        props: { device: createTestDevice({ slug: "drag-test" }) },
+      });
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
 
-			const setDataMock = vi.fn();
-			const dataTransfer = {
-				setData: setDataMock,
-				effectAllowed: ''
-			};
+      const setDataMock = vi.fn();
+      const dataTransfer = {
+        setData: setDataMock,
+        effectAllowed: "",
+      };
 
-			await fireEvent.dragStart(item, { dataTransfer });
+      await fireEvent.dragStart(item, { dataTransfer });
 
-			expect(setDataMock).toHaveBeenCalledWith('application/json', expect.any(String));
-			const dragData = JSON.parse(setDataMock.mock.calls[0][1]);
-			expect(dragData.type).toBe('palette');
-			expect(dragData.device.slug).toBe('drag-test');
-		});
+      expect(setDataMock).toHaveBeenCalledWith(
+        "application/json",
+        expect.any(String),
+      );
+      const dragData = JSON.parse(setDataMock.mock.calls[0][1]);
+      expect(dragData.type).toBe("palette");
+      expect(dragData.device.slug).toBe("drag-test");
+    });
 
-		// NOTE: happy-dom doesn't properly forward effectAllowed assignments to mock DataTransfer
-		// The component behavior is verified by the actual dragstart working in real browsers
-		it.skip('sets effectAllowed to "copy"', async () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			const item = document.querySelector('.device-palette-item') as HTMLElement;
+    // NOTE: happy-dom doesn't properly forward effectAllowed assignments to mock DataTransfer
+    // The component behavior is verified by the actual dragstart working in real browsers
+    it.skip('sets effectAllowed to "copy"', async () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      const item = document.querySelector(
+        ".device-palette-item",
+      ) as HTMLElement;
 
-			// Use a variable to capture effectAllowed assignment
-			// (happy-dom may not pass through assignments to plain mock objects)
-			let capturedEffectAllowed = '';
-			const dataTransfer = {
-				setData: vi.fn(),
-				get effectAllowed() {
-					return capturedEffectAllowed;
-				},
-				set effectAllowed(value: string) {
-					capturedEffectAllowed = value;
-				}
-			};
+      // Use a variable to capture effectAllowed assignment
+      // (happy-dom may not pass through assignments to plain mock objects)
+      let capturedEffectAllowed = "";
+      const dataTransfer = {
+        setData: vi.fn(),
+        get effectAllowed() {
+          return capturedEffectAllowed;
+        },
+        set effectAllowed(value: string) {
+          capturedEffectAllowed = value;
+        },
+      };
 
-			await fireEvent.dragStart(item, { dataTransfer });
+      await fireEvent.dragStart(item, { dataTransfer });
 
-			expect(capturedEffectAllowed).toBe('copy');
-		});
-	});
+      expect(capturedEffectAllowed).toBe("copy");
+    });
+  });
 
-	describe('Styling Classes', () => {
-		it('has device-palette-item class', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			expect(document.querySelector('.device-palette-item')).toBeTruthy();
-		});
+  describe("Styling Classes", () => {
+    it("has device-palette-item class", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      expect(document.querySelector(".device-palette-item")).toBeTruthy();
+    });
 
-		it('has drag-handle class', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			expect(document.querySelector('.drag-handle')).toBeTruthy();
-		});
+    it("has drag-handle class", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      expect(document.querySelector(".drag-handle")).toBeTruthy();
+    });
 
-		it('has device-name class', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			expect(document.querySelector('.device-name')).toBeTruthy();
-		});
+    it("has device-name class", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      expect(document.querySelector(".device-name")).toBeTruthy();
+    });
 
-		it('has device-height class', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			expect(document.querySelector('.device-height')).toBeTruthy();
-		});
+    it("has device-height class", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      expect(document.querySelector(".device-height")).toBeTruthy();
+    });
 
-		it('has category-icon-indicator class', () => {
-			render(DevicePaletteItem, { props: { device: createTestDevice() } });
-			expect(document.querySelector('.category-icon-indicator')).toBeTruthy();
-		});
-	});
+    it("has category-icon-indicator class", () => {
+      render(DevicePaletteItem, { props: { device: createTestDevice() } });
+      expect(document.querySelector(".category-icon-indicator")).toBeTruthy();
+    });
+  });
 
-	describe('Device Categories', () => {
-		const categories = [
-			'server',
-			'network',
-			'patch-panel',
-			'power',
-			'storage',
-			'kvm',
-			'av-media',
-			'cooling',
-			'shelf',
-			'blank',
-			'cable-management',
-			'other'
-		] as const;
+  describe("Depth Indicator", () => {
+    it("renders depth indicator for half-depth devices", () => {
+      const device = createTestDevice({ is_full_depth: false });
+      render(DevicePaletteItem, { props: { device } });
+      const indicator = document.querySelector(".depth-indicator");
+      expect(indicator).toBeTruthy();
+      expect(indicator?.textContent?.trim()).toBe("½D");
+    });
 
-		categories.forEach((category) => {
-			it(`renders ${category} category correctly`, () => {
-				const device = createTestDevice({
-					colour: '#123456',
-					category
-				});
-				render(DevicePaletteItem, { props: { device } });
-				const item = document.querySelector('.device-palette-item');
-				expect(item?.getAttribute('aria-label')).toContain(category);
-			});
-		});
-	});
+    it("does not render depth indicator for full-depth devices (explicit)", () => {
+      const device = createTestDevice({ is_full_depth: true });
+      render(DevicePaletteItem, { props: { device } });
+      const indicator = document.querySelector(".depth-indicator");
+      expect(indicator).toBeNull();
+    });
+
+    it("does not render depth indicator when is_full_depth is undefined (defaults to full-depth)", () => {
+      const device = createTestDevice(); // is_full_depth undefined
+      render(DevicePaletteItem, { props: { device } });
+      const indicator = document.querySelector(".depth-indicator");
+      expect(indicator).toBeNull();
+    });
+
+    it("depth indicator has accessible title attribute", () => {
+      const device = createTestDevice({ is_full_depth: false });
+      render(DevicePaletteItem, { props: { device } });
+      const indicator = document.querySelector(".depth-indicator");
+      expect(indicator?.getAttribute("title")).toBe(
+        "Half-depth: Mounts on one face only",
+      );
+    });
+
+    it("depth indicator has aria-label for screen readers", () => {
+      const device = createTestDevice({ is_full_depth: false });
+      render(DevicePaletteItem, { props: { device } });
+      const indicator = document.querySelector(".depth-indicator");
+      expect(indicator?.getAttribute("aria-label")).toBe("Half-depth device");
+    });
+  });
+
+  describe("Device Categories", () => {
+    const categories = [
+      "server",
+      "network",
+      "patch-panel",
+      "power",
+      "storage",
+      "kvm",
+      "av-media",
+      "cooling",
+      "shelf",
+      "blank",
+      "cable-management",
+      "other",
+    ] as const;
+
+    categories.forEach((category) => {
+      it(`renders ${category} category correctly`, () => {
+        const device = createTestDevice({
+          colour: "#123456",
+          category,
+        });
+        render(DevicePaletteItem, { props: { device } });
+        const item = document.querySelector(".device-palette-item");
+        expect(item?.getAttribute("aria-label")).toContain(category);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add a visual "½D" badge to DevicePaletteItem for half-depth devices. This helps users understand which face a device will occupy before placing it.

## Changes

- **DevicePaletteItem.svelte**: Add depth indicator badge after height badge
  - Only shows for half-depth devices (`is_full_depth === false`)
  - Includes tooltip: "Half-depth: Mounts on one face only"
  - Accessible with `aria-label` for screen readers
  - Styled consistently with existing height badge

## Test Plan

- [x] Unit test: renders depth indicator for half-depth devices
- [x] Unit test: does not render indicator for full-depth devices (explicit)
- [x] Unit test: does not render indicator when `is_full_depth` is undefined
- [x] Unit test: indicator has accessible title attribute
- [x] Unit test: indicator has proper aria-label
- [x] Lint passes
- [x] Build passes

## Visual Example

```
⠿ 🖥️ Dell R740          [img] 2U
⠿ 🔌 Patch Panel        [img] 1U ½D
```

Closes #240
Related to #227, #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a visual depth indicator badge ("½D") to device listings for devices that don't support full depth, providing clearer information about device dimensions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->