### PR TITLE
fix: respect face override on full-depth devices (#383)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -166,7 +166,12 @@
   const effectiveFaceFilter = $derived(faceFilter ?? rack.view);
 
   // Filter devices by face and preserve original indices for selection tracking
-  // Full-depth devices are visible from both sides, so they appear on both faces
+  // The face field on PlacedDevice is the source of truth for which face(s) a device occupies.
+  // - face="both": device shows on both front and rear (default for full-depth devices)
+  // - face="front": device only shows on front view
+  // - face="rear": device only shows on rear view
+  // Note: is_full_depth on DeviceType only affects default face assignment and collision detection,
+  // it does NOT override the user's explicit face selection (Issue #383).
   const visibleDevices = $derived(
     rack.devices
       .map((placedDevice, originalIndex) => ({ placedDevice, originalIndex }))
@@ -176,14 +181,7 @@
         if (face === "both") return true;
         // Devices on this face are always visible
         if (face === effectiveFaceFilter) return true;
-        // Full-depth devices on the opposite face are also visible (they span full rack depth)
-        if (faceFilter) {
-          const deviceType = getDeviceBySlug(placedDevice.device_type);
-          if (deviceType) {
-            const isFullDepth = deviceType.is_full_depth !== false;
-            if (isFullDepth) return true;
-          }
-        }
+        // Otherwise, device is on the opposite face and not "both", so not visible
         return false;
       }),
   );

--- a/src/tests/RackDualView.test.ts
+++ b/src/tests/RackDualView.test.ts
@@ -239,9 +239,10 @@ describe("RackDualView Component", () => {
       expect(rearDevices?.length).toBe(0);
     });
 
-    it("shows full-depth front-face devices in both views", () => {
+    it("respects face override even for full-depth devices (Issue #383)", () => {
       const rack = createTestRack({
-        // server-1 is full-depth, so it should be visible from both sides
+        // server-1 is full-depth, but face is explicitly set to "front"
+        // The face field is the source of truth - device should only show on front
         devices: [{ device_type: "server-1", position: 1, face: "front" }],
       });
       const { container } = render(RackDualView, {
@@ -255,7 +256,31 @@ describe("RackDualView Component", () => {
       const frontView = container.querySelector(".rack-front");
       const rearView = container.querySelector(".rack-rear");
 
-      // Full-depth device should be visible in both views
+      // Full-depth device with face="front" should only be visible in front view
+      const frontDevices = frontView?.querySelectorAll(".rack-device");
+      const rearDevices = rearView?.querySelectorAll(".rack-device");
+
+      expect(frontDevices?.length).toBe(1);
+      expect(rearDevices?.length).toBe(0); // Should NOT show on rear
+    });
+
+    it("shows full-depth devices with face='both' in both views", () => {
+      const rack = createTestRack({
+        // server-1 is full-depth with face="both" (the default), should be visible from both sides
+        devices: [{ device_type: "server-1", position: 1, face: "both" }],
+      });
+      const { container } = render(RackDualView, {
+        props: {
+          rack,
+          deviceLibrary: createTestDeviceLibrary(),
+          selected: false,
+        },
+      });
+
+      const frontView = container.querySelector(".rack-front");
+      const rearView = container.querySelector(".rack-rear");
+
+      // Full-depth device with face="both" should be visible in both views
       const frontDevices = frontView?.querySelectorAll(".rack-device");
       const rearDevices = rearView?.querySelectorAll(".rack-device");
 


### PR DESCRIPTION
## Summary
- Fix rendering to respect user's "Mounted Face" selection on full-depth devices
- The `face` field on `PlacedDevice` is now the single source of truth for visibility

## Problem
When a user explicitly sets "Mounted Face" to "Front" or "Rear" on a full-depth device, the device should only render on that face. Previously, the rendering logic ignored this and showed full-depth devices on both faces regardless of the user's selection.

## Solution
Remove the `is_full_depth` check from the `visibleDevices` filter in `Rack.svelte`. The `face` field now fully controls device visibility:
- `face="both"`: show on front and rear (default for full-depth devices)
- `face="front"`: show only on front
- `face="rear"`: show only on rear

## Files Changed
- `src/lib/components/Rack.svelte`: Remove buggy is_full_depth visibility override
- `src/tests/Rack-component.test.ts`: Add tests for face override behavior (+3 new tests)
- `src/tests/RackDualView.test.ts`: Update tests to reflect correct behavior (+1 new test)

## Test Plan
- [x] Full-depth device with `face="front"` only shows on front view
- [x] Full-depth device with `face="rear"` only shows on rear view  
- [x] Full-depth device with `face="both"` shows on both views (default behavior)
- [x] Half-depth devices continue to work as expected
- [x] Collision detection still respects `is_full_depth` (unchanged)
- [x] All 3001 tests pass

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved device visibility logic to respect explicit face assignment. Devices designated for a specific side (front, rear, or both) now appear only on their assigned side rather than potentially showing on both sides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->