### PR TITLE
docs: add Space Grotesk fallback to fonts README

### DIFF
--- a/static/fonts/README.md
+++ b/static/fonts/README.md
@@ -55,5 +55,6 @@ After adding fonts, run `npm run dev` and check the browser console for any 404 
 
 If fonts are missing, the app falls back to system fonts:
 
+- Space Grotesk -> system-ui, sans-serif
 - JetBrains Mono -> SF Mono, Consolas, monospace
 - Inter -> system-ui, -apple-system, sans-serif


### PR DESCRIPTION
## Summary
Add Space Grotesk to the Fallback Behaviour section in `static/fonts/README.md`.

This is a followup to #379 which added the self-hosted Space Grotesk font but missed documenting its fallback chain.

## Changes
- Added `Space Grotesk -> system-ui, sans-serif` to the fallback list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated font fallback configuration to include Space Grotesk with system font compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->