### PR TITLE
fix: capitalize Racks label in sidebar

### DIFF
--- a/src/lib/components/RackList.svelte
+++ b/src/lib/components/RackList.svelte
@@ -152,7 +152,7 @@
 <div class="rack-list">
   <div class="rack-list-header">
     <span class="rack-count">
-      {rackGroups.length + ungroupedRacks.length} rack{rackGroups.length +
+      {rackGroups.length + ungroupedRacks.length} Rack{rackGroups.length +
         ungroupedRacks.length !==
       1
         ? "s"


### PR DESCRIPTION
## Summary

- Capitalize "Rack"/"Racks" in the Racks pane header for consistent title case

## Changes

- `src/lib/components/RackList.svelte`: Changed `"rack"` to `"Rack"` in the count display

## Test Plan

- [ ] Verify sidebar shows "1 Rack" with single rack
- [ ] Verify sidebar shows "2 Racks" with multiple racks

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)