### PR TITLE
feat: add compact width option for bayed rack annotations (#717)

### DIFF
--- a/src/lib/components/AnnotationColumn.svelte
+++ b/src/lib/components/AnnotationColumn.svelte
@@ -14,6 +14,10 @@
     U_HEIGHT_PX,
     RAIL_WIDTH,
     RACK_PADDING_HIDDEN,
+    ANNOTATION_WIDTH,
+    ANNOTATION_TRUNCATE_LENGTH,
+    ANNOTATION_TRUNCATE_LENGTH_COMPACT,
+    ANNOTATION_WIDTH_COMPACT,
   } from "$lib/constants/layout";
   import { toHumanUnits } from "$lib/utils/position";
 
@@ -31,9 +35,16 @@
     rack,
     deviceLibrary,
     annotationField,
-    width = 100,
+    width = ANNOTATION_WIDTH,
     faceFilter,
   }: Props = $props();
+
+  // Determine truncation length based on width
+  const truncateLength = $derived(
+    width <= ANNOTATION_WIDTH_COMPACT
+      ? ANNOTATION_TRUNCATE_LENGTH_COMPACT
+      : ANNOTATION_TRUNCATE_LENGTH,
+  );
 
   // Padding from right edge for text alignment
   const TEXT_PADDING = 8;
@@ -114,7 +125,7 @@
   );
 
   // Truncate long values
-  function truncate(value: string, maxLength: number = 15): string {
+  function truncate(value: string, maxLength: number): string {
     if (value.length <= maxLength) return value;
     return value.slice(0, maxLength - 1) + "…";
   }
@@ -139,7 +150,7 @@
         text-anchor="end"
       >
         <title>{annotation.value}</title>
-        {truncate(annotation.value)}
+        {truncate(annotation.value, truncateLength)}
       </text>
     {/each}
   </svg>

--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -19,7 +19,10 @@
   import ULabels from "./ULabels.svelte";
   import AnnotationColumn from "./AnnotationColumn.svelte";
   import { useLongPress } from "$lib/utils/gestures";
-  import { RACK_PADDING_HIDDEN } from "$lib/constants/layout";
+  import {
+    RACK_PADDING_HIDDEN,
+    ANNOTATION_WIDTH_COMPACT,
+  } from "$lib/constants/layout";
 
   interface Props {
     group: RackGroup;
@@ -269,6 +272,7 @@
             {rack}
             {deviceLibrary}
             {annotationField}
+            width={ANNOTATION_WIDTH_COMPACT}
             faceFilter="front"
           />
         </div>
@@ -380,6 +384,7 @@
             {rack}
             {deviceLibrary}
             {annotationField}
+            width={ANNOTATION_WIDTH_COMPACT}
             faceFilter="rear"
           />
         </div>

--- a/src/lib/constants/layout.ts
+++ b/src/lib/constants/layout.ts
@@ -114,6 +114,39 @@ export const FIT_ALL_MAX_ZOOM = 2;
 export const SELECTION_HIGHLIGHT_PADDING = 8;
 
 // =============================================================================
+// Annotation Column
+// =============================================================================
+
+/**
+ * Default width of annotation columns for standalone racks
+ */
+export const ANNOTATION_WIDTH = 100;
+
+/**
+ * Compact width for annotation columns in bayed racks
+ * Narrower to prevent horizontal overflow with multiple bays
+ */
+export const ANNOTATION_WIDTH_COMPACT = 80;
+
+/**
+ * Max characters before truncation for standard annotation width (100px)
+ *
+ * Assumes ~6px per character at 10px monospace font.
+ * Width (100px) - padding (8px right) = 92px usable / ~6px = ~15 chars
+ * Keep in sync with ANNOTATION_WIDTH.
+ */
+export const ANNOTATION_TRUNCATE_LENGTH = 15;
+
+/**
+ * Max characters before truncation for compact annotation width (80px)
+ *
+ * Assumes ~6px per character at 10px monospace font.
+ * Width (80px) - padding (8px right) = 72px usable / ~6px = ~12 chars
+ * Using 11 for safety margin. Keep in sync with ANNOTATION_WIDTH_COMPACT.
+ */
+export const ANNOTATION_TRUNCATE_LENGTH_COMPACT = 11;
+
+// =============================================================================
 // Helper Functions
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- Add compact annotation width (80px) for bayed racks to prevent horizontal overflow with multiple bays
- Add truncation length constants that automatically adjust based on column width
- BayedRackView now uses the narrower annotation columns by default

## Files Changed

- `src/lib/constants/layout.ts`: Added `ANNOTATION_WIDTH`, `ANNOTATION_WIDTH_COMPACT`, `ANNOTATION_TRUNCATE_LENGTH`, and `ANNOTATION_TRUNCATE_LENGTH_COMPACT` constants
- `src/lib/components/AnnotationColumn.svelte`: Updated to use layout constants and dynamically select truncation length based on width prop
- `src/lib/components/BayedRackView.svelte`: Passes compact width to AnnotationColumn components

## Test plan

- [ ] Verify bayed rack annotations display at 80px width
- [ ] Verify standalone rack annotations still display at 100px width  
- [ ] Confirm text truncation works correctly at both widths
- [ ] Test with multiple bays to ensure no horizontal overflow

Closes #717

🤖 Generated with [Claude Code](https://claude.ai/code)