### PR TITLE
chore: Move import/add device features from sidebar to File menu (#774)

### DIFF
--- a/src/lib/components/FileMenu.svelte
+++ b/src/lib/components/FileMenu.svelte
@@ -1,6 +1,6 @@
 <!--
   FileMenu Component
-  Dropdown for file operations: Save, Load, Export, Share
+  Dropdown for file operations: Save, Load, Export, Share, Import Devices
   Uses bits-ui DropdownMenu with Iconoir folder trigger
 -->
 <script lang="ts">
@@ -15,10 +15,22 @@
     onload?: () => void;
     onexport?: () => void;
     onshare?: () => void;
+    onimportdevices?: () => void;
+    onimportnetbox?: () => void;
+    onnewcustomdevice?: () => void;
     hasRacks?: boolean;
   }
 
-  let { onsave, onload, onexport, onshare, hasRacks = false }: Props = $props();
+  let {
+    onsave,
+    onload,
+    onexport,
+    onshare,
+    onimportdevices,
+    onimportnetbox,
+    onnewcustomdevice,
+    hasRacks = false,
+  }: Props = $props();
 
   let open = $state(false);
 
@@ -66,6 +78,25 @@
         onSelect={handleSelect(onshare)}
       >
         <span class="menu-label">Share</span>
+      </DropdownMenu.Item>
+      <DropdownMenu.Separator class="menu-separator" />
+      <DropdownMenu.Item
+        class="menu-item"
+        onSelect={handleSelect(onimportdevices)}
+      >
+        <span class="menu-label">Import Devices</span>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        class="menu-item"
+        onSelect={handleSelect(onimportnetbox)}
+      >
+        <span class="menu-label">Import from NetBox</span>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item
+        class="menu-item"
+        onSelect={handleSelect(onnewcustomdevice)}
+      >
+        <span class="menu-label">New Custom Device</span>
       </DropdownMenu.Item>
     </DropdownMenu.Content>
   </DropdownMenu.Portal>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -38,6 +38,9 @@
     onload?: () => void;
     onexport?: () => void;
     onshare?: () => void;
+    onimportdevices?: () => void;
+    onimportnetbox?: () => void;
+    onnewcustomdevice?: () => void;
     onfitall?: () => void;
     ontoggletheme?: () => void;
     ontoggledisplaymode?: () => void;
@@ -60,6 +63,9 @@
     onload,
     onexport,
     onshare,
+    onimportdevices,
+    onimportnetbox,
+    onnewcustomdevice,
     onfitall,
     ontoggletheme,
     ontoggledisplaymode,
@@ -119,6 +125,21 @@
   function handleShare() {
     analytics.trackToolbarClick("share");
     onshare?.();
+  }
+
+  function handleImportDevices() {
+    analytics.trackToolbarClick("import-devices");
+    onimportdevices?.();
+  }
+
+  function handleImportNetBox() {
+    analytics.trackToolbarClick("import-netbox");
+    onimportnetbox?.();
+  }
+
+  function handleNewCustomDevice() {
+    analytics.trackToolbarClick("new-custom-device");
+    onnewcustomdevice?.();
   }
 
   function handleFitAll() {
@@ -253,6 +274,9 @@
       onload={handleLoad}
       onexport={handleExport}
       onshare={handleShare}
+      onimportdevices={handleImportDevices}
+      onimportnetbox={handleImportNetBox}
+      onnewcustomdevice={handleNewCustomDevice}
       {hasRacks}
     />
 


### PR DESCRIPTION
## Summary

- Move Import Devices, Import from NetBox, and New Custom Device from DevicePalette sidebar to File menu
- Add third menu group with separator for device library actions
- Clean up DevicePalette to focus on browse-and-drag functionality

## Files Changed

- `FileMenu.svelte`: Add three new menu items with separator
- `Toolbar.svelte`: Pass new handlers to FileMenu
- `App.svelte`: Add device import handler and hidden file input
- `DevicePalette.svelte`: Remove actions section (~180 lines deleted)

## Test Plan

- [ ] Open File menu → verify three new items in third group with separator
- [ ] Click "Import Devices" → verify JSON file picker opens
- [ ] Click "Import from NetBox" → verify NetBox dialog opens  
- [ ] Click "New Custom Device" → verify AddDeviceForm dialog opens
- [ ] Verify DevicePalette bottom area is clean (no buttons)
- [ ] Mobile: File menu accessible via toolbar

Closes #774

🤖 Generated with [Claude Code](https://claude.ai/code)