### PR TITLE
chore: extract getAllBrandDevices helper to eliminate duplication (#278)

### DIFF
--- a/src/lib/data/brandPacks/index.ts
+++ b/src/lib/data/brandPacks/index.ts
@@ -243,12 +243,11 @@ export function getBrandDevices(brandId: string): DeviceType[] {
 }
 
 /**
- * Find a device by slug across all brand packs
- * @returns The DeviceType if found, undefined otherwise
+ * Get all devices from all brand packs as a single array
+ * Used by findBrandDevice and getBrandSlugs to avoid duplication
  */
-export function findBrandDevice(slug: string): DeviceType | undefined {
-  // Search all brand packs
-  const allDevices = [
+export function getAllBrandDevices(): DeviceType[] {
+  return [
     ...ubiquitiDevices,
     ...mikrotikDevices,
     ...tplinkDevices,
@@ -268,8 +267,14 @@ export function findBrandDevice(slug: string): DeviceType | undefined {
     ...blackmagicdesignDevices,
     ...deskpiDevices,
   ];
+}
 
-  return allDevices.find((d) => d.slug === slug);
+/**
+ * Find a device by slug across all brand packs
+ * @returns The DeviceType if found, undefined otherwise
+ */
+export function findBrandDevice(slug: string): DeviceType | undefined {
+  return getAllBrandDevices().find((d) => d.slug === slug);
 }
 
 // Cached set of all brand device slugs
@@ -281,27 +286,7 @@ let brandSlugsCache: Set<string> | null = null;
  */
 export function getBrandSlugs(): Set<string> {
   if (!brandSlugsCache) {
-    const allDevices = [
-      ...ubiquitiDevices,
-      ...mikrotikDevices,
-      ...tplinkDevices,
-      ...synologyDevices,
-      ...apcDevices,
-      ...dellDevices,
-      ...supermicroDevices,
-      ...hpeDevices,
-      ...fortinetDevices,
-      ...eatonDevices,
-      ...netgearDevices,
-      ...paloaltoDevices,
-      ...qnapDevices,
-      ...lenovoDevices,
-      ...cyberpowerDevices,
-      ...netgateDevices,
-      ...blackmagicdesignDevices,
-      ...deskpiDevices,
-    ];
-    brandSlugsCache = new Set(allDevices.map((d) => d.slug));
+    brandSlugsCache = new Set(getAllBrandDevices().map((d) => d.slug));
   }
   return brandSlugsCache;
 }


### PR DESCRIPTION
## Summary

- Add new `getAllBrandDevices()` helper function that returns all devices from all brand packs as a single array
- Replace duplicated `allDevices` array construction in both `findBrandDevice()` and `getBrandSlugs()`
- Single source of truth for brand device aggregation - new brands only need to be added in one place

## Files Changed

- `src/lib/data/brandPacks/index.ts`: Added helper, refactored two functions

## Test Plan

- [x] Brandpack tests pass (62 tests)
- [x] Build succeeds

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code organization by consolidating device data aggregation logic to reduce duplication and enhance system maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->