### PR TITLE
refactor: pass rack ID directly to createDefaultRack (#516)

### DIFF
--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -344,7 +344,6 @@ function addRack(
     return null;
   }
 
-  const rackId = generateRackId();
   const newRack = createDefaultRack(
     name,
     height,
@@ -352,10 +351,9 @@ function addRack(
     form_factor ?? "4-post-cabinet",
     desc_units ?? false,
     starting_unit ?? 1,
+    true, // show_rear
+    generateRackId(), // id - pass directly
   );
-
-  // Add ID to the rack
-  const rackWithId = { ...newRack, id: rackId };
 
   // If this is the first rack, sync layout name
   const isFirstRack = layout.racks.length === 0;
@@ -363,18 +361,18 @@ function addRack(
   layout = {
     ...layout,
     name: isFirstRack ? name : layout.name,
-    racks: [...layout.racks, rackWithId],
+    racks: [...layout.racks, newRack],
   };
   isDirty = true;
 
   // Set as active rack
-  activeRackId = rackId;
+  activeRackId = newRack.id;
 
   // Mark as started (user has created a rack)
   hasStarted = true;
   saveHasStarted(true);
 
-  return rackWithId;
+  return newRack;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Refactored `addRack` function to pass `generateRackId()` directly to `createDefaultRack()` instead of generating the ID separately and spreading it onto the result
- Eliminates unnecessary intermediate `rackId` variable and `rackWithId` spread pattern
- `createDefaultRack` already accepts an `id` parameter (8th positional), so this simplifies the code

## Files Changed

- `src/lib/stores/layout.svelte.ts`: Simplified `addRack` function (lines 347-375)

## Test Plan

- [x] All 1569 unit tests pass
- [x] Lint passes
- [x] Pre-commit hooks pass (193 tests)

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)