### PR TITLE
fix: align banana with rack panel edge and correct rotation (#317)

### DIFF
--- a/src/lib/components/BananaForScale.svelte
+++ b/src/lib/components/BananaForScale.svelte
@@ -37,8 +37,8 @@
   aria-label="Banana for scale (approximately 7 inches)"
   role="img"
   style:--bottom-offset="{bottomOffset}px"
-  style:transform="rotate(-75deg)"
-  style:transform-origin="bottom right"
+  style:transform="rotate(75deg)"
+  style:transform-origin="bottom left"
 >
   <title>Banana for scale (7 inches)</title>
 

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -221,6 +221,12 @@
         {ondevicemoverack}
         {onplacementtap}
       />
+      <!-- Banana for scale (single view - front panel only) -->
+      {#if showBanana && !rack.show_rear}
+        <div class="banana-container" aria-hidden="true">
+          <BananaForScale />
+        </div>
+      {/if}
     </div>
 
     <!-- Rear view (conditionally shown based on rack.show_rear) -->
@@ -244,6 +250,12 @@
           {ondevicemoverack}
           {onplacementtap}
         />
+        <!-- Banana for scale (dual view - rear panel) -->
+        {#if showBanana}
+          <div class="banana-container" aria-hidden="true">
+            <BananaForScale />
+          </div>
+        {/if}
       </div>
     {/if}
 
@@ -252,13 +264,6 @@
       <div class="annotation-spacer" aria-hidden="true"></div>
     {/if}
   </div>
-
-  <!-- Banana for scale easter egg -->
-  {#if showBanana}
-    <div class="banana-container" aria-hidden="true">
-      <BananaForScale />
-    </div>
-  {/if}
 </div>
 
 <style>
@@ -322,6 +327,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    position: relative; /* For banana positioning */
   }
 
   /* Remove individual rack selection styling since we handle it at container level */
@@ -344,7 +350,7 @@
   /* Banana for scale easter egg container */
   .banana-container {
     position: absolute;
-    bottom: 0;
+    bottom: 8px;
     right: 0;
     pointer-events: none;
   }

--- a/src/tests/BananaForScale.test.ts
+++ b/src/tests/BananaForScale.test.ts
@@ -101,8 +101,8 @@ describe("BananaForScale", () => {
       const { container } = render(BananaForScale);
       const svg = container.querySelector("svg");
       const style = svg?.getAttribute("style") || "";
-      // Should have a rotation transform (negative angle to lean against right edge)
-      expect(style).toMatch(/rotate\(-?\d+deg\)/);
+      // Should have a positive rotation (clockwise) to lean against right edge with stem up
+      expect(style).toMatch(/rotate\(75deg\)/);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Move banana container inside rack-front/rack-rear divs for proper positioning relative to the panel
- Position banana at bottom-right of rear panel (dual view) or front panel (single view)
- Change rotation from -75deg to +75deg (clockwise) so stem points up-left
- Update transform-origin to bottom-left for correct pivot

## Files Changed

- `src/lib/components/BananaForScale.svelte`: Changed rotation and transform-origin
- `src/lib/components/RackDualView.svelte`: Moved banana inside rack panels, added position:relative
- `src/tests/BananaForScale.test.ts`: Updated test to match new rotation

## Test plan

- [x] BananaForScale tests pass
- [x] RackDualView tests pass
- [ ] Visual verification: banana appears at bottom-right of rack panel, leaning upright

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Banana overlay now conditionally appears in both front and rear views of the rack display.

* **Bug Fixes**
  * Improved banana orientation and repositioned for better visibility and placement.

* **Tests**
  * Updated test assertions to reflect banana orientation changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->