### PR TITLE
feat: multi-field device search with scoring (#308)

### DIFF
--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -3,25 +3,42 @@
  * Utility functions for searching and grouping devices
  */
 
-import type { DeviceType, DeviceCategory } from '$lib/types';
+import type { DeviceType, DeviceCategory } from "$lib/types";
 
 /**
- * Search device types by model/slug (case-insensitive)
+ * Search device types by model/slug, manufacturer, and category (case-insensitive)
+ * Results are scored and ranked: model matches (3) > manufacturer matches (2) > category matches (1)
  * @param devices - Array of device types to search
  * @param query - Search query string
- * @returns Filtered array of device types matching the query
+ * @returns Filtered array of device types matching the query, sorted by relevance score
  */
-export function searchDevices(devices: DeviceType[], query: string): DeviceType[] {
-	if (!query.trim()) {
-		return devices;
-	}
+export function searchDevices(
+  devices: DeviceType[],
+  query: string,
+): DeviceType[] {
+  if (!query.trim()) {
+    return devices;
+  }
 
-	const normalizedQuery = query.toLowerCase().trim();
+  const q = query.toLowerCase().trim();
+  const results: { device: DeviceType; score: number }[] = [];
 
-	return devices.filter((device) => {
-		const name = device.model ?? device.slug;
-		return name.toLowerCase().includes(normalizedQuery);
-	});
+  for (const device of devices) {
+    let score = 0;
+    const name = (device.model ?? device.slug).toLowerCase();
+    const manufacturer = (device.manufacturer ?? "").toLowerCase();
+    const category = (device.category ?? "").toLowerCase();
+
+    if (name.includes(q)) score += 3;
+    if (manufacturer.includes(q)) score += 2;
+    if (category.includes(q)) score += 1;
+
+    if (score > 0) {
+      results.push({ device, score });
+    }
+  }
+
+  return results.sort((a, b) => b.score - a.score).map((r) => r.device);
 }
 
 /**
@@ -29,15 +46,17 @@ export function searchDevices(devices: DeviceType[], query: string): DeviceType[
  * @param devices - Array of device types to group
  * @returns Map of category to device types in that category
  */
-export function groupDevicesByCategory(devices: DeviceType[]): Map<DeviceCategory, DeviceType[]> {
-	const groups = new Map<DeviceCategory, DeviceType[]>();
+export function groupDevicesByCategory(
+  devices: DeviceType[],
+): Map<DeviceCategory, DeviceType[]> {
+  const groups = new Map<DeviceCategory, DeviceType[]>();
 
-	for (const device of devices) {
-		const existing = groups.get(device.category) ?? [];
-		groups.set(device.category, [...existing, device]);
-	}
+  for (const device of devices) {
+    const existing = groups.get(device.category) ?? [];
+    groups.set(device.category, [...existing, device]);
+  }
 
-	return groups;
+  return groups;
 }
 
 /**
@@ -46,9 +65,12 @@ export function groupDevicesByCategory(devices: DeviceType[]): Map<DeviceCategor
  * @param query - Search query string
  * @returns First matching device or null if no matches
  */
-export function getFirstMatch(devices: DeviceType[], query: string): DeviceType | null {
-	const matches = searchDevices(devices, query);
-	return matches.length > 0 ? matches[0] : null;
+export function getFirstMatch(
+  devices: DeviceType[],
+  query: string,
+): DeviceType | null {
+  const matches = searchDevices(devices, query);
+  return matches.length > 0 ? matches[0] : null;
 }
 
 /**
@@ -57,22 +79,22 @@ export function getFirstMatch(devices: DeviceType[], query: string): DeviceType 
  * @returns Human-readable category name
  */
 export function getCategoryDisplayName(category: DeviceCategory): string {
-	const names: Record<DeviceCategory, string> = {
-		server: 'Servers',
-		network: 'Network',
-		'patch-panel': 'Patch Panels',
-		power: 'Power',
-		storage: 'Storage',
-		kvm: 'KVM',
-		'av-media': 'AV/Media',
-		cooling: 'Cooling',
-		shelf: 'Shelves',
-		blank: 'Blanks',
-		'cable-management': 'Cable Management',
-		other: 'Other'
-	};
+  const names: Record<DeviceCategory, string> = {
+    server: "Servers",
+    network: "Network",
+    "patch-panel": "Patch Panels",
+    power: "Power",
+    storage: "Storage",
+    kvm: "KVM",
+    "av-media": "AV/Media",
+    cooling: "Cooling",
+    shelf: "Shelves",
+    blank: "Blanks",
+    "cable-management": "Cable Management",
+    other: "Other",
+  };
 
-	return names[category] ?? category;
+  return names[category] ?? category;
 }
 
 /**
@@ -81,25 +103,27 @@ export function getCategoryDisplayName(category: DeviceCategory): string {
  * @param devices - Array of device types to sort
  * @returns New sorted array (does not mutate original)
  */
-export function sortDevicesByBrandThenModel(devices: DeviceType[]): DeviceType[] {
-	return [...devices].sort((a, b) => {
-		const aManufacturer = a.manufacturer?.toLowerCase() ?? '';
-		const bManufacturer = b.manufacturer?.toLowerCase() ?? '';
+export function sortDevicesByBrandThenModel(
+  devices: DeviceType[],
+): DeviceType[] {
+  return [...devices].sort((a, b) => {
+    const aManufacturer = a.manufacturer?.toLowerCase() ?? "";
+    const bManufacturer = b.manufacturer?.toLowerCase() ?? "";
 
-		// Devices with manufacturer come before those without
-		if (aManufacturer && !bManufacturer) return -1;
-		if (!aManufacturer && bManufacturer) return 1;
+    // Devices with manufacturer come before those without
+    if (aManufacturer && !bManufacturer) return -1;
+    if (!aManufacturer && bManufacturer) return 1;
 
-		// Sort by manufacturer first
-		if (aManufacturer !== bManufacturer) {
-			return aManufacturer.localeCompare(bManufacturer);
-		}
+    // Sort by manufacturer first
+    if (aManufacturer !== bManufacturer) {
+      return aManufacturer.localeCompare(bManufacturer);
+    }
 
-		// Then sort by model
-		const aModel = (a.model ?? a.slug).toLowerCase();
-		const bModel = (b.model ?? b.slug).toLowerCase();
-		return aModel.localeCompare(bModel);
-	});
+    // Then sort by model
+    const aModel = (a.model ?? a.slug).toLowerCase();
+    const bModel = (b.model ?? b.slug).toLowerCase();
+    return aModel.localeCompare(bModel);
+  });
 }
 
 /**
@@ -109,9 +133,9 @@ export function sortDevicesByBrandThenModel(devices: DeviceType[]): DeviceType[]
  * @returns New sorted array (does not mutate original)
  */
 export function sortDevicesAlphabetically(devices: DeviceType[]): DeviceType[] {
-	return [...devices].sort((a, b) => {
-		const aName = (a.model ?? a.slug).toLowerCase();
-		const bName = (b.model ?? b.slug).toLowerCase();
-		return aName.localeCompare(bName);
-	});
+  return [...devices].sort((a, b) => {
+    const aName = (a.model ?? a.slug).toLowerCase();
+    const bName = (b.model ?? b.slug).toLowerCase();
+    return aName.localeCompare(bName);
+  });
 }

--- a/src/tests/deviceFilters.test.ts
+++ b/src/tests/deviceFilters.test.ts
@@ -1,209 +1,272 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
-	searchDevices,
-	groupDevicesByCategory,
-	getCategoryDisplayName,
-	sortDevicesByBrandThenModel,
-	sortDevicesAlphabetically
-} from '$lib/utils/deviceFilters';
-import type { DeviceType, DeviceCategory } from '$lib/types';
+  searchDevices,
+  groupDevicesByCategory,
+  getCategoryDisplayName,
+  sortDevicesByBrandThenModel,
+  sortDevicesAlphabetically,
+} from "$lib/utils/deviceFilters";
+import type { DeviceType, DeviceCategory } from "$lib/types";
 
 const createDevice = (
-	slug: string,
-	model: string,
-	category: DeviceCategory,
-	manufacturer?: string
+  slug: string,
+  model: string,
+  category: DeviceCategory,
+  manufacturer?: string,
 ): DeviceType => ({
-	slug,
-	model,
-	u_height: 1,
-	colour: '#000000',
-	category,
-	manufacturer
+  slug,
+  model,
+  u_height: 1,
+  colour: "#000000",
+  category,
+  manufacturer,
 });
 
-describe('deviceFilters', () => {
-	describe('searchDevices', () => {
-		const devices: DeviceType[] = [
-			createDevice('1', 'Server 1', 'server'),
-			createDevice('2', 'Network Switch', 'network'),
-			createDevice('3', 'Power Strip', 'power')
-		];
+describe("deviceFilters", () => {
+  describe("searchDevices", () => {
+    const devices: DeviceType[] = [
+      createDevice("1", "Server 1", "server"),
+      createDevice("2", "Network Switch", "network"),
+      createDevice("3", "Power Strip", "power"),
+    ];
 
-		it('returns all devices when query is empty', () => {
-			expect(searchDevices(devices, '')).toEqual(devices);
-			expect(searchDevices(devices, '   ')).toEqual(devices);
-		});
+    it("returns all devices when query is empty", () => {
+      expect(searchDevices(devices, "")).toEqual(devices);
+      expect(searchDevices(devices, "   ")).toEqual(devices);
+    });
 
-		it('filters devices by name (case-insensitive)', () => {
-			expect(searchDevices(devices, 'server')).toHaveLength(1);
-			expect(searchDevices(devices, 'SERVER')).toHaveLength(1);
-			expect(searchDevices(devices, 'Server')).toHaveLength(1);
-		});
+    it("filters devices by name (case-insensitive)", () => {
+      expect(searchDevices(devices, "server")).toHaveLength(1);
+      expect(searchDevices(devices, "SERVER")).toHaveLength(1);
+      expect(searchDevices(devices, "Server")).toHaveLength(1);
+    });
 
-		it('returns empty array when no matches', () => {
-			expect(searchDevices(devices, 'xyz')).toHaveLength(0);
-		});
+    it("returns empty array when no matches", () => {
+      expect(searchDevices(devices, "xyz")).toHaveLength(0);
+    });
 
-		it('matches partial strings', () => {
-			expect(searchDevices(devices, 'net')).toHaveLength(1);
-			expect(searchDevices(devices, 'pow')).toHaveLength(1);
-		});
-	});
+    it("matches partial strings", () => {
+      expect(searchDevices(devices, "net")).toHaveLength(1);
+      expect(searchDevices(devices, "pow")).toHaveLength(1);
+    });
 
-	describe('groupDevicesByCategory', () => {
-		const devices: DeviceType[] = [
-			createDevice('1', 'Server 1', 'server'),
-			createDevice('2', 'Server 2', 'server'),
-			createDevice('3', 'Switch', 'network')
-		];
+    it("matches manufacturer field", () => {
+      const devicesWithManufacturer: DeviceType[] = [
+        createDevice("r650", "PowerEdge R650", "server", "Dell"),
+        createDevice("us-24", "USW-24", "network", "Ubiquiti"),
+        createDevice("generic", "1U Server", "server"),
+      ];
+      const result = searchDevices(devicesWithManufacturer, "dell");
+      expect(result).toHaveLength(1);
+      expect(result[0].manufacturer).toBe("Dell");
+    });
 
-		it('groups devices by category', () => {
-			const groups = groupDevicesByCategory(devices);
-			expect(groups.get('server')).toHaveLength(2);
-			expect(groups.get('network')).toHaveLength(1);
-		});
+    it("matches category field", () => {
+      const devicesWithCategories: DeviceType[] = [
+        createDevice("r650", "PowerEdge R650", "server", "Dell"),
+        createDevice("pdu", "Basic PDU", "power", "APC"),
+      ];
+      const result = searchDevices(devicesWithCategories, "server");
+      expect(result).toHaveLength(1);
+      expect(result[0].category).toBe("server");
+    });
 
-		it('returns empty map for empty array', () => {
-			const groups = groupDevicesByCategory([]);
-			expect(groups.size).toBe(0);
-		});
-	});
+    it("ranks model matches higher than manufacturer matches", () => {
+      const devicesForRanking: DeviceType[] = [
+        createDevice("r650", "PowerEdge R650", "server", "Dell"),
+        createDevice("dell-server", "Dell Server Pro", "server", "Acme"),
+      ];
+      const result = searchDevices(devicesForRanking, "dell");
+      expect(result).toHaveLength(2);
+      expect(result[0].slug).toBe("dell-server");
+      expect(result[1].slug).toBe("r650");
+    });
 
-	describe('getCategoryDisplayName', () => {
-		it('returns correct display names', () => {
-			expect(getCategoryDisplayName('server')).toBe('Servers');
-			expect(getCategoryDisplayName('network')).toBe('Network');
-			expect(getCategoryDisplayName('patch-panel')).toBe('Patch Panels');
-			expect(getCategoryDisplayName('power')).toBe('Power');
-			expect(getCategoryDisplayName('storage')).toBe('Storage');
-			expect(getCategoryDisplayName('kvm')).toBe('KVM');
-			expect(getCategoryDisplayName('av-media')).toBe('AV/Media');
-			expect(getCategoryDisplayName('cooling')).toBe('Cooling');
-			expect(getCategoryDisplayName('blank')).toBe('Blanks');
-			expect(getCategoryDisplayName('other')).toBe('Other');
-		});
-	});
+    it("ranks manufacturer matches higher than category matches", () => {
+      const devicesForRanking: DeviceType[] = [
+        createDevice("pdu", "Basic PDU", "power", "APC"),
+        createDevice("ups", "Smart UPS", "power", "PowerTech"),
+      ];
+      const result = searchDevices(devicesForRanking, "power");
+      expect(result).toHaveLength(2);
+      expect(result[0].slug).toBe("ups");
+      expect(result[1].slug).toBe("pdu");
+    });
 
-	describe('sortDevicesByBrandThenModel', () => {
-		it('sorts devices by manufacturer first, then by model', () => {
-			const devices: DeviceType[] = [
-				createDevice('dell-r740', 'PowerEdge R740', 'server', 'Dell'),
-				createDevice('hp-dl380', 'ProLiant DL380', 'server', 'HPE'),
-				createDevice('dell-r640', 'PowerEdge R640', 'server', 'Dell'),
-				createDevice('hp-dl360', 'ProLiant DL360', 'server', 'HPE')
-			];
+    it("combines scores from multiple field matches", () => {
+      const devicesForScoring: DeviceType[] = [
+        createDevice("srv1", "Server Pro", "network", "Acme"),
+        createDevice("srv2", "Server Basic", "server", "Acme"),
+      ];
+      const result = searchDevices(devicesForScoring, "server");
+      expect(result).toHaveLength(2);
+      expect(result[0].slug).toBe("srv2");
+      expect(result[1].slug).toBe("srv1");
+    });
 
-			const sorted = sortDevicesByBrandThenModel(devices);
+    it("handles case-insensitive matching across all fields", () => {
+      const devicesForCase: DeviceType[] = [
+        createDevice("r650", "PowerEdge R650", "server", "Dell"),
+      ];
+      expect(searchDevices(devicesForCase, "DELL")).toHaveLength(1);
+      expect(searchDevices(devicesForCase, "dell")).toHaveLength(1);
+      expect(searchDevices(devicesForCase, "SERVER")).toHaveLength(1);
+    });
+  });
 
-			// Dell devices first (alphabetically before HPE), sorted by model
-			expect(sorted[0].slug).toBe('dell-r640');
-			expect(sorted[1].slug).toBe('dell-r740');
-			// Then HPE devices, sorted by model
-			expect(sorted[2].slug).toBe('hp-dl360');
-			expect(sorted[3].slug).toBe('hp-dl380');
-		});
+  describe("groupDevicesByCategory", () => {
+    const devices: DeviceType[] = [
+      createDevice("1", "Server 1", "server"),
+      createDevice("2", "Server 2", "server"),
+      createDevice("3", "Switch", "network"),
+    ];
 
-		it('handles devices without manufacturer (sorted last)', () => {
-			const devices: DeviceType[] = [
-				createDevice('generic-server', 'Generic Server', 'server'),
-				createDevice('dell-r740', 'PowerEdge R740', 'server', 'Dell'),
-				createDevice('unknown-switch', 'Switch 24', 'network')
-			];
+    it("groups devices by category", () => {
+      const groups = groupDevicesByCategory(devices);
+      expect(groups.get("server")).toHaveLength(2);
+      expect(groups.get("network")).toHaveLength(1);
+    });
 
-			const sorted = sortDevicesByBrandThenModel(devices);
+    it("returns empty map for empty array", () => {
+      const groups = groupDevicesByCategory([]);
+      expect(groups.size).toBe(0);
+    });
+  });
 
-			// Dell first (has manufacturer)
-			expect(sorted[0].slug).toBe('dell-r740');
-			// Then devices without manufacturer, sorted by model
-			expect(sorted[1].slug).toBe('generic-server');
-			expect(sorted[2].slug).toBe('unknown-switch');
-		});
+  describe("getCategoryDisplayName", () => {
+    it("returns correct display names", () => {
+      expect(getCategoryDisplayName("server")).toBe("Servers");
+      expect(getCategoryDisplayName("network")).toBe("Network");
+      expect(getCategoryDisplayName("patch-panel")).toBe("Patch Panels");
+      expect(getCategoryDisplayName("power")).toBe("Power");
+      expect(getCategoryDisplayName("storage")).toBe("Storage");
+      expect(getCategoryDisplayName("kvm")).toBe("KVM");
+      expect(getCategoryDisplayName("av-media")).toBe("AV/Media");
+      expect(getCategoryDisplayName("cooling")).toBe("Cooling");
+      expect(getCategoryDisplayName("blank")).toBe("Blanks");
+      expect(getCategoryDisplayName("other")).toBe("Other");
+    });
+  });
 
-		it('sorts case-insensitively', () => {
-			const devices: DeviceType[] = [
-				createDevice('ubiquiti-usg', 'USG Pro', 'network', 'Ubiquiti'),
-				createDevice('apc-ups', 'Smart-UPS', 'power', 'APC')
-			];
+  describe("sortDevicesByBrandThenModel", () => {
+    it("sorts devices by manufacturer first, then by model", () => {
+      const devices: DeviceType[] = [
+        createDevice("dell-r740", "PowerEdge R740", "server", "Dell"),
+        createDevice("hp-dl380", "ProLiant DL380", "server", "HPE"),
+        createDevice("dell-r640", "PowerEdge R640", "server", "Dell"),
+        createDevice("hp-dl360", "ProLiant DL360", "server", "HPE"),
+      ];
 
-			const sorted = sortDevicesByBrandThenModel(devices);
+      const sorted = sortDevicesByBrandThenModel(devices);
 
-			expect(sorted[0].slug).toBe('apc-ups');
-			expect(sorted[1].slug).toBe('ubiquiti-usg');
-		});
+      // Dell devices first (alphabetically before HPE), sorted by model
+      expect(sorted[0].slug).toBe("dell-r640");
+      expect(sorted[1].slug).toBe("dell-r740");
+      // Then HPE devices, sorted by model
+      expect(sorted[2].slug).toBe("hp-dl360");
+      expect(sorted[3].slug).toBe("hp-dl380");
+    });
 
-		it('returns empty array for empty input', () => {
-			expect(sortDevicesByBrandThenModel([])).toEqual([]);
-		});
+    it("handles devices without manufacturer (sorted last)", () => {
+      const devices: DeviceType[] = [
+        createDevice("generic-server", "Generic Server", "server"),
+        createDevice("dell-r740", "PowerEdge R740", "server", "Dell"),
+        createDevice("unknown-switch", "Switch 24", "network"),
+      ];
 
-		it('does not mutate original array', () => {
-			const devices: DeviceType[] = [
-				createDevice('b-device', 'Bravo', 'server', 'Zebra'),
-				createDevice('a-device', 'Alpha', 'server', 'Alpha')
-			];
-			const original = [...devices];
+      const sorted = sortDevicesByBrandThenModel(devices);
 
-			sortDevicesByBrandThenModel(devices);
+      // Dell first (has manufacturer)
+      expect(sorted[0].slug).toBe("dell-r740");
+      // Then devices without manufacturer, sorted by model
+      expect(sorted[1].slug).toBe("generic-server");
+      expect(sorted[2].slug).toBe("unknown-switch");
+    });
 
-			expect(devices).toEqual(original);
-		});
-	});
+    it("sorts case-insensitively", () => {
+      const devices: DeviceType[] = [
+        createDevice("ubiquiti-usg", "USG Pro", "network", "Ubiquiti"),
+        createDevice("apc-ups", "Smart-UPS", "power", "APC"),
+      ];
 
-	describe('sortDevicesAlphabetically', () => {
-		it('sorts devices alphabetically by model name', () => {
-			const devices: DeviceType[] = [
-				createDevice('server-c', 'Zebra Server', 'server'),
-				createDevice('server-a', 'Alpha Server', 'server'),
-				createDevice('server-b', 'Bravo Switch', 'network')
-			];
+      const sorted = sortDevicesByBrandThenModel(devices);
 
-			const sorted = sortDevicesAlphabetically(devices);
+      expect(sorted[0].slug).toBe("apc-ups");
+      expect(sorted[1].slug).toBe("ubiquiti-usg");
+    });
 
-			expect(sorted[0].model).toBe('Alpha Server');
-			expect(sorted[1].model).toBe('Bravo Switch');
-			expect(sorted[2].model).toBe('Zebra Server');
-		});
+    it("returns empty array for empty input", () => {
+      expect(sortDevicesByBrandThenModel([])).toEqual([]);
+    });
 
-		it('sorts case-insensitively', () => {
-			const devices: DeviceType[] = [
-				createDevice('upper', 'UPPER CASE', 'server'),
-				createDevice('lower', 'lower case', 'server'),
-				createDevice('mixed', 'Mixed Case', 'server')
-			];
+    it("does not mutate original array", () => {
+      const devices: DeviceType[] = [
+        createDevice("b-device", "Bravo", "server", "Zebra"),
+        createDevice("a-device", "Alpha", "server", "Alpha"),
+      ];
+      const original = [...devices];
 
-			const sorted = sortDevicesAlphabetically(devices);
+      sortDevicesByBrandThenModel(devices);
 
-			expect(sorted[0].model).toBe('lower case');
-			expect(sorted[1].model).toBe('Mixed Case');
-			expect(sorted[2].model).toBe('UPPER CASE');
-		});
+      expect(devices).toEqual(original);
+    });
+  });
 
-		it('falls back to slug when model is undefined', () => {
-			const devices: DeviceType[] = [
-				createDevice('zebra-device', undefined as unknown as string, 'server'),
-				createDevice('alpha-device', undefined as unknown as string, 'server')
-			];
+  describe("sortDevicesAlphabetically", () => {
+    it("sorts devices alphabetically by model name", () => {
+      const devices: DeviceType[] = [
+        createDevice("server-c", "Zebra Server", "server"),
+        createDevice("server-a", "Alpha Server", "server"),
+        createDevice("server-b", "Bravo Switch", "network"),
+      ];
 
-			const sorted = sortDevicesAlphabetically(devices);
+      const sorted = sortDevicesAlphabetically(devices);
 
-			expect(sorted[0].slug).toBe('alpha-device');
-			expect(sorted[1].slug).toBe('zebra-device');
-		});
+      expect(sorted[0].model).toBe("Alpha Server");
+      expect(sorted[1].model).toBe("Bravo Switch");
+      expect(sorted[2].model).toBe("Zebra Server");
+    });
 
-		it('returns empty array for empty input', () => {
-			expect(sortDevicesAlphabetically([])).toEqual([]);
-		});
+    it("sorts case-insensitively", () => {
+      const devices: DeviceType[] = [
+        createDevice("upper", "UPPER CASE", "server"),
+        createDevice("lower", "lower case", "server"),
+        createDevice("mixed", "Mixed Case", "server"),
+      ];
 
-		it('does not mutate original array', () => {
-			const devices: DeviceType[] = [
-				createDevice('b-device', 'Bravo', 'server'),
-				createDevice('a-device', 'Alpha', 'server')
-			];
-			const original = [...devices];
+      const sorted = sortDevicesAlphabetically(devices);
 
-			sortDevicesAlphabetically(devices);
+      expect(sorted[0].model).toBe("lower case");
+      expect(sorted[1].model).toBe("Mixed Case");
+      expect(sorted[2].model).toBe("UPPER CASE");
+    });
 
-			expect(devices).toEqual(original);
-		});
-	});
+    it("falls back to slug when model is undefined", () => {
+      const devices: DeviceType[] = [
+        createDevice("zebra-device", undefined as unknown as string, "server"),
+        createDevice("alpha-device", undefined as unknown as string, "server"),
+      ];
+
+      const sorted = sortDevicesAlphabetically(devices);
+
+      expect(sorted[0].slug).toBe("alpha-device");
+      expect(sorted[1].slug).toBe("zebra-device");
+    });
+
+    it("returns empty array for empty input", () => {
+      expect(sortDevicesAlphabetically([])).toEqual([]);
+    });
+
+    it("does not mutate original array", () => {
+      const devices: DeviceType[] = [
+        createDevice("b-device", "Bravo", "server"),
+        createDevice("a-device", "Alpha", "server"),
+      ];
+      const original = [...devices];
+
+      sortDevicesAlphabetically(devices);
+
+      expect(devices).toEqual(original);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Extend device library search to match against model, manufacturer, and category fields
- Add weighted scoring: model (3) > manufacturer (2) > category (1)
- Results sorted by relevance score (highest first)

## Problem

Searching "Dell" returned no results because `searchDevices()` only searched the `model` field.

## Solution

Updated `searchDevices()` to search multiple fields with scoring:
- Model match: +3 points
- Manufacturer match: +2 points  
- Category match: +1 point

## Files Changed

- `src/lib/utils/deviceFilters.ts`: Updated search logic
- `src/tests/deviceFilters.test.ts`: Added 6 new tests

## Test Plan

- [x] Searching "Dell" returns all Dell devices
- [x] Searching "server" returns all server-category devices
- [x] Searching "PowerEdge" still works (model match)
- [x] Results ranked: model matches > manufacturer matches > category matches
- [x] Case-insensitive matching works ("DELL", "dell", "Dell")
- [x] All 23 tests pass
- [x] Build succeeds

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced device search with relevance-based ranking. Search now matches across manufacturer names, categories, and model names, with results ranked by relevance for improved device discovery.

* **Tests**
  * Expanded test coverage for search result ranking, multi-field matching, case-insensitive searching, and sorting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->