### PR TITLE
refactor: extract handleSelect helper in SettingsMenu

### DIFF
--- a/src/lib/components/SettingsMenu.svelte
+++ b/src/lib/components/SettingsMenu.svelte
@@ -34,6 +34,13 @@
   }: Props = $props();
 
   let open = $state(false);
+
+  function handleSelect(action?: () => void) {
+    return () => {
+      action?.();
+      open = false;
+    };
+  }
 </script>
 
 <DropdownMenu.Root bind:open>
@@ -49,10 +56,7 @@
     >
       <DropdownMenu.Item
         class="menu-item"
-        onSelect={() => {
-          ontoggletheme?.();
-          open = false;
-        }}
+        onSelect={handleSelect(ontoggletheme)}
       >
         <span class="menu-icon">
           {#if theme === "dark"}
@@ -69,10 +73,7 @@
       <DropdownMenu.CheckboxItem
         class="menu-item"
         checked={showAnnotations}
-        onCheckedChange={() => {
-          ontoggleannotations?.();
-          open = false;
-        }}
+        onCheckedChange={handleSelect(ontoggleannotations)}
       >
         {#snippet children({ checked })}
           <span class="menu-checkbox">
@@ -89,10 +90,7 @@
       <DropdownMenu.CheckboxItem
         class="menu-item"
         checked={showBanana}
-        onCheckedChange={() => {
-          ontogglebanana?.();
-          open = false;
-        }}
+        onCheckedChange={handleSelect(ontogglebanana)}
       >
         {#snippet children({ checked })}
           <span class="menu-checkbox">


### PR DESCRIPTION
## Summary

- Add `handleSelect` helper function to SettingsMenu (same pattern as FileMenu)
- Replace inline `onSelect` and `onCheckedChange` handlers with `handleSelect()` calls

## Motivation

DRY up the close-on-select behavior. FileMenu already uses this pattern, and SettingsMenu should be consistent.

## Changes

```typescript
// Before (repeated 3x)
onSelect={() => {
  ontoggletheme?.();
  open = false;
}}

// After
function handleSelect(action?: () => void) {
  return () => {
    action?.();
    open = false;
  };
}
onSelect={handleSelect(ontoggletheme)}
```

## Test plan

- [ ] Click Settings menu items - menu should close after selection
- [ ] Toggle theme - should work and close menu
- [ ] Toggle annotations checkbox - should work and close menu  
- [ ] Toggle banana checkbox - should work and close menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)