### PR TITLE
chore: remove redundant type and starter library tests (#407)

### DIFF
--- a/src/tests/starterLibrary.test.ts
+++ b/src/tests/starterLibrary.test.ts
@@ -1,20 +1,52 @@
 import { describe, it, expect } from "vitest";
 import { getStarterLibrary } from "$lib/data/starterLibrary";
-import { CATEGORY_COLOURS } from "$lib/types/constants";
 import { createLayout } from "$lib/utils/serialization";
+import { DeviceTypeSchema } from "$lib/schemas";
 
+/**
+ * Starter Device Library Tests
+ *
+ * These tests verify INVARIANTS about the starter library, not individual devices.
+ * Individual device properties are validated by DeviceTypeSchema.
+ *
+ * What we test:
+ * - Unique slugs (catches duplicate entries)
+ * - All categories represented (catches missing category coverage)
+ * - Business rules (starter library = generic devices only)
+ * - Schema compliance (all devices pass schema validation)
+ *
+ * What we DON'T test:
+ * - Exact device counts (breaks on intentional additions)
+ * - Individual device existence (static data, no value)
+ * - Property values already validated by schema
+ *
+ * See: docs/guides/TESTING.md - "Zero-Change Rule"
+ */
 describe("Starter Device Type Library", () => {
-  describe("getStarterLibrary", () => {
-    it("returns 51 generic device types", () => {
+  describe("Schema Validation", () => {
+    it("all devices pass DeviceTypeSchema validation", () => {
       const deviceTypes = getStarterLibrary();
-      expect(deviceTypes).toHaveLength(51);
+
+      for (const device of deviceTypes) {
+        expect(() => DeviceTypeSchema.parse(device)).not.toThrow();
+      }
+    });
+  });
+
+  describe("Invariants", () => {
+    it("device type slugs are unique", () => {
+      const deviceTypes = getStarterLibrary();
+      const slugs = deviceTypes.map((d) => d.slug);
+      const uniqueSlugs = new Set(slugs);
+
+      expect(uniqueSlugs.size).toBe(slugs.length);
     });
 
     it("all categories have at least one starter device type", () => {
       const deviceTypes = getStarterLibrary();
       const categoriesWithDevices = new Set(deviceTypes.map((d) => d.category));
 
-      // All categories should be represented
+      // Core categories should all be represented
       expect(categoriesWithDevices.has("server")).toBe(true);
       expect(categoriesWithDevices.has("network")).toBe(true);
       expect(categoriesWithDevices.has("storage")).toBe(true);
@@ -28,42 +60,6 @@ describe("Starter Device Type Library", () => {
       expect(categoriesWithDevices.has("cable-management")).toBe(true);
     });
 
-    it("all device types have valid properties", () => {
-      const deviceTypes = getStarterLibrary();
-
-      deviceTypes.forEach((deviceType) => {
-        expect(deviceType.slug).toBeTruthy();
-        expect(deviceType.u_height).toBeGreaterThanOrEqual(0.5);
-        expect(deviceType.u_height).toBeLessThanOrEqual(42);
-        expect(deviceType.colour).toBeTruthy();
-        expect(deviceType.category).toBeTruthy();
-      });
-    });
-
-    it("device type slugs are unique", () => {
-      const deviceTypes = getStarterLibrary();
-      const slugs = deviceTypes.map((d) => d.slug);
-      const uniqueSlugs = new Set(slugs);
-
-      expect(uniqueSlugs.size).toBe(slugs.length);
-    });
-
-    it("device types have correct category colours", () => {
-      const deviceTypes = getStarterLibrary();
-
-      deviceTypes.forEach((deviceType) => {
-        expect(deviceType.colour).toBe(CATEGORY_COLOURS[deviceType.category]);
-      });
-    });
-
-    it("device type slugs are kebab-case", () => {
-      const deviceTypes = getStarterLibrary();
-
-      deviceTypes.forEach((deviceType) => {
-        expect(deviceType.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
-      });
-    });
-
     it("no devices have manufacturer (all generic)", () => {
       const deviceTypes = getStarterLibrary();
 
@@ -71,537 +67,22 @@ describe("Starter Device Type Library", () => {
         expect(deviceType.manufacturer).toBeUndefined();
       });
     });
-  });
 
-  describe("server category (4 items)", () => {
-    it("includes Server (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Server" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("server");
-    });
+    it("half-width devices are half-depth", () => {
+      const deviceTypes = getStarterLibrary();
+      const halfWidthDevices = deviceTypes.filter((d) => d.slot_width === 1);
 
-    it("includes Server (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Server" && d.u_height === 2,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("server");
-    });
+      // Must have some half-width devices
+      expect(halfWidthDevices.length).toBeGreaterThan(0);
 
-    it("includes Server (3U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Server" && d.u_height === 3,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("server");
-    });
-
-    it("includes Server (4U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Server" && d.u_height === 4,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("server");
-    });
-  });
-
-  describe("network category (4 items)", () => {
-    it("includes Switch (24-Port)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Switch (24-Port)");
-      expect(device).toBeDefined();
-      expect(device?.u_height).toBe(1);
-      expect(device?.category).toBe("network");
-    });
-
-    it("includes Switch (48-Port)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Switch (48-Port)");
-      expect(device).toBeDefined();
-      expect(device?.u_height).toBe(1);
-      expect(device?.category).toBe("network");
-    });
-
-    it("includes Router/Firewall (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Router/Firewall" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("network");
-    });
-
-    it("includes Router/Firewall (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Router/Firewall" && d.u_height === 2,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("network");
-    });
-  });
-
-  describe("storage category (4 items)", () => {
-    it("includes Storage (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Storage" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("storage");
-    });
-
-    it("includes Storage (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Storage" && d.u_height === 2,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("storage");
-    });
-
-    it("includes Storage (3U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Storage" && d.u_height === 3,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("storage");
-    });
-
-    it("includes Storage (4U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Storage" && d.u_height === 4,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("storage");
-    });
-  });
-
-  describe("power category (4 items)", () => {
-    it("includes PDU (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "PDU" && d.u_height === 1);
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("power");
-    });
-
-    it("includes PDU (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "PDU" && d.u_height === 2);
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("power");
-    });
-
-    it("includes UPS (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "UPS" && d.u_height === 2);
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("power");
-    });
-
-    it("includes UPS (4U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "UPS" && d.u_height === 4);
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("power");
-    });
-  });
-
-  describe("patch-panel category (3 items)", () => {
-    it("includes Fiber Patch Panel", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Fiber Patch Panel");
-      expect(device).toBeDefined();
-      expect(device?.u_height).toBe(1);
-      expect(device?.category).toBe("patch-panel");
-    });
-
-    it("includes Patch Panel (24-Port)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Patch Panel (24-Port)");
-      expect(device).toBeDefined();
-      expect(device?.u_height).toBe(1);
-      expect(device?.category).toBe("patch-panel");
-    });
-
-    it("includes Patch Panel (48-Port)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Patch Panel (48-Port)");
-      expect(device).toBeDefined();
-      expect(device?.u_height).toBe(2);
-      expect(device?.category).toBe("patch-panel");
-    });
-  });
-
-  describe("kvm category (2 items)", () => {
-    it("includes KVM Switch", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "KVM Switch");
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("kvm");
-    });
-
-    it("includes Console Drawer", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Console Drawer");
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("kvm");
-    });
-  });
-
-  describe("av-media category (8 items)", () => {
-    it("includes Amplifier (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Amplifier" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("av-media");
-    });
-
-    it("includes Amplifier (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Amplifier" && d.u_height === 2,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("av-media");
-    });
-
-    it("includes AV Receiver (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "AV Receiver" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("av-media");
-    });
-
-    it("includes Power Amplifier (3U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Power Amplifier");
-      expect(device).toBeDefined();
-      expect(device?.u_height).toBe(3);
-      expect(device?.category).toBe("av-media");
-    });
-
-    it("has 8 av-media devices total", () => {
-      const library = getStarterLibrary();
-      const avDevices = library.filter((d) => d.category === "av-media");
-      expect(avDevices).toHaveLength(8);
-    });
-  });
-
-  describe("cooling category (2 items)", () => {
-    it("includes Fan Panel (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Fan Panel" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("cooling");
-    });
-
-    it("includes Fan Panel (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Fan Panel" && d.u_height === 2,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("cooling");
-    });
-  });
-
-  describe("shelf category (4 items)", () => {
-    it("includes Cantilever Shelf", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Cantilever Shelf");
-      expect(device).toBeDefined();
-      expect(device?.u_height).toBe(1);
-      expect(device?.category).toBe("shelf");
-    });
-
-    it("includes Shelf (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Shelf" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("shelf");
-    });
-
-    it("includes Shelf (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Shelf" && d.u_height === 2,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("shelf");
-    });
-
-    it("includes Vented Shelf", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Vented Shelf");
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("shelf");
-    });
-
-    it("shelf device types have Dracula comment colour", () => {
-      const library = getStarterLibrary();
-      const shelves = library.filter((d) => d.category === "shelf");
-
-      shelves.forEach((shelf) => {
-        expect(shelf.colour).toBe("#6272A4");
-      });
-    });
-  });
-
-  describe("blank category (5 items)", () => {
-    it("includes Blank Panel (0.5U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Blank Panel" && d.u_height === 0.5,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("blank");
-    });
-
-    it("includes Blank Panel (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Blank Panel" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("blank");
-    });
-
-    it("includes Blank Panel (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Blank Panel" && d.u_height === 2,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("blank");
-    });
-
-    it("includes Blank Panel (3U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Blank Panel" && d.u_height === 3,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("blank");
-    });
-
-    it("includes Blank Panel (4U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Blank Panel" && d.u_height === 4,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("blank");
-    });
-
-    it("full-width blank panels are half-depth (is_full_depth: false)", () => {
-      const library = getStarterLibrary();
-      const blanks = library.filter(
-        (d) => d.category === "blank" && d.slot_width === 2,
-      );
-
-      expect(blanks.length).toBe(5);
-      blanks.forEach((blank) => {
-        expect(blank.is_full_depth).toBe(false);
-      });
-    });
-  });
-
-  describe("cable-management category (3 items)", () => {
-    it("includes Brush Panel", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Brush Panel");
-      expect(device).toBeDefined();
-      expect(device?.u_height).toBe(1);
-      expect(device?.category).toBe("cable-management");
-    });
-
-    it("includes Cable Manager (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Cable Manager" && d.u_height === 1,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("cable-management");
-    });
-
-    it("includes Cable Manager (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Cable Manager" && d.u_height === 2,
-      );
-      expect(device).toBeDefined();
-      expect(device?.category).toBe("cable-management");
-    });
-
-    it("full-width cable-management devices have Dracula comment colour", () => {
-      const library = getStarterLibrary();
-      const cableDevices = library.filter(
-        (d) => d.category === "cable-management" && d.slot_width === 2,
-      );
-
-      expect(cableDevices).toHaveLength(3);
-      cableDevices.forEach((device) => {
-        expect(device.colour).toBe("#6272A4");
-      });
-    });
-  });
-
-  describe("half-width devices (8 items)", () => {
-    it("includes 8 half-width devices with slot_width: 1", () => {
-      const library = getStarterLibrary();
-      const halfWidthDevices = library.filter((d) => d.slot_width === 1);
-      expect(halfWidthDevices).toHaveLength(8);
-    });
-
-    it("includes Half Blank Panel (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.slug === "1u-half-blank");
-      expect(device).toBeDefined();
-      expect(device?.slot_width).toBe(1);
-      expect(device?.category).toBe("blank");
-    });
-
-    it("includes Half Blank Panel (2U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.slug === "2u-half-blank");
-      expect(device).toBeDefined();
-      expect(device?.slot_width).toBe(1);
-      expect(device?.u_height).toBe(2);
-    });
-
-    it("includes Half Shelf", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.slug === "1u-half-shelf");
-      expect(device).toBeDefined();
-      expect(device?.slot_width).toBe(1);
-      expect(device?.category).toBe("shelf");
-    });
-
-    it("includes Half Patch Panel", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.slug === "1u-half-patch-panel");
-      expect(device).toBeDefined();
-      expect(device?.slot_width).toBe(1);
-      expect(device?.category).toBe("patch-panel");
-    });
-
-    it("includes Half Switch (8-Port)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.slug === "1u-half-switch");
-      expect(device).toBeDefined();
-      expect(device?.slot_width).toBe(1);
-      expect(device?.category).toBe("network");
-    });
-
-    it("includes Half Brush Panel", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.slug === "1u-half-brush-panel");
-      expect(device).toBeDefined();
-      expect(device?.slot_width).toBe(1);
-      expect(device?.category).toBe("cable-management");
-    });
-
-    it("includes Mini UPS", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.slug === "1u-mini-ups");
-      expect(device).toBeDefined();
-      expect(device?.slot_width).toBe(1);
-      expect(device?.category).toBe("power");
-    });
-
-    it("includes Half Fan Panel", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.slug === "1u-half-fan");
-      expect(device).toBeDefined();
-      expect(device?.slot_width).toBe(1);
-      expect(device?.category).toBe("cooling");
-    });
-
-    it("all half-width devices are half-depth", () => {
-      const library = getStarterLibrary();
-      const halfWidthDevices = library.filter((d) => d.slot_width === 1);
-
+      // All half-width should be half-depth
       halfWidthDevices.forEach((device) => {
         expect(device.is_full_depth).toBe(false);
       });
     });
   });
 
