### PR TITLE
feat: add reorderRacksInGroup for bay numbering (#565)

### DIFF
--- a/scripts/generate-gh-dash-config.js
+++ b/scripts/generate-gh-dash-config.js
@@ -69,7 +69,7 @@ function fetchMilestones() {
       .split("\n")
       .filter((line) => line.trim())
       .map((line) => JSON.parse(line));
-  } catch (error) {
+  } catch (_error) {
     console.error("Warning: Could not fetch milestones from GitHub API.");
     console.error("Using fallback milestone v0.7.0");
     return [{ title: "v0.7.0", open_issues: 1 }];


### PR DESCRIPTION
## Summary
- Adds `reorderRacksInGroup(groupId, newOrder)` store function for reordering racks within a group
- Validates that new order contains same rack IDs (no additions/removals/duplicates)
- Undo/redo automatically supported through existing `updateRackGroup` command pattern

## Implementation Notes
This implements the **Store API** portion of #565. The UX approach (drag-to-reorder in canvas vs implicit by position) is deferred to a separate issue, as noted in the original issue's technical notes.

## Files Changed
- `src/lib/stores/layout.svelte.ts`: Add `reorderRacksInGroup` function and export
- `scripts/generate-gh-dash-config.js`: Fix unrelated lint error (unused catch variable)

## Test plan
- [ ] Lint passes (`npm run lint`)
- [ ] All unit tests pass (`npm run test:run`)
- [ ] Build succeeds (`npm run build`)
- [ ] Function exported from layout store

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)