### PR TITLE
fix: follow up swipe touch handling after #1076

### DIFF
--- a/src/lib/utils/gestures.ts
+++ b/src/lib/utils/gestures.ts
@@ -76,15 +76,17 @@ export function classifyRackSwipeGesture(
   const absDeltaY = Math.abs(deltaY);
   const totalDistance = Math.hypot(deltaX, deltaY);
 
+  const isVerticalPan =
+    totalDistance > panThreshold && absDeltaY > absDeltaX;
+
+  if (isVerticalPan) {
+    return null;
+  }
+
   const isHorizontalFlick =
     absDeltaX >= minSwipeDistance &&
     absDeltaX > absDeltaY * horizontalDominanceRatio &&
     input.durationMs <= maxSwipeDurationMs;
-
-  // If movement exceeded pan threshold but did not meet swipe criteria, treat as pan.
-  if (totalDistance > panThreshold && !isHorizontalFlick) {
-    return null;
-  }
 
   if (!isHorizontalFlick) {
     return null;

--- a/src/tests/gestures.test.ts
+++ b/src/tests/gestures.test.ts
@@ -411,6 +411,19 @@ describe("classifyRackSwipeGesture", () => {
     expect(direction).toBeNull();
   });
 
+  it("keeps horizontal swipes valid with moderate vertical drift", () => {
+    const direction = classifyRackSwipeGesture({
+      startX: 200,
+      startY: 120,
+      endX: 116,
+      endY: 168,
+      durationMs: 190,
+      isMultiTouch: false,
+    });
+
+    expect(direction).toBe("next");
+  });
+
   it("returns null for slow horizontal drags", () => {
     const direction = classifyRackSwipeGesture({
       startX: 200,


### PR DESCRIPTION
## **User description**
## Summary
- move canvas touch handlers from Svelte declarative `ontouch*` attributes to imperative `addEventListener` registration with explicit `{ capture: true, passive: true }` options and deterministic cleanup
- document touch event precedence: swipe listeners observe first but intentionally do not call `preventDefault`, leaving pan/pinch behavior to panzoom
- replace duplicated local swipe lock constant with canonical `RACK_SWIPE_PAN_THRESHOLD` from `gestures.ts`
- fix same-direction swipe animation replay by clearing direction state and re-applying it on a microtask boundary before timeout cleanup
- reduce touchmove churn by making `swipeGesture` non-reactive and mutating fields in place instead of object re-assignment
- add focused mobile debug logs for touch start/move/end/cancel and swipe direction transitions
- refine swipe classification to reject dominant vertical pans while removing redundant null-return guard logic
- add a regression test proving horizontal swipes with moderate vertical drift still classify correctly

## Test Plan
- [x] `npm run test:run -- src/tests/gestures.test.ts`
- [x] `npm run lint`
- [x] `npm run build`

## Context
Follow-up to comments on merged PR #1076.


___

## **CodeAnt-AI Description**
**Improve mobile touch handling and swipe classification on canvas**

### What Changed
- Canvas now captures touchstart/move/end/cancel with passive, capture listeners so pan/pinch (zoom) behavior remains controlled by the pan/zoom layer while we still observe gestures.
- Horizontal swipe detection rejects clear vertical pans earlier and preserves valid horizontal swipes that include moderate vertical drift, reducing missed swipes.
- Swipe state is updated in-place (less churn), swipe animation resets and re-applies direction on the next microtask to avoid replay glitches, and the global swipe threshold constant is used for consistent behavior.
- Added focused mobile debug logs for touch start/move/end/cancel and swipe outcomes to help diagnose touch interactions.

### Impact
`✅ More reliable rack switching on mobile`
`✅ Fewer accidental pan cancellations that block swipes`
`✅ Clearer mobile touch diagnostics`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
