### PR TITLE
fix: remove unused props from Toolbar component (#652)

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -25,7 +25,6 @@
   import { analytics } from "$lib/utils/analytics";
 
   interface Props {
-    hasSelection?: boolean;
     hasRacks?: boolean;
     theme?: "dark" | "light";
     displayMode?: DisplayMode;
@@ -37,7 +36,6 @@
     onload?: () => void;
     onexport?: () => void;
     onshare?: () => void;
-    ondelete?: () => void;
     onfitall?: () => void;
     ontoggletheme?: () => void;
     ontoggledisplaymode?: () => void;
@@ -47,7 +45,6 @@
   }
 
   let {
-    hasSelection = false,
     hasRacks = false,
     theme = "dark",
     displayMode = "label",
@@ -59,7 +56,6 @@
     onload,
     onexport,
     onshare,
-    ondelete,
     onfitall,
     ontoggletheme,
     ontoggledisplaymode,


### PR DESCRIPTION
## Summary

- Removed `hasSelection` prop (declared but never used)
- Removed `ondelete` prop (declared but never used)

These props were causing ESLint errors that failed the lint check in CI.

## Files Changed

- `src/lib/components/Toolbar.svelte`: Removed 2 unused props from Props interface and $props() destructuring

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run test:run` passes (1663 tests)
- [x] `npm run build` succeeds

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)