### PR TITLE
fix: RackDevice should validate slot_width against device type before rendering (#842)

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -202,12 +202,23 @@
   const deviceHeight = $derived(device.u_height * uHeight);
   // Full interior width (between rails)
   const fullWidth = $derived(rackWidth - RAIL_WIDTH * 2);
-  // Device width depends on slot position: half-width for left/right, full for full
+
+  // Defensive rendering: device type's slot_width is the source of truth
+  // A full-width device (slot_width: 2 or undefined) always renders full-width,
+  // even if placement data has incorrect slot_position
+  const isDeviceTypeHalfWidth = $derived(device.slot_width === 1);
+  const effectiveSlotPosition = $derived(
+    isDeviceTypeHalfWidth ? slotPosition : "full",
+  );
+
+  // Device width depends on effective slot position: half-width for left/right, full for full
   const deviceWidth = $derived(
-    slotPosition === "full" ? fullWidth : fullWidth / 2,
+    effectiveSlotPosition === "full" ? fullWidth : fullWidth / 2,
   );
   // X offset within the interior: 0 for left/full, half for right
-  const slotXOffset = $derived(slotPosition === "right" ? fullWidth / 2 : 0);
+  const slotXOffset = $derived(
+    effectiveSlotPosition === "right" ? fullWidth / 2 : 0,
+  );
 
   // Container helper: compute slot x offsets and widths for child positioning
   const slotGeometry = $derived.by(() => {


### PR DESCRIPTION
## Summary

- Add defensive rendering check that validates device type's `slot_width` before calculating device width
- Full-width devices (`slot_width: 2` or undefined) now always render full-width, even if placement data has corrupted `slot_position`
- This prevents visual misrepresentation from manually edited or corrupted save files

## Changes

- `src/lib/components/RackDevice.svelte`: Added `isDeviceTypeHalfWidth` and `effectiveSlotPosition` derived values to validate width before rendering

## Test plan

- [x] Lint passes
- [x] Unit tests pass (1714 tests)
- [x] Build succeeds
- [x] CodeRabbit CLI review passes

Closes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)