### PR TITLE
chore: harden docker-compose.yml and Dockerfile for self-hosted deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Rackula Docker Configuration
+# Copy this file to .env and customize as needed
+
+# Port to expose Rackula on (default: 8080)
+# Fun alternative: 8197 (embeds 1897, the year Dracula was published)
+RACKULA_PORT=8080

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,16 +19,22 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-# Production stage
-FROM nginx:alpine
+# Production stage - non-root nginx
+FROM nginxinc/nginx-unprivileged:alpine
+
+# OCI labels
+LABEL org.opencontainers.image.source="https://github.com/RackulaLives/Rackula"
+LABEL org.opencontainers.image.description="Rack Layout Designer for Homelabbers"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="Rackula"
 
 # Copy nginx config and built assets
 COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# Health check
+# Health check (port 8080 for unprivileged nginx, busybox wget is built-in)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://127.0.0.1/health || exit 1
+  CMD wget -q --spider http://127.0.0.1:8080/health || exit 1
 
-EXPOSE 80
+EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,5 +1,6 @@
 server {
-    listen 80;
+    listen 8080;
+    listen [::]:8080;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,38 @@
 services:
-  Rackula:
+  rackula:
     image: ghcr.io/rackulalives/rackula:latest
     # To build locally instead, comment out 'image' and uncomment 'build':
     # build: ./deploy
+    container_name: rackula
     ports:
-      - "8080:80"
+      - "${RACKULA_PORT:-8080}:8080"
     restart: unless-stopped
+    stop_grace_period: 10s
+
+    # Resource limits (requires Docker Compose v2)
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 128M
+        reservations:
+          cpus: "0.10"
+          memory: 16M
+
+    # Security hardening (no cap_add needed with non-root nginx)
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx:size=10M
+      - /var/run:size=1M
+      - /tmp:size=5M
+
+    # Logging
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## Summary

Hardens Docker configuration for security, reliability, and best practices:

- **Non-root execution**: Switch to `nginxinc/nginx-unprivileged:alpine` (UID 101)
- **Security hardening**: Drop ALL capabilities, read-only filesystem, no-new-privileges
- **Resource limits**: 128M memory, 0.5 CPU (based on measured production usage)
- **Log rotation**: 30MB max to prevent disk fill
- **IPv6 support**: Dual-stack networking
- **OCI labels**: Standard container metadata

## Files Changed

- `docker-compose.yml`: Full rewrite with hardening
- `deploy/Dockerfile`: Switch to unprivileged nginx, add OCI labels
- `deploy/nginx.conf`: Port 8080 + IPv6
- `.env.example`: New file for port configuration

## Test Plan

- [x] `docker compose config` validates successfully
- [x] Lint passes
- [x] Tests pass (1714 tests)
- [x] Build passes
- [x] CodeRabbit CLI review passes
- [ ] Container starts and serves content (manual verification)
- [ ] Healthcheck works (manual verification)

## Breaking Changes

- Internal port changed from 80 to 8080 (reverse proxies need update)
- Requires Docker Compose v2 (v1 deprecated June 2023)

## Design Document

See `docs/plans/2026-01-19-docker-compose-hardening-design.md`

Closes #808

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)