### PR TITLE
feat: add depth toggle to Add Device form (#241)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -555,6 +555,7 @@
     category: import("$lib/types").DeviceCategory;
     colour: string;
     notes: string;
+    isFullDepth: boolean;
     frontImage?: ImageData;
     rearImage?: ImageData;
   }) {
@@ -564,6 +565,7 @@
       category: data.category,
       colour: data.colour,
       comments: data.notes || undefined,
+      is_full_depth: data.isFullDepth ? undefined : false,
     });
 
     // Store images if provided (v0.1.0)

--- a/src/lib/components/AddDeviceForm.svelte
+++ b/src/lib/components/AddDeviceForm.svelte
@@ -3,405 +3,503 @@
   Form dialog for adding a new device to the library
 -->
 <script lang="ts">
-	import Dialog from './Dialog.svelte';
-	import ImageUpload from './ImageUpload.svelte';
-	import type { DeviceCategory } from '$lib/types';
-	import type { ImageData } from '$lib/types/images';
-	import {
-		ALL_CATEGORIES,
-		CATEGORY_COLOURS,
-		MIN_DEVICE_HEIGHT,
-		MAX_DEVICE_HEIGHT
-	} from '$lib/types/constants';
-	import { getDefaultColour } from '$lib/utils/device';
+  import Dialog from "./Dialog.svelte";
+  import ImageUpload from "./ImageUpload.svelte";
+  import type { DeviceCategory } from "$lib/types";
+  import type { ImageData } from "$lib/types/images";
+  import {
+    ALL_CATEGORIES,
+    CATEGORY_COLOURS,
+    MIN_DEVICE_HEIGHT,
+    MAX_DEVICE_HEIGHT,
+  } from "$lib/types/constants";
+  import { getDefaultColour } from "$lib/utils/device";
 
-	interface Props {
-		open: boolean;
-		onadd?: (data: {
-			name: string;
-			height: number;
-			category: DeviceCategory;
-			colour: string;
-			notes: string;
-			frontImage?: ImageData;
-			rearImage?: ImageData;
-		}) => void;
-		oncancel?: () => void;
-	}
+  interface Props {
+    open: boolean;
+    onadd?: (data: {
+      name: string;
+      height: number;
+      category: DeviceCategory;
+      colour: string;
+      notes: string;
+      isFullDepth: boolean;
+      frontImage?: ImageData;
+      rearImage?: ImageData;
+    }) => void;
+    oncancel?: () => void;
+  }
 
-	let { open, onadd, oncancel }: Props = $props();
+  let { open, onadd, oncancel }: Props = $props();
 
-	// Form state
-	let name = $state('');
-	let height = $state(1);
-	let category = $state<DeviceCategory>('server');
-	let colour = $state(getDefaultColour('server'));
-	let notes = $state('');
-	let userChangedColour = $state(false);
+  // Form state
+  let name = $state("");
+  let height = $state(1);
+  let category = $state<DeviceCategory>("server");
+  let colour = $state(getDefaultColour("server"));
+  let notes = $state("");
+  let isFullDepth = $state(true);
+  let userChangedColour = $state(false);
 
-	// Image state (v0.1.0)
-	let frontImage = $state<ImageData | undefined>(undefined);
-	let rearImage = $state<ImageData | undefined>(undefined);
+  // Image state (v0.1.0)
+  let frontImage = $state<ImageData | undefined>(undefined);
+  let rearImage = $state<ImageData | undefined>(undefined);
 
-	// Validation errors
-	let nameError = $state('');
-	let heightError = $state('');
+  // Validation errors
+  let nameError = $state("");
+  let heightError = $state("");
 
-	// Reset form when dialog opens
-	$effect(() => {
-		if (open) {
-			name = '';
-			height = 1;
-			category = 'server';
-			colour = getDefaultColour('server');
-			notes = '';
-			userChangedColour = false;
-			nameError = '';
-			heightError = '';
-			// Reset images (v0.1.0)
-			frontImage = undefined;
-			rearImage = undefined;
-		}
-	});
+  // Reset form when dialog opens
+  $effect(() => {
+    if (open) {
+      name = "";
+      height = 1;
+      category = "server";
+      colour = getDefaultColour("server");
+      notes = "";
+      isFullDepth = true;
+      userChangedColour = false;
+      nameError = "";
+      heightError = "";
+      // Reset images (v0.1.0)
+      frontImage = undefined;
+      rearImage = undefined;
+    }
+  });
 
-	// Update colour when category changes (unless user manually changed it)
-	function handleCategoryChange(event: Event) {
-		const newCategory = (event.target as HTMLSelectElement).value as DeviceCategory;
-		category = newCategory;
-		if (!userChangedColour) {
-			colour = getDefaultColour(newCategory);
-		}
-	}
+  // Update colour when category changes (unless user manually changed it)
+  function handleCategoryChange(event: Event) {
+    const newCategory = (event.target as HTMLSelectElement)
+      .value as DeviceCategory;
+    category = newCategory;
+    if (!userChangedColour) {
+      colour = getDefaultColour(newCategory);
+    }
+  }
 
-	function handleColourChange(event: Event) {
-		colour = (event.target as HTMLInputElement).value;
-		userChangedColour = true;
-	}
+  function handleColourChange(event: Event) {
+    colour = (event.target as HTMLInputElement).value;
+    userChangedColour = true;
+  }
 
