### PR TITLE
chore: standardize release process with changelog-first workflow (#386)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,302 @@
+# Release Workflow v1
+
+Create a new release with changelog entry, version bump, and tag push.
+CHANGELOG.md is the single source of truth - GitHub releases derive from it.
+
+**Arguments:** `$ARGUMENTS` (required: `patch`, `minor`, `major`, or explicit version like `0.7.0`)
+
+---
+
+## Permissions
+
+| Action | Scope |
+|--------|-------|
+| Git | add, commit, tag, push (to main) |
+| npm | version (no-git-tag-version) |
+| GitHub | None (GitHub Action handles release creation) |
+
+**Commands allowed:** `git log`, `git tag`, `gh pr list`, `gh issue list`, `npm version`
+
+---
+
+## Workflow
+
+```text
+START
+  │
+  ├─ Parse $ARGUMENTS → determine version type
+  │
+  ├─ PHASE 1: Gather Changes
+  │   - git log since last tag
+  │   - gh pr list --state merged since last release
+  │   - gh issue list --state closed since last release
+  │
+  ├─ PHASE 2: Draft Changelog Entry
+  │   - Categorize changes (Added, Changed, Fixed, etc.)
+  │   - Format in Keep a Changelog style
+  │   - Show preview to user
+  │
+  ├─ PHASE 3: User Confirmation
+  │   - Allow edits to draft
+  │   - Confirm ready to release
+  │
+  ├─ PHASE 4: Execute Release
+  │   - Update CHANGELOG.md
+  │   - npm version [type] --no-git-tag-version
+  │   - git add && git commit
+  │   - git tag vX.Y.Z
+  │   - git push && git push --tags
+  │
+  └─ PHASE 5: Monitor
+      - Show link to GitHub Actions
+      - Optionally watch for completion
+```
+
+---
+
+## Phase 1: Gather Changes
+
+### 1a. Get Last Release Tag
+
+```bash
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -z "$LAST_TAG" ]; then
+  echo "No previous tags found. This will be the first release."
+  LAST_TAG="HEAD~100"  # Fall back to recent history
+fi
+echo "Last release: $LAST_TAG"
+```
+
+### 1b. Get Commits Since Last Release
+
+```bash
+git log $LAST_TAG..HEAD --oneline --no-merges
+```
+
+### 1c. Get Merged PRs Since Last Release
+
+```bash
+# Get the date of the last tag
+LAST_DATE=$(git log -1 --format=%aI $LAST_TAG 2>/dev/null || echo "2025-01-01")
+
+gh pr list --state merged --search "merged:>$LAST_DATE" \
+  --json number,title,labels \
+  --jq '.[] | "- \(.title) (#\(.number))"'
+```
+
+### 1d. Get Closed Issues Since Last Release
+
+```bash
+gh issue list --state closed --search "closed:>$LAST_DATE" \
+  --json number,title,labels \
+  --jq '.[] | select(.labels | map(.name) | any(test("bug|feature|chore"))) | "#\(.number): \(.title)"'
+```
+
+---
+
+## Phase 2: Draft Changelog Entry
+
+### Categories (Keep a Changelog)
+
+| Category | Use For |
+|----------|---------|
+| **Added** | New features |
+| **Changed** | Changes to existing functionality |
+| **Deprecated** | Soon-to-be removed features |
+| **Removed** | Removed features |
+| **Fixed** | Bug fixes |
+| **Security** | Vulnerability fixes |
+| **Technical** | Internal changes (CI, tests, refactoring) |
+
+### Formatting Rules
+
+1. **No emojis** in changelog entries
+2. **Link format**: `(#123, PR #456)` when both issue and PR exist
+3. **Concise descriptions**: Focus on what changed, not implementation details
+4. **Consolidate related changes**: Group similar items (e.g., "3 new brand packs")
+5. **User-focused language**: Describe impact, not code changes
+
+### Entry Template
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+
+- Feature description (#issue, PR #pr)
+
+### Changed
+
+- Change description (#issue, PR #pr)
+
+### Fixed
+
+- Bug fix description (#issue, PR #pr)
+
+### Technical
+
+- Internal change description (PR #pr)
+```
+
+### Present Draft to User
+
+Show the draft entry and ask:
+```
+=== CHANGELOG DRAFT ===
+
+[Draft content here]
+
+=== END DRAFT ===
+
+Does this look correct? [y/n/edit]:
+```
+
+If 'edit', allow user to provide corrections and regenerate.
+
+---
+
+## Phase 3: User Confirmation
+
+Before executing release:
+
+```
+Ready to release v$NEW_VERSION
+
+Changes:
+- Update CHANGELOG.md with new entry
+- Bump version in package.json
+- Create git tag vX.Y.Z
+- Push to origin (triggers GitHub Action)
+
+Proceed? [y/n]:
+```
+
+**STOP** if user says no.
+
+---
+
+## Phase 4: Execute Release
+
+### 4a. Calculate New Version
+
+```bash
+CURRENT=$(node -p "require('./package.json').version")
+
+case "$ARGUMENTS" in
+  patch) NEW_VERSION=$(echo $CURRENT | awk -F. '{print $1"."$2"."$3+1}') ;;
+  minor) NEW_VERSION=$(echo $CURRENT | awk -F. '{print $1"."$2+1".0"}') ;;
+  major) NEW_VERSION=$(echo $CURRENT | awk -F. '{print $1+1".0.0"}') ;;
+  *) NEW_VERSION="$ARGUMENTS" ;;  # Explicit version
+esac
+```
+
+### 4b. Update CHANGELOG.md
+
+Insert the new entry after the header (line 7) and before the first existing version entry.
+
+Use the Edit tool to insert the changelog entry at the correct position.
+
+### 4c. Commit Changelog
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: update changelog for v$NEW_VERSION"
+```
+
+### 4d. Bump Version
+
+```bash
+npm version $NEW_VERSION --no-git-tag-version
+git add package.json package-lock.json
+git commit --amend -m "v$NEW_VERSION"
+```
+
+### 4e. Create Tag and Push
+
+```bash
+git tag "v$NEW_VERSION"
+git push origin main
+git push origin "v$NEW_VERSION"
+```
+
+---
+
+## Phase 5: Monitor
+
+### Show Release Status
+
+```bash
+echo "Release v$NEW_VERSION initiated!"
+echo ""
+echo "GitHub Actions:"
+echo "  - Release: https://github.com/RackulaLives/Rackula/actions/workflows/release.yml"
+echo "  - Deploy:  https://github.com/RackulaLives/Rackula/actions/workflows/deploy-prod.yml"
+echo ""
+echo "Once complete, release will be at:"
+echo "  https://github.com/RackulaLives/Rackula/releases/tag/v$NEW_VERSION"
+```
+
+### Optional: Watch CI
+
+```bash
+# User can optionally watch the release workflow
+gh run list --workflow=release.yml --limit 1
+gh run watch
+```
+
+---
+
+## Error Handling
+
+| Scenario | Response |
+|----------|----------|
+| No changes since last release | "No changes found. Nothing to release." |
+| Uncommitted changes | "Error: Working directory not clean. Commit or stash changes first." |
+| Not on main branch | "Error: Must be on main branch to release." |
+| Tag already exists | "Error: Tag vX.Y.Z already exists." |
+| Push fails | "Error: Push failed. Check permissions and try again." |
+
+---
+
+## Output Format
+
+### Success
+
+```
+=== Release v0.6.11 Complete ===
+
+Changelog: Updated with 3 entries
+Version: 0.6.10 → 0.6.11
+Tag: v0.6.11
+
+GitHub Actions triggered:
+- Release workflow: Creating GitHub release from CHANGELOG.md
+- Deploy workflow: Building and deploying to production
+
+Monitor at: https://github.com/RackulaLives/Rackula/actions
+```
+
+### Aborted
+
+```
+Release cancelled by user.
+No changes were made.
+```
+
+---
+
+## Quick Reference
+
+```bash
+# Patch release (bug fixes)
+/release patch
+
+# Minor release (new features)
+/release minor
+
+# Major release (breaking changes)
+/release major
+
+# Explicit version
+/release 1.0.0
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,49 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Extract version number
+        id: version
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION_NUM="${VERSION#v}"  # Remove 'v' prefix
+          echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
+
+      - name: Validate changelog entry exists
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+            echo "ERROR: No changelog entry found for version $VERSION"
+            echo "Please update CHANGELOG.md before releasing."
+            echo ""
+            echo "Expected format:"
+            echo "## [$VERSION] - YYYY-MM-DD"
+            exit 1
+          fi
+          echo "Changelog entry found for version $VERSION"
+
+      - name: Extract changelog entry
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Extract the section between this version header and the next version header
+          # Uses awk to capture everything between ## [X.Y.Z] and the next ## [
+          NOTES=$(awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+
+          # Remove leading/trailing whitespace
+          NOTES=$(echo "$NOTES" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+          # Handle multiline output for GitHub Actions
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create ${{ github.ref_name }} \
-            --generate-notes \
-            --title "${{ github.ref_name }}"
+            --title "${{ github.ref_name }}" \
+            --notes "${{ steps.changelog.outputs.notes }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,172 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.11] - 2026-01-02
+
+### Fixed
+
+- Face override not working on full-depth devices (#383, PR #385)
+
+## [0.6.10] - 2026-01-02
+
+### Added
+
+- Network interface port indicators on devices with color-coded types (#249, PR #378; #250, PR #382)
+- Fuzzy search with Fuse.js in device library (#310, PR #373)
+- Cable data model and schema (#261, PR #355)
+- Apple brand pack: Xserve, Xserve RAID (#340, PR #353)
+- AC Infinity brand pack: Cloudplate T1, T2, T7 cooling fans (#337, PR #343)
+- 27 Ubiquiti device images from vastoholic/draw-io (#339, PR #350)
+
+### Changed
+
+- Self-hosted Space Grotesk font for logo wordmark (#377, PR #379)
+
+### Fixed
+
+- Banana orientation and icon (#348, PR #349)
+- CodeRabbit feedback on PortIndicators and fuzzy search (PR #374, PR #381)
+
+### Technical
+
+- Collision toast notification test suite (#307, PR #351)
+- Extracted getDeviceDisplayName helper function (#348, PR #354)
+
+## [0.6.9] - 2025-12-31
+
+### Added
+
+- 21-inch rack support for OCP Open Rack width (#149)
+- NetBox YAML import for device types (#259)
+- Resizable device library sidebar with keyboard shortcuts (#318)
+- Multi-field device search with relevance scoring (#308)
+- Rack-side annotations column (#173)
+- Mobile long-press editing for devices (#230)
+- Paraglide JS 2.0 internationalization infrastructure (#182)
+- Build time indicator in dev environment (#328, #336)
+- MikroTik RB5009 device (#280)
+- Banana for scale easter egg (#313)
+
+### Fixed
+
+- Device library panel content after #259 regression
+- iOS Safari long press for device edit menu (#232)
+- Rack + annotations centering relative to name heading (#304)
+- Banana positioning and rotation (#317)
+
+### Technical
+
+- Research spikes: isometric rendering (#321), device search (#281), NetBox DnD patterns (#200)
+- Performance baseline for port visualization (#255)
+
+## [0.6.8] - 2025-12-30
+
+### Added
+
+- Device depth visibility badges and Add Device toggle (#240, #241)
+- DeskPi brand pack: 8 devices for 10-inch rack accessories (#226)
+- Tier 1 analytics for core feature adoption metrics (#223)
+- DRackula prefix for development environment (#215)
+
+### Changed
+
+- Restored Dracula purple logo with white brand text (#233)
+
+### Fixed
+
+- Consolidated duplicate createRack function exports (#224)
+
+### Technical
+
+- iOS Safari E2E tests via BrowserStack (#228)
+- Android Chrome E2E tests (#229)
+- Network interface visualization spike research (#237)
+
+## [0.6.7] - 2025-12-29
+
+### Added
+
+- Mobile tap-to-place editing experience (PR #174)
+- Toggle to disable rear view on canvas (#207, PR #222)
+- White logo with rainbow gradient on hover (#216, PR #221)
+
+### Fixed
+
+- Canvas.svelte a11y warnings with ARIA role (#208, PR #213)
+- U numbering direction in export (#217, PR #220)
+
+## [0.6.6] - 2025-12-29
+
+### Added
+
+- Invert U numbering toggle in EditPanel (#204, PR #210)
+
+### Fixed
+
+- Zod jitless mode to avoid CSP violations (#211, PR #212)
+
+## [0.6.5] - 2025-12-29
+
+### Added
+
+- UI controls for 0.5U device positioning (#145, PR #179)
+- Auto-resize device labels for longer text (PR #178)
+- create-issue Claude Code skill (#194, PR #195)
+
+### Changed
+
+- Extracted device movement logic into shared utility (PR #180)
+- Docker compose configuration update (PR #170)
+
+### Fixed
+
+- Export respects colour_override on placed devices (#171, PR #175)
+- localStorage mock and test timeout (#193, PR #197)
+- Removed invalid project-status-sync workflow (#201, PR #203)
+
+### Technical
+
+- Beszel monitoring backend spike (#199, PR #202)
+
+## [0.6.4] - 2025-12-28
+
+### Added
+
+- Face override on all device types (#161)
+- Warning modal for mobile users (#165)
+- Delete custom device types from library (#162, PR #164)
+
+### Fixed
+
+- Brand pink for mobile warning modal button (#163, PR #169)
+
+### Technical
+
+- Regression tests for blank panel depth detection (PR #160)
+- Regression tests for custom multi-U device placement (#166, PR #168)
+
+## [0.6.3] - 2025-12-28
+
+### Added
+
+- Widow's peak logo with Space Grotesk font and heartbeat animation (PR #148)
+
+### Fixed
+
+- Toolbar logo border and analytics subdomain (PR #147)
+
+## [0.6.2] - 2025-12-27
+
+### Changed
+
+- Minor fixes and improvements
+
+## [0.6.1] - 2025-12-27
+
+### Changed
+
+- Rebranded to Rackula name
+
 ## [0.5.9] - 2025-12-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,23 @@ We follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.html) 
 
 **Release Process:**
 
-Use `npm version` to create releases (auto-creates correctly-formatted tags):
+Use the `/release` skill to create releases with proper changelog entries:
 
 ```bash
-npm version patch   # 0.5.8 → 0.5.9, creates v0.5.9 tag
-npm version minor   # 0.5.9 → 0.6.0, creates v0.6.0 tag
-npm version major   # 0.6.0 → 1.0.0, creates v1.0.0 tag
-git push && git push --tags
+/release patch   # Bug fixes: 0.5.8 → 0.5.9
+/release minor   # Features: 0.5.9 → 0.6.0
+/release major   # Breaking: 0.6.0 → 1.0.0
+/release 1.0.0   # Explicit version
 ```
+
+The `/release` skill will:
+
+1. Gather changes since last release (commits, PRs, issues)
+2. Draft a changelog entry in Keep a Changelog format
+3. Preview and confirm with you
+4. Update CHANGELOG.md, bump version, tag, and push
+
+**Important:** CHANGELOG.md is the source of truth. GitHub releases are auto-generated from changelog entries. The release workflow will fail if no changelog entry exists.
 
 **Tag format:** Always use `v` prefix (e.g., `v0.5.8`, not `0.5.8`)
 


### PR DESCRIPTION
## Summary

- Add `/release` Claude Code skill for interactive release creation
- Backfill CHANGELOG.md with v0.6.1-v0.6.11 entries (was missing since v0.5.9)
- Update release.yml to read from CHANGELOG.md instead of auto-generating notes
- Release workflow now validates changelog entry exists before creating release
- Update CLAUDE.md with new release process documentation

## Files Changed

- `.claude/commands/release.md`: New skill for release workflow
- `.github/workflows/release.yml`: Read from CHANGELOG.md, validate entry exists
- `CHANGELOG.md`: Backfilled 11 versions (v0.6.1-v0.6.11)
- `CLAUDE.md`: Updated release process docs

## Test plan

- [ ] Verify CHANGELOG.md has correct format
- [ ] Verify release.yml validates changelog entries
- [ ] Create v0.6.11 release to test new workflow

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed face override functionality on full-depth devices.

* **Documentation**
  * Improved release workflow to generate structured release notes directly from changelog entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->