### PR TITLE
fix: Safari 18.x category icon positioning (#411)

### DIFF
--- a/src/lib/components/CategoryIconSVG.svelte
+++ b/src/lib/components/CategoryIconSVG.svelte
@@ -1,0 +1,81 @@
+<!--
+  CategoryIconSVG Component
+  Pure SVG rendering of category icons for use inside SVG elements.
+  Safari 18.x fix #411: Avoids foreignObject transform inheritance bug.
+-->
+<script lang="ts">
+  import type { DeviceCategory } from "$lib/types";
+  import {
+    Server,
+    Network,
+    EthernetPort,
+    Zap,
+    HardDrive,
+    Monitor,
+    Speaker,
+    Fan,
+    AlignEndHorizontal,
+    CircleOff,
+    Cable,
+    CircleQuestionMark,
+  } from "@lucide/svelte";
+  import type { Component } from "svelte";
+  import type { IconProps } from "@lucide/svelte";
+
+  interface Props {
+    category: DeviceCategory;
+    size?: number;
+    x?: number;
+    y?: number;
+  }
+
+  let { category, size = 16, x = 0, y = 0 }: Props = $props();
+
+  // Map categories to Lucide icon components
+  const iconMap: Record<DeviceCategory, Component<IconProps>> = {
+    server: Server,
+    network: Network,
+    "patch-panel": EthernetPort,
+    power: Zap,
+    storage: HardDrive,
+    kvm: Monitor,
+    "av-media": Speaker,
+    cooling: Fan,
+    shelf: AlignEndHorizontal,
+    blank: CircleOff,
+    "cable-management": Cable,
+    other: CircleQuestionMark,
+  };
+
+  // Get the icon component for this category (fallback to CircleQuestionMark)
+  const IconComponent = $derived(iconMap[category] ?? CircleQuestionMark);
+</script>
+
+<!--
+  Nested SVG for positioning within parent SVG context.
+  Safari requires explicit x/y on the SVG element rather than relying on
+  parent <g> transform inheritance with foreignObject.
+-->
+<svg
+  {x}
+  {y}
+  width={size}
+  height={size}
+  class="category-icon-svg"
+  aria-hidden="true"
+>
+  <IconComponent {size} />
+</svg>
+
+<style>
+  .category-icon-svg {
+    overflow: visible;
+    color: rgba(255, 255, 255, 0.8);
+    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+  }
+
+  .category-icon-svg :global(svg) {
+    /* Lucide icons render their own nested SVG - reset its position */
+    display: block;
+  }
+</style>

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -15,7 +15,7 @@
     createRackDeviceDragData,
     setCurrentDragData,
   } from "$lib/utils/dragdrop";
-  import CategoryIcon from "./CategoryIcon.svelte";
+  import CategoryIconSVG from "./CategoryIconSVG.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { useLongPress } from "$lib/utils/gestures";
@@ -454,20 +454,16 @@
       {fittedLabel.text}
     </text>
 
-    <!-- Category icon (vertically centered) -->
+    <!-- Category icon (vertically centered)
+         Safari 18.x fix #411: Use SVG-native component instead of foreignObject
+         to avoid transform inheritance bug -->
     {#if deviceHeight >= 22}
-      <foreignObject
-        x="8"
-        y="0"
-        width="16"
-        height={deviceHeight}
-        class="category-icon-wrapper"
-      >
-        <!-- xmlns required for foreignObject HTML content on mobile browsers -->
-        <div xmlns="http://www.w3.org/1999/xhtml" class="icon-container">
-          <CategoryIcon category={device.category} size={14} />
-        </div>
-      </foreignObject>
+      <CategoryIconSVG
+        category={device.category}
+        size={14}
+        x={8}
+        y={(deviceHeight - 14) / 2}
+      />
     {/if}
   {/if}
 
@@ -564,18 +560,8 @@
     user-select: none;
   }
 
