### PR TITLE
feat: Clear all selection state when clicking empty canvas or pressing Escape (#704)

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -245,6 +245,7 @@
     // Only clear selection if clicking directly on the canvas (not on a rack)
     if (event.target === event.currentTarget) {
       selectionStore.clearSelection();
+      layoutStore.setActiveRack(null);
     }
   }
 

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -83,8 +83,9 @@
             onfitall?.();
             return;
           }
-          // Otherwise clear selection and close drawers
+          // Otherwise clear selection, active rack, and close drawers
           selectionStore.clearSelection();
+          layoutStore.setActiveRack(null);
           uiStore.closeLeftDrawer();
           uiStore.closeRightDrawer();
         },


### PR DESCRIPTION
## Summary

- Clicking empty canvas space now clears rack highlight in sidebar list (was persisting)
- Pressing Escape now clears rack highlight in sidebar list (was persisting)
- Both actions already cleared device selection and closed edit panel

## Problem

Previously, clicking empty canvas space or pressing Escape would close the edit panel but leave visual highlights on:
- The previously selected rack (in the sidebar rack list)
- The rack wrapper on canvas (via `.active` class)

This created an inconsistent state where the UI suggested something was still selected.

## Solution

Added `layoutStore.setActiveRack(null)` to both:
- `handleCanvasClick()` in Canvas.svelte
- Escape key handler in KeyboardHandler.svelte

This ensures `activeRackId` is cleared alongside the selection store state.

## Test plan

- [ ] Click on a device to select it, then click empty canvas - verify device highlight clears
- [ ] Click on a rack in sidebar to select it, then click empty canvas - verify rack highlight in list clears
- [ ] Select a device, press Escape - verify all highlights clear
- [ ] Select a rack, press Escape - verify all highlights clear
- [ ] Verify placement mode still cancels correctly on Escape

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)