### PR TITLE
chore: replace custom debug utility with debug npm package (#515)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,36 @@ npm run build        # Production build
 npm run lint         # ESLint check
 ```
 
+### Debug Logging
+
+Uses the `debug` npm package with namespace filtering.
+
+**Enable in browser console:**
+
+```javascript
+localStorage.debug = "rackula:*"; // All logs
+localStorage.debug = "rackula:layout:*"; // Layout module only
+localStorage.debug = "rackula:*,-rackula:canvas:*"; // All except canvas
+```
+
+**Namespaces:**
+
+| Namespace                  | Purpose               |
+| -------------------------- | --------------------- |
+| `rackula:layout:state`     | Layout store state    |
+| `rackula:layout:device`    | Device placement/move |
+| `rackula:canvas:transform` | Pan/zoom calculations |
+| `rackula:canvas:panzoom`   | Panzoom lifecycle     |
+| `rackula:cable:validation` | Cable validation      |
+| `rackula:app:mobile`       | Mobile interactions   |
+
+**Usage:**
+
+```typescript
+import { layoutDebug } from "$lib/utils/debug";
+layoutDebug.device("placed device %s at U%d", slug, position);
+```
+
 ### Keyboard Shortcuts
 
 | Key            | Action                  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@lucide/svelte": "^0.559.0",
         "bits-ui": "^2.14.4",
+        "debug": "^4.4.3",
         "fuse.js": "^7.1.0",
         "js-yaml": "^4.1.1",
         "jspdf": "^4.0.0",
@@ -31,6 +32,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/svelte": "^5.2.6",
         "@testing-library/user-event": "^14.6.1",
+        "@types/debug": "^4.1.12",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^24.10.3",
         "@types/pako": "^2.0.4",
@@ -2174,6 +2176,16 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2198,6 +2210,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3241,7 +3260,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5144,7 +5162,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nano-spawn": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/svelte": "^5.2.6",
     "@testing-library/user-event": "^14.6.1",
+    "@types/debug": "^4.1.12",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.10.3",
     "@types/pako": "^2.0.4",
@@ -73,6 +74,7 @@
   "dependencies": {
     "@lucide/svelte": "^0.559.0",
     "bits-ui": "^2.14.4",
+    "debug": "^4.4.3",
     "fuse.js": "^7.1.0",
     "js-yaml": "^4.1.1",
     "jspdf": "^4.0.0",


### PR DESCRIPTION
## Summary

Replace the custom `debug.ts` utility with the industry-standard [`debug`](https://www.npmjs.com/package/debug) npm package to enable granular, namespace-based log filtering.

## Changes

- **Install** `debug` npm package with `@types/debug`
- **Replace** `src/lib/utils/debug.ts` with namespace-based implementation
- **Namespace pattern:** `rackula:module:concern`
- **Available namespaces:**
  - `rackula:layout:state` - Layout store state changes
  - `rackula:layout:device` - Device placement/movement
  - `rackula:canvas:transform` - Pan/zoom calculations
  - `rackula:canvas:panzoom` - Panzoom lifecycle
  - `rackula:cable:validation` - Cable validation warnings
  - `rackula:app:mobile` - Mobile interactions
- **Maintain** legacy compatibility via `debug` object
- **Update** tests for new implementation
- **Document** debug conventions in CLAUDE.md

## Usage

```javascript
// Enable all logs
localStorage.debug = 'rackula:*'

// Layout module only
localStorage.debug = 'rackula:layout:*'

// All except canvas
localStorage.debug = 'rackula:*,-rackula:canvas:*'
```

## Files Changed

- `package.json` / `package-lock.json`: Add debug dependency
- `src/lib/utils/debug.ts`: New namespace-based implementation
- `src/tests/debug.test.ts`: Updated tests
- `CLAUDE.md`: Documentation

## Test Plan

- [x] All 1569 unit tests pass
- [x] Lint passes
- [x] Build passes
- [x] Pre-commit hooks pass (233 tests)

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)