### PR TITLE
fix: Safari device selection using Pointer Events API (#397)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -226,6 +226,151 @@
     return validSlots;
   });
 
+  // Reference to the SVG element for coordinate conversion
+  let svgElement: SVGSVGElement | null = $state(null);
+
+  // Listen for custom pointer-based drag events from RackDevice (fixes Safari #397)
+  $effect(() => {
+    function handleDragMove(event: CustomEvent) {
+      if (!svgElement) return;
+      const { clientX, clientY, device } = event.detail;
+
+      // Determine if this is an internal move (same rack)
+      const isInternalMove = event.detail.rackId === RACK_ID;
+
+      // Calculate target position using transform-aware coordinates
+      const svgCoords = screenToSVG(svgElement, clientX, clientY);
+      const mouseY = svgCoords.y - RACK_PADDING;
+
+      const targetU = calculateDropPosition(
+        mouseY,
+        rack.height,
+        U_HEIGHT,
+        RACK_PADDING,
+      );
+
+      // For internal moves, exclude the source device from collision checks
+      const excludeIndex = isInternalMove
+        ? event.detail.deviceIndex
+        : undefined;
+      const feedback = getDropFeedback(
+        rack,
+        deviceLibrary,
+        device.u_height,
+        targetU,
+        excludeIndex,
+        effectiveFaceFilter,
+        device.is_full_depth ?? true,
+      );
+
+      dropPreview = {
+        position: targetU,
+        height: device.u_height,
+        feedback,
+      };
+    }
+
+    function handleDragEnd(event: CustomEvent) {
+      if (!svgElement) return;
+      const {
+        clientX,
+        clientY,
+        device,
+        rackId: sourceRackId,
+        deviceIndex,
+      } = event.detail;
+
+      // Clear preview
+      dropPreview = null;
+      _draggingDeviceIndex = null;
+
+      // Determine if this is an internal move
+      const isInternalMove = sourceRackId === RACK_ID;
+      const isCrossRackMove = sourceRackId !== RACK_ID;
+
+      // Calculate target position
+      const svgCoords = screenToSVG(svgElement, clientX, clientY);
+      const mouseY = svgCoords.y - RACK_PADDING;
+
+      const targetU = calculateDropPosition(
+        mouseY,
+        rack.height,
+        U_HEIGHT,
+        RACK_PADDING,
+      );
+
+      // Validate placement
+      const excludeIndex = isInternalMove ? deviceIndex : undefined;
+      const feedback = getDropFeedback(
+        rack,
+        deviceLibrary,
+        device.u_height,
+        targetU,
+        excludeIndex,
+        effectiveFaceFilter,
+        device.is_full_depth ?? true,
+      );
+
+      if (feedback === "valid") {
+        if (isInternalMove && deviceIndex !== undefined) {
+          // Internal move within same rack
+          ondevicemove?.(
+            new CustomEvent("devicemove", {
+              detail: {
+                rackId: RACK_ID,
+                deviceIndex: deviceIndex,
+                newPosition: targetU,
+              },
+            }),
+          );
+        } else if (isCrossRackMove && deviceIndex !== undefined) {
+          // Cross-rack move
+          ondevicemoverack?.(
+            new CustomEvent("devicemoverack", {
+              detail: {
+                sourceRackId: sourceRackId,
+                sourceIndex: deviceIndex,
+                targetRackId: RACK_ID,
+                targetPosition: targetU,
+              },
+            }),
+          );
+        }
+      } else {
+        // Invalid placement - haptic feedback
+        hapticError();
+      }
+
+      // Set flag to prevent rack selection on the click that follows
+      justFinishedDrag = true;
+      setTimeout(() => {
+        justFinishedDrag = false;
+      }, 100);
+    }
+
+    // Add listeners
+    document.addEventListener(
+      "rackula:dragmove",
+      handleDragMove as EventListener,
+    );
+    document.addEventListener(
+      "rackula:dragend",
+      handleDragEnd as EventListener,
+    );
+
+    // Cleanup
+    return () => {
+      document.removeEventListener(
+        "rackula:dragmove",
+        handleDragMove as EventListener,
+      );
+      document.removeEventListener(
+        "rackula:dragend",
+        handleDragEnd as EventListener,
+      );
+    };
+  });
+
   // Handle cancel placement when tapping outside rack content
   function handleCancelPlacement() {
     hapticCancel();
@@ -542,6 +687,7 @@
 >
   <!-- NOTE: Drag handle removed in v0.1.1 (single-rack mode) -->
   <svg
+    bind:this={svgElement}
     class="rack-svg"
     width={RACK_WIDTH}
     height={viewBoxHeight + NAME_Y_OFFSET}

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -12,11 +12,9 @@
   import PortIndicators from "./PortIndicators.svelte";
   import {
     createRackDeviceDragData,
-    serializeDragData,
     setCurrentDragData,
   } from "$lib/utils/dragdrop";
   import CategoryIcon from "./CategoryIcon.svelte";
-  import { IconGrip } from "./icons";
   import { getImageStore } from "$lib/stores/images.svelte";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { useLongPress } from "$lib/utils/gestures";
@@ -119,8 +117,15 @@
   // Viewport detection for mobile-specific interactions
   const viewportStore = getViewportStore();
 
-  // Drag handle element ref for long-press
-  let dragHandleElement: HTMLDivElement | null = $state(null);
+  // SVG group element ref for pointer events and long-press
+  let groupElement: SVGGElement | null = $state(null);
+
+  // Pointer tracking for click vs drag detection
+  const DRAG_THRESHOLD = 3; // pixels - movement beyond this initiates drag
+  type PointerState = "idle" | "pressing" | "dragging";
+  let pointerState: PointerState = $state("idle");
+  let pointerStartPos: { x: number; y: number } | null = $state(null);
+  let activePointerId: number | null = $state(null);
 
   // Image overflow: how far device images extend past rack rails (Issue #9)
   // Real equipment extends past the rails; this creates realistic front-mounting appearance
@@ -172,13 +177,7 @@
     `${deviceName}, ${device.u_height}U ${device.category} at U${position}${selected ? ", selected" : ""}`,
   );
 
