### PR TITLE
Add pre-commit check for package-lock.json sync

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,13 @@
+# Verify package-lock.json is in sync with package.json
+if git diff --cached --name-only | grep -q 'package.json'; then
+  echo "Checking package-lock.json is in sync..."
+  npm ci --dry-run --ignore-scripts 2>/dev/null || {
+    echo "Error: package-lock.json is out of sync with package.json"
+    echo "Run 'npm install' and stage package-lock.json"
+    exit 1
+  }
+fi
+
 npx lint-staged
 
 # Run tests only for files related to staged changes


### PR DESCRIPTION
## Summary

Adds a pre-commit hook check that validates `package-lock.json` is in sync with `package.json` before allowing commits.

## Problem

CI fails when `package.json` is modified without regenerating `package-lock.json`. This happens when:
- Manual edits to `package.json` without running `npm install`
- Different npm versions between contributors
- Merging branches that both modified dependencies

## Solution

The pre-commit hook now:
1. Detects when `package.json` is staged for commit
2. Runs `npm ci --dry-run` to validate lock file sync
3. Blocks the commit with a clear error message if out of sync

This catches the issue locally before it reaches CI.

Fixes #504