### PR TITLE
feat: update mobile warning modal with positive messaging (#647)

### DIFF
--- a/src/lib/components/MobileWarningModal.svelte
+++ b/src/lib/components/MobileWarningModal.svelte
@@ -1,6 +1,6 @@
 <!--
   MobileWarningModal Component
-  Shows a warning to users on small viewports that Rackula is designed for desktop.
+  Welcomes mobile users and sets expectations about the mobile experience.
   Dismissible and remembers dismissal for the session.
   Uses bits-ui AlertDialog for accessibility and focus management.
 -->
@@ -42,18 +42,20 @@
       </div>
 
       <AlertDialog.Title class="modal-title">
-        Rackula works best on desktop
+        Welcome to Rackula Mobile
       </AlertDialog.Title>
 
       <AlertDialog.Description class="modal-description">
-        This app is designed for screens 1024px or wider. For the best
-        experience, please visit on a desktop or laptop computer.
+        View and reference your rack layouts on the go. For full editing
+        features, visit on a desktop browser.
       </AlertDialog.Description>
 
-      <p class="modal-note">Mobile support is coming soon!</p>
+      <p class="modal-note">
+        Load a layout from the File menu or scan a Share QR code.
+      </p>
 
       <AlertDialog.Cancel class="continue-button">
-        Continue anyway
+        Got it
       </AlertDialog.Cancel>
     </AlertDialog.Content>
   </AlertDialog.Portal>

--- a/src/tests/MobileWarningModal.test.ts
+++ b/src/tests/MobileWarningModal.test.ts
@@ -25,7 +25,7 @@ describe("MobileWarningModal", () => {
 
       expect(screen.getByRole("alertdialog")).toBeInTheDocument();
       expect(
-        screen.getByText("Rackula works best on desktop"),
+        screen.getByText("Welcome to Rackula Mobile"),
       ).toBeInTheDocument();
     });
 
@@ -61,31 +61,31 @@ describe("MobileWarningModal", () => {
       render(MobileWarningModal);
 
       expect(
-        screen.getByText("Rackula works best on desktop"),
+        screen.getByText("Welcome to Rackula Mobile"),
       ).toBeInTheDocument();
     });
 
-    it("shows description about screen size", () => {
+    it("shows description about mobile experience", () => {
       render(MobileWarningModal);
 
       expect(
-        screen.getByText(/designed for screens 1024px or wider/i),
+        screen.getByText(/rack layouts on the go/i),
       ).toBeInTheDocument();
     });
 
-    it("shows mobile support coming soon message", () => {
+    it("shows file menu tip", () => {
       render(MobileWarningModal);
 
       expect(
-        screen.getByText(/mobile support is coming soon/i),
+        screen.getByText(/load a layout from the file menu/i),
       ).toBeInTheDocument();
     });
 
-    it("shows continue button", () => {
+    it("shows got it button", () => {
       render(MobileWarningModal);
 
       expect(
-        screen.getByRole("button", { name: /continue anyway/i }),
+        screen.getByRole("button", { name: /got it/i }),
       ).toBeInTheDocument();
     });
   });
@@ -98,16 +98,16 @@ describe("MobileWarningModal", () => {
     it("closes modal when continue button is clicked", async () => {
       render(MobileWarningModal);
 
-      const button = screen.getByRole("button", { name: /continue anyway/i });
+      const button = screen.getByRole("button", { name: /got it/i });
       await fireEvent.click(button);
 
       expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
     });
 
-    it("saves dismissal to sessionStorage when continue is clicked", async () => {
+    it("saves dismissal to sessionStorage when got it is clicked", async () => {
       render(MobileWarningModal);
 
-      const button = screen.getByRole("button", { name: /continue anyway/i });
+      const button = screen.getByRole("button", { name: /got it/i });
       await fireEvent.click(button);
 
       expect(sessionStorage.getItem("rackula-mobile-warning-dismissed")).toBe(


### PR DESCRIPTION
## **User description**
## Summary
- Replace negative "works best on desktop" warning with welcoming "Welcome to Rackula Mobile" messaging
- Update title, description, tip text, and button label to set positive expectations for mobile users
- Update corresponding test assertions to match new copy

## Changes
| Old | New |
|-----|-----|
| "Rackula works best on desktop" | "Welcome to Rackula Mobile" |
| "This app is designed for screens 1024px or wider..." | "View and reference your rack layouts on the go..." |
| "Mobile support is coming soon!" | "Load a layout from the File menu or scan a Share QR code." |
| "Continue anyway" | "Got it" |

## Test plan
- [x] All 15 MobileWarningModal tests pass
- [x] Lint clean
- [x] Build succeeds
- [ ] Visual verification on mobile viewport

Part of Mobile Phone Experience epic #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Replace desktop warning with a welcoming mobile message**

### What Changed
- Mobile modal now greets users with "Welcome to Rackula Mobile" instead of saying the app "works best on desktop"
- Modal body text now invites users to view and reference layouts on the go and points to the File menu / Share QR code for loading layouts
- Dismiss button text changed from "Continue anyway" to "Got it"; dismissal still closes the modal and is remembered for the session
- Tests updated to expect the new title, copy, tip, and button label and to verify same visibility and dismissal behavior

### Impact
`✅ Clearer mobile messaging`
`✅ Fewer confused mobile users`
`✅ Remembered dismissal during a session`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
