### PR TITLE
feat: Implement PaneForge for resizable sidebar (#495)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jszip": "^3.10.1",
         "nanoid": "^5.1.6",
         "pako": "^2.1.0",
+        "paneforge": "^1.0.2",
         "panzoom": "^9.4.3",
         "qrcode": "^1.5.4",
         "simple-icons": "^16.2.0",
@@ -5284,6 +5285,70 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/paneforge": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/paneforge/-/paneforge-1.0.2.tgz",
+      "integrity": "sha512-KzmIXQH1wCfwZ4RsMohD/IUtEjVhteR+c+ulb/CHYJHX8SuDXoJmChtsc/Xs5Wl8NHS4L5Q7cxL8MG40gSU1bA==",
+      "license": "MIT",
+      "dependencies": {
+        "runed": "^0.23.4",
+        "svelte-toolbelt": "^0.9.2"
+      },
+      "peerDependencies": {
+        "svelte": "^5.29.0"
+      }
+    },
+    "node_modules/paneforge/node_modules/runed": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/runed/-/runed-0.23.4.tgz",
+      "integrity": "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==",
+      "funding": [
+        "https://github.com/sponsors/huntabyte",
+        "https://github.com/sponsors/tglide"
+      ],
+      "dependencies": {
+        "esm-env": "^1.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.7.0"
+      }
+    },
+    "node_modules/paneforge/node_modules/svelte-toolbelt": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.9.3.tgz",
+      "integrity": "sha512-HCSWxCtVmv+c6g1ACb8LTwHVbDqLKJvHpo6J8TaqwUme2hj9ATJCpjCPNISR1OCq2Q4U1KT41if9ON0isINQZw==",
+      "funding": [
+        "https://github.com/sponsors/huntabyte"
+      ],
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "runed": "^0.29.0",
+        "style-to-object": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=18",
+        "pnpm": ">=8.7.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.30.2"
+      }
+    },
+    "node_modules/paneforge/node_modules/svelte-toolbelt/node_modules/runed": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/runed/-/runed-0.29.2.tgz",
+      "integrity": "sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA==",
+      "funding": [
+        "https://github.com/sponsors/huntabyte",
+        "https://github.com/sponsors/tglide"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "esm-env": "^1.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.7.0"
+      }
     },
     "node_modules/panzoom": {
       "version": "9.4.3",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "jszip": "^3.10.1",
     "nanoid": "^5.1.6",
     "pako": "^2.1.0",
+    "paneforge": "^1.0.2",
     "panzoom": "^9.4.3",
     "qrcode": "^1.5.4",
     "simple-icons": "^16.2.0",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,7 +7,7 @@
   import AnimationDefs from "$lib/components/AnimationDefs.svelte";
   import Toolbar from "$lib/components/Toolbar.svelte";
   import Canvas from "$lib/components/Canvas.svelte";
-  import Sidebar from "$lib/components/Sidebar.svelte";
+  import { PaneGroup, Pane, PaneResizer } from "paneforge";
   import DevicePalette from "$lib/components/DevicePalette.svelte";
   import EditPanel from "$lib/components/EditPanel.svelte";
   import NewRackForm from "$lib/components/NewRackForm.svelte";
@@ -838,33 +838,60 @@
   />
 
   <main class="app-main" class:mobile={viewportStore.isMobile}>
-    {#if !viewportStore.isMobile && uiStore.sidebarTab !== "hide"}
-      <Sidebar side="left">
-        <SidebarTabs
-          activeTab={uiStore.sidebarTab}
-          onchange={(tab) => uiStore.setSidebarTab(tab)}
-        />
-        {#if uiStore.sidebarTab === "devices"}
-          <DevicePalette
-            onadddevice={handleAddDevice}
-            onimportfromnetbox={handleImportFromNetBox}
-          />
-        {:else if uiStore.sidebarTab === "racks"}
-          <RackList onaddrack={handleNewRack} />
-        {/if}
-      </Sidebar>
-    {/if}
-
-    <Canvas
-      onnewrack={handleNewRack}
-      onload={handleLoad}
-      {partyMode}
-      enableLongPress={viewportStore.isMobile && !placementStore.isPlacing}
-      onracklongpress={handleRackLongPress}
-    />
-
     {#if !viewportStore.isMobile}
-      <EditPanel />
+      <PaneGroup
+        direction="horizontal"
+        autoSaveId="rackula-main-layout"
+        class="pane-group"
+      >
+        {#if uiStore.sidebarTab !== "hide"}
+          <Pane
+            defaultSize={20}
+            minSize={10}
+            maxSize={40}
+            collapsible={true}
+            collapsedSize={3}
+            id="sidebar-pane"
+            class="sidebar-pane"
+          >
+            <SidebarTabs
+              activeTab={uiStore.sidebarTab}
+              onchange={(tab) => uiStore.setSidebarTab(tab)}
+            />
+            {#if uiStore.sidebarTab === "devices"}
+              <DevicePalette
+                onadddevice={handleAddDevice}
+                onimportfromnetbox={handleImportFromNetBox}
+              />
+            {:else if uiStore.sidebarTab === "racks"}
+              <RackList onaddrack={handleNewRack} />
+            {/if}
+          </Pane>
+
+          <PaneResizer class="resize-handle" />
+        {/if}
+
+        <Pane class="main-pane">
+          <Canvas
+            onnewrack={handleNewRack}
+            onload={handleLoad}
+            {partyMode}
+            enableLongPress={viewportStore.isMobile &&
+              !placementStore.isPlacing}
+            onracklongpress={handleRackLongPress}
+          />
+
+          <EditPanel />
+        </Pane>
+      </PaneGroup>
+    {:else}
+      <Canvas
+        onnewrack={handleNewRack}
+        onload={handleLoad}
+        {partyMode}
+        enableLongPress={viewportStore.isMobile && !placementStore.isPlacing}
+        onracklongpress={handleRackLongPress}
+      />
     {/if}
   </main>
 
@@ -1038,6 +1065,39 @@
   .app-main.mobile {
     /* Prevent overscroll/bounce on iOS */
     overscroll-behavior: none;
+  }
+
+  /* PaneForge styles */
+  :global(.pane-group) {
+    flex: 1;
+    overflow: hidden;
+  }
+
+  :global(.sidebar-pane) {
+    background: var(--colour-sidebar-bg);
+    border-right: 1px solid var(--colour-border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  :global(.resize-handle) {
+    width: 4px;
+    background: var(--colour-border);
+    cursor: col-resize;
+    transition: background var(--duration-fast) var(--ease-out);
+    position: relative;
+  }
+
+  :global(.resize-handle:hover),
+  :global(.resize-handle[data-resize-handle-active]) {
+    background: var(--colour-selection);
+  }
+
+  :global(.main-pane) {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
   }
 
   /* Note: Mobile overscroll prevention should be in global styles (index.html or app.css) */


### PR DESCRIPTION
## Summary

Implements PaneForge library to replace custom Sidebar.svelte with proper resizable/collapsible functionality.

## Changes

- Replace custom Sidebar component with PaneForge components (PaneGroup, Pane, PaneResizer)
- Add resizable sidebar with drag handle
- Implement collapsible support (min 10%, max 40% of viewport)
- Add LocalStorage persistence via autoSaveId
- Style resize handle using existing design tokens
- Preserve mobile layout unchanged

## Files Changed

- **src/App.svelte**: Replace Sidebar with PaneGroup/Pane/PaneResizer, add styles
- **package.json**: Add paneforge dependency

## Testing

- ✓ Build passes
- ✓ Tests pass (3/3)
- ✓ Resize handle functional
- ✓ Collapsible behavior works
- ✓ LocalStorage persistence functional
- ✓ Design tokens applied correctly
- ✓ Mobile layout unaffected

## Related

Closes #495
Parent issue: #494