### PR TITLE
fix: banana stands upright with stem pointing up (#348)

### DIFF
--- a/src/lib/components/BananaForScale.svelte
+++ b/src/lib/components/BananaForScale.svelte
@@ -37,8 +37,8 @@
   aria-label="Banana for scale (approximately 7 inches)"
   role="img"
   style:--bottom-offset="{bottomOffset}px"
-  style:transform="rotate(75deg)"
-  style:transform-origin="bottom left"
+  style:transform="rotate(-80deg)"
+  style:transform-origin="right center"
 >
   <title>Banana for scale (7 inches)</title>
 

--- a/src/tests/BananaForScale.test.ts
+++ b/src/tests/BananaForScale.test.ts
@@ -97,14 +97,35 @@ describe("BananaForScale", () => {
   });
 
   describe("Orientation", () => {
-    it("is rotated to lean upright against rack", () => {
+    it("stands nearly vertical with stem pointing up", () => {
       const { container } = render(BananaForScale);
       const svg = container.querySelector("svg");
       const style = svg?.getAttribute("style") || "";
-      // Should have a positive rotation (clockwise) to lean against right edge with stem up
-      expect(style).toMatch(/rotate\(75deg\)/);
-      // Pivot point should be bottom-left so banana rotates correctly against rack edge
-      expect(style).toMatch(/transform-origin:\s*bottom left/);
+
+      // SVG is drawn horizontally (stem left at x≈6, tip right at x≈85)
+      // To stand upright with stem UP: rotate counter-clockwise ~-80deg
+      // This makes stem point up, tip point down (standing on tip)
+      // A slight lean (5-15deg from vertical) looks natural
+
+      // Should rotate counter-clockwise (negative angle) between -75 and -85 degrees
+      const rotateMatch = style.match(/rotate\((-?\d+)deg\)/);
+      expect(rotateMatch).toBeTruthy();
+      const angle = parseInt(rotateMatch![1], 10);
+      expect(angle).toBeGreaterThanOrEqual(-85);
+      expect(angle).toBeLessThanOrEqual(-75);
+    });
+
+    it("pivots from tip end to stand on bottom", () => {
+      const { container } = render(BananaForScale);
+      const svg = container.querySelector("svg");
+      const style = svg?.getAttribute("style") || "";
+
+      // After rotation, the tip (right side of SVG) becomes the bottom
+      // Transform-origin should be at the tip end so banana "stands" on it
+      // Using "right center" or "100% 50%" or similar
+      expect(style).toMatch(
+        /transform-origin:\s*(right center|100% 50%|right)/,
+      );
     });
   });
 });

--- a/src/tests/collision-toast.test.ts
+++ b/src/tests/collision-toast.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Collision Toast Tests
+ * Tests for toast notifications when device drops are blocked
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import type { DeviceType, PlacedDevice, Rack } from "$lib/types";
+import { findCollisions } from "$lib/utils/collision";
+import { getDropFeedback } from "$lib/utils/dragdrop";
+import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
+
+describe("Collision Toast Notifications", () => {
+  // Test devices
+  const serverDevice: DeviceType = {
+    slug: "server-1",
+    model: "PowerEdge R740",
+    manufacturer: "Dell",
+    u_height: 2,
+    colour: "#4A90D9",
+    category: "server",
+    is_full_depth: true,
+  };
+
+  const switchDevice: DeviceType = {
+    slug: "switch-1",
+    model: "Catalyst 9300",
+    manufacturer: "Cisco",
+    u_height: 1,
+    colour: "#7B68EE",
+    category: "network",
+    is_full_depth: true,
+  };
+
+  const halfDepthSwitch: DeviceType = {
+    slug: "half-switch-1",
+    model: "UniFi Switch 24",
+    manufacturer: "Ubiquiti",
+    u_height: 1,
+    colour: "#50fa7b",
+    category: "network",
+    is_full_depth: false,
+  };
+
+  const deviceLibrary: DeviceType[] = [
+    serverDevice,
+    switchDevice,
+    halfDepthSwitch,
+  ];
+
+  const baseRack: Rack = {
+    name: "Test Rack",
+    height: 12,
+    width: 19,
+    position: 0,
+    desc_units: false,
+    show_rear: true,
+    form_factor: "4-post",
+    starting_unit: 1,
+    devices: [],
+  };
+
+  beforeEach(() => {
+    resetToastStore();
+  });
+
+  describe("findCollisions with blocking device identification", () => {
+    it("returns empty array when no collisions", () => {
+      const rack: Rack = {
+        ...baseRack,
+        devices: [
+          { id: "id-1", device_type: "server-1", position: 1, face: "front" },
+        ],
+      };
+
+      const collisions = findCollisions(rack, deviceLibrary, 1, 5);
+      expect(collisions).toHaveLength(0);
+    });
+
+    it("returns single blocking device on collision", () => {
+      const rack: Rack = {
+        ...baseRack,
+        devices: [
+          { id: "id-1", device_type: "server-1", position: 5, face: "front" },
+        ],
+      };
+
+      // Try to place at position 5 where server already is (server is 2U, occupies 5-6)
+      const collisions = findCollisions(rack, deviceLibrary, 2, 5);
+      expect(collisions).toHaveLength(1);
+      expect(collisions[0]!.device_type).toBe("server-1");
+    });
+
+    it("returns multiple blocking devices when overlapping several", () => {
+      const rack: Rack = {
+        ...baseRack,
+        devices: [
+          { id: "id-1", device_type: "switch-1", position: 5, face: "front" },
+          { id: "id-2", device_type: "switch-1", position: 6, face: "front" },
+        ],
+      };
+
+      // Try to place 2U device at position 5 - would overlap both switches
+      const collisions = findCollisions(rack, deviceLibrary, 2, 5);
+      expect(collisions).toHaveLength(2);
+    });
+
+    it("identifies blocking device for half-depth collision", () => {
+      const rack: Rack = {
+        ...baseRack,
+        devices: [
+          { id: "id-1", device_type: "server-1", position: 5, face: "front" },
+        ],
+      };
+
+      // Half-depth switch on rear should still collide with full-depth server on front
+      const collisions = findCollisions(
+        rack,
+        deviceLibrary,
+        1,
+        5,
+        undefined,
+        "rear",
+        false,
+      );
+      // Full-depth server blocks the position even from rear
+      expect(collisions).toHaveLength(1);
+      expect(collisions[0]!.device_type).toBe("server-1");
+    });
+
+    it("allows half-depth devices on opposite faces with no collision", () => {
+      const rack: Rack = {
+        ...baseRack,
+        devices: [
+          {
+            id: "id-1",
+            device_type: "half-switch-1",
+            position: 5,
+            face: "front",
+          },
+        ],
+      };
+
+      // Another half-depth on rear should NOT collide
+      const collisions = findCollisions(
+        rack,
+        deviceLibrary,
+        1,
+        5,
+        undefined,
+        "rear",
+        false,
+      );
+      expect(collisions).toHaveLength(0);
+    });
+  });
+
+  describe("getDropFeedback returns correct state", () => {
+    it("returns blocked when collision detected", () => {
+      const rack: Rack = {
+        ...baseRack,
+        devices: [
+          { id: "id-1", device_type: "server-1", position: 5, face: "front" },
+        ],
+      };
+
+      const feedback = getDropFeedback(rack, deviceLibrary, 2, 5);
+      expect(feedback).toBe("blocked");
+    });
+
+    it("returns invalid when device exceeds rack height", () => {
+      const feedback = getDropFeedback(baseRack, deviceLibrary, 2, 12);
+      expect(feedback).toBe("invalid");
+    });
+
+    it("returns valid when placement is allowed", () => {
+      const feedback = getDropFeedback(baseRack, deviceLibrary, 2, 5);
+      expect(feedback).toBe("valid");
+    });
+  });
+
+  describe("Toast store integration", () => {
+    it("showToast creates warning notification", () => {
+      const toastStore = getToastStore();
+      toastStore.showToast(
+        "Position blocked by PowerEdge R740",
+        "warning",
+        3000,
+      );
+
+      expect(toastStore.toasts).toHaveLength(1);
+      expect(toastStore.toasts[0]!.type).toBe("warning");
+      expect(toastStore.toasts[0]!.message).toBe(
+        "Position blocked by PowerEdge R740",
+      );
+      expect(toastStore.toasts[0]!.duration).toBe(3000);
+    });
+
+    it("handles multiple blocking device message format", () => {
+      const blockingNames = ["PowerEdge R740", "Catalyst 9300"];
+      const message = `Position blocked by ${blockingNames.join(", ")}`;
+
+      const toastStore = getToastStore();
+      toastStore.showToast(message, "warning", 3000);
+
+      expect(toastStore.toasts[0]!.message).toBe(
+        "Position blocked by PowerEdge R740, Catalyst 9300",
+      );
+    });
+  });
+
+  describe("Blocking device name resolution", () => {
+    it("uses placement name when available", () => {
+      const placedDevice: PlacedDevice = {
+        id: "id-1",
+        device_type: "server-1",
+        position: 5,
+        face: "front",
+        name: "Primary Database Server",
+      };
+
+      // Name should take priority
+      expect(placedDevice.name).toBe("Primary Database Server");
+    });
+
+    it("falls back to device model when no placement name", () => {
+      const placedDevice: PlacedDevice = {
+        id: "id-1",
+        device_type: "server-1",
+        position: 5,
+        face: "front",
+      };
+
+      const deviceType = deviceLibrary.find(
+        (d) => d.slug === placedDevice.device_type,
+      );
+      expect(deviceType?.model).toBe("PowerEdge R740");
+    });
+
+    it("falls back to manufacturer when no model", () => {
+      const deviceWithOnlyManufacturer: DeviceType = {
+        slug: "no-model-device",
+        manufacturer: "Generic Co",
+        u_height: 1,
+        colour: "#888888",
+        category: "other",
+      };
+
+      expect(deviceWithOnlyManufacturer.model).toBeUndefined();
+      expect(deviceWithOnlyManufacturer.manufacturer).toBe("Generic Co");
+    });
+
+    it("falls back to slug when no name, model, or manufacturer", () => {
+      const minimalDevice: DeviceType = {
+        slug: "minimal-device",
+        u_height: 1,
+        colour: "#888888",
+        category: "other",
+      };
+
+      expect(minimalDevice.model).toBeUndefined();
+      expect(minimalDevice.manufacturer).toBeUndefined();
+      expect(minimalDevice.slug).toBe("minimal-device");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix banana orientation to stand upright with stem pointing UP and tip at BOTTOM
- Matches the reference photo of a standing banana

## Changes

- **Rotation**: `75deg` → `-80deg` (counter-clockwise for stem-up orientation)
- **Transform-origin**: `bottom left` → `right center` (pivot at tip so banana "stands" on it)

## Files Changed

- `src/lib/components/BananaForScale.svelte` - Updated rotation and transform-origin
- `src/tests/BananaForScale.test.ts` - Updated orientation tests

## Test Plan

- [x] Banana tests pass (11 tests)
- [x] Lint passes
- [x] Build succeeds
- [ ] Visual verification in browser

Closes #348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Device placement now provides feedback notifications when collisions occur or items exceed rack capacity, with details about blocking devices.

* **Tests**
  * Introduced comprehensive test coverage for collision detection and notification scenarios.
  * Updated and expanded orientation validation tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->