### PR TITLE
fix: position buttons use arrows and 1/3U fine movement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -763,7 +762,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -807,7 +805,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2424,7 +2421,6 @@
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.10.1.tgz",
       "integrity": "sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -3118,7 +3114,6 @@
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "deepmerge": "^4.3.1",
@@ -3167,7 +3162,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3331,7 +3325,6 @@
       "integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3425,7 +3418,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -3784,7 +3776,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4063,7 +4054,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4791,7 +4781,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7028,7 +7017,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7181,7 +7169,6 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8049,7 +8036,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.4.tgz",
       "integrity": "sha512-VJwdXrmv9L8L7ZasJeWcCjoIuMRVbhuxbss0fpVnR8yorMmjNDwcjIH08vS6wmSzzzgAG5CADQ1JuXPS2nwt9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -8263,7 +8249,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8460,7 +8445,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8629,7 +8613,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8738,7 +8721,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8772,7 +8754,6 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",

--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -11,7 +11,7 @@
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import SegmentedControl from "./SegmentedControl.svelte";
   import MarkdownPreview from "./MarkdownPreview.svelte";
-  import { IconEdit, IconChevronUp, IconChevronDown } from "./icons";
+  import { IconEdit } from "./icons";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
@@ -884,39 +884,39 @@
                 class="position-btn"
                 onclick={() => moveDevice(-1)}
                 disabled={!canMoveDown}
-                aria-label="Move down 1U"
+                aria-label="Move device down by 1 rack unit"
                 title="Move down 1U"
               >
-                <IconChevronDown />
+                <span class="arrow-label">↓</span>
               </button>
               <button
                 type="button"
                 class="position-btn"
                 onclick={() => moveDevice(1)}
                 disabled={!canMoveUp}
-                aria-label="Move up 1U"
+                aria-label="Move device up by 1 rack unit"
                 title="Move up 1U"
               >
-                <IconChevronUp />
+                <span class="arrow-label">↑</span>
               </button>
               <span class="position-divider"></span>
               <button
                 type="button"
                 class="position-btn position-btn-fine"
-                onclick={() => moveDevice(-1, 0.5)}
-                aria-label="Move down 0.5U"
-                title="Move down 0.5U (fine)"
+                onclick={() => moveDevice(-1, 1 / 3)}
+                aria-label="Move device down by one-third rack unit"
+                title="Move down ⅓U (fine)"
               >
-                <span class="fine-label">-½</span>
+                <span class="fine-label">-⅓</span>
               </button>
               <button
                 type="button"
                 class="position-btn position-btn-fine"
-                onclick={() => moveDevice(1, 0.5)}
-                aria-label="Move up 0.5U"
-                title="Move up 0.5U (fine)"
+                onclick={() => moveDevice(1, 1 / 3)}
+                aria-label="Move device up by one-third rack unit"
+                title="Move up ⅓U (fine)"
               >
-                <span class="fine-label">+½</span>
+                <span class="fine-label">+⅓</span>
               </button>
             </div>
           </div>
@@ -1476,6 +1476,12 @@
   .fine-label {
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-medium);
+  }
+
+  .arrow-label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    line-height: 1;
   }
 
   .position-divider {


### PR DESCRIPTION
## Summary

- Replace chevron icons with ↑/↓ arrow text labels for Up/Down buttons
- Change fine movement from 1/2U to 1/3U (matches actual rack hole spacing - 3 holes per U)
- Update fine movement button labels to -⅓/+⅓ instead of -½/+½
- Improve aria-labels for better screen reader support

## Test plan

- [ ] Open Edit Device Panel for a placed device
- [ ] Verify Up button shows ↑ arrow
- [ ] Verify Down button shows ↓ arrow
- [ ] Verify fine movement buttons show -⅓ and +⅓
- [ ] Click fine movement buttons and verify device moves by 1/3U increments
- [ ] Test keyboard navigation with Tab key
- [ ] Test with screen reader to verify accessible labels

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)