### PR TITLE
feat: derive API_PORT from RACKULA_API_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 # Environment variables:
 #   RACKULA_PORT: Host port for frontend (default: 8080)
-#   API_HOST: API hostname for nginx proxy (default: rackula-api)
-#   API_PORT: API port for nginx proxy (default: 3001)
 #   RACKULA_API_PORT: Port the API listens on (default: 3001)
+#   API_HOST: API hostname for nginx proxy (default: rackula-api)
+#   API_PORT: Derived from RACKULA_API_PORT (for nginx proxy target)
 
 services:
   rackula:
@@ -17,9 +17,9 @@ services:
     ports:
       - "${RACKULA_PORT:-8080}:8080"
     environment:
-      # API proxy target (should match RACKULA_API_PORT in rackula-api service)
+      # API proxy target (API_PORT derived from RACKULA_API_PORT)
       - API_HOST=${API_HOST:-rackula-api}
-      - API_PORT=${API_PORT:-3001}
+      - API_PORT=${RACKULA_API_PORT:-3001}
     restart: unless-stopped
     stop_grace_period: 10s
 


### PR DESCRIPTION
## **User description**
## Summary

Eliminates the need for users to manually keep `API_PORT` and `RACKULA_API_PORT` in sync.

**Before:** Users had to set both `API_PORT` and `RACKULA_API_PORT` to the same value if changing the API port.

**After:** `API_PORT` is automatically derived from `RACKULA_API_PORT`. Users only need to set one variable.

## Changes

- `docker-compose.yml`: `API_PORT=${RACKULA_API_PORT:-3001}` instead of `API_PORT=${API_PORT:-3001}`
- Updated header comments to clarify `API_PORT` is derived
- `API_HOST` remains `rackula-api` as before

## Test plan

- [ ] `docker compose config` validates without errors
- [ ] Setting `RACKULA_API_PORT=3002` propagates to both nginx proxy and API service
- [ ] Default behavior unchanged (port 3001)

Refs #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Derive API proxy port from RACKULA_API_PORT so only one env var controls the API port**

### What Changed
- The frontend service now uses API_PORT taken from RACKULA_API_PORT instead of its own API_PORT variable
- Updated docker-compose header comment to state API_PORT is derived from RACKULA_API_PORT
- Default behavior unchanged: if RACKULA_API_PORT is not set, the proxy target defaults to 3001

### Impact
`✅ Set one env var to change the API port`
`✅ Fewer nginx proxy target mismatches when changing ports`
`✅ Default port 3001 remains unchanged`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
