### PR TITLE
fix: ensure toolbar dropdown menus appear above edit panel (#694)

### DIFF
--- a/src/lib/components/Drawer.svelte
+++ b/src/lib/components/Drawer.svelte
@@ -3,80 +3,86 @@
   Slide-in drawer panel for left and right sides
 -->
 <script lang="ts">
-	import type { Snippet } from 'svelte';
-	import DrawerHeader from './DrawerHeader.svelte';
+  import type { Snippet } from "svelte";
+  import DrawerHeader from "./DrawerHeader.svelte";
 
-	interface Props {
-		side: 'left' | 'right';
-		open: boolean;
-		title: string;
-		id?: string;
-		showClose?: boolean;
-		showHeader?: boolean;
-		onclose?: () => void;
-		children?: Snippet;
-	}
+  interface Props {
+    side: "left" | "right";
+    open: boolean;
+    title: string;
+    id?: string;
+    showClose?: boolean;
+    showHeader?: boolean;
+    onclose?: () => void;
+    children?: Snippet;
+  }
 
-	let {
-		side,
-		open,
-		title,
-		id,
-		showClose = true,
-		showHeader = true,
-		onclose,
-		children
-	}: Props = $props();
+  let {
+    side,
+    open,
+    title,
+    id,
+    showClose = true,
+    showHeader = true,
+    onclose,
+    children,
+  }: Props = $props();
 </script>
 
-<aside {id} class="drawer drawer-{side}" class:open aria-label={title} aria-hidden={!open}>
-	{#if showHeader}
-		<DrawerHeader {title} {showClose} {onclose} />
-	{/if}
-	<div class="drawer-content">
-		{#if children}
-			{@render children()}
-		{/if}
-	</div>
+<aside
+  {id}
+  class="drawer drawer-{side}"
+  class:open
+  aria-label={title}
+  aria-hidden={!open}
+>
+  {#if showHeader}
+    <DrawerHeader {title} {showClose} {onclose} />
+  {/if}
+  <div class="drawer-content">
+    {#if children}
+      {@render children()}
+    {/if}
+  </div>
 </aside>
 
 <style>
-	.drawer {
-		position: fixed;
-		top: var(--toolbar-height);
-		bottom: 0;
-		width: var(--drawer-width);
-		background: var(--drawer-bg);
-		border: 1px solid var(--colour-border);
-		display: flex;
-		flex-direction: column;
-		transition: transform var(--transition-normal);
-		z-index: 100;
-	}
+  .drawer {
+    position: fixed;
+    top: var(--toolbar-height);
+    bottom: 0;
+    width: var(--drawer-width);
+    background: var(--drawer-bg);
+    border: 1px solid var(--colour-border);
+    display: flex;
+    flex-direction: column;
+    transition: transform var(--transition-normal);
+    z-index: var(--z-drawer);
+  }
 
-	.drawer-left {
-		left: 0;
-		border-left: none;
-		transform: translateX(-100%);
-	}
+  .drawer-left {
+    left: 0;
+    border-left: none;
+    transform: translateX(-100%);
+  }
 
-	.drawer-right {
-		right: 0;
-		border-right: none;
-		transform: translateX(100%);
-	}
+  .drawer-right {
+    right: 0;
+    border-right: none;
+    transform: translateX(100%);
+  }
 
-	.drawer-left.open {
-		transform: translateX(0);
-	}
+  .drawer-left.open {
+    transform: translateX(0);
+  }
 
-	.drawer-right.open {
-		transform: translateX(0);
-	}
+  .drawer-right.open {
+    transform: translateX(0);
+  }
 
-	.drawer-content {
-		flex: 1;
-		overflow-y: auto;
-		padding: var(--space-4);
-	}
+  .drawer-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-4);
+  }
 </style>

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -352,7 +352,7 @@
   --z-drawer-backdrop: 99;
   --z-drawer: 100;
   --z-fab: 100;
-  --z-dropdown: 150; /* Above drawer, below modal */
+  --z-dropdown: 250; /* Above drawer AND modal - toolbar menus must appear above edit panel */
   --z-bottom-sheet: 200;
   --z-modal: 200;
   --z-toast: 300;


### PR DESCRIPTION
## Summary

- Increase `--z-dropdown` from 150 to 250 to ensure toolbar dropdown menus render above the drawer (edit panel)
- Update Drawer.svelte to use `var(--z-drawer)` token instead of hardcoded z-index for consistency

## Problem

When the edit panel is visible (rack/device selected), clicking the File or Settings menu in the toolbar would cause the dropdown to render behind the edit panel, making menu items inaccessible.

## Solution

The z-index hierarchy was designed correctly (`--z-dropdown: 150` > `--z-drawer: 100`), but CSS stacking contexts prevented dropdowns from appearing above fixed-position drawers. Increasing the dropdown z-index to 250 (above the modal layer at 200) ensures proper visibility.

## Test plan

- [ ] Open the app and select a rack or device to show the edit panel
- [ ] Click the File menu in the toolbar - verify it appears above the edit panel
- [ ] Click the Settings menu in the toolbar - verify it appears above the edit panel
- [ ] Verify dropdowns still work correctly when edit panel is closed

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)