### PR TITLE
fix: consolidate bayed racks in export dialog (#850)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1309,6 +1309,7 @@
     <ExportDialog
       open={exportDialogOpen}
       racks={layoutStore.racks}
+      rackGroups={layoutStore.rack_groups}
       deviceTypes={layoutStore.device_types}
       images={imageStore.getAllImages()}
       displayMode={uiStore.displayMode}


### PR DESCRIPTION
## Summary
- Bayed rack groups now appear as single selectable entries in export dialog
- Individual bays consolidated into unified entry showing group name and bay count (e.g., "42U × 3-bay")
- Selection logic updated to toggle all racks in a group together
- Export button properly enables when racks are selected

## Files Changed
- `src/lib/components/ExportDialog.svelte`: Added `rackGroups` prop, created `SelectableItem` interface, implemented `selectableItems` derived state to consolidate bayed groups
- `src/App.svelte`: Pass `rackGroups` prop to ExportDialog

## Test plan
- [ ] Create a bayed rack group (2+ bays)
- [ ] Open Export dialog (Ctrl+E)
- [ ] Verify: Group appears as single entry (e.g., "Touring Rack - 42U × 3-bay")
- [ ] Verify: Toggling the group selects/deselects all its racks
- [ ] Verify: Export button enables when racks are selected
- [ ] Verify: Export works correctly for bayed groups

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)