### PR TITLE
fix: Add duplicate slug detection and airflow normalization

### DIFF
--- a/src/lib/data/brandPacks/index.ts
+++ b/src/lib/data/brandPacks/index.ts
@@ -3,7 +3,8 @@
  * Exports all brand-specific device packs
  */
 
-import type { DeviceType } from "$lib/types";
+import type { DeviceType, Airflow } from "$lib/types";
+import { debug } from "$lib/utils/debug";
 import { ubiquitiDevices } from "./ubiquiti";
 import { mikrotikDevices } from "./mikrotik";
 import { tplinkDevices } from "./tp-link";
@@ -330,23 +331,28 @@ export function getBrandSlugs(): Set<string> {
   if (!brandSlugsCache) {
     const devices = getAllBrandDevices();
     const slugs = new Set<string>();
-    const duplicates: string[] = [];
+    const duplicateSlugs = new Set<string>();
 
     for (const device of devices) {
       if (slugs.has(device.slug)) {
-        duplicates.push(device.slug);
+        duplicateSlugs.add(device.slug);
       } else {
         slugs.add(device.slug);
       }
     }
 
-    // Warn about duplicates in development mode
-    if (duplicates.length > 0 && !duplicateWarningShown) {
+    // Warn about duplicates in development mode only
+    if (
+      duplicateSlugs.size > 0 &&
+      !duplicateWarningShown &&
+      import.meta.env.DEV
+    ) {
       duplicateWarningShown = true;
-      console.warn(
-        `[Brand Packs] Duplicate device slugs detected (${duplicates.length}):`,
-        duplicates.join(", "),
-        "\nDuplicate slugs will cause incorrect device lookups. Please ensure all slugs are unique.",
+      const uniqueDuplicates = Array.from(duplicateSlugs);
+      debug.warn(
+        "[Brand Packs] Duplicate device slugs detected (%d): %s. Duplicate slugs will cause incorrect device lookups.",
+        uniqueDuplicates.length,
+        uniqueDuplicates.join(", "),
       );
     }
 
@@ -358,13 +364,15 @@ export function getBrandSlugs(): Set<string> {
 /**
  * Default airflow direction used when a device doesn't specify one
  */
-export const DEFAULT_AIRFLOW = "front-to-rear" as const;
+export const DEFAULT_AIRFLOW: Airflow = "front-to-rear";
 
 /**
  * Get a device with normalized properties (airflow defaults applied)
  * Use this when you need consistent device properties for rendering/logic
  */
-export function normalizeDevice(device: DeviceType): DeviceType & { airflow: string } {
+export function normalizeDevice(
+  device: DeviceType,
+): DeviceType & { airflow: Airflow } {
   return {
     ...device,
     airflow: device.airflow ?? DEFAULT_AIRFLOW,
@@ -377,7 +385,7 @@ export function normalizeDevice(device: DeviceType): DeviceType & { airflow: str
  */
 export function findBrandDeviceNormalized(
   slug: string,
-): (DeviceType & { airflow: string }) | undefined {
+): (DeviceType & { airflow: Airflow }) | undefined {
   const device = findBrandDevice(slug);
   return device ? normalizeDevice(device) : undefined;
 }


### PR DESCRIPTION
## **User description**
## Summary

Address CodeAnt AI review feedback from PR #988:

### 1. Duplicate Slug Detection
- `getBrandSlugs()` now validates for duplicate slugs when building the cache
- Warns in development mode if any duplicates are found
- Prevents silent failures from Set deduplication that could cause incorrect device lookups

### 2. Airflow Normalization
- Add `DEFAULT_AIRFLOW` constant (`'front-to-rear'`) for consistency
- Add `normalizeDevice()` helper to ensure devices have an airflow property
- Add `findBrandDeviceNormalized()` for lookups with defaults applied

This allows consuming code to either:
- Use raw devices (airflow may be undefined)
- Use normalized devices (airflow always has a value)

## Test Plan
- [x] `npm run lint` passes
- [x] `npm run test:run` passes (1792 tests)
- [x] `npm run build` succeeds
- [x] CodeRabbit local review passes

## Related
- Addresses feedback from: #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Detect duplicate brand slugs and ensure devices always have an airflow value**

### What Changed
- Builds the brand-slug cache while checking for duplicate slugs and logs a one-time warning in development when duplicates are found, preventing silent lookup errors caused by set deduplication
- Adds a default airflow value ("front-to-rear") and a normalization helper so consumers can obtain devices that always include an airflow property
- Adds a lookup that returns normalized devices so calling code can rely on a consistent airflow value without checking for undefined

### Impact
`✅ Fewer incorrect device lookups due to duplicate slugs`
`✅ Clearer developer warnings about data issues in dev mode`
`✅ Consistent device airflow for rendering and logic`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
