### PR TITLE
chore: remove unused face option from createTestDevice helper (#418)

### DIFF
--- a/src/tests/collision.test.ts
+++ b/src/tests/collision.test.ts
@@ -23,7 +23,6 @@ function createTestDevice(
   u_height: number,
   options?: {
     is_full_depth?: boolean;
-    face?: DeviceFace;
     slot_width?: SlotWidth;
   },
 ): DeviceType {
@@ -36,7 +35,6 @@ function createTestDevice(
     ...(options?.is_full_depth !== undefined && {
       is_full_depth: options.is_full_depth,
     }),
-    ...(options?.face !== undefined && { face: options.face }),
     ...(options?.slot_width !== undefined && {
       slot_width: options.slot_width,
     }),


### PR DESCRIPTION
## Summary

Remove dead code from `createTestDevice` helper in collision tests.

The `face` property belongs to `PlacedDevice`, not `DeviceType`. The helper was accepting and spreading a `face` option that had no effect.

## Changes

- Remove `face?: DeviceFace` from options type
- Remove dead conditional spread for `options?.face`
- Keep `DeviceFace` import (still used in `createTestRack`)

## Test plan

- [x] All 60 collision tests pass

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test device creation helper by removing face property configuration from options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->