### PR TITLE
fix: wrap toolbar dropdowns in Portal to fix z-index stacking (#694)

### DIFF
--- a/src/lib/components/FileMenu.svelte
+++ b/src/lib/components/FileMenu.svelte
@@ -41,29 +41,31 @@
     <IconFolderBold size={20} />
   </DropdownMenu.Trigger>
 
-  <DropdownMenu.Content
-    class="menu-content menu-inline"
-    sideOffset={4}
-    align="end"
-  >
-    <DropdownMenu.Item class="menu-item" onSelect={handleSelect(onsave)}>
-      <span class="menu-label">Save</span>
-      <span class="menu-shortcut">{shortcuts.save}</span>
-    </DropdownMenu.Item>
-    <DropdownMenu.Item class="menu-item" onSelect={handleSelect(onload)}>
-      <span class="menu-label">Load</span>
-      <span class="menu-shortcut">{shortcuts.load}</span>
-    </DropdownMenu.Item>
-    <DropdownMenu.Item class="menu-item" onSelect={handleSelect(onexport)}>
-      <span class="menu-label">Export</span>
-      <span class="menu-shortcut">{shortcuts.export}</span>
-    </DropdownMenu.Item>
-    <DropdownMenu.Item
-      class="menu-item"
-      disabled={!hasRacks}
-      onSelect={handleSelect(onshare)}
+  <DropdownMenu.Portal>
+    <DropdownMenu.Content
+      class="menu-content menu-inline"
+      sideOffset={4}
+      align="end"
     >
-      <span class="menu-label">Share</span>
-    </DropdownMenu.Item>
-  </DropdownMenu.Content>
+      <DropdownMenu.Item class="menu-item" onSelect={handleSelect(onsave)}>
+        <span class="menu-label">Save</span>
+        <span class="menu-shortcut">{shortcuts.save}</span>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item class="menu-item" onSelect={handleSelect(onload)}>
+        <span class="menu-label">Load</span>
+        <span class="menu-shortcut">{shortcuts.load}</span>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item class="menu-item" onSelect={handleSelect(onexport)}>
+        <span class="menu-label">Export</span>
+        <span class="menu-shortcut">{shortcuts.export}</span>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        class="menu-item"
+        disabled={!hasRacks}
+        onSelect={handleSelect(onshare)}
+      >
+        <span class="menu-label">Share</span>
+      </DropdownMenu.Item>
+    </DropdownMenu.Content>
+  </DropdownMenu.Portal>
 </DropdownMenu.Root>

--- a/src/lib/components/SettingsMenu.svelte
+++ b/src/lib/components/SettingsMenu.svelte
@@ -35,60 +35,63 @@
     <IconGearBold size={20} />
   </DropdownMenu.Trigger>
 
-  <DropdownMenu.Content
-    class="menu-content menu-inline"
-    sideOffset={4}
-    align="end"
-  >
-    <DropdownMenu.Item
-      class="menu-item"
-      onSelect={() => {
-        ontoggletheme?.();
-        open = false;
-      }}
+  <DropdownMenu.Portal>
+    <DropdownMenu.Content
+      class="menu-content menu-inline"
+      sideOffset={4}
+      align="end"
     >
-      <span class="menu-label">{theme === "dark" ? "Light" : "Dark"} Theme</span
+      <DropdownMenu.Item
+        class="menu-item"
+        onSelect={() => {
+          ontoggletheme?.();
+          open = false;
+        }}
       >
-    </DropdownMenu.Item>
+        <span class="menu-label"
+          >{theme === "dark" ? "Light" : "Dark"} Theme</span
+        >
+      </DropdownMenu.Item>
 
-    <DropdownMenu.CheckboxItem
-      class="menu-item"
-      checked={showAnnotations}
-      onCheckedChange={() => {
-        ontoggleannotations?.();
-        open = false;
-      }}
-    >
-      {#snippet children({ checked })}
-        <span class="menu-checkbox">
-          {#if checked}
-            <IconSquareFilled size={ICON_SIZE.sm} />
-          {:else}
-            <IconSquare size={ICON_SIZE.sm} />
-          {/if}
-        </span>
-        <span class="menu-label">Show Annotations</span>
-      {/snippet}
-    </DropdownMenu.CheckboxItem>
+      <DropdownMenu.CheckboxItem
+        class="menu-item"
+        checked={showAnnotations}
+        onCheckedChange={() => {
+          ontoggleannotations?.();
+          open = false;
+        }}
+      >
+        {#snippet children({ checked })}
+          <span class="menu-checkbox">
+            {#if checked}
+              <IconSquareFilled size={ICON_SIZE.sm} />
+            {:else}
+              <IconSquare size={ICON_SIZE.sm} />
+            {/if}
+          </span>
+          <span class="menu-label">Show Annotations</span>
+        {/snippet}
+      </DropdownMenu.CheckboxItem>
 
-    <DropdownMenu.CheckboxItem
-      class="menu-item"
-      checked={showBanana}
-      onCheckedChange={() => {
-        ontogglebanana?.();
-        open = false;
-      }}
-    >
-      {#snippet children({ checked })}
-        <span class="menu-checkbox">
-          {#if checked}
-            <IconSquareFilled size={ICON_SIZE.sm} />
-          {:else}
-            <IconSquare size={ICON_SIZE.sm} />
-          {/if}
-        </span>
-        <span class="menu-label">Banana for Scale</span>
-      {/snippet}
-    </DropdownMenu.CheckboxItem>
-  </DropdownMenu.Content>
+      <DropdownMenu.CheckboxItem
+        class="menu-item"
+        checked={showBanana}
+        onCheckedChange={() => {
+          ontogglebanana?.();
+          open = false;
+        }}
+      >
+        {#snippet children({ checked })}
+          <span class="menu-checkbox">
+            {#if checked}
+              <IconSquareFilled size={ICON_SIZE.sm} />
+            {:else}
+              <IconSquare size={ICON_SIZE.sm} />
+            {/if}
+          </span>
+          <span class="menu-label">Banana for Scale</span>
+        {/snippet}
+      </DropdownMenu.CheckboxItem>
+    </DropdownMenu.Content>
+  </DropdownMenu.Portal>
 </DropdownMenu.Root>


### PR DESCRIPTION
## Summary

- Wrap `DropdownMenu.Content` in `DropdownMenu.Portal` for FileMenu and SettingsMenu
- Portal renders content at document root, bypassing stacking context issues

## Problem

Dropdown menus from the toolbar (File/Settings) were rendering behind the edit panel when a device or rack was selected. This was a stacking context issue - the dropdown content was constrained by its parent's z-index.

## Solution

Using `DropdownMenu.Portal` (from bits-ui) teleports the dropdown content to the document body, ensuring it renders above all other elements regardless of the parent component's stacking context.

## Test plan

- [ ] Open the app with a rack containing devices
- [ ] Select a device (edit panel opens on the right)
- [ ] Click the File menu (folder icon) in toolbar
- [ ] Verify dropdown appears **above** the edit panel
- [ ] Repeat with Settings menu (gear icon)
- [ ] Verify both menus are fully interactive when edit panel is visible

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)