### PR TITLE
fix: half-width blocked slot indicators and remove arrow icon (#875)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -1250,29 +1250,6 @@
           stroke-width="1.5"
         />
       </pattern>
-
-      <!-- Arrow symbol pointing to indicate device is on opposite face -->
-      <symbol id="blocked-arrow-icon" viewBox="0 0 16 16">
-        <!-- Horizontal line -->
-        <line
-          x1="2"
-          y1="8"
-          x2="14"
-          y2="8"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-        />
-        <!-- Arrow head -->
-        <polyline
-          points="9,4 14,8 9,12"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          fill="none"
-        />
-      </symbol>
     </defs>
 
     <!-- Blocked Slots Overlay (renders before devices so devices appear on top) -->
@@ -1282,43 +1259,35 @@
       {@const slotY = (slot: { bottom: number; top: number }) =>
         (rack.height - slot.top) * U_HEIGHT}
       {@const slotWidth = RACK_WIDTH - 2 * RAIL_WIDTH}
-      {@const iconSize = 14}
       <g
         class="blocked-slots-layer"
         transform="translate(0, {RACK_PADDING + RAIL_WIDTH})"
       >
-        {#each blockedSlots as slot (slot.bottom + "-" + slot.top)}
+        {#each blockedSlots as slot (slot.bottom + "-" + slot.top + "-" + (slot.slotPosition ?? "full"))}
+          {@const slotX =
+            slot.slotPosition === "right"
+              ? RAIL_WIDTH + slotWidth / 2
+              : RAIL_WIDTH}
+          {@const slotW =
+            slot.slotPosition === "left" || slot.slotPosition === "right"
+              ? slotWidth / 2
+              : slotWidth}
           <!-- Background wash with improved opacity -->
           <rect
             class="blocked-slot blocked-slot-bg"
-            x={RAIL_WIDTH}
+            x={slotX}
             y={slotY(slot)}
-            width={slotWidth}
+            width={slotW}
             height={slotHeight(slot)}
           />
           <!-- Crosshatch pattern for accessibility (visual texture, not just color) -->
           <rect
             class="blocked-slot blocked-slot-pattern"
-            x={RAIL_WIDTH}
+            x={slotX}
             y={slotY(slot)}
-            width={slotWidth}
+            width={slotW}
             height={slotHeight(slot)}
             fill="url(#blocked-crosshatch-pattern)"
-          />
-          <!-- Directional arrow icon indicating device is on opposite face.
-               Arrow points right for front view (device on rear),
-               arrow points left for rear view (device on front).
-               Centered vertically in the blocked slot area. -->
-          <use
-            href="#blocked-arrow-icon"
-            class="blocked-slot-icon"
-            x={RAIL_WIDTH + slotWidth / 2 - iconSize / 2}
-            y={slotY(slot) + slotHeight(slot) / 2 - iconSize / 2}
-            width={iconSize}
-            height={iconSize}
-            transform={faceFilter === "rear"
-              ? `rotate(180, ${RAIL_WIDTH + slotWidth / 2}, ${slotY(slot) + slotHeight(slot) / 2})`
-              : ""}
           />
         {/each}
       </g>
@@ -1668,13 +1637,6 @@
   .blocked-slot-pattern {
     pointer-events: none;
     opacity: 0.9;
-  }
-
-  /* Arrow icon indicating device is on opposite face */
-  .blocked-slot-icon {
-    color: var(--colour-blocked-icon, rgba(239, 68, 68, 0.7));
-    pointer-events: none;
-    opacity: 0.85;
   }
 
   /* Party mode: rainbow glow animation */

--- a/src/lib/utils/blocked-slots.ts
+++ b/src/lib/utils/blocked-slots.ts
@@ -5,15 +5,17 @@
  * Used for rendering visual indicators in dual-view mode.
  */
 
-import type { Rack, DeviceType, RackView } from "$lib/types";
+import type { Rack, DeviceType, RackView, SlotPosition } from "$lib/types";
 import { toHumanUnits } from "$lib/utils/position";
 
 /**
- * Represents a range of U positions (inclusive)
+ * Represents a range of U positions (inclusive) with optional slot positioning
  */
 export interface URange {
   bottom: number; // Lower U position
   top: number; // Upper U position
+  /** Slot position for half-width devices. undefined = full-width */
+  slotPosition?: SlotPosition;
 }
 
 /**
@@ -64,7 +66,12 @@ export function getBlockedSlots(
     const bottom = positionU;
     const top = positionU + deviceType.u_height - 1;
 
-    blocked.push({ bottom, top });
+    // Determine slot position for half-width devices
+    // slot_width: 1 = half-width, 2 or undefined = full-width
+    const isHalfWidth = deviceType.slot_width === 1;
+    const slotPosition = isHalfWidth ? placedDevice.slot_position : undefined;
+
+    blocked.push({ bottom, top, slotPosition });
   }
 
   return blocked;

--- a/src/tests/blocked-slots.test.ts
+++ b/src/tests/blocked-slots.test.ts
@@ -194,4 +194,124 @@ describe("getBlockedSlots", () => {
       expect(blockedSlots.length).toBe(0);
     });
   });
+
+  describe("slot position", () => {
+    it("returns undefined slotPosition for full-width devices", () => {
+      const rack = createTestRack({
+        height: 42,
+        devices: [
+          createTestDevice({
+            device_type: "full-width-half-depth",
+            position: 10,
+            face: "front",
+          }),
+        ],
+      });
+
+      const deviceLibrary = [
+        createTestDeviceType({
+          slug: "full-width-half-depth",
+          u_height: 1,
+          is_full_depth: false,
+          slot_width: 2, // Full-width
+        }),
+      ];
+
+      const blockedSlots = getBlockedSlots(rack, "rear", deviceLibrary);
+
+      expect(blockedSlots.length).toBe(1);
+      expect(blockedSlots[0].slotPosition).toBeUndefined();
+    });
+
+    it("returns left slotPosition for half-width device in left slot", () => {
+      const rack = createTestRack({
+        height: 42,
+        devices: [
+          createTestDevice({
+            device_type: "half-width-half-depth",
+            position: 10,
+            face: "front",
+            slot_position: "left",
+          }),
+        ],
+      });
+
+      const deviceLibrary = [
+        createTestDeviceType({
+          slug: "half-width-half-depth",
+          u_height: 1,
+          is_full_depth: false,
+          slot_width: 1, // Half-width
+        }),
+      ];
+
+      const blockedSlots = getBlockedSlots(rack, "rear", deviceLibrary);
+
+      expect(blockedSlots.length).toBe(1);
+      expect(blockedSlots[0].slotPosition).toBe("left");
+    });
+
+    it("returns right slotPosition for half-width device in right slot", () => {
+      const rack = createTestRack({
+        height: 42,
+        devices: [
+          createTestDevice({
+            device_type: "half-width-half-depth",
+            position: 10,
+            face: "rear",
+            slot_position: "right",
+          }),
+        ],
+      });
+
+      const deviceLibrary = [
+        createTestDeviceType({
+          slug: "half-width-half-depth",
+          u_height: 1,
+          is_full_depth: false,
+          slot_width: 1, // Half-width
+        }),
+      ];
+
+      const blockedSlots = getBlockedSlots(rack, "front", deviceLibrary);
+
+      expect(blockedSlots.length).toBe(1);
+      expect(blockedSlots[0].slotPosition).toBe("right");
+    });
+
+    it("handles multiple half-width devices with different positions", () => {
+      const rack = createTestRack({
+        height: 42,
+        devices: [
+          createTestDevice({
+            device_type: "half-width-half-depth",
+            position: 10,
+            face: "front",
+            slot_position: "left",
+          }),
+          createTestDevice({
+            device_type: "half-width-half-depth",
+            position: 10,
+            face: "front",
+            slot_position: "right",
+          }),
+        ],
+      });
+
+      const deviceLibrary = [
+        createTestDeviceType({
+          slug: "half-width-half-depth",
+          u_height: 1,
+          is_full_depth: false,
+          slot_width: 1,
+        }),
+      ];
+
+      const blockedSlots = getBlockedSlots(rack, "rear", deviceLibrary);
+
+      expect(blockedSlots.length).toBe(2);
+      expect(blockedSlots[0].slotPosition).toBe("left");
+      expect(blockedSlots[1].slotPosition).toBe("right");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Remove unexpected red arrow icon from blocked slot indicators
- Fix half-width half-depth device indicators to only cover the same slot as the device (not full width)

## Changes

- Updated `URange` interface to include optional `slotPosition` field for half-width devices
- Modified `getBlockedSlots()` to capture `slot_position` when device has `slot_width === 1`
- Removed arrow symbol definition and `<use>` element from Rack.svelte blocked slots section
- Updated blocked slot rect rendering to calculate X position and width based on `slotPosition`
- Removed unused `.blocked-slot-icon` CSS class
- Added 4 new tests for slot position behavior in blocked-slots.test.ts

## Files Changed

- `src/lib/utils/blocked-slots.ts`: Add slotPosition to URange and capture in getBlockedSlots()
- `src/lib/components/Rack.svelte`: Remove arrow, update rect positioning for half-width
- `src/tests/blocked-slots.test.ts`: Add slot position tests

## Test Plan

- [x] Lint passes
- [x] All 1738 unit tests pass
- [x] Build succeeds
- [ ] Manual verification: half-width half-depth device shows indicator in same slot only
- [ ] Manual verification: no arrow icon in blocked indicators

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)