### PR TITLE
chore: move New Rack button from toolbar to Racks panel (#852)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1131,7 +1131,6 @@
       warnOnUnsavedChanges={uiStore.warnOnUnsavedChanges}
       promptCleanupOnSave={uiStore.promptCleanupOnSave}
       {partyMode}
-      onnewrack={handleNewRack}
       onsave={maybeSave}
       onload={handleLoad}
       onexport={maybeExport}
@@ -1174,11 +1173,11 @@
               <DevicePalette oncreatedevice={handleAddDevice} />
             {:else if uiStore.sidebarTab === "racks"}
               <RackList
+                onnewrack={handleNewRack}
                 onexport={handleRackContextExport}
                 onedit={handleRackContextEdit}
                 onrename={handleRackContextRename}
                 onduplicate={handleRackContextDuplicate}
-                ondelete={handleRackContextDelete}
               />
             {/if}
           </Pane>

--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -650,7 +650,8 @@
     );
 
     if (!success) {
-      toastStore.showToast(`${targetSlot} slot is occupied`, "error");
+      const slotName = targetSlot.charAt(0).toUpperCase() + targetSlot.slice(1);
+      toastStore.showToast(`${slotName} slot is occupied`, "error");
     }
   }
 

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -2,7 +2,7 @@
   Toolbar Component
   Geismar-minimal three-zone layout:
   - Left: Logo lockup (clickable for help)
-  - Center: Action cluster (New, Undo, Redo, View, Fit)
+  - Center: Action cluster (Undo, Redo, View, Fit, Export, Share)
   - Right: Dropdown menus (File, Settings)
 -->
 <script lang="ts">
@@ -11,7 +11,6 @@
   import SettingsMenu from "./SettingsMenu.svelte";
   import LogoLockup from "./LogoLockup.svelte";
   import {
-    IconPlusBold,
     IconUndoBold,
     IconRedoBold,
     IconTextBold,
@@ -36,7 +35,6 @@
     warnOnUnsavedChanges?: boolean;
     promptCleanupOnSave?: boolean;
     partyMode?: boolean;
-    onnewrack?: () => void;
     onsave?: () => void;
     onload?: () => void;
     onexport?: () => void;
@@ -64,7 +62,6 @@
     warnOnUnsavedChanges = true,
     promptCleanupOnSave = true,
     partyMode = false,
-    onnewrack,
     onsave,
     onload,
     onexport,
@@ -107,12 +104,6 @@
     layoutStore.redo();
     toastStore.showToast(`Redid: ${desc}`, "info");
     analytics.trackToolbarClick("redo");
-  }
-
-  function handleNewRack() {
-    analytics.trackRackCreate();
-    analytics.trackToolbarClick("new-rack");
-    onnewrack?.();
   }
 
   function handleSave() {
@@ -209,17 +200,6 @@
 
   <!-- Center: Action cluster -->
   <div class="toolbar-section toolbar-center">
-    <Tooltip text="New Rack" position="bottom">
-      <button
-        class="toolbar-icon-btn"
-        aria-label="New Rack"
-        onclick={handleNewRack}
-        data-testid="btn-new-rack"
-      >
-        <IconPlusBold size={ICON_SIZE.md} />
-      </button>
-    </Tooltip>
-
     <Tooltip
       text={layoutStore.undoDescription ?? "Undo"}
       shortcut="Ctrl+Z"

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -2970,7 +2970,7 @@ function updateDeviceColourRecorded(
  * Update device slot position with undo/redo support (for half-width devices)
  * @param rackId - Rack ID
  * @param deviceIndex - Device index
- * @param slotPosition - New slot position ('left' or 'right')
+ * @param slotPosition - New slot position ('left', 'right', or 'full')
  * @returns true if successful, false if blocked
  */
 function updateDeviceSlotPositionRecorded(

--- a/src/lib/utils/collision.ts
+++ b/src/lib/utils/collision.ts
@@ -152,7 +152,7 @@ export function isSlotOccupied(
     // Only check devices at the same position
     if (device.position !== position) return false;
     // Skip container children - they're in a different collision space
-    if (device.container_id) return false;
+    if (isContainerChild(device)) return false;
 
     const existingSlot = device.slot_position ?? "full";
     // Check if the slots would overlap


### PR DESCRIPTION
## Summary

- Move New Rack (+) button from Toolbar center zone to RackList panel header
- Button matches styling of "New Device" button in DevicePalette
- Same keyboard shortcut and wizard functionality

## Additional Improvements (CodeRabbit fixes)

- **RackList delete handling**: Context menu delete now properly handles bayed rack groups (previously only deleted first rack)
- **Consistent delete UX**: Both X button and context menu use the same internal delete handlers
- **collision.ts**: Use `isContainerChild()` helper consistently
- **EditPanel**: Capitalize slot position names in toast messages ("Left slot is occupied")
- **layout.svelte.ts**: Fix JSDoc to document 'full' slot position option

## Files Changed

- `src/lib/components/Toolbar.svelte`: Remove New Rack button and handler
- `src/lib/components/RackList.svelte`: Add New Rack button to header, refactor delete handling
- `src/App.svelte`: Wire up onnewrack to RackList instead of Toolbar
- `src/lib/utils/collision.ts`: Use isContainerChild() helper consistently
- `src/lib/components/EditPanel.svelte`: Capitalize slot names in toasts
- `src/lib/stores/layout.svelte.ts`: Fix JSDoc documentation

## Test Plan

- [x] Lint passes
- [x] All 1714 tests pass
- [x] Build succeeds
- [ ] New Rack button visible in Racks panel header
- [ ] Clicking button opens NewRackWizard dialog
- [ ] Context menu delete properly deletes entire bayed rack group

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)