### PR TITLE
fix: address CodeRabbit feedback on PortIndicators (#249)

### DIFF
--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -32,17 +32,18 @@
   }: Props = $props();
 
   // Color scheme by interface type (NetBox-inspired)
+  // Uses CSS custom properties from tokens.css for design system consistency
   const INTERFACE_COLORS: Partial<Record<InterfaceType, string>> = {
-    "1000base-t": "#10b981", // Emerald - 1GbE
-    "10gbase-t": "#3b82f6", // Blue - 10GbE copper
-    "10gbase-x-sfpp": "#8b5cf6", // Purple - SFP+
-    "25gbase-x-sfp28": "#f59e0b", // Amber - SFP28
-    "40gbase-x-qsfpp": "#ef4444", // Red - QSFP+
-    "100gbase-x-qsfp28": "#ec4899", // Pink - QSFP28
+    "1000base-t": "var(--colour-port-1gbe)", // Emerald - 1GbE
+    "10gbase-t": "var(--colour-port-10gbe)", // Blue - 10GbE copper
+    "10gbase-x-sfpp": "var(--colour-port-sfpp)", // Purple - SFP+
+    "25gbase-x-sfp28": "var(--colour-port-sfp28)", // Amber - SFP28
+    "40gbase-x-qsfpp": "var(--colour-port-qsfpp)", // Red - QSFP+
+    "100gbase-x-qsfp28": "var(--colour-port-qsfp28)", // Pink - QSFP28
   };
 
   // Default color for unknown types
-  const DEFAULT_COLOR = "#6b7280";
+  const DEFAULT_COLOR = "var(--colour-port-default)";
 
   // Constants for port rendering
   const PORT_RADIUS = 3;
@@ -147,19 +148,12 @@
           cy={y}
           r={PORT_RADIUS}
           fill={color}
-          stroke="rgba(0,0,0,0.3)"
           stroke-width="0.5"
         />
 
         <!-- Management interface indicator (smaller inner circle) -->
         {#if iface.mgmt_only}
-          <circle
-            class="port-mgmt-indicator"
-            cx={x}
-            cy={y}
-            r={1}
-            fill="white"
-          />
+          <circle class="port-mgmt-indicator" cx={x} cy={y} r={1} />
         {/if}
 
         <!-- PoE indicator (lightning bolt for PSE interfaces) -->
@@ -207,7 +201,6 @@
             height={BADGE_HEIGHT}
             rx="2"
             fill={color}
-            stroke="rgba(0,0,0,0.3)"
             stroke-width="0.5"
           />
           <text
@@ -230,10 +223,12 @@
   }
 
   .port-circle {
+    stroke: var(--colour-port-stroke);
     transition: r 150ms ease-out;
   }
 
   .port-mgmt-indicator {
+    fill: var(--colour-port-indicator);
     pointer-events: none;
   }
 
@@ -265,11 +260,11 @@
   }
 
   .port-click-target:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: var(--colour-port-hover);
   }
 
   .port-click-target:focus {
-    outline: 2px solid var(--colour-selection, #ff79c6);
+    outline: 2px solid var(--colour-selection);
     outline-offset: 1px;
   }
 
@@ -286,14 +281,15 @@
   }
 
   .port-count-text {
-    fill: white;
+    fill: var(--colour-port-indicator);
     font-size: 6px;
     font-weight: 600;
     font-family: var(--font-mono, monospace);
-    text-shadow: 0 0.5px 1px rgba(0, 0, 0, 0.5);
+    text-shadow: var(--shadow-port-text);
   }
 
   .port-group-badge rect {
+    stroke: var(--colour-port-stroke);
     transition: transform 150ms ease-out;
   }
 

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -93,6 +93,15 @@
   --amber-500: #f59e0b;
   --amber-600: #d97706;
 
+  /* Color Palette - Emerald (Network interfaces) */
+  --emerald-500: #10b981;
+
+  /* Color Palette - Purple (Network interfaces) */
+  --purple-500: #8b5cf6;
+
+  /* Color Palette - Pink (Network interfaces) */
+  --pink-500: #ec4899;
+
   /* Typography - Font Families (Dracula Brand) */
   --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Consolas, monospace;
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
@@ -218,6 +227,19 @@
   --colour-airflow-exhaust: var(--dracula-red);
   --colour-airflow-passive: var(--dracula-comment);
   --colour-airflow-conflict: var(--dracula-orange);
