### PR TITLE
fix: bayed rack U labels, selection, and highlight issues (#805)

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -311,6 +311,20 @@
     onrackselect?.(event);
   }
 
+  function handleGroupSelect(event: CustomEvent<{ groupId: string }>) {
+    const { groupId } = event.detail;
+    // Find the first rack in the group to set as active (for device operations)
+    const group = layoutStore.rack_groups.find((g) => g.id === groupId);
+    if (group && group.rack_ids.length > 0) {
+      // Find the first rack in the group
+      const firstRack = racks.find((r) => r.id === group.rack_ids[0]);
+      if (firstRack) {
+        layoutStore.setActiveRack(firstRack.id);
+      }
+    }
+    selectionStore.selectGroup(groupId);
+  }
+
   function handleDeviceSelect(
     rackId: string,
     event: CustomEvent<{ slug: string; position: number }>,
@@ -459,13 +473,16 @@
                 selectedRackId={selectionStore.selectedType === "rack"
                   ? selectionStore.selectedRackId
                   : null}
+                selectedGroupId={selectionStore.selectedType === "group"
+                  ? selectionStore.selectedGroupId
+                  : null}
                 displayMode={uiStore.displayMode}
                 showLabelsOnImages={uiStore.showLabelsOnImages}
                 showAnnotations={uiStore.showAnnotations}
                 annotationField={uiStore.annotationField}
                 {partyMode}
                 {enableLongPress}
-                onselect={(e) => handleRackSelect(e)}
+                ongroupselect={handleGroupSelect}
                 ondeviceselect={(e) => {
                   const rackId = activeRackId ?? groupRacks[0]?.id;
                   if (rackId) handleDeviceSelect(rackId, e);

--- a/src/lib/components/ULabels.svelte
+++ b/src/lib/components/ULabels.svelte
@@ -16,9 +16,11 @@
     uColumnHeight: number;
     /** Height of the top/bottom rail bars in pixels */
     railWidth: number;
+    /** Padding at top of column (to match rack padding) */
+    topPadding?: number;
   }
 
-  let { uLabels, uColumnHeight, railWidth }: Props = $props();
+  let { uLabels, uColumnHeight, railWidth, topPadding = 0 }: Props = $props();
 </script>
 
 <svg
@@ -32,8 +34,14 @@
   <!-- Background -->
   <rect x="0" y="0" width="32" height={uColumnHeight} class="u-column-bg" />
 
-  <!-- Top rail -->
-  <rect x="0" y="0" width="32" height={railWidth} class="u-column-rail" />
+  <!-- Top rail (offset by topPadding to match Rack.svelte layout) -->
+  <rect
+    x="0"
+    y={topPadding}
+    width="32"
+    height={railWidth}
+    class="u-column-rail"
+  />
 
   <!-- Bottom rail -->
   <rect

--- a/src/lib/stores/selection.svelte.ts
+++ b/src/lib/stores/selection.svelte.ts
@@ -7,28 +7,31 @@
  * - Selection remains valid after device additions/deletions
  */
 
-import type { PlacedDevice } from '$lib/types';
+import type { PlacedDevice } from "$lib/types";
 
 // Selection types
-type SelectionType = 'rack' | 'device' | null;
+type SelectionType = "rack" | "group" | "device" | null;
 
 // Module-level state (using $state rune)
 let selectedType = $state<SelectionType>(null);
 let selectedRackId = $state<string | null>(null);
+let selectedGroupId = $state<string | null>(null);
 let selectedDeviceId = $state<string | null>(null);
 
 // Derived values (using $derived rune)
 const hasSelection = $derived(selectedType !== null);
-const isRackSelected = $derived(selectedType === 'rack');
-const isDeviceSelected = $derived(selectedType === 'device');
+const isRackSelected = $derived(selectedType === "rack");
+const isGroupSelected = $derived(selectedType === "group");
+const isDeviceSelected = $derived(selectedType === "device");
 
 /**
  * Reset the store to initial state (primarily for testing)
  */
 export function resetSelectionStore(): void {
-	selectedType = null;
-	selectedRackId = null;
-	selectedDeviceId = null;
+  selectedType = null;
+  selectedRackId = null;
+  selectedGroupId = null;
+  selectedDeviceId = null;
 }
 
 /**
@@ -36,37 +39,44 @@ export function resetSelectionStore(): void {
  * @returns Store object with state and actions
  */
 export function getSelectionStore() {
-	return {
-		// State getters
-		get selectedType() {
-			return selectedType;
-		},
-		get selectedRackId() {
-			return selectedRackId;
-		},
-		get selectedDeviceId() {
-			return selectedDeviceId;
-		},
+  return {
+    // State getters
+    get selectedType() {
+      return selectedType;
+    },
+    get selectedRackId() {
+      return selectedRackId;
+    },
+    get selectedGroupId() {
+      return selectedGroupId;
+    },
+    get selectedDeviceId() {
+      return selectedDeviceId;
+    },
 
-		// Derived getters
-		get hasSelection() {
-			return hasSelection;
-		},
-		get isRackSelected() {
-			return isRackSelected;
-		},
-		get isDeviceSelected() {
-			return isDeviceSelected;
-		},
+    // Derived getters
+    get hasSelection() {
+      return hasSelection;
+    },
+    get isRackSelected() {
+      return isRackSelected;
+    },
+    get isGroupSelected() {
+      return isGroupSelected;
+    },
+    get isDeviceSelected() {
+      return isDeviceSelected;
+    },
 
-		// Actions
-		selectRack,
-		selectDevice,
-		clearSelection,
+    // Actions
+    selectRack,
+    selectGroup,
+    selectDevice,
+    clearSelection,
 
-		// Helpers
-		getSelectedDeviceIndex
-	};
+    // Helpers
+    getSelectedDeviceIndex,
+  };
 }
 
 /**
@@ -74,9 +84,21 @@ export function getSelectionStore() {
  * @param rackId - ID of the rack to select
  */
 function selectRack(rackId: string): void {
-	selectedType = 'rack';
-	selectedRackId = rackId;
-	selectedDeviceId = null;
+  selectedType = "rack";
+  selectedRackId = rackId;
+  selectedGroupId = null;
+  selectedDeviceId = null;
+}
+
+/**
+ * Select a rack group (bayed rack)
+ * @param groupId - ID of the group to select
+ */
+function selectGroup(groupId: string): void {
+  selectedType = "group";
+  selectedRackId = null;
+  selectedGroupId = groupId;
+  selectedDeviceId = null;
 }
 
 /**
@@ -85,18 +107,20 @@ function selectRack(rackId: string): void {
  * @param deviceId - Unique ID of the placed device (UUID)
  */
 function selectDevice(rackId: string, deviceId: string): void {
-	selectedType = 'device';
-	selectedRackId = rackId;
-	selectedDeviceId = deviceId;
+  selectedType = "device";
+  selectedRackId = rackId;
+  selectedGroupId = null;
+  selectedDeviceId = deviceId;
 }
 
 /**
  * Clear the current selection
  */
 function clearSelection(): void {
-	selectedType = null;
-	selectedRackId = null;
-	selectedDeviceId = null;
+  selectedType = null;
+  selectedRackId = null;
+  selectedGroupId = null;
+  selectedDeviceId = null;
 }
 
 /**
@@ -105,7 +129,7 @@ function clearSelection(): void {
  * @returns The index of the selected device, or null if not found
  */
 function getSelectedDeviceIndex(devices: PlacedDevice[]): number | null {
-	if (!selectedDeviceId) return null;
-	const index = devices.findIndex((d) => d.id === selectedDeviceId);
-	return index >= 0 ? index : null;
+  if (!selectedDeviceId) return null;
+  const index = devices.findIndex((d) => d.id === selectedDeviceId);
+  return index >= 0 ? index : null;
 }


### PR DESCRIPTION
## Summary

- Fix U label alignment in bayed racks by adding `topPadding` prop to ULabels component to match Rack.svelte's padding structure
- Implement group-level selection in selection store with new `selectGroup` action and `selectedGroupId` state
- Update BayedRackView to emit `ongroupselect` with group ID when clicking any bay, so the entire bayed rack is selected as a unit
- Reduce padding and outline-offset in BayedRackView for tighter selection highlight

## Files Changed

- `src/lib/components/ULabels.svelte`: Added `topPadding` prop to offset top rail position
- `src/lib/stores/selection.svelte.ts`: Added group selection type, state, and `selectGroup` action
- `src/lib/components/BayedRackView.svelte`: Changed selection to use `ongroupselect`, reduced highlight spacing
- `src/lib/components/Canvas.svelte`: Added `handleGroupSelect` handler for bayed rack group selection

## Test plan

- [ ] Visual verification of U label alignment with U slot lines
- [ ] Click any bay in a bayed rack - entire group should be selected
- [ ] Selection outline should have uniform, tight spacing around content

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)