### PR TITLE
feat: PortIndicators SVG component (#249)

### DIFF
--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -1,0 +1,307 @@
+<!--
+  PortIndicators SVG Component
+  Renders network interface port indicators on device SVG elements.
+
+  Features:
+  - Color-coded circles by interface type
+  - Low-density mode: individual ports (≤24 ports)
+  - High-density mode: grouped badges (>24 ports)
+  - Management interface indicator (inner white dot)
+  - PoE indicator (lightning bolt) for PSE interfaces
+  - Click targets via foreignObject overlays
+-->
+<script lang="ts">
+  import type { InterfaceTemplate, InterfaceType, RackView } from "$lib/types";
+
+  interface Props {
+    interfaces: InterfaceTemplate[];
+    deviceWidth: number;
+    deviceHeight: number;
+    rackView: RackView;
+    showPorts?: boolean;
+    onPortClick?: (iface: InterfaceTemplate) => void;
+  }
+
+  let {
+    interfaces,
+    deviceWidth,
+    deviceHeight,
+    rackView,
+    showPorts = true,
+    onPortClick,
+  }: Props = $props();
+
+  // Color scheme by interface type (NetBox-inspired)
+  const INTERFACE_COLORS: Partial<Record<InterfaceType, string>> = {
+    "1000base-t": "#10b981", // Emerald - 1GbE
+    "10gbase-t": "#3b82f6", // Blue - 10GbE copper
+    "10gbase-x-sfpp": "#8b5cf6", // Purple - SFP+
+    "25gbase-x-sfp28": "#f59e0b", // Amber - SFP28
+    "40gbase-x-qsfpp": "#ef4444", // Red - QSFP+
+    "100gbase-x-qsfp28": "#ec4899", // Pink - QSFP28
+  };
+
+  // Default color for unknown types
+  const DEFAULT_COLOR = "#6b7280";
+
+  // Constants for port rendering
+  const PORT_RADIUS = 3;
+  const PORT_SPACING = 8;
+  const PORT_Y_OFFSET = 8; // Distance from bottom of device
+
+  // High-density threshold
+  const HIGH_DENSITY_THRESHOLD = 24;
+
+  // Badge dimensions for high-density mode
+  const BADGE_WIDTH = 24;
+  const BADGE_HEIGHT = 8;
+  const BADGE_SPACING = 4;
+
+  // Get color for interface type
+  function getInterfaceColor(type: InterfaceType): string {
+    return INTERFACE_COLORS[type] ?? DEFAULT_COLOR;
+  }
+
+  // Filter interfaces for current view
+  const visibleInterfaces = $derived(
+    interfaces.filter((iface) => {
+      const pos = iface.position ?? "front";
+      return pos === rackView;
+    }),
+  );
+
+  // Check if we're in high-density mode
+  const isHighDensity = $derived(
+    visibleInterfaces.length > HIGH_DENSITY_THRESHOLD,
+  );
+
+  // Calculate port positions (centered horizontally)
+  const portPositions = $derived.by(() => {
+    if (isHighDensity) return [];
+
+    const count = visibleInterfaces.length;
+    if (count === 0) return [];
+
+    const totalWidth = (count - 1) * PORT_SPACING;
+    const startX = (deviceWidth - totalWidth) / 2;
+    const y = deviceHeight - PORT_Y_OFFSET;
+
+    return visibleInterfaces.map((iface, i) => ({
+      iface,
+      x: startX + i * PORT_SPACING,
+      y,
+      color: getInterfaceColor(iface.type),
+    }));
+  });
+
+  // Group ports by type for high-density mode
+  const portGroups = $derived.by(() => {
+    if (!isHighDensity) return [];
+
+    // Use object instead of Map for ESLint compatibility
+    const groups: Record<string, InterfaceTemplate[]> = {};
+    for (const iface of visibleInterfaces) {
+      const key = iface.type;
+      if (!groups[key]) {
+        groups[key] = [];
+      }
+      groups[key].push(iface);
+    }
+
+    return Object.entries(groups).map(([type, ifaces]) => ({
+      type: type as InterfaceType,
+      count: ifaces.length,
+      color: getInterfaceColor(type as InterfaceType),
+    }));
+  });
+
+  // Calculate badge positions for high-density mode
+  const badgePositions = $derived.by(() => {
+    if (portGroups.length === 0) return [];
+
+    const totalWidth =
+      portGroups.length * (BADGE_WIDTH + BADGE_SPACING) - BADGE_SPACING;
+    const startX = (deviceWidth - totalWidth) / 2;
+    const y = deviceHeight - PORT_Y_OFFSET;
+
+    return portGroups.map((group, i) => ({
+      ...group,
+      x: startX + i * (BADGE_WIDTH + BADGE_SPACING),
+      y: y - BADGE_HEIGHT / 2,
+    }));
+  });
+
+  function handlePortClick(iface: InterfaceTemplate) {
+    onPortClick?.(iface);
+  }
+</script>
+
+{#if showPorts && visibleInterfaces.length > 0}
+  <g class="port-indicators">
+    {#if !isHighDensity}
+      <!-- Individual port circles for low-density devices -->
+      {#each portPositions as { iface, x, y, color } (iface.name)}
+        <circle
+          class="port-circle"
+          cx={x}
+          cy={y}
+          r={PORT_RADIUS}
+          fill={color}
+          stroke="rgba(0,0,0,0.3)"
+          stroke-width="0.5"
+        />
+
+        <!-- Management interface indicator (smaller inner circle) -->
+        {#if iface.mgmt_only}
+          <circle
+            class="port-mgmt-indicator"
+            cx={x}
+            cy={y}
+            r={1}
+            fill="white"
+          />
+        {/if}
+
+        <!-- PoE indicator (lightning bolt for PSE interfaces) -->
+        {#if iface.poe_mode === "pse"}
+          <text
+            class="port-poe-indicator"
+            {x}
+            y={y - PORT_RADIUS - 2}
+            text-anchor="middle"
+            dominant-baseline="auto"
+          >
+            ⚡
+          </text>
+        {/if}
+      {/each}
+
+      <!-- Invisible click targets (larger than visual ports) -->
+      <foreignObject
+        x="0"
+        y={deviceHeight - PORT_Y_OFFSET - 8}
+        width={deviceWidth}
+        height="16"
+        class="port-click-overlay"
+      >
+        <div xmlns="http://www.w3.org/1999/xhtml" class="port-click-container">
+          {#each portPositions as { iface, x } (iface.name)}
+            <button
+              type="button"
+              class="port-click-target"
+              style="left: {x - 6}px; top: 2px;"
+              title="{iface.name} ({iface.type})"
+              onclick={() => handlePortClick(iface)}
+            >
+              <span class="sr-only">{iface.name}</span>
+            </button>
+          {/each}
+        </div>
+      </foreignObject>
+    {:else}
+      <!-- Grouped port summary for high-density devices -->
+      {#each badgePositions as { type, count, color, x, y } (type)}
+        <g class="port-group-badge" transform="translate({x}, {y})">
+          <rect
+            width={BADGE_WIDTH}
+            height={BADGE_HEIGHT}
+            rx="2"
+            fill={color}
+            stroke="rgba(0,0,0,0.3)"
+            stroke-width="0.5"
+          />
+          <text
+            x={BADGE_WIDTH / 2}
+            y={BADGE_HEIGHT - 2}
+            text-anchor="middle"
+            class="port-count-text"
+          >
+            {count}
+          </text>
+        </g>
+      {/each}
+    {/if}
+  </g>
+{/if}
+
+<style>
+  .port-indicators {
+    pointer-events: none;
+  }
+
+  .port-circle {
+    transition: r 150ms ease-out;
+  }
+
+  .port-mgmt-indicator {
+    pointer-events: none;
+  }
+
+  .port-poe-indicator {
+    font-size: 6px;
+    pointer-events: none;
+  }
+
+  .port-click-overlay {
+    overflow: visible;
+    pointer-events: auto;
+  }
+
+  .port-click-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+
+  .port-click-target {
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    border-radius: 50%;
+  }
+
+  .port-click-target:hover {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .port-click-target:focus {
+    outline: 2px solid var(--colour-selection, #ff79c6);
+    outline-offset: 1px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .port-count-text {
+    fill: white;
+    font-size: 6px;
+    font-weight: 600;
+    font-family: var(--font-mono, monospace);
+    text-shadow: 0 0.5px 1px rgba(0, 0, 0, 0.5);
+  }
+
+  .port-group-badge rect {
+    transition: transform 150ms ease-out;
+  }
+
+  /* Respect reduced motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .port-circle,
+    .port-group-badge rect {
+      transition: none;
+    }
+  }
+</style>

--- a/src/tests/PortIndicators.test.ts
+++ b/src/tests/PortIndicators.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import PortIndicators from "$lib/components/PortIndicators.svelte";
+import type { InterfaceTemplate, InterfaceType } from "$lib/types";
+
+describe("PortIndicators SVG Component", () => {
+  // Helper to create interface templates
+  function createInterface(
+    name: string,
+    type: InterfaceType,
+    options: Partial<InterfaceTemplate> = {},
+  ): InterfaceTemplate {
+    return { name, type, ...options };
+  }
+
+  const defaultProps = {
+    interfaces: [
+      createInterface("eth0", "1000base-t"),
+      createInterface("eth1", "1000base-t"),
+    ],
+    deviceWidth: 186,
+    deviceHeight: 22, // 1U
+    rackView: "front" as const,
+  };
+
+  describe("Basic Rendering", () => {
+    it("renders port indicators group when showPorts is true (default)", () => {
+      const { container } = render(PortIndicators, { props: defaultProps });
+
+      const group = container.querySelector("g.port-indicators");
+      expect(group).toBeInTheDocument();
+    });
+
+    it("does not render when showPorts is false", () => {
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, showPorts: false },
+      });
+
+      const group = container.querySelector("g.port-indicators");
+      expect(group).not.toBeInTheDocument();
+    });
+
+    it("does not render when interfaces array is empty", () => {
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces: [] },
+      });
+
+      const group = container.querySelector("g.port-indicators");
+      expect(group).not.toBeInTheDocument();
+    });
+
+    it("renders correct number of port circles for low-density devices", () => {
+      const interfaces = Array.from({ length: 8 }, (_, i) =>
+        createInterface(`eth${i}`, "1000base-t"),
+      );
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circles = container.querySelectorAll("circle.port-circle");
+      expect(circles).toHaveLength(8);
+    });
+  });
+
+  describe("Color Coding", () => {
+    it("renders 1GbE ports in emerald (#10b981)", () => {
+      const interfaces = [createInterface("eth0", "1000base-t")];
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circle = container.querySelector("circle.port-circle");
+      expect(circle?.getAttribute("fill")).toBe("#10b981");
+    });
+
+    it("renders 10GbE copper ports in blue (#3b82f6)", () => {
+      const interfaces = [createInterface("eth0", "10gbase-t")];
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circle = container.querySelector("circle.port-circle");
+      expect(circle?.getAttribute("fill")).toBe("#3b82f6");
+    });
+
+    it("renders SFP+ ports in purple (#8b5cf6)", () => {
+      const interfaces = [createInterface("sfp0", "10gbase-x-sfpp")];
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circle = container.querySelector("circle.port-circle");
+      expect(circle?.getAttribute("fill")).toBe("#8b5cf6");
+    });
+
+    it("renders SFP28 ports in amber (#f59e0b)", () => {
+      const interfaces = [createInterface("sfp0", "25gbase-x-sfp28")];
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circle = container.querySelector("circle.port-circle");
+      expect(circle?.getAttribute("fill")).toBe("#f59e0b");
+    });
+
+    it("renders QSFP+ ports in red (#ef4444)", () => {
+      const interfaces = [createInterface("qsfp0", "40gbase-x-qsfpp")];
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circle = container.querySelector("circle.port-circle");
+      expect(circle?.getAttribute("fill")).toBe("#ef4444");
+    });
+
+    it("renders QSFP28 ports in pink (#ec4899)", () => {
+      const interfaces = [createInterface("qsfp0", "100gbase-x-qsfp28")];
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circle = container.querySelector("circle.port-circle");
+      expect(circle?.getAttribute("fill")).toBe("#ec4899");
+    });
+
+    it("renders unknown types in gray (#6b7280)", () => {
+      const interfaces = [createInterface("other0", "other" as InterfaceType)];
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circle = container.querySelector("circle.port-circle");
+      expect(circle?.getAttribute("fill")).toBe("#6b7280");
+    });
+  });
+
+  describe("Position Filtering", () => {
+    it("shows only front-positioned interfaces in front view", () => {
+      const interfaces = [
+        createInterface("eth0", "1000base-t", { position: "front" }),
+        createInterface("eth1", "1000base-t", { position: "rear" }),
+        createInterface("eth2", "1000base-t", { position: "front" }),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces, rackView: "front" },
+      });
+
+      const circles = container.querySelectorAll("circle.port-circle");
+      expect(circles).toHaveLength(2);
+    });
+
+    it("shows only rear-positioned interfaces in rear view", () => {
+      const interfaces = [
+        createInterface("eth0", "1000base-t", { position: "front" }),
+        createInterface("eth1", "1000base-t", { position: "rear" }),
+        createInterface("eth2", "1000base-t", { position: "rear" }),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces, rackView: "rear" },
+      });
+
+      const circles = container.querySelectorAll("circle.port-circle");
+      expect(circles).toHaveLength(2);
+    });
+
+    it("treats interfaces with no position as front by default", () => {
+      const interfaces = [
+        createInterface("eth0", "1000base-t"), // no position = front
+        createInterface("eth1", "1000base-t", { position: "rear" }),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces, rackView: "front" },
+      });
+
+      const circles = container.querySelectorAll("circle.port-circle");
+      expect(circles).toHaveLength(1);
+    });
+  });
+
+  describe("Management Interface Indicator", () => {
+    it("renders inner dot for management-only interfaces", () => {
+      const interfaces = [
+        createInterface("mgmt0", "1000base-t", { mgmt_only: true }),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const mgmtIndicator = container.querySelector(
+        "circle.port-mgmt-indicator",
+      );
+      expect(mgmtIndicator).toBeInTheDocument();
+      expect(mgmtIndicator?.getAttribute("fill")).toBe("white");
+      expect(mgmtIndicator?.getAttribute("r")).toBe("1");
+    });
+
+    it("does not render inner dot for non-management interfaces", () => {
+      const interfaces = [createInterface("eth0", "1000base-t")];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const mgmtIndicator = container.querySelector(
+        "circle.port-mgmt-indicator",
+      );
+      expect(mgmtIndicator).not.toBeInTheDocument();
+    });
+  });
+
+  describe("PoE Indicator", () => {
+    it("renders lightning bolt for PSE interfaces", () => {
+      const interfaces = [
+        createInterface("eth0", "1000base-t", { poe_mode: "pse" }),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const poeIndicator = container.querySelector("text.port-poe-indicator");
+      expect(poeIndicator).toBeInTheDocument();
+      expect(poeIndicator?.textContent).toBe("⚡");
+    });
+
+    it("does not render PoE indicator for PD interfaces", () => {
+      const interfaces = [
+        createInterface("eth0", "1000base-t", { poe_mode: "pd" }),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const poeIndicator = container.querySelector("text.port-poe-indicator");
+      expect(poeIndicator).not.toBeInTheDocument();
+    });
+
+    it("does not render PoE indicator when poe_mode is not set", () => {
+      const interfaces = [createInterface("eth0", "1000base-t")];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const poeIndicator = container.querySelector("text.port-poe-indicator");
+      expect(poeIndicator).not.toBeInTheDocument();
+    });
+  });
+
+  describe("High-Density Mode (>24 ports)", () => {
+    it("renders grouped badges instead of individual ports", () => {
+      // Create 48 1GbE ports
+      const interfaces = Array.from({ length: 48 }, (_, i) =>
+        createInterface(`eth${i}`, "1000base-t"),
+      );
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      // Should NOT have individual circles
+      const circles = container.querySelectorAll("circle.port-circle");
+      expect(circles).toHaveLength(0);
+
+      // Should have badge groups
+      const badges = container.querySelectorAll("g.port-group-badge");
+      expect(badges.length).toBeGreaterThan(0);
+    });
+
+    it("shows count in badge for each interface type", () => {
+      // Create 30 1GbE and 18 SFP+ ports
+      const interfaces = [
+        ...Array.from({ length: 30 }, (_, i) =>
+          createInterface(`eth${i}`, "1000base-t"),
+        ),
+        ...Array.from({ length: 18 }, (_, i) =>
+          createInterface(`sfp${i}`, "10gbase-x-sfpp"),
+        ),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      // Should have 2 badge groups (one for each type)
+      const badges = container.querySelectorAll("g.port-group-badge");
+      expect(badges).toHaveLength(2);
+
+      // Check count text
+      const countTexts = container.querySelectorAll("text.port-count-text");
+      const counts = Array.from(countTexts).map((t) => t.textContent);
+      expect(counts).toContain("30");
+      expect(counts).toContain("18");
+    });
+
+    it("uses correct colors for badge backgrounds", () => {
+      const interfaces = Array.from({ length: 48 }, (_, i) =>
+        createInterface(`eth${i}`, "1000base-t"),
+      );
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const badgeRect = container.querySelector("g.port-group-badge rect");
+      expect(badgeRect?.getAttribute("fill")).toBe("#10b981"); // 1GbE color
+    });
+
+    it("threshold is >24 ports for high-density mode", () => {
+      // 24 ports should show individual circles
+      const interfaces24 = Array.from({ length: 24 }, (_, i) =>
+        createInterface(`eth${i}`, "1000base-t"),
+      );
+
+      const { container: container24 } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces: interfaces24 },
+      });
+
+      expect(container24.querySelectorAll("circle.port-circle")).toHaveLength(
+        24,
+      );
+
+      // 25 ports should show badges
+      const interfaces25 = Array.from({ length: 25 }, (_, i) =>
+        createInterface(`eth${i}`, "1000base-t"),
+      );
+
+      const { container: container25 } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces: interfaces25 },
+      });
+
+      expect(container25.querySelectorAll("circle.port-circle")).toHaveLength(
+        0,
+      );
+      expect(
+        container25.querySelectorAll("g.port-group-badge").length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Click Handling", () => {
+    it("renders foreignObject click overlay for low-density mode", () => {
+      const { container } = render(PortIndicators, {
+        props: defaultProps,
+      });
+
+      const overlay = container.querySelector(
+        "foreignObject.port-click-overlay",
+      );
+      expect(overlay).toBeInTheDocument();
+    });
+
+    it("renders click targets for each port", () => {
+      const interfaces = [
+        createInterface("eth0", "1000base-t"),
+        createInterface("eth1", "1000base-t"),
+        createInterface("eth2", "1000base-t"),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const clickTargets = container.querySelectorAll(
+        "button.port-click-target",
+      );
+      expect(clickTargets).toHaveLength(3);
+    });
+
+    it("click targets have accessible title", () => {
+      const interfaces = [createInterface("eth0", "1000base-t")];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const clickTarget = container.querySelector("button.port-click-target");
+      expect(clickTarget?.getAttribute("title")).toBe("eth0 (1000base-t)");
+    });
+
+    it("calls onPortClick when port is clicked", async () => {
+      const handlePortClick = vi.fn();
+      const interfaces = [createInterface("eth0", "1000base-t")];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces, onPortClick: handlePortClick },
+      });
+
+      const clickTarget = container.querySelector("button.port-click-target");
+      await clickTarget?.click();
+
+      expect(handlePortClick).toHaveBeenCalledWith(interfaces[0]);
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("click targets have screen-reader-only text", () => {
+      const interfaces = [createInterface("eth0", "1000base-t")];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const srOnly = container.querySelector(".sr-only");
+      expect(srOnly).toBeInTheDocument();
+      expect(srOnly?.textContent).toBe("eth0");
+    });
+
+    it("click targets are focusable buttons", () => {
+      const interfaces = [createInterface("eth0", "1000base-t")];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const button = container.querySelector("button.port-click-target");
+      expect(button).toHaveAttribute("type", "button");
+    });
+  });
+
+  describe("Port Positioning", () => {
+    it("centers ports horizontally within device width", () => {
+      const interfaces = [
+        createInterface("eth0", "1000base-t"),
+        createInterface("eth1", "1000base-t"),
+        createInterface("eth2", "1000base-t"),
+      ];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circles = container.querySelectorAll("circle.port-circle");
+      const cxValues = Array.from(circles).map((c) =>
+        parseFloat(c.getAttribute("cx") || "0"),
+      );
+
+      // First and last ports should be equidistant from edges
+      const firstPort = cxValues[0];
+      const lastPort = cxValues[cxValues.length - 1];
+      const distFromStart = firstPort;
+      const distFromEnd = defaultProps.deviceWidth - lastPort;
+
+      // They should be symmetric (with some tolerance for spacing)
+      expect(Math.abs(distFromStart - distFromEnd)).toBeLessThan(1);
+    });
+
+    it("positions ports near device bottom edge", () => {
+      const interfaces = [createInterface("eth0", "1000base-t")];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const circle = container.querySelector("circle.port-circle");
+      const cy = parseFloat(circle?.getAttribute("cy") || "0");
+
+      // Should be positioned near bottom (within last 10px of device height)
+      expect(cy).toBeGreaterThan(defaultProps.deviceHeight - 10);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Create `PortIndicators.svelte` component for network interface port visualization
- Render SVG circles color-coded by interface type (1GbE, 10GbE, SFP+, SFP28, QSFP+, QSFP28)
- Support low-density mode (≤24 ports) with individual circles and high-density mode (>24 ports) with grouped badges
- Include management interface indicator (white inner dot) and PoE indicator (lightning bolt) for PSE interfaces
- Use foreignObject overlays for accessible click targets with proper focus management
- Support `position: 'front' | 'rear'` filtering based on rackView

## Test plan

- [ ] Run `npm run test:run -- src/tests/PortIndicators.test.ts` - 31 tests passing
- [ ] Run `npm run lint` - no errors
- [ ] Run `npm run build` - builds successfully

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual port indicators on device displays with colour-coded interface types
  * Supports two display modes: individual indicators for fewer ports and grouped badges for many ports
  * Added management interface and PoE indicator markers
  * Enabled clickable port selection with accessible targeting

* **Tests**
  * Added comprehensive test suite for port indicator rendering, colour coding, and interactions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->