### PR TITLE
feat: expand InterfaceTemplate type and Zod schema (#247)

### DIFF
--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -93,6 +93,66 @@ export const AirflowSchema = z.enum([
  */
 export const SubdeviceRoleSchema = z.enum(["parent", "child"]);
 
+/**
+ * Network interface type enum (NetBox-compatible subset)
+ */
+export const InterfaceTypeSchema = z.enum([
+  // Copper Ethernet
+  "100base-tx",
+  "1000base-t",
+  "2.5gbase-t",
+  "5gbase-t",
+  "10gbase-t",
+  // Modular - SFP/SFP+/SFP28
+  "1000base-x-sfp",
+  "10gbase-x-sfpp",
+  "25gbase-x-sfp28",
+  // Modular - QSFP/QSFP28/QSFP-DD
+  "40gbase-x-qsfpp",
+  "100gbase-x-qsfp28",
+  "100gbase-x-qsfpdd",
+  "200gbase-x-qsfp56",
+  "200gbase-x-qsfpdd",
+  "400gbase-x-qsfpdd",
+  // Console & Management
+  "console",
+  "usb-a",
+  "usb-b",
+  "usb-c",
+  "usb-mini-b",
+  "usb-micro-b",
+  // Virtual
+  "virtual",
+  "lag",
+  // Other
+  "other",
+]);
+
+/**
+ * PoE type enum (NetBox-compatible)
+ */
+export const PoETypeSchema = z.enum([
+  "type1-ieee802.3af",
+  "type2-ieee802.3at",
+  "type3-ieee802.3bt",
+  "type4-ieee802.3bt",
+  "passive-24v-1pair",
+  "passive-24v-2pair",
+  "passive-48v-1pair",
+  "passive-48v-2pair",
+  "passive-56v-4pair",
+]);
+
+/**
+ * PoE mode enum
+ */
+export const PoEModeSchema = z.enum(["pd", "pse"]);
+
+/**
+ * Interface position enum
+ */
+export const InterfacePositionSchema = z.enum(["front", "rear"]);
+
 // ============================================================================
 // Utility Functions
 // ============================================================================
@@ -126,7 +186,23 @@ export function validateSlugUniqueness(
 // ============================================================================
 
 /**
- * Network interface schema
+ * Network interface template schema (NetBox-compatible with Rackula extensions)
+ */
+export const InterfaceTemplateSchema = z
+  .object({
+    name: z.string().min(1, "Interface name is required"),
+    type: InterfaceTypeSchema,
+    label: z.string().max(64).optional(),
+    mgmt_only: z.boolean().optional(),
+    position: InterfacePositionSchema.optional(),
+    poe_mode: PoEModeSchema.optional(),
+    poe_type: PoETypeSchema.optional(),
+  })
+  .passthrough();
+
+/**
+ * @deprecated Use InterfaceTemplateSchema instead
+ * Legacy network interface schema (kept for backward compatibility)
  */
 export const InterfaceSchema = z
   .object({
@@ -240,7 +316,7 @@ export const DeviceTypeSchema = z
     custom_fields: z.record(z.string(), z.any()).optional(),
 
     // --- Component Arrays ---
-    interfaces: z.array(InterfaceSchema).optional(),
+    interfaces: z.array(InterfaceTemplateSchema).optional(),
     power_ports: z.array(PowerPortSchema).optional(),
     power_outlets: z.array(PowerOutletSchema).optional(),
     device_bays: z.array(DeviceBaySchema).optional(),
@@ -370,6 +446,12 @@ export type WeightUnit = z.infer<typeof WeightUnitSchema>;
 export type DisplayMode = z.infer<typeof DisplayModeSchema>;
 export type Airflow = z.infer<typeof AirflowSchema>;
 export type SubdeviceRole = z.infer<typeof SubdeviceRoleSchema>;
+export type InterfaceType = z.infer<typeof InterfaceTypeSchema>;
+export type PoEType = z.infer<typeof PoETypeSchema>;
+export type PoEMode = z.infer<typeof PoEModeSchema>;
+export type InterfacePosition = z.infer<typeof InterfacePositionSchema>;
+export type InterfaceTemplate = z.infer<typeof InterfaceTemplateSchema>;
+/** @deprecated Use InterfaceTemplate instead */
 export type Interface = z.infer<typeof InterfaceSchema>;
 export type PowerPort = z.infer<typeof PowerPortSchema>;
 export type PowerOutlet = z.infer<typeof PowerOutletSchema>;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -74,12 +74,94 @@ export type Airflow =
  */
 export type SubdeviceRole = "parent" | "child";
 
+/**
+ * Network interface type (NetBox-compatible subset)
+ * Common physical interface types for rack equipment
+ */
+export type InterfaceType =
+  // Copper Ethernet
+  | "100base-tx" // 100 Mbps RJ45
+  | "1000base-t" // 1 GbE RJ45
+  | "2.5gbase-t" // 2.5 GbE RJ45
+  | "5gbase-t" // 5 GbE RJ45
+  | "10gbase-t" // 10 GbE RJ45
+  // Modular - SFP/SFP+/SFP28
+  | "1000base-x-sfp" // 1 GbE SFP
+  | "10gbase-x-sfpp" // 10 GbE SFP+
+  | "25gbase-x-sfp28" // 25 GbE SFP28
+  // Modular - QSFP/QSFP28/QSFP-DD
+  | "40gbase-x-qsfpp" // 40 GbE QSFP+
+  | "100gbase-x-qsfp28" // 100 GbE QSFP28
+  | "100gbase-x-qsfpdd" // 100 GbE QSFP-DD
+  | "200gbase-x-qsfp56" // 200 GbE QSFP56
+  | "200gbase-x-qsfpdd" // 200 GbE QSFP-DD
+  | "400gbase-x-qsfpdd" // 400 GbE QSFP-DD
+  // Console & Management
+  | "console" // Console port (RJ45/USB)
+  | "usb-a" // USB Type A
+  | "usb-b" // USB Type B
+  | "usb-c" // USB Type C
+  | "usb-mini-b" // USB Mini B
+  | "usb-micro-b" // USB Micro B
+  // Virtual
+  | "virtual" // Virtual interface
+  | "lag" // Link Aggregation Group
+  // Other
+  | "other"; // Catch-all for unlisted types
+
+/**
+ * PoE type (NetBox-compatible)
+ * Power over Ethernet standards
+ */
+export type PoEType =
+  | "type1-ieee802.3af" // 15.4W max
+  | "type2-ieee802.3at" // 30W max (PoE+)
+  | "type3-ieee802.3bt" // 60W max (PoE++ 4-pair)
+  | "type4-ieee802.3bt" // 100W max (PoE++ 4-pair)
+  | "passive-24v-1pair" // Passive 24V (1-pair)
+  | "passive-24v-2pair" // Passive 24V (2-pair)
+  | "passive-48v-1pair" // Passive 48V (1-pair)
+  | "passive-48v-2pair" // Passive 48V (2-pair)
+  | "passive-56v-4pair"; // Passive 56V (4-pair, Ubiquiti)
+
+/**
+ * PoE mode - powered device or power sourcing equipment
+ */
+export type PoEMode = "pd" | "pse";
+
+/**
+ * Interface position on device face
+ */
+export type InterfacePosition = "front" | "rear";
+
 // =============================================================================
 // Component Types (NetBox-compatible, schema-only)
 // =============================================================================
 
 /**
- * Network interface definition
+ * Network interface template definition (NetBox-compatible with Rackula extensions)
+ * Used to define interface templates on DeviceType
+ */
+export interface InterfaceTemplate {
+  /** Interface name (e.g., 'eth0', 'Gi1/0/1', 'Port 1') */
+  name: string;
+  /** Interface type (from InterfaceType enum) */
+  type: InterfaceType;
+  /** Alternative display label */
+  label?: string;
+  /** Management interface only (default: false) */
+  mgmt_only?: boolean;
+  /** Interface position on device face (Rackula extension for visual layout) */
+  position?: InterfacePosition;
+  /** PoE mode: pd (powered device) or pse (power sourcing equipment) */
+  poe_mode?: PoEMode;
+  /** PoE type/standard */
+  poe_type?: PoEType;
+}
+
+/**
+ * @deprecated Use InterfaceTemplate instead
+ * Legacy interface definition (kept for backward compatibility)
  */
 export interface Interface {
   /** Interface name (e.g., 'eth0', 'Gi1/0/1') */
@@ -214,8 +296,8 @@ export interface DeviceType {
   custom_fields?: Record<string, unknown>;
 
   // --- Component Arrays (schema-only, future features) ---
-  /** Network interfaces */
-  interfaces?: Interface[];
+  /** Network interface templates */
+  interfaces?: InterfaceTemplate[];
   /** Power input ports */
   power_ports?: PowerPort[];
   /** Power output outlets (for PDUs) */


### PR DESCRIPTION
## Summary

Expand the existing `Interface` type to a full `InterfaceTemplate` with NetBox-compatible fields and Rackula extensions for visual positioning.

- Create `InterfaceType` enum with common interface types (22 types covering RJ45, SFP+, QSFP+, console, USB, etc.)
- Add `PoEType` enum for PoE standards (IEEE 802.3af/at/bt, passive variants)
- Add `PoEMode` enum (pd/pse) and `InterfacePosition` enum (front/rear)
- Expand `InterfaceTemplate` with fields: name, type, label, mgmt_only, position, poe_mode, poe_type
- Update Zod schema with `InterfaceTemplateSchema` validation
- Maintain backward compatibility with deprecated `Interface` type

## Files Changed

- `src/lib/types/index.ts`: Added 4 new enums, new InterfaceTemplate interface
- `src/lib/schemas/index.ts`: Added 4 new schema definitions, updated DeviceTypeSchema

## Test Plan

- [x] Schema tests pass (112 tests)
- [x] Build succeeds
- [x] TypeScript compiles without errors

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)