### PR TITLE
feat: add port tooltips on hover (#251)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -16,6 +16,7 @@
   import ConfirmDialog from "$lib/components/ConfirmDialog.svelte";
   import ConfirmReplaceDialog from "$lib/components/ConfirmReplaceDialog.svelte";
   import ToastContainer from "$lib/components/ToastContainer.svelte";
+  import PortTooltip from "$lib/components/PortTooltip.svelte";
   import KeyboardHandler from "$lib/components/KeyboardHandler.svelte";
   import ExportDialog from "$lib/components/ExportDialog.svelte";
   import ShareDialog from "$lib/components/ShareDialog.svelte";
@@ -948,6 +949,9 @@
   />
 
   <ToastContainer />
+
+  <!-- Port tooltip for network interface hover -->
+  <PortTooltip />
 
   <!-- Mobile device library FAB and bottom sheet -->
   <DeviceLibraryFAB onclick={handleDeviceLibraryFABClick} />

--- a/src/lib/components/PortTooltip.svelte
+++ b/src/lib/components/PortTooltip.svelte
@@ -1,0 +1,139 @@
+<!--
+  PortTooltip Component
+  Shows detailed information about a network interface port on hover.
+  Renders at the document level, positioned using fixed coordinates.
+-->
+<script lang="ts">
+  import type { InterfaceType } from "$lib/types";
+  import { getPortTooltipState } from "$lib/stores/portTooltip.svelte";
+
+  // Get reactive tooltip state from store
+  const tooltipState = $derived(getPortTooltipState());
+  const port = $derived(tooltipState.port);
+  const x = $derived(tooltipState.x);
+  const y = $derived(tooltipState.y);
+  const visible = $derived(tooltipState.visible);
+
+  // Human-readable type names
+  const TYPE_LABELS: Partial<Record<InterfaceType, string>> = {
+    "1000base-t": "1GbE (RJ45)",
+    "10gbase-t": "10GbE (RJ45)",
+    "10gbase-x-sfpp": "10GbE SFP+",
+    "25gbase-x-sfp28": "25GbE SFP28",
+    "40gbase-x-qsfpp": "40GbE QSFP+",
+    "100gbase-x-qsfp28": "100GbE QSFP28",
+    "1000base-x-sfp": "1GbE SFP",
+    console: "Console",
+    management: "Management",
+  };
+
+  // Get human-readable type label
+  function getTypeLabel(type: InterfaceType): string {
+    return TYPE_LABELS[type] ?? type;
+  }
+
+  // Get PoE label
+  function getPoELabel(
+    poeMode?: "pd" | "pse",
+    poeType?: string,
+  ): string | null {
+    if (!poeMode) return null;
+
+    const modeLabel = poeMode === "pse" ? "PoE Source" : "PoE Powered";
+    if (poeType) {
+      // Parse common PoE types
+      if (poeType.includes("802.3af")) return `${modeLabel} (802.3af)`;
+      if (poeType.includes("802.3at")) return `${modeLabel} (PoE+)`;
+      if (poeType.includes("802.3bt")) return `${modeLabel} (PoE++)`;
+      return `${modeLabel} (${poeType})`;
+    }
+    return modeLabel;
+  }
+</script>
+
+{#if visible && port}
+  <div class="port-tooltip" role="tooltip" style="left: {x}px; top: {y}px;">
+    <div class="port-tooltip-name">{port.label ?? port.name}</div>
+    <div class="port-tooltip-type">{getTypeLabel(port.type)}</div>
+    {#if port.mgmt_only}
+      <div class="port-tooltip-badge mgmt">Management Only</div>
+    {/if}
+    {#if port.poe_mode}
+      <div class="port-tooltip-badge poe">
+        ⚡ {getPoELabel(port.poe_mode, port.poe_type)}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .port-tooltip {
+    position: fixed;
+    z-index: var(--z-tooltip, 1000);
+    padding: var(--space-2);
+    background-color: var(--colour-surface-overlay);
+    color: var(--colour-text-inverse);
+    font-size: var(--font-size-xs);
+    border-radius: var(--radius-sm);
+    pointer-events: none;
+    box-shadow: var(--shadow-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 120px;
+    max-width: 200px;
+    transform: translate(-50%, -100%) translateY(-8px);
+    animation: tooltip-fade-in var(--duration-fast, 100ms)
+      var(--ease-out, ease-out);
+  }
+
+  @keyframes tooltip-fade-in {
+    from {
+      opacity: 0;
+      transform: translate(-50%, -100%) translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, -100%) translateY(-8px);
+    }
+  }
+
+  .port-tooltip-name {
+    font-weight: 600;
+    font-family: var(--font-mono, monospace);
+    color: var(--colour-text-inverse);
+    word-break: break-word;
+  }
+
+  .port-tooltip-type {
+    color: var(--colour-text-muted-inverse, rgba(255, 255, 255, 0.7));
+    font-size: var(--font-size-xs);
+  }
+
+  .port-tooltip-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 2px 6px;
+    border-radius: var(--radius-xs, 2px);
+    font-size: 10px;
+    font-weight: 500;
+  }
+
+  .port-tooltip-badge.mgmt {
+    background-color: rgba(255, 255, 255, 0.15);
+    color: var(--colour-text-inverse);
+  }
+
+  .port-tooltip-badge.poe {
+    background-color: rgba(251, 191, 36, 0.2);
+    color: var(--colour-warning, #fbbf24);
+  }
+
+  /* Reduced motion */
+  @media (prefers-reduced-motion: reduce) {
+    .port-tooltip {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/stores/portTooltip.svelte.ts
+++ b/src/lib/stores/portTooltip.svelte.ts
@@ -1,0 +1,57 @@
+/**
+ * Port Tooltip Store
+ *
+ * Global state for managing port tooltip visibility and content.
+ * Used by PortIndicators to show tooltips and App to render them.
+ */
+
+import type { InterfaceTemplate } from "$lib/types";
+
+/** Port tooltip state */
+export interface PortTooltipState {
+  port: InterfaceTemplate | null;
+  x: number;
+  y: number;
+  visible: boolean;
+}
+
+/** Port tooltip store singleton */
+let tooltipState = $state<PortTooltipState>({
+  port: null,
+  x: 0,
+  y: 0,
+  visible: false,
+});
+
+/**
+ * Show the port tooltip at the specified position
+ */
+export function showPortTooltip(
+  port: InterfaceTemplate,
+  x: number,
+  y: number,
+): void {
+  tooltipState = {
+    port,
+    x,
+    y,
+    visible: true,
+  };
+}
+
+/**
+ * Hide the port tooltip
+ */
+export function hidePortTooltip(): void {
+  tooltipState = {
+    ...tooltipState,
+    visible: false,
+  };
+}
+
+/**
+ * Get the current tooltip state (reactive)
+ */
+export function getPortTooltipState(): PortTooltipState {
+  return tooltipState;
+}

--- a/src/tests/portTooltip.test.ts
+++ b/src/tests/portTooltip.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  showPortTooltip,
+  hidePortTooltip,
+  getPortTooltipState,
+} from "$lib/stores/portTooltip.svelte";
+import type { InterfaceTemplate } from "$lib/types";
+
+describe("Port Tooltip Store", () => {
+  // Sample port for testing
+  const samplePort: InterfaceTemplate = {
+    name: "GigabitEthernet1/0/1",
+    type: "1000base-t",
+    label: "Uplink Port 1",
+    mgmt_only: false,
+    poe_mode: "pse",
+    poe_type: "type2-ieee802.3at",
+  };
+
+  beforeEach(() => {
+    // Reset tooltip state before each test
+    hidePortTooltip();
+  });
+
+  describe("showPortTooltip", () => {
+    it("should set visible to true", () => {
+      showPortTooltip(samplePort, 100, 200);
+
+      const state = getPortTooltipState();
+      expect(state.visible).toBe(true);
+    });
+
+    it("should set the port data", () => {
+      showPortTooltip(samplePort, 100, 200);
+
+      const state = getPortTooltipState();
+      expect(state.port).toEqual(samplePort);
+    });
+
+    it("should set the coordinates", () => {
+      showPortTooltip(samplePort, 150, 250);
+
+      const state = getPortTooltipState();
+      expect(state.x).toBe(150);
+      expect(state.y).toBe(250);
+    });
+
+    it("should update when called multiple times", () => {
+      const port1: InterfaceTemplate = { name: "eth0", type: "1000base-t" };
+      const port2: InterfaceTemplate = { name: "eth1", type: "10gbase-t" };
+
+      showPortTooltip(port1, 100, 100);
+      expect(getPortTooltipState().port?.name).toBe("eth0");
+
+      showPortTooltip(port2, 200, 200);
+      expect(getPortTooltipState().port?.name).toBe("eth1");
+      expect(getPortTooltipState().x).toBe(200);
+      expect(getPortTooltipState().y).toBe(200);
+    });
+  });
+
+  describe("hidePortTooltip", () => {
+    it("should set visible to false", () => {
+      showPortTooltip(samplePort, 100, 200);
+      expect(getPortTooltipState().visible).toBe(true);
+
+      hidePortTooltip();
+      expect(getPortTooltipState().visible).toBe(false);
+    });
+
+    it("should preserve port data when hiding", () => {
+      showPortTooltip(samplePort, 100, 200);
+      hidePortTooltip();
+
+      // Port data is preserved (but tooltip is hidden)
+      // This is intentional to allow smooth animations
+      const state = getPortTooltipState();
+      expect(state.visible).toBe(false);
+    });
+  });
+
+  describe("getPortTooltipState", () => {
+    it("should return hidden state after hidePortTooltip", () => {
+      // The store is a singleton, so after beforeEach calls hidePortTooltip(),
+      // we should have visible=false. Port data may be preserved for animations.
+      const state = getPortTooltipState();
+
+      expect(state.visible).toBe(false);
+      // Port data is intentionally preserved when hiding (for smooth animations)
+      // so we only check that visible is false
+    });
+
+    it("should return reactive state", () => {
+      // First check
+      let state = getPortTooltipState();
+      expect(state.visible).toBe(false);
+
+      // Show tooltip
+      showPortTooltip(samplePort, 100, 200);
+
+      // Get fresh state
+      state = getPortTooltipState();
+      expect(state.visible).toBe(true);
+      expect(state.port).toEqual(samplePort);
+    });
+  });
+
+  describe("PoE and management port handling", () => {
+    it("should handle port with PoE PSE mode", () => {
+      const poePort: InterfaceTemplate = {
+        name: "Gi1/0/1",
+        type: "1000base-t",
+        poe_mode: "pse",
+        poe_type: "type2-ieee802.3at",
+      };
+
+      showPortTooltip(poePort, 100, 200);
+
+      const state = getPortTooltipState();
+      expect(state.port?.poe_mode).toBe("pse");
+      expect(state.port?.poe_type).toBe("type2-ieee802.3at");
+    });
+
+    it("should handle port with PoE PD mode", () => {
+      const pdPort: InterfaceTemplate = {
+        name: "eth0",
+        type: "1000base-t",
+        poe_mode: "pd",
+      };
+
+      showPortTooltip(pdPort, 100, 200);
+
+      const state = getPortTooltipState();
+      expect(state.port?.poe_mode).toBe("pd");
+    });
+
+    it("should handle management-only port", () => {
+      const mgmtPort: InterfaceTemplate = {
+        name: "mgmt0",
+        type: "1000base-t",
+        mgmt_only: true,
+      };
+
+      showPortTooltip(mgmtPort, 100, 200);
+
+      const state = getPortTooltipState();
+      expect(state.port?.mgmt_only).toBe(true);
+    });
+  });
+
+  describe("interface types", () => {
+    const interfaceTypes = [
+      "1000base-t",
+      "10gbase-t",
+      "10gbase-x-sfpp",
+      "25gbase-x-sfp28",
+      "40gbase-x-qsfpp",
+      "100gbase-x-qsfp28",
+    ] as const;
+
+    interfaceTypes.forEach((type) => {
+      it(`should handle ${type} interface type`, () => {
+        const port: InterfaceTemplate = {
+          name: "test-port",
+          type,
+        };
+
+        showPortTooltip(port, 100, 200);
+
+        const state = getPortTooltipState();
+        expect(state.port?.type).toBe(type);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add rich tooltips when hovering over network interface port indicators on devices.

- Display port name (with label fallback)
- Show port type with human-readable labels (e.g., "1GbE (RJ45)", "10GbE SFP+")
- Show "Management Only" badge for management interfaces
- Show PoE badge with mode and type (PSE/PD, 802.3af/at/bt)
- 300ms hover delay to prevent flickering

## Files Changed

- `src/lib/stores/portTooltip.svelte.ts` - Global tooltip state store
- `src/lib/components/PortTooltip.svelte` - Tooltip component with fixed positioning
- `src/lib/components/PortIndicators.svelte` - Added mouseenter/mouseleave handlers to SVG hit targets
- `src/App.svelte` - Integrated PortTooltip component
- `src/tests/portTooltip.test.ts` - 17 tests for tooltip store

## Test Plan

- [x] Lint passes
- [x] Build succeeds
- [x] 49 port-related tests pass
- [ ] Manual: Hover over port indicators shows tooltip after 300ms delay
- [ ] Manual: Tooltip displays port name, type, and PoE info correctly
- [ ] Manual: Moving mouse away hides tooltip

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Port tooltips now display when hovering over ports, providing detailed information including port name, type classification, management status, and Power over Ethernet specifications with smooth animations.

* **Tests**
  * Added comprehensive unit tests validating tooltip display, state management, successive updates, and handling of various port configurations including PoE and management ports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->