### PR TITLE
feat: promote Export and Share to toolbar with dedicated icons (#849)

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -18,6 +18,8 @@
     IconImageBold,
     IconFitAllBold,
     IconImageLabel,
+    IconDownloadBold,
+    IconShareBold,
   } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import type { DisplayMode } from "$lib/types";
@@ -279,6 +281,30 @@
         data-testid="btn-fit-all"
       >
         <IconFitAllBold size={ICON_SIZE.md} />
+      </button>
+    </Tooltip>
+
+    <Tooltip text="Export" shortcut="Ctrl+E" position="bottom">
+      <button
+        class="toolbar-icon-btn"
+        aria-label="Export"
+        disabled={!hasRacks}
+        onclick={handleExport}
+        data-testid="btn-export"
+      >
+        <IconDownloadBold size={ICON_SIZE.md} />
+      </button>
+    </Tooltip>
+
+    <Tooltip text="Share" shortcut="Ctrl+H" position="bottom">
+      <button
+        class="toolbar-icon-btn"
+        aria-label="Share"
+        disabled={!hasRacks}
+        onclick={handleShare}
+        data-testid="btn-share"
+      >
+        <IconShareBold size={ICON_SIZE.md} />
       </button>
     </Tooltip>
   </div>

--- a/src/lib/components/icons/IconDownloadBold.svelte
+++ b/src/lib/components/icons/IconDownloadBold.svelte
@@ -1,0 +1,22 @@
+<!--
+  Download icon (Phosphor Bold) - for Export action
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 256 256"
+  fill="currentColor"
+  aria-hidden="true"
+>
+  <path
+    d="M71.51,88.49a12,12,0,0,1,17-17L116,99V24a12,12,0,0,1,24,0V99l27.51-27.52a12,12,0,0,1,17,17l-48,48a12,12,0,0,1-17,0ZM224,116H188a12,12,0,0,0,0,24h32v56H36V140H68a12,12,0,0,0,0-24H32a20,20,0,0,0-20,20v64a20,20,0,0,0,20,20H224a20,20,0,0,0,20-20V136A20,20,0,0,0,224,116Zm-20,52a16,16,0,1,0-16,16A16,16,0,0,0,204,168Z"
+  />
+</svg>

--- a/src/lib/components/icons/IconShareBold.svelte
+++ b/src/lib/components/icons/IconShareBold.svelte
@@ -1,0 +1,22 @@
+<!--
+  Share icon (Phosphor Bold) - iOS-style box with upward arrow
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 256 256"
+  fill="currentColor"
+  aria-hidden="true"
+>
+  <path
+    d="M220,112v96a20,20,0,0,1-20,20H56a20,20,0,0,1-20-20V112A20,20,0,0,1,56,92H76a12,12,0,0,1,0,24H60v88H196V116H180a12,12,0,0,1,0-24h20A20,20,0,0,1,220,112ZM96.49,72.49,116,53v83a12,12,0,0,0,24,0V53l19.51,19.52a12,12,0,1,0,17-17l-40-40a12,12,0,0,0-17,0l-40,40a12,12,0,1,0,17,17Z"
+  />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -77,3 +77,5 @@ export { default as IconFolderBold } from "./IconFolderBold.svelte";
 export { default as IconGearBold } from "./IconGearBold.svelte";
 export { default as IconSunBold } from "./IconSunBold.svelte";
 export { default as IconMoonBold } from "./IconMoonBold.svelte";
+export { default as IconDownloadBold } from "./IconDownloadBold.svelte";
+export { default as IconShareBold } from "./IconShareBold.svelte";


### PR DESCRIPTION
## Summary

- Add Export and Share buttons to the toolbar center zone for better discoverability
- Create `IconDownloadBold.svelte` using Phosphor Bold download icon
- Create `IconShareBold.svelte` using Phosphor Bold iOS-style share icon (box with upward arrow)
- Both buttons are disabled when no racks exist
- Both buttons show tooltips with keyboard shortcuts (Ctrl+E, Ctrl+H)
- Export and Share remain available in File menu for dual access

## Files Changed

- `src/lib/components/Toolbar.svelte`: Added Export and Share buttons to center zone
- `src/lib/components/icons/IconDownloadBold.svelte`: New download icon component
- `src/lib/components/icons/IconShareBold.svelte`: New share icon component
- `src/lib/components/icons/index.ts`: Export new icons

## Test Plan

- [ ] Verify Export and Share buttons appear in toolbar center zone after Fit All
- [ ] Verify buttons are disabled when no racks exist
- [ ] Verify buttons are enabled when racks exist
- [ ] Verify Export button opens Export dialog
- [ ] Verify Share button opens Share dialog
- [ ] Verify tooltips show keyboard shortcuts (Ctrl+E for Export, Ctrl+H for Share)
- [ ] Verify Export and Share still work from File menu

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)