### PR TITLE
fix: revert to simple D prefix for dev indicator (#279)

### DIFF
--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -7,7 +7,6 @@
 
   v4: DRackula prefix for dev/local environments (blood-red D)
   v5: Purple logo mark with white brand text (restoring Dracula theming)
-  v6: DevRackula prefix (blood-red "Dev" with smaller "ev")
 -->
 <script lang="ts">
   import SantaHat from "./SantaHat.svelte";
@@ -250,22 +249,22 @@
   </div>
 
   <!-- Title (SVG text for gradient support) - Space Grotesk -->
-  <!-- DevRackula: adds red "Dev" prefix on dev/local environments -->
+  <!-- DRackula: adds red "D" prefix on dev/local environments -->
   <svg
     class="logo-title"
     class:logo-title--celebrate={celebrate}
     class:logo-title--party={partyMode}
     class:logo-title--showcase={showcase}
     class:logo-title--hover={hovering && !partyMode && !celebrate && !showcase}
-    viewBox="0 0 {showEnvPrefix ? 210 : 160} 50"
+    viewBox="0 0 {showEnvPrefix ? 180 : 160} 50"
     height={titleHeight}
     role="img"
     aria-label={showEnvPrefix
-      ? "DevRackula - development environment"
+      ? "DRackula - development environment"
       : "Rackula"}
     style={gradientId ? `--active-gradient: ${gradientId}` : undefined}
   >
-    <text x="0" y="38">{#if showEnvPrefix}<tspan class="env-prefix">D</tspan><tspan class="env-prefix-small" font-size="19" font-weight="400" dy="2">ev</tspan>{/if}<tspan>Rackula</tspan></text>
+    <text x="0" y="38">{#if showEnvPrefix}<tspan class="env-prefix">D</tspan>{/if}<tspan>Rackula</tspan></text>
   </svg>
 </div>
 
@@ -316,25 +315,14 @@
     font-weight: 500;
   }
 
-  /* DevRackula: blood-red "Dev" prefix for dev/local environments */
+  /* DRackula: blood-red "D" prefix for dev/local environments */
   /* Always red - never changes with gradient animations */
   .logo-title text .env-prefix,
-  .logo-title text .env-prefix-small,
   .logo-title--hover text .env-prefix,
-  .logo-title--hover text .env-prefix-small,
   .logo-title--celebrate text .env-prefix,
-  .logo-title--celebrate text .env-prefix-small,
   .logo-title--party text .env-prefix,
-  .logo-title--party text .env-prefix-small,
-  .logo-title--showcase text .env-prefix,
-  .logo-title--showcase text .env-prefix-small {
+  .logo-title--showcase text .env-prefix {
     fill: var(--dracula-red, #ff5555) !important;
-  }
-
-  /* Smaller "ev" in DevRackula prefix */
-  .logo-title text .env-prefix-small {
-    font-size: 26px;
-    font-weight: 400;
   }
 
   /* Celebrate state: rainbow wave for 3s */
@@ -428,9 +416,8 @@
       animation: none;
     }
 
-    /* DevRackula prefix stays red in reduced motion */
-    .logo-title text .env-prefix,
-    .logo-title text .env-prefix-small {
+    /* DRackula prefix stays red in reduced motion */
+    .logo-title text .env-prefix {
       fill: var(--dracula-red, #ff5555) !important;
     }
   }

--- a/src/tests/LogoLockup.test.ts
+++ b/src/tests/LogoLockup.test.ts
@@ -33,10 +33,10 @@ describe("LogoLockup", () => {
       const { container } = render(LogoLockup);
       const logoTitle = container.querySelector(".logo-title");
 
-      // Tests run on localhost, so DevRackula prefix shows
+      // Tests run on localhost, so DRackula prefix shows
       expect(logoTitle).toHaveAttribute(
         "aria-label",
-        "DevRackula - development environment",
+        "DRackula - development environment",
       );
     });
   });
@@ -261,8 +261,8 @@ describe("LogoLockup", () => {
       const logoTitle = container.querySelector(".logo-title");
       const viewBox = logoTitle?.getAttribute("viewBox");
 
-      // Tests run on localhost, so DevRackula prefix shows (wider viewBox)
-      expect(viewBox).toBe("0 0 210 50");
+      // Tests run on localhost, so DRackula prefix shows (wider viewBox)
+      expect(viewBox).toBe("0 0 180 50");
 
       // Validate format: exactly 4 space-separated numeric values
       const values = viewBox?.split(" ");
@@ -293,27 +293,22 @@ describe("LogoLockup", () => {
     });
   });
 
-  describe("DevRackula Prefix (#215, #279)", () => {
-    // Tests run on localhost, so the Dev prefix should show by default
-    it("shows red Dev prefix on localhost", () => {
+  describe("DRackula Prefix (#215)", () => {
+    // Tests run on localhost, so the D prefix should show by default
+    it("shows red D prefix on localhost", () => {
       const { container } = render(LogoLockup);
       const envPrefix = container.querySelector(".env-prefix");
-      const envPrefixSmall = container.querySelector(".env-prefix-small");
 
       expect(envPrefix).toBeInTheDocument();
       expect(envPrefix?.textContent).toBe("D");
-      expect(envPrefixSmall).toBeInTheDocument();
-      expect(envPrefixSmall?.textContent).toBe("ev");
     });
 
-    it("Dev prefix has Dracula red fill CSS class", () => {
+    it("D prefix has Dracula red fill CSS class", () => {
       const { container } = render(LogoLockup);
       const envPrefix = container.querySelector(".env-prefix");
-      const envPrefixSmall = container.querySelector(".env-prefix-small");
 
-      // Both classes exist (actual color is applied via CSS stylesheet)
+      // Class exists (actual color is applied via CSS stylesheet)
       expect(envPrefix).toBeInTheDocument();
-      expect(envPrefixSmall).toBeInTheDocument();
     });
 
     it("shows local tooltip on localhost", () => {
@@ -323,33 +318,13 @@ describe("LogoLockup", () => {
       expect(lockup).toHaveAttribute("title", "Local development environment");
     });
 
-    it("title text contains Dev prefix and Rackula", () => {
+    it("title text contains D prefix and Rackula", () => {
       const { container } = render(LogoLockup);
       const logoTitle = container.querySelector(".logo-title");
       const textContent = logoTitle?.textContent?.replace(/\s+/g, "");
 
-      // Text content combines Dev prefix + Rackula
-      expect(textContent).toBe("DevRackula");
-    });
-
-    it("'ev' tspan has 50% smaller font-size attribute (#279)", () => {
-      const { container } = render(LogoLockup);
-      const envPrefixSmall = container.querySelector(".env-prefix-small");
-
-      // SVG tspan needs inline font-size attribute (CSS class doesn't work)
-      // 19px = 50% of 38px (the main text size)
-      expect(envPrefixSmall).toHaveAttribute("font-size", "19");
-      expect(envPrefixSmall).toHaveAttribute("font-weight", "400");
-    });
-
-    it("viewBox is wide enough for full DevRackula text (#279)", () => {
-      const { container } = render(LogoLockup);
-      const logoTitle = container.querySelector(".logo-title");
-      const viewBox = logoTitle?.getAttribute("viewBox");
-      const width = viewBox?.split(" ")[2];
-
-      // viewBox width must be >= 210 to prevent text cutoff
-      expect(Number(width)).toBeGreaterThanOrEqual(210);
+      // Text content combines D prefix + Rackula
+      expect(textContent).toBe("DRackula");
     });
 
     // Note: The following tests would require module re-initialization

--- a/src/tests/ToolbarResponsive.test.ts
+++ b/src/tests/ToolbarResponsive.test.ts
@@ -51,17 +51,17 @@ describe("Toolbar Responsive Structure", () => {
       const { container } = render(Toolbar);
 
       // LogoLockup uses SVG text for the brand name with aria-label
-      // Tests run on localhost, so DevRackula prefix shows
+      // Tests run on localhost, so DRackula prefix shows
       const logoTitle = container.querySelector(".logo-title");
       expect(logoTitle).toBeInTheDocument();
       expect(logoTitle?.getAttribute("aria-label")).toBe(
-        "DevRackula - development environment",
+        "DRackula - development environment",
       );
-      // Text content includes Dev prefix and Rackula (whitespace normalized)
+      // Text content includes D prefix and Rackula (whitespace normalized)
       const textContent =
         logoTitle?.querySelector("text")?.textContent?.replace(/\s+/g, "") ??
         "";
-      expect(textContent).toBe("DevRackula");
+      expect(textContent).toBe("DRackula");
     });
 
     it("brand section does not contain tagline (moved to About)", () => {


### PR DESCRIPTION
## Summary
Reverts to the original simple "D" prefix design. The "Dev" styling with smaller "ev" was overly complex and didn't render correctly in SVG.

## Changes
- Single red "D" immediately before "Rackula" (no gap)
- Removed all "ev" related code and tests
- viewBox back to 180

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)