### PR TITLE
chore(test): reset all hoisted mocks in cleanup prompt spec (#1150)

### DIFF
--- a/src/tests/App.cleanupPrompt.test.ts
+++ b/src/tests/App.cleanupPrompt.test.ts
@@ -111,6 +111,49 @@ function openCleanupPrompt(operation: "save" | "export"): void {
   dialogStore.open("cleanupPrompt");
 }
 
+function resetHoistedMocks(): void {
+  shareMocks.getShareParam.mockReset();
+  shareMocks.getShareParam.mockReturnValue(null);
+  shareMocks.clearShareParam.mockReset();
+  shareMocks.decodeLayout.mockReset();
+  shareMocks.decodeLayout.mockReturnValue(null);
+  shareMocks.generateShareUrl.mockReset();
+  shareMocks.generateShareUrl.mockReturnValue(null);
+
+  persistenceStoreMocks.initializePersistence.mockReset();
+  persistenceStoreMocks.initializePersistence.mockResolvedValue(false);
+  persistenceStoreMocks.isApiAvailable.mockReset();
+  persistenceStoreMocks.isApiAvailable.mockReturnValue(false);
+  persistenceStoreMocks.setApiAvailable.mockReset();
+  persistenceStoreMocks.getApiAvailableState.mockReset();
+  persistenceStoreMocks.getApiAvailableState.mockReturnValue(false);
+  persistenceStoreMocks.hasEverConnectedToApi.mockReset();
+  persistenceStoreMocks.hasEverConnectedToApi.mockReturnValue(false);
+
+  persistenceApiMocks.saveLayoutToServer.mockReset();
+  persistenceApiMocks.saveLayoutToServer.mockResolvedValue("layout-1");
+  persistenceApiMocks.checkApiHealth.mockReset();
+  persistenceApiMocks.checkApiHealth.mockResolvedValue(false);
+  persistenceApiMocks.listSavedLayouts.mockReset();
+  persistenceApiMocks.listSavedLayouts.mockResolvedValue([]);
+  persistenceApiMocks.loadSavedLayout.mockReset();
+  persistenceApiMocks.deleteSavedLayout.mockReset();
+  persistenceApiMocks.deleteSavedLayout.mockResolvedValue(undefined);
+
+  sessionStorageMocks.saveSession.mockReset();
+  sessionStorageMocks.loadSessionWithTimestamp.mockReset();
+  sessionStorageMocks.loadSessionWithTimestamp.mockReturnValue(null);
+  sessionStorageMocks.clearSession.mockReset();
+  sessionStorageMocks.isServerNewer.mockReset();
+  sessionStorageMocks.isServerNewer.mockReturnValue(false);
+
+  archiveMocks.downloadArchive.mockReset();
+  archiveMocks.downloadArchive.mockResolvedValue(undefined);
+  archiveMocks.generateArchiveFilename.mockReset();
+  archiveMocks.generateArchiveFilename.mockReturnValue("cleanup-test.Rackula.zip");
+  archiveMocks.extractFolderArchive.mockReset();
+}
+
 describe("App cleanup prompt flow", () => {
   const layoutStore = getLayoutStore();
   const uiStore = getUIStore();
@@ -127,20 +170,7 @@ describe("App cleanup prompt flow", () => {
     resetViewportStore();
     dialogStore.close();
     dialogStore.closeSheet();
-
-    shareMocks.getShareParam.mockReset();
-    shareMocks.getShareParam.mockReturnValue(null);
-    shareMocks.decodeLayout.mockReset();
-    shareMocks.decodeLayout.mockReturnValue(null);
-    shareMocks.clearShareParam.mockReset();
-
-    persistenceStoreMocks.initializePersistence.mockReset();
-    persistenceStoreMocks.initializePersistence.mockResolvedValue(false);
-    persistenceStoreMocks.isApiAvailable.mockReset();
-    persistenceStoreMocks.isApiAvailable.mockReturnValue(false);
-
-    persistenceApiMocks.listSavedLayouts.mockReset();
-    persistenceApiMocks.listSavedLayouts.mockResolvedValue([]);
+    resetHoistedMocks();
 
     const layoutWithUnusedType = createTestLayout({
       name: "Cleanup Prompt Test Layout",
@@ -154,19 +184,10 @@ describe("App cleanup prompt flow", () => {
     });
     layoutStore.loadLayout(layoutWithUnusedType);
 
-    sessionStorageMocks.loadSessionWithTimestamp.mockReset();
     sessionStorageMocks.loadSessionWithTimestamp.mockReturnValue({
       layout: layoutWithUnusedType,
       savedAt: new Date("2026-02-09T00:00:00.000Z").toISOString(),
     });
-    sessionStorageMocks.clearSession.mockReset();
-
-    archiveMocks.downloadArchive.mockReset();
-    archiveMocks.downloadArchive.mockResolvedValue(undefined);
-    archiveMocks.generateArchiveFilename.mockReset();
-    archiveMocks.generateArchiveFilename.mockReturnValue(
-      "cleanup-test.Rackula.zip",
-    );
   });
 
   it("routes Review & Clean Up into cleanup workflow and then saves after deletion", async () => {


### PR DESCRIPTION
## **User description**
## Summary
- centralize reset/setup for all hoisted mocks in `App.cleanupPrompt.test.ts`
- ensure every mocked function has deterministic defaults in `beforeEach`
- keep existing cleanup prompt behavior tests intact

## Test Plan
- [x] npm run lint
- [x] npm run test:run -- src/tests/App.cleanupPrompt.test.ts
- [x] npm run build
- [x] codeant static-analysis --uncommitted --fail-on INFO
- [x] codeant security-analysis --uncommitted --fail-on INFO
- [x] codeant secrets --uncommitted --fail-on all
- [x] coderabbit --prompt-only --type uncommitted

Closes #1150


___

## **CodeAnt-AI Description**
Centralize and reset all hoisted mocks for the cleanup prompt tests

### What Changed
- Introduced a single resetHoistedMocks() that resets and sets deterministic defaults for all hoisted mocks (share params, persistence store & API, session storage, archive).
- Replaced scattered individual mock resets in the test setup with a single call to resetHoistedMocks() in beforeEach.
- Removed duplicate mock-reset lines and ensured session and archive mocks use the intended default return values during tests.

### Impact
`✅ Fewer flaky tests`
`✅ Shorter test setup`
`✅ Clearer test failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
