### PR TITLE
chore(ui): improve settings menu checkbox visibility (#677)

### DIFF
--- a/src/lib/components/SettingsMenu.svelte
+++ b/src/lib/components/SettingsMenu.svelte
@@ -5,7 +5,8 @@
 -->
 <script lang="ts">
   import { DropdownMenu } from "bits-ui";
-  import { IconGearBold } from "./icons";
+  import { IconGearBold, IconSquare, IconSquareFilled } from "./icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
   import "$lib/styles/menu.css";
 
   interface Props {
@@ -59,7 +60,13 @@
       }}
     >
       {#snippet children({ checked })}
-        <span class="menu-checkbox">{checked ? "✓" : ""}</span>
+        <span class="menu-checkbox">
+          {#if checked}
+            <IconSquareFilled size={ICON_SIZE.sm} />
+          {:else}
+            <IconSquare size={ICON_SIZE.sm} />
+          {/if}
+        </span>
         <span class="menu-label">Show Annotations</span>
       {/snippet}
     </DropdownMenu.CheckboxItem>
@@ -73,7 +80,13 @@
       }}
     >
       {#snippet children({ checked })}
-        <span class="menu-checkbox">{checked ? "✓" : ""}</span>
+        <span class="menu-checkbox">
+          {#if checked}
+            <IconSquareFilled size={ICON_SIZE.sm} />
+          {:else}
+            <IconSquare size={ICON_SIZE.sm} />
+          {/if}
+        </span>
         <span class="menu-label">Banana for Scale</span>
       {/snippet}
     </DropdownMenu.CheckboxItem>

--- a/src/lib/components/icons/IconSquare.svelte
+++ b/src/lib/components/icons/IconSquare.svelte
@@ -1,0 +1,23 @@
+<!--
+  Empty square icon for unchecked checkbox state
+  Based on Phosphor Square icon
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 16 }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 256 256"
+  fill="currentColor"
+  aria-hidden="true"
+>
+  <path
+    d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm0,176H48V48H208V208Z"
+  />
+</svg>

--- a/src/lib/components/icons/IconSquareFilled.svelte
+++ b/src/lib/components/icons/IconSquareFilled.svelte
@@ -1,0 +1,23 @@
+<!--
+  Filled square icon for checked checkbox state
+  Based on Phosphor SquareFill icon
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 16 }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 256 256"
+  fill="currentColor"
+  aria-hidden="true"
+>
+  <path
+    d="M208,32H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Z"
+  />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -38,3 +38,7 @@ export { default as IconGearBold } from "./IconGearBold.svelte";
 
 // Iconoir icons via @iconify/svelte
 export { default as IconClose } from "./IconClose.svelte";
+
+// Checkbox indicator icons
+export { default as IconSquare } from "./IconSquare.svelte";
+export { default as IconSquareFilled } from "./IconSquareFilled.svelte";

--- a/src/lib/constants/sizing.ts
+++ b/src/lib/constants/sizing.ts
@@ -1,0 +1,16 @@
+/**
+ * Icon Size Constants
+ * Centralized values matching CSS tokens in tokens.css
+ *
+ * Use these instead of hardcoded pixel values in icon components.
+ * This ensures consistency and makes global changes easier.
+ */
+
+export const ICON_SIZE = {
+  sm: 16, // --icon-size-sm
+  md: 20, // --icon-size-md
+  lg: 24, // --icon-size-lg
+  xl: 28, // --icon-size-xl
+} as const;
+
+export type IconSize = keyof typeof ICON_SIZE;


### PR DESCRIPTION
## Summary

- Replace invisible text checkmarks with filled/empty square SVG icons
- Unchecked state now shows visible empty square (□) instead of nothing
- Checked state shows filled square (■) instead of text checkmark
- Both states clearly distinguishable in dark and light themes

## Changes

- `src/lib/constants/sizing.ts` (new): ICON_SIZE constants centralizing icon sizing
- `src/lib/components/icons/IconSquare.svelte` (new): Empty square icon for unchecked
- `src/lib/components/icons/IconSquareFilled.svelte` (new): Filled square icon for checked
- `src/lib/components/icons/index.ts`: Export new icons
- `src/lib/components/SettingsMenu.svelte`: Use new icons with ICON_SIZE.sm

## Test Plan

- [ ] Open settings menu (gear icon in toolbar)
- [ ] Verify "Show Annotations" shows empty square when unchecked
- [ ] Toggle "Show Annotations" - verify it shows filled square when checked
- [ ] Verify "Banana for Scale" shows same behavior
- [ ] Test in both dark and light themes - icons should be visible in both
- [ ] Verify icons inherit correct color from menu text

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)