### PR TITLE
feat: add Cmd+H keyboard shortcut for Share (#775)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,6 +430,7 @@ layoutDebug.device("placed device %s at U%d", slug, position);
 | `Ctrl+S`       | Save layout                    |
 | `Ctrl+O`       | Load layout                    |
 | `Ctrl+E`       | Export                         |
+| `Ctrl+H`       | Share                          |
 | `Ctrl+D`       | Duplicate selected device/rack |
 | `I`            | Toggle display mode            |
 | `F`            | Fit all                        |

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1215,6 +1215,7 @@
       onsave={handleSave}
       onload={handleLoad}
       onexport={handleExport}
+      onshare={handleShare}
       ondelete={handleDelete}
       onfitall={handleFitAll}
       onhelp={handleHelp}

--- a/src/lib/components/FileMenu.svelte
+++ b/src/lib/components/FileMenu.svelte
@@ -39,6 +39,7 @@
     save: formatShortcut("mod", "S"),
     load: formatShortcut("mod", "O"),
     export: formatShortcut("mod", "E"),
+    share: formatShortcut("mod", "H"),
   };
 
   function handleSelect(action?: () => void) {
@@ -78,6 +79,7 @@
         onSelect={handleSelect(onshare)}
       >
         <span class="menu-label">Share</span>
+        <span class="menu-shortcut">{shortcuts.share}</span>
       </DropdownMenu.Item>
       <DropdownMenu.Separator class="menu-separator" />
       <DropdownMenu.Item

--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -187,6 +187,7 @@
         { key: formatShortcut("mod", "S"), action: "Save layout" },
         { key: formatShortcut("mod", "O"), action: "Load layout" },
         { key: formatShortcut("mod", "E"), action: "Export image" },
+        { key: formatShortcut("mod", "H"), action: "Share" },
         { key: formatShortcut("mod", "Z"), action: "Undo" },
         { key: formatShortcut("mod", "shift", "Z"), action: "Redo" },
       ],

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -21,6 +21,7 @@
     onsave?: () => void;
     onload?: () => void;
     onexport?: () => void;
+    onshare?: () => void;
     ondelete?: () => void;
     onfitall?: () => void;
     onhelp?: () => void;
@@ -32,6 +33,7 @@
     onsave,
     onload,
     onexport,
+    onshare,
     ondelete,
     onfitall,
     onhelp,
@@ -227,6 +229,18 @@
         key: "e",
         meta: true,
         action: () => onexport?.(),
+      },
+
+      // Ctrl/Cmd+H - share
+      {
+        key: "h",
+        ctrl: true,
+        action: () => onshare?.(),
+      },
+      {
+        key: "h",
+        meta: true,
+        action: () => onshare?.(),
       },
 
       // Ctrl/Cmd+D - duplicate selected (device or rack)


### PR DESCRIPTION
## Summary

- Add platform-aware keyboard shortcut (Cmd+H on Mac, Ctrl+H on Windows/Linux) to trigger Share action
- Display shortcut in File menu next to Share item
- Add global keyboard handler so shortcut works when menu is closed
- Update HelpPanel keyboard shortcuts documentation
- Update CLAUDE.md keyboard shortcuts reference table

## Files Changed

- `src/lib/components/FileMenu.svelte`: Add share shortcut constant and display in menu
- `src/lib/components/KeyboardHandler.svelte`: Add onshare prop and Ctrl/Cmd+H handlers
- `src/App.svelte`: Wire up onshare callback to handleShare function
- `src/lib/components/HelpPanel.svelte`: Add Share shortcut to File shortcuts group
- `CLAUDE.md`: Add Ctrl+H to keyboard shortcuts reference table

## Test plan

- [ ] Open the app with at least one rack
- [ ] Press Cmd+H (Mac) or Ctrl+H (Windows/Linux) - should open Share dialog
- [ ] Open File menu - Share item should display "Cmd + H" (Mac) or "Ctrl + H" (Windows/Linux) next to it
- [ ] Press ? to open Help panel - Share shortcut should appear in File section
- [ ] Shortcut should work even when File menu is closed

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)