### PR TITLE
fix: Device placement broken - convert internal position units to human U (#750)

### DIFF
--- a/src/lib/components/AnnotationColumn.svelte
+++ b/src/lib/components/AnnotationColumn.svelte
@@ -15,6 +15,7 @@
     RAIL_WIDTH,
     RACK_PADDING_HIDDEN,
   } from "$lib/constants/layout";
+  import { toHumanUnits } from "$lib/utils/position";
 
   interface Props {
     rack: RackType;
@@ -70,12 +71,15 @@
   }
 
   // Calculate Y position for a device annotation (vertically centered)
-  function getAnnotationY(position: number, uHeight: number): number {
-    // SVG Y = (rackHeight - position - u_height + 1) * U_HEIGHT + offset
+  // Position is in internal units (1/6U), must convert to human U for calculation
+  function getAnnotationY(positionInternal: number, uHeight: number): number {
+    // Convert internal units to human U
+    const positionU = toHumanUnits(positionInternal);
+    // SVG Y = (rackHeight - positionU - u_height + 1) * U_HEIGHT + offset
     // We add RACK_PADDING_HIDDEN (since dual-view hides rack name) + RAIL_WIDTH (top bar)
     const topOffset = RACK_PADDING_HIDDEN + RAIL_WIDTH;
     const deviceTopY =
-      (rack.height - position - uHeight + 1) * U_HEIGHT_PX + topOffset;
+      (rack.height - positionU - uHeight + 1) * U_HEIGHT_PX + topOffset;
     const deviceHeight = uHeight * U_HEIGHT_PX;
     // Return center Y position
     return deviceTopY + deviceHeight / 2;

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -19,6 +19,7 @@
   import { getPlacementStore } from "$lib/stores/placement.svelte";
   // Note: getViewportStore removed - was only used for PlacementIndicator condition
   import { hapticSuccess } from "$lib/utils/haptics";
+  import { toHumanUnits } from "$lib/utils/position";
   import RackDualView from "./RackDualView.svelte";
   import BayedRackView from "./BayedRackView.svelte";
   import WelcomeScreen from "./WelcomeScreen.svelte";
@@ -367,13 +368,14 @@
     const activeRack = layoutStore.activeRack;
     if (!activeRack || activeRack.devices.length === 0) return "";
     const deviceNames = [...activeRack.devices]
-      .sort((a, b) => b.position - a.position) // Top to bottom
+      .sort((a, b) => b.position - a.position) // Top to bottom (internal units preserve order)
       .map((d) => {
         const deviceType = layoutStore.device_types.find(
           (dt) => dt.slug === d.device_type,
         );
         const name = d.label || deviceType?.model || d.device_type;
-        return `U${d.position}: ${name}`;
+        // Convert internal units to human U for display
+        return `U${toHumanUnits(d.position)}: ${name}`;
       });
     return `Active rack devices from top to bottom: ${deviceNames.join(", ")}`;
   });

--- a/src/lib/components/DeviceDetails.svelte
+++ b/src/lib/components/DeviceDetails.svelte
@@ -8,6 +8,7 @@
   import CategoryIcon from "./CategoryIcon.svelte";
   import { IconChevronUp, IconChevronDown, IconTrash } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
+  import { toHumanUnits } from "$lib/utils/position";
 
   interface Props {
     device: PlacedDevice;
@@ -48,11 +49,11 @@
 
   // Format position display (e.g., "U12-U13, Front")
   const positionDisplay = $derived.by(() => {
-    const topU = device.position + deviceType.u_height - 1;
+    // Convert from internal units to human U for display
+    const positionU = toHumanUnits(device.position);
+    const topU = positionU + deviceType.u_height - 1;
     const positionStr =
-      deviceType.u_height === 1
-        ? `U${device.position}`
-        : `U${device.position}-U${topU}`;
+      deviceType.u_height === 1 ? `U${positionU}` : `U${positionU}-U${topU}`;
     const faceStr =
       device.face === "both"
         ? "Both Faces"

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -37,6 +37,7 @@
     DEVICE_LABEL_ICON_SPACE_LEFT,
     DEVICE_LABEL_ICON_SPACE_RIGHT,
   } from "$lib/utils/text-sizing";
+  import { toHumanUnits } from "$lib/utils/position";
 
   interface Props {
     device: DeviceType;
@@ -180,10 +181,14 @@
   // Real equipment extends past the rails; this creates realistic front-mounting appearance
   const IMAGE_OVERFLOW = 4;
 
+  // Convert position from internal units (1/6U) to human U units for rendering
+  // PlacedDevice.position is stored in internal units (e.g., 6 = U1, 252 = U42)
+  const positionHuman = $derived(toHumanUnits(position));
+
   // Position calculation (SVG y-coordinate, origin at top)
-  // y = (rackHeight - position - device.u_height + 1) * uHeight
+  // y = (rackHeight - positionHuman - device.u_height + 1) * uHeight
   const yPosition = $derived(
-    (rackHeight - position - device.u_height + 1) * uHeight,
+    (rackHeight - positionHuman - device.u_height + 1) * uHeight,
   );
   const deviceHeight = $derived(device.u_height * uHeight);
   // Full interior width (between rails)
@@ -272,7 +277,7 @@
     }
 
     // Rack-level device: standard announcement
-    return `${base} at U${position}${selected ? ", selected" : ""}`;
+    return `${base} at U${positionHuman}${selected ? ", selected" : ""}`;
   });
 
   // Handle keyboard activation (Enter/Space to select, Tab to enter container)

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -16,6 +16,7 @@ import {
   DUAL_VIEW_GAP,
   DUAL_VIEW_EXTRA_HEIGHT,
 } from "$lib/constants/layout";
