### PR TITLE
fix: integrate Start Screen into app launch flow (#1002)

### DIFF
--- a/src/tests/App.startScreen.test.ts
+++ b/src/tests/App.startScreen.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import App from "../App.svelte";
+import { dialogStore } from "$lib/stores/dialogs.svelte";
+import { resetLayoutStore } from "$lib/stores/layout.svelte";
+import { resetSelectionStore } from "$lib/stores/selection.svelte";
+import { resetUIStore } from "$lib/stores/ui.svelte";
+import { resetCanvasStore } from "$lib/stores/canvas.svelte";
+import { resetPlacementStore } from "$lib/stores/placement.svelte";
+import { resetImageStore } from "$lib/stores/images.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+import { resetViewportStore } from "$lib/utils/viewport.svelte";
+import { createTestLayout, createTestRack } from "./factories";
+
+const shareMocks = vi.hoisted(() => ({
+  getShareParam: vi.fn<() => string | null>(() => null),
+  clearShareParam: vi.fn(),
+  decodeLayout: vi.fn(),
+  generateShareUrl: vi.fn(() => null),
+}));
+
+const persistenceStoreMocks = vi.hoisted(() => ({
+  initializePersistence: vi.fn(async () => true),
+  isApiAvailable: vi.fn(() => true),
+  setApiAvailable: vi.fn(),
+  getApiAvailableState: vi.fn(() => true),
+  hasEverConnectedToApi: vi.fn(() => true),
+}));
+
+const persistenceApiMocks = vi.hoisted(() => ({
+  saveLayoutToServer: vi.fn(async () => "layout-1"),
+  checkApiHealth: vi.fn(async () => true),
+  listSavedLayouts: vi.fn(async () => []),
+  loadSavedLayout: vi.fn(),
+  deleteSavedLayout: vi.fn(async () => undefined),
+  PersistenceError: class PersistenceError extends Error {
+    statusCode?: number;
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.name = "PersistenceError";
+      this.statusCode = statusCode;
+    }
+  },
+}));
+
+const sessionStorageMocks = vi.hoisted(() => ({
+  saveSession: vi.fn(),
+  loadSessionWithTimestamp: vi.fn(() => null),
+  clearSession: vi.fn(),
+  isServerNewer: vi.fn(() => false),
+}));
+
+vi.mock("$lib/utils/share", async () => {
+  const actual = await vi.importActual<typeof import("$lib/utils/share")>(
+    "$lib/utils/share",
+  );
+
+  return {
+    ...actual,
+    getShareParam: shareMocks.getShareParam,
+    clearShareParam: shareMocks.clearShareParam,
+    decodeLayout: shareMocks.decodeLayout,
+    generateShareUrl: shareMocks.generateShareUrl,
+  };
+});
+
+vi.mock("$lib/stores/persistence.svelte", () => ({
+  initializePersistence: persistenceStoreMocks.initializePersistence,
+  isApiAvailable: persistenceStoreMocks.isApiAvailable,
+  setApiAvailable: persistenceStoreMocks.setApiAvailable,
+  getApiAvailableState: persistenceStoreMocks.getApiAvailableState,
+  hasEverConnectedToApi: persistenceStoreMocks.hasEverConnectedToApi,
+}));
+
+vi.mock("$lib/utils/persistence-api", () => ({
+  saveLayoutToServer: persistenceApiMocks.saveLayoutToServer,
+  checkApiHealth: persistenceApiMocks.checkApiHealth,
+  listSavedLayouts: persistenceApiMocks.listSavedLayouts,
+  loadSavedLayout: persistenceApiMocks.loadSavedLayout,
+  deleteSavedLayout: persistenceApiMocks.deleteSavedLayout,
+  PersistenceError: persistenceApiMocks.PersistenceError,
+}));
+
+vi.mock("$lib/utils/session-storage", () => ({
+  saveSession: sessionStorageMocks.saveSession,
+  loadSessionWithTimestamp: sessionStorageMocks.loadSessionWithTimestamp,
+  clearSession: sessionStorageMocks.clearSession,
+  isServerNewer: sessionStorageMocks.isServerNewer,
+}));
+
+describe("App Start Screen integration", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetUIStore();
+    resetCanvasStore();
+    resetPlacementStore();
+    resetImageStore();
+    resetHistoryStore();
+    resetToastStore();
+    resetViewportStore();
+    dialogStore.close();
+    dialogStore.closeSheet();
+
+    shareMocks.getShareParam.mockReturnValue(null);
+    shareMocks.decodeLayout.mockReturnValue(null);
+    shareMocks.clearShareParam.mockReset();
+
+    persistenceStoreMocks.initializePersistence.mockResolvedValue(true);
+    persistenceStoreMocks.isApiAvailable.mockReturnValue(true);
+
+    persistenceApiMocks.listSavedLayouts.mockResolvedValue([]);
+    persistenceApiMocks.loadSavedLayout.mockReset();
+
+    sessionStorageMocks.loadSessionWithTimestamp.mockReturnValue(null);
+    sessionStorageMocks.clearSession.mockReset();
+  });
+
+  it("shows Start Screen on load when API is available and no share link", async () => {
+    render(App);
+
+    expect(await screen.findByRole("button", { name: "New Layout" })).toBeVisible();
+  });
+
+  it("skips Start Screen when loading a share link", async () => {
+    const sharedLayout = createTestLayout({
+      name: "Shared Test",
+      racks: [createTestRack({ id: "rack-1", name: "Rack 1" })],
+    });
+
+    shareMocks.getShareParam.mockReturnValue("encoded");
+    shareMocks.decodeLayout.mockReturnValue(sharedLayout);
+
+    render(App);
+
+    await waitFor(() => {
+      expect(shareMocks.decodeLayout).toHaveBeenCalledWith("encoded");
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "New Layout" }),
+    ).not.toBeInTheDocument();
+    expect(shareMocks.clearShareParam).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
- render `StartScreen` on app load when the persistence API is available and there is no local autosave session
- preserve share-link priority and existing server-vs-local timestamp conflict handling when local autosave exists
- add start-screen integration tests for API-enabled launch and share-link bypass behavior with deterministic mocks

## Test Plan
- [x] npm run lint
- [x] npm run test:run -- src/tests/App.startScreen.test.ts
- [x] npm run test:run
- [x] npm run build

Closes #1002


___

## **CodeAnt-AI Description**
Integrate Start Screen into app launch to let users pick saved/new layouts

### What Changed
- App now shows the Start Screen on launch when the persistence API is available and there is no local autosave, letting users choose a saved layout, import, or start fresh
- Share-link loading still takes priority: a valid share link loads immediately and bypasses the Start Screen; invalid links show an error and clear the param
- When both server and local autosave exist, the app compares timestamps and loads the newer source; stale local autosave is cleared after loading newer server data
- Added integration tests covering API-enabled startup, share-link bypass, and deterministic persistence/session mocks

### Impact
`✅ Clearer startup choices when cloud persistence is available`
`✅ Fewer accidental overwrites from stale local autosave`
`✅ Consistent share-link loading behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
