### PR TITLE
feat: add setting to disable unsaved changes warning

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -669,7 +669,7 @@
 
   // Beforeunload handler for unsaved changes
   function handleBeforeUnload(event: BeforeUnloadEvent) {
-    if (layoutStore.isDirty) {
+    if (uiStore.warnOnUnsavedChanges && layoutStore.isDirty) {
       event.preventDefault();
       // Modern browsers ignore custom messages, but we set it for legacy support
       event.returnValue = "You have unsaved changes. Leave anyway?";
@@ -917,6 +917,7 @@
       displayMode={uiStore.displayMode}
       showAnnotations={uiStore.showAnnotations}
       showBanana={uiStore.showBanana}
+      warnOnUnsavedChanges={uiStore.warnOnUnsavedChanges}
       {partyMode}
       onnewrack={handleNewRack}
       onsave={handleSave}
@@ -929,6 +930,7 @@
       ontoggledisplaymode={handleToggleDisplayMode}
       ontoggleannotations={handleToggleAnnotations}
       ontogglebanana={() => uiStore.toggleBanana()}
+      ontogglewarnunsaved={() => uiStore.toggleWarnOnUnsavedChanges()}
       onhelp={handleHelp}
     />
 

--- a/src/lib/components/SettingsMenu.svelte
+++ b/src/lib/components/SettingsMenu.svelte
@@ -19,18 +19,22 @@
     theme?: "dark" | "light";
     showAnnotations?: boolean;
     showBanana?: boolean;
+    warnOnUnsavedChanges?: boolean;
     ontoggletheme?: () => void;
     ontoggleannotations?: () => void;
     ontogglebanana?: () => void;
+    ontogglewarnunsaved?: () => void;
   }
 
   let {
     theme = "dark",
     showAnnotations = false,
     showBanana = false,
+    warnOnUnsavedChanges = true,
     ontoggletheme,
     ontoggleannotations,
     ontogglebanana,
+    ontogglewarnunsaved,
   }: Props = $props();
 
   let open = $state(false);
@@ -101,6 +105,25 @@
             {/if}
           </span>
           <span class="menu-label">Banana for Scale</span>
+        {/snippet}
+      </DropdownMenu.CheckboxItem>
+
+      <DropdownMenu.Separator class="menu-separator" />
+
+      <DropdownMenu.CheckboxItem
+        class="menu-item"
+        checked={warnOnUnsavedChanges}
+        onCheckedChange={handleSelect(ontogglewarnunsaved)}
+      >
+        {#snippet children({ checked })}
+          <span class="menu-checkbox">
+            {#if checked}
+              <IconSquareFilled size={ICON_SIZE.sm} />
+            {:else}
+              <IconSquare size={ICON_SIZE.sm} />
+            {/if}
+          </span>
+          <span class="menu-label">Warn on Unsaved Changes</span>
         {/snippet}
       </DropdownMenu.CheckboxItem>
     </DropdownMenu.Content>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -30,6 +30,7 @@
     displayMode?: DisplayMode;
     showAnnotations?: boolean;
     showBanana?: boolean;
+    warnOnUnsavedChanges?: boolean;
     partyMode?: boolean;
     onnewrack?: () => void;
     onsave?: () => void;
@@ -41,6 +42,7 @@
     ontoggledisplaymode?: () => void;
     ontoggleannotations?: () => void;
     ontogglebanana?: () => void;
+    ontogglewarnunsaved?: () => void;
     onhelp?: () => void;
   }
 
@@ -50,6 +52,7 @@
     displayMode = "label",
     showAnnotations = false,
     showBanana = false,
+    warnOnUnsavedChanges = true,
     partyMode = false,
     onnewrack,
     onsave,
@@ -61,6 +64,7 @@
     ontoggledisplaymode,
     ontoggleannotations,
     ontogglebanana,
+    ontogglewarnunsaved,
     onhelp,
   }: Props = $props();
 
@@ -139,6 +143,11 @@
   function handleToggleBanana() {
     analytics.trackToolbarClick("banana");
     ontogglebanana?.();
+  }
+
+  function handleToggleWarnUnsaved() {
+    analytics.trackToolbarClick("warn-unsaved");
+    ontogglewarnunsaved?.();
   }
 </script>
 
@@ -250,9 +259,11 @@
       {theme}
       {showAnnotations}
       {showBanana}
+      {warnOnUnsavedChanges}
       ontoggletheme={handleToggleTheme}
       ontoggleannotations={handleToggleAnnotations}
       ontogglebanana={handleToggleBanana}
+      ontogglewarnunsaved={handleToggleWarnUnsaved}
     />
   </div>
 </header>


### PR DESCRIPTION
## Summary
- Add user preference to disable the browser's beforeunload confirmation dialog
- Setting persisted to localStorage (`Rackula_warn_unsaved`)
- Toggle available in Settings menu

## Changes
- `src/lib/stores/ui.svelte.ts` - Add `warnOnUnsavedChanges` state with localStorage persistence
- `src/lib/components/SettingsMenu.svelte` - Add checkbox toggle with separator
- `src/lib/components/Toolbar.svelte` - Pass-through props to SettingsMenu
- `src/App.svelte` - Check setting in `handleBeforeUnload`

## Test plan
- [x] Build passes
- [x] All 1698 tests pass
- [x] CodeRabbit local review passes
- [ ] Manual test: toggle setting off, make changes, close tab → no warning
- [ ] Manual test: toggle setting on, make changes, close tab → warning appears
- [ ] Setting persists after page reload

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)