### PR TITLE
fix: make D prefix slightly larger (#279)

### DIFF
--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -264,7 +264,7 @@
       : "Rackula"}
     style={gradientId ? `--active-gradient: ${gradientId}` : undefined}
   >
-    <text x="0" y="38">{#if showEnvPrefix}<tspan class="env-prefix">D</tspan>{/if}<tspan>Rackula</tspan></text>
+    <text x="0" y="38">{#if showEnvPrefix}<tspan class="env-prefix" font-size="44">D</tspan>{/if}<tspan>Rackula</tspan></text>
   </svg>
 </div>
 


### PR DESCRIPTION
Makes the red D prefix 44px (vs 38px for Rackula text) - about 15% larger.

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)