### PR TITLE
feat: add rack width selection to NetBox import dialog (#667)

### DIFF
--- a/src/lib/utils/netbox-import.ts
+++ b/src/lib/utils/netbox-import.ts
@@ -3,7 +3,12 @@
  * Parses NetBox devicetype-library YAML format and converts to Rackula DeviceType
  */
 
-import type { DeviceType, DeviceCategory, Airflow } from "$lib/types";
+import type {
+  DeviceType,
+  DeviceCategory,
+  Airflow,
+  RackWidth,
+} from "$lib/types";
 import type { InterfaceTemplate } from "$lib/types";
 import { CATEGORY_COLOURS } from "$lib/types/constants";
 import { parseYaml } from "./yaml";
@@ -337,6 +342,7 @@ export function convertToDeviceType(
   options?: {
     category?: DeviceCategory;
     colour?: string;
+    rack_widths?: RackWidth[];
   },
 ): ImportResult {
   const warnings: string[] = [];
@@ -358,6 +364,11 @@ export function convertToDeviceType(
     colour,
     category,
   };
+
+  // Apply rack_widths if provided (NetBox doesn't have this field)
+  if (options?.rack_widths && options.rack_widths.length > 0) {
+    deviceType.rack_widths = options.rack_widths;
+  }
 
   // Optional fields
   if (netbox.part_number) {


### PR DESCRIPTION
## Summary

- Add rack width selector to NetBox import dialog, allowing users to specify rack width compatibility (10", 19", 23", or Universal) when importing custom devices from YAML
- Update `convertToDeviceType` function to accept `rack_widths` option
- Default selection is 19" (standard rack width)
- Universal option sets `[10, 19, 23]` for maximum compatibility

## Problem

Custom devices imported via NetBox YAML were getting `rack_widths: undefined`, making them default to 19"-only. Users importing 10" devices (like DeskPi mini-rack equipment) couldn't specify the correct rack width, so those devices wouldn't appear when working on 10" racks.

## Test plan

- [ ] Import a NetBox YAML device and verify rack width selector appears after parsing
- [ ] Select each option (10", 19", 23", Universal) and verify the imported device has correct `rack_widths` field
- [ ] Verify default selection is 19"
- [ ] Verify imported 10" device appears in device palette when working with 10" rack

Closes #667

🤖 Generated with [Claude Code](https://claude.ai/code)