### PR TITLE
fix: Safari 18.x device positioning by moving pointer events to rect (#411)

### DIFF
--- a/src/tests/RackDevice.test.ts
+++ b/src/tests/RackDevice.test.ts
@@ -232,18 +232,18 @@ describe("RackDevice SVG Component", () => {
         props: { ...defaultProps, onselect: handleSelect },
       });
 
-      // Interact via pointer events (the new interaction model)
-      const group = container.querySelector("g.rack-device");
-      expect(group).toBeInTheDocument();
+      // Safari 18.x fix #411: Pointer events on device-rect (explicit geometry)
+      const rect = container.querySelector(".device-rect");
+      expect(rect).toBeInTheDocument();
 
       // Simulate a click: pointerdown followed by pointerup at same position
-      await fireEvent.pointerDown(group!, {
+      await fireEvent.pointerDown(rect!, {
         isPrimary: true,
         pointerId: 1,
         clientX: 100,
         clientY: 100,
       });
-      await fireEvent.pointerUp(group!, {
+      await fireEvent.pointerUp(rect!, {
         isPrimary: true,
         pointerId: 1,
         clientX: 100,
@@ -265,22 +265,23 @@ describe("RackDevice SVG Component", () => {
         props: { ...defaultProps, ondragstart: handleDragStart },
       });
 
-      const group = container.querySelector("g.rack-device");
+      // Safari 18.x fix #411: Pointer events on device-rect (explicit geometry)
+      const rect = container.querySelector(".device-rect");
 
       // Small movement (less than 3px threshold) should not trigger drag
-      await fireEvent.pointerDown(group!, {
+      await fireEvent.pointerDown(rect!, {
         isPrimary: true,
         pointerId: 1,
         clientX: 100,
         clientY: 100,
       });
-      await fireEvent.pointerMove(group!, {
+      await fireEvent.pointerMove(rect!, {
         isPrimary: true,
         pointerId: 1,
         clientX: 101,
         clientY: 101,
       });
-      await fireEvent.pointerUp(group!, {
+      await fireEvent.pointerUp(rect!, {
         isPrimary: true,
         pointerId: 1,
         clientX: 101,
@@ -298,16 +299,17 @@ describe("RackDevice SVG Component", () => {
         props: { ...defaultProps, ondragstart: handleDragStart },
       });
 
-      const group = container.querySelector("g.rack-device");
+      // Safari 18.x fix #411: Pointer events on device-rect (explicit geometry)
+      const rect = container.querySelector(".device-rect");
 
       // Movement of exactly 3px should trigger drag
-      await fireEvent.pointerDown(group!, {
+      await fireEvent.pointerDown(rect!, {
         isPrimary: true,
         pointerId: 1,
         clientX: 100,
         clientY: 100,
       });
-      await fireEvent.pointerMove(group!, {
+      await fireEvent.pointerMove(rect!, {
         isPrimary: true,
         pointerId: 1,
         clientX: 103, // 3px horizontal movement
@@ -358,16 +360,16 @@ describe("RackDevice SVG Component", () => {
   });
 
   describe("Drag Affordance", () => {
-    // Issue #397: Replaced foreignObject drag overlay with pointer events on SVG group
-    // These tests verify the new pointer events implementation
+    // Issue #397: Replaced foreignObject drag overlay with pointer events
+    // Issue #411: Moved pointer events to device-rect for Safari 18.x compatibility
 
-    it("has grab cursor on rack-device group", () => {
+    it("has grab cursor on device-rect element", () => {
       const { container } = render(RackDevice, { props: defaultProps });
 
-      // The SVG group should have the rack-device class with grab cursor via CSS
-      const group = container.querySelector("g.rack-device");
-      expect(group).toBeInTheDocument();
-      expect(group).toHaveClass("rack-device");
+      // Safari 18.x fix #411: cursor on device-rect (explicit geometry element)
+      const rect = container.querySelector(".device-rect");
+      expect(rect).toBeInTheDocument();
+      // Cursor style applied via CSS on .device-rect class
     });
 
     it("has CSS properties for iOS Safari long-press support (#232)", () => {


### PR DESCRIPTION
## Summary

- Fix Safari 18.x device positioning issue where grab handles (cursor) appear stacked at top of rack instead of on each device
- Move pointer event handlers from SVG `<g>` element to `<rect class="device-rect">` which has explicit geometry
- Safari 18.x doesn't properly compute hit areas on transformed SVG `<g>` elements

## Changes

- `RackDevice.svelte`: Move `onpointer*` handlers to `.device-rect` element
- `RackDevice.svelte`: Add `rectElement` ref for pointer capture
- `RackDevice.svelte`: Move cursor styling from `.rack-device` to `.device-rect`
- `RackDevice.test.ts`: Update tests to target `.device-rect` for pointer events

## Technical Details

The `<g>` element is a grouping element with no geometry - its hit area depends on its children's painted areas. Safari 18.x doesn't correctly compute this for transformed groups. The fix uses the `.device-rect` element which has explicit `x`, `y`, `width`, `height` bounds that Safari can correctly use for pointer event hit testing.

The `<g>` element retains keyboard handlers and accessibility attributes (role, tabindex, aria-label) for proper a11y support.

## Test plan

- [x] All RackDevice tests pass (46 tests)
- [x] Full test suite passes (3118 tests)
- [x] Build succeeds
- [ ] Manual testing on Safari 18.x (needs reporter verification)

@brandonb927 - Would you be able to test this fix once deployed to d.racku.la? 🙏

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Addressed Safari 18.x pointer event hit-area detection issues that affected interaction reliability with draggable elements.
- Improved cursor visual feedback and responsiveness during drag-and-drop operations.
- Refined pointer capture handling for better cross-browser compatibility and consistent user interaction behaviour across platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->