### PR TITLE
feat: add 48U as standard rack height option (#733)

### DIFF
--- a/src/lib/types/constants.ts
+++ b/src/lib/types/constants.ts
@@ -53,7 +53,7 @@ export const ALL_CATEGORIES: readonly DeviceCategory[] = [
 /**
  * Common rack heights for quick selection
  */
-export const COMMON_RACK_HEIGHTS: readonly number[] = [12, 18, 24, 42] as const;
+export const COMMON_RACK_HEIGHTS: readonly number[] = [12, 18, 24, 42, 48] as const;
 
 /**
  * Rack height constraints


### PR DESCRIPTION
## Summary

- Adds 48U to the standard rack height quick-select options

## References

- Eaton 48U rack catalog: https://tripplite.eaton.com/products/server-racks~12
- Community request: https://github.com/RackulaLives/Rackula/discussions/443#discussioncomment-15524676

## Files Changed

- `src/lib/types/constants.ts`: Added 48 to `COMMON_RACK_HEIGHTS` array

## Test Plan

- [x] Lint passes
- [x] Build succeeds
- [ ] 48U appears as selectable option in rack creation wizard
- [ ] 48U appears as selectable option in rack edit form

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)