-  describe("slug generation", () => {
-    it("generates correct slug for Router/Firewall (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Router/Firewall" && d.u_height === 1,
-      );
-      expect(device?.slug).toBe("1u-router-firewall");
-    });
-
-    it("generates correct slug for Switch (24-Port)", () => {
-      const library = getStarterLibrary();
-      const device = library.find((d) => d.model === "Switch (24-Port)");
-      expect(device?.slug).toBe("24-port-switch");
-    });
-
-    it("generates correct slug for Blank Panel (0.5U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Blank Panel" && d.u_height === 0.5,
-      );
-      expect(device?.slug).toBe("0-5u-blank");
-    });
-
-    it("generates correct slug for Cable Manager (1U)", () => {
-      const library = getStarterLibrary();
-      const device = library.find(
-        (d) => d.model === "Cable Manager" && d.u_height === 1,
-      );
-      expect(device?.slug).toBe("1u-cable-manager");
-    });
-  });
-
-  describe("all devices have required properties", () => {
-    it("every device has a slug", () => {
-      const library = getStarterLibrary();
-      library.forEach((device) => {
-        expect(device.slug).toBeDefined();
-        expect(device.slug.length).toBeGreaterThan(0);
-      });
-    });
-
-    it("every device has u_height > 0", () => {
-      const library = getStarterLibrary();
-      library.forEach((device) => {
-        expect(device.u_height).toBeGreaterThan(0);
-      });
-    });
-
-    it("every device has a category color", () => {
-      const library = getStarterLibrary();
-      library.forEach((device) => {
-        expect(device.colour).toBeDefined();
-        expect(device.colour).toMatch(/^#[0-9A-Fa-f]{6}$/);
-      });
-    });
-  });
-
-  describe("Layout integration", () => {
+  describe("Layout Integration", () => {
     it("new layout has empty device_types (starter library is runtime constant)", () => {
       const layout = createLayout();
 
@@ -609,22 +90,9 @@ describe("Starter Device Type Library", () => {
       expect(layout.device_types.length).toBe(0);
     });
 
-    it("starter library contains only generic devices", () => {
+    it("starter library is non-empty", () => {
       const starterLibrary = getStarterLibrary();
-
-      // Library should have 51 generic devices (43 full-width + 8 half-width)
-      expect(starterLibrary.length).toBe(51);
-      expect(starterLibrary[0]?.slug).toBeTruthy();
-    });
-
-    it("starter device types have valid structure", () => {
-      const starterLibrary = getStarterLibrary();
-      const starterDeviceType = starterLibrary[0];
-
-      expect(starterDeviceType).toBeDefined();
-      expect(starterDeviceType!.slug).toBeTruthy();
-      expect(starterDeviceType!.u_height).toBeGreaterThan(0);
-      expect(starterDeviceType!.category).toBeTruthy();
+      expect(starterLibrary.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/tests/types.test.ts
+++ b/src/tests/types.test.ts
@@ -1,587 +1,116 @@
-import { describe, it, expect } from 'vitest';
-import type {
-	DeviceType,
-	PlacedDevice,
-	Rack,
-	Layout,
-	LayoutSettings,
-	DeviceCategory,
-	RackView,
-	DeviceFace,
-	Airflow,
-	WeightUnit,
-	FormFactor,
-	DisplayMode
-} from '$lib/types';
+import { describe, it, expect } from "vitest";
+import type { DeviceCategory } from "$lib/types";
 import {
-	CATEGORY_COLOURS,
-	ALL_CATEGORIES,
-	CURRENT_VERSION,
-	DEFAULT_RACK_VIEW,
-	DEFAULT_DEVICE_FACE,
-	MIN_DEVICE_HEIGHT
-} from '$lib/types/constants';
-
-describe('Types', () => {
-	describe('DeviceType interface', () => {
-		it('accepts valid device type object', () => {
-			const deviceType: DeviceType = {
-				slug: '1u-server',
-				u_height: 1,
-				colour: '#4A90D9',
-				category: 'server'
-			};
-
-			expect(deviceType.slug).toBe('1u-server');
-			expect(deviceType.u_height).toBe(1);
-			expect(deviceType.colour).toBe('#4A90D9');
-			expect(deviceType.category).toBe('server');
-		});
-
-		it('accepts device type with optional notes', () => {
-			const deviceType: DeviceType = {
-				slug: '2u-server',
-				u_height: 2,
-				notes: 'Primary application server',
-				colour: '#4A90D9',
-				category: 'server'
-			};
-
-			expect(deviceType.notes).toBe('Primary application server');
-		});
-
-		it('accepts device type with all optional fields', () => {
-			const deviceType: DeviceType = {
-				slug: 'dell-r740',
-				u_height: 2,
-				manufacturer: 'Dell',
-				model: 'PowerEdge R740',
-				is_full_depth: true,
-				weight: 25.5,
-				weight_unit: 'kg',
-				airflow: 'front-to-rear',
-				notes: 'Primary database server',
-				colour: '#4A90D9',
-				category: 'server',
-				tags: ['production', 'database']
-			};
-
-			expect(deviceType.manufacturer).toBe('Dell');
-			expect(deviceType.model).toBe('PowerEdge R740');
-			expect(deviceType.is_full_depth).toBe(true);
-			expect(deviceType.weight).toBe(25.5);
-			expect(deviceType.weight_unit).toBe('kg');
-			expect(deviceType.airflow).toBe('front-to-rear');
-			expect(deviceType.tags).toEqual(['production', 'database']);
-		});
-
-		it('works without optional fields', () => {
-			const deviceType: DeviceType = {
-				slug: '1u-switch',
-				u_height: 1,
-				colour: '#7B68EE',
-				category: 'network'
-			};
-
-			expect(deviceType.manufacturer).toBeUndefined();
-			expect(deviceType.model).toBeUndefined();
-			expect(deviceType.airflow).toBeUndefined();
-			expect(deviceType.weight).toBeUndefined();
-		});
-	});
-
-	describe('Airflow type', () => {
-		it('accepts all valid airflow values (4 types)', () => {
-			const airflowValues: Airflow[] = [
-				'passive',
-				'front-to-rear',
-				'rear-to-front',
-				'side-to-rear'
-			];
-
-			expect(airflowValues).toHaveLength(4);
-			airflowValues.forEach((value) => {
-				expect(typeof value).toBe('string');
-			});
-		});
-	});
-
-	describe('WeightUnit type', () => {
-		it('accepts all valid weight unit values', () => {
-			const weightUnits: WeightUnit[] = ['kg', 'lb'];
-
-			expect(weightUnits).toHaveLength(2);
-			expect(weightUnits).toContain('kg');
-			expect(weightUnits).toContain('lb');
-		});
-	});
-
-	describe('PlacedDevice interface', () => {
-		it('references device type by slug correctly', () => {
-			const placedDevice: PlacedDevice = {
-				id: crypto.randomUUID(),
-				device_type: 'dell-r740',
-				position: 5,
-				face: 'front'
-			};
-
-			expect(placedDevice.device_type).toBe('dell-r740');
-			expect(placedDevice.position).toBe(5);
-			expect(placedDevice.face).toBe('front');
-		});
-
-		it('accepts optional custom name', () => {
-			const placedDevice: PlacedDevice = {
-				id: crypto.randomUUID(),
-				device_type: 'dell-r740',
-				position: 5,
-				face: 'front',
-				name: 'Web Server 1'
-			};
-
-			expect(placedDevice.name).toBe('Web Server 1');
-		});
-
-		it('accepts all valid face values', () => {
-			const frontDevice: PlacedDevice = {
-				id: crypto.randomUUID(),
-				device_type: 'dev-1',
-				position: 1,
-				face: 'front'
-			};
-			const rearDevice: PlacedDevice = {
-				id: crypto.randomUUID(),
-				device_type: 'dev-2',
-				position: 2,
-				face: 'rear'
-			};
-			const bothDevice: PlacedDevice = {
-				id: crypto.randomUUID(),
-				device_type: 'dev-3',
-				position: 3,
-				face: 'both'
-			};
-
-			expect(frontDevice.face).toBe('front');
-			expect(rearDevice.face).toBe('rear');
-			expect(bothDevice.face).toBe('both');
-		});
-	});
-
-	describe('Rack interface', () => {
-		it('accepts valid rack object', () => {
-			const rack: Rack = {
-				name: 'Main Rack',
-				height: 42,
-				width: 19,
-				desc_units: false,
-				form_factor: '4-post-cabinet',
-				starting_unit: 1,
-				position: 0,
-				devices: []
-			};
-
-			expect(rack.name).toBe('Main Rack');
-			expect(rack.height).toBe(42);
-			expect(rack.width).toBe(19);
-			expect(rack.desc_units).toBe(false);
-			expect(rack.form_factor).toBe('4-post-cabinet');
-			expect(rack.starting_unit).toBe(1);
-			expect(rack.position).toBe(0);
-			expect(rack.devices).toEqual([]);
-		});
-
-		it('accepts rack with runtime view', () => {
-			const rack: Rack = {
-				name: 'Rear Rack',
-				height: 42,
-				width: 19,
-				desc_units: false,
-				form_factor: '4-post-cabinet',
-				starting_unit: 1,
-				position: 0,
-				devices: [],
-				view: 'rear'
-			};
-
-			expect(rack.view).toBe('rear');
-		});
-
-		it('accepts rack with placed devices', () => {
-			const rack: Rack = {
-				name: 'Main Rack',
-				height: 42,
-				width: 19,
-				desc_units: false,
-				form_factor: '4-post-cabinet',
-				starting_unit: 1,
-				position: 0,
-				devices: [
-					{ id: crypto.randomUUID(), device_type: 'device-1', position: 1, face: 'front' },
-					{ id: crypto.randomUUID(), device_type: 'device-2', position: 5, face: 'both' }
-				]
-			};
-
-			expect(rack.devices).toHaveLength(2);
-			expect(rack.devices[0]?.device_type).toBe('device-1');
-			expect(rack.devices[0]?.position).toBe(1);
-			expect(rack.devices[0]?.face).toBe('front');
-		});
-
-		it('accepts rack with descending units', () => {
-			const rack: Rack = {
-				name: 'Descending Rack',
-				height: 42,
-				width: 19,
-				desc_units: true,
-				form_factor: '4-post-cabinet',
-				starting_unit: 5,
-				position: 0,
-				devices: []
-			};
-
-			expect(rack.desc_units).toBe(true);
-			expect(rack.starting_unit).toBe(5);
-		});
-
-		it('accepts 10-inch rack width', () => {
-			const rack: Rack = {
-				name: 'Narrow Rack',
-				height: 12,
-				width: 10,
-				desc_units: false,
-				form_factor: 'wall-mount',
-				starting_unit: 1,
-				position: 0,
-				devices: []
-			};
-
-			expect(rack.width).toBe(10);
-		});
-	});
-
-	describe('FormFactor type', () => {
-		it('accepts all valid form factor values', () => {
-			const formFactors: FormFactor[] = [
-				'2-post',
-				'4-post',
-				'4-post-cabinet',
-				'wall-mount',
-				'open-frame'
-			];
-
-			expect(formFactors).toHaveLength(5);
-			formFactors.forEach((value) => {
-				expect(typeof value).toBe('string');
-			});
-		});
-	});
-
-	describe('RackView type', () => {
-		it('accepts front view', () => {
-			const view: RackView = 'front';
-			expect(view).toBe('front');
-		});
-
-		it('accepts rear view', () => {
-			const view: RackView = 'rear';
-			expect(view).toBe('rear');
-		});
-	});
-
-	describe('DeviceFace type', () => {
-		it('accepts front, rear, and both', () => {
-			const faces: DeviceFace[] = ['front', 'rear', 'both'];
-			expect(faces).toHaveLength(3);
-			expect(faces).toContain('front');
-			expect(faces).toContain('rear');
-			expect(faces).toContain('both');
-		});
-	});
-
-	describe('Layout interface', () => {
-		it('accepts valid layout object', () => {
-			const layout: Layout = {
-				version: '0.2.0',
-				name: 'My Homelab',
-				rack: {
-					name: 'Main Rack',
-					height: 42,
-					width: 19,
-					desc_units: false,
-					form_factor: '4-post-cabinet',
-					starting_unit: 1,
-					position: 0,
-					devices: []
-				},
-				device_types: [],
-				settings: {
-					display_mode: 'label',
-					show_labels_on_images: false
-				}
-			};
-
-			expect(layout.version).toBe('0.2.0');
-			expect(layout.name).toBe('My Homelab');
-			expect(layout.device_types).toEqual([]);
-			expect(layout.rack.name).toBe('Main Rack');
-		});
-
-		it('accepts layout with device types and placed devices', () => {
-			const deviceType: DeviceType = {
-				slug: '1u-server',
-				u_height: 1,
-				model: 'Server',
-				colour: '#4A90D9',
-				category: 'server'
-			};
-
-			const layout: Layout = {
-				version: '0.2.0',
-				name: 'My Homelab',
-				rack: {
-					name: 'Main Rack',
-					height: 42,
-					width: 19,
-					desc_units: false,
-					form_factor: '4-post-cabinet',
-					starting_unit: 1,
-					position: 0,
-					devices: [
-						{ id: crypto.randomUUID(), device_type: '1u-server', position: 1, face: 'front' }
-					]
-				},
-				device_types: [deviceType],
-				settings: {
-					display_mode: 'image',
-					show_labels_on_images: true
-				}
-			};
-
-			expect(layout.device_types).toHaveLength(1);
-			expect(layout.rack.devices).toHaveLength(1);
-			expect(layout.settings.display_mode).toBe('image');
-		});
-	});
-
-	describe('LayoutSettings interface', () => {
-		it('requires display_mode and show_labels_on_images', () => {
-			const settings: LayoutSettings = {
-				display_mode: 'label',
-				show_labels_on_images: false
-			};
-
-			expect(settings.display_mode).toBe('label');
-			expect(settings.show_labels_on_images).toBe(false);
-		});
-
-		it('accepts all display mode values', () => {
-			const labelSettings: LayoutSettings = {
-				display_mode: 'label',
-				show_labels_on_images: false
-			};
-
-			const imageSettings: LayoutSettings = {
-				display_mode: 'image',
-				show_labels_on_images: true
-			};
-
-			expect(labelSettings.display_mode).toBe('label');
-			expect(imageSettings.display_mode).toBe('image');
-		});
-	});
-
-	describe('DisplayMode type', () => {
-		it('accepts label and image values', () => {
-			const modes: DisplayMode[] = ['label', 'image'];
-
-			expect(modes).toHaveLength(2);
-			expect(modes).toContain('label');
-			expect(modes).toContain('image');
-		});
-	});
-});
-
-describe('Constants', () => {
-	describe('CATEGORY_COLOURS', () => {
-		it('has entry for every DeviceCategory', () => {
-			const categories: DeviceCategory[] = [
-				'server',
-				'network',
-				'patch-panel',
-				'power',
-				'storage',
-				'kvm',
-				'av-media',
-				'cooling',
-				'shelf',
-				'blank',
-				'cable-management',
-				'other'
-			];
-
-			categories.forEach((category) => {
-				expect(CATEGORY_COLOURS[category]).toBeDefined();
-				expect(CATEGORY_COLOURS[category]).toMatch(/^#[0-9A-Fa-f]{6}$/);
-			});
-		});
-
-		it('returns correct colour for cable-management category (Dracula comment)', () => {
-			expect(CATEGORY_COLOURS['cable-management']).toBe('#6272A4');
-		});
-
-		it('returns correct colour for server category (muted cyan)', () => {
-			expect(CATEGORY_COLOURS.server).toBe('#4A7A8A');
-		});
-
-		it('returns correct colour for network category (muted purple)', () => {
-			expect(CATEGORY_COLOURS.network).toBe('#7B6BA8');
-		});
-
-		it('returns correct colour for shelf category (Dracula comment)', () => {
-			expect(CATEGORY_COLOURS.shelf).toBe('#6272A4');
-		});
-	});
-
-	describe('ALL_CATEGORIES', () => {
-		it('contains all 12 categories', () => {
-			expect(ALL_CATEGORIES).toHaveLength(12);
-		});
-
-		it('includes all expected categories', () => {
-			expect(ALL_CATEGORIES).toContain('server');
-			expect(ALL_CATEGORIES).toContain('network');
-			expect(ALL_CATEGORIES).toContain('patch-panel');
-			expect(ALL_CATEGORIES).toContain('power');
-			expect(ALL_CATEGORIES).toContain('storage');
-			expect(ALL_CATEGORIES).toContain('kvm');
-			expect(ALL_CATEGORIES).toContain('av-media');
-			expect(ALL_CATEGORIES).toContain('cooling');
-			expect(ALL_CATEGORIES).toContain('shelf');
-			expect(ALL_CATEGORIES).toContain('blank');
-			expect(ALL_CATEGORIES).toContain('cable-management');
-			expect(ALL_CATEGORIES).toContain('other');
-		});
-
-		it('has shelf category before blank', () => {
-			const shelfIndex = ALL_CATEGORIES.indexOf('shelf');
-			const blankIndex = ALL_CATEGORIES.indexOf('blank');
-			expect(shelfIndex).toBeLessThan(blankIndex);
-		});
-
-		it('has cable-management category before other', () => {
-			const cableMgmtIndex = ALL_CATEGORIES.indexOf('cable-management');
-			const otherIndex = ALL_CATEGORIES.indexOf('other');
-			expect(cableMgmtIndex).toBeLessThan(otherIndex);
-		});
-	});
-
-	describe('CURRENT_VERSION', () => {
-		it('is set to 1.0.0', () => {
-			// Schema v1.0.0: Stable schema version
-			expect(CURRENT_VERSION).toBe('1.0.0');
-		});
-	});
-
-	describe('DEFAULT_RACK_VIEW', () => {
-		it('is front', () => {
-			expect(DEFAULT_RACK_VIEW).toBe('front');
-		});
-	});
-
-	describe('DEFAULT_DEVICE_FACE', () => {
-		it('is front', () => {
-			expect(DEFAULT_DEVICE_FACE).toBe('front');
-		});
-	});
-
-	describe('MIN_DEVICE_HEIGHT', () => {
-		it('supports half-U devices (0.5)', () => {
-			expect(MIN_DEVICE_HEIGHT).toBe(0.5);
-		});
-	});
-});
-
-describe('Image Types', () => {
-	describe('ImageData interface', () => {
-		it('accepts valid ImageData structure', () => {
-			// Create a mock ImageData
-			const mockBlob = new Blob(['test'], { type: 'image/png' });
-			const imageData: import('$lib/types/images').ImageData = {
-				blob: mockBlob,
-				dataUrl: 'data:image/png;base64,dGVzdA==',
-				filename: 'test-device-front.png'
-			};
-
-			expect(imageData.blob).toBeInstanceOf(Blob);
-			expect(imageData.dataUrl).toContain('data:image/png');
-			expect(imageData.filename).toBe('test-device-front.png');
-		});
-	});
-
-	describe('Image Format Types', () => {
-		it('SUPPORTED_IMAGE_FORMATS includes png, jpeg, and webp', async () => {
-			const { SUPPORTED_IMAGE_FORMATS } = await import('$lib/types/constants');
-
-			expect(SUPPORTED_IMAGE_FORMATS).toContain('image/png');
-			expect(SUPPORTED_IMAGE_FORMATS).toContain('image/jpeg');
-			expect(SUPPORTED_IMAGE_FORMATS).toContain('image/webp');
-			expect(SUPPORTED_IMAGE_FORMATS.length).toBe(3);
-		});
-
-		it('MAX_IMAGE_SIZE_MB is 5', async () => {
-			const { MAX_IMAGE_SIZE_MB } = await import('$lib/types/constants');
-			expect(MAX_IMAGE_SIZE_MB).toBe(5);
-		});
-
-		it('MAX_IMAGE_SIZE_BYTES is 5MB', async () => {
-			const { MAX_IMAGE_SIZE_BYTES } = await import('$lib/types/constants');
-			expect(MAX_IMAGE_SIZE_BYTES).toBe(5 * 1024 * 1024);
-		});
-	});
-
-	describe('ImageUploadResult interface', () => {
-		it('accepts successful result with data', async () => {
-			const mockBlob = new Blob(['test'], { type: 'image/png' });
-			const result: import('$lib/types/images').ImageUploadResult = {
-				success: true,
-				data: {
-					blob: mockBlob,
-					dataUrl: 'data:image/png;base64,dGVzdA==',
-					filename: 'test-front.png'
-				}
-			};
-
-			expect(result.success).toBe(true);
-			expect(result.data).toBeDefined();
-			expect(result.error).toBeUndefined();
-		});
-
-		it('accepts failed result with error', async () => {
-			const result: import('$lib/types/images').ImageUploadResult = {
-				success: false,
-				error: 'File too large'
-			};
-
-			expect(result.success).toBe(false);
-			expect(result.error).toBe('File too large');
-			expect(result.data).toBeUndefined();
-		});
-	});
-
-	describe('SupportedImageFormat type', () => {
-		it('type guards work for supported formats', async () => {
-			const { SUPPORTED_IMAGE_FORMATS } = await import('$lib/types/constants');
-
-			// Test that these are the only supported formats
-			const formats = ['image/png', 'image/jpeg', 'image/webp'];
-			formats.forEach((format) => {
-				expect(SUPPORTED_IMAGE_FORMATS).toContain(format);
-			});
-
-			// Test that other formats are not included
-			expect(SUPPORTED_IMAGE_FORMATS).not.toContain('image/gif');
-			expect(SUPPORTED_IMAGE_FORMATS).not.toContain('image/bmp');
-		});
-	});
+  CATEGORY_COLOURS,
+  ALL_CATEGORIES,
+  CURRENT_VERSION,
+  DEFAULT_RACK_VIEW,
+  DEFAULT_DEVICE_FACE,
+  MIN_DEVICE_HEIGHT,
+  SUPPORTED_IMAGE_FORMATS,
+  MAX_IMAGE_SIZE_MB,
+  MAX_IMAGE_SIZE_BYTES,
+} from "$lib/types/constants";
+
+/**
+ * Constants Tests
+ *
+ * These tests verify the completeness and correctness of type system constants.
+ * TypeScript interface tests are intentionally NOT included here because:
+ * - TypeScript validates interface compliance at compile time
+ * - Runtime tests that just prove TS works add no value
+ *
+ * See: docs/guides/TESTING.md - "Trust the Schema" principle
+ */
+describe("Constants", () => {
+  describe("CATEGORY_COLOURS", () => {
+    it("has entry for every DeviceCategory", () => {
+      const categories: DeviceCategory[] = [
+        "server",
+        "network",
+        "patch-panel",
+        "power",
+        "storage",
+        "kvm",
+        "av-media",
+        "cooling",
+        "shelf",
+        "blank",
+        "cable-management",
+        "other",
+      ];
+
+      categories.forEach((category) => {
+        expect(CATEGORY_COLOURS[category]).toBeDefined();
+        expect(CATEGORY_COLOURS[category]).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      });
+    });
+  });
+
+  describe("ALL_CATEGORIES", () => {
+    it("contains all 12 categories", () => {
+      expect(ALL_CATEGORIES).toHaveLength(12);
+    });
+
+    it("includes all expected categories", () => {
+      const expectedCategories: DeviceCategory[] = [
+        "server",
+        "network",
+        "patch-panel",
+        "power",
+        "storage",
+        "kvm",
+        "av-media",
+        "cooling",
+        "shelf",
+        "blank",
+        "cable-management",
+        "other",
+      ];
+
+      expectedCategories.forEach((category) => {
+        expect(ALL_CATEGORIES).toContain(category);
+      });
+    });
+  });
+
+  describe("Version and Defaults", () => {
+    it("CURRENT_VERSION is 1.0.0 (stable schema)", () => {
+      expect(CURRENT_VERSION).toBe("1.0.0");
+    });
+
+    it("DEFAULT_RACK_VIEW is front", () => {
+      expect(DEFAULT_RACK_VIEW).toBe("front");
+    });
+
+    it("DEFAULT_DEVICE_FACE is front", () => {
+      expect(DEFAULT_DEVICE_FACE).toBe("front");
+    });
+
+    it("MIN_DEVICE_HEIGHT supports half-U devices", () => {
+      expect(MIN_DEVICE_HEIGHT).toBe(0.5);
+    });
+  });
+
+  describe("Image Format Constants", () => {
+    it("SUPPORTED_IMAGE_FORMATS includes png, jpeg, and webp", () => {
+      expect(SUPPORTED_IMAGE_FORMATS).toContain("image/png");
+      expect(SUPPORTED_IMAGE_FORMATS).toContain("image/jpeg");
+      expect(SUPPORTED_IMAGE_FORMATS).toContain("image/webp");
+      expect(SUPPORTED_IMAGE_FORMATS).toHaveLength(3);
+    });
+
+    it("does not support gif or bmp", () => {
+      expect(SUPPORTED_IMAGE_FORMATS).not.toContain("image/gif");
+      expect(SUPPORTED_IMAGE_FORMATS).not.toContain("image/bmp");
+    });
+
+    it("MAX_IMAGE_SIZE_MB is 5", () => {
+      expect(MAX_IMAGE_SIZE_MB).toBe(5);
+    });
+
+    it("MAX_IMAGE_SIZE_BYTES equals 5MB", () => {
+      expect(MAX_IMAGE_SIZE_BYTES).toBe(5 * 1024 * 1024);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Remove tests that duplicate TypeScript/Zod validation or test static data:

- **types.test.ts**: 587 → 117 lines (-470 lines, -80%)
  - Removed all TypeScript interface compile tests (TS validates at compile time)
  - Kept constants completeness tests (CATEGORY_COLOURS, ALL_CATEGORIES)

- **starterLibrary.test.ts**: 630 → 98 lines (-532 lines, -84%)
  - Removed 40+ individual device existence tests
  - Removed exact count tests (`toHaveLength(51)`)
  - Kept invariant tests: unique slugs, all categories covered, no manufacturer
  - Added single schema validation test to catch real issues

**Total reduction: 1,002 lines (-82%)**

## Rationale

From our testing guidelines:
- **Zero-Change Rule**: Adding a device should require zero test changes
- **Trust the Schema**: If `DeviceTypeSchema.parse()` passes, don't re-test fields
- TypeScript already validates interface compliance at compile time

## Files Changed

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| `src/tests/types.test.ts` | 587 | 117 | -470 (80%) |
| `src/tests/starterLibrary.test.ts` | 630 | 98 | -532 (84%) |

## Test Plan

- [x] All remaining tests pass
- [x] Lint passes
- [x] Build succeeds
- [x] No regression in coverage (tests were redundant, not valuable)

Closes #407
Part of #405 (Test Suite Rationalization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test suite structure for improved maintainability and clarity.
  * Enhanced validation coverage with comprehensive schema and invariant checks.
  * Consolidated granular tests into broader invariant validations for critical system properties.
  * Improved test focus on system reliability and data integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->