### PR TITLE
fix: refactor PortIndicators to use SVG-native pointer events (#400)

### DIFF
--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -8,7 +8,7 @@
   - High-density mode: grouped badges (>24 ports)
   - Management interface indicator (inner white dot)
   - PoE indicator (lightning bolt) for PSE interfaces
-  - Click targets via foreignObject overlays
+  - SVG-native click targets (Safari compatible, fixes #400)
 -->
 <script lang="ts">
   import type { InterfaceTemplate, InterfaceType, RackView } from "$lib/types";
@@ -170,28 +170,28 @@
         {/if}
       {/each}
 
-      <!-- Invisible click targets (larger than visual ports) -->
-      <foreignObject
-        x="0"
-        y={deviceHeight - PORT_Y_OFFSET - 8}
-        width={deviceWidth}
-        height="16"
-        class="port-click-overlay"
-      >
-        <div xmlns="http://www.w3.org/1999/xhtml" class="port-click-container">
-          {#each portPositions as { iface, x } (iface.name)}
-            <button
-              type="button"
-              class="port-click-target"
-              style="left: {x - 6}px; top: 2px;"
-              title="{iface.name} ({iface.type})"
-              onclick={() => handlePortClick(iface)}
-            >
-              <span class="sr-only">{iface.name}</span>
-            </button>
-          {/each}
-        </div>
-      </foreignObject>
+      <!-- Invisible SVG click targets (larger than visual ports, Safari compatible) -->
+      {#each portPositions as { iface, x, y } (iface.name)}
+        <circle
+          class="port-hit-target"
+          cx={x}
+          cy={y}
+          r={6}
+          fill="transparent"
+          role="button"
+          tabindex="0"
+          aria-label="{iface.name} ({iface.type})"
+          onclick={() => handlePortClick(iface)}
+          onkeydown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handlePortClick(iface);
+            }
+          }}
+        >
+          <title>{iface.name} ({iface.type})</title>
+        </circle>
+      {/each}
     {:else}
       <!-- Grouped port summary for high-density devices -->
       {#each badgePositions as { type, count, color, x, y } (type)}
@@ -237,47 +237,18 @@
     pointer-events: none;
   }
 
-  .port-click-overlay {
-    overflow: visible;
+  .port-hit-target {
     pointer-events: auto;
-  }
-
-  .port-click-container {
-    position: relative;
-    width: 100%;
-    height: 100%;
-  }
-
-  .port-click-target {
-    position: absolute;
-    width: 12px;
-    height: 12px;
-    background: transparent;
-    border: none;
     cursor: pointer;
-    padding: 0;
-    border-radius: 50%;
   }
 
-  .port-click-target:hover {
-    background: var(--colour-port-hover);
+  .port-hit-target:hover {
+    fill: var(--colour-port-hover);
   }
 
-  .port-click-target:focus {
+  .port-hit-target:focus {
     outline: 2px solid var(--colour-selection);
     outline-offset: 1px;
-  }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
   }
 
   .port-count-text {

--- a/src/tests/RackDevice.test.ts
+++ b/src/tests/RackDevice.test.ts
@@ -738,11 +738,11 @@ describe("RackDevice SVG Component", () => {
         },
       });
 
-      // Find and click a port click target
-      const portClickTarget = container.querySelector(".port-click-target");
-      expect(portClickTarget).toBeInTheDocument();
+      // Find and click a port hit target (SVG circle, not button - Safari compatible)
+      const portHitTarget = container.querySelector("circle.port-hit-target");
+      expect(portHitTarget).toBeInTheDocument();
 
-      await fireEvent.click(portClickTarget!);
+      portHitTarget!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
       expect(handlePortClick).toHaveBeenCalledTimes(1);
       expect(handlePortClick).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Replace foreignObject click overlay with SVG-native circle hit targets
- Fix Safari port click compatibility (WebKit Bug #230304)
- Add keyboard accessibility (Enter/Space key handlers)
- Add proper ARIA attributes (role="button", tabindex, aria-label)

## Technical Details

The foreignObject approach suffered from the same Safari bug that was fixed in RackDevice.svelte (#397/#398). This PR applies the same pattern of SVG-native elements with pointer events to PortIndicators.

**Before:** Used foreignObject containing HTML button elements for click targets
**After:** Uses invisible SVG circle elements (r=6, transparent) with onclick handlers

## Test plan

- [ ] Verify port clicks work in Safari
- [ ] Verify port clicks work in Chrome
- [ ] Verify port clicks work in Firefox
- [ ] Verify keyboard navigation works (Tab to port, Enter/Space to activate)
- [ ] Run test suite: `npm run test:run`

Fixes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed port click target compatibility with Safari browsers
  * Enhanced keyboard accessibility with Enter and Space key support
  * Improved port interaction precision and ARIA labeling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->