### PR TITLE
feat: Half-width device UI - creation, rendering, and indicators (#833)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -647,6 +647,7 @@
     colour: string;
     notes: string;
     isFullDepth: boolean;
+    isHalfWidth: boolean;
     frontImage?: ImageData;
     rearImage?: ImageData;
   }) {
@@ -657,6 +658,7 @@
       colour: data.colour,
       comments: data.notes || undefined,
       is_full_depth: data.isFullDepth ? undefined : false,
+      slot_width: data.isHalfWidth ? 1 : undefined,
     });
 
     // Store images if provided (v0.1.0)

--- a/src/lib/components/AddDeviceForm.svelte
+++ b/src/lib/components/AddDeviceForm.svelte
@@ -24,6 +24,7 @@
       colour: string;
       notes: string;
       isFullDepth: boolean;
+      isHalfWidth: boolean;
       frontImage?: ImageData;
       rearImage?: ImageData;
     }) => void;
@@ -39,6 +40,7 @@
   let colour = $state(getDefaultColour("server"));
   let notes = $state("");
   let isFullDepth = $state(true);
+  let isHalfWidth = $state(false);
   let userChangedColour = $state(false);
 
   // Image state (v0.1.0)
@@ -58,6 +60,7 @@
       colour = getDefaultColour("server");
       notes = "";
       isFullDepth = true;
+      isHalfWidth = false;
       userChangedColour = false;
       nameError = "";
       heightError = "";
@@ -127,6 +130,7 @@
         colour,
         notes: notes.trim(),
         isFullDepth,
+        isHalfWidth,
         frontImage,
         rearImage,
       });
@@ -255,6 +259,21 @@
         <span class="toggle-text">Full Depth</span>
       </label>
       <span class="helper-text">Occupies both front and rear rack faces</span>
+    </div>
+
+    <!-- Half-width toggle (#833) -->
+    <div class="form-group toggle-group">
+      <label class="toggle-label">
+        <input
+          type="checkbox"
+          id="device-half-width"
+          bind:checked={isHalfWidth}
+          class="toggle-input"
+        />
+        <span class="toggle-switch"></span>
+        <span class="toggle-text">Half Width</span>
+      </label>
+      <span class="helper-text">Occupies left or right half of rack width</span>
     </div>
 
     <!-- Image uploads (v0.1.0) -->

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -45,6 +45,18 @@
   // Device display name: model or slug
   const deviceName = $derived(device.model ?? device.slug);
 
+  // Check if device is half-width
+  const isHalfWidth = $derived(device.slot_width === 1);
+
+  // Build accessible description for device
+  const ariaDescription = $derived.by(() => {
+    const parts = [deviceName, `${device.u_height}U`, device.category];
+    if (isHalfWidth) parts.push("half-width");
+    if (!isCompatible && incompatibilityReason)
+      parts.push(`(${incompatibilityReason})`);
+    return parts.join(", ");
+  });
+
   // Highlighted text segments for search matching
   const highlightedSegments = $derived(highlightMatch(deviceName, searchQuery));
 
@@ -118,9 +130,7 @@
   ondragstart={handleDragStart}
   ondrag={handleDrag}
   ondragend={handleDragEnd}
-  aria-label="{deviceName}, {device.u_height}U {device.category}{!isCompatible
-    ? ` (${incompatibilityReason})`
-    : ''}"
+  aria-label={ariaDescription}
 >
   <span class="drag-handle" aria-hidden="true">
     <IconGrip size={ICON_SIZE.sm} />
@@ -145,6 +155,13 @@
     />
   {/if}
   <span class="device-height">{device.u_height}U</span>
+  {#if isHalfWidth}
+    <span
+      class="width-indicator"
+      title="Half-width: Occupies left or right half of rack"
+      aria-label="Half-width device">½</span
+    >
+  {/if}
   {#if device.is_full_depth === false}
     <span
       class="depth-indicator"
@@ -261,6 +278,17 @@
   }
 
   .depth-indicator {
+    background-color: var(--colour-surface-hover);
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-full);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    color: var(--colour-text-muted);
+    flex-shrink: 0;
+    cursor: help;
+  }
+
+  .width-indicator {
     background-color: var(--colour-surface-hover);
     padding: 2px var(--space-2);
     border-radius: var(--radius-full);

--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -912,6 +912,12 @@
             >{getCategoryDisplayName(selectedDeviceInfo.device.category)}</span
           >
         </div>
+        {#if selectedDeviceInfo.device.slot_width === 1}
+          <div class="info-row">
+            <span class="info-label">Width</span>
+            <span class="info-value">Half</span>
+          </div>
+        {/if}
         <div class="info-row position-row">
           <span class="info-label">Position</span>
           <div class="position-controls">


### PR DESCRIPTION
## Summary

- Add "Half Width" checkbox to AddDeviceForm for creating half-width devices
- Add "½" badge indicator in DevicePaletteItem for half-width devices  
- Add "Width: Half" info row in EditPanel for half-width devices
- Update aria-label to include half-width status for accessibility

## Implementation Details

This PR implements the UI components for half-width device support as designed in `docs/plans/2026-01-20-half-width-device-ui.md`:

1. **AddDeviceForm.svelte**: Added "Half Width" toggle after the "Full Depth" toggle. When checked, the device is created with `slot_width: 1`.

2. **DevicePaletteItem.svelte**: Added "½" badge next to the height indicator for devices with `slot_width === 1`. Also updated aria-label to announce "half-width" for screen readers.

3. **EditPanel.svelte**: Added "Width: Half" info row in the device details section, shown only for half-width devices (per design: "reduce noise, full-width is assumed default").

## Test plan

- [ ] Create a custom device with "Half Width" checked
- [ ] Verify "½" badge appears next to device height in palette
- [ ] Verify "Width: Half" row shows in device details when selected
- [ ] Verify existing full-width devices are unchanged
- [ ] Verify screen reader announces "half-width" for half-width devices

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)