### PR TITLE
fix(persistence): prevent auto-save of empty layouts to server (#1003)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -292,14 +292,14 @@
           layoutStore.markClean();
           toastStore.showToast(
             `Loaded "${mostRecent.name}" from server`,
-              "success",
-            );
+            "success",
+          );
 
-            // Reset view to center the loaded rack after DOM updates
-            requestAnimationFrame(() => {
-              canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
-            });
-            return;
+          // Reset view to center the loaded rack after DOM updates
+          requestAnimationFrame(() => {
+            canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
+          });
+          return;
         }
       } catch (error) {
         // If loading fails, just continue to show new rack dialog
@@ -1187,6 +1187,7 @@
   });
 
   // Auto-save to server when API is available
+  // Only saves layouts with meaningful content (user has interacted)
   let serverSaveTimer: ReturnType<typeof setTimeout> | null = null;
   $effect(() => {
     // Check runtime API availability instead of build-time flag
@@ -1194,6 +1195,12 @@
 
     const layout = layoutStore.layout;
     if (!layout.name) return;
+
+    // Don't auto-save empty layouts to server (fixes #1003)
+    // hasStarted is true when user has added a rack, loaded a layout, or placed a device
+    // This prevents polluting server with empty "Racky McRackface" layouts on every visit
+    // Note: localStorage session save (lines 1164-1186) still saves empty state for recovery
+    if (!layoutStore.hasStarted) return;
 
     // Clear existing timer
     if (serverSaveTimer) {


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause:** Auto-save effect only checked `layout.name`, not whether user had meaningful content
- **Fix:** Added check for `layoutStore.hasStarted` before server auto-save

## Changes

- `src/App.svelte`: Added guard condition to prevent auto-saving layouts where `hasStarted` is false

## How It Works

The `hasStarted` flag is already tracked by the layout store and becomes `true` when the user:
- Adds a rack (`addRack`, `addBayedRackGroup`)
- Loads an existing layout (`loadLayout`)
- Places a device (`placeDevice`)

This prevents saving "empty" layouts (just a default name like "Racky McRackface" with no racks) while still allowing:
- localStorage session saves (for recovery on refresh)
- Explicit manual saves (if user wants to save an empty layout)

## Test Plan

- [x] Lint passes
- [x] Build passes  
- [x] All 1792 unit tests pass
- [x] CodeRabbit local review passes

**Manual verification:**
1. Visit `/` with persistence enabled
2. Wait 2+ seconds - verify NO server request is made
3. Add a rack - verify server auto-save now triggers
4. Reload page - verify localStorage recovery still works

## Related

- Created #1012 for the separate "stale localStorage overwrites server" bug reported by @Mihai-B

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent auto-saving empty layouts to server**

### What Changed
- Server auto-save now skips layouts unless the user has actively started working on the layout (added a rack, placed a device, or loaded an existing layout), preventing default/empty layouts from being saved on page visit
- Local session saves for recovery remain unchanged and still save empty state
- Loading the most recent server layout and showing the success message remains the same

### Impact
`✅ Fewer empty layouts saved to server`
`✅ Cleaner saved-layouts list for users`
`✅ Session recovery still works as before`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
