### PR TITLE
feat: allow configuring API host/port via environment variables (#960)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -36,8 +36,14 @@ LABEL org.opencontainers.image.description="Rack Layout Designer for Homelabbers
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.title="Rackula"
 
-# Copy nginx config and built assets
-COPY ./deploy/nginx.conf /etc/nginx/conf.d/default.conf
+# API proxy configuration (processed by nginx's envsubst on startup)
+# API_HOST: Hostname or IP of the API server (default: rackula-api)
+# API_PORT: Port the API listens on (default: 3001)
+ENV API_HOST=rackula-api
+ENV API_PORT=3001
+
+# Copy nginx config template (auto-processed by nginx's /docker-entrypoint.d/20-envsubst-on-templates.sh)
+COPY ./deploy/nginx.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
 
 # Health check (port 8080 for unprivileged nginx, busybox wget is built-in)

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -21,10 +21,11 @@ server {
     # API proxy (when sidecar is running)
     # Use variable to defer DNS resolution to request time (allows nginx to start without API)
     # Note: With variable-based proxy_pass, URI is NOT appended, so we pass to base URL
+    # Configure via environment variables: API_HOST (default: rackula-api), API_PORT (default: 3001)
     location /api/ {
         resolver 127.0.0.11 valid=30s;
-        set $api_upstream rackula-api;
-        proxy_pass http://$api_upstream:3001;
+        set $api_upstream ${API_HOST};
+        proxy_pass http://$api_upstream:${API_PORT};
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -48,8 +49,8 @@ server {
     # Health check endpoint (proxied to API when available)
     location = /health {
         resolver 127.0.0.11 valid=30s;
-        set $api_upstream rackula-api;
-        proxy_pass http://$api_upstream:3001/health;
+        set $api_upstream ${API_HOST};
+        proxy_pass http://$api_upstream:${API_PORT}/health;
         proxy_connect_timeout 2s;
         proxy_read_timeout 2s;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,8 @@
+# Environment variables:
+#   RACKULA_PORT: Host port for frontend (default: 8080)
+#   API_HOST: API hostname for nginx proxy (default: rackula-api)
+#   API_PORT: API port for nginx proxy (default: 3001)
+
 services:
   rackula:
     image: ghcr.io/rackulalives/rackula:latest
@@ -10,6 +15,10 @@ services:
     container_name: rackula
     ports:
       - "${RACKULA_PORT:-8080}:8080"
+    environment:
+      # API proxy target (override if API runs on different host/port)
+      - API_HOST=${API_HOST:-rackula-api}
+      - API_PORT=${API_PORT:-3001}
     restart: unless-stopped
     stop_grace_period: 10s
 


### PR DESCRIPTION
## **User description**
## Summary

Make the nginx API proxy configuration flexible via environment variables, allowing self-hosters and developers to point Rackula's frontend to an API running on any host/port.

## Changes

- **Rename** `deploy/nginx.conf` → `deploy/nginx.conf.template` with `${API_HOST}` and `${API_PORT}` placeholders
- **Update Dockerfile** to set ENV defaults and copy template to `/etc/nginx/templates/` (nginx auto-processes on startup)
- **Update docker-compose.yml** with environment section and documentation comments

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `API_HOST` | `rackula-api` | Hostname or IP of the API server |
| `API_PORT` | `3001` | Port the API listens on |

## Why This Approach

- **No custom entrypoint script** — uses nginx's built-in `/etc/nginx/templates/` pattern
- **No new dependencies** — envsubst is already in the nginx image
- **Backwards compatible** — defaults match current hardcoded values
- **Minimal changes** — only 3 files modified

## Test Plan

- [ ] Build and run with defaults, verify API proxy works
- [ ] Run with `API_HOST=localhost API_PORT=4000`, verify proxy target changes
- [ ] Verify container starts without errors

Closes #960

---
🤖 Generated with [Claude Code](https://claude.ai/code)


___

## **CodeAnt-AI Description**
**Allow configuring API host and port via environment variables**

### What Changed
- Frontend's nginx proxy target can be set with API_HOST and API_PORT environment variables instead of a hardcoded host/port
- Docker image provides sensible defaults (rackula-api:3001) so behavior is unchanged unless variables are overridden
- docker-compose includes environment entries so users can point the frontend to a different API host/port without editing config files

### Impact
`✅ Can point frontend at a local or remote API without rebuilding`
`✅ Shorter self-host setup for custom API locations`
`✅ No manual nginx config edits required`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