-	function getCategoryLabel(cat: DeviceCategory): string {
-		const labels: Record<DeviceCategory, string> = {
-			server: 'Server',
-			network: 'Network',
-			'patch-panel': 'Patch Panel',
-			power: 'Power',
-			storage: 'Storage',
-			kvm: 'KVM',
-			'av-media': 'AV/Media',
-			cooling: 'Cooling',
-			shelf: 'Shelf',
-			blank: 'Blank Panel',
-			'cable-management': 'Cable Management',
-			other: 'Other'
-		};
-		return labels[cat];
-	}
+  function getCategoryLabel(cat: DeviceCategory): string {
+    const labels: Record<DeviceCategory, string> = {
+      server: "Server",
+      network: "Network",
+      "patch-panel": "Patch Panel",
+      power: "Power",
+      storage: "Storage",
+      kvm: "KVM",
+      "av-media": "AV/Media",
+      cooling: "Cooling",
+      shelf: "Shelf",
+      blank: "Blank Panel",
+      "cable-management": "Cable Management",
+      other: "Other",
+    };
+    return labels[cat];
+  }
 
-	function validate(): boolean {
-		let valid = true;
-		nameError = '';
-		heightError = '';
+  function validate(): boolean {
+    let valid = true;
+    nameError = "";
+    heightError = "";
 
-		if (!name.trim()) {
-			nameError = 'Name is required';
-			valid = false;
-		}
+    if (!name.trim()) {
+      nameError = "Name is required";
+      valid = false;
+    }
 
-		if (height < MIN_DEVICE_HEIGHT || height > MAX_DEVICE_HEIGHT) {
-			heightError = `Height must be between ${MIN_DEVICE_HEIGHT} and ${MAX_DEVICE_HEIGHT}`;
-			valid = false;
-		}
+    if (height < MIN_DEVICE_HEIGHT || height > MAX_DEVICE_HEIGHT) {
+      heightError = `Height must be between ${MIN_DEVICE_HEIGHT} and ${MAX_DEVICE_HEIGHT}`;
+      valid = false;
+    }
 
-		return valid;
-	}
+    return valid;
+  }
 
-	function handleSubmit() {
-		if (validate()) {
-			onadd?.({
-				name: name.trim(),
-				height,
-				category,
-				colour,
-				notes: notes.trim(),
-				frontImage,
-				rearImage
-			});
-		}
-	}
+  function handleSubmit() {
+    if (validate()) {
+      onadd?.({
+        name: name.trim(),
+        height,
+        category,
+        colour,
+        notes: notes.trim(),
+        isFullDepth,
+        frontImage,
+        rearImage,
+      });
+    }
+  }
 
-	function handleCancel() {
-		oncancel?.();
-	}
+  function handleCancel() {
+    oncancel?.();
+  }
 
-	function handleKeyDown(event: KeyboardEvent) {
-		if (event.key === 'Enter' && event.target instanceof HTMLTextAreaElement === false) {
-			event.preventDefault();
-			handleSubmit();
-		}
-	}
+  function handleKeyDown(event: KeyboardEvent) {
+    if (
+      event.key === "Enter" &&
+      event.target instanceof HTMLTextAreaElement === false
+    ) {
+      event.preventDefault();
+      handleSubmit();
+    }
+  }
 </script>
 
 <Dialog {open} title="Add Device" width="480px" onclose={handleCancel}>
