### PR TITLE
chore: add /api/* compatibility aliases (#1009)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -33,17 +33,23 @@ const maxAssetSize =
   Number.isFinite(parsedMaxAssetSize) && parsedMaxAssetSize > 0
     ? parsedMaxAssetSize
     : DEFAULT_MAX_ASSET_SIZE;
-app.use(
-  "/assets/*",
-  bodyLimit({
-    maxSize: maxAssetSize,
-    onError: (c) => c.json({ error: "File too large" }, 413),
-  }),
-);
+// Body size limits for asset uploads
+const assetBodyLimit = bodyLimit({
+  maxSize: maxAssetSize,
+  onError: (c) => c.json({ error: "File too large" }, 413),
+});
+app.use("/assets/*", assetBodyLimit);
+app.use("/api/assets/*", assetBodyLimit);
 
 // Mount routes at root paths (nginx strips /api prefix when proxying)
 app.route("/layouts", layouts);
 app.route("/assets", assets);
+
+// Compatibility aliases for direct API access (without nginx proxy)
+// These allow clients to use /api/* paths when accessing the API directly
+app.route("/api/layouts", layouts);
+app.route("/api/assets", assets);
+app.get("/api/health", (c) => c.text("OK"));
 
 // 404 handler
 app.notFound((c) => c.json({ error: "Not found" }, 404));


### PR DESCRIPTION
## **User description**
## Summary

- Add route aliases for direct API access without nginx proxy
- `/api/layouts`, `/api/assets`, and `/api/health` now work alongside root paths
- Body size limits apply to both `/assets/*` and `/api/assets/*`

## Context

Following #1008, the API routes moved from `/api/layouts` to `/layouts` (nginx strips the prefix). This PR adds compatibility aliases so clients can access the API directly via `/api/*` paths without requiring nginx.

## Changes

| Endpoint | Primary | Alias |
|----------|---------|-------|
| Layouts | `/layouts` | `/api/layouts` |
| Assets | `/assets` | `/api/assets` |
| Health | `/health` | `/api/health` |

## Test plan

- [x] Lint passes
- [x] All 1802 tests pass
- [x] Production build succeeds
- [x] CodeRabbit CLI review passes

Closes #1009

🤖 Generated with [Claude Code](https://claude.ai/code)


___

## **CodeAnt-AI Description**
Provide direct /api/* endpoints so clients can call the API without a proxy

### What Changed
- /assets upload size limit now applies to both /assets/* and /api/assets/*, returning "File too large" (413) when exceeded
- API routes are available at both root paths and /api/* aliases: /layouts and /api/layouts, /assets and /api/assets
- Added /api/health which returns "OK" for simple health checks

### Impact
`✅ Direct API access via /api/* without nginx`
`✅ Same upload size enforcement for /api/assets uploads`
`✅ Fewer proxy-related routing failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
