### PR TITLE
fix: use pointer capture for sidebar resize handle (Firefox fix)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -73,6 +73,7 @@
   import { debug } from "$lib/utils/debug";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
   import { Tooltip } from "bits-ui";
+  import { pointerCapture } from "$lib/utils/pointer-capture";
 
   // Build-time environment constant from vite.config.ts
   declare const __BUILD_ENV__: string;
@@ -952,7 +953,11 @@
               {/if}
             </Pane>
 
-            <PaneResizer class="resize-handle" />
+            <PaneResizer class="resize-handle">
+              {#snippet child({ props })}
+                <div use:pointerCapture {...props}></div>
+              {/snippet}
+            </PaneResizer>
           {/if}
 
           <Pane class="main-pane">

--- a/src/lib/utils/pointer-capture.ts
+++ b/src/lib/utils/pointer-capture.ts
@@ -1,0 +1,64 @@
+/**
+ * Pointer capture utility for cross-browser resize handle compatibility.
+ *
+ * Firefox has known issues where mouse events during drag operations can be
+ * interrupted or "stuck" when the pointer leaves and re-enters the element
+ * boundaries. This is due to Firefox's native drag-and-drop detection
+ * interfering with standard mouse events.
+ *
+ * Using setPointerCapture ensures the element continues receiving all pointer
+ * events for the duration of the drag operation, regardless of where the
+ * pointer moves on screen.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=43258
+ */
+import type { Action } from "svelte/action";
+import Debug from "debug";
+
+const debug = Debug("rackula:utils:pointer-capture");
+
+/**
+ * Svelte action that enables pointer capture on pointerdown for resize handles.
+ *
+ * This action listens for pointerdown events and captures the pointer to ensure
+ * all subsequent pointer events (pointermove, pointerup, etc.) are directed to
+ * this element until the pointer is released. This fixes resize handle
+ * "sticking" issues in Firefox.
+ *
+ * The pointer capture is automatically released when:
+ * - pointerup fires
+ * - pointercancel fires
+ * - The element is removed from the DOM
+ *
+ * @example
+ * ```svelte
+ * <div use:pointerCapture class="resize-handle">
+ * ```
+ */
+export const pointerCapture: Action<HTMLElement> = (node) => {
+  const handlePointerDown = (event: PointerEvent) => {
+    // Only capture primary pointer (left mouse button or first touch)
+    if (!event.isPrimary) return;
+
+    // Set pointer capture to ensure we receive all subsequent events
+    // This is the key fix for Firefox's drag event interference
+    try {
+      node.setPointerCapture(event.pointerId);
+      debug("captured pointer %d", event.pointerId);
+    } catch (error) {
+      // setPointerCapture may fail if pointer is already captured elsewhere
+      // Log for debugging but don't throw as this is a progressive enhancement
+      debug("failed to capture pointer %d: %O", event.pointerId, error);
+    }
+  };
+
+  // Listen for pointerdown to initiate capture
+  node.addEventListener("pointerdown", handlePointerDown);
+
+  return {
+    destroy() {
+      node.removeEventListener("pointerdown", handlePointerDown);
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- Fixes sidebar resize getting "stuck" and becoming unresponsive in Firefox
- Uses `setPointerCapture` API to ensure reliable pointer event delivery during drag operations
- Firefox has [known issues](https://bugzilla.mozilla.org/show_bug.cgi?id=43258) where mouse events can be interrupted when pointer crosses element boundaries

## Changes

- Added `src/lib/utils/pointer-capture.ts` - Svelte action that enables pointer capture on resize handles
- Updated `src/App.svelte` - Use paneforge's `child` snippet pattern to wrap resize handle with pointer capture action
- Includes debug logging via `debug` package for troubleshooting

## Test plan

- [ ] Manual test in Firefox: drag sidebar resize handle, verify smooth continuous resize
- [ ] Manual test in Safari: verify no regression in resize behavior  
- [ ] Manual test in Chrome: verify no regression in resize behavior
- [ ] Test rapid back-and-forth dragging across browser window
- [ ] Test releasing mouse button outside window while dragging

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)