### PR TITLE
fix: address CodeRabbit feedback on debug utility

### DIFF
--- a/src/lib/utils/debug.ts
+++ b/src/lib/utils/debug.ts
@@ -38,14 +38,20 @@ export const appDebug = {
   mobile: Debug("rackula:app:mobile"),
 };
 
+// Create shared instances for reuse
+const generalLog = Debug("rackula:general");
+const infoLog = Debug("rackula:info");
+const warnLog = Debug("rackula:warn");
+const errorLog = Debug("rackula:error");
+
 // Legacy compatibility - maps to new namespaces
 // This maintains backward compatibility with existing code
 export const debug = {
-  log: Debug("rackula:general"),
-  info: Debug("rackula:info"),
-  warn: Debug("rackula:warn"),
-  error: Debug("rackula:error"),
-  group: (label: string) => Debug("rackula:general")(`--- ${label} ---`),
+  log: generalLog,
+  info: infoLog,
+  warn: warnLog,
+  error: errorLog,
+  group: (label: string) => generalLog(`--- ${label} ---`),
   groupEnd: () => {},
   isEnabled: () => Debug.enabled("rackula:*"),
   devicePlace: (data: {
@@ -69,14 +75,14 @@ export const debug = {
 
 // Auto-enable in development (browser only)
 if (typeof window !== "undefined") {
-  const isDev = (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env
-    ?.DEV;
-  const isTest =
-    (import.meta as ImportMeta & { env?: { MODE?: string } }).env?.MODE ===
-    "test";
+  // Use Vite's built-in env types
+  const isDev = import.meta.env.DEV;
+  const isTest = import.meta.env.MODE === "test";
 
   // Auto-enable in dev mode (unless already configured)
   if (isDev && !isTest && !localStorage.getItem("debug")) {
     localStorage.setItem("debug", "rackula:*");
+    // Enable immediately so logs work without page reload
+    Debug.enable("rackula:*");
   }
 }

--- a/src/tests/debug.test.ts
+++ b/src/tests/debug.test.ts
@@ -17,18 +17,6 @@ import {
 
 describe("Debug utilities", () => {
   describe("Legacy compatibility", () => {
-    it("exports debug object with expected methods", () => {
-      expect(debug.log).toBeDefined();
-      expect(debug.info).toBeDefined();
-      expect(debug.warn).toBeDefined();
-      expect(debug.error).toBeDefined();
-      expect(debug.group).toBeDefined();
-      expect(debug.groupEnd).toBeDefined();
-      expect(debug.isEnabled).toBeDefined();
-      expect(debug.devicePlace).toBeDefined();
-      expect(debug.deviceMove).toBeDefined();
-    });
-
     it("debug methods are callable without errors", () => {
       // These should not throw even when disabled
       expect(() => debug.log("test")).not.toThrow();
@@ -68,36 +56,16 @@ describe("Debug utilities", () => {
   });
 
   describe("Namespace loggers", () => {
-    it("exports layoutDebug with state and device namespaces", () => {
-      expect(layoutDebug.state).toBeDefined();
-      expect(layoutDebug.device).toBeDefined();
-      expect(typeof layoutDebug.state).toBe("function");
-      expect(typeof layoutDebug.device).toBe("function");
-    });
-
-    it("exports canvasDebug with transform and panzoom namespaces", () => {
-      expect(canvasDebug.transform).toBeDefined();
-      expect(canvasDebug.panzoom).toBeDefined();
-      expect(typeof canvasDebug.transform).toBe("function");
-      expect(typeof canvasDebug.panzoom).toBe("function");
-    });
-
-    it("exports cableDebug with validation namespace", () => {
-      expect(cableDebug.validation).toBeDefined();
-      expect(typeof cableDebug.validation).toBe("function");
-    });
-
-    it("exports appDebug with mobile namespace", () => {
-      expect(appDebug.mobile).toBeDefined();
-      expect(typeof appDebug.mobile).toBe("function");
-    });
-
-    it("namespace loggers are callable without errors", () => {
+    it("all namespace loggers are callable without errors", () => {
+      // Layout namespace loggers
       expect(() => layoutDebug.state("test")).not.toThrow();
       expect(() => layoutDebug.device("test")).not.toThrow();
+      // Canvas namespace loggers
       expect(() => canvasDebug.transform("test")).not.toThrow();
       expect(() => canvasDebug.panzoom("test")).not.toThrow();
+      // Cable namespace logger
       expect(() => cableDebug.validation("test")).not.toThrow();
+      // App namespace logger
       expect(() => appDebug.mobile("test")).not.toThrow();
     });
   });


### PR DESCRIPTION
## Summary
- Use shared Debug instances instead of creating new ones on each call
- Use `Debug.enable()` for immediate effect without page reload
- Use Vite's built-in env types for cleaner code
- Remove redundant `toBeDefined` checks in tests
- Consolidate namespace logger tests to callable behavior only

## Context
Addresses CodeRabbit feedback from PR #519.

## Test plan
- [x] Debug tests pass
- [x] Lint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)