### PR TITLE
fix: Rear view toggle works for bayed rack groups (#874)

### DIFF
--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -40,6 +40,8 @@
     showLabelsOnImages?: boolean;
     /** Party mode visual effects active */
     partyMode?: boolean;
+    /** Show rear row of bayed rack group (controlled by Edit Panel toggle) */
+    showRear?: boolean;
     /** Show annotation column */
     showAnnotations?: boolean;
     /** Which field to display in annotation column */
@@ -105,6 +107,7 @@
     displayMode = "label",
     showLabelsOnImages = false,
     partyMode = false,
+    showRear = true,
     showAnnotations = false,
     annotationField = "name",
     enableLongPress = false,
@@ -340,81 +343,84 @@
     {/each}
   </div>
 
-  <!-- Rear row label -->
-  <div class="row-label">REAR</div>
+  <!-- Rear row (conditionally rendered based on showRear toggle) -->
+  {#if showRear}
+    <!-- Rear row label -->
+    <div class="row-label">REAR</div>
 
-  <!-- Rear row: racks right-to-left with U-labels between adjacent bays (mirrored: Bay 1 on right) -->
-  <div class="bayed-row rear-row">
-    {#each reversedRacks as rack, reversedIndex (rack.id)}
-      {@const bayIndex = racks.length - 1 - reversedIndex}
-      {@const isActive = rack.id === activeRackId}
-      {@const isSelected = rack.id === selectedRackId}
-      <!-- U-labels column between adjacent bays (not before first bay in reversed order) -->
-      {#if reversedIndex > 0}
-        <div class="u-labels-column">
-          <ULabels
-            {uLabels}
-            {uColumnHeight}
-            railWidth={RAIL_WIDTH}
-            topPadding={RACK_PADDING_HIDDEN}
-          />
-        </div>
-      {/if}
-      <RackContextMenu
-        onexport={() => onexport?.(racks.map((r) => r.id))}
-        onfocus={() => onfocus?.(racks.map((r) => r.id))}
-        onedit={() => onedit?.(rack.id)}
-        onrename={() => onrename?.(rack.id)}
-        onduplicate={() => onduplicate?.(rack.id)}
-        ondelete={() => ondelete?.(rack.id)}
-      >
-        <div
-          class="bay-container"
-          class:active={isActive}
-          class:selected={isSelected}
-          role="presentation"
-          onpointerdown={() => (longPressRackId = rack.id)}
+    <!-- Rear row: racks right-to-left with U-labels between adjacent bays (mirrored: Bay 1 on right) -->
+    <div class="bayed-row rear-row">
+      {#each reversedRacks as rack, reversedIndex (rack.id)}
+        {@const bayIndex = racks.length - 1 - reversedIndex}
+        {@const isActive = rack.id === activeRackId}
+        {@const isSelected = rack.id === selectedRackId}
+        <!-- U-labels column between adjacent bays (not before first bay in reversed order) -->
+        {#if reversedIndex > 0}
+          <div class="u-labels-column">
+            <ULabels
+              {uLabels}
+              {uColumnHeight}
+              railWidth={RAIL_WIDTH}
+              topPadding={RACK_PADDING_HIDDEN}
+            />
+          </div>
+        {/if}
+        <RackContextMenu
+          onexport={() => onexport?.(racks.map((r) => r.id))}
+          onfocus={() => onfocus?.(racks.map((r) => r.id))}
+          onedit={() => onedit?.(rack.id)}
+          onrename={() => onrename?.(rack.id)}
+          onduplicate={() => onduplicate?.(rack.id)}
+          ondelete={() => ondelete?.(rack.id)}
         >
-          <div class="bay-label">Bay {bayIndex + 1}</div>
-          <Rack
-            {rack}
-            {deviceLibrary}
-            selected={false}
-            selectedDeviceId={isActive ? selectedDeviceId : null}
-            {displayMode}
-            {showLabelsOnImages}
-            {partyMode}
-            faceFilter="rear"
-            hideRackName={true}
-            hideULabels={true}
-            onselect={() =>
-              ongroupselect?.(
-                new CustomEvent("groupselect", {
-                  detail: { groupId: group.id },
-                }),
-              )}
-            {ondeviceselect}
-            ondevicedrop={(e) => handleRearDeviceDrop(rack.id, e)}
-            {ondevicemove}
-            {ondevicemoverack}
-            {onplacementtap}
-          />
-        </div>
-      </RackContextMenu>
-      <!-- Annotation column RIGHT of rear bay (mirrored) -->
-      {#if showAnnotations}
-        <div class="annotation-wrapper">
-          <AnnotationColumn
-            {rack}
-            {deviceLibrary}
-            {annotationField}
-            width={ANNOTATION_WIDTH_COMPACT}
-            faceFilter="rear"
-          />
-        </div>
-      {/if}
-    {/each}
-  </div>
+          <div
+            class="bay-container"
+            class:active={isActive}
+            class:selected={isSelected}
+            role="presentation"
+            onpointerdown={() => (longPressRackId = rack.id)}
+          >
+            <div class="bay-label">Bay {bayIndex + 1}</div>
+            <Rack
+              {rack}
+              {deviceLibrary}
+              selected={false}
+              selectedDeviceId={isActive ? selectedDeviceId : null}
+              {displayMode}
+              {showLabelsOnImages}
+              {partyMode}
+              faceFilter="rear"
+              hideRackName={true}
+              hideULabels={true}
+              onselect={() =>
+                ongroupselect?.(
+                  new CustomEvent("groupselect", {
+                    detail: { groupId: group.id },
+                  }),
+                )}
+              {ondeviceselect}
+              ondevicedrop={(e) => handleRearDeviceDrop(rack.id, e)}
+              {ondevicemove}
+              {ondevicemoverack}
+              {onplacementtap}
+            />
+          </div>
+        </RackContextMenu>
+        <!-- Annotation column RIGHT of rear bay (mirrored) -->
+        {#if showAnnotations}
+          <div class="annotation-wrapper">
+            <AnnotationColumn
+              {rack}
+              {deviceLibrary}
+              {annotationField}
+              width={ANNOTATION_WIDTH_COMPACT}
+              faceFilter="rear"
+            />
+          </div>
+        {/if}
+      {/each}
+    </div>
+  {/if}
 </div>
 
 <style>

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -469,6 +469,7 @@
           {#each organizedRacks.groupEntries as { group, racks: groupRacks } (group.id)}
             {#if group.layout_preset === "bayed"}
               <!-- Bayed/touring racks use special stacked view -->
+              <!-- showRear derived from first rack in group (all bays share the same setting) -->
               <BayedRackView
                 {group}
                 racks={groupRacks}
@@ -486,6 +487,7 @@
                   : null}
                 displayMode={uiStore.displayMode}
                 showLabelsOnImages={uiStore.showLabelsOnImages}
+                showRear={groupRacks[0]?.show_rear ?? true}
                 showAnnotations={uiStore.showAnnotations}
                 annotationField={uiStore.annotationField}
                 {partyMode}

--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -825,10 +825,17 @@
             { value: "hide", label: "Hide" },
           ]}
           value={selectedRack.show_rear ? "show" : "hide"}
-          onchange={(value) =>
-            layoutStore.updateRack(currentRackId!, {
-              show_rear: value === "show",
-            })}
+          onchange={(value) => {
+            const showRear = value === "show";
+            if (selectedGroup) {
+              // For bayed racks, update all racks in the group
+              for (const rackId of selectedGroup.rack_ids) {
+                layoutStore.updateRack(rackId, { show_rear: showRear });
+              }
+            } else {
+              layoutStore.updateRack(currentRackId!, { show_rear: showRear });
+            }
+          }}
           ariaLabel="Show rear view on canvas"
         />
       </div>

--- a/src/lib/components/RackEditSheet.svelte
+++ b/src/lib/components/RackEditSheet.svelte
@@ -260,10 +260,17 @@
           { value: "hide", label: "Hide" },
         ]}
         value={rack.show_rear ? "show" : "hide"}
-        onchange={(value) =>
-          layoutStore.updateRack(rack.id, {
-            show_rear: value === "show",
-          })}
+        onchange={(value) => {
+          const showRear = value === "show";
+          if (rackGroup) {
+            // For bayed racks, update all racks in the group
+            for (const rackId of rackGroup.rack_ids) {
+              layoutStore.updateRack(rackId, { show_rear: showRear });
+            }
+          } else {
+            layoutStore.updateRack(rack.id, { show_rear: showRear });
+          }
+        }}
         ariaLabel="Show rear view on canvas"
       />
     </div>


### PR DESCRIPTION
## **User description**
## Summary

- Makes the "Show Rear View" toggle in the Edit Panel work for bayed rack groups
- Previously the toggle had no effect because BayedRackView always rendered both front and rear rows
- Now the rear row is conditionally rendered based on the showRear prop

## Changes

- **BayedRackView.svelte**: Added `showRear` prop (defaults to `true`), wrapped rear row in `{#if showRear}` conditional
- **Canvas.svelte**: Passes `showRear={groupRacks[0]?.show_rear ?? true}` to BayedRackView
- **EditPanel.svelte**: Updates all racks in bayed group when toggle changes
- **RackEditSheet.svelte**: Same group-aware toggle logic for mobile

## Test plan

- [ ] Create a 2-bay bayed rack group
- [ ] Select the bayed rack group
- [ ] Toggle "Show Rear View" to Hide
- [ ] Verify rear row disappears from canvas
- [ ] Toggle back to Show
- [ ] Verify rear row reappears
- [ ] Close and reopen Edit Panel, verify toggle state persists

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make "Show Rear View" toggle hide rear row for bayed rack groups

### What Changed
- The canvas now hides the entire rear row for bayed rack groups when "Show Rear View" is set to Hide.
- Changing the toggle updates every rack in the bayed group (desktop Edit Panel and mobile Rack Edit Sheet), so all bays reflect the same rear-view setting.
- The bayed rack view receives the group's rear-view setting so the canvas and edit panels show consistent state.

### Impact
`✅ Rear row hides on canvas when hidden in group`
`✅ All bays in a bayed group update together when toggled`
`✅ Mobile and desktop toggles remain in sync`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
