### PR TITLE
feat: add bits-ui Checkbox component (#828)

### DIFF
--- a/src/lib/components/Checkbox.svelte
+++ b/src/lib/components/Checkbox.svelte
@@ -1,0 +1,121 @@
+<!--
+  Checkbox Component
+  Reusable checkbox using bits-ui Checkbox primitive
+  Consistent styling and accessibility across the application
+-->
+<script lang="ts">
+  import { Checkbox } from "bits-ui";
+  import { IconSquare, IconSquareFilled } from "./icons";
+
+  interface Props {
+    /** Current checked state */
+    checked?: boolean;
+    /** Whether the checkbox is disabled */
+    disabled?: boolean;
+    /** ID for form labeling */
+    id?: string;
+    /** Label text to display next to checkbox */
+    label?: string;
+    /** Callback when checked state changes */
+    onchange?: (checked: boolean) => void;
+  }
+
+  let {
+    checked = $bindable(false),
+    disabled = false,
+    id: providedId,
+    label,
+    onchange,
+  }: Props = $props();
+
+  // Generate a stable fallback ID if none provided
+  const fallbackId = `checkbox-${Math.random().toString(36).slice(2, 9)}`;
+  const id = $derived(providedId || fallbackId);
+
+  function handleCheckedChange(newChecked: boolean | "indeterminate") {
+    if (newChecked !== "indeterminate") {
+      checked = newChecked;
+      onchange?.(newChecked);
+    }
+  }
+</script>
+
+<div class="checkbox-wrapper">
+  <Checkbox.Root
+    {id}
+    {disabled}
+    {checked}
+    onCheckedChange={handleCheckedChange}
+  >
+    {#snippet children({ checked: isChecked })}
+      <span class="checkbox-indicator">
+        {#if isChecked}
+          <IconSquareFilled size={16} />
+        {:else}
+          <IconSquare size={16} />
+        {/if}
+      </span>
+    {/snippet}
+  </Checkbox.Root>
+  {#if label}
+    <label for={id} class="checkbox-label" class:disabled>{label}</label>
+  {/if}
+</div>
+
+<style>
+  .checkbox-wrapper {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  /* Style bits-ui Checkbox.Root rendered element */
+  .checkbox-wrapper :global(button) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--colour-text);
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .checkbox-wrapper :global(button:hover:not([data-disabled])) {
+    color: var(--colour-selection);
+  }
+
+  .checkbox-wrapper :global(button:focus-visible) {
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  .checkbox-wrapper :global(button[data-disabled]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .checkbox-wrapper :global(button[data-state="checked"]) {
+    color: var(--colour-selection);
+  }
+
+  .checkbox-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .checkbox-label {
+    font-size: var(--font-size-base);
+    color: var(--colour-text);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .checkbox-label.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/lib/components/ExportDialog.svelte
+++ b/src/lib/components/ExportDialog.svelte
@@ -18,6 +18,7 @@
   import Dialog from "./Dialog.svelte";
   import LogoLoader from "./LogoLoader.svelte";
   import Shimmer from "./Shimmer.svelte";
+  import Checkbox from "./Checkbox.svelte";
   import { generateExportSVG, generateExportFilename } from "$lib/utils/export";
   import { analytics } from "$lib/utils/analytics";
   import { SvelteSet } from "svelte/reactivity";
@@ -468,26 +469,29 @@
 
       {#if canSelectTransparent}
         <div class="form-group checkbox-group">
-          <label>
-            <input type="checkbox" bind:checked={transparent} />
-            Transparent background
-          </label>
+          <Checkbox
+            id="transparent-bg"
+            bind:checked={transparent}
+            label="Transparent background"
+          />
         </div>
       {/if}
 
       <div class="form-group checkbox-group">
-        <label>
-          <input type="checkbox" bind:checked={includeLegend} />
-          Include legend
-        </label>
+        <Checkbox
+          id="include-legend"
+          bind:checked={includeLegend}
+          label="Include legend"
+        />
       </div>
 
       {#if canIncludeQR}
         <div class="form-group checkbox-group">
-          <label>
-            <input type="checkbox" bind:checked={includeQR} />
-            Include sharing QR code
-          </label>
+          <Checkbox
+            id="include-qr"
+            bind:checked={includeQR}
+            label="Include sharing QR code"
+          />
         </div>
       {/if}
     {/if}
@@ -882,21 +886,6 @@
   .checkbox-group {
     flex-direction: row;
     align-items: center;
-  }
-
-  .checkbox-group label {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    cursor: pointer;
-    font-weight: var(--font-weight-normal);
-  }
-
-  .checkbox-group input[type="checkbox"] {
-    width: var(--space-4);
-    height: var(--space-4);
-    accent-color: var(--colour-selection);
-    cursor: pointer;
   }
 
   .form-group select:disabled {


### PR DESCRIPTION
## Summary

- Create reusable `Checkbox.svelte` component using bits-ui Checkbox primitive
- Replace native checkboxes in `ExportDialog.svelte` with new component
- Consistent styling with IconSquare/IconSquareFilled for check states
- Better accessibility with proper ARIA attributes from bits-ui
- Auto-generated fallback IDs when no id prop provided

## Files Changed

- `src/lib/components/Checkbox.svelte` (new)
- `src/lib/components/ExportDialog.svelte`

## Notes

- AddDeviceForm uses toggle switches (different visual pattern) - tracked separately in #880
- The fallback ID uses `Math.random()` which is fine for this client-side only app (no SSR)

## Test Plan

- [x] Lint passes
- [x] All 1738 unit tests pass
- [x] Production build succeeds
- [x] CodeRabbit CLI review addressed

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)