### PR TITLE
fix: align canProceed validation with validateStep for bayed racks (#759)

### DIFF
--- a/src/lib/components/wizard/NewRackWizard.svelte
+++ b/src/lib/components/wizard/NewRackWizard.svelte
@@ -157,6 +157,9 @@
         const height = config.isCustomHeight
           ? config.customHeight
           : config.height;
+        if (config.layoutType === "bayed") {
+          return height >= BAYED_MIN_HEIGHT && height <= BAYED_MAX_HEIGHT;
+        }
         return height >= MIN_RACK_HEIGHT && height <= MAX_RACK_HEIGHT;
       }
       default:


### PR DESCRIPTION
## Summary

- Fixes validation inconsistency where `canProceed` used generic height limits (1-52U) for all layouts, while `validateStep` correctly enforced bayed rack limits (10-24U)
- The "Create" button can no longer be enabled for invalid bayed rack heights

## Files Changed

- `src/lib/components/wizard/NewRackWizard.svelte`: Added conditional check in `canProceed` case 2 to use `BAYED_MIN_HEIGHT`/`BAYED_MAX_HEIGHT` for bayed racks

## Test Plan

- [x] Lint passes
- [x] All 1708 tests pass
- [x] Build succeeds
- [x] CodeRabbit CLI review passes

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)