### PR TITLE
fix: simplify device panel to binary collapsed/open with wider default (#468)

### DIFF
--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -20,7 +20,6 @@
     saveGroupingModeToStorage,
     type DeviceGroupingMode,
   } from "$lib/utils/deviceGrouping";
-  import { type SidebarWidthPreset } from "$lib/utils/sidebarWidth";
   import { debounce } from "$lib/utils/debounce";
   import { truncateWithEllipsis } from "$lib/utils/searchHighlight";
   import { parseDeviceLibraryImport } from "$lib/utils/import";
@@ -63,17 +62,6 @@
   function handleGroupingModeChange(newMode: DeviceGroupingMode) {
     groupingMode = newMode;
     saveGroupingModeToStorage(newMode);
-  }
-
-  // Width preset options for SegmentedControl
-  const widthPresetOptions: { value: SidebarWidthPreset; label: string }[] = [
-    { value: "compact", label: "S" },
-    { value: "normal", label: "M" },
-    { value: "wide", label: "L" },
-  ];
-
-  function handleWidthPresetChange(newPreset: SidebarWidthPreset) {
-    uiStore.setSidebarWidth(newPreset);
   }
 
   function handleCollapseToggle() {
@@ -407,7 +395,7 @@
     </div>
   {:else}
     <!-- Expanded view: full controls -->
-    <!-- Header with collapse toggle and width presets -->
+    <!-- Header with collapse toggle -->
     <div class="palette-header">
       <button
         class="collapse-toggle"
@@ -419,13 +407,6 @@
       >
         <span class="collapse-icon">←</span>
       </button>
-      <SegmentedControl
-        options={widthPresetOptions}
-        value={uiStore.sidebarWidth}
-        onchange={handleWidthPresetChange}
-        ariaLabel="Panel width"
-        size="small"
-      />
     </div>
 
     <!-- Grouping Mode and Search -->

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -10,12 +10,9 @@ import {
   type Theme,
 } from "$lib/utils/theme";
 import {
-  loadSidebarWidthFromStorage,
-  saveSidebarWidthToStorage,
   loadSidebarCollapsedFromStorage,
   saveSidebarCollapsedToStorage,
   getEffectiveSidebarWidth,
-  type SidebarWidthPreset,
 } from "$lib/utils/sidebarWidth";
 import type { DisplayMode, AnnotationField } from "$lib/types";
 
@@ -26,7 +23,6 @@ export const ZOOM_STEP = 25;
 
 // Load initial values from storage
 const initialTheme = loadThemeFromStorage();
-const initialSidebarWidth = loadSidebarWidthFromStorage();
 const initialSidebarCollapsed = loadSidebarCollapsedFromStorage();
 
 // Module-level state (using $state rune)
@@ -38,7 +34,6 @@ let displayMode = $state<DisplayMode>("label");
 let showAnnotations = $state(false);
 let annotationField = $state<AnnotationField>("name");
 let showBanana = $state(false);
-let sidebarWidth = $state<SidebarWidthPreset>(initialSidebarWidth);
 let sidebarCollapsed = $state(initialSidebarCollapsed);
 
 // Derived values (using $derived rune)
@@ -47,10 +42,8 @@ const canZoomOut = $derived(zoom > ZOOM_MIN);
 const zoomScale = $derived(zoom / 100);
 // Derive showLabelsOnImages from displayMode for backward compatibility
 const showLabelsOnImages = $derived(displayMode === "image-label");
-// Derive effective sidebar width in pixels based on preset and collapsed state
-const sidebarWidthPx = $derived(
-  getEffectiveSidebarWidth(sidebarWidth, sidebarCollapsed),
-);
+// Derive effective sidebar width in pixels based on collapsed state
+const sidebarWidthPx = $derived(getEffectiveSidebarWidth(sidebarCollapsed));
 
 // Apply initial theme to document (using the non-reactive initial value)
 applyThemeToDocument(initialTheme);
@@ -67,7 +60,6 @@ export function resetUIStore(): void {
   showAnnotations = false;
   annotationField = "name";
   showBanana = false;
-  sidebarWidth = loadSidebarWidthFromStorage();
   sidebarCollapsed = loadSidebarCollapsedFromStorage();
   applyThemeToDocument(theme);
 }
@@ -126,10 +118,7 @@ export function getUIStore() {
       return showBanana;
     },
 
-    // Sidebar width state getters
-    get sidebarWidth() {
-      return sidebarWidth;
-    },
+    // Sidebar state getters
     get sidebarCollapsed() {
       return sidebarCollapsed;
     },
@@ -166,8 +155,7 @@ export function getUIStore() {
     // Easter egg actions
     toggleBanana,
 
-    // Sidebar width actions
-    setSidebarWidth,
+    // Sidebar actions
     toggleSidebarCollapsed,
     collapseSidebar,
     expandSidebar,
@@ -332,15 +320,6 @@ function setAnnotationField(field: AnnotationField): void {
  */
 function toggleBanana(): void {
   showBanana = !showBanana;
-}
-
-/**
- * Set sidebar width preset
- * @param preset - Width preset to set
- */
-function setSidebarWidth(preset: SidebarWidthPreset): void {
-  sidebarWidth = preset;
-  saveSidebarWidthToStorage(preset);
 }
 
 /**

--- a/src/lib/utils/sidebarWidth.ts
+++ b/src/lib/utils/sidebarWidth.ts
@@ -1,69 +1,16 @@
 /**
  * Sidebar Width Utilities
- * Persistence and management for device library panel width preferences
+ * Persistence and management for device library panel collapsed state
  */
 
-/** Available sidebar width presets */
-export type SidebarWidthPreset = "compact" | "normal" | "wide";
-
-/** Pixel values for each preset */
-export const SIDEBAR_WIDTHS: Record<SidebarWidthPreset, number> = {
-  compact: 200,
-  normal: 280,
-  wide: 400,
-} as const;
+/** Width when sidebar is open */
+export const SIDEBAR_OPEN_WIDTH = 320;
 
 /** Width when sidebar is collapsed */
 export const SIDEBAR_COLLAPSED_WIDTH = 40;
 
-/** Valid preset values for validation */
-const VALID_PRESETS: readonly SidebarWidthPreset[] = [
-  "compact",
-  "normal",
-  "wide",
-] as const;
-
-/** localStorage keys */
-const WIDTH_STORAGE_KEY = "Rackula-sidebar-width";
+/** localStorage key for collapsed state */
 const COLLAPSED_STORAGE_KEY = "Rackula-sidebar-collapsed";
-
-/**
- * Check if a value is a valid SidebarWidthPreset
- */
-function isValidPreset(value: string): value is SidebarWidthPreset {
-  return VALID_PRESETS.includes(value as SidebarWidthPreset);
-}
-
-/**
- * Load sidebar width preset from localStorage
- * @returns The saved preset, or 'normal' as default
- */
-export function loadSidebarWidthFromStorage(): SidebarWidthPreset {
-  try {
-    const stored = localStorage.getItem(WIDTH_STORAGE_KEY);
-    if (stored && isValidPreset(stored)) {
-      return stored;
-    }
-  } catch (e) {
-    console.warn(
-      "[Rackula] Failed to load sidebar width from localStorage:",
-      e,
-    );
-  }
-  return "normal";
-}
-
-/**
- * Save sidebar width preset to localStorage
- * @param preset - The preset to save
- */
-export function saveSidebarWidthToStorage(preset: SidebarWidthPreset): void {
-  try {
-    localStorage.setItem(WIDTH_STORAGE_KEY, preset);
-  } catch (e) {
-    console.warn("[Rackula] Failed to save sidebar width to localStorage:", e);
-  }
-}
 
 /**
  * Load sidebar collapsed state from localStorage
@@ -102,23 +49,10 @@ export function saveSidebarCollapsedToStorage(collapsed: boolean): void {
 }
 
 /**
- * Get the pixel width for a given preset
- * @param preset - The width preset
- * @returns Pixel width value
- */
-export function getPresetWidth(preset: SidebarWidthPreset): number {
-  return SIDEBAR_WIDTHS[preset];
-}
-
-/**
  * Calculate the effective sidebar width in pixels
- * @param preset - The width preset
  * @param collapsed - Whether the sidebar is collapsed
  * @returns Effective pixel width
  */
-export function getEffectiveSidebarWidth(
-  preset: SidebarWidthPreset,
-  collapsed: boolean,
-): number {
-  return collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTHS[preset];
+export function getEffectiveSidebarWidth(collapsed: boolean): number {
+  return collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_OPEN_WIDTH;
 }

--- a/src/tests/sidebarWidth.test.ts
+++ b/src/tests/sidebarWidth.test.ts
@@ -1,14 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
-  loadSidebarWidthFromStorage,
-  saveSidebarWidthToStorage,
   loadSidebarCollapsedFromStorage,
   saveSidebarCollapsedToStorage,
-  getPresetWidth,
   getEffectiveSidebarWidth,
-  SIDEBAR_WIDTHS,
+  SIDEBAR_OPEN_WIDTH,
   SIDEBAR_COLLAPSED_WIDTH,
-  type SidebarWidthPreset as _SidebarWidthPreset,
 } from "$lib/utils/sidebarWidth";
 
 describe("sidebarWidth", () => {
@@ -32,68 +28,6 @@ describe("sidebarWidth", () => {
   beforeEach(() => {
     localStorageMock.clear();
     vi.stubGlobal("localStorage", localStorageMock);
-  });
-
-  describe("loadSidebarWidthFromStorage", () => {
-    it('returns "normal" when no value stored', () => {
-      expect(loadSidebarWidthFromStorage()).toBe("normal");
-    });
-
-    it('returns stored "compact" value', () => {
-      localStorageMock.setItem("Rackula-sidebar-width", "compact");
-      expect(loadSidebarWidthFromStorage()).toBe("compact");
-    });
-
-    it('returns stored "wide" value', () => {
-      localStorageMock.setItem("Rackula-sidebar-width", "wide");
-      expect(loadSidebarWidthFromStorage()).toBe("wide");
-    });
-
-    it('returns "normal" for invalid stored value', () => {
-      localStorageMock.setItem("Rackula-sidebar-width", "invalid");
-      expect(loadSidebarWidthFromStorage()).toBe("normal");
-    });
-
-    it('returns "normal" when localStorage throws', () => {
-      localStorageMock.getItem.mockImplementationOnce(() => {
-        throw new Error("localStorage disabled");
-      });
-      expect(loadSidebarWidthFromStorage()).toBe("normal");
-    });
-  });
-
-  describe("saveSidebarWidthToStorage", () => {
-    it('saves "compact" to localStorage', () => {
-      saveSidebarWidthToStorage("compact");
-      expect(localStorageMock.setItem).toHaveBeenCalledWith(
-        "Rackula-sidebar-width",
-        "compact",
-      );
-    });
-
-    it('saves "normal" to localStorage', () => {
-      saveSidebarWidthToStorage("normal");
-      expect(localStorageMock.setItem).toHaveBeenCalledWith(
-        "Rackula-sidebar-width",
-        "normal",
-      );
-    });
-
-    it('saves "wide" to localStorage', () => {
-      saveSidebarWidthToStorage("wide");
-      expect(localStorageMock.setItem).toHaveBeenCalledWith(
-        "Rackula-sidebar-width",
-        "wide",
-      );
-    });
-
-    it("handles localStorage errors gracefully", () => {
-      localStorageMock.setItem.mockImplementationOnce(() => {
-        throw new Error("QuotaExceeded");
-      });
-      // Should not throw
-      expect(() => saveSidebarWidthToStorage("wide")).not.toThrow();
-    });
   });
 
   describe("loadSidebarCollapsedFromStorage", () => {
@@ -143,11 +77,9 @@ describe("sidebarWidth", () => {
     });
   });
 
-  describe("SIDEBAR_WIDTHS constants", () => {
-    it("has correct width values", () => {
-      expect(SIDEBAR_WIDTHS.compact).toBe(200);
-      expect(SIDEBAR_WIDTHS.normal).toBe(280);
-      expect(SIDEBAR_WIDTHS.wide).toBe(400);
+  describe("width constants", () => {
+    it("open width is 320px", () => {
+      expect(SIDEBAR_OPEN_WIDTH).toBe(320);
     });
 
     it("collapsed width is 40px", () => {
@@ -155,31 +87,13 @@ describe("sidebarWidth", () => {
     });
   });
 
-  describe("getPresetWidth", () => {
-    it("returns correct width for compact", () => {
-      expect(getPresetWidth("compact")).toBe(200);
-    });
-
-    it("returns correct width for normal", () => {
-      expect(getPresetWidth("normal")).toBe(280);
-    });
-
-    it("returns correct width for wide", () => {
-      expect(getPresetWidth("wide")).toBe(400);
-    });
-  });
-
   describe("getEffectiveSidebarWidth", () => {
     it("returns collapsed width when collapsed", () => {
-      expect(getEffectiveSidebarWidth("normal", true)).toBe(40);
-      expect(getEffectiveSidebarWidth("wide", true)).toBe(40);
-      expect(getEffectiveSidebarWidth("compact", true)).toBe(40);
+      expect(getEffectiveSidebarWidth(true)).toBe(40);
     });
 
-    it("returns preset width when not collapsed", () => {
-      expect(getEffectiveSidebarWidth("compact", false)).toBe(200);
-      expect(getEffectiveSidebarWidth("normal", false)).toBe(280);
-      expect(getEffectiveSidebarWidth("wide", false)).toBe(400);
+    it("returns open width when not collapsed", () => {
+      expect(getEffectiveSidebarWidth(false)).toBe(320);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Remove S/M/L width preset selector from device panel header
- Replace three-preset width system with fixed 320px open width (up from 280px)
- Simplify to binary collapsed/open toggle

## Files Changed
- `src/lib/utils/sidebarWidth.ts`: Simplified to binary width model with `SIDEBAR_OPEN_WIDTH = 320`
- `src/lib/stores/ui.svelte.ts`: Removed preset state and `setSidebarWidth` action
- `src/lib/components/DevicePalette.svelte`: Removed width preset SegmentedControl
- `src/tests/sidebarWidth.test.ts`: Updated tests for simplified API

## Test Plan
- [x] Build passes
- [x] Unit tests pass (1529 tests)
- [x] Changed files pass lint
- [ ] Manual: Panel opens by default on fresh load
- [ ] Manual: Device names display without truncation at 320px width

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)