### PR TITLE
feat: change Shift+Arrow to 1/3U movement (#635)

### DIFF
--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -904,7 +904,7 @@
             </div>
           </div>
         </div>
-        <p class="helper-text position-hint">Use ↑↓ keys (Shift for 0.5U)</p>
+        <p class="helper-text position-hint">Use ↑↓ keys (Shift for ⅓U)</p>
         <!-- Colour row - clickable to open picker -->
         <button
           type="button"

--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -178,7 +178,7 @@
       shortcuts: [
         { key: "Delete", action: "Delete selected" },
         { key: "↑ / ↓", action: "Move device up/down" },
-        { key: "Shift + ↑ / ↓", action: "Move device 0.5U (fine)" },
+        { key: "Shift + ↑ / ↓", action: "Move device ⅓U (fine)" },
       ],
     },
     {

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -100,16 +100,16 @@
         key: "ArrowDown",
         action: () => moveSelectedDevice(-1),
       },
-      // Shift+Arrow keys - move by 0.5U (fine movement)
+      // Shift+Arrow keys - move by 1/3U (fine movement to align with rack holes)
       {
         key: "ArrowUp",
         shift: true,
-        action: () => moveSelectedDevice(1, 0.5),
+        action: () => moveSelectedDevice(1, 1 / 3),
       },
       {
         key: "ArrowDown",
         shift: true,
-        action: () => moveSelectedDevice(-1, 0.5),
+        action: () => moveSelectedDevice(-1, 1 / 3),
       },
       // Left/Right arrows - move selected rack (disabled in single-rack mode)
       {
@@ -271,7 +271,7 @@
    * Move the selected device up or down, using shared movement utility.
    * Leapfrogs over blocking devices to find valid positions.
    * @param direction - 1 for up (higher U), -1 for down (lower U)
-   * @param stepOverride - Optional step size (default: device height). Use 0.5 for fine movement.
+   * @param stepOverride - Optional step size (default: device height). Use 1/3 for fine movement.
    */
   function moveSelectedDevice(direction: 1 | -1, stepOverride?: number) {
     if (!selectionStore.isDeviceSelected) return;

--- a/src/lib/utils/device-movement.ts
+++ b/src/lib/utils/device-movement.ts
@@ -39,7 +39,7 @@ export type MoveDirection = 1 | -1;
  * @param deviceTypes - Device type definitions for collision checking
  * @param deviceIndex - Index of the device in rack.devices array
  * @param direction - 1 for up (higher U), -1 for down (lower U)
- * @param stepOverride - Optional step size (default: device height). Use 0.5 for fine movement.
+ * @param stepOverride - Optional step size in U (default: device height). Use 1/3 for fine movement.
  * @returns MoveResult indicating success/failure and new position
  */
 export function findNextValidPosition(

--- a/src/tests/keyboard.test.ts
+++ b/src/tests/keyboard.test.ts
@@ -637,8 +637,8 @@ describe("KeyboardHandler Component", () => {
     });
   });
 
-  describe("Fine Movement (0.5U) with Shift+Arrow", () => {
-    it("Shift+ArrowUp moves device up by 0.5U", async () => {
+  describe("Fine Movement (1/3U) with Shift+Arrow", () => {
+    it("Shift+ArrowUp moves device up by 1/3U", async () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
@@ -659,13 +659,13 @@ describe("KeyboardHandler Component", () => {
       const initialPosition = layoutStore.rack!.devices[0]!.position;
       await fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true });
 
-      // Should move by 0.5U instead of full device height (0.5U = UNITS_PER_U / 2 = 3 internal units)
+      // Should move by 1/3U instead of full device height (1/3U = UNITS_PER_U / 3 = 2 internal units)
       expect(layoutStore.rack!.devices[0]!.position).toBe(
-        initialPosition + UNITS_PER_U / 2,
+        initialPosition + UNITS_PER_U / 3,
       );
     });
 
-    it("Shift+ArrowDown moves device down by 0.5U", async () => {
+    it("Shift+ArrowDown moves device down by 1/3U", async () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
@@ -686,9 +686,9 @@ describe("KeyboardHandler Component", () => {
       const initialPosition = layoutStore.rack!.devices[0]!.position;
       await fireEvent.keyDown(window, { key: "ArrowDown", shiftKey: true });
 
-      // Should move by 0.5U instead of full device height (0.5U = UNITS_PER_U / 2 = 3 internal units)
+      // Should move by 1/3U instead of full device height (1/3U = UNITS_PER_U / 3 = 2 internal units)
       expect(layoutStore.rack!.devices[0]!.position).toBe(
-        initialPosition - UNITS_PER_U / 2,
+        initialPosition - UNITS_PER_U / 3,
       );
     });
 
@@ -730,7 +730,7 @@ describe("KeyboardHandler Component", () => {
       });
 
       // Place devices with a 1U gap at U5 and U7
-      // This allows the U5 device to move up 0.5U without collision
+      // This allows the U5 device to move up 1/3U without collision
       layoutStore.placeDevice(rackId, deviceType.slug, 5);
       const firstDeviceId = layoutStore.rack!.devices[0]!.id;
       layoutStore.placeDevice(rackId, deviceType.slug, 7);
@@ -740,18 +740,27 @@ describe("KeyboardHandler Component", () => {
 
       render(KeyboardHandler);
 
-      // Move up 0.5U - position 5.5 is valid (no collision - device at U7)
-      // U5.5 = toInternalUnits(5.5) = 33
+      // Move up 1/3U - position 5⅓ is valid (no collision - device at U7)
+      // U5⅓ = 5 * 6 + 2 = 32 internal units
       await fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true });
-      expect(layoutStore.rack!.devices[0]!.position).toBe(toInternalUnits(5.5));
+      expect(layoutStore.rack!.devices[0]!.position).toBe(
+        toInternalUnits(5) + 2,
+      );
 
-      // Move up another 0.5U - position 6 is valid (gap exists before U7)
-      // U6 = toInternalUnits(6) = 36
+      // Move up another 1/3U - position 5⅔ is valid (gap exists before U7)
+      // U5⅔ = 5 * 6 + 4 = 34 internal units
+      await fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true });
+      expect(layoutStore.rack!.devices[0]!.position).toBe(
+        toInternalUnits(5) + 4,
+      );
+
+      // Move up another 1/3U - position 6 is valid
+      // U6 = 6 * 6 = 36 internal units
       await fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true });
       expect(layoutStore.rack!.devices[0]!.position).toBe(toInternalUnits(6));
     });
 
-    it("2U device with Shift+Arrow moves by 0.5U not 2U", async () => {
+    it("2U device with Shift+Arrow moves by 1/3U not 2U", async () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
@@ -772,9 +781,9 @@ describe("KeyboardHandler Component", () => {
       const initialPosition = layoutStore.rack!.devices[0]!.position;
       await fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true });
 
-      // Should move by 0.5U, not by device height (2U) - 0.5U = UNITS_PER_U / 2 = 3 internal units
+      // Should move by 1/3U, not by device height (2U) - 1/3U = UNITS_PER_U / 3 = 2 internal units
       expect(layoutStore.rack!.devices[0]!.position).toBe(
-        initialPosition + UNITS_PER_U / 2,
+        initialPosition + UNITS_PER_U / 3,
       );
     });
   });


### PR DESCRIPTION
## Summary

- Changed keyboard shortcut `Shift + Arrow Up/Down` from 0.5U to 1/3U movement
- Updated help text in HelpPanel and EditPanel to reflect the new behavior
- Updated unit tests for the new movement increment

## Background

Standard racks have 3 holes per U. The previous 0.5U movement was physically impossible—devices can only mount at 1/3U intervals (holes). This change aligns the software with physical reality.

## Technical Details

With `UNITS_PER_U = 6` (LCM of 2 and 3 for integer collision math):
- Regular `Arrow Up/Down` continues to move by 1U (6 internal units)
- `Shift + Arrow Up/Down` now moves by 1/3U (2 internal units)

## Files Changed

- `src/lib/components/KeyboardHandler.svelte`: Changed stepOverride from 0.5 to 1/3
- `src/lib/components/HelpPanel.svelte`: Updated shortcut description
- `src/lib/components/EditPanel.svelte`: Updated helper text
- `src/lib/utils/device-movement.ts`: Updated JSDoc
- `src/tests/keyboard.test.ts`: Updated test expectations

## Test Plan

- [x] All existing keyboard tests updated and passing
- [x] Lint passes
- [x] Build passes

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)