### PR TITLE
feat: add RACKULA_LISTEN_PORT for configurable nginx port (#980)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -39,10 +39,12 @@ LABEL org.opencontainers.image.title="Rackula"
 # API proxy configuration
 # API_HOST: Hostname or IP of the API server (default: rackula-api)
 # API_PORT: Port the API listens on (default: 3001)
+# RACKULA_LISTEN_PORT: Port nginx listens on inside the container (default: 8080)
 # NGINX_ENVSUBST_FILTER: Regex filter - only substitute these env vars, leave nginx vars ($host etc.) alone
 ENV API_HOST=rackula-api
 ENV API_PORT=3001
-ENV NGINX_ENVSUBST_FILTER=^(API_HOST|API_PORT)$
+ENV RACKULA_LISTEN_PORT=8080
+ENV NGINX_ENVSUBST_FILTER=^(API_HOST|API_PORT|RACKULA_LISTEN_PORT)$
 
 # Copy nginx config template (auto-processed by nginx's /docker-entrypoint.d/20-envsubst-on-templates.sh)
 COPY ./deploy/nginx.conf.template /etc/nginx/templates/default.conf.template

--- a/deploy/docker-compose.persist.yml
+++ b/deploy/docker-compose.persist.yml
@@ -12,10 +12,11 @@ services:
     image: ghcr.io/rackulalives/rackula:persist
     container_name: rackula
     ports:
-      - "${RACKULA_PORT:-8080}:8080"
+      - "${RACKULA_PORT:-8080}:${RACKULA_LISTEN_PORT:-8080}"
     environment:
       - API_HOST=rackula-api
       - API_PORT=${RACKULA_API_PORT:-3001}
+      - RACKULA_LISTEN_PORT=${RACKULA_LISTEN_PORT:-8080}
     restart: unless-stopped
     depends_on:
       rackula-api:

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -1,6 +1,6 @@
 server {
-    listen 8080;
-    listen [::]:8080;
+    listen ${RACKULA_LISTEN_PORT};
+    listen [::]:${RACKULA_LISTEN_PORT};
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
@@ -22,7 +22,7 @@ server {
     # Use variable to defer DNS resolution to request time (allows nginx to start without API)
     # Note: With variable-based proxy_pass, URI is NOT appended, so we pass to base URL
     # Configure via environment variables: API_HOST (default: rackula-api), API_PORT (default: 3001)
-    # Note: NGINX_ENVSUBST_FILTER in Dockerfile restricts substitution to API_HOST and API_PORT only
+    # Note: NGINX_ENVSUBST_FILTER in Dockerfile restricts substitution to API_HOST, API_PORT, and RACKULA_LISTEN_PORT only
     location /api/ {
         resolver 127.0.0.11 valid=30s;
         set $api_upstream ${API_HOST};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@
 #
 # Environment variables:
 #   RACKULA_PORT: Host port for frontend (default: 8080)
+#   RACKULA_LISTEN_PORT: Port nginx listens on inside container (default: 8080)
 #   RACKULA_API_PORT: Port the API listens on (default: 3001)
 #   API_HOST: API hostname for nginx proxy (default: rackula-api)
 #   API_PORT: Derived from RACKULA_API_PORT (for nginx proxy target)
@@ -20,11 +21,13 @@ services:
     # image: ghcr.io/rackulalives/rackula:persist
     container_name: rackula
     ports:
-      - "${RACKULA_PORT:-8080}:8080"
+      - "${RACKULA_PORT:-8080}:${RACKULA_LISTEN_PORT:-8080}"
     environment:
       # API proxy target (API_PORT derived from RACKULA_API_PORT)
       - API_HOST=${API_HOST:-rackula-api}
       - API_PORT=${RACKULA_API_PORT:-3001}
+      # nginx listen port inside container (allows matching host port if needed)
+      - RACKULA_LISTEN_PORT=${RACKULA_LISTEN_PORT:-8080}
     restart: unless-stopped
     stop_grace_period: 10s
 

--- a/docs/guides/SELF-HOSTING.md
+++ b/docs/guides/SELF-HOSTING.md
@@ -97,13 +97,31 @@ All variables have sensible defaults. Only configure if you need to change somet
 
 ### Runtime Variables
 
-| Variable           | Default       | Description                                 |
-| ------------------ | ------------- | ------------------------------------------- |
-| `RACKULA_PORT`     | `8080`        | Host port for the web UI                    |
-| `RACKULA_API_PORT` | `3001`        | Port the API listens on                     |
-| `API_HOST`         | `rackula-api` | Hostname of API container (for nginx proxy) |
-| `API_PORT`         | `3001`        | Port of API container (for nginx proxy)     |
-| `DATA_DIR`         | `/data`       | Path to data directory inside API container |
+| Variable              | Default       | Description                                     |
+| --------------------- | ------------- | ----------------------------------------------- |
+| `RACKULA_PORT`        | `8080`        | Host port for the web UI                        |
+| `RACKULA_LISTEN_PORT` | `8080`        | Port nginx listens on inside the container      |
+| `RACKULA_API_PORT`    | `3001`        | Port the API listens on                         |
+| `API_HOST`            | `rackula-api` | Hostname of API container (for nginx proxy)     |
+| `API_PORT`            | `3001`        | Port of API container (for nginx proxy)         |
+| `DATA_DIR`            | `/data`       | Path to data directory inside API container     |
+
+**Port mapping explained:**
+
+By default, both `RACKULA_PORT` and `RACKULA_LISTEN_PORT` are `8080`, meaning:
+- Host port 8080 → Container port 8080 → nginx listening on 8080
+
+For most users, just set `RACKULA_PORT` to change the host port:
+
+```bash
+RACKULA_PORT=3000 docker compose up -d  # Access at localhost:3000
+```
+
+If you need nginx to listen on a specific port inside the container (e.g., for rootless Podman or specific orchestration requirements), set both:
+
+```bash
+RACKULA_PORT=3000 RACKULA_LISTEN_PORT=3000 docker compose up -d
+```
 
 ### Build-Time Variables
 


### PR DESCRIPTION
## **User description**
## Summary

Adds backward-compatible support for configuring the nginx listen port inside the container:

- **New variable**: `RACKULA_LISTEN_PORT` controls what port nginx listens on inside the container
- **Backward compatible**: Default behavior unchanged (8080 everywhere)
- **Documented**: Updated SELF-HOSTING.md with port mapping explanation

### Behavior Matrix

| Config | Host Port | Container Port | nginx |
|--------|-----------|----------------|-------|
| Default | 8080 | 8080 | 8080 |
| `RACKULA_PORT=3000` | 3000 | 8080 | 8080 |
| `RACKULA_PORT=3000 RACKULA_LISTEN_PORT=3000` | 3000 | 3000 | 3000 |

### Use Cases

- **Most users**: Just set `RACKULA_PORT=3000` to run on a different host port
- **Advanced**: Set both when you need host and container ports to match (rootless Podman, specific orchestration requirements)

## Files Changed

- `deploy/Dockerfile` - Added `RACKULA_LISTEN_PORT` env var and updated envsubst filter
- `deploy/nginx.conf.template` - Use `${RACKULA_LISTEN_PORT}` instead of hardcoded 8080
- `deploy/docker-compose.persist.yml` - Port mapping and env var
- `docker-compose.yml` - Port mapping and env var
- `docs/guides/SELF-HOSTING.md` - Documented new variable with examples

## Test Plan

- [ ] Verify default behavior unchanged: `docker compose up -d` serves on :8080
- [ ] Verify host port change: `RACKULA_PORT=3000 docker compose up -d` serves on :3000
- [ ] Verify full port change: `RACKULA_PORT=3000 RACKULA_LISTEN_PORT=3000 docker compose up -d` works

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add RACKULA_LISTEN_PORT to control the nginx listen port inside the container

### What Changed
- Introduces RACKULA_LISTEN_PORT (default 8080) so nginx inside the container can listen on a configurable port
- Compose files map host:RACKULA_PORT to container:RACKULA_LISTEN_PORT, allowing host and container ports to differ or match
- Updated nginx template, Dockerfile env substitution, and SELF-HOSTING guide with examples and explanation; default behavior remains unchanged (8080)

### Impact
`✅ Can run frontend with matching host and container ports`
`✅ Works with rootless Podman and orchestration setups that require identical ports`
`✅ Clearer self-hosting port-mapping instructions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
