### PR TITLE
fix: align U-label positions with rack viewBox in bayed racks (#754)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rackula",
-  "version": "0.6.16",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rackula",
-      "version": "0.6.16",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@iconify/svelte": "^5.2.1",

--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -19,6 +19,7 @@
   import ULabels from "./ULabels.svelte";
   import AnnotationColumn from "./AnnotationColumn.svelte";
   import { useLongPress } from "$lib/utils/gestures";
+  import { RACK_PADDING_HIDDEN } from "$lib/constants/layout";
 
   interface Props {
     group: RackGroup;
@@ -122,12 +123,17 @@
   const uLabels = $derived(
     Array.from({ length: maxHeight }, (_, i) => {
       const uNumber = maxHeight - i;
-      const yPosition = i * U_HEIGHT + U_HEIGHT / 2 + RAIL_WIDTH;
+      // Match Rack.svelte yPosition: includes RACK_PADDING_HIDDEN to align with hidden rack name mode
+      const yPosition =
+        i * U_HEIGHT + U_HEIGHT / 2 + RACK_PADDING_HIDDEN + RAIL_WIDTH;
       return { uNumber, yPosition };
     }),
   );
 
-  const uColumnHeight = $derived(maxHeight * U_HEIGHT + RAIL_WIDTH * 2);
+  // Column height must match Rack.svelte viewBoxHeight when hideRackName=true
+  const uColumnHeight = $derived(
+    RACK_PADDING_HIDDEN + maxHeight * U_HEIGHT + RAIL_WIDTH * 2,
+  );
 
   // Reversed racks for rear row (mirrored layout)
   const reversedRacks = $derived([...racks].reverse());


### PR DESCRIPTION
## Summary

- Fix U-label offset in bayed rack views by including `RACK_PADDING_HIDDEN` (4px) in the ULabels column height and position calculations
- The ULabels column now matches Rack.svelte's viewBoxHeight when `hideRackName=true`

## Root Cause

BayedRackView was calculating U-label positions without accounting for the `RACK_PADDING_HIDDEN` that Rack.svelte includes when rendering with `hideRackName={true}`. This caused the ULabels column to be 4px shorter than the racks, making labels appear offset by ~1U.

**Before:**
```javascript
yPosition = i * U_HEIGHT + U_HEIGHT / 2 + RAIL_WIDTH;
uColumnHeight = maxHeight * U_HEIGHT + RAIL_WIDTH * 2;
```

**After:**
```javascript
yPosition = i * U_HEIGHT + U_HEIGHT / 2 + RACK_PADDING_HIDDEN + RAIL_WIDTH;
uColumnHeight = RACK_PADDING_HIDDEN + maxHeight * U_HEIGHT + RAIL_WIDTH * 2;
```

## Files Changed

- `src/lib/components/BayedRackView.svelte`: Import `RACK_PADDING_HIDDEN` and add it to position/height calculations

## Test Plan

- [x] Lint passes
- [x] All 1715 unit tests pass
- [x] Build succeeds
- [ ] Visual verification: U-labels in bayed racks align with rack unit positions

Closes #754

🤖 Generated with [Claude Code](https://claude.ai/code)