### PR TITLE
chore: configure Vite file watcher to ignore .worktree directory

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,13 @@ export default defineConfig(() => ({
   base: process.env.VITE_BASE_PATH || "/",
   publicDir: "static",
   plugins: [svelte()],
+  server: {
+    watch: {
+      // Ignore git worktrees and other development artifacts
+      // Vite already ignores .git/, node_modules/, test-results/, cacheDir, build.outDir
+      ignored: ["**/.worktree/**", "**/coverage/**", "**/playwright-report/**"],
+    },
+  },
   define: {
     // Inject version at build time
     __APP_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## Summary
- Configure Vite's file watcher to ignore `.worktree/` directory to prevent unnecessary hot reloads during parallel development
- Also ignore `coverage/` and `playwright-report/` directories which are development artifacts
- Vite already ignores `.git/`, `node_modules/`, `test-results/`, `cacheDir`, and `build.outDir` by default

## Test plan
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual: Start dev server, make changes in `.worktree/`, confirm no hot reload triggered in main workspace

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)