### PR TITLE
chore: Replace inline close icons with Iconoir IconClose (#671)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.16",
       "license": "MIT",
       "dependencies": {
+        "@iconify/svelte": "^5.2.1",
         "@lucide/svelte": "^0.562.0",
         "bits-ui": "^2.15.4",
         "debug": "^4.4.3",
@@ -1088,6 +1089,27 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@iconify/svelte": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-5.2.1.tgz",
+      "integrity": "sha512-zHmsIPmnIhGd5gc95bNN5FL+GifwMZv7M2rlZEpa7IXYGFJm/XGHdWf6PWQa6OBoC+R69WyiPO9NAj5wjfjbow==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "svelte": ">5.0.0"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     ]
   },
   "dependencies": {
+    "@iconify/svelte": "^5.2.1",
     "@lucide/svelte": "^0.562.0",
     "bits-ui": "^2.15.4",
     "debug": "^4.4.3",

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -5,6 +5,7 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { Dialog } from "bits-ui";
+  import { IconClose } from "./icons";
 
   interface Props {
     open: boolean;
@@ -49,20 +50,7 @@
           {/if}
           {#if showClose}
             <Dialog.Close class="dialog-close" aria-label="Close dialog">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 20 20"
-                fill="none"
-                aria-hidden="true"
-              >
-                <path
-                  d="M15 5L5 15M5 5L15 15"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
+              <IconClose />
             </Dialog.Close>
           {/if}
         </div>

--- a/src/lib/components/DrawerHeader.svelte
+++ b/src/lib/components/DrawerHeader.svelte
@@ -3,75 +3,69 @@
   Header section for drawers with title and optional close button
 -->
 <script lang="ts">
-	interface Props {
-		title: string;
-		showClose?: boolean;
-		onclose?: () => void;
-	}
+  import { IconClose } from "./icons";
 
-	let { title, showClose = true, onclose }: Props = $props();
+  interface Props {
+    title: string;
+    showClose?: boolean;
+    onclose?: () => void;
+  }
+
+  let { title, showClose = true, onclose }: Props = $props();
 </script>
 
 <div class="drawer-header">
-	<h2 class="drawer-title">{title}</h2>
-	{#if showClose}
-		<button type="button" class="close-button" aria-label="Close drawer" onclick={onclose}>
-			<svg
-				width="20"
-				height="20"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-				aria-hidden="true"
-			>
-				<line x1="18" y1="6" x2="6" y2="18" />
-				<line x1="6" y1="6" x2="18" y2="18" />
-			</svg>
-		</button>
-	{/if}
+  <h2 class="drawer-title">{title}</h2>
+  {#if showClose}
+    <button
+      type="button"
+      class="close-button"
+      aria-label="Close drawer"
+      onclick={onclose}
+    >
+      <IconClose />
+    </button>
+  {/if}
 </div>
 
 <style>
-	.drawer-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: var(--space-3) var(--space-4);
-		border-bottom: 1px solid var(--colour-border);
-		flex-shrink: 0;
-	}
+  .drawer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--colour-border);
+    flex-shrink: 0;
+  }
 
-	.drawer-title {
-		font-size: var(--font-size-md);
-		font-weight: 600;
-		margin: 0;
-		color: var(--colour-text);
-	}
+  .drawer-title {
+    font-size: var(--font-size-md);
+    font-weight: 600;
+    margin: 0;
+    color: var(--colour-text);
+  }
 
-	.close-button {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 32px;
-		height: 32px;
-		border-radius: var(--radius-md);
-		background: transparent;
-		color: var(--colour-text-muted);
-		transition:
-			background-color var(--transition-fast),
-			color var(--transition-fast);
-	}
+  .close-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--colour-text-muted);
+    transition:
+      background-color var(--transition-fast),
+      color var(--transition-fast);
+  }
 
-	.close-button:hover {
-		background: var(--colour-surface-hover);
-		color: var(--colour-text);
-	}
+  .close-button:hover {
+    background: var(--colour-surface-hover);
+    color: var(--colour-text);
+  }
 
-	.close-button:focus-visible {
-		outline: 2px solid var(--colour-selection);
-		outline-offset: 2px;
-	}
+  .close-button:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: 2px;
+  }
 </style>

--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -7,6 +7,7 @@
   import { Dialog } from "bits-ui";
   import { VERSION } from "$lib/version";
   import LogoLockup from "./LogoLockup.svelte";
+  import { IconClose } from "./icons";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { formatShortcut } from "$lib/utils/platform";
@@ -204,20 +205,7 @@
       <div class="dialog-header">
         <Dialog.Title class="dialog-title">About</Dialog.Title>
         <Dialog.Close class="dialog-close" aria-label="Close dialog">
-          <svg
-            width="20"
-            height="20"
-            viewBox="0 0 20 20"
-            fill="none"
-            aria-hidden="true"
-          >
-            <path
-              d="M15 5L5 15M5 5L15 15"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-            />
-          </svg>
+          <IconClose />
         </Dialog.Close>
       </div>
       <Dialog.Description class="help-dialog-description">

