### PR TITLE
feat: add banana for scale easter egg (#313)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -901,7 +901,12 @@
     onclose={handleShareClose}
   />
 
-  <HelpPanel open={helpPanelOpen} onclose={handleHelpClose} />
+  <HelpPanel
+    open={helpPanelOpen}
+    showBanana={uiStore.showBanana}
+    onclose={handleHelpClose}
+    ontogglebanana={() => uiStore.toggleBanana()}
+  />
 
   <ToastContainer />
 

--- a/src/lib/components/BananaForScale.svelte
+++ b/src/lib/components/BananaForScale.svelte
@@ -1,0 +1,101 @@
+<!--
+  BananaForScale Component
+  A silly easter egg that draws an accurately-scaled banana
+  next to the rack for visual scale reference.
+
+  Scale: 1U = 1.75" = 22px, so 1" ≈ 12.57px
+  Average banana: ~7" long × ~1.5" diameter
+  Banana dimensions: ~88px × ~19px
+-->
+<script lang="ts">
+  import { U_HEIGHT_PX } from "$lib/constants/layout";
+
+  interface Props {
+    /** Vertical offset from bottom of rack in pixels */
+    bottomOffset?: number;
+  }
+
+  let { bottomOffset = 8 }: Props = $props();
+
+  // Scale calculation:
+  // 1U = 1.75" = U_HEIGHT_PX (22px from layout constants)
+  // 1" = U_HEIGHT_PX / 1.75 ≈ 12.57px
+  // Average banana: 7" long × 1.5" diameter
+  const PIXELS_PER_INCH = U_HEIGHT_PX / 1.75;
+  const BANANA_LENGTH_INCHES = 7;
+  const BANANA_WIDTH_INCHES = 1.5;
+
+  const bananaLength = Math.round(BANANA_LENGTH_INCHES * PIXELS_PER_INCH); // ~88px
+  const bananaWidth = Math.round(BANANA_WIDTH_INCHES * PIXELS_PER_INCH); // ~19px
+</script>
+
+<svg
+  class="banana-for-scale"
+  width={bananaLength}
+  height={bananaWidth + 10}
+  viewBox="0 0 88 29"
+  aria-label="Banana for scale (approximately 7 inches)"
+  role="img"
+  style:--bottom-offset="{bottomOffset}px"
+>
+  <title>Banana for scale (7 inches)</title>
+
+  <!-- Banana body - curved yellow shape -->
+  <path
+    d="M8 20
+       C3 18, 2 14, 4 10
+       C6 5, 14 3, 25 2
+       C40 1, 60 1, 75 3
+       C82 4, 86 7, 86 12
+       C86 16, 82 20, 75 22
+       C60 25, 35 26, 18 24
+       C12 23, 10 22, 8 20
+       Z"
+    fill="#FFE135"
+  />
+
+  <!-- Darker yellow for depth/shadow -->
+  <path
+    d="M10 19
+       C6 17, 5 14, 6 11
+       C8 7, 15 5, 28 4
+       C45 3, 62 3, 74 5
+       C79 6, 82 8, 82 12
+       C82 14, 80 17, 74 19
+       C60 21, 40 22, 22 21
+       C15 20, 12 20, 10 19
+       Z"
+    fill="#F5D000"
+  />
+
+  <!-- Light highlight -->
+  <path
+    d="M25 6
+       C40 5, 55 5, 68 7
+       C72 8, 74 10, 73 12
+       C65 10, 45 9, 28 10
+       C22 10, 20 9, 25 6
+       Z"
+    fill="#FFF176"
+    opacity="0.6"
+  />
+
+  <!-- Stem -->
+  <ellipse cx="6" cy="15" rx="4" ry="3" fill="#8B7355" />
+  <ellipse cx="5" cy="15" rx="2.5" ry="2" fill="#6B5344" />
+
+  <!-- End tip -->
+  <ellipse cx="85" cy="11" rx="3" ry="4" fill="#4A3728" />
+
+  <!-- Brown spots (ripe banana) -->
+  <ellipse cx="30" cy="14" rx="2" ry="1.5" fill="#8B4513" opacity="0.3" />
+  <ellipse cx="50" cy="10" rx="1.5" ry="1" fill="#8B4513" opacity="0.25" />
+  <ellipse cx="65" cy="15" rx="1.8" ry="1.2" fill="#8B4513" opacity="0.3" />
+</svg>
+
+<style>
+  .banana-for-scale {
+    pointer-events: none;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
+  }
+</style>

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -327,6 +327,7 @@
           showLabelsOnImages={uiStore.showLabelsOnImages}
           showAnnotations={uiStore.showAnnotations}
           annotationField={uiStore.annotationField}
+          showBanana={uiStore.showBanana}
           {partyMode}
           {enableLongPress}
           onselect={(e) => handleRackSelect(e)}

--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -12,10 +12,14 @@
 
   interface Props {
     open: boolean;
+    /** Whether banana for scale easter egg is enabled */
+    showBanana?: boolean;
     onclose?: () => void;
+    /** Toggle banana for scale easter egg */
+    ontogglebanana?: () => void;
   }
 
-  let { open, onclose }: Props = $props();
+  let { open, showBanana = false, onclose, ontogglebanana }: Props = $props();
 
   // Track panel open/close
   $effect(() => {
@@ -237,6 +241,23 @@
       </a>
     </div>
 
+    <!-- Easter Eggs section -->
+    <section class="easter-eggs-section">
+      <h4>Easter Eggs</h4>
+      <label class="toggle-row">
+        <input
+          type="checkbox"
+          checked={showBanana}
+          onchange={() => ontogglebanana?.()}
+          aria-label="Banana for scale"
+        />
+        <span class="toggle-label">Banana for scale</span>
+        <span class="toggle-description"
+          >Show an accurately-scaled banana next to the rack</span
+        >
+      </label>
+    </section>
+
     <p class="made-in">Made in Canada 🇨🇦 with ❤️</p>
   </div>
 </Dialog>
@@ -421,5 +442,47 @@
     font-size: var(--font-size-sm);
     color: var(--colour-text-muted);
     text-align: center;
+  }
+
+  /* Easter Eggs section */
+  .easter-eggs-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding-top: var(--space-3);
+    border-top: 1px solid var(--colour-border);
+  }
+
+  .easter-eggs-section h4 {
+    margin: 0;
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    color: var(--colour-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .toggle-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    cursor: pointer;
+  }
+
+  .toggle-row input[type="checkbox"] {
+    margin-top: 2px;
+    cursor: pointer;
+  }
+
+  .toggle-label {
+    font-size: var(--font-size-sm);
+    color: var(--colour-text);
+    font-weight: 500;
+  }
+
+  .toggle-description {
+    font-size: var(--font-size-xs);
+    color: var(--colour-text-muted);
+    margin-left: auto;
   }
 </style>

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -12,6 +12,7 @@
   } from "$lib/types";
   import Rack from "./Rack.svelte";
   import AnnotationColumn from "./AnnotationColumn.svelte";
+  import BananaForScale from "./BananaForScale.svelte";
   import { useLongPress } from "$lib/utils/gestures";
 
   // Synthetic rack ID for single-rack mode
@@ -31,6 +32,8 @@
     showAnnotations?: boolean;
     /** Which field to display in annotation column */
     annotationField?: AnnotationField;
+    /** Show banana for scale easter egg */
+    showBanana?: boolean;
     /** Enable long press gesture for mobile rack editing */
     enableLongPress?: boolean;
     onselect?: (event: CustomEvent<{ rackId: string }>) => void;
@@ -78,6 +81,7 @@
     partyMode = false,
     showAnnotations = false,
     annotationField = "name",
+    showBanana = false,
     enableLongPress = false,
     onselect,
     ondeviceselect,
@@ -248,6 +252,13 @@
       <div class="annotation-spacer" aria-hidden="true"></div>
     {/if}
   </div>
+
+  <!-- Banana for scale easter egg -->
+  {#if showBanana}
+    <div class="banana-container" aria-hidden="true">
+      <BananaForScale />
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -260,6 +271,7 @@
     border-radius: var(--radius-md);
     background: transparent;
     cursor: inherit;
+    position: relative; /* For banana positioning */
   }
 
   .rack-dual-view:focus {
@@ -327,5 +339,13 @@
   .annotation-spacer {
     width: 100px; /* Must match AnnotationColumn default width */
     flex-shrink: 0;
+  }
+
+  /* Banana for scale easter egg container */
+  .banana-container {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    pointer-events: none;
   }
 </style>

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -27,6 +27,7 @@ let rightDrawerOpen = $state(false);
 let displayMode = $state<DisplayMode>("label");
 let showAnnotations = $state(false);
 let annotationField = $state<AnnotationField>("name");
+let showBanana = $state(false);
 
 // Derived values (using $derived rune)
 const canZoomIn = $derived(zoom < ZOOM_MAX);
@@ -49,6 +50,7 @@ export function resetUIStore(): void {
   displayMode = "label";
   showAnnotations = false;
   annotationField = "name";
+  showBanana = false;
   applyThemeToDocument(theme);
 }
 
@@ -101,6 +103,11 @@ export function getUIStore() {
       return annotationField;
     },
 
+    // Easter egg state getters
+    get showBanana() {
+      return showBanana;
+    },
+
     // Theme actions
     toggleTheme,
     setTheme,
@@ -126,6 +133,9 @@ export function getUIStore() {
     // Annotation actions
     toggleAnnotations,
     setAnnotationField,
+
+    // Easter egg actions
+    toggleBanana,
   };
 }
 
@@ -280,4 +290,11 @@ function setAnnotationField(field: AnnotationField): void {
   if (isValidAnnotationField(field)) {
     annotationField = field;
   }
+}
+
+/**
+ * Toggle banana for scale easter egg
+ */
+function toggleBanana(): void {
+  showBanana = !showBanana;
 }

--- a/src/tests/BananaForScale.test.ts
+++ b/src/tests/BananaForScale.test.ts
@@ -1,0 +1,98 @@
+/**
+ * BananaForScale Component Tests
+ * Tests for the silly "banana for scale" easter egg feature
+ *
+ * TDD: Write tests first, then implement component
+ */
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import BananaForScale from "$lib/components/BananaForScale.svelte";
+import { U_HEIGHT_PX } from "$lib/constants/layout";
+
+describe("BananaForScale", () => {
+  describe("Rendering", () => {
+    it("renders an SVG element", () => {
+      const { container } = render(BananaForScale);
+      const svg = container.querySelector("svg");
+      expect(svg).toBeTruthy();
+      expect(svg).toHaveClass("banana-for-scale");
+    });
+
+    it("has accessible role and label", () => {
+      const { container } = render(BananaForScale);
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("role", "img");
+      expect(svg?.getAttribute("aria-label")).toContain("Banana for scale");
+    });
+
+    it("includes a title element for tooltip", () => {
+      const { container } = render(BananaForScale);
+      const title = container.querySelector("title");
+      expect(title).toBeTruthy();
+      expect(title?.textContent).toContain("Banana");
+    });
+  });
+
+  describe("Accurate Scale", () => {
+    // Scale: 1U = 1.75" = U_HEIGHT_PX (22px)
+    // So 1" = 22px / 1.75 ≈ 12.57px
+    // Average banana: ~7" long × ~1.5" wide
+    const PIXELS_PER_INCH = U_HEIGHT_PX / 1.75;
+    const EXPECTED_LENGTH = Math.round(7 * PIXELS_PER_INCH); // ~88px
+    const _EXPECTED_WIDTH = Math.round(1.5 * PIXELS_PER_INCH); // ~19px (kept for documentation)
+
+    it("banana length is approximately 7 inches in pixels", () => {
+      const { container } = render(BananaForScale);
+      const svg = container.querySelector("svg");
+      const width = parseInt(svg?.getAttribute("width") || "0", 10);
+
+      // Allow 5px tolerance for rounding
+      expect(width).toBeGreaterThanOrEqual(EXPECTED_LENGTH - 5);
+      expect(width).toBeLessThanOrEqual(EXPECTED_LENGTH + 5);
+    });
+
+    it("uses U_HEIGHT_PX constant for scale calculation", () => {
+      // This verifies that if U_HEIGHT_PX changes, banana would scale accordingly
+      // The banana should be ~4U tall equivalent (7" ÷ 1.75" per U ≈ 4U)
+      const bananaInUnits = 7 / 1.75;
+      expect(bananaInUnits).toBeCloseTo(4, 0);
+    });
+  });
+
+  describe("Visual Elements", () => {
+    it("contains yellow banana body", () => {
+      const { container } = render(BananaForScale);
+      // Look for yellow-ish fill color
+      const yellowPath = container.querySelector(
+        'path[fill="#FFE135"], path[fill="#F5D000"]',
+      );
+      expect(yellowPath).toBeTruthy();
+    });
+
+    it("contains brown stem", () => {
+      const { container } = render(BananaForScale);
+      // Look for brown fill colors
+      const stem = container.querySelector(
+        'ellipse[fill="#8B7355"], ellipse[fill="#6B5344"]',
+      );
+      expect(stem).toBeTruthy();
+    });
+
+    it("contains brown end tip", () => {
+      const { container } = render(BananaForScale);
+      const tip = container.querySelector('ellipse[fill="#4A3728"]');
+      expect(tip).toBeTruthy();
+    });
+  });
+
+  describe("Non-Interactive", () => {
+    it("has pointer-events: none to not interfere with interactions", () => {
+      const { container } = render(BananaForScale);
+      const svg = container.querySelector("svg");
+      expect(svg).toBeTruthy();
+      // CSS class should handle this, but we verify the class is present
+      expect(svg).toHaveClass("banana-for-scale");
+    });
+  });
+});

--- a/src/tests/HelpPanel.test.ts
+++ b/src/tests/HelpPanel.test.ts
@@ -184,4 +184,56 @@ describe("HelpPanel", () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("Easter Eggs Section", () => {
+    it("shows Easter Eggs section heading", () => {
+      render(HelpPanel, { props: { open: true } });
+
+      expect(screen.getByText("Easter Eggs")).toBeInTheDocument();
+    });
+
+    it("shows banana toggle checkbox", () => {
+      render(HelpPanel, { props: { open: true } });
+
+      const bananaToggle = screen.getByRole("checkbox", {
+        name: /banana for scale/i,
+      });
+      expect(bananaToggle).toBeInTheDocument();
+    });
+
+    it("banana toggle starts unchecked", () => {
+      render(HelpPanel, { props: { open: true } });
+
+      const bananaToggle = screen.getByRole("checkbox", {
+        name: /banana for scale/i,
+      });
+      expect(bananaToggle).not.toBeChecked();
+    });
+
+    it("banana toggle calls ontogglebanana when clicked", async () => {
+      const onToggleBanana = vi.fn();
+
+      render(HelpPanel, {
+        props: { open: true, ontogglebanana: onToggleBanana },
+      });
+
+      const bananaToggle = screen.getByRole("checkbox", {
+        name: /banana for scale/i,
+      });
+      await fireEvent.click(bananaToggle);
+
+      expect(onToggleBanana).toHaveBeenCalledTimes(1);
+    });
+
+    it("banana toggle reflects showBanana prop", () => {
+      render(HelpPanel, {
+        props: { open: true, showBanana: true },
+      });
+
+      const bananaToggle = screen.getByRole("checkbox", {
+        name: /banana for scale/i,
+      });
+      expect(bananaToggle).toBeChecked();
+    });
+  });
 });

