### PR TITLE
feat: add shelf containers and mini devices for non-rack-mount equipment (#143)

### DIFF
--- a/src/lib/components/ContainerSlots.svelte
+++ b/src/lib/components/ContainerSlots.svelte
@@ -41,6 +41,9 @@
   // Get slots from container type, defaulting to empty array
   const slots = $derived(containerType.slots ?? []);
 
+  // Detect if this is a shelf container for visual styling
+  const isShelf = $derived(containerType.category === "shelf");
+
   // Pre-compute cumulative x offsets for all slots (O(n) instead of O(n²))
   // Each slot lookup becomes O(1) since we just read from this array by index
   const cumulativeXOffsets = $derived.by(() => {
@@ -123,7 +126,7 @@
   }
 </script>
 
-<g class="container-slots">
+<g class="container-slots" class:shelf-style={isShelf}>
   {#each slots as slot, index (slot.id)}
     {@const geometry = getSlotGeometry(slot, index)}
     {@const slotClass = getSlotClass(slot.id)}
@@ -196,6 +199,34 @@
     stroke-width: 2;
     stroke-dasharray: 4 2;
     fill: var(--colour-dnd-invalid-bg);
+  }
+
+  /* Shelf-specific styling - lighter, more subtle */
+  .shelf-style .container-slot {
+    stroke: var(--neutral-400);
+    stroke-width: 0.5;
+    stroke-dasharray: 2 4;
+    opacity: 0.7;
+  }
+
+  .shelf-style .container-slot:hover {
+    stroke: var(--colour-selection);
+    stroke-dasharray: none;
+    opacity: 1;
+  }
+
+  .shelf-style .container-slot:focus {
+    stroke: var(--colour-focus-ring);
+    stroke-width: 2;
+    stroke-dasharray: none;
+    opacity: 1;
+  }
+
+  .shelf-style .container-slot.selected {
+    stroke: var(--colour-selection);
+    stroke-width: 1.5;
+    stroke-dasharray: none;
+    opacity: 1;
   }
 
   /* Respect reduced motion preference */

--- a/src/lib/data/starterLibrary.ts
+++ b/src/lib/data/starterLibrary.ts
@@ -2,13 +2,15 @@
  * Starter Device Type Library
  * Generic rack devices for quick prototyping and universal fallbacks
  *
- * Total devices: 51 generic devices (no manufacturer)
+ * Total devices: 62 generic devices
  * - 43 full-width devices
  * - 8 half-width devices (slot_width: 1)
+ * - 4 shelf containers with slots
+ * - 7 mini devices for shelf placement
  * All branded devices have been moved to brandPacks/
  */
 
-import type { DeviceType, DeviceCategory } from "$lib/types";
+import type { DeviceType, DeviceCategory, Slot } from "$lib/types";
 import { CATEGORY_COLOURS } from "$lib/types/constants";
 
 interface StarterDeviceSpec {
@@ -19,6 +21,8 @@ interface StarterDeviceSpec {
   is_full_depth?: boolean;
   /** Width in slots: 1 = half-width, 2 = full-width. Default: 2 */
   slot_width?: 1 | 2;
+  /** Container slots for shelf/container devices */
+  slots?: Slot[];
 }
 
 const STARTER_DEVICES: StarterDeviceSpec[] = [
@@ -176,7 +180,7 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
     is_full_depth: false,
   },
 
-  // Shelves (4)
+  // Shelves - Static (4)
   {
     slug: "1u-cantilever-shelf",
     model: "Cantilever Shelf",
@@ -191,6 +195,169 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
     model: "Vented Shelf",
     u_height: 1,
     category: "shelf",
+  },
+
+  // Shelf Containers - with slots for mini devices (4)
+  {
+    slug: "shelf-1u-2slot",
+    model: "Shelf (2 Slot)",
+    u_height: 1,
+    category: "shelf",
+    slots: [
+      {
+        id: "left",
+        name: "Left",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.5,
+        height_units: 1,
+      },
+      {
+        id: "right",
+        name: "Right",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.5,
+        height_units: 1,
+      },
+    ],
+  },
+  {
+    slug: "shelf-1u-3slot",
+    model: "Shelf (3 Slot)",
+    u_height: 1,
+    category: "shelf",
+    slots: [
+      {
+        id: "left",
+        name: "Left",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.33,
+        height_units: 1,
+      },
+      {
+        id: "center",
+        name: "Center",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.34,
+        height_units: 1,
+      },
+      {
+        id: "right",
+        name: "Right",
+        position: { row: 0, col: 2 },
+        width_fraction: 0.33,
+        height_units: 1,
+      },
+    ],
+  },
+  {
+    slug: "shelf-2u-2slot",
+    model: "Shelf (2 Slot)",
+    u_height: 2,
+    category: "shelf",
+    slots: [
+      {
+        id: "left",
+        name: "Left",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.5,
+        height_units: 2,
+      },
+      {
+        id: "right",
+        name: "Right",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.5,
+        height_units: 2,
+      },
+    ],
+  },
+  {
+    slug: "shelf-2u-3slot",
+    model: "Shelf (3 Slot)",
+    u_height: 2,
+    category: "shelf",
+    slots: [
+      {
+        id: "left",
+        name: "Left",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.33,
+        height_units: 2,
+      },
+      {
+        id: "center",
+        name: "Center",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.34,
+        height_units: 2,
+      },
+      {
+        id: "right",
+        name: "Right",
+        position: { row: 0, col: 2 },
+        width_fraction: 0.33,
+        height_units: 2,
+      },
+    ],
+  },
+
+  // Mini Devices - for placement on shelf slots (7)
+  // Note: Brand names in model field, no manufacturer (keeps starter library generic)
+  {
+    slug: "generic-mini-pc",
+    model: "Mini PC",
+    u_height: 1,
+    category: "server",
+    slot_width: 1,
+    is_full_depth: false,
+  },
+  {
+    slug: "intel-nuc",
+    model: "Intel NUC",
+    u_height: 1,
+    category: "server",
+    slot_width: 1,
+    is_full_depth: false,
+  },
+  {
+    slug: "beelink-mini-s12-pro",
+    model: "Beelink Mini S12 Pro",
+    u_height: 1,
+    category: "server",
+    slot_width: 1,
+    is_full_depth: false,
+  },
+  {
+    slug: "raspberry-pi-5",
+    model: "Raspberry Pi 5",
+    u_height: 0.5,
+    category: "server",
+    slot_width: 1,
+    is_full_depth: false,
+  },
+  {
+    slug: "raspberry-pi-4",
+    model: "Raspberry Pi 4",
+    u_height: 0.5,
+    category: "server",
+    slot_width: 1,
+    is_full_depth: false,
+  },
+  {
+    slug: "zimaboard",
+    model: "Zimaboard",
+    u_height: 0.5,
+    category: "server",
+    slot_width: 1,
+    is_full_depth: false,
+  },
+  {
+    slug: "apple-mac-mini",
+    model: "Mac Mini",
+    u_height: 1,
+    category: "server",
+    slot_width: 1,
+    is_full_depth: false,
   },
 
   // Blanks (5)
@@ -337,6 +504,7 @@ export function getStarterLibrary(): DeviceType[] {
       slot_width: spec.slot_width ?? 2,
       colour: CATEGORY_COLOURS[spec.category],
       category: spec.category,
+      slots: spec.slots,
     }));
   }
   return cachedStarterLibrary;

