### PR TITLE
fix(ux): hide persistence warning for SaaS users

### DIFF
--- a/src/lib/components/StartScreen.svelte
+++ b/src/lib/components/StartScreen.svelte
@@ -13,7 +13,10 @@
     type SavedLayoutItem,
     PersistenceError,
   } from "$lib/utils/persistence-api";
-  import { initializePersistence } from "$lib/stores/persistence.svelte";
+  import {
+    initializePersistence,
+    hasEverConnectedToApi,
+  } from "$lib/stores/persistence.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
@@ -53,6 +56,9 @@
   let error = $state<string | null>(null);
   let apiAvailable = $state(true);
   let deletingId = $state<string | null>(null);
+
+  /** Only show offline warning if user previously had API working */
+  let showOfflineWarning = $derived(!apiAvailable && hasEverConnectedToApi());
 
   onMount(async () => {
     // Initialize persistence and check API health
@@ -206,7 +212,7 @@
       </button>
     </div>
 
-    {#if !apiAvailable}
+    {#if showOfflineWarning}
       <div class="offline-warning">
         <IconCloudOff size={18} />
         <div class="offline-text">

--- a/src/lib/stores/persistence.svelte.ts
+++ b/src/lib/stores/persistence.svelte.ts
@@ -125,6 +125,9 @@ export async function recheckApiAvailability(): Promise<boolean> {
 
 /**
  * Set API availability state directly (for error recovery)
+ * Note: Does NOT call markApiConnected() because this is for temporary
+ * overrides, not confirmed API connectivity. Only health checks should
+ * mark the API as "ever connected".
  */
 export function setApiAvailable(available: boolean): void {
   log("setApiAvailable: setting to %s", available);


### PR DESCRIPTION
## **User description**
## Summary

- Only show "Persistence API unavailable" warning to users who previously had a working API connection
- SaaS users (who never had persistence API) see a clean splash screen
- Self-hosters whose API breaks still get the warning

## Problem

v0.7.0 shows a yellow warning "Persistence API unavailable" to every user on count.racku.la. This is alarming and confusing for SaaS users who never configured persistence.

## Solution

Track in localStorage whether the API was ever successfully connected. Only show the warning if:
- API is currently unavailable AND
- User previously had successful API connection

Fixes #942

## Test plan

- [ ] Fresh user (clear localStorage) sees no warning when API unavailable
- [ ] User who previously connected to API sees warning when API becomes unavailable
- [ ] User with working API sees no warning (just the saved layouts list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Hide persistence API warning for users who never connected

### What Changed
- The "Persistence API unavailable" warning on the start screen is shown only if the user previously had a working API connection; new users who never connected will not see the warning.
- When the app successfully connects to the persistence API, it records that fact so future API outages will trigger the warning for that user.
- Temporary overrides of API availability (manual state changes) do not mark the user as having connected; only real health checks record a successful connection.

### Impact
`✅ Clearer splash for new SaaS users`
`✅ Fewer alarming warnings for first-time visitors`
`✅ Clearer offline warning for self-hosted users after a prior successful connection`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
