### PR TITLE
chore: add maxlength attribute to rack name inputs (#654)

### DIFF
--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -618,6 +618,7 @@
           bind:value={rackName}
           onblur={handleNameBlur}
           onkeydown={handleNameKeydown}
+          maxlength="50"
         />
       </div>
 

--- a/src/lib/components/RackEditSheet.svelte
+++ b/src/lib/components/RackEditSheet.svelte
@@ -137,6 +137,7 @@
         bind:value={rackName}
         onblur={handleNameBlur}
         onkeydown={handleNameKeydown}
+        maxlength="50"
       />
     </div>
 

--- a/src/lib/components/wizard/NewRackWizard.svelte
+++ b/src/lib/components/wizard/NewRackWizard.svelte
@@ -305,6 +305,7 @@
             class="input-field"
             bind:value={config.name}
             placeholder="e.g., Main Server Rack"
+            maxlength="50"
             class:error={nameError}
           />
           {#if nameError}


### PR DESCRIPTION
## Summary

- Add `maxlength="50"` to all rack name input fields to prevent excessively long names that could cause UI overflow issues

## Files Changed

- `src/lib/components/wizard/NewRackWizard.svelte`: Add maxlength to creation wizard input
- `src/lib/components/EditPanel.svelte`: Add maxlength to desktop edit panel input
- `src/lib/components/RackEditSheet.svelte`: Add maxlength to mobile edit sheet input

## Test Plan

- [x] Lint passes
- [x] All tests pass (1684 tests)
- [x] Build succeeds
- [x] Verified existing CSS handles name truncation gracefully (RackList.svelte already has `text-overflow: ellipsis`)

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)