### PR TITLE
chore: fix type cast inconsistency in NewRackWizard width config (#739)

### DIFF
--- a/src/lib/components/wizard/NewRackWizard.svelte
+++ b/src/lib/components/wizard/NewRackWizard.svelte
@@ -102,7 +102,7 @@
   let currentStep = $state(1);
   let config = $state<WizardConfig>({
     name: "",
-    width: STANDARD_RACK_WIDTH as 10 | 19 | 23,
+    width: STANDARD_RACK_WIDTH as WizardConfig["width"],
     layoutType: "column",
     height: 42,
     bayCount: 2,
@@ -180,7 +180,7 @@
       currentStep = 1;
       config = {
         name: "Racky McRackface",
-        width: STANDARD_RACK_WIDTH as 10 | 19 | 23,
+        width: STANDARD_RACK_WIDTH as WizardConfig["width"],
         layoutType: "column",
         height: 42,
         bayCount: 2,


### PR DESCRIPTION
## Summary

- Fix hardcoded type cast `as 10 | 19 | 23` that excludes the 21" width option
- Use `WizardConfig["width"]` to reference the interface definition directly

## Files Changed

- `src/lib/components/wizard/NewRackWizard.svelte`: Updated type casts at lines 105 and 183

## Test plan

- [x] TypeScript compiles without errors
- [x] Build passes
- [x] Lint passes

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)