-  .category-icon-wrapper {
-    pointer-events: none;
-    overflow: visible;
-  }
-
-  .icon-container {
-    display: flex;
-    align-items: center;
-    height: 100%;
-    color: rgba(255, 255, 255, 0.8);
-    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
-  }
+  /* Safari 18.x fix #411: category-icon-wrapper and icon-container CSS removed
+     Category icons now use SVG-native CategoryIconSVG component */
 
   .label-overlay-wrapper {
     overflow: visible;

--- a/src/tests/RackDevice.test.ts
+++ b/src/tests/RackDevice.test.ts
@@ -148,22 +148,14 @@ describe("RackDevice SVG Component", () => {
     it("displays category icon for devices", () => {
       const { container } = render(RackDevice, { props: defaultProps });
 
-      // Category icon is rendered via foreignObject with class category-icon-wrapper
-      const foreignObject = container.querySelector(
-        "foreignObject.category-icon-wrapper",
-      );
-      expect(foreignObject).toBeInTheDocument();
+      // Safari 18.x fix #411: Category icons now use SVG-native component
+      // instead of foreignObject (which has transform inheritance bugs in Safari)
+      const categoryIconSvg = container.querySelector("svg.category-icon-svg");
+      expect(categoryIconSvg).toBeInTheDocument();
 
-      // Icon container should have the icon
-      const iconContainer = foreignObject?.querySelector(".icon-container");
-      expect(iconContainer).toBeInTheDocument();
-
-      // The CategoryIcon SVG should be present (Lucide icon inside .category-icon wrapper)
-      const categoryIconWrapper =
-        iconContainer?.querySelector(".category-icon");
-      expect(categoryIconWrapper).toBeInTheDocument();
-      const iconSvg = categoryIconWrapper?.querySelector("svg");
-      expect(iconSvg).toBeInTheDocument();
+      // The Lucide icon SVG should be nested inside
+      const nestedIconSvg = categoryIconSvg?.querySelector("svg");
+      expect(nestedIconSvg).toBeInTheDocument();
     });
 
     it("displays category icon for multi-U devices", () => {
@@ -172,34 +164,32 @@ describe("RackDevice SVG Component", () => {
         props: { ...defaultProps, device: device2U },
       });
 
-      const foreignObject = container.querySelector("foreignObject");
-      expect(foreignObject).toBeInTheDocument();
+      // Safari 18.x fix #411: Category icons now use SVG-native component
+      const categoryIconSvg = container.querySelector("svg.category-icon-svg");
+      expect(categoryIconSvg).toBeInTheDocument();
     });
 
-    it("centers icon vertically by spanning full device height", () => {
+    it("centers icon vertically using SVG positioning", () => {
+      // Safari 18.x fix #411: Category icons now use SVG-native component
+      // with explicit x/y positioning instead of foreignObject
       const device2U: DeviceType = { ...mockDevice, u_height: 2 };
       const { container } = render(RackDevice, {
         props: { ...defaultProps, device: device2U },
       });
 
-      // Get the category icon wrapper (not the drag handle overlay)
-      const foreignObject = container.querySelector(
-        "foreignObject.category-icon-wrapper",
-      );
-      expect(foreignObject).toBeInTheDocument();
+      // Get the category icon SVG element
+      const categoryIconSvg = container.querySelector("svg.category-icon-svg");
+      expect(categoryIconSvg).toBeInTheDocument();
 
-      // Foreign object should span full device height (2U * 22px = 44px)
-      const expectedHeight = 2 * U_HEIGHT;
-      expect(foreignObject?.getAttribute("height")).toBe(
-        String(expectedHeight),
-      );
+      // Icon should have explicit x positioning (left margin)
+      expect(categoryIconSvg?.getAttribute("x")).toBe("8");
 
-      // Y position should be 0 (starts at top of device)
-      expect(foreignObject?.getAttribute("y")).toBe("0");
-
-      // Icon container should have flexbox class (CSS applied)
-      const iconContainer = foreignObject?.querySelector(".icon-container");
-      expect(iconContainer).toBeInTheDocument();
+      // Icon should be vertically centered: y = (deviceHeight - iconSize) / 2
+      // For 2U device: height = 44px, icon size = 14px, y = (44 - 14) / 2 = 15
+      const deviceHeight = 2 * U_HEIGHT;
+      const iconSize = 14;
+      const expectedY = (deviceHeight - iconSize) / 2;
+      expect(categoryIconSvg?.getAttribute("y")).toBe(String(expectedY));
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace foreignObject-based category icons with SVG-native component
- Safari 18.x has a transform inheritance bug that caused foreignObject icons to render at upper-left corner
- New CategoryIconSVG component uses nested SVG with explicit x/y positioning

## Changes

- **CategoryIconSVG.svelte** (new): Pure SVG component for category icons
  - Uses nested `<svg>` element with explicit x/y positioning
  - Maps all 12 device categories to Lucide icons
  - Styled with drop-shadow for visibility

- **RackDevice.svelte**: Use CategoryIconSVG instead of foreignObject
  - Removed foreignObject wrapper for category icons
  - Removed obsolete CSS for icon-container

- **RackDevice.test.ts**: Updated tests for SVG-native component
  - Updated selectors from foreignObject to svg.category-icon-svg

## Test plan

- [x] All 257 tests pass
- [x] Lint passes
- [x] Build passes
- [ ] Visual verify on Safari 18.x/26.x that icons render at correct positions

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device category icon rendering across all supported browsers, with targeted enhancements for Safari 18.x compatibility. Category icons now display consistently and reliably on all platforms, eliminating previous rendering issues and providing a more stable visual experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->