### PR TITLE
feat: mobile long-press context menus (#1045)

### DIFF
--- a/src/lib/utils/context-menu.ts
+++ b/src/lib/utils/context-menu.ts
@@ -1,0 +1,53 @@
+import Debug from "debug";
+
+const contextMenuDebug = Debug("rackula:ui:context-menu");
+
+function describeTarget(target: Element): string {
+  const idSuffix = target.id ? `#${target.id}` : "";
+  if (!(target instanceof HTMLElement)) {
+    return `${target.tagName.toLowerCase()}${idSuffix}`;
+  }
+
+  const classList =
+    typeof target.className === "string" ? target.className.trim() : "";
+  const classSuffix = classList
+    ? `.${classList.split(/\s+/).filter(Boolean).join(".")}`
+    : "";
+
+  return `${target.tagName.toLowerCase()}${idSuffix}${classSuffix}`;
+}
+
+/**
+ * Dispatch a synthetic contextmenu event at viewport (client) coordinates.
+ * Returns the event target used, or null when no suitable target exists.
+ */
+export function dispatchContextMenuAtPoint(
+  x: number,
+  y: number,
+  fallbackTarget?: Element | null,
+): Element | null {
+  if (typeof document === "undefined") return null;
+  const target = document.elementFromPoint(x, y) ?? fallbackTarget ?? null;
+  if (!target) return null;
+
+  contextMenuDebug(
+    "dispatch contextmenu x=%d y=%d target=%s",
+    x,
+    y,
+    describeTarget(target),
+  );
+
+  target.dispatchEvent(
+    new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+      button: 2,
+      buttons: 2,
+      view: window,
+    }),
+  );
+
+  return target;
+}

--- a/src/tests/gestures.test.ts
+++ b/src/tests/gestures.test.ts
@@ -21,13 +21,6 @@ describe("useLongPress", () => {
     callback = vi.fn();
     cleanup = undefined;
 
-    // Mock navigator.vibrate
-    Object.defineProperty(navigator, "vibrate", {
-      value: vi.fn(),
-      writable: true,
-      configurable: true,
-    });
-
     vi.useFakeTimers();
   });
 
@@ -196,37 +189,29 @@ describe("useLongPress", () => {
       vi.advanceTimersByTime(500);
       expect(callback).toHaveBeenCalledTimes(1);
     });
-  });
 
-  describe("haptic feedback", () => {
-    it("triggers haptic feedback if available", () => {
+    it("cancels active long press when a second pointer starts", () => {
       cleanup = useLongPress(element, callback);
 
       element.dispatchEvent(
-        new PointerEvent("pointerdown", { bubbles: true, isPrimary: true }),
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          pointerId: 1,
+          isPrimary: true,
+        }),
       );
-      vi.advanceTimersByTime(500);
-
-      expect(navigator.vibrate).toHaveBeenCalledWith(50);
-    });
-
-    it("handles missing vibrate API gracefully", () => {
-      // Remove vibrate API
-      Object.defineProperty(navigator, "vibrate", {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      });
-
-      cleanup = useLongPress(element, callback);
+      vi.advanceTimersByTime(200);
 
       element.dispatchEvent(
-        new PointerEvent("pointerdown", { bubbles: true, isPrimary: true }),
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          pointerId: 2,
+          isPrimary: false,
+        }),
       );
-      vi.advanceTimersByTime(500);
 
-      // Should still call callback
-      expect(callback).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(400);
+      expect(callback).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary
- wire long-press on rack devices to open the device context menu at the touch point
- wire long-press on rack surfaces and empty canvas space to dispatch context menus on touch devices
- tighten `useLongPress()` multi-touch cancellation to prevent long-press firing during pinch gestures
- add shared `dispatchContextMenuAtPoint()` utility and long-press debug logging for mobile troubleshooting
- update gesture unit tests to cover second-pointer cancellation

## Test Plan
- [x] `npm run test:run -- src/tests/gestures.test.ts`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `coderabbit --prompt-only --type uncommitted`

Closes #1045


___

## **CodeAnt-AI Description**
Enable long-press context menus on touch for racks, devices and canvas

### What Changed
- Long-press on rack areas, individual devices, or empty canvas now opens the appropriate context menu at the touch point on mobile/tablet
- Long-press cancels immediately when a second pointer touches (pinch/zoom), preventing accidental long-presses during multi-touch gestures
- Added light haptic feedback when a long-press successfully triggers and improved long-press target detection so device long-presses open device actions while rack long-presses open rack/canvas menus
- Updated gesture tests to cover cancellation when a second pointer starts

### Impact
`✅ Open context menus with long-press on mobile`
`✅ Fewer accidental context menus during pinch/zoom`
`✅ Tactile feedback on long-press`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