-	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-	<form class="add-device-form" onsubmit={(e) => e.preventDefault()} onkeydown={handleKeyDown}>
-		<div class="form-group">
-			<label for="device-name">Name</label>
-			<input
-				type="text"
-				id="device-name"
-				class="input-field"
-				bind:value={name}
-				placeholder="e.g., Dell PowerEdge R740"
-				class:error={nameError}
-			/>
-			{#if nameError}
-				<span class="error-message">{nameError}</span>
-			{/if}
-		</div>
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <form
+    class="add-device-form"
+    onsubmit={(e) => e.preventDefault()}
+    onkeydown={handleKeyDown}
+  >
+    <div class="form-group">
+      <label for="device-name">Name</label>
+      <input
+        type="text"
+        id="device-name"
+        class="input-field"
+        bind:value={name}
+        placeholder="e.g., Dell PowerEdge R740"
+        class:error={nameError}
+      />
+      {#if nameError}
+        <span class="error-message">{nameError}</span>
+      {/if}
+    </div>
 
-		<div class="form-row">
-			<div class="form-group">
-				<label for="device-height">Height (U)</label>
-				<input
-					type="number"
-					id="device-height"
-					class="input-field"
-					bind:value={height}
-					min={MIN_DEVICE_HEIGHT}
-					max={MAX_DEVICE_HEIGHT}
-					class:error={heightError}
-				/>
-				{#if heightError}
-					<span class="error-message">{heightError}</span>
-				{/if}
-			</div>
+    <div class="form-row">
+      <div class="form-group">
+        <label for="device-height">Height (U)</label>
+        <input
+          type="number"
+          id="device-height"
+          class="input-field"
+          bind:value={height}
+          min={MIN_DEVICE_HEIGHT}
+          max={MAX_DEVICE_HEIGHT}
+          class:error={heightError}
+        />
+        {#if heightError}
+          <span class="error-message">{heightError}</span>
+        {/if}
+      </div>
 
-			<div class="form-group">
-				<label for="device-category">Category</label>
-				<select
-					id="device-category"
-					class="input-field"
-					value={category}
-					onchange={handleCategoryChange}
-				>
-					{#each ALL_CATEGORIES as cat (cat)}
-						<option value={cat}>{getCategoryLabel(cat)}</option>
-					{/each}
-				</select>
-			</div>
-		</div>
+      <div class="form-group">
+        <label for="device-category">Category</label>
+        <select
+          id="device-category"
+          class="input-field"
+          value={category}
+          onchange={handleCategoryChange}
+        >
+          {#each ALL_CATEGORIES as cat (cat)}
+            <option value={cat}>{getCategoryLabel(cat)}</option>
+          {/each}
+        </select>
+      </div>
+    </div>
 
-		<div class="form-group">
-			<label for="device-colour">Colour</label>
-			<div class="colour-input-wrapper">
-				<input
-					type="color"
-					id="device-colour"
-					value={colour}
-					onchange={handleColourChange}
-					class="colour-input"
-				/>
-				<span class="colour-hex">{colour}</span>
-			</div>
-			<div class="colour-presets">
-				{#each ALL_CATEGORIES as cat (cat)}
-					<button
-						type="button"
-						class="colour-preset"
-						style="background-color: {CATEGORY_COLOURS[cat]}"
-						title={getCategoryLabel(cat)}
-						onclick={() => {
-							colour = CATEGORY_COLOURS[cat];
-							userChangedColour = true;
-						}}
-						aria-label="Use {getCategoryLabel(cat)} colour"
-					></button>
-				{/each}
-			</div>
-		</div>
+    <div class="form-group">
+      <label for="device-colour">Colour</label>
+      <div class="colour-input-wrapper">
+        <input
+          type="color"
+          id="device-colour"
+          value={colour}
+          onchange={handleColourChange}
+          class="colour-input"
+        />
+        <span class="colour-hex">{colour}</span>
+      </div>
+      <div class="colour-presets">
+        {#each ALL_CATEGORIES as cat (cat)}
+          <button
+            type="button"
+            class="colour-preset"
+            style="background-color: {CATEGORY_COLOURS[cat]}"
+            title={getCategoryLabel(cat)}
+            onclick={() => {
+              colour = CATEGORY_COLOURS[cat];
+              userChangedColour = true;
+            }}
+            aria-label="Use {getCategoryLabel(cat)} colour"
+          ></button>
+        {/each}
+      </div>
+    </div>
 
-		<div class="form-group">
-			<label for="device-notes">Notes (optional)</label>
-			<textarea
-				id="device-notes"
-				class="input-field"
-				bind:value={notes}
-				placeholder="Additional notes about the device..."
-				rows="3"
-			></textarea>
-		</div>
+    <div class="form-group">
+      <label for="device-notes">Notes (optional)</label>
+      <textarea
+        id="device-notes"
+        class="input-field"
+        bind:value={notes}
+        placeholder="Additional notes about the device..."
+        rows="3"
+      ></textarea>
+    </div>
 
-		<!-- Image uploads (v0.1.0) -->
-		<div class="form-row form-row-symmetric">
-			<ImageUpload
-				face="front"
-				currentImage={frontImage}
-				onupload={(data) => (frontImage = data)}
-				onremove={() => (frontImage = undefined)}
-			/>
-			<ImageUpload
-				face="rear"
-				currentImage={rearImage}
-				onupload={(data) => (rearImage = data)}
-				onremove={() => (rearImage = undefined)}
-			/>
-		</div>
+    <!-- Depth toggle (#241) -->
+    <div class="form-group toggle-group">
+      <label class="toggle-label">
+        <input
+          type="checkbox"
+          id="device-full-depth"
+          bind:checked={isFullDepth}
+          class="toggle-input"
+        />
+        <span class="toggle-switch"></span>
+        <span class="toggle-text">Full Depth</span>
+      </label>
+      <span class="helper-text">Occupies both front and rear rack faces</span>
+    </div>
 
-		<div class="form-actions">
-			<button type="button" class="btn btn-secondary" onclick={handleCancel}> Cancel </button>
-			<button type="submit" class="btn btn-primary" onclick={handleSubmit}> Add </button>
-		</div>
-	</form>
+    <!-- Image uploads (v0.1.0) -->
+    <div class="form-row form-row-symmetric">
+      <ImageUpload
+        face="front"
+        currentImage={frontImage}
+        onupload={(data) => (frontImage = data)}
+        onremove={() => (frontImage = undefined)}
+      />
+      <ImageUpload
+        face="rear"
+        currentImage={rearImage}
+        onupload={(data) => (rearImage = data)}
+        onremove={() => (rearImage = undefined)}
+      />
+    </div>
+
+    <div class="form-actions">
+      <button type="button" class="btn btn-secondary" onclick={handleCancel}>
+        Cancel
+      </button>
+      <button type="submit" class="btn btn-primary" onclick={handleSubmit}>
+        Add
+      </button>
+    </div>
+  </form>
 </Dialog>
 
 <style>
-	.add-device-form {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-4);
-	}
+  .add-device-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
 
-	.form-group {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1-5);
-	}
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5);
+  }
 
-	.form-group label {
-		font-weight: var(--font-weight-medium);
-		color: var(--colour-text);
-		font-size: var(--font-size-base);
-	}
+  .form-group label {
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text);
+    font-size: var(--font-size-base);
+  }
 
-	.form-row {
-		display: grid;
-		grid-template-columns: 1fr 2fr;
-		gap: var(--space-4);
-	}
+  .form-row {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: var(--space-4);
+  }
 
-	.form-row-symmetric {
-		grid-template-columns: 1fr 1fr;
-	}
+  .form-row-symmetric {
+    grid-template-columns: 1fr 1fr;
+  }
 
-	.form-group input[type='text'],
-	.form-group input[type='number'],
-	.form-group select,
-	.form-group textarea {
-		padding: var(--space-2) var(--space-3);
-		background: var(--colour-input-bg, var(--colour-bg));
-		border: 1px solid var(--colour-border);
-		border-radius: var(--radius-md);
-		color: var(--colour-text);
-		font-size: var(--font-size-base);
-		font-family: inherit;
-	}
+  .form-group input[type="text"],
+  .form-group input[type="number"],
+  .form-group select,
+  .form-group textarea {
+    padding: var(--space-2) var(--space-3);
+    background: var(--colour-input-bg, var(--colour-bg));
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    color: var(--colour-text);
+    font-size: var(--font-size-base);
+    font-family: inherit;
+  }
 
-	.form-group textarea {
-		resize: vertical;
-		min-height: 60px;
-	}
+  .form-group textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
 
-	.form-group input:focus,
-	.form-group select:focus,
-	.form-group textarea:focus {
-		outline: none;
-		border-color: var(--colour-selection);
-		box-shadow: var(--glow-pink-sm);
-	}
+  .form-group input:focus,
+  .form-group select:focus,
+  .form-group textarea:focus {
+    outline: none;
+    border-color: var(--colour-selection);
+    box-shadow: var(--glow-pink-sm);
+  }
 
-	.form-group input.error {
-		border-color: var(--colour-error);
-	}
+  .form-group input.error {
+    border-color: var(--colour-error);
+  }
 
-	.error-message {
-		font-size: var(--font-size-sm);
-		color: var(--colour-error);
-	}
+  .error-message {
+    font-size: var(--font-size-sm);
+    color: var(--colour-error);
+  }
 
-	.colour-input-wrapper {
-		display: flex;
-		align-items: center;
-		gap: var(--space-3);
-	}
+  .colour-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
 
-	.colour-input {
-		width: 50px;
-		height: 36px;
-		padding: 2px;
-		border: 1px solid var(--colour-border);
-		border-radius: var(--radius-sm);
-		background: transparent;
-		cursor: pointer;
-	}
+  .colour-input {
+    width: 50px;
+    height: 36px;
+    padding: 2px;
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    cursor: pointer;
+  }
 
-	.colour-input::-webkit-color-swatch {
-		border: none;
-		border-radius: 2px;
-	}
+  .colour-input::-webkit-color-swatch {
+    border: none;
+    border-radius: 2px;
+  }
 
-	.colour-hex {
-		font-family: monospace;
-		font-size: var(--font-size-base);
-		color: var(--colour-text-muted);
-	}
+  .colour-hex {
+    font-family: monospace;
+    font-size: var(--font-size-base);
+    color: var(--colour-text-muted);
+  }
 
-	.colour-presets {
-		display: flex;
-		gap: var(--space-1-5);
-		flex-wrap: wrap;
-		margin-top: var(--space-2);
-	}
+  .colour-presets {
+    display: flex;
+    gap: var(--space-1-5);
+    flex-wrap: wrap;
+    margin-top: var(--space-2);
+  }
 
-	.colour-preset {
-		width: 24px;
-		height: 24px;
-		border: 1px solid var(--colour-border);
-		border-radius: var(--radius-sm);
-		cursor: pointer;
-		padding: 0;
-		transition: transform var(--transition-fast);
-	}
+  .colour-preset {
+    width: 24px;
+    height: 24px;
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    padding: 0;
+    transition: transform var(--transition-fast);
+  }
 
-	.colour-preset:hover {
-		transform: scale(1.1);
-	}
+  .colour-preset:hover {
+    transform: scale(1.1);
+  }
 
-	.colour-preset:focus-visible {
-		outline: 2px solid var(--colour-selection);
-		outline-offset: 2px;
-	}
+  .colour-preset:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: 2px;
+  }
 
-	.form-actions {
-		display: flex;
-		justify-content: flex-end;
-		gap: var(--space-3);
-		margin-top: var(--space-2);
-	}
+  .form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-3);
+    margin-top: var(--space-2);
+  }
 
-	.btn {
-		padding: var(--space-2) var(--space-5);
-		border: none;
-		border-radius: var(--radius-md);
-		font-size: var(--font-size-base);
-		font-weight: var(--font-weight-medium);
-		cursor: pointer;
-		transition: all var(--transition-fast);
-	}
+  .btn {
+    padding: var(--space-2) var(--space-5);
+    border: none;
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+  }
 
-	.btn-secondary {
-		background: var(--colour-button-bg);
-		color: var(--colour-text);
-	}
+  .btn-secondary {
+    background: var(--colour-button-bg);
+    color: var(--colour-text);
+  }
 
-	.btn-secondary:hover {
-		background: var(--colour-button-hover);
-	}
+  .btn-secondary:hover {
+    background: var(--colour-button-hover);
+  }
 
-	.btn-primary {
-		background: var(--colour-selection);
-		color: white;
-	}
+  .btn-primary {
+    background: var(--colour-selection);
+    color: white;
+  }
 
-	.btn-primary:hover {
-		background: var(--colour-selection-hover);
-	}
+  .btn-primary:hover {
+    background: var(--colour-selection-hover);
+  }
+
+  /* Toggle switch styles (#241) */
+  .toggle-group {
+    gap: var(--space-1);
+  }
+
+  .toggle-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .toggle-input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+
+  .toggle-switch {
+    position: relative;
+    width: 40px;
+    height: 22px;
+    background: var(--colour-surface-active);
+    border-radius: var(--radius-full);
+    transition: background var(--duration-fast) var(--ease-out);
+    flex-shrink: 0;
+  }
+
+  .toggle-switch::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    background: var(--colour-text-muted);
+    border-radius: 50%;
+    transition: all var(--duration-fast) var(--ease-out);
+  }
+
+  .toggle-input:checked + .toggle-switch {
+    background: var(--colour-selection);
+  }
+
+  .toggle-input:checked + .toggle-switch::after {
+    transform: translateX(18px);
+    background: white;
+  }
+
+  .toggle-input:focus-visible + .toggle-switch {
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .toggle-text {
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text);
+  }
+
+  .helper-text {
+    font-size: var(--font-size-sm);
+    color: var(--colour-text-muted);
+    margin-left: calc(40px + var(--space-2));
+  }
 </style>

