### PR TITLE
refactor: extract dialog state management to centralized store (#513)

### DIFF
--- a/src/lib/stores/dialogs.svelte.ts
+++ b/src/lib/stores/dialogs.svelte.ts
@@ -1,0 +1,131 @@
+/**
+ * Centralized dialog state management
+ *
+ * Provides a single source of truth for all dialog/sheet open states.
+ * Handlers remain in App.svelte as they require access to other stores.
+ *
+ * Only one dialog can be open at a time (enforced by using single openDialog state).
+ * Sheets (mobile bottom sheets) use a separate state since they coexist with dialogs.
+ */
+
+export type DialogId =
+  | "newRack"
+  | "addDevice"
+  | "confirmDelete"
+  | "export"
+  | "share"
+  | "help"
+  | "importNetBox"
+  | "confirmReplace";
+
+export type SheetId = "deviceDetails" | "deviceLibrary" | "rackEdit";
+
+export interface DeleteTarget {
+  type: "rack" | "device";
+  name: string;
+}
+
+// Dialog state
+let openDialog = $state<DialogId | null>(null);
+let deleteTarget = $state<DeleteTarget | null>(null);
+let pendingSaveFirst = $state(false);
+let exportQrCodeDataUrl = $state<string | undefined>(undefined);
+
+// Mobile sheet state
+let openSheet = $state<SheetId | null>(null);
+let selectedDeviceIndex = $state<number | null>(null);
+
+/**
+ * Open a dialog by ID. Closes any other open dialog.
+ */
+function open(id: DialogId) {
+  openDialog = id;
+}
+
+/**
+ * Close the current dialog and reset associated state.
+ */
+function close() {
+  openDialog = null;
+  deleteTarget = null;
+  pendingSaveFirst = false;
+}
+
+/**
+ * Check if a specific dialog is currently open.
+ */
+function isOpen(id: DialogId): boolean {
+  return openDialog === id;
+}
+
+/**
+ * Open a mobile sheet by ID.
+ */
+function openSheetById(id: SheetId, deviceIndex?: number) {
+  openSheet = id;
+  if (deviceIndex !== undefined) {
+    selectedDeviceIndex = deviceIndex;
+  }
+}
+
+/**
+ * Close the current mobile sheet.
+ */
+function closeSheet() {
+  openSheet = null;
+  selectedDeviceIndex = null;
+}
+
+/**
+ * Check if a specific sheet is currently open.
+ */
+function isSheetOpen(id: SheetId): boolean {
+  return openSheet === id;
+}
+
+// Export the dialog store
+export const dialogStore = {
+  // Dialog state getters
+  get openDialog() {
+    return openDialog;
+  },
+  get deleteTarget() {
+    return deleteTarget;
+  },
+  set deleteTarget(value: DeleteTarget | null) {
+    deleteTarget = value;
+  },
+  get pendingSaveFirst() {
+    return pendingSaveFirst;
+  },
+  set pendingSaveFirst(value: boolean) {
+    pendingSaveFirst = value;
+  },
+  get exportQrCodeDataUrl() {
+    return exportQrCodeDataUrl;
+  },
+  set exportQrCodeDataUrl(value: string | undefined) {
+    exportQrCodeDataUrl = value;
+  },
+
+  // Dialog actions
+  open,
+  close,
+  isOpen,
+
+  // Sheet state getters
+  get currentSheet() {
+    return openSheet;
+  },
+  get selectedDeviceIndex() {
+    return selectedDeviceIndex;
+  },
+  set selectedDeviceIndex(value: number | null) {
+    selectedDeviceIndex = value;
+  },
+
+  // Sheet actions
+  openSheet: openSheetById,
+  closeSheet,
+  isSheetOpen,
+};


### PR DESCRIPTION
## Summary

- Created `src/lib/stores/dialogs.svelte.ts` with centralized dialog/sheet state management
- Migrated all dialog state from App.svelte local `$state` to central `dialogStore`
- Single `openDialog` state ensures only one dialog open at a time
- Separate `openSheet` state for mobile bottom sheets (can coexist with dialogs)
- Handlers remain in App.svelte as they need access to other stores

## Dialog Types Migrated
- `newRack`, `addDevice`, `confirmDelete`, `export`, `share`, `help`, `importNetBox`, `confirmReplace`

## Sheet Types Migrated  
- `deviceDetails`, `deviceLibrary`, `rackEdit`

## Files Changed
- `src/lib/stores/dialogs.svelte.ts`: New centralized store
- `src/App.svelte`: Uses dialogStore for all dialog/sheet state

## Test Plan
- [x] All 1569 unit tests pass
- [x] Build completes without warnings
- [x] Lint passes
- [ ] Manual: Verify dialogs open/close correctly
- [ ] Manual: Mobile bottom sheets work properly

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)