### PR TITLE
fix: center rack + annotations relative to name heading (#304)

### DIFF
--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -242,6 +242,11 @@
         />
       </div>
     {/if}
+
+    <!-- Balancing spacer to keep rack centered when annotations are shown -->
+    {#if showAnnotations}
+      <div class="annotation-spacer" aria-hidden="true"></div>
+    {/if}
   </div>
 </div>
 
@@ -316,5 +321,11 @@
   .rack-front :global(.rack-container:focus),
   .rack-rear :global(.rack-container:focus) {
     outline: none !important;
+  }
+
+  /* Balancing spacer matches annotation column width to keep rack centered */
+  .annotation-spacer {
+    width: 100px; /* Must match AnnotationColumn default width */
+    flex-shrink: 0;
   }
 </style>


### PR DESCRIPTION
## Summary

- Add a balancing spacer element on the right side when annotations are shown
- Keeps the rack views visually centered under the rack name heading
- Spacer matches the annotation column width (100px)

## Problem

When annotations are toggled on, the rack views shifted right because the annotation column only adds width to the left side, throwing off the visual balance.

## Solution

Add an invisible spacer `div` on the right that matches the annotation column width, so the layout becomes:

```
         [Rack Name]
[ANN][FRONT][REAR][SPACER]
```

Both ANN and SPACER are 100px, keeping FRONT/REAR centered.

## Files Changed

- `src/lib/components/RackDualView.svelte`: Add annotation-spacer div and CSS

## Test Plan

- [x] RackDualView tests pass (30 tests)
- [x] Build passes
- [ ] Visual verification: toggle annotations and confirm rack stays centered

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rack centering to remain properly aligned when the annotation column is displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->