### PR TITLE
fix: align vertical-pan rejection with swipe dominance ratio (#1090)

### DIFF
--- a/src/tests/gestures.test.ts
+++ b/src/tests/gestures.test.ts
@@ -436,6 +436,39 @@ describe("classifyRackSwipeGesture", () => {
     expect(direction).toBe("next");
   });
 
+  it("keeps near-diagonal swipes valid with permissive dominance ratios", () => {
+    const direction = classifyRackSwipeGesture(
+      {
+        startX: 240,
+        startY: 120,
+        endX: 160,
+        endY: 215,
+        durationMs: 170,
+        isMultiTouch: false,
+      },
+      { horizontalDominanceRatio: 0.8 },
+    );
+
+    expect(Math.hypot(80, 95)).toBeGreaterThan(RACK_SWIPE_PAN_THRESHOLD);
+    expect(direction).toBe("next");
+  });
+
+  it("returns null for short diagonal movement even with permissive ratios", () => {
+    const direction = classifyRackSwipeGesture(
+      {
+        startX: 180,
+        startY: 120,
+        endX: 140,
+        endY: 150,
+        durationMs: 110,
+        isMultiTouch: false,
+      },
+      { horizontalDominanceRatio: 0.8 },
+    );
+
+    expect(direction).toBeNull();
+  });
+
   it("returns null for slow horizontal drags", () => {
     const direction = classifyRackSwipeGesture({
       startX: 200,


### PR DESCRIPTION
## **User description**
## Summary
- align vertical-pan rejection with configured swipe dominance semantics by using reciprocal dominance bounds
- keep horizontal flick detection focused on a shared horizontal-dominance check
- add regression tests for permissive ratio behavior and short diagonal gestures

## Test Plan
- [x] npm run test:run -- src/tests/gestures.test.ts
- [x] npm run test:run
- [x] npm run build
- [x] npm run lint

Closes #1090


___

## **CodeAnt-AI Description**
Align rack-swipe detection with configured swipe dominance so vertical pans are rejected correctly

### What Changed
- Multi-touch inputs are rejected before any swipe checks.
- Vertical-pan rejection now uses the reciprocal of the configured horizontal dominance ratio, preventing misclassification of vertical pans as swipes.
- Horizontal flick checks reuse a single dominance check so horizontal swipes are detected consistently; permissive dominance ratios are accepted but fall back to a default if given as non-positive.
- Added tests: valid near-diagonal swipes are accepted when the ratio is permissive, and short diagonal movements are rejected even with permissive ratios.

### Impact
`✅ Fewer accidental rack navigations`
`✅ Valid near-diagonal swipes accepted when intended`
`✅ Short diagonal gestures ignored, reducing false positives`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
