### PR TITLE
chore: replace hardcoded spacing values with design tokens (#655)

### DIFF
--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -717,7 +717,7 @@
 
   .category-header {
     margin: 0;
-    padding: var(--space-2) var(--space-3) 4px;
+    padding: var(--space-2) var(--space-3) var(--space-1);
     font-size: var(--font-size-xs);
     font-weight: 600;
     text-transform: uppercase;
@@ -751,7 +751,7 @@
   }
 
   .empty-hint {
-    margin: 4px 0 0;
+    margin: var(--space-1) 0 0;
     font-size: var(--font-size-sm);
     color: var(--colour-text-muted);
   }
@@ -772,7 +772,7 @@
     justify-content: center;
     gap: var(--space-1-5);
     flex: 1;
-    padding: 10px var(--space-3);
+    padding: var(--space-3) var(--space-3);
     font-size: var(--font-size-sm);
     font-weight: 500;
     color: var(--colour-text);

--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -1187,11 +1187,11 @@
   .height-presets {
     display: flex;
     gap: var(--space-2);
-    margin-top: 4px;
+    margin-top: var(--space-1);
   }
 
   .preset-btn {
-    padding: 4px var(--space-2);
+    padding: var(--space-1) var(--space-2);
     background: var(--button-bg);
     border: 1px solid var(--colour-border);
     border-radius: var(--radius-sm);
@@ -1356,7 +1356,7 @@
 
   .btn-danger {
     width: 100%;
-    padding: 10px var(--space-4);
+    padding: var(--space-3) var(--space-4);
     background: var(--colour-error);
     border: none;
     border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary

- Replace all hardcoded `4px` values with `var(--space-1)` in EditPanel.svelte and DevicePalette.svelte
- Replace all `10px` values with `var(--space-3)` (12px) for button padding - rounded up from 10px for better touch targets
- Ensures consistent use of design tokens from tokens.css

## Decision

For 10px values, chose to round up to `--space-3` (12px) rather than down to `--space-2` (8px) because:
1. These are button padding values where larger is safer for touch targets
2. 12px provides slightly more generous visual weight for action buttons

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] No remaining hardcoded 4px or 10px spacing values in affected files
- [ ] Visual regression check (buttons and height presets should look similar)

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)