### PR TITLE
feat: implement per-bay annotations for bayed racks (#716)

### DIFF
--- a/src/lib/components/AnnotationColumn.svelte
+++ b/src/lib/components/AnnotationColumn.svelte
@@ -22,9 +22,17 @@
     annotationField: AnnotationField;
     /** Width of the annotation column in pixels */
     width?: number;
+    /** Filter to show only front or rear mounted devices */
+    faceFilter?: "front" | "rear";
   }
 
-  let { rack, deviceLibrary, annotationField, width = 100 }: Props = $props();
+  let {
+    rack,
+    deviceLibrary,
+    annotationField,
+    width = 100,
+    faceFilter,
+  }: Props = $props();
 
   // Padding from right edge for text alignment
   const TEXT_PADDING = 8;
@@ -78,9 +86,16 @@
     RACK_PADDING_HIDDEN + RAIL_WIDTH * 2 + rack.height * U_HEIGHT_PX,
   );
 
-  // Get annotations for all devices
+  // Filter devices by face if faceFilter is provided
+  const filteredDevices = $derived(
+    faceFilter
+      ? rack.devices.filter((d) => d.face === faceFilter)
+      : rack.devices,
+  );
+
+  // Get annotations for filtered devices
   const annotations = $derived(
-    rack.devices.map((device) => {
+    filteredDevices.map((device) => {
       const deviceType = deviceTypeMap.get(device.device_type);
       const uHeight = deviceType?.u_height ?? 1;
       const value = getAnnotationValue(device, deviceType, annotationField);

--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -16,6 +16,7 @@
   import Rack from "./Rack.svelte";
   import RackContextMenu from "./RackContextMenu.svelte";
   import ULabels from "./ULabels.svelte";
+  import AnnotationColumn from "./AnnotationColumn.svelte";
   import { useLongPress } from "$lib/utils/gestures";
 
   interface Props {
@@ -93,8 +94,8 @@
     displayMode = "label",
     showLabelsOnImages = false,
     partyMode = false,
-    showAnnotations: _showAnnotations = false, // Reserved for future annotation support
-    annotationField: _annotationField = "name", // Reserved for future annotation support
+    showAnnotations = false,
+    annotationField = "name",
     enableLongPress = false,
     onselect,
     ondeviceselect,
@@ -258,6 +259,17 @@
     {#each racks as rack, bayIndex (rack.id)}
       {@const isActive = rack.id === activeRackId}
       {@const isSelected = rack.id === selectedRackId}
+      <!-- Annotation column LEFT of front bay -->
+      {#if showAnnotations}
+        <div class="annotation-wrapper">
+          <AnnotationColumn
+            {rack}
+            {deviceLibrary}
+            {annotationField}
+            faceFilter="front"
+          />
+        </div>
+      {/if}
       <RackContextMenu
         onadddevice={() => onadddevice?.(rack.id)}
         onedit={() => onedit?.(rack.id)}
@@ -346,6 +358,17 @@
           />
         </div>
       </RackContextMenu>
+      <!-- Annotation column RIGHT of rear bay (mirrored) -->
+      {#if showAnnotations}
+        <div class="annotation-wrapper">
+          <AnnotationColumn
+            {rack}
+            {deviceLibrary}
+            {annotationField}
+            faceFilter="rear"
+          />
+        </div>
+      {/if}
     {/each}
     <!-- U-labels column (right side of rear row) -->
     <div class="u-labels-column">
@@ -460,6 +483,16 @@
     align-items: center;
     justify-content: flex-start;
     /* Match bay-label height so U-labels align with rack content */
+    padding-top: var(--bay-label-block-height);
+  }
+
+  /* Annotation column wrapper - align with rack content below bay label */
+  .annotation-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    /* Match bay-label height so annotations align with rack content */
     padding-top: var(--bay-label-block-height);
   }
 </style>


### PR DESCRIPTION
## Summary

- Add `faceFilter` prop to AnnotationColumn to filter devices by mounting face (front/rear)
- Wire up `showAnnotations` and `annotationField` props in BayedRackView (previously reserved but unused)
- Render AnnotationColumn LEFT of each front bay with `faceFilter="front"`
- Render AnnotationColumn RIGHT of each rear bay with `faceFilter="rear"` (mirrored layout)
- Add `annotation-wrapper` CSS class for proper vertical alignment with rack content

## Layout Structure

```
FRONT: [U-labels] [Ann1][Bay1] [Ann2][Bay2] ...
REAR:  ... [Bay2][Ann2] [Bay1][Ann1] [U-labels]
```

## Test Plan

- [ ] Enable annotations on a bayed rack and verify per-bay columns appear
- [ ] Verify front row shows only front-mounted device annotations
- [ ] Verify rear row shows only rear-mounted device annotations
- [ ] Verify annotations align vertically with device U positions
- [ ] Verify mirrored layout (annotations on right side of rear row bays)

Closes #716
Also implements #715 (faceFilter prop for AnnotationColumn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)