### PR TITLE
feat: container slot overlay for drag-drop placement (#766)

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -72,6 +72,12 @@
     }>;
     /** ID of currently selected child device (for highlighting) */
     selectedChildId?: string | null;
+    /** Whether a device is being dragged over this container (shows slot overlay) */
+    isDragOverContainer?: boolean;
+    /** The slot ID currently targeted during drag (null if none) */
+    dragTargetSlotId?: string | null;
+    /** Whether the current drag target slot is valid for the dragged device */
+    isDragTargetValid?: boolean;
     onselect?: (event: CustomEvent<{ slug: string; position: number }>) => void;
     ondragstart?: (
       event: CustomEvent<{ rackId: string; deviceIndex: number }>,
@@ -112,6 +118,9 @@
     deviceLibrary = [],
     containerChildDevices = [],
     selectedChildId = null,
+    isDragOverContainer = false,
+    dragTargetSlotId = null,
+    isDragTargetValid = false,
     onselect,
     ondragstart: ondragstartProp,
     ondragend: ondragendProp,
@@ -605,13 +614,15 @@
     />
   {/if}
 
-  <!-- Container slot grid (shown when selected container) -->
-  {#if isContainer && selected}
+  <!-- Container slot grid (shown when selected OR during drag-over) -->
+  {#if isContainer && (selected || isDragOverContainer)}
     <ContainerSlots
       containerType={device}
       containerWidth={deviceWidth}
       containerHeight={deviceHeight}
       selectedSlotId={null}
+      dropTargetSlotId={isDragOverContainer ? dragTargetSlotId : null}
+      isValidDropTarget={isDragTargetValid}
     />
   {/if}
 


### PR DESCRIPTION
## Summary

- Adds visual feedback when dragging devices over containers with slots
- Shows slot grid overlay highlighting which slot is under the cursor
- Indicates slot compatibility (valid/invalid targets) with color coding

## Changes

- Added `detectContainerHover()` function to `dragdrop.ts` for detecting when cursor is over a container
- Added `ContainerHoverInfo` interface to track hover state
- Added `isSlotCompatible()` helper to check if dragged device fits in slot
- Added `isDragOverContainer`, `dragTargetSlotId`, `isDragTargetValid` props to RackDevice
- Updated Rack.svelte to track and pass container hover state during drag operations

## Test plan

- [x] Lint passes
- [x] Tests pass  
- [x] Build succeeds
- [ ] Manual testing: drag device over container, verify slot overlay appears
- [ ] Manual testing: drag incompatible device, verify invalid styling

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>