### PR TITLE
feat: add fuzzy search with Fuse.js (#310)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@lucide/svelte": "^0.559.0",
         "bits-ui": "^2.14.4",
+        "fuse.js": "^7.1.0",
         "js-yaml": "^4.1.1",
         "jspdf": "^3.0.4",
         "jszip": "^3.10.1",
@@ -3933,6 +3934,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-caller-file": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@lucide/svelte": "^0.559.0",
     "bits-ui": "^2.14.4",
+    "fuse.js": "^7.1.0",
     "js-yaml": "^4.1.1",
     "jspdf": "^3.0.4",
     "jszip": "^3.10.1",


### PR DESCRIPTION
## Summary

- Add Fuse.js for fuzzy search with typo tolerance in the device library
- Enable multi-word AND queries that work across fields (e.g., "MikroTik RB" returns only MikroTik RB* devices)
- Tune threshold to 0.3 for balanced precision vs recall

## Changes

- `package.json`: Added fuse.js dependency (~6.7 kB gzipped)
- `src/lib/utils/deviceFilters.ts`: Replaced substring matching with Fuse.js fuzzy search
- `src/tests/deviceFilters.test.ts`: Added tests for fuzzy and multi-word AND queries

## Test plan

- [ ] Search "Ubiqiti" finds Ubiquiti devices (typo tolerance)
- [ ] Search "Deli" finds Dell devices (typo tolerance)
- [ ] Search "MikroTik RB" returns only MikroTik RB* devices (multi-word AND)
- [ ] Search "Dell PowerEdge" returns Dell PowerEdge servers (cross-field AND)
- [ ] Single word queries still work
- [ ] Exact matches still work

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Device search now supports fuzzy matching with typo tolerance, enabling users to find devices even with spelling mistakes in manufacturer or model names (e.g., "Deli" matches "Dell").
  * Multi-word search queries benefit from improved ranking and filtering across all device attributes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->