### PR TITLE
chore: remove About header and X button from about dialog (#900)

### DIFF
--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -7,14 +7,7 @@
   import { Dialog } from "bits-ui";
   import { VERSION } from "$lib/version";
   import LogoLockup from "./LogoLockup.svelte";
-  import {
-    IconClose,
-    IconGitHub,
-    IconBug,
-    IconChat,
-    IconCheck,
-    IconCopy,
-  } from "./icons";
+  import { IconGitHub, IconBug, IconChat, IconCheck, IconCopy } from "./icons";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { formatShortcut } from "$lib/utils/platform";
@@ -212,12 +205,8 @@
   <Dialog.Portal>
     <Dialog.Overlay class="dialog-backdrop" />
     <Dialog.Content class="help-dialog" style="width: 600px;">
-      <div class="dialog-header">
-        <Dialog.Title class="dialog-title">About</Dialog.Title>
-        <Dialog.Close class="dialog-close" aria-label="Close dialog">
-          <IconClose />
-        </Dialog.Close>
-      </div>
+      <!-- Visually hidden title for accessibility -->
+      <Dialog.Title class="sr-only">About Rackula</Dialog.Title>
       <Dialog.Description class="help-dialog-description">
         Application help, keyboard shortcuts, and build information
       </Dialog.Description>
@@ -367,20 +356,13 @@
     z-index: calc(var(--z-modal, 200) + 1);
   }
 
-  .dialog-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--space-3) var(--space-4);
-    border-bottom: 1px solid var(--colour-border);
-  }
-
   .dialog-content {
     padding: var(--space-4);
     overflow-y: auto;
   }
 
   /* Screen reader only - visually hidden but accessible */
+  :global(.help-dialog .sr-only),
   :global(.help-dialog-description) {
     position: absolute;
     width: 1px;


### PR DESCRIPTION
## **User description**
## Summary
- Remove "About" header text and X close button from help dialog
- Logo and title now appear as topmost elements
- Dialog still closes via click outside or Escape key (bits-ui default behavior)
- Visually-hidden title maintained for screen reader accessibility

## Files Changed
- `src/lib/components/HelpPanel.svelte`: Remove dialog-header section and IconClose import

## Test plan
- [x] Lint passes
- [x] Unit tests pass (1741 tests)
- [x] Build succeeds
- [x] CodeRabbit CLI review passes (local)
- [ ] Verify dialog closes on click outside
- [ ] Verify dialog closes on Escape key press
- [ ] Verify logo/title are now topmost visible elements

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Remove visible "About" header and close button from Help dialog

### What Changed
- The visible "About" header text and the top-right "X" close button were removed from the help/about dialog; the logo and title now appear as the topmost visible elements inside the dialog.
- The dialog keeps a hidden title for screen readers so assistive tech still announces the dialog as "About Rackula".
- Dialog closing remains available by clicking outside the dialog or pressing Escape (no visible close button).

### Impact
`✅ Fewer UI distractions in the help dialog`
`✅ Maintained screen reader accessibility`
`✅ Unchanged keyboard/backdrop closing behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
