### PR TITLE
style: use design tokens for hardcoded values

### DIFF
--- a/src/lib/components/CleanupDialog.svelte
+++ b/src/lib/components/CleanupDialog.svelte
@@ -287,7 +287,7 @@
 
   .btn-destructive {
     background: var(--colour-error);
-    color: white;
+    color: var(--colour-text-inverse);
   }
 
   .btn-destructive:hover:not(:disabled) {

--- a/src/lib/styles/menu.css
+++ b/src/lib/styles/menu.css
@@ -58,7 +58,7 @@
   font-weight: var(--font-weight-medium);
   color: var(--colour-text-muted-inverse);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--letter-spacing-wide);
 }
 
 .menu-shortcut {

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -127,6 +127,11 @@
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
 
+  /* Letter Spacing */
+  --letter-spacing-tight: -0.025em;
+  --letter-spacing-normal: 0;
+  --letter-spacing-wide: 0.05em; /* For uppercase labels/headers */
+
   /* Icon Sizes */
   --icon-size-xs: 14px;
   --icon-size-sm: 16px;


### PR DESCRIPTION
## Summary
- Added letter-spacing tokens to tokens.css (`--letter-spacing-tight`, `--letter-spacing-normal`, `--letter-spacing-wide`)
- Replaced hardcoded `letter-spacing: 0.05em` in menu.css with `var(--letter-spacing-wide)`
- Replaced hardcoded `color: white` in CleanupDialog.svelte with `var(--colour-text-inverse)`

## Context
Addresses CodeRabbit nitpicks from PR #838:
- menu.css: Use design token for letter-spacing instead of hardcoded value
- CleanupDialog.svelte: Use design token for text color instead of hardcoded value

## Test plan
- [ ] Verify Settings menu "Device Library" header displays correctly
- [ ] Verify destructive button in CleanupDialog has correct white text

🤖 Generated with [Claude Code](https://claude.com/claude-code)