### PR TITLE
fix: use absolute paths for worktree operations in dev-issue skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,9 @@ browserstackSetupConfig.json
 playwright-browserstack-sdk.config.temp.json
 playwright-browserstack-sdk.config.ts
 
-# Claude
-.claude/
+# Claude Code - track commands/skills, ignore local settings
+.claude/settings.local.json
+.claude/plans/
 
 # Paraglide generated files
 src/lib/i18n/paraglide/


### PR DESCRIPTION
## Summary

- Update dev-issue.md to use `WORKTREE_DIR` variable and subshells for all worktree operations
- Update .gitignore to selectively track `.claude/` files (commands yes, settings.local.json no)

## Problem

When `/dev-issue` creates a worktree and does `cd ../Rackula-issue-<N>`, Claude Code's session stays anchored to the original project directory. The shell cwd resets back, causing:
- Repeated "Shell cwd was reset" messages
- Wasted tokens from failed `cd` commands

## Solution

Use absolute paths pattern:
```bash
WORKTREE_DIR="$(pwd)/../Rackula-issue-<N>"
(cd "$WORKTREE_DIR" && npm install)
(cd "$WORKTREE_DIR" && npm run lint && npm run test:run && npm run build)
```

## Changes

### dev-issue.md
- Define `WORKTREE_DIR` after worktree creation
- Use subshells `(cd "$WORKTREE_DIR" && ...)` for npm commands
- Update Quick Reference, Phase 3a, and Pre-Commit sections
- Add explanation of why this pattern is needed

### .gitignore
- Replace blanket `.claude/` ignore with selective ignores
- Ignore `.claude/settings.local.json` (contains bash permission history)
- Ignore `.claude/plans/` (temporary files)
- Allow `.claude/commands/` and `.claude/settings.json` to be tracked

## Test plan

- [ ] CodeRabbit approves this PR (demonstrating the workflow)
- [ ] Next `/dev-issue` run uses absolute paths without cwd reset messages

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development workflow documentation with clearer patterns and standardized conventions for improved consistency.
  * Refined version control ignore rules to better balance project structure visibility with local settings protection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->