### PR TITLE
chore: consolidate dialog styles and fix code quality issues (#512)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -69,6 +69,7 @@
   import type { ImportResult } from "$lib/utils/netbox-import";
   import { analytics } from "$lib/utils/analytics";
   import { hapticTap } from "$lib/utils/haptics";
+  import { debug } from "$lib/utils/debug";
 
   // Build-time environment constant from vite.config.ts
   declare const __BUILD_ENV__: string;
@@ -663,20 +664,20 @@
       const deviceIndex = selectionStore.getSelectedDeviceIndex(
         activeRack?.devices ?? [],
       );
-      console.log("[Mobile] Device selected:", {
+      debug.log("[Mobile] Device selected:", {
         deviceIndex,
         hasRack: !!activeRack,
       });
       if (deviceIndex !== null && activeRack) {
         selectedDeviceForSheet = deviceIndex;
         bottomSheetOpen = true;
-        console.log("[Mobile] Opening bottom sheet for device", deviceIndex);
+        debug.log("[Mobile] Opening bottom sheet for device", deviceIndex);
         // Note: Not zooming because bottom sheet covers most of viewport
       }
     } else if (!selectionStore.isDeviceSelected) {
       // When device deselected, close sheet and fit all
       if (viewportStore.isMobile && bottomSheetOpen) {
-        console.log(
+        debug.log(
           "[Mobile] Device deselected, closing bottom sheet and fitting all",
         );
         bottomSheetOpen = false;

--- a/src/app.css
+++ b/src/app.css
@@ -3,6 +3,7 @@
 /* Import Design Token System - must come first per CSS spec */
 @import "./lib/styles/tokens.css";
 @import "./lib/styles/animations.css";
+@import "./lib/styles/dialogs.css";
 
 /* ==========================================================================
    FONT FACE DECLARATIONS

--- a/src/lib/components/ConfirmReplaceDialog.svelte
+++ b/src/lib/components/ConfirmReplaceDialog.svelte
@@ -61,32 +61,16 @@
 </Dialog.Root>
 
 <style>
-  /* Dialog backdrop and content styles (bits-ui applies these via class) */
-  :global(.dialog-backdrop) {
-    position: fixed;
-    inset: 0;
-    background: var(--colour-backdrop, rgba(0, 0, 0, 0.6));
-    z-index: var(--z-modal, 200);
-  }
+  /* Base dialog styles (.dialog-backdrop, .dialog, .dialog-title, .dialog-close)
+     are defined in src/lib/styles/dialogs.css and imported globally */
 
+  /* Component-specific overrides */
   :global(.dialog) {
-    position: fixed;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    background: var(--colour-dialog-bg, var(--colour-bg));
-    border: 1px solid var(--colour-border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-lg);
     padding: var(--space-5);
-    z-index: calc(var(--z-modal, 200) + 1);
   }
 
   :global(.dialog-title) {
-    margin: 0 0 var(--space-3) 0;
-    font-size: var(--font-size-lg);
-    font-weight: 600;
-    color: var(--colour-text);
+    margin-bottom: var(--space-3);
   }
 
   :global(.message) {

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -70,25 +70,13 @@
 </Dialog.Root>
 
 <style>
-  :global(.dialog-backdrop) {
-    position: fixed;
-    inset: 0;
-    background: var(--colour-backdrop, rgba(0, 0, 0, 0.6));
-    z-index: var(--z-modal, 200);
-  }
+  /* Base dialog styles (.dialog-backdrop, .dialog, .dialog-title, .dialog-close)
+     are defined in src/lib/styles/dialogs.css and imported globally */
 
+  /* Dialog-specific layout: adds flex column for header/content structure */
   :global(.dialog) {
-    position: fixed;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    background: var(--colour-dialog-bg, var(--colour-bg));
-    border: 1px solid var(--colour-border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-lg);
     display: flex;
     flex-direction: column;
-    z-index: calc(var(--z-modal, 200) + 1);
   }
 
   .dialog-header {
@@ -97,38 +85,6 @@
     justify-content: space-between;
     padding: var(--space-4) var(--space-5);
     border-bottom: 1px solid var(--colour-border);
-  }
-
-  :global(.dialog-title) {
-    margin: 0;
-    font-size: var(--font-size-lg);
-    font-weight: 600;
-    color: var(--colour-text);
-  }
-
-  :global(.dialog-close) {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    border-radius: var(--radius-sm);
-    color: var(--colour-text-muted);
-    cursor: pointer;
-    transition: all var(--duration-fast);
-  }
-
-  :global(.dialog-close:hover) {
-    background: var(--colour-surface-hover);
-    color: var(--colour-text);
-  }
-
-  :global(.dialog-close:focus-visible) {
-    outline: 2px solid var(--colour-selection);
-    outline-offset: 2px;
   }
 
   .dialog-content {

--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -166,7 +166,7 @@
   const GITHUB_URL = "https://github.com/RackulaLives/Rackula";
 
   // Pre-filled issue URLs
-  const bugReportUrl = $derived(() => {
+  const bugReportUrl = $derived.by(() => {
     const params = new URLSearchParams({
       template: "bug-report.yml",
       browser: `Rackula v${VERSION} on ${userAgent}`,
@@ -179,7 +179,7 @@
 
 <Dialog.Root {open} onOpenChange={handleOpenChange}>
   <Dialog.Portal>
-    <Dialog.Overlay class="help-dialog-backdrop" />
+    <Dialog.Overlay class="dialog-backdrop" />
     <Dialog.Content class="help-dialog" style="width: 600px;">
       <div class="dialog-header">
         <Dialog.Title class="dialog-title">About</Dialog.Title>
@@ -249,7 +249,7 @@
               Project
             </a>
             <a
-              href={bugReportUrl()}
+              href={bugReportUrl}
               target="_blank"
               rel="noopener noreferrer"
               class="quick-link"
@@ -400,14 +400,10 @@
 </Dialog.Root>
 
 <style>
-  /* Dialog backdrop and container styles */
-  :global(.help-dialog-backdrop) {
-    position: fixed;
-    inset: 0;
-    background: var(--colour-backdrop, rgba(0, 0, 0, 0.6));
-    z-index: var(--z-modal, 200);
-  }
+  /* Base dialog styles (.dialog-backdrop, .dialog-title, .dialog-close)
+     are defined in src/lib/styles/dialogs.css and imported globally */
 
+  /* HelpPanel-specific dialog container with size constraints */
   :global(.help-dialog) {
     position: fixed;
     left: 50%;
@@ -430,38 +426,6 @@
     justify-content: space-between;
     padding: var(--space-3) var(--space-4);
     border-bottom: 1px solid var(--colour-border);
-  }
-
-  :global(.dialog-title) {
-    margin: 0;
-    font-size: var(--font-size-lg);
-    font-weight: 600;
-    color: var(--colour-text);
-  }
-
-  :global(.dialog-close) {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    border-radius: var(--radius-sm);
-    color: var(--colour-text-muted);
-    cursor: pointer;
-    transition: all var(--duration-fast);
-  }
-
-  :global(.dialog-close:hover) {
-    background: var(--colour-surface-hover);
-    color: var(--colour-text);
-  }
-
-  :global(.dialog-close:focus-visible) {
-    outline: 2px solid var(--colour-selection);
-    outline-offset: 2px;
   }
 
   .dialog-content {

--- a/src/lib/styles/dialogs.css
+++ b/src/lib/styles/dialogs.css
@@ -1,0 +1,60 @@
+/**
+ * Shared Dialog Styles
+ * Base styles for bits-ui Dialog components used throughout the app.
+ * These styles are applied globally via class names on Dialog primitives.
+ */
+
+/* Dialog backdrop overlay */
+.dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--colour-backdrop, rgba(0, 0, 0, 0.6));
+  z-index: var(--z-modal, 200);
+}
+
+/* Dialog container */
+.dialog {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--colour-dialog-bg, var(--colour-bg));
+  border: 1px solid var(--colour-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  z-index: calc(var(--z-modal, 200) + 1);
+}
+
+/* Dialog title */
+.dialog-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--colour-text);
+}
+
+/* Dialog close button */
+.dialog-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--colour-text-muted);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+
+.dialog-close:hover {
+  background: var(--colour-surface-hover);
+  color: var(--colour-text);
+}
+
+.dialog-close:focus-visible {
+  outline: 2px solid var(--colour-selection);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- Create shared `dialogs.css` with base dialog styles (backdrop, container, title, close button)
- Remove duplicated `:global()` styles from `Dialog.svelte`, `HelpPanel.svelte`, `ConfirmReplaceDialog.svelte`
- Fix `HelpPanel` `bugReportUrl` to use correct `$derived.by` pattern instead of `$derived(() => ...)`
- Replace `console.log` with `debug.log` utility in `App.svelte` mobile handlers

## Files Changed
- `src/lib/styles/dialogs.css` (new): Shared dialog base styles
- `src/app.css`: Import dialogs.css
- `src/lib/components/Dialog.svelte`: Remove duplicated styles, add comment
- `src/lib/components/HelpPanel.svelte`: Remove duplicated styles, fix $derived pattern
- `src/lib/components/ConfirmReplaceDialog.svelte`: Remove duplicated styles
- `src/App.svelte`: Replace console.log with debug.log, add import

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] All 1569 unit tests pass
- [ ] Manual: Open HelpPanel via `?` key - verify styling unchanged
- [ ] Manual: Open ConfirmReplaceDialog (create new rack when one exists) - verify styling
- [ ] Manual: Check bug report link in HelpPanel works
- [ ] Manual: Verify debug logging only appears in dev mode (check browser console)

Closes #512

🤖 Generated with [Claude Code](https://claude.ai/claude-code)