### PR TITLE
fix: resolve Svelte a11y build warnings (#1028)

### DIFF
--- a/src/lib/components/BottomSheet.svelte
+++ b/src/lib/components/BottomSheet.svelte
@@ -13,9 +13,11 @@
   let { open = false, title, onclose, children }: Props = $props();
 
   let sheetElement: HTMLDivElement | null = $state(null);
+  let closeButtonElement: HTMLButtonElement | null = $state(null);
   let startY = $state(0);
   let currentY = $state(0);
   let isDragging = $state(false);
+  let restoreFocusElement: HTMLElement | null = null;
 
   // Transform value for dragging (positive = dragging down)
   const translateY = $derived(isDragging ? Math.max(0, currentY - startY) : 0);
@@ -83,6 +85,30 @@
     }
   }
 
+  // Move focus into the dialog while open, then restore prior focus on close.
+  $effect(() => {
+    if (!open) return;
+    restoreFocusElement =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    const frame = requestAnimationFrame(() => {
+      const firstInteractiveElement = sheetElement?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      (closeButtonElement ?? firstInteractiveElement ?? sheetElement)?.focus();
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+      if (restoreFocusElement && document.contains(restoreFocusElement)) {
+        restoreFocusElement.focus();
+      }
+      restoreFocusElement = null;
+    };
+  });
+
   // Prevent body scroll when sheet is open
   $effect(() => {
     if (open) {
@@ -116,6 +142,7 @@
       class:dragging={isDragging}
       style:transform={isDragging ? `translateY(${translateY}px)` : ""}
       role="dialog"
+      tabindex="-1"
       aria-modal="true"
       onpointerdown={handlePointerDown}
       onpointermove={handlePointerMove}
@@ -132,6 +159,7 @@
             <div></div>
           {/if}
           <button
+            bind:this={closeButtonElement}
             type="button"
             class="close-button"
             onclick={closeSheet}

--- a/src/lib/components/CleanupPromptDialog.svelte
+++ b/src/lib/components/CleanupPromptDialog.svelte
@@ -26,12 +26,25 @@
   }: Props = $props();
 
   let dontAskAgain = $state(false);
+  let keepAllButton: HTMLButtonElement | null = $state(null);
 
   // Reset checkbox state when dialog opens
   $effect(() => {
     if (open) {
       dontAskAgain = false;
     }
+  });
+
+  // Focus the first non-destructive action when the dialog opens.
+  $effect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => {
+      keepAllButton?.focus();
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
   });
 
   function handleReview() {
@@ -93,7 +106,12 @@
       <button type="button" class="btn btn-secondary" onclick={handleCancel}>
         Cancel
       </button>
-      <button type="button" class="btn btn-secondary" onclick={handleKeepAll} autofocus>
+      <button
+        bind:this={keepAllButton}
+        type="button"
+        class="btn btn-secondary"
+        onclick={handleKeepAll}
+      >
         Keep All
       </button>
       <button type="button" class="btn btn-primary" onclick={handleReview}>

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -557,6 +557,8 @@
     fill={effectiveColour}
     rx="2"
     ry="2"
+    role="presentation"
+    aria-hidden="true"
     onpointerdown={handlePointerDown}
     onpointermove={handlePointerMove}
     onpointerup={handlePointerUp}


### PR DESCRIPTION
## **User description**
## Summary
- remove `autofocus` from `CleanupPromptDialog` and focus the Keep All action programmatically on open
- add keyboard-focusable dialog semantics to `BottomSheet` (`tabindex=-1`) and move initial focus to the close button with focus restoration on close
- mark `RackDevice` pointer-capture geometry `<rect>` as presentational/hidden so the parent interactive `<g>` remains the sole accessible control
- resolves Svelte build a11y warnings for issue #1028 across the three reported components

## Test Plan
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run test:run -- src/tests/BottomSheet.test.ts src/tests/App.cleanupPrompt.test.ts`
- [x] `npm run build`
- [x] `codeant static-analysis --uncommitted --fail-on INFO`
- [x] `codeant security-analysis --uncommitted --fail-on INFO`
- [x] `codeant secrets --uncommitted --fail-on all`
- [x] `codeant static-analysis --last-commit --fail-on INFO`
- [x] `codeant security-analysis --last-commit --fail-on INFO`
- [x] `codeant secrets --last-commit --fail-on all`

Closes #1028


___

## **CodeAnt-AI Description**
Fix accessibility focus and semantics in dialogs and rack device

### What Changed
- Cleanup prompt dialog no longer uses element autofocus; the "Keep All" button receives focus programmatically when the dialog opens so the first non-destructive action is focused.
- Bottom sheet now receives programmatic focus on open (preferring the close button or first interactive element), is keyboard-focusable while open, and restores the previously focused element when closed; body scrolling is still prevented while open.
- Device rectangle in rack visuals is marked as presentational/hidden to screen readers so the parent interactive element remains the single accessible control.

### Impact
`✅ Clearer dialog focus for screen readers`
`✅ Preserves user focus after closing bottom sheets`
`✅ Screen readers ignore decorative device geometry`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
