### PR TITLE
Update u_height for Ubiquiti USP-PDU-Pro

### DIFF
--- a/src/lib/data/brandPacks/ubiquiti.ts
+++ b/src/lib/data/brandPacks/ubiquiti.ts
@@ -570,7 +570,7 @@ export const ubiquitiDevices: DeviceType[] = [
 	// ============================================
 	{
 		slug: 'ubiquiti-usp-pdu-pro',
-		u_height: 1,
+		u_height: 2,
 		manufacturer: 'Ubiquiti',
 		model: 'USP-PDU-Pro',
 		is_full_depth: false,


### PR DESCRIPTION
## Summary

This PR updates the number of mounting units a Unifi [USP-PDU-Pro](https://ca.store.ui.com/ca/en/category/accessories-poe-power/collections/unifi-power-tech-power-distribution) uses.  It is not 1U, but is actually a 2U unit.

## Changes

- Only updates the attribute in the brandpack to be 2U

## Testing

How was this tested?

- [ ] Unit tests pass (`npm run test:run`)
- [ ] E2E tests pass (`npm run test:e2e`)
- [ ] Manual testing completed

## Screenshots

If applicable, add screenshots showing the changes.

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] No new warnings introduced
- [ ] Tests added for new functionality (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the rack unit height specification for the Ubiquiti USP PDU Pro device from 1U to 2U, ensuring accurate layout and portrait rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->