### PR TITLE
fix: reset view to fit rack when exiting focus states (#189)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -453,6 +453,7 @@
 
   function handleExportCancel() {
     dialogStore.close();
+    handleFitAll();
   }
 
   function handleShare() {
@@ -468,6 +469,7 @@
 
   function handleShareClose() {
     dialogStore.close();
+    handleFitAll();
   }
 
   function handleDelete() {
@@ -523,6 +525,7 @@
 
   function handleCancelDelete() {
     dialogStore.close();
+    handleFitAll();
   }
 
   function handleFitAll() {
@@ -553,6 +556,7 @@
 
   function handleHelpClose() {
     dialogStore.close();
+    handleFitAll();
   }
 
   function handleAddDevice() {
@@ -689,6 +693,7 @@
   function handleBottomSheetClose() {
     dialogStore.closeSheet();
     selectionStore.clearSelection();
+    handleFitAll();
   }
 
   // Handle mobile device actions (remove, move)
@@ -743,6 +748,7 @@
   // Handle device library sheet close
   function handleDeviceLibrarySheetClose() {
     dialogStore.closeSheet();
+    handleFitAll();
   }
 
   // Handle rack long press (mobile rack editing)
@@ -759,6 +765,7 @@
   // Handle rack edit sheet close
   function handleRackEditSheetClose() {
     dialogStore.closeSheet();
+    handleFitAll();
   }
 
   // Handle mobile device selection from palette (enters placement mode)

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -103,6 +103,8 @@
     if (success) {
       hapticSuccess();
       placementStore.completePlacement();
+      // Reset view to show full rack after placement completes
+      canvasStore.fitAll(layoutStore.racks);
     }
   }
 

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -78,6 +78,8 @@
           // Priority: cancel placement mode first
           if (placementStore.isPlacing) {
             placementStore.cancelPlacement();
+            // Reset view to show full rack after placement is cancelled
+            onfitall?.();
             return;
           }
           // Otherwise clear selection and close drawers

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -375,6 +375,8 @@
   function handleCancelPlacement() {
     hapticCancel();
     placementStore.cancelPlacement();
+    // Reset view to show full rack after placement is cancelled
+    canvasStore.fitAll(layoutStore.racks);
   }
 
   function handleClick(_event: MouseEvent) {


### PR DESCRIPTION
## Summary
- View now automatically resets to show the full rack when exiting focus states
- Provides a consistent "home" state and prevents users from getting lost in zoomed views
- Handles reduced motion preference automatically (via existing fitAll implementation)

## Scenarios Handled
- Closing modal dialogs (Help, Share, Export, ConfirmDelete)
- Exiting placement mode (after placing device or canceling)
- Closing mobile bottom sheets (device details, device library, rack edit)
- Pressing Escape to cancel placement mode

## Files Changed
- `src/App.svelte`: Added handleFitAll() calls to dialog/sheet close handlers
- `src/lib/components/Canvas.svelte`: Call fitAll after placement completion
- `src/lib/components/Rack.svelte`: Call fitAll after placement cancellation
- `src/lib/components/KeyboardHandler.svelte`: Call onfitall callback after Escape cancels placement

## Test Plan
- [x] Lint passes
- [x] All 1573 unit tests pass
- [x] Build succeeds
- [ ] Manual testing: Open Help dialog, close it → view resets to show rack
- [ ] Manual testing: Enter placement mode, place device → view resets
- [ ] Manual testing: Enter placement mode, press Escape → view resets
- [ ] Manual testing (mobile): Open bottom sheet, close it → view resets

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)