### PR TITLE
fix(nginx): handle /api and /api/ edge cases consistently (#1010)

### DIFF
--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -37,6 +37,18 @@ server {
         # No fallback - let it fail to signal API unavailability
     }
     
+    # Handle /api and /api/ edge cases - return JSON error, not SPA fallback (#1010)
+    # These paths don't correspond to valid API endpoints
+    location = /api {
+        default_type application/json;
+        return 400 '{"error": "Invalid API path", "hint": "Use /api/layouts, /api/assets, or /api/health"}';
+    }
+
+    location = /api/ {
+        default_type application/json;
+        return 400 '{"error": "Invalid API path", "hint": "Use /api/layouts, /api/assets, or /api/health"}';
+    }
+
     location /api/ {
         resolver 127.0.0.11 valid=30s;
         set $api_upstream ${API_HOST};


### PR DESCRIPTION
## **User description**
## Summary

Add explicit location blocks for `/api` and `/api/` paths to return a JSON error instead of falling through to the SPA fallback.

## Problem

The previous nginx configuration:
- `location /api/` only matched paths WITH content after the slash
- `/api` (no slash) fell through to SPA fallback (returned index.html)
- `/api/` (just slash) matched but rewrite failed (empty capture group)

## Solution

Added two exact-match location blocks that return 400 Bad Request with helpful JSON:

```json
{"error": "Invalid API path", "hint": "Use /api/layouts, /api/assets, or /api/health"}
```

## Test Plan

- [ ] Request to `/api` returns JSON error (not HTML)
- [ ] Request to `/api/` returns JSON error (not HTML)
- [ ] Request to `/api/health` still works
- [ ] Request to `/api/layouts` still works

## Files Changed

- `deploy/nginx.conf.template`: Add edge case handlers

Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Return JSON error for `/api` and `/api/` instead of serving the SPA**

### What Changed
- Requests to the exact paths `/api` and `/api/` now return a 400 response with JSON `{"error":"Invalid API path","hint":"Use /api/layouts, /api/assets, or /api/health"}` instead of falling back to the frontend SPA HTML
- Valid API endpoints under `/api/` (for example `/api/health`, `/api/layouts`) continue to be proxied to the API backend unchanged

### Impact
`✅ Clearer API error for invalid root API requests`
`✅ Fewer unexpected HTML responses for `/api` requests`
`✅ Predictable behavior when clients hit `/api` or `/api/``
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
