### PR TITLE
fix: correct Dev indicator styling and prevent text cutoff (#279)

### DIFF
--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -257,7 +257,7 @@
     class:logo-title--party={partyMode}
     class:logo-title--showcase={showcase}
     class:logo-title--hover={hovering && !partyMode && !celebrate && !showcase}
-    viewBox="0 0 {showEnvPrefix ? 195 : 160} 50"
+    viewBox="0 0 {showEnvPrefix ? 210 : 160} 50"
     height={titleHeight}
     role="img"
     aria-label={showEnvPrefix
@@ -267,9 +267,11 @@
   >
     <text x="0" y="38">
       {#if showEnvPrefix}
-        <tspan class="env-prefix">D</tspan><tspan class="env-prefix-small"
-          >ev</tspan
-        >
+        <tspan class="env-prefix">D</tspan><tspan
+          class="env-prefix-small"
+          font-size="26"
+          font-weight="400"
+          dy="1">ev</tspan>
       {/if}
       <tspan>Rackula</tspan>
     </text>

--- a/src/tests/LogoLockup.test.ts
+++ b/src/tests/LogoLockup.test.ts
@@ -262,7 +262,7 @@ describe("LogoLockup", () => {
       const viewBox = logoTitle?.getAttribute("viewBox");
 
       // Tests run on localhost, so DevRackula prefix shows (wider viewBox)
-      expect(viewBox).toBe("0 0 195 50");
+      expect(viewBox).toBe("0 0 210 50");
 
       // Validate format: exactly 4 space-separated numeric values
       const values = viewBox?.split(" ");
@@ -330,6 +330,25 @@ describe("LogoLockup", () => {
 
       // Text content combines Dev prefix + Rackula
       expect(textContent).toBe("DevRackula");
+    });
+
+    it("'ev' tspan has smaller font-size attribute (#279)", () => {
+      const { container } = render(LogoLockup);
+      const envPrefixSmall = container.querySelector(".env-prefix-small");
+
+      // SVG tspan needs inline font-size attribute (CSS class doesn't work)
+      expect(envPrefixSmall).toHaveAttribute("font-size", "26");
+      expect(envPrefixSmall).toHaveAttribute("font-weight", "400");
+    });
+
+    it("viewBox is wide enough for full DevRackula text (#279)", () => {
+      const { container } = render(LogoLockup);
+      const logoTitle = container.querySelector(".logo-title");
+      const viewBox = logoTitle?.getAttribute("viewBox");
+      const width = viewBox?.split(" ")[2];
+
+      // viewBox width must be >= 210 to prevent text cutoff
+      expect(Number(width)).toBeGreaterThanOrEqual(210);
     });
 
     // Note: The following tests would require module re-initialization


### PR DESCRIPTION
## Summary
Fixes visual issues from the initial implementation of the "Dev" environment indicator:

**Problems fixed:**
1. "ev" wasn't rendering smaller - CSS `font-size` on tspan elements doesn't work in SVG
2. "Rackula" text was cut off due to insufficient viewBox width
3. Minor baseline alignment issue with smaller text

**Solutions:**
- Use inline `font-size="26"` and `font-weight="400"` attributes on the "ev" tspan
- Increase viewBox width from 195 to 210
- Add `dy="1"` for proper baseline alignment

## Changes
- `LogoLockup.svelte`: Add inline SVG attributes, increase viewBox
- `LogoLockup.test.ts`: Add regression tests for font-size and viewBox width

## Test plan
- [x] "ev" renders smaller than "D"
- [x] Full "DevRackula" text visible (no cutoff)
- [x] Regression tests pass for font-size attribute
- [x] Regression tests pass for viewBox minimum width

## Before/After
Before: Text cut off, "ev" same size as "D"
After: Full text visible, "ev" properly smaller

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)