### PR TITLE
chore: replace inline navigation arrows with Iconoir chevrons (#672)

### DIFF
--- a/src/lib/components/DeviceDetails.svelte
+++ b/src/lib/components/DeviceDetails.svelte
@@ -6,6 +6,7 @@
 <script lang="ts">
   import type { PlacedDevice, DeviceType, RackView } from "$lib/types";
   import CategoryIcon from "./CategoryIcon.svelte";
+  import { IconChevronUp, IconChevronDown, IconTrash } from "./icons";
 
   interface Props {
     device: PlacedDevice;
@@ -129,18 +130,7 @@
           disabled={!canMoveUp}
           aria-label="Move device up"
         >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <polyline points="18 15 12 9 6 15"></polyline>
-          </svg>
+          <IconChevronUp />
           Move Up
         </button>
         <button
@@ -150,18 +140,7 @@
           disabled={!canMoveDown}
           aria-label="Move device down"
         >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <polyline points="6 9 12 15 18 9"></polyline>
-          </svg>
+          <IconChevronDown />
           Move Down
         </button>
       </div>
@@ -171,21 +150,7 @@
         onclick={onremove}
         aria-label="Remove device from rack"
       >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <polyline points="3 6 5 6 21 6"></polyline>
-          <path
-            d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
-          ></path>
-        </svg>
+        <IconTrash size={16} />
         Remove from Rack
       </button>
     </div>
@@ -303,6 +268,11 @@
     flex: 1;
     background: var(--colour-surface-secondary);
     color: var(--colour-text);
+  }
+
+  .btn-secondary :global(svg) {
+    width: var(--icon-size-sm);
+    height: var(--icon-size-sm);
   }
 
   .btn-secondary:hover:not(:disabled) {

--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -11,7 +11,7 @@
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import SegmentedControl from "./SegmentedControl.svelte";
   import MarkdownPreview from "./MarkdownPreview.svelte";
-  import { IconEdit } from "./icons";
+  import { IconEdit, IconChevronUp, IconChevronDown } from "./icons";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
@@ -853,16 +853,7 @@
                 aria-label="Move down 1U"
                 title="Move down 1U"
               >
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2.5"
-                >
-                  <polyline points="6 9 12 15 18 9"></polyline>
-                </svg>
+                <IconChevronDown />
               </button>
               <button
                 type="button"
@@ -872,16 +863,7 @@
                 aria-label="Move up 1U"
                 title="Move up 1U"
               >
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2.5"
-                >
-                  <polyline points="18 15 12 9 6 15"></polyline>
-                </svg>
+                <IconChevronUp />
               </button>
               <span class="position-divider"></span>
               <button
@@ -1425,6 +1407,11 @@
     transition:
       background-color var(--duration-fast),
       border-color var(--duration-fast);
+  }
+
+  .position-btn :global(svg) {
+    width: var(--icon-size-xs);
+    height: var(--icon-size-xs);
   }
 
   .position-btn:hover:not(:disabled) {

--- a/src/lib/components/icons/IconChevronDown.svelte
+++ b/src/lib/components/icons/IconChevronDown.svelte
@@ -1,0 +1,23 @@
+<!--
+  Chevron Down icon using Iconoir via Iconify
+  Part of #608 icon standardization
+
+  Sizing: Uses --icon-size-md (20px) by default.
+  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
+-->
+<script lang="ts">
+  import Icon from "@iconify/svelte";
+</script>
+
+<Icon
+  icon="iconoir:nav-arrow-down"
+  class="icon-chevron-down"
+  aria-hidden="true"
+/>
+
+<style>
+  :global(.icon-chevron-down) {
+    width: var(--icon-size-md);
+    height: var(--icon-size-md);
+  }
+</style>

--- a/src/lib/components/icons/IconChevronUp.svelte
+++ b/src/lib/components/icons/IconChevronUp.svelte
@@ -1,0 +1,19 @@
+<!--
+  Chevron Up icon using Iconoir via Iconify
+  Part of #608 icon standardization
+
+  Sizing: Uses --icon-size-md (20px) by default.
+  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
+-->
+<script lang="ts">
+  import Icon from "@iconify/svelte";
+</script>
+
+<Icon icon="iconoir:nav-arrow-up" class="icon-chevron-up" aria-hidden="true" />
+
+<style>
+  :global(.icon-chevron-up) {
+    width: var(--icon-size-md);
+    height: var(--icon-size-md);
+  }
+</style>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -46,3 +46,7 @@ export { default as IconPlusIconoir } from "./IconPlusIconoir.svelte";
 // Checkbox indicator icons
 export { default as IconSquare } from "./IconSquare.svelte";
 export { default as IconSquareFilled } from "./IconSquareFilled.svelte";
+
+// Navigation chevron icons
+export { default as IconChevronUp } from "./IconChevronUp.svelte";
+export { default as IconChevronDown } from "./IconChevronDown.svelte";


### PR DESCRIPTION
## Summary

- Create `IconChevronUp` and `IconChevronDown` components using Iconoir `nav-arrow` icons
- Replace 4 inline navigation arrow SVGs in EditPanel.svelte and DeviceDetails.svelte
- Also replace inline trash SVG with `IconTrash` component in DeviceDetails.svelte
- Add CSS overrides to use design token icon sizes (`--icon-size-xs`, `--icon-size-sm`)

Part of #608 icon standardization

## Files Changed

- `src/lib/components/icons/IconChevronUp.svelte` (new)
- `src/lib/components/icons/IconChevronDown.svelte` (new)
- `src/lib/components/icons/index.ts` - Export new components
- `src/lib/components/EditPanel.svelte` - Replace position control SVGs
- `src/lib/components/DeviceDetails.svelte` - Replace move/trash button SVGs

## Test Plan

- [x] All navigation arrow icons use shared Iconoir components
- [x] Icon sizing uses design tokens
- [x] Lint passes
- [x] All 1684 tests pass
- [x] Production build succeeds

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)