### PR TITLE
fix: Bayed rack rendering issues (highlight, U marking, default name) (#680)

### DIFF
--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -129,6 +129,10 @@
   // Reversed racks for rear row (mirrored layout)
   const reversedRacks = $derived([...racks].reverse());
 
+  // Compute if ANY bay in the group is active/selected (for whole-group highlighting)
+  const isGroupActive = $derived(racks.some((r) => r.id === activeRackId));
+  const isGroupSelected = $derived(racks.some((r) => r.id === selectedRackId));
+
   // Element reference for long press
   let containerElement: HTMLDivElement | null = $state(null);
 
@@ -228,6 +232,8 @@
   bind:this={containerElement}
   class="bayed-rack-view"
   class:long-press-active={longPressActive}
+  class:active={isGroupActive}
+  class:selected={isGroupSelected}
   tabindex="0"
   role="group"
   aria-label="{group.name ?? 'Bayed Rack Group'}, {racks.length} bays"
@@ -272,6 +278,7 @@
             {partyMode}
             faceFilter="front"
             hideRackName={true}
+            hideULabels={true}
             onselect={() =>
               onselect?.(
                 new CustomEvent("select", { detail: { rackId: rack.id } }),
@@ -362,6 +369,7 @@
             {partyMode}
             faceFilter="rear"
             hideRackName={true}
+            hideULabels={true}
             onselect={() =>
               onselect?.(
                 new CustomEvent("select", { detail: { rackId: rack.id } }),
@@ -391,6 +399,16 @@
   }
 
   .bayed-rack-view:focus {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: 2px;
+  }
+
+  /* Selection highlight for entire bayed rack group */
+  .bayed-rack-view.active {
+    box-shadow: 0 0 0 2px var(--colour-selection);
+  }
+
+  .bayed-rack-view.selected {
     outline: 2px solid var(--colour-selection);
     outline-offset: 2px;
   }
@@ -441,17 +459,10 @@
     flex-direction: column;
     align-items: center;
     border-radius: var(--radius-sm);
-    transition: box-shadow var(--duration-fast) var(--ease-out);
   }
 
-  .bay-container.active {
-    box-shadow: 0 0 0 2px var(--colour-selection);
-  }
-
-  .bay-container.selected {
-    outline: 2px solid var(--colour-selection);
-    outline-offset: 2px;
-  }
+  /* Per-bay active/selected classes kept for device selection context,
+     but visual highlight is applied to the whole bayed-rack-view */
 
   .bay-label {
     font-size: var(--font-size-xs);

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -61,6 +61,8 @@
     viewLabel?: string;
     /** Hide the rack name (useful when container shows it instead) */
     hideRackName?: boolean;
+    /** Hide the U labels (useful when bayed rack view shows shared labels) */
+    hideULabels?: boolean;
     /** Party mode visual effects active */
     partyMode?: boolean;
     onselect?: (event: CustomEvent<{ rackId: string }>) => void;
@@ -101,6 +103,7 @@
     faceFilter,
     viewLabel,
     hideRackName = false,
+    hideULabels = false,
     partyMode = false,
     onselect,
     ondeviceselect,
@@ -1067,18 +1070,20 @@
       />
     {/each}
 
-    <!-- U labels (always on left rail) -->
-    {#each uLabels as { uNumber, yPosition } (uNumber)}
-      <text
-        x={RAIL_WIDTH / 2}
-        y={yPosition}
-        class="u-label"
-        class:u-label-highlight={uNumber % 5 === 0}
-        dominant-baseline="middle"
-      >
-        {uNumber}
-      </text>
-    {/each}
+    <!-- U labels (always on left rail) - hidden when bayed rack view shows shared labels -->
+    {#if !hideULabels}
+      {#each uLabels as { uNumber, yPosition } (uNumber)}
+        <text
+          x={RAIL_WIDTH / 2}
+          y={yPosition}
+          class="u-label"
+          class:u-label-highlight={uNumber % 5 === 0}
+          dominant-baseline="middle"
+        >
+          {uNumber}
+        </text>
+      {/each}
+    {/if}
 
     <!-- SVG Defs for blocked slots pattern -->
     <defs>

--- a/src/lib/components/wizard/NewRackWizard.svelte
+++ b/src/lib/components/wizard/NewRackWizard.svelte
@@ -149,15 +149,19 @@
     }
   });
 
-  // Reset height and width when layout type changes
+  // Reset height, width, and name when layout type changes
   $effect(() => {
     if (config.layoutType === "bayed") {
       config.height = BAYED_DEFAULT_HEIGHT;
       config.isCustomHeight = false;
       // Bayed racks are always 19" standard width
       config.width = 19;
+      // Use fun default name for bayed racks
+      config.name = "Bayoncé";
     } else {
       config.height = 42;
+      // Use fun default name for column racks
+      config.name = "Racky McRackface";
     }
   });
 


### PR DESCRIPTION
## Summary

- **Selection highlight now applies to entire bayed rack group** instead of individual bays
- **U labels hidden in individual racks** when rendered in BayedRackView (uses shared center column instead)
- **Default bayed rack name is now "Bayoncé"** (matching the "Racky McRackface" fun style)

## Files Changed

- `BayedRackView.svelte`: Add group-level active/selected state, pass hideULabels to Rack, add CSS for whole-group highlighting
- `Rack.svelte`: Add hideULabels prop to conditionally hide U labels
- `NewRackWizard.svelte`: Update layout type change effect to set appropriate default names

## Test plan

- [ ] Create a new bayed rack and verify default name is "Bayoncé"
- [ ] Select a bay in a bayed rack and verify the entire bayed rack gets highlighted (not just the individual bay)
- [ ] Verify no stray U marking strip appears between FRONT and REAR views
- [ ] Verify existing rack functionality still works

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)