### PR TITLE
chore: widen New Rack dialog to fit all height buttons inline (#344)

### DIFF
--- a/src/lib/components/NewRackForm.svelte
+++ b/src/lib/components/NewRackForm.svelte
@@ -117,7 +117,7 @@
 	}
 </script>
 
-<Dialog {open} title="New Rack" showClose={false}>
+<Dialog {open} title="New Rack" width="460px" showClose={false}>
 	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 	<form class="new-rack-form" onsubmit={(e) => e.preventDefault()} onkeydown={handleKeyDown}>
 		<div class="form-group">


### PR DESCRIPTION
## Summary
- Increased New Rack dialog width from 400px to 460px
- All height buttons (12U, 18U, 24U, 42U, Custom) now fit on a single row

## Files Changed
- `src/lib/components/NewRackForm.svelte`: Added `width="460px"` prop to Dialog component

## Test Plan
- [ ] Open "New Rack" dialog and verify all height buttons appear on one row
- [ ] Verify the dialog still looks balanced with the wider layout
- [ ] Test on mobile/narrow viewports to ensure buttons wrap gracefully

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the width of the New Rack form dialog for improved layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->