### PR TITLE
feat: add issue locking and worktree enforcement to dev-issue workflow

### DIFF
--- a/.claude/commands/dev-issue.md
+++ b/.claude/commands/dev-issue.md
@@ -372,22 +372,22 @@ gh pr merge --squash --delete-branch --auto
 
 ### 3h. Cleanup
 
-**Release the lock** — remove `in-progress` label (issue will close via PR merge):
+1. **Release the lock** — remove `in-progress` label (issue will close via PR merge):
 
-```bash
-gh issue edit <number> --remove-label "in-progress"
-```
+    ```bash
+    gh issue edit <number> --remove-label "in-progress"
+    ```
 
-If using worktree, return to main directory, pull, remove worktree, prune:
+2. If using worktree, return to main directory, pull, remove worktree, prune:
 
-```bash
-cd /path/to/Rackula  # main directory
-git pull origin main
-git worktree remove ../Rackula-issue-<N>
-git worktree prune
-```
+    ```bash
+    cd /path/to/Rackula  # main directory
+    git pull origin main
+    git worktree remove ../Rackula-issue-<N>
+    git worktree prune
+    ```
 
-Update progress file status to "Completed" with PR URL.
+3. Update progress file status to "Completed" with PR URL.
 
 <!-- CHECKPOINT: Phase 3 Complete -->
 
@@ -434,9 +434,9 @@ If not, read error and fix manually.
 
 2. **Release the lock** — remove `in-progress` label, so others can pick it up:
 
-```bash
-gh issue edit <N> --remove-label "in-progress"
-```
+    ```bash
+    gh issue edit <N> --remove-label "in-progress"
+    ```
 
 3. **Comment on issue** with status, completed items, blocker description, what was attempted, next steps needed, WIP branch name
 


### PR DESCRIPTION
## Summary

Prevents multiple Claude agents from working on the same issue simultaneously and ensures agents don't pollute the main directory with branch checkouts.

### Issue Locking Protocol
- Add `in-progress` label when claiming an issue
- Filter `in-progress` issues from available issues query  
- Race detection after claiming (2s delay + re-check for conflicts)
- Release label on completion or blocker

### Worktree Enforcement
- Make worktree creation **mandatory** (never work on main directory)
- Add critical branch checkout rules section (NEVER `git checkout <branch>` in main)
- Add main branch verification as first pre-flight check
- Fix it automatically if found on wrong branch

### Other Changes
- Update decision flow diagram with locking steps
- Add `gh issue edit` permission to permissions table
- Version bump: v5 → v6

## Test plan
- [ ] Run `/dev-issue` - should claim with `in-progress` label
- [ ] Run second `/dev-issue` in parallel - should skip in-progress issues
- [ ] Verify worktree is created, not branch checkout
- [ ] Verify label removed on completion
- [ ] Verify label removed on blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised development workflow: introduced an issue locking protocol, mandatory per-issue worktrees, and stricter main-branch checkout rules.
  * Added explicit claim/release steps, race-detection and conflict-handling guidance, and updated phase sequencing, task steps and cleanup/label-release flows.
  * Updated ready-issue filtering and progress/status guidance to reflect the new locking-centric process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->