--- a/src/tests/ui-store.test.ts
+++ b/src/tests/ui-store.test.ts
@@ -349,4 +349,22 @@ describe("UI Store", () => {
       expect(store.annotationField).toBe("name");
     });
   });
+
+  describe("Banana for Scale (Easter Egg)", () => {
+    it("initial showBanana is false", () => {
+      const store = getUIStore();
+      expect(store.showBanana).toBe(false);
+    });
+
+    it("toggleBanana toggles showBanana", () => {
+      const store = getUIStore();
+      expect(store.showBanana).toBe(false);
+
+      store.toggleBanana();
+      expect(store.showBanana).toBe(true);
+
+      store.toggleBanana();
+      expect(store.showBanana).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add "Show Banana" toggle in About/Help panel Easter Eggs section
- Display accurately-scaled banana (7 inches / ~88px) next to rack
- Banana uses rack scale calculation (1U = 1.75" = 22px)

## Files Changed

- `src/lib/components/BananaForScale.svelte` - New SVG banana component
- `src/lib/stores/ui.svelte.ts` - Add showBanana state and toggleBanana action
- `src/lib/components/HelpPanel.svelte` - Add Easter Eggs section with toggle
- `src/lib/components/RackDualView.svelte` - Render banana at lower right of rack
- `src/lib/components/Canvas.svelte` - Pass showBanana prop to RackDualView
- `src/App.svelte` - Wire up HelpPanel with showBanana state

## Test Plan

- [x] BananaForScale component tests (9 tests)
- [x] UI store showBanana state tests (2 tests)
- [x] HelpPanel Easter Eggs section tests (5 tests)
- [x] All 367 pre-commit tests pass

## TDD Approach

Tests written first (red), then implementation added to make them pass (green).

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Banana for Scale" easter egg toggle in the Help Panel, allowing users to display a banana illustration on the rack view for visual scale reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->