### PR TITLE
feat: Framework7-inspired MobileBottomNav upgrade

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1552,7 +1552,12 @@
 
     <!-- Mobile bottom navigation bar -->
     <MobileBottomNav
-      activeTab={fileSheetOpen ? "file" : (deviceLibrarySheetOpen ? "devices" : null)}
+      activeTab={fileSheetOpen
+        ? "file"
+        : deviceLibrarySheetOpen
+          ? "devices"
+          : null}
+      hidden={false}
       onfileclick={handleFileTabClick}
       onviewclick={() => {
         /* noop — future #643 */
@@ -1653,7 +1658,7 @@
     overscroll-behavior: none;
     /* Account for fixed bottom nav */
     padding-bottom: calc(
-      var(--touch-target-comfortable) + env(safe-area-inset-bottom, 0px)
+      var(--bottom-nav-height) + env(safe-area-inset-bottom, 0px)
     );
   }
 

--- a/src/lib/components/mobile/MobileBottomNav.svelte
+++ b/src/lib/components/mobile/MobileBottomNav.svelte
@@ -13,6 +13,7 @@
 
   interface Props {
     activeTab?: Tab | null;
+    hidden?: boolean;
     onfileclick?: () => void;
     onviewclick?: () => void;
     ondevicesclick?: () => void;
@@ -20,6 +21,7 @@
 
   let {
     activeTab = null,
+    hidden = false,
     onfileclick,
     onviewclick,
     ondevicesclick,
@@ -29,7 +31,7 @@
 </script>
 
 {#if viewportStore.isMobile}
-  <nav class="bottom-nav" aria-label="Mobile navigation">
+  <nav class="bottom-nav" class:hidden aria-label="Mobile navigation">
     <button
       class="nav-tab"
       class:active={activeTab === "file"}
@@ -37,7 +39,7 @@
       aria-current={activeTab === "file" ? "page" : undefined}
       onclick={onfileclick}
     >
-      <IconFolderBold size={ICON_SIZE.lg} />
+      <IconFolderBold size={ICON_SIZE.xl} />
       <span class="nav-label">File</span>
     </button>
 
@@ -48,7 +50,7 @@
       aria-current={activeTab === "view" ? "page" : undefined}
       onclick={onviewclick}
     >
-      <IconFitAllBold size={ICON_SIZE.lg} />
+      <IconFitAllBold size={ICON_SIZE.xl} />
       <span class="nav-label">View</span>
     </button>
 
@@ -59,7 +61,7 @@
       aria-current={activeTab === "devices" ? "page" : undefined}
       onclick={ondevicesclick}
     >
-      <IconServerBold size={ICON_SIZE.lg} />
+      <IconServerBold size={ICON_SIZE.xl} />
       <span class="nav-label">Devices</span>
     </button>
   </nav>
@@ -74,35 +76,66 @@
     z-index: var(--z-bottom-nav, 100);
     display: flex;
     justify-content: space-around;
-    align-items: center;
+    align-items: stretch;
+    height: var(--bottom-nav-height);
     padding-bottom: env(safe-area-inset-bottom);
-    background: var(--colour-toolbar-bg, var(--toolbar-bg));
-    border-top: 1px solid var(--colour-toolbar-border, var(--toolbar-border));
+    background: var(--bottom-nav-bg);
+    backdrop-filter: blur(var(--bottom-nav-blur));
+    -webkit-backdrop-filter: blur(var(--bottom-nav-blur));
+    border-top: 0.5px solid var(--bottom-nav-border);
+    transform: translateY(0);
+    transition: transform var(--bottom-nav-transition) var(--ease-in-out);
+    will-change: transform;
     user-select: none;
     -webkit-tap-highlight-color: transparent;
   }
 
+  .bottom-nav.hidden {
+    transform: translateY(100%);
+  }
+
   .nav-tab {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-width: var(--touch-target-min);
+    flex: 1;
     min-height: var(--touch-target-min);
-    gap: var(--space-0-5);
-    padding: var(--space-1) var(--space-2);
+    gap: var(--space-1);
+    padding: var(--space-2);
     border: none;
     background: transparent;
     cursor: pointer;
-    transition: color var(--duration-fast) var(--ease-out);
+    color: var(--bottom-nav-inactive-colour);
+    transition: color var(--duration-normal) var(--ease-out);
+  }
+
+  /* Pill-shaped active indicator */
+  .nav-tab::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -65%) scaleX(0);
+    width: 64px;
+    height: 32px;
+    border-radius: var(--bottom-nav-pill-radius);
+    background: var(--bottom-nav-active-pill-bg);
+    opacity: 0;
+    transition:
+      transform var(--duration-normal) var(--ease-spring),
+      opacity var(--duration-normal) var(--ease-out);
+    z-index: -1;
+  }
+
+  .nav-tab.active::before {
+    transform: translate(-50%, -65%) scaleX(1);
+    opacity: 1;
   }
 
   .nav-tab.active {
-    color: var(--colour-primary);
-  }
-
-  .nav-tab:not(.active) {
-    color: var(--colour-text-muted);
+    color: var(--bottom-nav-active-colour);
   }
 
   .nav-tab:focus-visible {
@@ -112,7 +145,19 @@
   }
 
   .nav-label {
-    font-size: var(--font-size-2xs);
+    font-size: var(--bottom-nav-label-size);
+    font-weight: var(--font-weight-medium);
     line-height: 1;
+    letter-spacing: var(--letter-spacing-wide);
+    text-transform: uppercase;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bottom-nav {
+      transition: none;
+    }
+    .nav-tab::before {
+      transition: none;
+    }
   }
 </style>

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -372,6 +372,19 @@
   --touch-target-min: 48px;
   --touch-target-comfortable: 56px;
 
+  /* Bottom Navigation (Framework7-inspired) */
+  --bottom-nav-height: 64px;
+  --bottom-nav-icon-size: 28px;
+  --bottom-nav-label-size: var(--font-size-2xs);
+  --bottom-nav-bg: rgba(33, 34, 44, 0.85);
+  --bottom-nav-border: rgba(52, 55, 70, 0.6);
+  --bottom-nav-blur: 20px;
+  --bottom-nav-active-pill-bg: rgba(139, 233, 253, 0.12);
+  --bottom-nav-active-colour: var(--colour-primary);
+  --bottom-nav-inactive-colour: var(--colour-text-muted);
+  --bottom-nav-transition: 400ms;
+  --bottom-nav-pill-radius: 16px;
+
   /* Overlays & Shadows */
   --colour-backdrop: rgba(0, 0, 0, 0.5);
   --shadow-sheet: 0 -4px 20px rgba(0, 0, 0, 0.15);
@@ -597,6 +610,10 @@
 
   --toast-bg: var(--alucard-floating);
   --toast-border: var(--alucard-bg-light);
+
+  --bottom-nav-bg: rgba(239, 237, 220, 0.85);
+  --bottom-nav-border: rgba(222, 220, 207, 0.6);
+  --bottom-nav-active-pill-bg: rgba(3, 106, 150, 0.1);
 
   --colour-error-hover: #b33030;
 


### PR DESCRIPTION
## **User description**
## Summary

- Restyle `MobileBottomNav` with frosted glass background (`backdrop-filter: blur(20px)`), pill-shaped active indicator (Material Design 3), taller 64px bar, and 28px icons
- Add 11 `--bottom-nav-*` design tokens with light theme overrides
- Add `hidden` prop with slide-out transition for future hide-on-scroll (#642/#643)
- Add `prefers-reduced-motion` support for all animations

Closes #1062

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 1808 tests pass
- [x] `npm run build` — successful
- [ ] Deploy to d.racku.la, test on iPhone SE Safari
- [ ] Verify frosted glass, pill indicator, taller bar, larger icons
- [ ] Verify light theme (Alucard) overrides
- [ ] Verify safe area inset on iPhone (no content behind home indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Revamp mobile bottom navigation with frosted-glass background, pill-shaped active indicator, and larger touch targets

### What Changed
- Mobile bottom bar height increased to 64px with larger 28px icons and updated spacing so controls are easier to tap and content accounts for the safe-area inset
- Visual restyle: translucent frosted-glass background, subtle top border, and a pill-shaped active indicator that animates under the active tab; inactive tabs use muted color while the active tab uses the primary color
- Adds a hide state and slide-out transform for the bar so it can be hidden off-screen (prefers-reduced-motion respected to disable animations)

### Impact
`✅ Clearer active tab indication`
`✅ Fewer accidental taps on mobile due to larger touch targets`
`✅ No content hidden behind the bottom nav on devices with home indicator` 
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
