### PR TITLE
chore: migrate ConfirmReplaceDialog to bits-ui Dialog (#501)

### DIFF
--- a/src/lib/components/ConfirmReplaceDialog.svelte
+++ b/src/lib/components/ConfirmReplaceDialog.svelte
@@ -1,84 +1,150 @@
+<!--
+  ConfirmReplaceDialog Component
+  Confirmation dialog for replacing unsaved rack data
+  Uses bits-ui Dialog primitives for accessibility and focus management
+-->
 <script lang="ts">
-	import Dialog from './Dialog.svelte';
-	import { getLayoutStore } from '$lib/stores/layout.svelte';
+  import { Dialog } from "bits-ui";
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
 
-	interface Props {
-		open: boolean;
-		onSaveFirst: () => void;
-		onReplace: () => void;
-		onCancel: () => void;
-	}
+  interface Props {
+    open: boolean;
+    onSaveFirst: () => void;
+    onReplace: () => void;
+    onCancel: () => void;
+  }
 
-	let { open, onSaveFirst, onReplace, onCancel }: Props = $props();
+  let {
+    open = $bindable(),
+    onSaveFirst,
+    onReplace,
+    onCancel,
+  }: Props = $props();
 
-	const layoutStore = getLayoutStore();
+  const layoutStore = getLayoutStore();
 
-	const rackName = $derived(layoutStore.rack?.name || 'Untitled Rack');
-	const deviceCount = $derived(layoutStore.rack?.devices.length ?? 0);
-	const deviceWord = $derived(deviceCount === 1 ? 'device' : 'devices');
-	const message = $derived(
-		`"${rackName}" has ${deviceCount} ${deviceWord} placed. Save your layout first?`
-	);
+  const rackName = $derived(layoutStore.rack?.name || "Untitled Rack");
+  const deviceCount = $derived(layoutStore.rack?.devices.length ?? 0);
+  const deviceWord = $derived(deviceCount === 1 ? "device" : "devices");
+  const message = $derived(
+    `"${rackName}" has ${deviceCount} ${deviceWord} placed. Save your layout first?`,
+  );
+
+  function handleOpenChange(newOpen: boolean) {
+    open = newOpen;
+    if (!newOpen) {
+      onCancel();
+    }
+  }
 </script>
 
-<Dialog {open} title="Replace Current Rack?" width="420px" showClose={false} onclose={onCancel}>
-	<p class="message">{message}</p>
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+  <Dialog.Portal>
+    <Dialog.Overlay class="dialog-backdrop" />
+    <Dialog.Content class="dialog" style="width: 420px; max-width: 90vw;">
+      <Dialog.Title class="dialog-title">Replace Current Rack?</Dialog.Title>
+      <Dialog.Description class="message">{message}</Dialog.Description>
 
-	<div class="actions">
-		<button type="button" class="btn btn-secondary" onclick={onCancel}> Cancel </button>
-		<button type="button" class="btn btn-primary" onclick={onSaveFirst}> Save First </button>
-		<button type="button" class="btn btn-destructive" onclick={onReplace}> Replace </button>
-	</div>
-</Dialog>
+      <div class="actions">
+        <button type="button" class="btn btn-secondary" onclick={onCancel}>
+          Cancel
+        </button>
+        <button type="button" class="btn btn-primary" onclick={onSaveFirst}>
+          Save First
+        </button>
+        <button type="button" class="btn btn-destructive" onclick={onReplace}>
+          Replace
+        </button>
+      </div>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>
 
 <style>
-	.message {
-		margin: 0 0 24px 0;
-		color: var(--colour-text-muted);
-		line-height: 1.5;
-	}
+  /* Dialog backdrop and content styles (bits-ui applies these via class) */
+  :global(.dialog-backdrop) {
+    position: fixed;
+    inset: 0;
+    background: var(--colour-backdrop, rgba(0, 0, 0, 0.6));
+    z-index: var(--z-modal, 200);
+  }
 
-	.actions {
-		display: flex;
-		gap: var(--space-3);
-		justify-content: flex-end;
-	}
+  :global(.dialog) {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--colour-dialog-bg, var(--colour-bg));
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    padding: var(--space-5);
+    z-index: calc(var(--z-modal, 200) + 1);
+  }
 
-	.btn {
-		padding: var(--space-2) var(--space-4);
-		border-radius: var(--radius-md);
-		font-size: 0.875rem;
-		font-weight: 500;
-		cursor: pointer;
-		border: none;
-		transition: opacity 0.15s;
-	}
+  :global(.dialog-title) {
+    margin: 0 0 var(--space-3) 0;
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    color: var(--colour-text);
+  }
 
-	.btn:hover {
-		opacity: 0.9;
-	}
+  :global(.message) {
+    margin: 0 0 var(--space-5) 0;
+    color: var(--colour-text-muted);
+    line-height: 1.5;
+  }
 
-	.btn-primary {
-		background: var(--colour-button-primary);
-		color: var(--colour-text-on-primary);
-	}
+  .actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: flex-end;
+  }
 
-	.btn-primary:hover {
-		background: var(--colour-button-primary-hover);
-	}
+  .btn {
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+    transition: opacity 0.15s;
+  }
 
-	.btn-destructive {
-		background: var(--colour-button-destructive);
-		color: var(--colour-text-on-primary);
-	}
+  .btn:hover {
+    opacity: 0.9;
+  }
 
-	.btn-destructive:hover {
-		background: var(--colour-button-destructive-hover);
-	}
+  .btn:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: 2px;
+  }
 
-	.btn-secondary {
-		background: transparent;
-		border: 1px solid var(--colour-border);
-		color: var(--colour-text);
-	}
+  .btn-primary {
+    background: var(--colour-button-primary);
+    color: var(--colour-text-on-primary);
+  }
+
+  .btn-primary:hover {
+    background: var(--colour-button-primary-hover);
+  }
+
+  .btn-destructive {
+    background: var(--colour-button-destructive);
+    color: var(--colour-text-on-primary);
+  }
+
+  .btn-destructive:hover {
+    background: var(--colour-button-destructive-hover);
+  }
+
+  .btn-secondary {
+    background: transparent;
+    border: 1px solid var(--colour-border);
+    color: var(--colour-text);
+  }
+
+  .btn-secondary:hover {
+    background: var(--colour-surface-hover);
+  }
 </style>


### PR DESCRIPTION
## Summary
Migrates ConfirmReplaceDialog.svelte from custom Dialog wrapper to bits-ui Dialog primitives.

## Changes
- Replace `Dialog.svelte` wrapper import with direct `bits-ui` Dialog primitives
- Use `Dialog.Root`, `Dialog.Portal`, `Dialog.Overlay`, `Dialog.Content`, `Dialog.Title`, `Dialog.Description`
- Add `onOpenChange` handler for escape key and click-outside-to-dismiss
- Update styles to use `:global()` selectors for bits-ui class application
- Add `focus-visible` styles for keyboard navigation
- Add hover state for secondary button

## Benefits
- Built-in accessibility (ARIA attributes, screen reader support)
- Built-in focus trapping and keyboard navigation
- Escape key and click-outside-to-dismiss handled by bits-ui
- Consistent with bits-ui ecosystem already in use (Accordion, Dialog.svelte)

## Testing
- Lint passes
- All 1569 unit tests pass
- Build succeeds

Closes #501