### PR TITLE
fix: build Docker images for both amd64 and arm64

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -44,7 +44,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: deploy/Dockerfile
@@ -52,6 +52,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
           build-args: |
             VITE_ENV=production
             VITE_UMAMI_ENABLED=true


### PR DESCRIPTION
## Summary

- Add QEMU setup for cross-platform emulation
- Add Docker Buildx for multi-platform builds
- Build for `linux/amd64` and `linux/arm64`

This eliminates the platform mismatch warning when running on ARM hosts (Apple Silicon, ARM Linux servers).

## Test plan

- [ ] Next release triggers workflow and builds successfully
- [ ] `docker manifest inspect ghcr.io/rackulalives/rackula:latest` shows both platforms
- [ ] No platform warning when running on ARM64 host

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment pipeline with multi-architecture support (64-bit and ARM64).
  * Enabled build caching to speed and stabilize builds.
  * Updated build tooling and added platform setup steps to support broader build environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->