### PR TITLE
feat: add Discussions link to About/Help menu (#649)

### DIFF
--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -174,6 +174,7 @@
   });
 
   const featureRequestUrl = `${GITHUB_URL}/issues/new?template=feature-request.yml`;
+  const discussionsUrl = `${GITHUB_URL}/discussions`;
 </script>
 
 <Dialog.Root {open} onOpenChange={handleOpenChange}>
@@ -284,6 +285,25 @@
                 />
               </svg>
               Request Feature
+            </a>
+            <a
+              href={discussionsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="quick-link"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                width="16"
+                height="16"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"
+                />
+              </svg>
+              Share Ideas
             </a>
           </div>
 


### PR DESCRIPTION
## Summary

- Adds a "Share Ideas" link to the quick-links section of the About/Help menu
- Links to GitHub Discussions to encourage users to submit ideas there rather than as issues
- Uses the comment-discussion octicon for visual consistency

## Files Changed

- `src/lib/components/HelpPanel.svelte`: Added discussionsUrl constant and new link element

## Test Plan

- [ ] Open Help panel (click ? icon or press `?`)
- [ ] Verify "Share Ideas" link appears inline with other quick-links
- [ ] Click "Share Ideas" and verify it opens GitHub Discussions in a new tab

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)