### PR TITLE
fix: Dev badge tooltip appears behind canvas (#438)

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -420,6 +420,7 @@
     border-bottom: 1px solid var(--colour-toolbar-border, var(--toolbar-border));
     flex-shrink: 0;
     position: relative;
+    z-index: var(--z-toolbar);
   }
 
   .toolbar-section {

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -316,6 +316,7 @@
   --colour-surface-secondary: var(--dracula-bg-light);
 
   /* Z-Index Layers */
+  --z-toolbar: 10;
   --z-sidebar: 10;
   --z-drawer-backdrop: 99;
   --z-drawer: 100;


### PR DESCRIPTION
## Summary
- Added `--z-toolbar: 10` design token to establish toolbar stacking context
- Applied `z-index: var(--z-toolbar)` to `.toolbar` class
- Tooltip now renders above the canvas as expected

## Files Changed
- `src/lib/styles/tokens.css`: Added `--z-toolbar` token
- `src/lib/components/Toolbar.svelte`: Applied z-index to toolbar

## Test plan
- [ ] Open dev environment (d.racku.la or localhost)
- [ ] Hover over the Dev badge info icon (i)
- [ ] Verify tooltip appears above the canvas, not behind it

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted toolbar layering to maintain proper visual positioning in the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->