### PR TITLE
chore: mark DeskPi devices as half-width (slot_width: 1)

### DIFF
--- a/src/lib/data/brandPacks/deskpi.ts
+++ b/src/lib/data/brandPacks/deskpi.ts
@@ -2,6 +2,9 @@
  * DeskPi Brand Pack
  * Pre-defined device types for DeskPi 10-inch rack accessories
  * Popular homelab brand for Raspberry Pi rack mounting solutions
+ *
+ * All DeskPi devices are 10-inch rack width (rack_widths: [10]),
+ * which is half-width when used in a standard 19-inch rack (slot_width: 1).
  */
 
 import type { DeviceType } from "$lib/types";
@@ -21,6 +24,7 @@ export const deskpiDevices: DeviceType[] = [
     manufacturer: "DeskPi",
     model: "12-Port CAT6 Patch Panel",
     is_full_depth: false,
+    slot_width: 1,
     rack_widths: [10],
     colour: CATEGORY_COLOURS["patch-panel"],
     category: "patch-panel",
@@ -31,6 +35,7 @@ export const deskpiDevices: DeviceType[] = [
     manufacturer: "DeskPi",
     model: "12-Port CAT6 Keystone Patch Panel",
     is_full_depth: false,
+    slot_width: 1,
     rack_widths: [10],
     colour: CATEGORY_COLOURS["patch-panel"],
     category: "patch-panel",
@@ -41,6 +46,7 @@ export const deskpiDevices: DeviceType[] = [
     manufacturer: "DeskPi",
     model: "7D D-Type Patch Panel",
     is_full_depth: false,
+    slot_width: 1,
     rack_widths: [10],
     colour: CATEGORY_COLOURS["patch-panel"],
     category: "patch-panel",
@@ -56,6 +62,7 @@ export const deskpiDevices: DeviceType[] = [
     model: "RackMate 1U (2x Raspberry Pi)",
     is_full_depth: false,
     airflow: "passive",
+    slot_width: 1,
     rack_widths: [10],
     colour: CATEGORY_COLOURS.server,
     category: "server",
@@ -67,6 +74,7 @@ export const deskpiDevices: DeviceType[] = [
     model: "RackMate 2U (4x Raspberry Pi)",
     is_full_depth: false,
     airflow: "passive",
+    slot_width: 1,
     rack_widths: [10],
     colour: CATEGORY_COLOURS.server,
     category: "server",
@@ -81,6 +89,7 @@ export const deskpiDevices: DeviceType[] = [
     manufacturer: "DeskPi",
     model: "Brush Cable Manager",
     is_full_depth: false,
+    slot_width: 1,
     rack_widths: [10],
     colour: CATEGORY_COLOURS["cable-management"],
     category: "cable-management",
@@ -91,6 +100,7 @@ export const deskpiDevices: DeviceType[] = [
     manufacturer: "DeskPi",
     model: "Vented Rack Shelf",
     is_full_depth: false,
+    slot_width: 1,
     rack_widths: [10],
     colour: CATEGORY_COLOURS.shelf,
     category: "shelf",
@@ -101,6 +111,7 @@ export const deskpiDevices: DeviceType[] = [
     manufacturer: "DeskPi",
     model: "Rack Shelf",
     is_full_depth: false,
+    slot_width: 1,
     rack_widths: [10],
     colour: CATEGORY_COLOURS.shelf,
     category: "shelf",


### PR DESCRIPTION
## Summary

- Added `slot_width: 1` to all 8 DeskPi brand pack devices
- DeskPi devices are 10-inch rack accessories, which are half-width when used in a standard 19-inch rack

## Changes

All DeskPi devices now have `slot_width: 1`:
- `deskpi-12-port-patch-panel-0-5u`
- `deskpi-12-port-keystone-patch-panel-1u`
- `deskpi-d-type-patch-panel-1u`
- `deskpi-rackmate-1u-2-pi`
- `deskpi-rackmate-2u-4-pi`
- `deskpi-brush-panel-0-5u`
- `deskpi-vented-shelf-0-5u`
- `deskpi-rack-shelf-1u`

## Test plan

- [x] Lint passes
- [x] All tests pass (1714 tests)
- [x] Build succeeds

Related to #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)