### PR TITLE
chore: improve bundle chunking (#454)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -95,9 +95,17 @@ export default defineConfig(() => ({
             if (id.includes("/svelte/")) return "vendor-svelte";
           }
           // App data files - split for lazy loading potential
-          if (id.includes("/src/lib/data/brandPacks/"))
+          // Guard against node_modules paths that might contain these strings
+          if (
+            !id.includes("node_modules") &&
+            id.includes("/src/lib/data/brandPacks/")
+          )
             return "data-brandpacks";
-          if (id.includes("/src/lib/data/bundledImages")) return "data-images";
+          if (
+            !id.includes("node_modules") &&
+            id.includes("/src/lib/data/bundledImages")
+          )
+            return "data-images";
         },
       },
     },


### PR DESCRIPTION
## Summary

- Eliminates the build warning about chunks exceeding 500 kB
- Switches from object-based to function-based `manualChunks` for more granular control
- Splits vendor libraries and app data into separate chunks

**Before:** Main `index` chunk was 1,212 kB (warning threshold: 500 kB)
**After:** All chunks under 500 kB; main chunk reduced to 263 kB

## Changes

| Chunk | Size | Purpose |
|-------|------|---------|
| `vendor-svelte` | 44 kB | Svelte runtime |
| `vendor-zod` | 65 kB | Validation library |
| `vendor-bits-ui` | 21 kB | UI components |
| `vendor-panzoom` | 18 kB | Pan/zoom functionality |
| `vendor-archive` | 138 kB | JSZip + JS-YAML |
| `vendor-icons` | 25 kB | Lucide + Simple Icons |
| `vendor-fuse` | 18 kB | Search library |
| `vendor-pako` | 48 kB | Compression |
| `data-brandpacks` | 84 kB | Device definitions |
| `data-images` | 75 kB | Image path references |
| `index` (main) | 263 kB | App code |

Also set `assetsInlineLimit: 0` to prevent base64 inlining, which was bloating the data-images chunk.

## Test plan

- [x] Build succeeds without chunk size warnings
- [x] All unit tests pass
- [x] vite.config.ts passes lint

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)