--- a/src/lib/stores/layout-helpers.ts
+++ b/src/lib/stores/layout-helpers.ts
@@ -12,6 +12,7 @@ import type {
   Airflow,
   WeightUnit,
   InterfaceTemplate,
+  Slot,
 } from "$lib/types";
 import { generateDeviceSlug } from "$lib/utils/slug";
 import { generateId } from "$lib/utils/device";
@@ -34,6 +35,8 @@ export interface CreateDeviceTypeInput {
   notes?: string;
   tags?: string[];
   interfaces?: InterfaceTemplate[];
+  /** Container slots for shelf/enclosure devices */
+  slots?: Slot[];
 }
 
 /**
@@ -90,6 +93,9 @@ export function createDeviceType(data: CreateDeviceTypeInput): DeviceType {
   }
   if (data.interfaces && data.interfaces.length > 0) {
     deviceType.interfaces = data.interfaces;
+  }
+  if (data.slots && data.slots.length > 0) {
+    deviceType.slots = data.slots;
   }
 
   return deviceType;

--- a/src/lib/utils/collision.ts
+++ b/src/lib/utils/collision.ts
@@ -15,6 +15,7 @@ import type {
   PlacedDevice,
   Rack,
   SlotPosition,
+  Slot,
 } from "$lib/types";
 import { UNITS_PER_U, heightToInternalUnits } from "$lib/utils/position";
 
@@ -378,6 +379,41 @@ export function snapToNearestValidPosition(
 }
 
 /**
+ * Check if a device type fits within a slot's dimensions.
+ * Validates that the child device's width and height fit within the slot.
+ *
+ * slot_width mapping:
+ * - 1 = fits in ~1/3 width slot (width_fraction ~0.33)
+ * - 2 = fits in ~1/2 width slot (width_fraction ~0.5)
+ * - Default (2) = full width device
+ *
+ * @param childType - The device type to place
+ * @param slot - The target slot
+ * @returns true if device fits, false otherwise
+ */
+export function canPlaceInSlot(childType: DeviceType, slot: Slot): boolean {
+  // Convert slot_width to fraction (1=0.33, 2=0.5)
+  // Default slot_width is 2 (full-width), which requires at least 0.5 width_fraction
+  const slotWidth = childType.slot_width ?? 2;
+  const requiredFraction = slotWidth === 1 ? 0.33 : 0.5;
+
+  // Check width fits
+  const availableFraction = slot.width_fraction ?? 1.0;
+  if (requiredFraction > availableFraction + 0.01) {
+    // +0.01 for floating point tolerance
+    return false;
+  }
+
+  // Check height fits (child u_height <= slot height_units)
+  const slotHeight = slot.height_units ?? 1;
+  if (childType.u_height > slotHeight) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Check if a device can be placed inside a container at a specific slot and position
  *
  * Container children:
@@ -414,6 +450,17 @@ export function canPlaceInContainer(
   // Child device must fit within container height
   const topPosition = targetPosition + childType.u_height - 1;
   if (topPosition >= containerType.u_height) {
+    return false;
+  }
+
+  // Validate target slot exists and check dimension fit
+  const targetSlot = containerType.slots?.find((s) => s.id === targetSlotId);
+  if (!targetSlot) {
+    return false;
+  }
+
+  // Check if child device dimensions fit within the slot
+  if (!canPlaceInSlot(childType, targetSlot)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Add 4 shelf container presets with configurable slots (1U/2U × 2-slot/3-slot)
- Add 7 mini device types for shelf placement (Generic Mini PC, Intel NUC, Beelink Mini S12 Pro, Raspberry Pi 4/5, Zimaboard, Mac Mini)
- Add shelf-specific CSS styling with lighter slot borders than enclosed bays
- Add dimension validation to check device fits in slot
- Fix slots not being preserved when creating device types via addDeviceType

## Files Changed

- `src/lib/data/starterLibrary.ts`: Add shelf containers and mini device types
- `src/lib/components/ContainerSlots.svelte`: Add shelf-style CSS variant
- `src/lib/utils/collision.ts`: Add `canPlaceInSlot()` dimension validation
- `src/lib/stores/layout-helpers.ts`: Add slots support to CreateDeviceTypeInput

## Test plan

- [x] All 1698 tests pass
- [x] Build completes successfully
- [x] Lint passes
- [ ] Manual: Place shelf container in rack, slots should be visible
- [ ] Manual: Place mini device on shelf slot
- [ ] Manual: Verify dimension validation prevents oversized devices

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)