### PR TITLE
fix(api): mount routes at /layouts instead of /api/layouts (#1007)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -34,16 +34,16 @@ const maxAssetSize =
     ? parsedMaxAssetSize
     : DEFAULT_MAX_ASSET_SIZE;
 app.use(
-  "/api/assets/*",
+  "/assets/*",
   bodyLimit({
     maxSize: maxAssetSize,
     onError: (c) => c.json({ error: "File too large" }, 413),
   }),
 );
 
-// Mount routes
-app.route("/api/layouts", layouts);
-app.route("/api/assets", assets);
+// Mount routes at root paths (nginx strips /api prefix when proxying)
+app.route("/layouts", layouts);
+app.route("/assets", assets);
 
 // 404 handler
 app.notFound((c) => c.json({ error: "Not found" }, 404));

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -1,8 +1,16 @@
 /**
  * Asset API routes
+ *
+ * When accessed directly (e.g., docker run -p 3001:3001 rackula-api):
+ * GET    /assets/:layoutId/:deviceSlug/:face - Get asset image
+ * PUT    /assets/:layoutId/:deviceSlug/:face - Upload asset image
+ * DELETE /assets/:layoutId/:deviceSlug/:face - Delete asset image
+ *
+ * When accessed through nginx proxy (recommended):
  * GET    /api/assets/:layoutId/:deviceSlug/:face - Get asset image
  * PUT    /api/assets/:layoutId/:deviceSlug/:face - Upload asset image
  * DELETE /api/assets/:layoutId/:deviceSlug/:face - Delete asset image
+ * (nginx strips /api prefix before forwarding to API)
  */
 import { Hono } from "hono";
 import { LayoutIdSchema } from "../schemas/layout";

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -1,9 +1,18 @@
 /**
  * Layout API routes (UUID-based)
+ *
+ * When accessed directly (e.g., docker run -p 3001:3001 rackula-api):
+ * GET    /layouts       - List all layouts
+ * GET    /layouts/:uuid - Get layout by UUID
+ * PUT    /layouts/:uuid - Create or update layout
+ * DELETE /layouts/:uuid - Delete layout
+ *
+ * When accessed through nginx proxy (recommended):
  * GET    /api/layouts       - List all layouts
  * GET    /api/layouts/:uuid - Get layout by UUID
  * PUT    /api/layouts/:uuid - Create or update layout
  * DELETE /api/layouts/:uuid - Delete layout
+ * (nginx strips /api prefix before forwarding to API)
  */
 import { Hono } from "hono";
 import { UuidSchema, LayoutFileSchema } from "../schemas/layout";

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -40,7 +40,12 @@ server {
     location /api/ {
         resolver 127.0.0.11 valid=30s;
         set $api_upstream ${API_HOST};
-        proxy_pass http://$api_upstream:${API_PORT}$uri$is_args$args;
+
+        # Strip /api prefix: /api/layouts -> /layouts
+        # Using rewrite to capture path after /api and forward without prefix
+        rewrite ^/api(/.*)$ $1 break;
+
+        proxy_pass http://$api_upstream:${API_PORT};
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause:** The API server mounted routes at `/api/layouts` and `/api/assets`, but users calling the API directly (bypassing nginx) expected routes at `/layouts` and `/assets`
- **Fix:** Changed API to mount routes at root paths (`/layouts`, `/assets`) and updated nginx to strip the `/api` prefix when proxying requests

## Changes

1. **`api/src/index.ts`**: Mount routes at `/layouts` and `/assets` instead of `/api/layouts` and `/api/assets`
2. **`deploy/nginx.conf.template`**: Use `rewrite` to strip `/api` prefix before proxying to API
3. **Route documentation**: Updated comments in `layouts.ts` and `assets.ts` to document both direct and proxied access patterns

## Test Plan

- [x] `curl http://localhost:3001/layouts` returns `200 {"layouts":[]}`
- [x] `curl http://localhost:3001/layouts/:uuid` with valid UUID works
- [x] `PUT /layouts/:uuid` creates/updates layouts correctly
- [x] `DELETE /layouts/:uuid` deletes layouts correctly
- [x] Health check at `/health` still works
- [x] Main app lint passes
- [x] Main app build passes
- [x] Main app tests pass (1792 tests)
- [x] CodeRabbit review passes

## Before/After

| Endpoint | Before | After |
|----------|--------|-------|
| Direct API access: `GET /layouts` | 404 ❌ | 200 ✓ |
| Via nginx: `GET /api/layouts` | ✓ (nginx passed `/api/layouts`) | ✓ (nginx strips to `/layouts`) |

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Expose API endpoints at /layouts and /assets and have nginx strip the /api prefix

### What Changed
- API routes now respond at /layouts and /assets (previously mounted under /api/...), so direct calls to the API (e.g., docker run -p 3001:3001 ...) to /layouts and /assets return results instead of 404
- nginx proxy configuration rewrites incoming /api/* requests to remove the /api prefix before forwarding, so frontend requests to /api/layouts and /api/assets continue to work through the proxy
- Route documentation updated to show both direct paths (/, e.g., /layouts) and proxied paths (/api/..., with nginx stripping /api)

### Impact
`✅ Fewer API 404s when calling the service directly`
`✅ Frontend requests to /api/layouts and /api/assets succeed through the proxy`
`✅ Simpler local testing of the API using root paths (/layouts, /assets)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
