### PR TITLE
fix: make 'ev' 50% smaller and eliminate whitespace gap (#279)

### DIFF
--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -265,16 +265,7 @@
       : "Rackula"}
     style={gradientId ? `--active-gradient: ${gradientId}` : undefined}
   >
-    <text x="0" y="38">
-      {#if showEnvPrefix}
-        <tspan class="env-prefix">D</tspan><tspan
-          class="env-prefix-small"
-          font-size="26"
-          font-weight="400"
-          dy="1">ev</tspan>
-      {/if}
-      <tspan>Rackula</tspan>
-    </text>
+    <text x="0" y="38">{#if showEnvPrefix}<tspan class="env-prefix">D</tspan><tspan class="env-prefix-small" font-size="19" font-weight="400" dy="2">ev</tspan>{/if}<tspan>Rackula</tspan></text>
   </svg>
 </div>
 

--- a/src/tests/LogoLockup.test.ts
+++ b/src/tests/LogoLockup.test.ts
@@ -332,12 +332,13 @@ describe("LogoLockup", () => {
       expect(textContent).toBe("DevRackula");
     });
 
-    it("'ev' tspan has smaller font-size attribute (#279)", () => {
+    it("'ev' tspan has 50% smaller font-size attribute (#279)", () => {
       const { container } = render(LogoLockup);
       const envPrefixSmall = container.querySelector(".env-prefix-small");
 
       // SVG tspan needs inline font-size attribute (CSS class doesn't work)
-      expect(envPrefixSmall).toHaveAttribute("font-size", "26");
+      // 19px = 50% of 38px (the main text size)
+      expect(envPrefixSmall).toHaveAttribute("font-size", "19");
       expect(envPrefixSmall).toHaveAttribute("font-weight", "400");
     });
 


### PR DESCRIPTION
## Summary
Final fix for the Dev environment indicator styling:

1. **'ev' now 50% smaller** - font-size changed from 26 to 19 (half of 38px)
2. **No more space between Dev and Rackula** - All tspan elements on single line to eliminate SVG whitespace rendering

## Technical detail
SVG text elements render whitespace between child elements as visible space. By putting all tspans on a single line with no whitespace, the gap is eliminated.

## Test plan
- [x] 'ev' renders at 50% size
- [x] No visible gap between 'Dev' and 'Rackula'
- [x] All tests pass

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual presentation of the environment prefix text with adjusted font sizing and vertical alignment.

* **Tests**
  * Updated test expectations to reflect styling changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->