### PR TITLE
fix: export dialog preview and button now work correctly (#866)

### DIFF
--- a/src/lib/components/ExportDialog.svelte
+++ b/src/lib/components/ExportDialog.svelte
@@ -87,7 +87,8 @@
   let includeQR = $state(false);
 
   // Rack selection state (stores rack IDs, not item IDs)
-  let selectedRacks = new SvelteSet<string>();
+  // Using SvelteSet for reactive mutations (.add/.delete/.clear)
+  const selectedRacks = new SvelteSet<string>();
 
   // Preview pagination state (for 4+ racks)
   let previewIndex = $state(0);
@@ -146,12 +147,18 @@
   // Initialize rack selection when dialog opens or selectedRackIds changes
   $effect(() => {
     if (open) {
+      // Clear and repopulate the set (mutation triggers reactivity)
+      selectedRacks.clear();
       if (initialSelectedRackIds && initialSelectedRackIds.length > 0) {
         // Pre-select specified racks (from context menu)
-        selectedRacks = new SvelteSet(initialSelectedRackIds);
+        for (const id of initialSelectedRackIds) {
+          selectedRacks.add(id);
+        }
       } else {
         // Default: all racks selected
-        selectedRacks = new SvelteSet(racks.map((r) => r.id));
+        for (const rack of racks) {
+          selectedRacks.add(rack.id);
+        }
       }
       previewIndex = 0;
     }


### PR DESCRIPTION
## Summary

- Fixed the Export dialog showing "No rack selected" and disabled Export button
- Root cause: SvelteSet reassignment in `$effect` wasn't triggering reactivity updates
- Fix: Changed from reassigning to mutating the SvelteSet using `.clear()` and `.add()`

## Root Cause Analysis

The bug was in `ExportDialog.svelte`:

```javascript
// BEFORE (broken): Reassignment isn't reactive
let selectedRacks = new SvelteSet<string>();

$effect(() => {
  if (open) {
    selectedRacks = new SvelteSet(racks.map((r) => r.id)); // This doesn't trigger updates!
  }
});
```

`SvelteSet` provides reactive mutations (`.add()`, `.delete()`, `.clear()`), but the **variable itself** must be declared with `$state` for **reassignment** to be reactive. Since we were reassigning without `$state`, the `$derived` that depends on `selectedRacks.has()` never re-ran.

```javascript
// AFTER (fixed): Mutate instead of reassign
const selectedRacks = new SvelteSet<string>();

$effect(() => {
  if (open) {
    selectedRacks.clear();
    for (const rack of racks) {
      selectedRacks.add(rack.id); // Mutations ARE reactive!
    }
  }
});
```

## Test plan

- [x] Lint passes
- [x] Build passes
- [x] All 1728 tests pass
- [ ] Manual test: Open Export dialog with racks selected - preview shows content
- [ ] Manual test: Export button is enabled when racks exist
- [ ] Manual test: Multi-rack selection works correctly
- [ ] Manual test: Context menu "Export rack" pre-selects that rack

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)