--- a/src/tests/AddDeviceForm.test.ts
+++ b/src/tests/AddDeviceForm.test.ts
@@ -1,249 +1,345 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/svelte';
-import AddDeviceForm from '$lib/components/AddDeviceForm.svelte';
-import { ALL_CATEGORIES } from '$lib/types/constants';
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import AddDeviceForm from "$lib/components/AddDeviceForm.svelte";
+import { ALL_CATEGORIES } from "$lib/types/constants";
 
 // Setup URL mocks for jsdom (needed for ImageUpload component)
 const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
 
 beforeAll(() => {
-	URL.createObjectURL = vi.fn(() => 'blob:mock-url');
-	URL.revokeObjectURL = vi.fn();
+  URL.createObjectURL = vi.fn(() => "blob:mock-url");
+  URL.revokeObjectURL = vi.fn();
 });
 
 afterAll(() => {
-	URL.createObjectURL = originalCreateObjectURL;
-	URL.revokeObjectURL = originalRevokeObjectURL;
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
 });
 
-describe('AddDeviceForm Component', () => {
-	describe('Open state', () => {
-		it('renders when open=true', () => {
-			render(AddDeviceForm, { props: { open: true } });
-			expect(screen.getByRole('dialog')).toBeInTheDocument();
-		});
+describe("AddDeviceForm Component", () => {
+  describe("Open state", () => {
+    it("renders when open=true", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
 
-		it('is hidden when open=false', () => {
-			render(AddDeviceForm, { props: { open: false } });
-			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-		});
-	});
+    it("is hidden when open=false", () => {
+      render(AddDeviceForm, { props: { open: false } });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
 
-	describe('Form fields', () => {
-		it('renders all fields', () => {
-			render(AddDeviceForm, { props: { open: true } });
-			expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
-			expect(screen.getByLabelText(/^height/i)).toBeInTheDocument();
-			expect(screen.getByLabelText(/^category$/i)).toBeInTheDocument();
-			expect(screen.getByLabelText(/^colour$/i)).toBeInTheDocument();
-			expect(screen.getByLabelText(/^notes/i)).toBeInTheDocument();
-		});
+  describe("Form fields", () => {
+    it("renders all fields", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^height/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^category$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^colour$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^notes/i)).toBeInTheDocument();
+    });
 
-		it('category dropdown has all 10 categories', () => {
-			render(AddDeviceForm, { props: { open: true } });
-			const categorySelect = screen.getByLabelText(/category/i) as HTMLSelectElement;
+    it("category dropdown has all 10 categories", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      const categorySelect = screen.getByLabelText(
+        /category/i,
+      ) as HTMLSelectElement;
 
-			// Check that all categories are present
-			ALL_CATEGORIES.forEach((category) => {
-				const option = categorySelect.querySelector(`option[value="${category}"]`);
-				expect(option).toBeInTheDocument();
-			});
-		});
-	});
+      // Check that all categories are present
+      ALL_CATEGORIES.forEach((category) => {
+        const option = categorySelect.querySelector(
+          `option[value="${category}"]`,
+        );
+        expect(option).toBeInTheDocument();
+      });
+    });
+  });
 
-	describe('Colour defaults', () => {
-		it('colour defaults to category colour', async () => {
-			render(AddDeviceForm, { props: { open: true } });
+  describe("Colour defaults", () => {
+    it("colour defaults to category colour", async () => {
+      render(AddDeviceForm, { props: { open: true } });
 
-			// Default category is 'server', which has muted cyan colour #4A7A8A
-			const colourInput = screen.getByLabelText(/^colour$/i) as HTMLInputElement;
-			expect(colourInput.value.toLowerCase()).toBe('#4a7a8a');
-		});
+      // Default category is 'server', which has muted cyan colour #4A7A8A
+      const colourInput = screen.getByLabelText(
+        /^colour$/i,
+      ) as HTMLInputElement;
+      expect(colourInput.value.toLowerCase()).toBe("#4a7a8a");
+    });
 
-		it('colour updates when category changes', async () => {
-			render(AddDeviceForm, { props: { open: true } });
+    it("colour updates when category changes", async () => {
+      render(AddDeviceForm, { props: { open: true } });
 
-			const categorySelect = screen.getByLabelText(/^category$/i);
-			await fireEvent.change(categorySelect, { target: { value: 'network' } });
+      const categorySelect = screen.getByLabelText(/^category$/i);
+      await fireEvent.change(categorySelect, { target: { value: "network" } });
 
-			const colourInput = screen.getByLabelText(/^colour$/i) as HTMLInputElement;
-			// Network colour is muted purple #7B6BA8
-			expect(colourInput.value.toLowerCase()).toBe('#7b6ba8');
-		});
-	});
+      const colourInput = screen.getByLabelText(
+        /^colour$/i,
+      ) as HTMLInputElement;
+      // Network colour is muted purple #7B6BA8
+      expect(colourInput.value.toLowerCase()).toBe("#7b6ba8");
+    });
+  });
 
-	describe('Validation', () => {
-		it('rejects empty name', async () => {
-			render(AddDeviceForm, { props: { open: true } });
+  describe("Validation", () => {
+    it("rejects empty name", async () => {
+      render(AddDeviceForm, { props: { open: true } });
 
-			const submitBtn = screen.getByRole('button', { name: /add/i });
-			await fireEvent.click(submitBtn);
+      const submitBtn = screen.getByRole("button", { name: /add/i });
+      await fireEvent.click(submitBtn);
 
-			expect(screen.getByText(/name is required/i)).toBeInTheDocument();
-		});
+      expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+    });
 
-		it('rejects height < 1', async () => {
-			render(AddDeviceForm, { props: { open: true } });
+    it("rejects height < 1", async () => {
+      render(AddDeviceForm, { props: { open: true } });
 
-			// Fill name
-			const nameInput = screen.getByLabelText(/^name$/i);
-			await fireEvent.input(nameInput, { target: { value: 'Test Device' } });
+      // Fill name
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await fireEvent.input(nameInput, { target: { value: "Test Device" } });
 
-			// Set invalid height
-			const heightInput = screen.getByLabelText(/^height/i);
-			await fireEvent.input(heightInput, { target: { value: '0' } });
+      // Set invalid height
+      const heightInput = screen.getByLabelText(/^height/i);
+      await fireEvent.input(heightInput, { target: { value: "0" } });
 
-			const submitBtn = screen.getByRole('button', { name: /add/i });
-			await fireEvent.click(submitBtn);
+      const submitBtn = screen.getByRole("button", { name: /add/i });
+      await fireEvent.click(submitBtn);
 
-			expect(screen.getByText(/height must be between 0.5 and 42/i)).toBeInTheDocument();
-		});
+      expect(
+        screen.getByText(/height must be between 0.5 and 42/i),
+      ).toBeInTheDocument();
+    });
 
-		it('rejects height > 42', async () => {
-			render(AddDeviceForm, { props: { open: true } });
+    it("rejects height > 42", async () => {
+      render(AddDeviceForm, { props: { open: true } });
 
-			// Fill name
-			const nameInput = screen.getByLabelText(/^name$/i);
-			await fireEvent.input(nameInput, { target: { value: 'Test Device' } });
+      // Fill name
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await fireEvent.input(nameInput, { target: { value: "Test Device" } });
 
-			// Set invalid height
-			const heightInput = screen.getByLabelText(/^height/i);
-			await fireEvent.input(heightInput, { target: { value: '43' } });
+      // Set invalid height
+      const heightInput = screen.getByLabelText(/^height/i);
+      await fireEvent.input(heightInput, { target: { value: "43" } });
 
-			const submitBtn = screen.getByRole('button', { name: /add/i });
-			await fireEvent.click(submitBtn);
+      const submitBtn = screen.getByRole("button", { name: /add/i });
+      await fireEvent.click(submitBtn);
 
-			expect(screen.getByText(/height must be between 0.5 and 42/i)).toBeInTheDocument();
-		});
-	});
+      expect(
+        screen.getByText(/height must be between 0.5 and 42/i),
+      ).toBeInTheDocument();
+    });
+  });
 
-	describe('Submit', () => {
-		it('adds device to library on valid submit', async () => {
-			const onAdd = vi.fn();
-			render(AddDeviceForm, { props: { open: true, onadd: onAdd } });
+  describe("Submit", () => {
+    it("adds device to library on valid submit", async () => {
+      const onAdd = vi.fn();
+      render(AddDeviceForm, { props: { open: true, onadd: onAdd } });
 
-			// Fill form
-			const nameInput = screen.getByLabelText(/^name$/i);
-			await fireEvent.input(nameInput, { target: { value: 'My Server' } });
+      // Fill form
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await fireEvent.input(nameInput, { target: { value: "My Server" } });
 
-			const heightInput = screen.getByLabelText(/^height/i);
-			await fireEvent.input(heightInput, { target: { value: '2' } });
+      const heightInput = screen.getByLabelText(/^height/i);
+      await fireEvent.input(heightInput, { target: { value: "2" } });
 
-			const categorySelect = screen.getByLabelText(/^category$/i);
-			await fireEvent.change(categorySelect, { target: { value: 'server' } });
+      const categorySelect = screen.getByLabelText(/^category$/i);
+      await fireEvent.change(categorySelect, { target: { value: "server" } });
 
-			const notesInput = screen.getByLabelText(/^notes/i);
-			await fireEvent.input(notesInput, { target: { value: 'Test notes' } });
+      const notesInput = screen.getByLabelText(/^notes/i);
+      await fireEvent.input(notesInput, { target: { value: "Test notes" } });
 
-			const submitBtn = screen.getByRole('button', { name: /add/i });
-			await fireEvent.click(submitBtn);
+      const submitBtn = screen.getByRole("button", { name: /add/i });
+      await fireEvent.click(submitBtn);
 
-			expect(onAdd).toHaveBeenCalledTimes(1);
-			const callArg = onAdd.mock.calls[0]![0];
-			expect(callArg.name).toBe('My Server');
-			expect(callArg.height).toBe(2);
-			expect(callArg.category).toBe('server');
-			expect(callArg.colour.toLowerCase()).toBe('#4a7a8a'); // muted cyan
-			expect(callArg.notes).toBe('Test notes');
-		});
+      expect(onAdd).toHaveBeenCalledTimes(1);
+      const callArg = onAdd.mock.calls[0]![0];
+      expect(callArg.name).toBe("My Server");
+      expect(callArg.height).toBe(2);
+      expect(callArg.category).toBe("server");
+      expect(callArg.colour.toLowerCase()).toBe("#4a7a8a"); // muted cyan
+      expect(callArg.notes).toBe("Test notes");
+    });
 
-		it('submits with empty notes', async () => {
-			const onAdd = vi.fn();
-			render(AddDeviceForm, { props: { open: true, onadd: onAdd } });
+    it("submits with empty notes", async () => {
+      const onAdd = vi.fn();
+      render(AddDeviceForm, { props: { open: true, onadd: onAdd } });
 
-			// Fill only required fields
-			const nameInput = screen.getByLabelText(/^name$/i);
-			await fireEvent.input(nameInput, { target: { value: 'Simple Device' } });
+      // Fill only required fields
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await fireEvent.input(nameInput, { target: { value: "Simple Device" } });
 
-			const heightInput = screen.getByLabelText(/^height/i);
-			await fireEvent.input(heightInput, { target: { value: '1' } });
+      const heightInput = screen.getByLabelText(/^height/i);
+      await fireEvent.input(heightInput, { target: { value: "1" } });
 
-			const submitBtn = screen.getByRole('button', { name: /add/i });
-			await fireEvent.click(submitBtn);
+      const submitBtn = screen.getByRole("button", { name: /add/i });
+      await fireEvent.click(submitBtn);
 
-			expect(onAdd).toHaveBeenCalledWith(
-				expect.objectContaining({
-					name: 'Simple Device',
-					height: 1,
-					notes: ''
-				})
-			);
-		});
-	});
+      expect(onAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Simple Device",
+          height: 1,
+          notes: "",
+        }),
+      );
+    });
+  });
 
-	describe('Cancel', () => {
-		it('has a cancel button', () => {
-			render(AddDeviceForm, { props: { open: true } });
-			expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
-		});
+  describe("Cancel", () => {
+    it("has a cancel button", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
+    });
 
-		it('dispatches cancel event when cancel button clicked', async () => {
-			const onCancel = vi.fn();
-			render(AddDeviceForm, { props: { open: true, oncancel: onCancel } });
+    it("dispatches cancel event when cancel button clicked", async () => {
+      const onCancel = vi.fn();
+      render(AddDeviceForm, { props: { open: true, oncancel: onCancel } });
 
-			const cancelBtn = screen.getByRole('button', { name: /cancel/i });
-			await fireEvent.click(cancelBtn);
+      const cancelBtn = screen.getByRole("button", { name: /cancel/i });
+      await fireEvent.click(cancelBtn);
 
-			expect(onCancel).toHaveBeenCalledTimes(1);
-		});
-	});
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
 
-	describe('Form reset', () => {
-		it('resets form when closed and reopened', async () => {
-			const { rerender } = render(AddDeviceForm, { props: { open: true } });
+  describe("Form reset", () => {
+    it("resets form when closed and reopened", async () => {
+      const { rerender } = render(AddDeviceForm, { props: { open: true } });
 
-			// Enter some data
-			const nameInput = screen.getByLabelText(/^name$/i);
-			await fireEvent.input(nameInput, { target: { value: 'Test' } });
+      // Enter some data
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await fireEvent.input(nameInput, { target: { value: "Test" } });
 
-			// Close and reopen
-			await rerender({ open: false });
-			await rerender({ open: true });
+      // Close and reopen
+      await rerender({ open: false });
+      await rerender({ open: true });
 
-			// Check form is reset
-			const newNameInput = screen.getByLabelText(/^name$/i);
-			expect(newNameInput).toHaveValue('');
-		});
-	});
+      // Check form is reset
+      const newNameInput = screen.getByLabelText(/^name$/i);
+      expect(newNameInput).toHaveValue("");
+    });
+  });
 
-	describe('Keyboard shortcuts', () => {
-		it('Escape key cancels form', async () => {
-			const onCancel = vi.fn();
-			render(AddDeviceForm, { props: { open: true, oncancel: onCancel } });
+  describe("Keyboard shortcuts", () => {
+    it("Escape key cancels form", async () => {
+      const onCancel = vi.fn();
+      render(AddDeviceForm, { props: { open: true, oncancel: onCancel } });
 
-			await fireEvent.keyDown(document, { key: 'Escape' });
+      await fireEvent.keyDown(document, { key: "Escape" });
 
-			expect(onCancel).toHaveBeenCalledTimes(1);
-		});
-	});
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
 
-	describe('Image uploads (v0.1.0)', () => {
-		it('shows image upload for front', () => {
-			render(AddDeviceForm, { props: { open: true } });
-			expect(screen.getByText(/front image/i)).toBeInTheDocument();
-		});
+  describe("Depth toggle (#241)", () => {
+    it("renders depth toggle", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      expect(screen.getByLabelText(/full depth/i)).toBeInTheDocument();
+    });
 
-		it('shows image upload for rear', () => {
-			render(AddDeviceForm, { props: { open: true } });
-			expect(screen.getByText(/rear image/i)).toBeInTheDocument();
-		});
+    it("depth toggle defaults to ON (full-depth)", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      const toggle = screen.getByLabelText(/full depth/i) as HTMLInputElement;
+      expect(toggle.checked).toBe(true);
+    });
 
-		it('images are optional - form submits without them', async () => {
-			const onAdd = vi.fn();
-			render(AddDeviceForm, { props: { open: true, onadd: onAdd } });
+    it("created device has isFullDepth=true when toggle ON", async () => {
+      const onAdd = vi.fn();
+      render(AddDeviceForm, { props: { open: true, onadd: onAdd } });
 
-			// Fill only required fields
-			const nameInput = screen.getByLabelText(/^name$/i);
-			await fireEvent.input(nameInput, { target: { value: 'Test Device' } });
+      // Fill required fields
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await fireEvent.input(nameInput, {
+        target: { value: "Full Depth Server" },
+      });
 
-			const submitBtn = screen.getByRole('button', { name: /add/i });
-			await fireEvent.click(submitBtn);
+      // Toggle should be ON by default
+      const submitBtn = screen.getByRole("button", { name: /add/i });
+      await fireEvent.click(submitBtn);
 
-			expect(onAdd).toHaveBeenCalledTimes(1);
-			const callArg = onAdd.mock.calls[0]?.[0];
-			expect(callArg?.frontImage).toBeUndefined();
-			expect(callArg?.rearImage).toBeUndefined();
-		});
-	});
+      expect(onAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isFullDepth: true,
+        }),
+      );
+    });
+
+    it("created device has isFullDepth=false when toggle OFF", async () => {
+      const onAdd = vi.fn();
+      render(AddDeviceForm, { props: { open: true, onadd: onAdd } });
+
+      // Fill required fields
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await fireEvent.input(nameInput, {
+        target: { value: "Half Depth Switch" },
+      });
+
+      // Turn OFF the toggle
+      const toggle = screen.getByLabelText(/full depth/i);
+      await fireEvent.click(toggle);
+
+      const submitBtn = screen.getByRole("button", { name: /add/i });
+      await fireEvent.click(submitBtn);
+
+      expect(onAdd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isFullDepth: false,
+        }),
+      );
+    });
+
+    it("toggle state resets when form reopens", async () => {
+      const { rerender } = render(AddDeviceForm, { props: { open: true } });
+
+      // Turn OFF the toggle
+      const toggle = screen.getByLabelText(/full depth/i) as HTMLInputElement;
+      await fireEvent.click(toggle);
+      expect(toggle.checked).toBe(false);
+
+      // Close and reopen
+      await rerender({ open: false });
+      await rerender({ open: true });
+
+      // Toggle should be back to ON (default)
+      const newToggle = screen.getByLabelText(
+        /full depth/i,
+      ) as HTMLInputElement;
+      expect(newToggle.checked).toBe(true);
+    });
+
+    it("displays helper text explaining full-depth", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      expect(screen.getByText(/occupies.*front.*rear/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("Image uploads (v0.1.0)", () => {
+    it("shows image upload for front", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      expect(screen.getByText(/front image/i)).toBeInTheDocument();
+    });
+
+    it("shows image upload for rear", () => {
+      render(AddDeviceForm, { props: { open: true } });
+      expect(screen.getByText(/rear image/i)).toBeInTheDocument();
+    });
+
+    it("images are optional - form submits without them", async () => {
+      const onAdd = vi.fn();
+      render(AddDeviceForm, { props: { open: true, onadd: onAdd } });
+
+      // Fill only required fields
+      const nameInput = screen.getByLabelText(/^name$/i);
+      await fireEvent.input(nameInput, { target: { value: "Test Device" } });
+
+      const submitBtn = screen.getByRole("button", { name: /add/i });
+      await fireEvent.click(submitBtn);
+
+      expect(onAdd).toHaveBeenCalledTimes(1);
+      const callArg = onAdd.mock.calls[0]?.[0];
+      expect(callArg?.frontImage).toBeUndefined();
+      expect(callArg?.rearImage).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add "Full Depth" toggle to Add Device form, defaulting to ON
- Toggle controls whether custom devices occupy both rack faces or just one
- Improves discoverability of the Mounted Face feature for new devices

## Changes
- `AddDeviceForm.svelte`: Added `isFullDepth` state with toggle UI and CSS styling
- `App.svelte`: Updated handler to pass `is_full_depth` to layoutStore.addDeviceType
- `AddDeviceForm.test.ts`: Added 6 tests covering toggle behavior

## Test plan
- [x] Toggle renders in form
- [x] Toggle defaults to ON (full-depth)
- [x] Created device has correct `isFullDepth` value based on toggle state
- [x] Toggle state resets when form closes and reopens
- [x] Helper text explains what full-depth means

Closes #241
Related to #238, #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)