### PR TITLE
feat: add rack indicator strip with navigation dots (#645)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,6 +27,7 @@
   import BottomSheet from "$lib/components/BottomSheet.svelte";
   import DeviceDetails from "$lib/components/DeviceDetails.svelte";
   import MobileBottomNav from "$lib/components/mobile/MobileBottomNav.svelte";
+  import RackIndicator from "$lib/components/mobile/RackIndicator.svelte";
   import RackEditSheet from "$lib/components/RackEditSheet.svelte";
   import SidebarTabs from "$lib/components/SidebarTabs.svelte";
   import RackList from "$lib/components/RackList.svelte";
@@ -1340,6 +1341,8 @@
       onopencleanup={handleOpenCleanupDialog}
       onhelp={handleHelp}
     />
+
+    <RackIndicator />
 
     <main class="app-main" class:mobile={viewportStore.isMobile}>
       {#if !viewportStore.isMobile}

--- a/src/lib/components/mobile/RackIndicator.svelte
+++ b/src/lib/components/mobile/RackIndicator.svelte
@@ -1,0 +1,129 @@
+<!--
+  RackIndicator Component
+  Shows current rack name and navigation dots on mobile when multiple racks exist.
+  Switches to counter format (1/12) when >7 racks.
+  Self-guarded: only renders on mobile with 2+ racks.
+-->
+<script lang="ts">
+  import { getViewportStore } from "$lib/utils/viewport.svelte";
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getCanvasStore } from "$lib/stores/canvas.svelte";
+
+  const viewportStore = getViewportStore();
+  const layoutStore = getLayoutStore();
+  const canvasStore = getCanvasStore();
+
+  const DOT_THRESHOLD = 7;
+
+  let activeIndex = $derived.by(() => {
+    const idx = layoutStore.racks.findIndex(
+      (r) => r.id === layoutStore.activeRackId,
+    );
+    return idx < 0 ? 0 : idx;
+  });
+  let activeRackName = $derived(layoutStore.activeRack?.name ?? "");
+  let shouldShow = $derived(
+    viewportStore.isMobile && layoutStore.racks.length > 1,
+  );
+  let useDots = $derived(layoutStore.racks.length <= DOT_THRESHOLD);
+
+  function handleDotClick(rackId: string) {
+    layoutStore.setActiveRack(rackId);
+    canvasStore.focusRack(
+      [rackId],
+      layoutStore.racks,
+      layoutStore.rack_groups,
+      0,
+    );
+  }
+</script>
+
+{#if shouldShow}
+  <div class="rack-indicator">
+    <span class="rack-name">{activeRackName}</span>
+    <div class="rack-nav">
+      {#if useDots}
+        {#each layoutStore.racks as rack (rack.id)}
+          <button
+            class="dot"
+            class:active={rack.id === layoutStore.activeRackId}
+            type="button"
+            aria-label="Switch to {rack.name}"
+            onclick={() => handleDotClick(rack.id)}
+          >
+            <span class="dot-indicator"></span>
+          </button>
+        {/each}
+      {:else}
+        <span class="rack-counter"
+          >{activeIndex + 1}/{layoutStore.racks.length}</span
+        >
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .rack-indicator {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: var(--space-1) var(--space-4);
+    background: var(--colour-toolbar-bg);
+    border-bottom: 1px solid var(--colour-border);
+    flex-shrink: 0;
+  }
+
+  .rack-name {
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    color: var(--colour-text);
+  }
+
+  .rack-nav {
+    display: flex;
+    align-items: center;
+    gap: var(--space-0-5);
+  }
+
+  .dot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .dot:focus-visible {
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: -2px;
+    border-radius: var(--radius-md);
+  }
+
+  .dot-indicator {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1.5px solid var(--colour-text-muted);
+    background: transparent;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+  }
+
+  .dot.active .dot-indicator {
+    background: var(--colour-primary);
+    border-color: var(--colour-primary);
+  }
+
+  .rack-counter {
+    font-size: var(--font-size-sm);
+    color: var(--colour-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+</style>


### PR DESCRIPTION
## **User description**
## Summary

- Add rack indicator strip between toolbar and main content on mobile
- Shows current rack name and clickable navigation dots when 2+ racks exist
- Dots switch to counter format (`1/12`) when >7 racks to avoid overflow
- Tapping a dot switches the active rack and animates canvas focus
- Touch targets: 44px minimum (8px visual dot inside 44px button)
- Self-guarded: only renders on mobile with multiple racks
- Safely handles missing `activeRackId` (clamps index to 0)

## Test plan

- [ ] Open in Chrome DevTools mobile simulation (iPhone SE 375px)
- [ ] Create 2+ racks, verify indicator strip appears with rack name and dots
- [ ] Tap a dot, verify rack switches and canvas focuses
- [ ] Create 8+ racks, verify counter format shows instead of dots
- [ ] Verify single-rack layouts show no indicator
- [ ] Verify desktop layout is completely unchanged
- [ ] Lint, tests (1802), and build all pass

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add mobile rack indicator with navigation dots and counter

### What Changed
- Shows a compact strip above the canvas on mobile when a layout has 2+ racks, displaying the current rack name and a navigation control
- Navigation uses tappable dots for up to 7 racks and switches to a numeric counter (e.g., "3/12") when more than 7 to avoid overflow
- Tapping a dot switches the active rack and refocuses the canvas; touch targets meet a 44px minimum for easier tapping
- The indicator does not render on desktop or when there is only one rack

### Impact
`✅ Clearer rack navigation on mobile`
`✅ Faster rack switching`
`✅ Fewer wrong taps due to larger touch targets`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
