### PR TITLE
test: remove hardcoded HAS_STARTED_KEY in contract test

### DIFF
--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -76,7 +76,7 @@ import {
 } from "./commands";
 
 // localStorage key for tracking if user has started (created/loaded a rack)
-const HAS_STARTED_KEY = "Rackula_has_started";
+export const HAS_STARTED_KEY = "Rackula_has_started";
 
 // Check if user has previously started (created or loaded a rack)
 function loadHasStarted(): boolean {

--- a/src/tests/layout-store-contract.test.ts
+++ b/src/tests/layout-store-contract.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
-import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getLayoutStore,
+  HAS_STARTED_KEY,
+  resetLayoutStore,
+} from "$lib/stores/layout.svelte";
 import { getHistoryStore, resetHistoryStore } from "$lib/stores/history.svelte";
 
-const HAS_STARTED_KEY = "Rackula_has_started";
 /**
  * Compile-time API contract for the public LayoutStore surface.
  * This tuple is intentionally type-level only (not a runtime Object.keys assertion):


### PR DESCRIPTION
## **User description**
## Summary
- export `HAS_STARTED_KEY` from `src/lib/stores/layout.svelte.ts`
- replace the local magic string in `src/tests/layout-store-contract.test.ts` with an import from the store
- keep test cleanup aligned with the store source of truth to prevent key drift

## Test Plan
- [x] npm run lint
- [x] npm run test:run
- [x] npm run build
- [x] coderabbit --prompt-only --type uncommitted

Refs #910


___

## **CodeAnt-AI Description**
Reuse the store's HAS_STARTED key in the layout store contract test

### What Changed
- The has-started localStorage key was exported from the layout store so callers can reference the single source of truth
- The contract test now imports that exported key instead of using a hardcoded string, and uses it for test cleanup and assertions

### Impact
`✅ Fewer flaky tests due to mismatched cleanup keys`
`✅ Consistent localStorage cleanup across tests`
`✅ Easier, safer reuse of the has-started key in other code`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
