### PR TITLE
chore(ui): use design tokens for tooltip shortcut badge (#653)

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -89,11 +89,11 @@
 
   :global(.tooltip-shortcut) {
     padding: 1px 4px;
-    background-color: rgba(255, 255, 255, 0.15);
+    background-color: var(--colour-shortcut-bg);
     border-radius: 2px;
     font-size: var(--font-size-xs);
     font-family: var(--font-mono, monospace);
-    color: var(--colour-text-muted-inverse, rgba(255, 255, 255, 0.7));
+    color: var(--colour-text-muted-inverse);
   }
 
   /* Reduced motion */

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -202,6 +202,12 @@
     255,
     0.1
   ); /* Borders/separators on overlays */
+  --colour-shortcut-bg: rgba(
+    255,
+    255,
+    255,
+    0.15
+  ); /* Keyboard shortcut badge background on overlays */
 
   /* Text */
   --colour-text: var(--dracula-foreground);


### PR DESCRIPTION
## Summary
- Add `--colour-shortcut-bg` design token for keyboard shortcut badge background on overlays
- Replace hardcoded `rgba(255, 255, 255, 0.15)` with `var(--colour-shortcut-bg)` in Tooltip
- Remove hardcoded RGBA fallback from `--colour-text-muted-inverse` usage

## Test plan
- [x] Verify tooltip shortcut badge renders correctly in dark theme
- [x] Build passes
- [ ] Visual check in both dark and light themes (shortcut badge should maintain contrast)

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)