### PR TITLE
chore: remove redundant width step from bayed rack wizard (#755)

### DIFF
--- a/src/lib/components/RackEditSheet.svelte
+++ b/src/lib/components/RackEditSheet.svelte
@@ -192,6 +192,14 @@
       </div>
     </div>
 
+    <!-- Width (read-only for bayed racks) -->
+    {#if isBayedRack}
+      <div class="form-group">
+        <span class="form-label">Width</span>
+        <div class="read-only-value">19" (Standard)</div>
+      </div>
+    {/if}
+
     <!-- Bay Count (only for bayed racks) -->
     {#if isBayedRack}
       <div class="form-group">
@@ -366,6 +374,18 @@
 
   .helper-text.error {
     color: var(--colour-error);
+  }
+
+  .read-only-value {
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--font-size-base);
+    color: var(--colour-text-secondary);
+    background: var(--colour-surface-secondary);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    min-height: var(--touch-target-min);
+    display: flex;
+    align-items: center;
   }
 
   .height-presets {


### PR DESCRIPTION
## Summary

- Remove the redundant width step from the bayed rack creation wizard
- Bayed racks now automatically use 19" width without requiring user confirmation
- Add read-only width display to bayed rack edit UI (RackEditSheet)

## Changes

- **NewRackWizard.svelte**: 
  - Bayed rack flow reduced from 3 steps to 2 steps
  - Step 1: Name and layout type selection (unchanged)
  - Step 2: Bay count and height (previously step 3)
  - Width auto-set to 19" via existing effect
  - Removed unused `.width-locked` CSS

- **RackEditSheet.svelte**: 
  - Added read-only width display for bayed racks showing "19" (Standard)"

## Test plan

- [ ] Create a bayed rack - verify wizard has only 2 steps
- [ ] Verify bayed rack automatically gets 19" width
- [ ] Edit a bayed rack - verify width is shown as read-only
- [ ] Create a column rack - verify width selection still works (unchanged)

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)