### PR TITLE
fix: About/Help menu icons, emoji, and reopening issues (#722)

### DIFF
--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -37,15 +37,17 @@
   /**
    * Handle dialog open state changes.
    * Tracks analytics and calls onclose callback when dialog closes.
+   * Important: Set open state FIRST to ensure bits-ui state stays in sync
+   * before triggering parent callbacks that may cause re-renders.
    */
   function handleOpenChange(newOpen: boolean) {
+    open = newOpen;
     if (newOpen) {
       analytics.trackPanelOpen("help");
     } else {
       analytics.trackPanelClose("help");
       onclose?.();
     }
-    open = newOpen;
   }
 
   // Get browser user agent for troubleshooting
@@ -336,7 +338,7 @@
             </button>
           </section>
 
-          <p class="made-in">Made in Canada with love</p>
+          <p class="made-in">Made in Canada 🇨🇦 with ❤️</p>
         </div>
       </div>
     </Dialog.Content>

--- a/src/lib/components/icons/IconBug.svelte
+++ b/src/lib/components/icons/IconBug.svelte
@@ -1,25 +1,27 @@
 <!--
-  Bug Report icon using Iconoir via Iconify
-  Part of #608 icon standardization
-
-  Uses iconoir:warning-triangle for the "Report Bug" link. The warning
-  triangle (⚠️) is universally recognized for reporting issues/problems.
-
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
-
-  Note: :global() is required because @iconify/svelte generates the SVG
-  internally, so Svelte's scoped styles cannot target it directly.
+  Bug/Warning icon (Iconoir warning-triangle)
+  Converted to inline SVG for offline support
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:warning-triangle" class="icon-bug" aria-hidden="true" />
-
-<style>
-  :global(.icon-bug) {
-    width: var(--icon-size-md, 20px);
-    height: var(--icon-size-md, 20px);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-linecap="round"
+  stroke-width="1.5"
+  aria-hidden="true"
+>
+  <path
+    d="M20.043 21H3.957c-1.538 0-2.5-1.664-1.734-2.997l8.043-13.988c.77-1.337 2.699-1.337 3.468 0l8.043 13.988C22.543 19.336 21.58 21 20.043 21ZM12 9v4"
+  />
+  <path stroke-linejoin="round" d="m12 17.01l.01-.011" />
+</svg>

--- a/src/lib/components/icons/IconChat.svelte
+++ b/src/lib/components/icons/IconChat.svelte
@@ -1,22 +1,26 @@
 <!--
-  Chat/Discussion icon using Iconoir via Iconify
-  Part of #608 icon standardization
-
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
-
-  Note: :global() is required because @iconify/svelte generates the SVG
-  internally, so Svelte's scoped styles cannot target it directly.
+  Chat/Discussion icon (Iconoir message-text)
+  Converted to inline SVG for offline support
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:message-text" class="icon-chat" aria-hidden="true" />
-
-<style>
-  :global(.icon-chat) {
-    width: var(--icon-size-md, 20px);
-    height: var(--icon-size-md, 20px);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  aria-hidden="true"
+>
+  <path stroke-linecap="round" stroke-linejoin="round" d="M7 12h10M7 8h6" />
+  <path
+    d="M3 20.29V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H7.961a2 2 0 0 0-1.561.75l-2.331 2.914A.6.6 0 0 1 3 20.29Z"
+  />
+</svg>

--- a/src/lib/components/icons/IconGitHub.svelte
+++ b/src/lib/components/icons/IconGitHub.svelte
@@ -1,22 +1,28 @@
 <!--
-  GitHub icon using Iconoir via Iconify
-  Part of #608 icon standardization
-
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
-
-  Note: :global() is required because @iconify/svelte generates the SVG
-  internally, so Svelte's scoped styles cannot target it directly.
+  GitHub icon (Iconoir)
+  Converted to inline SVG for offline support
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:github" class="icon-github" aria-hidden="true" />
-
-<style>
-  :global(.icon-github) {
-    width: var(--icon-size-md, 20px);
-    height: var(--icon-size-md, 20px);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  stroke-width="1.5"
+  aria-hidden="true"
+>
+  <path
+    d="M16 22.027v-2.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7a5.44 5.44 0 0 0-1.5-3.75a5.07 5.07 0 0 0-.09-3.77s-1.18-.35-3.91 1.48a13.4 13.4 0 0 0-7 0c-2.73-1.83-3.91-1.48-3.91-1.48A5.07 5.07 0 0 0 5 5.797a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7a3.37 3.37 0 0 0-.94 2.58v2.87"
+  />
+  <path d="M9 20.027c-3 .973-5.5 0-7-3" />
+</svg>


### PR DESCRIPTION
## Summary
- Convert IconGitHub, IconBug, IconChat from @iconify/svelte (CDN) to inline SVG for reliable offline rendering
- Add Canadian flag 🇨🇦 and heart ❤️ emoji to "Made in Canada" footer
- Fix dialog state sync issue that prevented menu from reopening after first use

## Changes
- `src/lib/components/icons/IconGitHub.svelte` - Inline SVG
- `src/lib/components/icons/IconBug.svelte` - Inline SVG
- `src/lib/components/icons/IconChat.svelte` - Inline SVG
- `src/lib/components/HelpPanel.svelte` - Emoji + handleOpenChange fix

## Root Cause Analysis
**Icons**: Were using `@iconify/svelte` which fetches from CDN at runtime - fails when offline or CDN unavailable. Converted to inline SVG like other Bold icons.

**Dialog reopening**: The `handleOpenChange` callback was calling `onclose?.()` before setting `open = newOpen`. This triggered parent re-renders before local state was updated, causing bits-ui Dialog to get out of sync.

## Test plan
- [x] Lint passes
- [x] Build passes  
- [x] All 1698 unit tests pass
- [x] CodeRabbit CLI review passes
- [ ] Manual: Icons render in About dialog
- [ ] Manual: Emoji visible in footer
- [ ] Manual: Can open/close dialog multiple times

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)