### PR TITLE
feat(ui): add missing brand icons to BrandIcon component (#990)

### DIFF
--- a/src/lib/components/BrandIcon.svelte
+++ b/src/lib/components/BrandIcon.svelte
@@ -11,7 +11,15 @@
 		siSupermicro,
 		siTplink,
 		siHp,
-		siSchneiderelectric
+		siSchneiderelectric,
+		siFortinet,
+		siNetgear,
+		siPaloaltonetworks,
+		siCisco,
+		siQnap,
+		siLenovo,
+		siBlackmagicdesign,
+		siApple
 	} from 'simple-icons';
 	import { Zap } from '@lucide/svelte';
 
@@ -32,7 +40,15 @@
 		supermicro: siSupermicro,
 		tplink: siTplink,
 		hp: siHp,
-		schneiderelectric: siSchneiderelectric
+		schneiderelectric: siSchneiderelectric,
+		fortinet: siFortinet,
+		netgear: siNetgear,
+		paloaltonetworks: siPaloaltonetworks,
+		cisco: siCisco,
+		qnap: siQnap,
+		lenovo: siLenovo,
+		blackmagicdesign: siBlackmagicdesign,
+		apple: siApple
 	};
 
 	const icon = $derived(slug ? iconMap[slug] : undefined);


### PR DESCRIPTION
## **User description**
## Summary

- Add 8 brand icons from simple-icons: Fortinet, Netgear, Palo Alto Networks, Cisco, QNAP, Lenovo, Blackmagic Design, Apple
- Total brand icon coverage: 16 of 21 brand packs (76%)

## Brands Still Missing Icons

These brands are not available in simple-icons v16.6.1:
- Eaton (UPS manufacturer)
- Netgate (pfSense)
- CyberPower (UPS)
- DeskPi (Raspberry Pi enclosures)
- AC Infinity (cooling)

These will continue using the Zap fallback icon.

## Test Plan

- [x] Lint passes
- [x] Build passes
- [ ] Visual verification in DevicePalette (CI will test)

Closes #990


___

## **CodeAnt-AI Description**
Add eight missing brand icons to BrandIcon component

### What Changed
- BrandIcon now includes icons for Fortinet, Netgear, Palo Alto Networks, Cisco, QNAP, Lenovo, Blackmagic Design, and Apple
- Those brands will render their proper logos instead of the Zap fallback in device lists and palettes
- The component's slug-to-icon mapping was extended so passing these brand slugs shows the correct logo at the requested size

### Impact
`✅ Clearer device branding in device lists`
`✅ Fewer fallback (Zap) icons shown`
`✅ Easier identification of devices by brand`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
