### PR TITLE
fix: clear stale canvas ref and tighten swipe edge cases

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -114,6 +114,9 @@
   const SWIPE_SWITCH_ANIMATION_MS = 200;
   const TOUCH_MOVE_LOG_INTERVAL_MS = 120;
   const TOUCH_LISTENER_OPTIONS: AddEventListenerOptions = {
+    // Capture keeps swipe tracking robust even if child components stop bubbling.
+    // Because listeners are passive and never call stopPropagation/preventDefault,
+    // child touch handlers still run and panzoom keeps gesture ownership.
     capture: true,
     passive: true,
   };
@@ -237,6 +240,7 @@
         handleCanvasTouchCancel,
         TOUCH_LISTENER_OPTIONS,
       );
+      canvasStore.setCanvasElement(null);
     };
   });
 

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -231,9 +231,9 @@ function smoothMoveTo(x: number, y: number, scale: number): void {
 }
 
 /**
- * Set the canvas container element (for viewport measurements)
+ * Set or clear the canvas container element (for viewport measurements)
  */
-function setCanvasElement(element: HTMLElement): void {
+function setCanvasElement(element: HTMLElement | null): void {
   canvasElement = element;
 }
 

--- a/src/tests/canvas-store.test.ts
+++ b/src/tests/canvas-store.test.ts
@@ -354,6 +354,32 @@ describe('Canvas Store', () => {
 			expect(store.zoom).toBe(initialZoom);
 		});
 
+		it('fitAll does nothing when canvas element is cleared', () => {
+			const store = getCanvasStore();
+			const mockPanzoom = createMockPanzoom(1);
+
+			store.setPanzoomInstance(mockPanzoom as ReturnType<typeof import('panzoom').default>);
+			store.setCanvasElement(null);
+
+			const mockRacks = [
+				{
+					name: 'Test',
+					height: 42,
+					width: 19 as const,
+					position: 0,
+					desc_units: false,
+					form_factor: '4-post' as const,
+					starting_unit: 1,
+					devices: []
+				}
+			] as Parameters<typeof store.fitAll>[0];
+
+			store.fitAll(mockRacks);
+
+			expect(mockPanzoom.zoomAbs).not.toHaveBeenCalled();
+			expect(mockPanzoom.moveTo).not.toHaveBeenCalled();
+		});
+
 		it('fitAll centers rack in viewport when panzoom is available', () => {
 			const store = getCanvasStore();
 			const mockPanzoom = createMockPanzoom(1);

--- a/src/tests/gestures.test.ts
+++ b/src/tests/gestures.test.ts
@@ -424,6 +424,33 @@ describe("classifyRackSwipeGesture", () => {
     expect(direction).toBe("next");
   });
 
+  it("returns null for short fast diagonal swipes below minimum distance", () => {
+    const direction = classifyRackSwipeGesture({
+      startX: 220,
+      startY: 180,
+      endX: 220 - (RACK_SWIPE_MIN_DISTANCE - 5),
+      endY: 156,
+      durationMs: 90,
+      isMultiTouch: false,
+    });
+
+    expect(direction).toBeNull();
+  });
+
+  it("keeps horizontal-dominant diagonal swipes over pan threshold valid", () => {
+    const direction = classifyRackSwipeGesture({
+      startX: 250,
+      startY: 110,
+      endX: 172,
+      endY: 68,
+      durationMs: 170,
+      isMultiTouch: false,
+    });
+
+    expect(Math.hypot(78, 42)).toBeGreaterThan(RACK_SWIPE_PAN_THRESHOLD);
+    expect(direction).toBe("next");
+  });
+
   it("returns null for slow horizontal drags", () => {
     const direction = classifyRackSwipeGesture({
       startX: 200,


### PR DESCRIPTION
## **User description**
## Summary
- clear stale canvas element references by calling `canvasStore.setCanvasElement(null)` when the reactive touch-listener effect tears down
- update canvas store API to support clearing the element (`HTMLElement | null`) and add coverage verifying `fitAll` is a no-op after clear
- document why touch listeners use capture+passive and how that preserves child handlers/panzoom ownership
- expand swipe classifier tests for short fast diagonals and horizontal-dominant diagonal swipes over the pan threshold to protect edge-case ordering

## Test Plan
- [x] `npm run test:run -- src/tests/gestures.test.ts src/tests/canvas-store.test.ts`
- [x] `npm run lint`
- [x] `npm run build`

## Context
Follow-up PR after #1082 per additional review comments.


___

## **CodeAnt-AI Description**
Clear canvas reference on touch teardown, make swipe detection stricter, and add tests

### What Changed
- Touch listener teardown now clears the stored canvas element so subsequent viewport operations do nothing if the element is gone
- Touch listeners use capture+passive to keep swipe tracking reliable while still allowing child touch handlers and pan/zoom to handle gestures
- Swipe classifier gains tests and behavior changes: short fast diagonal swipes below the minimum distance are ignored, and horizontal-dominant diagonal swipes that exceed the pan threshold still register as horizontal swipes
- Added a test ensuring fit-all silently no-ops when the canvas element is cleared (no zoom or pan calls)

### Impact
`✅ Fewer unexpected zooms or pans after canvas unmount`
`✅ Fewer misclassified swipe gestures at diagonal/short-edge cases`
`✅ Clearer test coverage for swipe and canvas lifecycle behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
