### PR TITLE
chore: tokenize shared dialog mobile content padding (#1162)

### DIFF
--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -85,10 +85,6 @@
     gap: var(--space-3);
   }
 
-  .dialog-content {
-    padding: var(--space-5);
-  }
-
   @media (max-width: 430px) {
     .dialog-header {
       padding: var(--space-3) var(--space-4);
@@ -96,14 +92,6 @@
 
     .dialog-header-actions {
       gap: var(--space-2);
-    }
-
-    .dialog-content {
-      padding: var(--space-4);
-      padding-bottom: max(
-        var(--space-5),
-        calc(env(safe-area-inset-bottom, 0px) + var(--space-3))
-      );
     }
   }
 </style>

--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -339,8 +339,12 @@
   /* Base dialog styles (.dialog-backdrop, .dialog-title, .dialog-close)
      are defined in src/lib/styles/dialogs.css and imported globally */
 
+  /* Keep HelpPanel denser than default dialog spacing, especially on mobile. */
   .dialog-content {
-    padding: var(--space-4);
+    --dialog-content-padding: var(--space-4);
+    --dialog-content-mobile-padding: var(--space-4);
+    --dialog-content-mobile-padding-bottom-min: var(--space-4);
+    --dialog-content-mobile-safe-area-offset: var(--space-2);
   }
 
   /* Screen reader only - visually hidden but accessible */
@@ -360,15 +364,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
-  }
-
-  @media (max-width: 430px) {
-    .dialog-content {
-      padding-bottom: max(
-        var(--space-4),
-        calc(env(safe-area-inset-bottom, 0px) + var(--space-2))
-      );
-    }
   }
 
   /* Header row: Logo + Version */

--- a/src/lib/styles/dialogs.css
+++ b/src/lib/styles/dialogs.css
@@ -45,6 +45,7 @@
   overflow-y: auto;
   flex: 1 1 auto;
   min-height: 0;
+  padding: var(--dialog-content-padding, var(--space-5));
 }
 
 /* Dialog close button */
@@ -89,6 +90,17 @@
   .dialog-close {
     width: 44px;
     height: 44px;
+  }
+
+  .dialog .dialog-content {
+    padding: var(--dialog-content-mobile-padding, var(--space-4));
+    padding-bottom: max(
+      var(--dialog-content-mobile-padding-bottom-min, var(--space-5)),
+      calc(
+        env(safe-area-inset-bottom, 0px) +
+          var(--dialog-content-mobile-safe-area-offset, var(--space-3))
+      )
+    );
   }
 
   .dialog


### PR DESCRIPTION
## **User description**
## Summary
- move mobile `.dialog-content` safe-area padding logic into shared `src/lib/styles/dialogs.css`
- drive shared mobile and desktop dialog content spacing via CSS tokens
- remove duplicate `.dialog-content` mobile overrides from `Dialog.svelte` and `HelpPanel.svelte`
- keep HelpPanel's denser mobile spacing by overriding component-level tokens

## Test Plan
- [x] `npm run test:run`
- [x] `npm run build`
- [ ] `npm run lint` *(fails locally: missing `eslint-plugin-vitest` in this environment)*
- [x] `codeant static-analysis --uncommitted --fail-on INFO`
- [x] `codeant security-analysis --uncommitted --fail-on INFO`
- [x] `codeant secrets --uncommitted --fail-on all`
- [x] `coderabbit --prompt-only --type uncommitted`

Closes #1162


___

## **CodeAnt-AI Description**
**Tokenize dialog content padding and respect mobile safe-area insets**

### What Changed
- Dialog content padding is now driven by shared CSS tokens so all dialogs use the same spacing variables.
- Mobile dialogs apply a bottom padding that accounts for device safe-area inset, preventing content from being obscured by on-screen indicators.
- HelpPanel keeps a denser content spacing by setting component-level padding tokens instead of hardcoded padding.
- Removed duplicated per-component padding so dialog components inherit the shared token-driven spacing.

### Impact
`✅ Consistent dialog spacing across components`
`✅ Dialog content no longer gets hidden by mobile safe-area (e.g., iPhone home indicator)`
`✅ Denser HelpPanel content spacing preserved on mobile`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
