### PR TITLE
fix: 10-inch racks render all devices at full-width

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -1344,6 +1344,7 @@
             selected={selectedDeviceId === placedDevice.id}
             uHeight={U_HEIGHT}
             rackWidth={RACK_WIDTH}
+            rackPhysicalWidth={rack.width}
             {displayMode}
             rackView={effectiveFaceFilter}
             {showLabelsOnImages}

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -48,6 +48,8 @@
     selected: boolean;
     uHeight: number;
     rackWidth: number;
+    /** Physical rack width in inches (10, 19, 23). Used for slot calculation. */
+    rackPhysicalWidth?: number;
     displayMode?: DisplayMode;
     rackView?: RackView;
     showLabelsOnImages?: boolean;
@@ -107,6 +109,7 @@
     selected,
     uHeight,
     rackWidth,
+    rackPhysicalWidth = 19,
     displayMode = "label",
     rackView = "front",
     showLabelsOnImages = false,
@@ -206,7 +209,14 @@
   // Defensive rendering: device type's slot_width is the source of truth
   // A full-width device (slot_width: 2 or undefined) always renders full-width,
   // even if placement data has incorrect slot_position
-  const isDeviceTypeHalfWidth = $derived(device.slot_width === 1);
+  //
+  // 10-inch racks have only 1 slot - all devices render full-width regardless
+  // of their slot_width. This allows 10" devices to work correctly in both
+  // 10" racks (full-width) and 19" racks (half-width).
+  const rackHasTwoSlots = $derived(rackPhysicalWidth > 10);
+  const isDeviceTypeHalfWidth = $derived(
+    device.slot_width === 1 && rackHasTwoSlots,
+  );
   const effectiveSlotPosition = $derived(
     isDeviceTypeHalfWidth ? slotPosition : "full",
   );


### PR DESCRIPTION
## Summary
- 10-inch mini racks should have only 1 slot (no half-width concept)
- Adds `rackPhysicalWidth` prop to RackDevice component
- Devices render full-width in 10" racks, half-width in 19"+ racks

This is a follow-up to PR #847 which marked DeskPi devices as half-width. That change revealed that 10-inch racks need special handling: they should behave as single-slot racks where all devices render at full-width regardless of their `slot_width` property.

## Test plan
- [x] All 1714 tests pass
- [x] Production build succeeds
- [ ] Manual verification: Place DeskPi device in 10" rack → renders full-width
- [ ] Manual verification: Place DeskPi device in 19" rack → renders half-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)