### PR TITLE
feat: change half-width indicator from ½ to ½W for consistency (#867)

### DIFF
--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -181,7 +181,7 @@
     <span
       class="width-indicator"
       title="Half-width: Occupies left or right half of rack"
-      aria-label="Half-width device">½</span
+      aria-label="Half-width device">½W</span
     >
   {/if}
   {#if device.is_full_depth === false}


### PR DESCRIPTION
## Summary
- Changed half-width device indicator from `½` to `½W` to match the half-depth indicator format `½D`
- Maintains visual consistency across width and depth indicators in the device palette

## Files Changed
- `src/lib/components/DevicePaletteItem.svelte`: Updated indicator text from `½` to `½W`

## Test Plan
- [x] Verified lint passes
- [x] Verified all tests pass
- [x] Verified build succeeds
- [ ] Visual verification: half-width devices now show `½W` badge

Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)