--- a/src/lib/components/PlacementIndicator.svelte
+++ b/src/lib/components/PlacementIndicator.svelte
@@ -6,6 +6,7 @@
 <script lang="ts">
   import type { DeviceType } from "$lib/types";
   import { hapticCancel } from "$lib/utils/haptics";
+  import { IconClose } from "./icons";
 
   interface Props {
     isPlacing: boolean;
@@ -34,21 +35,7 @@
       onclick={handleCancel}
       aria-label="Cancel placement"
     >
-      <!-- X icon -->
-      <svg
-        width="20"
-        height="20"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        aria-hidden="true"
-      >
-        <line x1="18" y1="6" x2="6" y2="18" />
-        <line x1="6" y1="6" x2="18" y2="18" />
-      </svg>
+      <IconClose />
     </button>
   </div>
 {/if}

--- a/src/lib/components/RackGroupPanel.svelte
+++ b/src/lib/components/RackGroupPanel.svelte
@@ -7,6 +7,7 @@
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import type { RackGroup, RackGroupLayoutPreset } from "$lib/types";
+  import { IconClose } from "./icons";
 
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
@@ -61,18 +62,7 @@
             aria-label="Delete group {group.name ?? 'unnamed'}"
             title="Delete group (keeps racks)"
           >
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              aria-hidden="true"
-            >
-              <line x1="18" y1="6" x2="6" y2="18"></line>
-              <line x1="6" y1="6" x2="18" y2="18"></line>
-            </svg>
+            <IconClose />
           </button>
         </div>
         <div class="group-racks">
@@ -166,6 +156,11 @@
     cursor: pointer;
     opacity: 0.6;
     transition: all var(--duration-fast) var(--ease-out);
+  }
+
+  .delete-btn :global(svg) {
+    width: var(--icon-size-sm);
+    height: var(--icon-size-sm);
   }
 
   .delete-btn:hover {

--- a/src/lib/components/VaulBottomSheet.svelte
+++ b/src/lib/components/VaulBottomSheet.svelte
@@ -5,6 +5,7 @@
 -->
 <script lang="ts">
   import { Drawer } from "vaul-svelte";
+  import { IconClose } from "./icons";
 
   interface Props {
     open: boolean;
@@ -42,19 +43,7 @@
             <div></div>
           {/if}
           <Drawer.Close class="close-button" aria-label="Close">
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <line x1="18" y1="6" x2="6" y2="18"></line>
-              <line x1="6" y1="6" x2="18" y2="18"></line>
-            </svg>
+            <IconClose />
           </Drawer.Close>
         </div>
       </div>
@@ -141,6 +130,11 @@
   :global(.close-button:focus-visible) {
     background: var(--colour-surface-secondary);
     color: var(--colour-text);
+  }
+
+  :global(.close-button svg) {
+    width: var(--icon-size-lg);
+    height: var(--icon-size-lg);
   }
 
   :global(.close-button:focus-visible) {

--- a/src/lib/components/icons/IconClose.svelte
+++ b/src/lib/components/icons/IconClose.svelte
@@ -1,0 +1,19 @@
+<!--
+  Close (X) icon using Iconoir via Iconify
+  Part of #608 icon standardization
+
+  Sizing: Uses --icon-size-md (20px) by default.
+  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-lg); }
+-->
+<script lang="ts">
+  import Icon from "@iconify/svelte";
+</script>
+
+<Icon icon="iconoir:xmark" class="icon-close" aria-hidden="true" />
+
+<style>
+  :global(.icon-close) {
+    width: var(--icon-size-md);
+    height: var(--icon-size-md);
+  }
+</style>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -35,3 +35,6 @@ export { default as IconImageBold } from "./IconImageBold.svelte";
 export { default as IconFitAllBold } from "./IconFitAllBold.svelte";
 export { default as IconFolderBold } from "./IconFolderBold.svelte";
 export { default as IconGearBold } from "./IconGearBold.svelte";
+
+// Iconoir icons via @iconify/svelte
+export { default as IconClose } from "./IconClose.svelte";


### PR DESCRIPTION
## Summary

- Install `@iconify/svelte` for Svelte 5 compatible Iconoir icons
- Create `IconClose.svelte` component using `iconoir:xmark`
- Replace inline SVG X icons in 6 components with shared IconClose
- Icon sizing uses design tokens (`--icon-size-md` default)

## Files Changed

- `package.json` / `package-lock.json`: Added @iconify/svelte
- `src/lib/components/icons/IconClose.svelte`: New Iconoir close icon
- `src/lib/components/icons/index.ts`: Export IconClose
- `src/lib/components/Dialog.svelte`: Use IconClose
- `src/lib/components/HelpPanel.svelte`: Use IconClose
- `src/lib/components/RackGroupPanel.svelte`: Use IconClose (--icon-size-sm via CSS)
- `src/lib/components/DrawerHeader.svelte`: Use IconClose
- `src/lib/components/PlacementIndicator.svelte`: Use IconClose
- `src/lib/components/VaulBottomSheet.svelte`: Use IconClose (--icon-size-lg via CSS)

## Test plan

- [x] Lint passes
- [x] All 1682 tests pass
- [x] Build succeeds
- [ ] Visual verification: close buttons render correctly in dialogs/panels

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)