### PR TITLE
fix: bundle Iconify icons as inline SVG for CSP compliance (#865)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@iconify/svelte": "^5.2.1",
         "@lucide/svelte": "^0.562.0",
         "bits-ui": "^2.15.4",
         "debug": "^4.4.3",
@@ -1560,27 +1559,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@iconify/svelte": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-5.2.1.tgz",
-      "integrity": "sha512-zHmsIPmnIhGd5gc95bNN5FL+GifwMZv7M2rlZEpa7IXYGFJm/XGHdWf6PWQa6OBoC+R69WyiPO9NAj5wjfjbow==",
-      "license": "MIT",
-      "dependencies": {
-        "@iconify/types": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyberalien"
-      },
-      "peerDependencies": {
-        "svelte": ">5.0.0"
-      }
-    },
-    "node_modules/@iconify/types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     ]
   },
   "dependencies": {
-    "@iconify/svelte": "^5.2.1",
     "@lucide/svelte": "^0.562.0",
     "bits-ui": "^2.15.4",
     "debug": "^4.4.3",

--- a/src/lib/components/icons/IconCheck.svelte
+++ b/src/lib/components/icons/IconCheck.svelte
@@ -1,22 +1,28 @@
 <!--
-  Check/Success icon using Iconoir via Iconify
+  Check/Success icon (Iconoir)
   Part of #608 icon standardization
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
-
-  Note: :global() is required because @iconify/svelte generates the SVG
-  internally, so Svelte's scoped styles cannot target it directly.
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:check" class="icon-check" aria-hidden="true" />
-
-<style>
-  :global(.icon-check) {
-    width: var(--icon-size-md, 20px);
-    height: var(--icon-size-md, 20px);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M5 13L9 17L19 7" />
+</svg>

--- a/src/lib/components/icons/IconChevronDown.svelte
+++ b/src/lib/components/icons/IconChevronDown.svelte
@@ -1,23 +1,28 @@
 <!--
-  Chevron Down icon using Iconoir via Iconify
+  Chevron Down icon (Iconoir nav-arrow-down)
   Part of #608 icon standardization
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon
-  icon="iconoir:nav-arrow-down"
-  class="icon-chevron-down"
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
   aria-hidden="true"
-/>
-
-<style>
-  :global(.icon-chevron-down) {
-    width: var(--icon-size-md);
-    height: var(--icon-size-md);
-  }
-</style>
+>
+  <path d="M6 9L12 15L18 9" />
+</svg>

--- a/src/lib/components/icons/IconChevronUp.svelte
+++ b/src/lib/components/icons/IconChevronUp.svelte
@@ -1,19 +1,28 @@
 <!--
-  Chevron Up icon using Iconoir via Iconify
+  Chevron Up icon (Iconoir nav-arrow-up)
   Part of #608 icon standardization
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:nav-arrow-up" class="icon-chevron-up" aria-hidden="true" />
-
-<style>
-  :global(.icon-chevron-up) {
-    width: var(--icon-size-md);
-    height: var(--icon-size-md);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M6 15L12 9L18 15" />
+</svg>

--- a/src/lib/components/icons/IconClose.svelte
+++ b/src/lib/components/icons/IconClose.svelte
@@ -1,19 +1,30 @@
 <!--
-  Close (X) icon using Iconoir via Iconify
+  Close (X) icon (Iconoir xmark)
   Part of #608 icon standardization
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-lg); }
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:xmark" class="icon-close" aria-hidden="true" />
-
-<style>
-  :global(.icon-close) {
-    width: var(--icon-size-md);
-    height: var(--icon-size-md);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path
+    d="M6.75827 17.2426L12.0009 12M17.2435 6.75736L12.0009 12M12.0009 12L6.75827 6.75736M12.0009 12L17.2435 17.2426"
+  />
+</svg>

--- a/src/lib/components/icons/IconCopy.svelte
+++ b/src/lib/components/icons/IconCopy.svelte
@@ -1,22 +1,33 @@
 <!--
-  Copy/Clipboard icon using Iconoir via Iconify
+  Copy/Clipboard icon (Iconoir)
   Part of #608 icon standardization
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
-
-  Note: :global() is required because @iconify/svelte generates the SVG
-  internally, so Svelte's scoped styles cannot target it directly.
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:copy" class="icon-copy" aria-hidden="true" />
-
-<style>
-  :global(.icon-copy) {
-    width: var(--icon-size-md, 20px);
-    height: var(--icon-size-md, 20px);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path
+    d="M19.4 20H9.6C9.26863 20 9 19.7314 9 19.4V9.6C9 9.26863 9.26863 9 9.6 9H19.4C19.7314 9 20 9.26863 20 9.6V19.4C20 19.7314 19.7314 20 19.4 20Z"
+  />
+  <path
+    d="M15 9V4.6C15 4.26863 14.7314 4 14.4 4H4.6C4.26863 4 4 4.26863 4 4.6V14.4C4 14.7314 4.26863 15 4.6 15H9"
+  />
+</svg>

--- a/src/lib/components/icons/IconEdit.svelte
+++ b/src/lib/components/icons/IconEdit.svelte
@@ -1,19 +1,30 @@
 <!--
-  Edit/pencil icon using Iconoir via Iconify
+  Edit/pencil icon (Iconoir)
   Part of #608 icon standardization
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-sm); }
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:edit-pencil" class="icon-edit" aria-hidden="true" />
-
-<style>
-  :global(.icon-edit) {
-    width: var(--icon-size-md);
-    height: var(--icon-size-md);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path
+    d="M14.3632 5.65156L15.8431 4.17157C16.6242 3.39052 17.8905 3.39052 18.6716 4.17157L20.0858 5.58579C20.8668 6.36683 20.8668 7.63316 20.0858 8.41421L18.6058 9.8942M14.3632 5.65156L4.74749 15.2672C4.41542 15.5993 4.21079 16.0376 4.16947 16.5054L3.92738 19.2459C3.87261 19.8659 4.39148 20.3848 5.0115 20.33L7.75191 20.0879C8.21972 20.0466 8.65806 19.8419 8.99013 19.5099L18.6058 9.8942M14.3632 5.65156L18.6058 9.8942"
+  />
+</svg>

--- a/src/lib/components/icons/IconMobile.svelte
+++ b/src/lib/components/icons/IconMobile.svelte
@@ -1,19 +1,31 @@
 <!--
-  Mobile/smartphone icon using Iconoir via Iconify
+  Mobile/smartphone icon (Iconoir smartphone-device)
   Part of #608 icon standardization
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: 48px; height: 48px; }
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:smartphone" class="icon-mobile" aria-hidden="true" />
-
-<style>
-  :global(.icon-mobile) {
-    width: var(--icon-size-md);
-    height: var(--icon-size-md);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M12 16.01L12.01 15.9989" />
+  <path
+    d="M7 19.4V4.6C7 4.26863 7.26863 4 7.6 4H16.4C16.7314 4 17 4.26863 17 4.6V19.4C17 19.7314 16.7314 20 16.4 20H7.6C7.26863 20 7 19.7314 7 19.4Z"
+  />
+</svg>

--- a/src/lib/components/icons/IconPlusIconoir.svelte
+++ b/src/lib/components/icons/IconPlusIconoir.svelte
@@ -1,22 +1,31 @@
 <!--
-  Plus icon using Iconoir via Iconify
+  Plus icon (Iconoir)
   Part of #608 icon standardization
 
   Note: This is an Iconoir version separate from the existing IconPlus (Lucide)
   for use in components migrating to the Iconoir standard.
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-lg); }
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:plus" class="icon-plus-iconoir" aria-hidden="true" />
-
-<style>
-  :global(.icon-plus-iconoir) {
-    width: var(--icon-size-md);
-    height: var(--icon-size-md);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M6 12H12M18 12H12M12 12V6M12 12V18" />
+</svg>

--- a/src/lib/components/icons/IconUpload.svelte
+++ b/src/lib/components/icons/IconUpload.svelte
@@ -1,19 +1,29 @@
 <!--
-  Upload icon using Iconoir via Iconify
+  Upload icon (Iconoir)
   Part of #608 icon standardization
 
-  Sizing: Uses --icon-size-md (20px) by default.
-  Override via parent CSS: .parent :global(svg) { width: var(--icon-size-lg); }
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
 -->
 <script lang="ts">
-  import Icon from "@iconify/svelte";
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
 </script>
 
-<Icon icon="iconoir:upload" class="icon-upload" aria-hidden="true" />
-
-<style>
-  :global(.icon-upload) {
-    width: var(--icon-size-md);
-    height: var(--icon-size-md);
-  }
-</style>
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M6 20L18 20" />
+  <path d="M12 16V4M12 4L15.5 7.5M12 4L8.5 7.5" />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -2,7 +2,7 @@
 //
 // Icon Categories:
 // - Brand: Custom brand-specific icons (logo, rack illustrations)
-// - Iconoir: Standard UI icons via @iconify/svelte
+// - Iconoir: Standard UI icons (bundled inline SVG for CSP compliance)
 // - Custom: App-specific composite icons
 
 // =============================================================================
@@ -24,7 +24,7 @@ export { default as BayedRackIcon } from "./BayedRackIcon.svelte";
 export { default as IconImageLabel } from "./IconImageLabel.svelte";
 
 // =============================================================================
-// Iconoir Icons (via @iconify/svelte wrappers)
+// Iconoir Icons (bundled inline SVG)
 // =============================================================================
 
 // Action icons


### PR DESCRIPTION
## Summary

- Convert 9 icon components from `@iconify/svelte` runtime loading to bundled inline SVG
- Remove `@iconify/svelte` dependency (no longer used anywhere in codebase)
- Icons now work offline and comply with Content-Security-Policy headers

## Problem

CSP headers were blocking icon requests to `api.simplesvg.com` and `api.unisvg.com`, causing icons to not display in the share dialog and other areas.

## Solution

Replaced runtime icon fetching with inline SVG components that are bundled at build time. This follows the project's existing pattern for other icons.

## Files Changed

- `src/lib/components/icons/IconCheck.svelte` - inline SVG
- `src/lib/components/icons/IconChevronDown.svelte` - inline SVG
- `src/lib/components/icons/IconChevronUp.svelte` - inline SVG
- `src/lib/components/icons/IconClose.svelte` - inline SVG
- `src/lib/components/icons/IconCopy.svelte` - inline SVG
- `src/lib/components/icons/IconEdit.svelte` - inline SVG
- `src/lib/components/icons/IconMobile.svelte` - inline SVG
- `src/lib/components/icons/IconPlusIconoir.svelte` - inline SVG
- `src/lib/components/icons/IconUpload.svelte` - inline SVG
- `src/lib/components/icons/index.ts` - updated comments
- `package.json` / `package-lock.json` - removed @iconify/svelte

## Test plan

- [x] All 1728 unit tests pass
- [x] Production build succeeds
- [x] Lint passes
- [ ] Manual verification: open share dialog and verify copy icon is visible
- [ ] Manual verification: no CSP violations in browser console

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)