### PR TITLE
chore: automate SECURITY.md version updates in /release skill (#553)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -42,6 +42,7 @@ START
   │
   ├─ PHASE 4: Execute Release
   │   - Update CHANGELOG.md
+  │   - Update SECURITY.md (supported version)
   │   - npm version [type] --no-git-tag-version
   │   - git add && git commit
   │   - git tag vX.Y.Z
@@ -164,6 +165,7 @@ Ready to release v$NEW_VERSION
 
 Changes:
 - Update CHANGELOG.md with new entry
+- Update SECURITY.md supported version
 - Bump version in package.json
 - Create git tag vX.Y.Z
 - Push to origin (triggers GitHub Action)
@@ -196,14 +198,29 @@ Insert the new entry after the header (line 7) and before the first existing ver
 
 Use the Edit tool to insert the changelog entry at the correct position.
 
-### 4c. Commit Changelog
+### 4c. Update SECURITY.md
 
-```bash
-git add CHANGELOG.md
-git commit -m "docs: update changelog for v$NEW_VERSION"
+Update the supported versions table in SECURITY.md to reflect the new release version.
+
+Use the Edit tool to replace the version table:
+
+```markdown
+| Version | Supported          |
+| ------- | ------------------ |
+| $NEW_VERSION   | :white_check_mark: |
+| < $NEW_VERSION | :x:                |
 ```
 
-### 4d. Bump Version
+This ensures SECURITY.md always shows the current release as the only supported version.
+
+### 4d. Commit Release Files
+
+```bash
+git add CHANGELOG.md SECURITY.md
+git commit -m "docs: update changelog and security policy for v$NEW_VERSION"
+```
+
+### 4e. Bump Version
 
 ```bash
 npm version $NEW_VERSION --no-git-tag-version
@@ -211,7 +228,7 @@ git add package.json package-lock.json
 git commit --amend -m "v$NEW_VERSION"
 ```
 
-### 4e. Create Tag and Push
+### 4f. Create Tag and Push
 
 ```bash
 git tag "v$NEW_VERSION"


### PR DESCRIPTION
## Summary

- Add step to `/release` skill that automatically updates SECURITY.md supported versions table during each release
- Ensures SECURITY.md always shows current version as supported, all previous as unsupported
- No more stale security policy versions (was stuck at 0.5.9)

## Changes

- **Step 4c added**: Update SECURITY.md with new version using Edit tool
- **Step 4d updated**: Include SECURITY.md in release commit alongside CHANGELOG.md
- **Workflow diagram**: Updated to mention SECURITY.md
- **Phase 3 confirmation**: Now shows SECURITY.md will be updated

## Files Changed

- `.claude/commands/release.md`: +22/-5 lines (new step, updated commit command, renumbered steps)

## Test Plan

- [ ] Manual verification: next `/release patch` run will update SECURITY.md automatically

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)