-  function handleClick(event: MouseEvent) {
-    event.stopPropagation();
-    onselect?.(
-      new CustomEvent("select", { detail: { slug: device.slug, position } }),
-    );
-  }
-
+  // Handle keyboard activation (Enter/Space to select)
   function handleKeyDown(event: KeyboardEvent) {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
@@ -189,25 +188,130 @@
     }
   }
 
-  function handleDragStart(event: DragEvent) {
-    if (!event.dataTransfer) return;
+  // Pointer Events for unified mouse/touch handling (fixes Safari foreignObject bug #397)
+  function handlePointerDown(event: PointerEvent) {
+    // Only handle primary pointer (left mouse button or first touch)
+    if (!event.isPrimary) return;
 
-    const dragData = createRackDeviceDragData(device, rackId, deviceIndex);
-    event.dataTransfer.setData("application/json", serializeDragData(dragData));
-    event.dataTransfer.effectAllowed = "move";
+    // Don't interfere with port clicks
+    const target = event.target as Element;
+    if (target.closest(".port-indicators")) return;
 
-    // Set shared drag state for dragover (browsers block getData during dragover)
-    setCurrentDragData(dragData);
-    isDragging = true;
-    ondragstartProp?.(
-      new CustomEvent("dragstart", { detail: { rackId, deviceIndex } }),
-    );
+    event.stopPropagation();
+
+    // Record starting position for click vs drag detection
+    pointerStartPos = { x: event.clientX, y: event.clientY };
+    pointerState = "pressing";
+    activePointerId = event.pointerId;
+
+    // Capture pointer to receive events even if cursor leaves element
+    // Note: setPointerCapture may not exist in test environments (happy-dom)
+    if (groupElement?.setPointerCapture) {
+      groupElement.setPointerCapture(event.pointerId);
+    }
   }
 
-  function handleDragEnd() {
-    setCurrentDragData(null);
-    isDragging = false;
-    ondragendProp?.();
+  function handlePointerMove(event: PointerEvent) {
+    // Only track the pointer we started with
+    if (event.pointerId !== activePointerId) return;
+    if (!pointerStartPos) return;
+
+    if (pointerState === "pressing") {
+      // Check if we've moved beyond the drag threshold
+      const distance = Math.hypot(
+        event.clientX - pointerStartPos.x,
+        event.clientY - pointerStartPos.y,
+      );
+
+      if (distance >= DRAG_THRESHOLD) {
+        // Transition to dragging state
+        pointerState = "dragging";
+        isDragging = true;
+
+        // Set up drag data for drop handling
+        const dragData = createRackDeviceDragData(device, rackId, deviceIndex);
+        setCurrentDragData(dragData);
+
+        ondragstartProp?.(
+          new CustomEvent("dragstart", { detail: { rackId, deviceIndex } }),
+        );
+      }
+    }
+
+    if (pointerState === "dragging") {
+      // Dispatch pointermove to document for Rack to track drop position
+      // The Rack listens for this via document-level handler
+      document.dispatchEvent(
+        new CustomEvent("rackula:dragmove", {
+          detail: {
+            clientX: event.clientX,
+            clientY: event.clientY,
+            device,
+            rackId,
+            deviceIndex,
+          },
+        }),
+      );
+    }
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    if (event.pointerId !== activePointerId) return;
+
+    // Release pointer capture (may not exist in test environments)
+    if (groupElement?.releasePointerCapture && activePointerId !== null) {
+      try {
+        groupElement.releasePointerCapture(activePointerId);
+      } catch {
+        // Ignore if capture was already released
+      }
+    }
+
+    if (pointerState === "pressing") {
+      // No significant movement - this is a click
+      event.stopPropagation();
+      onselect?.(
+        new CustomEvent("select", { detail: { slug: device.slug, position } }),
+      );
+    } else if (pointerState === "dragging") {
+      // Complete the drag operation
+      document.dispatchEvent(
+        new CustomEvent("rackula:dragend", {
+          detail: {
+            clientX: event.clientX,
+            clientY: event.clientY,
+            device,
+            rackId,
+            deviceIndex,
+          },
+        }),
+      );
+
+      setCurrentDragData(null);
+      isDragging = false;
+      ondragendProp?.();
+    }
+
+    // Reset state
+    pointerState = "idle";
+    pointerStartPos = null;
+    activePointerId = null;
+  }
+
+  function handlePointerCancel(event: PointerEvent) {
+    if (event.pointerId !== activePointerId) return;
+
+    // Cancel any in-progress drag
+    if (pointerState === "dragging") {
+      setCurrentDragData(null);
+      isDragging = false;
+      ondragendProp?.();
+    }
+
+    // Reset state
+    pointerState = "idle";
+    pointerStartPos = null;
+    activePointerId = null;
   }
 
   // Long-press handler for mobile (triggers selection + details)
@@ -223,25 +327,37 @@
 
   // Set up long-press gesture on mobile (reactive to viewport changes)
   $effect(() => {
-    if (viewportStore.isMobile && dragHandleElement) {
+    if (viewportStore.isMobile && groupElement) {
       console.log(
         "[RackDevice] Setting up long-press for device:",
         device.slug,
         "isMobile:",
         viewportStore.isMobile,
       );
-      const cleanup = useLongPress(dragHandleElement, handleLongPress);
+      const cleanup = useLongPress(groupElement, handleLongPress);
       return cleanup;
     }
   });
 </script>
 
 <g
+  bind:this={groupElement}
   data-device-id={device.slug}
+  data-device-position={position}
   transform="translate({RAIL_WIDTH}, {yPosition})"
   class="rack-device"
   class:selected
   class:dragging={isDragging}
+  role="button"
+  tabindex="0"
+  aria-label={ariaLabel}
+  aria-pressed={selected}
+  onpointerdown={handlePointerDown}
+  onpointermove={handlePointerMove}
+  onpointerup={handlePointerUp}
+  onpointercancel={handlePointerCancel}
+  onclick={(e) => e.stopPropagation()}
+  onkeydown={handleKeyDown}
 >
   <!-- Device rectangle -->
   <rect
@@ -343,7 +459,7 @@
     {/if}
   {/if}
 
-  <!-- Port indicators (layer 3.5: after device content, before drag overlay) -->
+  <!-- Port indicators (rendered after device content) -->
   {#if device.interfaces?.length}
     <PortIndicators
       interfaces={device.interfaces}
@@ -353,36 +469,6 @@
       {onPortClick}
     />
   {/if}
-
-  <!-- Invisible HTML overlay for drag-and-drop (rendered last to be on top for click events) -->
-  <foreignObject
-    x="0"
-    y="0"
-    width={deviceWidth}
-    height={deviceHeight}
-    class="drag-overlay"
-  >
-    <!-- xmlns required for foreignObject HTML content on mobile browsers -->
-    <div
-      xmlns="http://www.w3.org/1999/xhtml"
-      bind:this={dragHandleElement}
-      class="drag-handle"
-      role="button"
-      aria-label={ariaLabel}
-      aria-pressed={selected}
-      tabindex="0"
-      draggable="true"
-      onclick={handleClick}
-      onkeydown={handleKeyDown}
-      ondragstart={handleDragStart}
-      ondragend={handleDragEnd}
-    >
-      <!-- Grip icon for drag affordance -->
-      <div class="grip-icon-container">
-        <IconGrip size={12} />
-      </div>
-    </div>
-  </foreignObject>
 </g>
 
 <style>
@@ -407,20 +493,10 @@
     filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
   }
 
-  .drag-overlay {
-    overflow: visible;
-  }
-
-  .drag-handle {
-    position: relative;
-    width: 100%;
-    height: 100%;
+  /* Cursor and touch behavior for interactive SVG group */
+  .rack-device {
     cursor: grab;
-    background: transparent;
-    border: none;
-    padding: 0;
-    margin: 0;
-    /* iOS Safari long-press fixes (#232):
+    /* iOS Safari fixes (#232):
        - Disable Safari's default callout/context menu on long press
        - Prevent text selection during touch gestures
        - Allow pan/pinch zoom but disable double-tap zoom delay */
@@ -430,15 +506,23 @@
     touch-action: manipulation;
   }
 
-  .drag-handle:active {
+  .rack-device:active {
     cursor: grabbing;
   }
 
-  .drag-handle:focus {
+  /* Focus styling for keyboard navigation */
+  .rack-device:focus {
     outline: none;
   }
 
+  .rack-device:focus .device-rect,
   .rack-device:focus-within .device-rect {
+    stroke: var(--colour-selection);
+    stroke-width: 2;
+  }
+
+  /* Focus-visible for keyboard-only focus indication */
+  .rack-device:focus-visible .device-rect {
     stroke: var(--colour-selection);
     stroke-width: 2;
   }
@@ -446,7 +530,7 @@
   .device-rect {
     stroke: rgba(0, 0, 0, 0.2);
     stroke-width: 1;
-    pointer-events: none;
+    /* pointer-events enabled for SVG group interaction (no foreignObject overlay) */
   }
 
   .device-selection {
@@ -477,29 +561,6 @@
     height: 100%;
     color: rgba(255, 255, 255, 0.8);
     filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
-  }
-
-  .grip-icon-container {
-    position: absolute;
-    right: 4px;
-    top: 50%;
-    transform: translateY(-50%);
-    opacity: 0;
-    transition:
-      opacity var(--duration-fast, 100ms) var(--ease-out, ease-out),
-      transform var(--duration-fast, 100ms) var(--ease-out, ease-out);
-    color: rgba(255, 255, 255, 0.6);
-    pointer-events: none;
-  }
-
-  .drag-handle:hover .grip-icon-container,
-  .drag-handle:focus .grip-icon-container {
-    opacity: 1;
-  }
-
-  .drag-handle:active .grip-icon-container {
-    opacity: 1;
-    transform: translateY(-50%) scale(0.9);
   }
 
   .label-overlay-wrapper {

--- a/src/lib/utils/gestures.ts
+++ b/src/lib/utils/gestures.ts
@@ -28,7 +28,7 @@ export interface LongPressOptions {
  * @returns Cleanup function to remove event listeners
  */
 export function useLongPress(
-  element: HTMLElement,
+  element: HTMLElement | SVGElement,
   callback: () => void,
   options: LongPressOptions | number = {},
 ): () => void {


### PR DESCRIPTION
## Summary

Fixes Safari device selection and drag-and-drop by replacing foreignObject-based drag handling with native SVG pointer events.

**Root Cause:** WebKit Bug #230304 - foreignObject elements in SVG don't properly receive click events in Safari. This bug has been open since 2021 with no fix in sight.

**Solution:** Following industry best practices (used by React Flow, Excalidraw, d3-drag), we now use the Pointer Events API directly on SVG group elements with a 3px click-vs-drag threshold.

### Changes
- Remove foreignObject drag overlay from RackDevice
- Add pointer event handlers directly on SVG `<g>` element
- Implement click vs drag detection (3px threshold)
- Add custom events for cross-component drag communication
- Update tests for new pointer events model

## Test plan

@Daishi1938 - Would you be able to test this fix on your Safari setup? 🙏

**To test:**
1. Visit https://d.racku.la after this PR merges (or build locally)
2. Click on a device in the rack → should select it
3. Drag a device → should move within rack
4. Delete a selected device → should work
5. Drag from palette to rack → should place device

**Browsers verified locally:** Safari 26.2, Chrome, Firefox

---

Thanks to @Daishi1938 for reporting this issue!

Fixes #397, closes #393, closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved drag-and-drop compatibility across browsers, particularly enhancing Safari support with updated pointer-based interactions.
  * Fixed touch and mobile gesture handling for dragging operations on rack devices.

* **Improvements**
  * Enhanced drag-and-drop responsiveness with refined pointer event handling for smoother interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->