### PR TITLE
fix: follow up swipe listener lifecycle and logging

### DIFF
--- a/src/lib/utils/gestures.ts
+++ b/src/lib/utils/gestures.ts
@@ -77,7 +77,8 @@ export function classifyRackSwipeGesture(
   const totalDistance = Math.hypot(deltaX, deltaY);
 
   const isVerticalPan =
-    totalDistance > panThreshold && absDeltaY > absDeltaX;
+    totalDistance > panThreshold &&
+    absDeltaY > absDeltaX * horizontalDominanceRatio;
 
   if (isVerticalPan) {
     return null;


### PR DESCRIPTION
## **User description**
## Summary
- attach/detach touch listeners reactively when the `canvasContainer` reference changes, instead of only once in `onMount`
- keep explicit touch listener options (`capture: true`, `passive: true`) and preserve panzoom gesture ownership by never calling `preventDefault`
- gate mobile touch logs behind `mobileDebug.enabled` and throttle `touchmove` logging to reduce runtime overhead on low-end devices
- align vertical-pan detection with the configured `horizontalDominanceRatio` for more consistent swipe-vs-pan classification behavior

## Test Plan
- [x] `npm run test:run -- src/tests/gestures.test.ts`
- [x] `npm run lint`
- [x] `npm run build`

## Context
Additional follow-up after merged PR #1081.


___

## **CodeAnt-AI Description**
Improve touch/swipe handling: consistent swipe classification, reactive listeners, and throttled mobile logs

### What Changed
- Horizontal swipes now remain valid when they include moderate vertical drift; vertical pans that exceed the configured dominance ratio are rejected so swipes are not misclassified during vertical movement.
- Touch listeners are attached and removed whenever the canvas element changes, ensuring touch handling works reliably across mounts/unmounts and allowing the pan/zoom library to keep control (no prevented default).
- Mobile touch logging is gated behind the mobile debug flag and touchmove logs are throttled to reduce console noise and runtime overhead on low-end devices.
- Swipe animations are serialized so rapid input no longer produces overlapping or transient animation states, and horizontal swipe threshold uses the unified pan threshold to reduce accidental triggers.

### Impact
`✅ Fewer accidental rack switches during vertical pans`
`✅ Clearer, lower-overhead mobile touch logs`
`✅ More reliable swipe animations and rack switching`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
