### PR TITLE
fix: prevent autosave from loading after New Layout click (#899)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -76,7 +76,9 @@
   import { debug, persistenceDebug } from "$lib/utils/debug";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
   import { Tooltip } from "bits-ui";
-  import StartScreen from "$lib/components/StartScreen.svelte";
+  import StartScreen, {
+    type StartScreenCloseOptions,
+  } from "$lib/components/StartScreen.svelte";
   import { PERSIST_ENABLED } from "$lib/utils/persistence-config";
   import {
     saveLayoutToServer,
@@ -1202,12 +1204,17 @@
   });
 
   // Handler for StartScreen close
-  function handleStartScreenClose(layoutId?: string) {
-    currentLayoutId = layoutId;
+  function handleStartScreenClose(options?: StartScreenCloseOptions) {
+    currentLayoutId = options?.layoutId;
     showStartScreen = false;
 
     // If no layout was loaded from API (offline mode), check localStorage
-    if (!layoutId && layoutStore.rackCount === 0) {
+    // Skip if user explicitly requested a new layout (skipAutosave flag)
+    if (
+      !options?.layoutId &&
+      !options?.skipAutosave &&
+      layoutStore.rackCount === 0
+    ) {
       const autosaved = loadSession();
       if (autosaved) {
         // Deep-clone to prevent race conditions with concurrent session changes

--- a/src/lib/components/StartScreen.svelte
+++ b/src/lib/components/StartScreen.svelte
@@ -30,8 +30,16 @@
   import LogoLockup from "$lib/components/LogoLockup.svelte";
   import { VERSION } from "$lib/version";
 
+  /** Options passed to onClose callback */
+  export interface StartScreenCloseOptions {
+    /** Layout ID if a saved layout was selected */
+    layoutId?: string;
+    /** Skip loading autosaved session (used when creating new layout) */
+    skipAutosave?: boolean;
+  }
+
   interface Props {
-    onClose: (layoutId?: string) => void;
+    onClose: (options?: StartScreenCloseOptions) => void;
   }
 
   let { onClose }: Props = $props();
@@ -87,7 +95,7 @@
       const layout = await loadSavedLayout(item.id);
       layoutStore.loadLayout(layout);
       toastStore.showToast(`Opened "${item.name}"`, "info");
-      onClose(item.id);
+      onClose({ layoutId: item.id });
     } catch (e) {
       const message =
         e instanceof PersistenceError ? e.message : "Failed to open layout";
@@ -116,7 +124,8 @@
   function handleNewLayout() {
     layoutStore.resetLayout();
     dialogStore.open("newRack");
-    onClose();
+    // Skip autosave - user explicitly wants a fresh layout
+    onClose({ skipAutosave: true });
   }
 
   async function handleImportFile() {


### PR DESCRIPTION
## **User description**
## Summary
- Fixed the double-rack bug when clicking "New Layout" from the splash screen
- Added `skipAutosave` flag to `StartScreenCloseOptions` interface
- `handleStartScreenClose()` now respects the flag and skips autosave loading when user explicitly creates new layout

## Root Cause
When clicking "New Layout" on the splash screen:
1. `resetLayout()` correctly cleared all racks
2. `dialogStore.open("newRack")` opened the wizard
3. `onClose()` called `handleStartScreenClose()` which loaded the autosaved session, **overwriting the reset**
4. User completed wizard → rack added to existing autosaved rack(s) → 2+ racks

## Fix
Pass `{ skipAutosave: true }` when "New Layout" is clicked, so `handleStartScreenClose()` skips loading autosaved sessions when user explicitly wants a fresh layout.

## Test Plan
- [ ] Click "New Layout" on splash screen when autosave exists
- [ ] Complete New Rack Wizard
- [ ] Verify only ONE rack exists (the wizard-created one)
- [ ] Verify "Continue" in offline mode still loads autosave
- [ ] Verify clicking saved layout still works

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Don't load autosave when user chooses "New Layout" from the start screen**

### What Changed
- "New Layout" now signals the app to skip loading an autosaved session, so the canvas stays empty when the user starts a new layout
- Opening a saved layout sends its ID to the app; the start-screen close handler uses that ID to decide whether to load autosave
- The app no longer overwrites an explicit "new layout" reset with an autosaved session, preventing an extra rack from appearing after completing the new-rack wizard

### Impact
`✅ No duplicate racks when creating a new layout`
`✅ New Layout reliably opens an empty canvas`
`✅ Autosave still loads when the user chooses to continue`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
