### PR TITLE
feat(api): UUID-based API routes (#917)

### DIFF
--- a/api/src/schemas/layout.ts
+++ b/api/src/schemas/layout.ts
@@ -19,6 +19,14 @@ const UUID_EXTRACTION_PATTERN =
   /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
 /**
+ * UUID schema for route parameter validation.
+ * Used to validate :uuid route parameters in layout API routes.
+ */
+export const UuidSchema = z
+  .string()
+  .regex(UUID_PATTERN, "Invalid layout UUID format");
+
+/**
  * Check if a string is a valid UUID format
  */
 export function isUuid(str: string): boolean {
@@ -133,8 +141,10 @@ export const LayoutIdSchema = z
   );
 
 // Layout list item returned by GET /api/layouts (with counts)
+// Layout list item returned by GET /api/layouts (with counts)
+// The id field is the layout's UUID from metadata.id (stable identity)
 export const LayoutListItemSchema = z.object({
-  id: z.string(),
+  id: z.string().regex(UUID_PATTERN, "Invalid UUID format"),
   name: z.string(),
   version: z.string(),
   updatedAt: z.string().datetime(),

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -114,7 +114,8 @@
 
   // Persistence state
   let showStartScreen = $state(PERSIST_ENABLED);
-  let currentLayoutId = $state<string | undefined>(undefined);
+  // Diagnostic: tracks current layout UUID (assigned but not actively read - for debugging)
+  let _currentLayoutId = $state<string | undefined>(undefined);
   let saveStatus = $state<SaveStatusType>("idle");
   let apiAvailable = $state(true);
 
@@ -1159,8 +1160,9 @@
     serverSaveTimer = setTimeout(async () => {
       saveStatus = "saving";
       try {
-        const newId = await saveLayoutToServer(snapshot, currentLayoutId);
-        currentLayoutId = newId;
+        // UUID comes from layout metadata now, not passed as parameter
+        const newId = await saveLayoutToServer(snapshot);
+        _currentLayoutId = newId;
         saveStatus = "saved";
       } catch (e) {
         console.warn("Auto-save failed:", e);
@@ -1205,7 +1207,7 @@
 
   // Handler for StartScreen close
   function handleStartScreenClose(options?: StartScreenCloseOptions) {
-    currentLayoutId = options?.layoutId;
+    _currentLayoutId = options?.layoutId;
     showStartScreen = false;
 
     // If no layout was loaded from API (offline mode), check localStorage


### PR DESCRIPTION
## **User description**
## Summary
- Migrate API routes from slug-based to UUID-based routing
- Provides stable URLs that don't change when layouts are renamed

## Changes
- Add `UuidSchema` for route parameter validation
- Update `LayoutListItemSchema` to validate UUID format for `id` field
- Add `layoutExistsByUuid()`, `getLayoutByUuid()`, `saveLayoutByUuid()`, `deleteLayoutByUuid()` functions
- Update all route handlers to use UUID-based functions
- Fix frontend `persistence-api.ts` to use UUID from metadata
- Implement atomic writes with temp file + rename
- Add slug collision detection

## Test plan
- [ ] List layouts returns valid UUIDs
- [ ] GET `/api/layouts/{uuid}` returns correct layout
- [ ] PUT `/api/layouts/{uuid}` saves layout data
- [ ] DELETE `/api/layouts/{uuid}` removes layout
- [ ] Invalid UUID returns 400 error

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Use stable UUIDs for layout persistence and API routes

### What Changed
- All layout API endpoints now use the layout UUID (metadata.id) instead of filename/slug: list, get, put, delete endpoints accept/return UUIDs.
- The layout list returns UUIDs as the id field and excludes files that lack a metadata.id UUID so only addressable layouts appear.
- Saving requires the YAML to include metadata.id that matches the route UUID; mismatches and invalid UUIDs return clear 400 errors.
- Saves use an atomic write (temp file + rename) and detect slug name collisions to prevent overwriting a different layout with the same filename.
- The frontend persistence client was updated to read/write using metadata.id UUIDs and will reject saves for layouts missing metadata.id.

### Impact
`✅ Stable layout URLs across renames`
`✅ Fewer accidental overwrites due to slug collisions`
`✅ Clearer errors for invalid or mismatched UUIDs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
