### PR TITLE
fix: address CodeRabbit feedback on performance baseline (#255)

### DIFF
--- a/docs/research/performance-baseline.md
+++ b/docs/research/performance-baseline.md
@@ -265,4 +265,4 @@ if (performance.memory) {
 
 ---
 
-**End of Performance Baseline Document**
+## End of Performance Baseline Document


### PR DESCRIPTION
## Summary

Follow-up to PR #294 addressing CodeRabbit review feedback:

1. **Markdown formatting** (trivial): Use heading instead of emphasis for document ending to comply with MD036 markdownlint rule

2. **Critical boundary check bug** (critical): Fix `generatePlacedDevices()` boundary check
   - Old: `currentU <= rackHeight - 1` - prevented valid placements like 1U at U42
   - New: `currentU + deviceType.u_height - 1 > rackHeight` - correctly checks if entire device fits

3. **expectedElements consistency** (minor): 
   - Added constants: `EMPTY_RACK_ELEMENTS`, `ELEMENTS_PER_DEVICE`, `PORT_ELEMENTS_*`
   - Made expectedElements consistently represent total SVG elements (rack + devices + ports)
   - Added JSDoc comment explaining the field
   - Fixed incorrect formula (was `42 * 6 + 43 + 42 * 2`, now uses documented `1 + 4 + 42 + 43 + 252 + 42 = 384`)

## Test Plan
- [x] Benchmark script runs successfully
- [x] Lint passes
- [x] All scenarios generate expected data

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated formatting in performance baseline documentation.

* **Bug Fixes**
  * Fixed device placement validation to prevent exceeding rack capacity limits.

* **Refactor**
  * Standardized SVG rendering workload element count calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->