### PR TITLE
feat: integrate PortIndicators into RackDevice (#250)

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -3,7 +3,13 @@
   Renders a device within a rack at the specified U position
 -->
 <script lang="ts">
-  import type { DeviceType, DisplayMode, RackView } from "$lib/types";
+  import type {
+    DeviceType,
+    DisplayMode,
+    InterfaceTemplate,
+    RackView,
+  } from "$lib/types";
+  import PortIndicators from "./PortIndicators.svelte";
   import {
     createRackDeviceDragData,
     serializeDragData,
@@ -45,6 +51,7 @@
       event: CustomEvent<{ rackId: string; deviceIndex: number }>,
     ) => void;
     ondragend?: () => void;
+    onPortClick?: (iface: InterfaceTemplate) => void;
   }
 
   let {
@@ -65,6 +72,7 @@
     onselect,
     ondragstart: ondragstartProp,
     ondragend: ondragendProp,
+    onPortClick,
   }: Props = $props();
 
   // Device display name: model or slug
@@ -333,6 +341,17 @@
         </div>
       </foreignObject>
     {/if}
+  {/if}
+
+  <!-- Port indicators (layer 3.5: after device content, before drag overlay) -->
+  {#if device.interfaces?.length}
+    <PortIndicators
+      interfaces={device.interfaces}
+      {deviceWidth}
+      {deviceHeight}
+      {rackView}
+      {onPortClick}
+    />
   {/if}
 
   <!-- Invisible HTML overlay for drag-and-drop (rendered last to be on top for click events) -->


### PR DESCRIPTION
## Summary

Wire up the PortIndicators component (created in #249) into RackDevice.svelte, passing interface data from device types to render network port indicators.

- Import PortIndicators component in RackDevice.svelte
- Add `onPortClick` prop to RackDevice interface for event bubbling
- Conditionally render PortIndicators only when `device.interfaces?.length > 0`
- Position component in layer 3.5 (after device content, before drag overlay)
- Pass `deviceWidth`, `deviceHeight`, `rackView`, and `onPortClick` props

## Test plan

- [x] Does not render when device has no interfaces
- [x] Does not render when interfaces array is empty  
- [x] Renders when device has interfaces
- [x] Passes correct props (verified via port circle count)
- [x] Passes rackView prop (front/rear interface filtering works)
- [x] Emits onPortClick event when port is clicked
- [x] Renders in correct layer order (before drag overlay)
- [x] All 2998 existing tests pass
- [x] Lint passes
- [x] Build passes

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Port indicators are now shown on rack devices, reflecting interface presence and adapting to front/rear view.
  * Port clicks are captured and exposed to the application for interaction handling.
  * Port indicators render in the correct visual order relative to overlay elements.

* **Tests**
  * Added comprehensive tests for port indicators covering rendering, view filtering, click events, and DOM layering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->