+import { toHumanUnits } from "$lib/utils/position";
 
 // Panzoom constants
 export const ZOOM_MIN = 0.25; // 25% - allows fitting 6+ large racks
@@ -289,9 +290,11 @@ function zoomToDevice(
 
   // Calculate device position in SVG coordinates
   // Device Y position: from top of SVG viewBox
+  // Convert device.position from internal units to human U
   const rackHeight = rack.height;
+  const positionU = toHumanUnits(device.position);
   const deviceYInRack =
-    (rackHeight - device.position - deviceType.u_height + 1) * U_HEIGHT_PX;
+    (rackHeight - positionU - deviceType.u_height + 1) * U_HEIGHT_PX;
   const deviceHeight = deviceType.u_height * U_HEIGHT_PX;
 
   // Device absolute Y: includes rack padding, top rail, and dual-view extra height

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -25,6 +25,7 @@ import {
   RAIL_WIDTH,
   RACK_PADDING_HIDDEN,
 } from "$lib/constants/layout";
+import { toHumanUnits } from "$lib/utils/position";
 
 // Note: jsPDF is imported dynamically in exportAsPDF() to avoid loading
 // the large jsPDF + html2canvas bundle (~200KB) on app startup.
@@ -734,8 +735,10 @@ export function generateExportSVG(
       const deviceDisplayName = device.model ?? device.slug;
 
       // Device Y position matches Rack.svelte: includes RACK_PADDING + RAIL_WIDTH offset
+      // Convert position from internal units to human U
+      const positionU = toHumanUnits(placedDevice.position);
       const deviceY =
-        (rack.height - placedDevice.position - device.u_height + 1) * U_HEIGHT +
+        (rack.height - positionU - device.u_height + 1) * U_HEIGHT +
         RACK_PADDING +
         RAIL_WIDTH;
       const deviceHeight = device.u_height * U_HEIGHT - 2;

--- a/src/tests/DeviceDetails.test.ts
+++ b/src/tests/DeviceDetails.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/svelte";
 import DeviceDetails from "$lib/components/DeviceDetails.svelte";
 import type { DeviceType, PlacedDevice } from "$lib/types";
+import { toInternalUnits } from "$lib/utils/position";
 
 describe("DeviceDetails", () => {
   // Helper to create test device type
@@ -24,14 +25,20 @@ describe("DeviceDetails", () => {
   }
 
   // Helper to create test placed device
+  // Position is expected in human U and converted to internal units
   function createTestPlacedDevice(
     overrides: Partial<PlacedDevice> = {},
   ): PlacedDevice {
+    const humanPosition = overrides.position ?? 5;
     return {
       device_type: "test-server",
-      position: 5,
+      position: toInternalUnits(humanPosition),
       face: "front",
       ...overrides,
+      // Ensure position override is converted
+      ...(overrides.position !== undefined
+        ? { position: toInternalUnits(overrides.position) }
+        : {}),
     };
   }
 


### PR DESCRIPTION
## Summary

- Device positions were stored in internal units (1/6U) but used directly in rendering calculations
- This caused devices to appear at incorrect vertical positions (much higher than intended)
- Root cause: Commit 61bec974 introduced internal position units but didn't update all rendering code

## Files Changed

**Component Fixes:**
- `RackDevice.svelte`: yPosition calculation and accessibility label
- `Rack.svelte`: containerPosition conversion, context menu move handlers, canMove checks
- `EditPanel.svelte`: displayPosition, containerPosition, moveDevice/canMove functions
- `DeviceDetails.svelte`: position display string
- `Canvas.svelte`: accessibility device list description
- `AnnotationColumn.svelte`: annotation Y position calculation

**Store/Utility Fixes:**
- `canvas.svelte.ts`: zoomToDevice calculation
- `export.ts`: SVG export device Y position

**Test Fix:**
- `DeviceDetails.test.ts`: Update test helper to convert positions to internal units

## Test Plan

- [x] Lint passes
- [x] All 68 test files pass (1708 tests)
- [x] Build succeeds
- [ ] Manual testing: Drag device to rack, verify correct vertical placement
- [ ] Manual testing: Move device via context menu, verify correct positioning
- [ ] Manual testing: Export to SVG, verify device positions

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)