+
+  /* Port/Interface Indicators */
+  --colour-port-1gbe: var(--emerald-500);
+  --colour-port-10gbe: var(--blue-500);
+  --colour-port-sfpp: var(--purple-500);
+  --colour-port-sfp28: var(--amber-500);
+  --colour-port-qsfpp: var(--red-500);
+  --colour-port-qsfp28: var(--pink-500);
+  --colour-port-default: var(--neutral-500);
+  --colour-port-stroke: rgba(0, 0, 0, 0.3);
+  --colour-port-indicator: white;
+  --colour-port-hover: rgba(255, 255, 255, 0.2);
+  --shadow-port-text: 0 0.5px 1px rgba(0, 0, 0, 0.5);
 
   /* Glow Effects - Dracula style neon glows */
   --glow-cyan-sm: 0 0 12px rgba(139, 233, 253, 0.3);

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -203,7 +203,11 @@ export interface InterfaceTemplate {
   label?: string;
   /** Management interface only (default: false) */
   mgmt_only?: boolean;
-  /** Interface position on device face (Rackula extension for visual layout) */
+  /**
+   * Interface position on device face (Rackula extension for visual layout).
+   * When omitted, defaults to 'front' (matching DEFAULT_RACK_VIEW constant).
+   * @default 'front'
+   */
   position?: InterfacePosition;
   /** PoE mode: pd (powered device) or pse (power sourcing equipment) */
   poe_mode?: PoEMode;

--- a/src/tests/PortIndicators.test.ts
+++ b/src/tests/PortIndicators.test.ts
@@ -64,74 +64,74 @@ describe("PortIndicators SVG Component", () => {
   });
 
   describe("Color Coding", () => {
-    it("renders 1GbE ports in emerald (#10b981)", () => {
+    it("renders 1GbE ports with design token color", () => {
       const interfaces = [createInterface("eth0", "1000base-t")];
       const { container } = render(PortIndicators, {
         props: { ...defaultProps, interfaces },
       });
 
       const circle = container.querySelector("circle.port-circle");
-      expect(circle?.getAttribute("fill")).toBe("#10b981");
+      expect(circle?.getAttribute("fill")).toBe("var(--colour-port-1gbe)");
     });
 
-    it("renders 10GbE copper ports in blue (#3b82f6)", () => {
+    it("renders 10GbE copper ports with design token color", () => {
       const interfaces = [createInterface("eth0", "10gbase-t")];
       const { container } = render(PortIndicators, {
         props: { ...defaultProps, interfaces },
       });
 
       const circle = container.querySelector("circle.port-circle");
-      expect(circle?.getAttribute("fill")).toBe("#3b82f6");
+      expect(circle?.getAttribute("fill")).toBe("var(--colour-port-10gbe)");
     });
 
-    it("renders SFP+ ports in purple (#8b5cf6)", () => {
+    it("renders SFP+ ports with design token color", () => {
       const interfaces = [createInterface("sfp0", "10gbase-x-sfpp")];
       const { container } = render(PortIndicators, {
         props: { ...defaultProps, interfaces },
       });
 
       const circle = container.querySelector("circle.port-circle");
-      expect(circle?.getAttribute("fill")).toBe("#8b5cf6");
+      expect(circle?.getAttribute("fill")).toBe("var(--colour-port-sfpp)");
     });
 
-    it("renders SFP28 ports in amber (#f59e0b)", () => {
+    it("renders SFP28 ports with design token color", () => {
       const interfaces = [createInterface("sfp0", "25gbase-x-sfp28")];
       const { container } = render(PortIndicators, {
         props: { ...defaultProps, interfaces },
       });
 
       const circle = container.querySelector("circle.port-circle");
-      expect(circle?.getAttribute("fill")).toBe("#f59e0b");
+      expect(circle?.getAttribute("fill")).toBe("var(--colour-port-sfp28)");
     });
 
-    it("renders QSFP+ ports in red (#ef4444)", () => {
+    it("renders QSFP+ ports with design token color", () => {
       const interfaces = [createInterface("qsfp0", "40gbase-x-qsfpp")];
       const { container } = render(PortIndicators, {
         props: { ...defaultProps, interfaces },
       });
 
       const circle = container.querySelector("circle.port-circle");
-      expect(circle?.getAttribute("fill")).toBe("#ef4444");
+      expect(circle?.getAttribute("fill")).toBe("var(--colour-port-qsfpp)");
     });
 
-    it("renders QSFP28 ports in pink (#ec4899)", () => {
+    it("renders QSFP28 ports with design token color", () => {
       const interfaces = [createInterface("qsfp0", "100gbase-x-qsfp28")];
       const { container } = render(PortIndicators, {
         props: { ...defaultProps, interfaces },
       });
 
       const circle = container.querySelector("circle.port-circle");
-      expect(circle?.getAttribute("fill")).toBe("#ec4899");
+      expect(circle?.getAttribute("fill")).toBe("var(--colour-port-qsfp28)");
     });
 
-    it("renders unknown types in gray (#6b7280)", () => {
+    it("renders unknown types with default design token color", () => {
       const interfaces = [createInterface("other0", "other" as InterfaceType)];
       const { container } = render(PortIndicators, {
         props: { ...defaultProps, interfaces },
       });
 
       const circle = container.querySelector("circle.port-circle");
-      expect(circle?.getAttribute("fill")).toBe("#6b7280");
+      expect(circle?.getAttribute("fill")).toBe("var(--colour-port-default)");
     });
   });
 
@@ -195,7 +195,7 @@ describe("PortIndicators SVG Component", () => {
         "circle.port-mgmt-indicator",
       );
       expect(mgmtIndicator).toBeInTheDocument();
-      expect(mgmtIndicator?.getAttribute("fill")).toBe("white");
+      // fill is controlled by CSS via design tokens
       expect(mgmtIndicator?.getAttribute("r")).toBe("1");
     });
 
@@ -299,7 +299,7 @@ describe("PortIndicators SVG Component", () => {
       expect(counts).toContain("18");
     });
 
-    it("uses correct colors for badge backgrounds", () => {
+    it("uses correct design token colors for badge backgrounds", () => {
       const interfaces = Array.from({ length: 48 }, (_, i) =>
         createInterface(`eth${i}`, "1000base-t"),
       );
@@ -309,7 +309,7 @@ describe("PortIndicators SVG Component", () => {
       });
 
       const badgeRect = container.querySelector("g.port-group-badge rect");
-      expect(badgeRect?.getAttribute("fill")).toBe("#10b981"); // 1GbE color
+      expect(badgeRect?.getAttribute("fill")).toBe("var(--colour-port-1gbe)");
     });
 
     it("threshold is >24 ports for high-density mode", () => {
@@ -421,6 +421,21 @@ describe("PortIndicators SVG Component", () => {
 
       const button = container.querySelector("button.port-click-target");
       expect(button).toHaveAttribute("type", "button");
+    });
+
+    it("applies focus styles when port is focused", () => {
+      const interfaces = [createInterface("eth0", "1000base-t")];
+
+      const { container } = render(PortIndicators, {
+        props: { ...defaultProps, interfaces },
+      });
+
+      const button = container.querySelector(
+        "button.port-click-target",
+      ) as HTMLButtonElement;
+      button?.focus();
+
+      expect(button).toHaveFocus();
     });
   });
 


### PR DESCRIPTION
## Summary

Address 7 review comments from CodeRabbit on PR #378:

- Replace hardcoded interface colors with design tokens (`--colour-port-*`)
- Add primitive color tokens (`--emerald-500`, `--purple-500`, `--pink-500`)
- Document implicit default position in InterfaceTemplate type JSDoc
- Replace hardcoded stroke/fill values with CSS variables
- Replace hardcoded hover/focus styling with tokens
- Add `--shadow-port-text` token for text-shadow
- Add focus test for accessibility
- Update tests to check for CSS variable values instead of hex

## Test plan

- [x] Run `npm run test:run -- src/tests/PortIndicators.test.ts` - 32 tests passing
- [x] Run `npm run lint` - no errors
- [x] Run `npm run build` - builds successfully

Related to #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Port indicator colors now use CSS design tokens for consistent theming across the interface.
  * Enhanced focus state visibility for port interactions.

* **Documentation**
  * Clarified interface configuration defaults and properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->