### PR TITLE
feat: add container model schema foundation (#452)

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -308,6 +308,40 @@ export interface DeviceLink {
 }
 
 // =============================================================================
+// Container Slot Types (v0.6.0)
+// =============================================================================
+
+/**
+ * Position within a container's slot grid
+ */
+export interface SlotPosition2D {
+  /** Row index (0-indexed from bottom of container) */
+  row: number;
+  /** Column index (0-indexed from left) */
+  col: number;
+}
+
+/**
+ * Slot definition for container devices
+ * A DeviceType with slots[] is a container that can hold child devices.
+ * Container identification: slots.length > 0 implies container (no separate boolean).
+ */
+export interface Slot {
+  /** Unique identifier within this DeviceType (e.g., "bay-1") */
+  id: string;
+  /** Display label (e.g., "Left Bay") */
+  name?: string;
+  /** Position in container's slot grid */
+  position: SlotPosition2D;
+  /** Horizontal width as fraction of container width (0.5 = half-width, default: 1.0) */
+  width_fraction?: number;
+  /** Slot height in rack units (default: 1) */
+  height_units?: number;
+  /** Categories of devices this slot accepts (empty = accepts all) */
+  accepts?: DeviceCategory[];
+}
+
+// =============================================================================
 // PlacedPort Types
 // =============================================================================
 
@@ -468,6 +502,14 @@ export interface DeviceType {
   // --- Power Device Properties ---
   /** VA capacity (e.g., 1500, 3000) - for UPS devices */
   va_rating?: number;
+
+  // --- Container Support (v0.6.0) ---
+  /**
+   * Slot definitions for container devices.
+   * Presence of slots[] with length > 0 indicates this is a container device.
+   * Container devices can hold child PlacedDevices in their slots.
+   */
+  slots?: Slot[];
 }
 
 /**
@@ -507,6 +549,21 @@ export interface PlacedDevice {
   parent_device?: string;
   /** Bay name in parent device */
   device_bay?: string;
+
+  // --- Container Child Placement (v0.6.0) ---
+  /**
+   * UUID of parent PlacedDevice (if this device is nested in a container).
+   * When set, this device is a child of the container and:
+   * - position is relative (0-indexed from bottom of container)
+   * - device is excluded from rack-level collision detection
+   * - device inherits face from parent container
+   */
+  container_id?: string;
+  /**
+   * Which slot in parent container (references Slot.id in parent's DeviceType.slots).
+   * Required when container_id is set.
+   */
+  slot_id?: string;
 
   // --- Extension Fields ---
   /** Notes for this placement */

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -22,6 +22,7 @@ import type {
   Layout,
   LayoutSettings,
   Airflow,
+  Slot,
 } from "$lib/types";
 import type { Command, CommandType } from "$lib/stores/commands/types";
 
@@ -220,6 +221,95 @@ export function createTestDeviceLibrary(): DeviceType[] {
       category: "network",
     }),
   ];
+}
+
+// =============================================================================
+// Container/Slot Factories (v0.6.0)
+// =============================================================================
+
+/**
+ * Creates a test Slot for container devices.
+ */
+export function createTestSlot(overrides: Partial<Slot> = {}): Slot {
+  return {
+    id: overrides.id ?? "slot-1",
+    name: overrides.name,
+    position: overrides.position ?? { row: 0, col: 0 },
+    width_fraction: overrides.width_fraction,
+    height_units: overrides.height_units,
+    accepts: overrides.accepts,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a DeviceType that is a container (has slots).
+ * Containers can hold child PlacedDevices.
+ *
+ * @example
+ * // Simple 2U blade chassis with 2 half-width slots
+ * const chassis = createTestContainerType();
+ *
+ * // Custom container with server-only slots
+ * const serverChassis = createTestContainerType({
+ *   slug: 'blade-chassis-16',
+ *   u_height: 4,
+ *   slots: [
+ *     createTestSlot({ id: 'bay-1', position: { row: 0, col: 0 } }),
+ *     createTestSlot({ id: 'bay-2', position: { row: 0, col: 1 } }),
+ *   ],
+ * });
+ */
+export function createTestContainerType(
+  overrides: Partial<DeviceType> = {},
+): DeviceType {
+  const defaultSlots: Slot[] = [
+    createTestSlot({
+      id: "slot-left",
+      position: { row: 0, col: 0 },
+      width_fraction: 0.5,
+    }),
+    createTestSlot({
+      id: "slot-right",
+      position: { row: 0, col: 1 },
+      width_fraction: 0.5,
+    }),
+  ];
+
+  return {
+    slug: overrides.slug ?? "test-container",
+    u_height: overrides.u_height ?? 2,
+    model: overrides.model ?? "Test Container",
+    category: overrides.category ?? "server",
+    colour: overrides.colour ?? "#8B4513",
+    slots: overrides.slots ?? defaultSlots,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a PlacedDevice that is a child of a container.
+ *
+ * @example
+ * const container = createTestDevice({ id: 'container-1' });
+ * const child = createTestContainerChild({
+ *   container_id: 'container-1',
+ *   slot_id: 'slot-left',
+ * });
+ */
+export function createTestContainerChild(
+  overrides: Partial<PlacedDevice> & { container_id: string; slot_id: string },
+): PlacedDevice {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    device_type: overrides.device_type ?? "test-device",
+    position: overrides.position ?? 0, // 0-indexed relative position in container
+    face: overrides.face ?? "front",
+    container_id: overrides.container_id,
+    slot_id: overrides.slot_id,
+    ports: overrides.ports ?? [],
+    ...overrides,
+  };
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Add `Slot` and `SlotPosition2D` interfaces for container slot definitions
- Add `slots?: Slot[]` to `DeviceType` (presence indicates container)
- Add `container_id` and `slot_id` to `PlacedDevice` for child device placement
- Add `SlotSchema` and `SlotPosition2DSchema` with full validation
- Add `LayoutSchema.superRefine()` container validations:
  - container_id must reference existing device in same rack
  - Container's DeviceType must have slots
  - slot_id must exist in container's slots
  - Single-level nesting only (containers cannot nest in containers)
- Add test factory utilities: `createTestSlot()`, `createTestContainerType()`, `createTestContainerChild()`
- Add comprehensive tests for all new schemas and validations

## Files Changed

- `src/lib/types/index.ts`: Add Slot, SlotPosition2D interfaces; update DeviceType and PlacedDevice
- `src/lib/schemas/index.ts`: Add SlotSchema, SlotPosition2DSchema; update validation rules
- `src/tests/factories.ts`: Add container-specific test factories
- `src/tests/schemas.test.ts`: Add container schema tests; fix lint issues in existing tests

## Test Plan

- [x] SlotPosition2DSchema validates position coordinates
- [x] SlotSchema validates slot definitions with all optional fields
- [x] DeviceTypeSchema accepts device types with/without slots
- [x] PlacedDeviceSchema validates container_id requires slot_id
- [x] PlacedDeviceSchema allows position 0 for container children
- [x] PlacedDeviceSchema requires position >= 1 for rack-level devices
- [x] LayoutSchema rejects non-existent container_id references
- [x] LayoutSchema rejects invalid slot_id references
- [x] LayoutSchema rejects placing devices in non-containers
- [x] LayoutSchema enforces single-level nesting
- [x] All 1508 tests pass
- [x] Build succeeds

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)