### PR TITLE
revert: roll back auth-gate merge from #1182

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,18 +24,6 @@ ALLOW_INSECURE_CORS=false
 # Leave empty to disable write-route token enforcement
 RACKULA_API_WRITE_TOKEN=
 
-# Authentication mode for self-hosted deployments:
-# - none (default): no auth gate
-# - oidc: provider-backed auth (planned)
-# - local: username/password auth (planned)
-RACKULA_AUTH_MODE=none
-
-# Required when RACKULA_AUTH_MODE is not "none".
-# Use a strong random secret (minimum 32 characters).
-# Example: RACKULA_AUTH_SESSION_SECRET=$(openssl rand -hex 32)
-# Recommended format: 64-char hex (32 random bytes) or equivalent entropy.
-RACKULA_AUTH_SESSION_SECRET=
-
 # Optional nginx proxy override (default internal API service name)
 API_HOST=rackula-api
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,8 @@ For production/self-hosted API security:
 
 - `CORS_ORIGIN` should be your real app URL (restricts which browser origins can call the API).
 - `RACKULA_API_WRITE_TOKEN` protects API `PUT`/`DELETE` routes (optional, strongly recommended). If unset, write routes remain open.
-- `RACKULA_AUTH_MODE` enables centralized auth gate behavior:
-  - `none`: no app/API auth gate
-  - `oidc`: external OpenID Connect provider mode
-  - `local`: built-in username/password mode
-- `RACKULA_AUTH_SESSION_SECRET` is required when auth mode is enabled (minimum 32 characters).
 
-Generate strong secrets (32 random bytes as hex):
+Generate a strong token:
 
 ```bash
 openssl rand -hex 32
@@ -103,24 +98,9 @@ Set values in a `.env` file beside `docker-compose.yml`:
 cat > .env <<'EOF'
 CORS_ORIGIN=https://rack.example.com
 RACKULA_API_WRITE_TOKEN=replace-with-generated-token
-RACKULA_AUTH_MODE=none
-# Enable auth mode by setting both values below:
-# RACKULA_AUTH_MODE=local
-# RACKULA_AUTH_SESSION_SECRET=replace-with-32-byte-hex
 EOF
 docker compose up -d
 ```
-
-Example `.env` with auth mode enabled:
-
-```bash
-CORS_ORIGIN=https://rack.example.com
-RACKULA_API_WRITE_TOKEN=replace-with-generated-token
-RACKULA_AUTH_MODE=local
-RACKULA_AUTH_SESSION_SECRET=replace-with-32-byte-hex
-```
-
-See [Self-Hosting Guide](docs/guides/SELF-HOSTING.md) for deployment and hardening details.
 
 Or pass them inline:
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,28 +1,17 @@
-import { Hono, type Context } from "hono";
+import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { bodyLimit } from "hono/body-limit";
 import layouts from "./routes/layouts";
 import assets from "./routes/assets";
 import {
-  createAuthGateMiddleware,
   createWriteAuthMiddleware,
-  resolveAuthenticatedSessionClaims,
   resolveApiSecurityConfig,
   type EnvMap,
 } from "./security";
 
 const DEFAULT_MAX_ASSET_SIZE = 5 * 1024 * 1024; // 5MB
 const DEFAULT_MAX_LAYOUT_SIZE = 1 * 1024 * 1024; // 1MB
-type AuthCheckResult =
-  | { status: 204; body: null }
-  | {
-      status: 401;
-      body: {
-        error: string;
-        message: string;
-      };
-    };
 
 export function createApp(env: EnvMap = process.env): Hono {
   const app = new Hono();
@@ -40,12 +29,6 @@ export function createApp(env: EnvMap = process.env): Hono {
     );
   }
 
-  if (securityConfig.authEnabled) {
-    console.warn(
-      `🔒 Authentication gate enabled (mode=${securityConfig.authMode}). Anonymous access is blocked by default.`,
-    );
-  }
-
   app.use("*", logger());
   app.use(
     "*",
@@ -55,56 +38,6 @@ export function createApp(env: EnvMap = process.env): Hono {
       allowHeaders: ["Content-Type", "Authorization"],
     }),
   );
-  app.use(
-    "*",
-    createAuthGateMiddleware({
-      authEnabled: securityConfig.authEnabled,
-      authLoginPath: securityConfig.authLoginPath,
-      authSessionSecret: securityConfig.authSessionSecret,
-      authSessionCookieName: securityConfig.authSessionCookieName,
-    }),
-  );
-
-  const authNotConfiguredResponse = {
-    error: "Auth provider not configured",
-    message:
-      "Authentication is enabled, but login/callback handlers are not implemented yet.",
-  };
-
-  const authCheckHandler = (request: Request): AuthCheckResult => {
-    const claims = resolveAuthenticatedSessionClaims(request, {
-      authEnabled: securityConfig.authEnabled,
-      authSessionSecret: securityConfig.authSessionSecret,
-      authSessionCookieName: securityConfig.authSessionCookieName,
-    });
-
-    if (!securityConfig.authEnabled || claims) {
-      return { status: 204 as const, body: null };
-    }
-
-    return {
-      status: 401 as const,
-      body: {
-        error: "Unauthorized",
-        message: "Authentication required.",
-      },
-    };
-  };
-
-  const authNotConfiguredHandler = (c: Context) =>
-    c.json(
-      {
-        ...authNotConfiguredResponse,
-        mode: securityConfig.authMode,
-      },
-      501,
-    );
-
-  const authCheckRouteHandler = (c: Context) => {
-    const result = authCheckHandler(c.req.raw);
-    if (result.status === 204) return c.body(null, 204);
-    return c.json(result.body, 401);
-  };
 
   // Hono's "/path/*" pattern matches both "/path" and "/path/...".
   // Keep write-auth and body-limit middleware on matching wildcard path sets:
@@ -118,12 +51,6 @@ export function createApp(env: EnvMap = process.env): Hono {
   // Health check
   app.get("/health", (c) => c.text("OK"));
   app.get("/api/health", (c) => c.text("OK"));
-  app.get("/auth/login", authNotConfiguredHandler);
-  app.get("/api/auth/login", authNotConfiguredHandler);
-  app.get("/auth/callback", authNotConfiguredHandler);
-  app.get("/api/auth/callback", authNotConfiguredHandler);
-  app.get("/auth/check", authCheckRouteHandler);
-  app.get("/api/auth/check", authCheckRouteHandler);
 
   // Apply body size limit to asset uploads (5MB default, configurable via env)
   const parsedMaxAssetSize = Number.parseInt(env.MAX_ASSET_SIZE ?? "", 10);

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -5,13 +5,7 @@
 import { createApp } from "./app";
 import { ensureDataDir } from "./storage/filesystem";
 
-let app: ReturnType<typeof createApp>;
-try {
-  app = createApp();
-} catch (error) {
-  console.error("Failed to initialize Rackula API configuration:", error);
-  process.exit(1);
-}
+const app = createApp();
 
 // Startup
 // RACKULA_API_PORT preferred, PORT for backwards compatibility

--- a/api/src/security.test.ts
+++ b/api/src/security.test.ts
@@ -1,14 +1,8 @@
 import { describe, it, expect } from "bun:test";
 import { createApp } from "./app";
-import {
-  createSignedAuthSessionToken,
-  resolveApiSecurityConfig,
-  verifySignedAuthSessionToken,
-  type EnvMap,
-} from "./security";
+import { resolveApiSecurityConfig, type EnvMap } from "./security";
 
 const TEST_TOKEN = "test-write-token";
-const TEST_AUTH_SECRET = "rackula-auth-session-secret-for-tests-0123456789";
 
 function buildEnv(overrides: EnvMap = {}): EnvMap {
   return {
@@ -17,66 +11,11 @@ function buildEnv(overrides: EnvMap = {}): EnvMap {
   };
 }
 
-function buildAuthEnabledEnv(overrides: EnvMap = {}): EnvMap {
-  return buildEnv({
-    RACKULA_AUTH_MODE: "oidc",
-    RACKULA_AUTH_SESSION_SECRET: TEST_AUTH_SECRET,
-    CORS_ORIGIN: "https://rack.example.com",
-    ...overrides,
-  });
-}
-
-function buildAuthCookie(subject = "admin@example.com"): string {
-  const issuedAt = Math.floor(Date.now() / 1000);
-  const token = createSignedAuthSessionToken(
-    {
-      sub: subject,
-      iat: issuedAt,
-      exp: issuedAt + 300,
-    },
-    TEST_AUTH_SECRET,
-  );
-  return `rackula_auth_session=${token}`;
-}
-
 describe("resolveApiSecurityConfig", () => {
   it("uses wildcard CORS in non-production by default", () => {
     const config = resolveApiSecurityConfig(buildEnv());
     expect(config.corsOrigin).toBe("*");
     expect(config.isProduction).toBe(false);
-    expect(config.authMode).toBe("none");
-    expect(config.authEnabled).toBe(false);
-  });
-
-  it("rejects invalid auth mode", () => {
-    expect(() =>
-      resolveApiSecurityConfig(
-        buildEnv({
-          RACKULA_AUTH_MODE: "jwt",
-        }),
-      ),
-    ).toThrow("Invalid auth mode");
-  });
-
-  it("requires auth session secret when auth mode is enabled", () => {
-    expect(() =>
-      resolveApiSecurityConfig(
-        buildEnv({
-          RACKULA_AUTH_MODE: "oidc",
-        }),
-      ),
-    ).toThrow("RACKULA_AUTH_SESSION_SECRET");
-  });
-
-  it("rejects short auth session secret when auth mode is enabled", () => {
-    expect(() =>
-      resolveApiSecurityConfig(
-        buildEnv({
-          RACKULA_AUTH_MODE: "oidc",
-          RACKULA_AUTH_SESSION_SECRET: "too-short",
-        }),
-      ),
-    ).toThrow("at least 32 characters");
   });
 
   it("rejects production startup when CORS_ORIGIN is missing", () => {
@@ -114,139 +53,6 @@ describe("resolveApiSecurityConfig", () => {
       }),
     );
     expect(config.corsOrigin).toBe("https://rack.example.com");
-  });
-});
-
-describe("signed session tokens", () => {
-  it("rejects oversized token payloads before parsing", () => {
-    const oversized = "a".repeat(8193);
-    const claims = verifySignedAuthSessionToken(oversized, TEST_AUTH_SECRET);
-    expect(claims).toBeNull();
-  });
-
-  it("rejects expired signed auth session tokens", () => {
-    const now = Math.floor(Date.now() / 1000);
-    const token = createSignedAuthSessionToken(
-      {
-        sub: "admin@example.com",
-        exp: now - 30,
-      },
-      TEST_AUTH_SECRET,
-    );
-
-    const claims = verifySignedAuthSessionToken(token, TEST_AUTH_SECRET);
-    expect(claims).toBeNull();
-  });
-
-  it("rejects stale signed tokens without exp using max-age policy", () => {
-    const now = Math.floor(Date.now() / 1000);
-    const token = createSignedAuthSessionToken(
-      {
-        sub: "admin@example.com",
-        iat: now - 86_500,
-      },
-      TEST_AUTH_SECRET,
-    );
-
-    const claims = verifySignedAuthSessionToken(token, TEST_AUTH_SECRET);
-    expect(claims).toBeNull();
-  });
-
-  it("accepts non-expired signed auth session tokens", () => {
-    const now = Math.floor(Date.now() / 1000);
-    const token = createSignedAuthSessionToken(
-      {
-        sub: "admin@example.com",
-        iat: now,
-        exp: now + 300,
-      },
-      TEST_AUTH_SECRET,
-    );
-
-    const claims = verifySignedAuthSessionToken(token, TEST_AUTH_SECRET);
-    expect(claims).not.toBeNull();
-    expect(claims?.sub).toBe("admin@example.com");
-    expect(claims?.iat).toBe(now);
-    expect(claims?.exp).toBe(now + 300);
-  });
-});
-
-describe("authentication gate", () => {
-  it("rejects anonymous API request when auth is enabled", async () => {
-    const app = createApp(buildAuthEnabledEnv());
-
-    const response = await app.request("/layouts/not-a-uuid");
-    expect(response.status).toBe(401);
-    expect(await response.json()).toEqual({
-      error: "Unauthorized",
-      message: "Authentication required.",
-    });
-  });
-
-  it("redirects anonymous app routes to login when auth is enabled", async () => {
-    const app = createApp(buildAuthEnabledEnv());
-
-    const response = await app.request("/dashboard");
-    expect(response.status).toBe(302);
-    expect(response.headers.get("location")).toBe("/auth/login?next=%2Fdashboard");
-  });
-
-  it("allows signed-session requests through the auth gate", async () => {
-    const app = createApp(buildAuthEnabledEnv());
-
-    const response = await app.request("/layouts/not-a-uuid", {
-      headers: {
-        Cookie: buildAuthCookie(),
-      },
-    });
-
-    // Auth gate passed; route-level UUID validation should run.
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: "Invalid layout UUID format",
-    });
-  });
-
-  it("keeps health/login/callback routes reachable when auth is enabled", async () => {
-    const app = createApp(buildAuthEnabledEnv());
-
-    const health = await app.request("/health");
-    expect(health.status).toBe(200);
-    expect(await health.text()).toBe("OK");
-
-    const login = await app.request("/auth/login");
-    expect(login.status).toBe(501);
-
-    const callback = await app.request("/auth/callback");
-    expect(callback.status).toBe(501);
-  });
-
-  it("returns auth check endpoint status for nginx auth_request usage", async () => {
-    const app = createApp(buildAuthEnabledEnv());
-
-    const unauthorized = await app.request("/auth/check");
-    expect(unauthorized.status).toBe(401);
-    expect(await unauthorized.json()).toEqual({
-      error: "Unauthorized",
-      message: "Authentication required.",
-    });
-
-    const authorized = await app.request("/auth/check", {
-      headers: {
-        Cookie: buildAuthCookie(),
-      },
-    });
-    expect(authorized.status).toBe(204);
-  });
-
-  it("preserves existing behavior when auth mode is disabled", async () => {
-    const app = createApp(buildEnv());
-
-    const response = await app.request("/layouts/not-a-uuid");
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: "Invalid layout UUID format",
-    });
   });
 });
 
@@ -313,8 +119,7 @@ describe("write-route authentication", () => {
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({
       error: "Unauthorized",
-      message:
-        "Malformed Authorization header. Expected format: Bearer <token>.",
+      message: "Malformed Authorization header. Expected format: Bearer <token>.",
     });
   });
 

--- a/api/src/security.ts
+++ b/api/src/security.ts
@@ -1,48 +1,16 @@
 import type { MiddlewareHandler } from "hono";
-import { createHash, createHmac, timingSafeEqual } from "node:crypto";
-
-export type AuthMode = "none" | "oidc" | "local";
-
-export interface AuthSessionClaims {
-  sub: string;
-  role?: string;
-  iat?: number;
-  exp?: number;
-}
+import { createHash, timingSafeEqual } from "node:crypto";
 
 export interface ApiSecurityConfig {
   corsOrigin: string | string[];
   allowInsecureCors: boolean;
   isProduction: boolean;
   writeAuthToken?: string;
-  authMode: AuthMode;
-  authEnabled: boolean;
-  authSessionSecret?: string;
-  authSessionCookieName: string;
-  authLoginPath: string;
 }
 
 export type EnvMap = Record<string, string | undefined>;
 
 const WRITE_METHODS = new Set(["PUT", "DELETE"]);
-const AUTH_MODES = new Set<AuthMode>(["none", "oidc", "local"]);
-const AUTH_PUBLIC_PATHS = new Set([
-  "/health",
-  "/api/health",
-  "/auth/login",
-  "/auth/callback",
-  "/auth/check",
-  "/api/auth/login",
-  "/api/auth/callback",
-  "/api/auth/check",
-]);
-const API_ROUTE_PREFIXES = ["/api", "/layouts", "/assets"];
-const SESSION_SECRET_MIN_LENGTH = 32;
-const MAX_SIGNED_AUTH_SESSION_TOKEN_BYTES = 8 * 1024;
-const MAX_SESSION_AGE_SECONDS = 24 * 60 * 60;
-const DEFAULT_AUTH_COOKIE_NAME = "rackula_auth_session";
-const DEFAULT_AUTH_LOGIN_PATH = "/auth/login";
-const COOKIE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 function timingSafeTokenCompare(
   presentedToken: string,
@@ -69,11 +37,7 @@ function parseCorsOrigins(raw: string): string | string[] {
     );
   }
 
-  if (origins.length === 1) {
-    return origins[0] ?? "";
-  }
-
-  return origins;
+  return origins.length === 1 ? origins[0] : origins;
 }
 
 function hasWildcardOrigin(origin: string | string[]): boolean {
@@ -83,236 +47,10 @@ function hasWildcardOrigin(origin: string | string[]): boolean {
   return origin.includes("*");
 }
 
-function parseAuthMode(value: string | undefined): AuthMode {
-  const normalized = value?.trim().toLowerCase() ?? "none";
-  if (AUTH_MODES.has(normalized as AuthMode)) {
-    return normalized as AuthMode;
-  }
-
-  throw new Error(
-    `Invalid auth mode: "${value}". Supported values: none, oidc, local.`,
-  );
-}
-
-function parseAuthCookieName(value: string | undefined): string {
-  const cookieName = value?.trim() || DEFAULT_AUTH_COOKIE_NAME;
-  if (!COOKIE_NAME_PATTERN.test(cookieName)) {
-    throw new Error(
-      `Invalid auth session cookie name: "${cookieName}". Use alphanumeric, '-' or '_' characters only.`,
-    );
-  }
-  return cookieName;
-}
-
-function parseLoginPath(value: string | undefined): string {
-  const path = value?.trim() || DEFAULT_AUTH_LOGIN_PATH;
-  if (!path.startsWith("/")) {
-    throw new Error(
-      `Invalid auth login path: "${path}". Expected an absolute path like "/auth/login".`,
-    );
-  }
-  if (path.includes("://")) {
-    throw new Error(
-      `Invalid auth login path: "${path}". External URLs are not allowed.`,
-    );
-  }
-  return path;
-}
-
-function isApiRequestPath(pathname: string): boolean {
-  return API_ROUTE_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
-  );
-}
-
-function isAuthPublicPath(pathname: string): boolean {
-  return AUTH_PUBLIC_PATHS.has(pathname);
-}
-
-function buildLoginRedirectUrl(requestUrl: string, loginPath: string): string {
-  const url = new URL(requestUrl);
-  const next = `${url.pathname}${url.search}`;
-  return `${loginPath}?next=${encodeURIComponent(next)}`;
-}
-
-function extractCookieValue(
-  cookieHeader: string | null | undefined,
-  cookieName: string,
-): string | undefined {
-  if (!cookieHeader) {
-    return undefined;
-  }
-
-  const cookies = cookieHeader.split(";");
-  for (const rawCookie of cookies) {
-    const trimmed = rawCookie.trim();
-    if (trimmed.length === 0) continue;
-
-    const separatorIndex = trimmed.indexOf("=");
-    if (separatorIndex <= 0) continue;
-
-    const name = trimmed.slice(0, separatorIndex);
-    if (name !== cookieName) continue;
-
-    const value = trimmed.slice(separatorIndex + 1).trim();
-    return value.length > 0 ? value : undefined;
-  }
-
-  return undefined;
-}
-
-function createSessionSignature(payloadPart: string, secret: string): Buffer {
-  return createHmac("sha256", secret).update(payloadPart).digest();
-}
-
-interface AuthSessionPayload {
-  v: number;
-  sub: string;
-  role?: string;
-  iat?: number;
-  exp?: number;
-}
-
-export function createSignedAuthSessionToken(
-  claims: AuthSessionClaims,
-  secret: string,
-): string {
-  const subject = claims.sub.trim();
-  if (!subject) {
-    throw new Error("Auth session claims must include a non-empty subject.");
-  }
-
-  const payload: AuthSessionPayload = {
-    v: 1,
-    sub: subject,
-  };
-
-  if (claims.role) {
-    payload.role = claims.role;
-  }
-  payload.iat =
-    typeof claims.iat === "number"
-      ? claims.iat
-      : Math.floor(Date.now() / 1000);
-  if (typeof claims.exp === "number") {
-    payload.exp = claims.exp;
-  }
-
-  const payloadPart = Buffer.from(JSON.stringify(payload), "utf-8").toString(
-    "base64url",
-  );
-  const signaturePart = createSessionSignature(payloadPart, secret).toString(
-    "base64url",
-  );
-
-  return `${payloadPart}.${signaturePart}`;
-}
-
-export function verifySignedAuthSessionToken(
-  token: string,
-  secret: string,
-): AuthSessionClaims | null {
-  if (
-    token.length === 0 ||
-    token.length > MAX_SIGNED_AUTH_SESSION_TOKEN_BYTES
-  ) {
-    return null;
-  }
-
-  const parts = token.split(".");
-  if (parts.length !== 2) {
-    return null;
-  }
-
-  const [payloadPart, signaturePart] = parts;
-  if (!payloadPart || !signaturePart) {
-    return null;
-  }
-
-  let presentedSignature: Buffer;
-  try {
-    presentedSignature = Buffer.from(signaturePart, "base64url");
-  } catch {
-    return null;
-  }
-
-  const expectedSignature = createSessionSignature(payloadPart, secret);
-  if (
-    presentedSignature.length !== expectedSignature.length ||
-    !timingSafeEqual(presentedSignature, expectedSignature)
-  ) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    const decoded = Buffer.from(payloadPart, "base64url").toString("utf-8");
-    parsed = JSON.parse(decoded);
-  } catch {
-    return null;
-  }
-
-  if (!parsed || typeof parsed !== "object") {
-    return null;
-  }
-
-  const payload = parsed as Partial<AuthSessionPayload>;
-  if (payload.v !== 1 || typeof payload.sub !== "string" || !payload.sub.trim()) {
-    return null;
-  }
-
-  const now = Math.floor(Date.now() / 1000);
-  const claims: AuthSessionClaims = { sub: payload.sub.trim() };
-  if (typeof payload.role === "string" && payload.role.length > 0) {
-    claims.role = payload.role;
-  }
-  if (typeof payload.iat === "number" && Number.isFinite(payload.iat)) {
-    if (now - payload.iat > MAX_SESSION_AGE_SECONDS) {
-      return null;
-    }
-    claims.iat = payload.iat;
-  }
-  if (typeof payload.exp === "number" && Number.isFinite(payload.exp)) {
-    if (payload.exp <= now) {
-      return null;
-    }
-    claims.exp = payload.exp;
-  }
-  if (claims.exp === undefined && claims.iat === undefined) {
-    return null;
-  }
-
-  return claims;
-}
-
-export function resolveAuthenticatedSessionClaims(
-  request: Request,
-  securityConfig: Pick<
-    ApiSecurityConfig,
-    "authEnabled" | "authSessionSecret" | "authSessionCookieName"
-  >,
-): AuthSessionClaims | null {
-  if (!securityConfig.authEnabled || !securityConfig.authSessionSecret) {
-    return null;
-  }
-
-  const cookieHeader = request.headers.get("cookie");
-  const token = extractCookieValue(cookieHeader, securityConfig.authSessionCookieName);
-  if (!token) {
-    return null;
-  }
-
-  return verifySignedAuthSessionToken(token, securityConfig.authSessionSecret);
-}
-
-export function resolveApiSecurityConfig(
-  env: EnvMap = process.env,
-): ApiSecurityConfig {
+export function resolveApiSecurityConfig(env: EnvMap = process.env): ApiSecurityConfig {
   const isProduction = env.NODE_ENV === "production";
   const allowInsecureCors = parseBoolean(env.ALLOW_INSECURE_CORS);
   const configuredOrigin = env.CORS_ORIGIN?.trim();
-  const authMode = parseAuthMode(env.RACKULA_AUTH_MODE ?? env.AUTH_MODE);
-  const authEnabled = authMode !== "none";
 
   let corsOrigin: string | string[];
 
@@ -337,94 +75,24 @@ export function resolveApiSecurityConfig(
   const writeAuthTokenRaw = env.RACKULA_API_WRITE_TOKEN ?? env.API_WRITE_TOKEN;
   const writeAuthToken = writeAuthTokenRaw?.trim() || undefined;
 
-  const authSessionCookieName = parseAuthCookieName(
-    env.RACKULA_AUTH_SESSION_COOKIE_NAME ?? env.AUTH_SESSION_COOKIE_NAME,
-  );
-  const authLoginPath = parseLoginPath(env.RACKULA_AUTH_LOGIN_PATH);
-  const authSessionSecretRaw =
-    env.RACKULA_AUTH_SESSION_SECRET ?? env.AUTH_SESSION_SECRET;
-  const authSessionSecret = authSessionSecretRaw?.trim() || undefined;
-
-  if (authEnabled && !authSessionSecret) {
-    throw new Error(
-      "AUTH_MODE is enabled but RACKULA_AUTH_SESSION_SECRET is not set.",
-    );
-  }
-
-  if (
-    authEnabled &&
-    authSessionSecret &&
-    authSessionSecret.length < SESSION_SECRET_MIN_LENGTH
-  ) {
-    throw new Error(
-      `RACKULA_AUTH_SESSION_SECRET must be at least ${SESSION_SECRET_MIN_LENGTH} characters when auth is enabled.`,
-    );
-  }
-
   return {
     corsOrigin,
     allowInsecureCors,
     isProduction,
     writeAuthToken,
-    authMode,
-    authEnabled,
-    authSessionSecret,
-    authSessionCookieName,
-    authLoginPath,
-  };
-}
-
-export function createAuthGateMiddleware(
-  securityConfig: Pick<
-    ApiSecurityConfig,
-    "authEnabled" | "authLoginPath" | "authSessionSecret" | "authSessionCookieName"
-  >,
-): MiddlewareHandler {
-  return async (c, next): Promise<void | Response> => {
-    if (!securityConfig.authEnabled) {
-      await next();
-      return;
-    }
-
-    const { pathname } = new URL(c.req.url);
-    if (isAuthPublicPath(pathname)) {
-      await next();
-      return;
-    }
-
-    const claims = resolveAuthenticatedSessionClaims(c.req.raw, securityConfig);
-    if (claims) {
-      c.set("authSubject", claims.sub);
-      await next();
-      return;
-    }
-
-    if (isApiRequestPath(pathname)) {
-      return c.json(
-        {
-          error: "Unauthorized",
-          message: "Authentication required.",
-        },
-        401,
-      );
-    }
-
-    return c.redirect(buildLoginRedirectUrl(c.req.url, securityConfig.authLoginPath));
   };
 }
 
 export function createWriteAuthMiddleware(
   writeAuthToken?: string,
 ): MiddlewareHandler {
-  return async (c, next): Promise<void | Response> => {
+  return (c, next) => {
     if (!WRITE_METHODS.has(c.req.method)) {
-      await next();
-      return;
+      return next();
     }
 
     if (!writeAuthToken) {
-      await next();
-      return;
+      return next();
     }
 
     const authorization = c.req.header("Authorization");
@@ -465,6 +133,6 @@ export function createWriteAuthMiddleware(
       );
     }
 
-    await next();
+    return next();
   };
 }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -40,13 +40,12 @@ LABEL org.opencontainers.image.title="Rackula"
 # API_HOST: Hostname or IP of the API server (default: rackula-api)
 # API_PORT: Port the API listens on (default: 3001)
 # API_WRITE_TOKEN: Optional bearer token injected for PUT/DELETE API requests (runtime env)
-# RACKULA_AUTH_MODE: Auth mode toggle for app/API anonymous access gate (none|oidc|local)
 # RACKULA_LISTEN_PORT: Port nginx listens on inside the container (default: 8080)
 # NGINX_ENVSUBST_FILTER: Regex filter - only substitute these env vars, leave nginx vars ($host etc.) alone
 ENV API_HOST=rackula-api
 ENV API_PORT=3001
 ENV RACKULA_LISTEN_PORT=8080
-ENV NGINX_ENVSUBST_FILTER=^(API_HOST|API_PORT|API_WRITE_TOKEN|RACKULA_AUTH_MODE|RACKULA_LISTEN_PORT)$
+ENV NGINX_ENVSUBST_FILTER=^(API_HOST|API_PORT|API_WRITE_TOKEN|RACKULA_LISTEN_PORT)$
 
 # Copy nginx config template (auto-processed by nginx's /docker-entrypoint.d/20-envsubst-on-templates.sh)
 COPY ./deploy/nginx.conf.template /etc/nginx/templates/default.conf.template

--- a/deploy/docker-compose.persist.yml
+++ b/deploy/docker-compose.persist.yml
@@ -19,8 +19,6 @@ services:
       - RACKULA_LISTEN_PORT=${RACKULA_LISTEN_PORT:-8080}
       # Optional: token forwarded to API for PUT/DELETE route auth
       - API_WRITE_TOKEN=${RACKULA_API_WRITE_TOKEN:-}
-      # Auth gate mode for app-route checks in nginx
-      - RACKULA_AUTH_MODE=${RACKULA_AUTH_MODE:-none}
     restart: unless-stopped
     stop_grace_period: 10s
     depends_on:
@@ -70,10 +68,6 @@ services:
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:8080}
       # Optional (recommended): protects PUT/DELETE routes via Bearer token
       - RACKULA_API_WRITE_TOKEN=${RACKULA_API_WRITE_TOKEN:-}
-      # Optional auth mode model: none | oidc | local
-      - RACKULA_AUTH_MODE=${RACKULA_AUTH_MODE:-none}
-      # Required when auth mode is enabled (oidc/local)
-      - RACKULA_AUTH_SESSION_SECRET=${RACKULA_AUTH_SESSION_SECRET:-}
       # Explicit insecure fallback (use only for isolated/local testing)
       - ALLOW_INSECURE_CORS=${ALLOW_INSECURE_CORS:-false}
 

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -20,13 +20,6 @@ map "$rackula_is_write_method:$rackula_has_api_write_token" $rackula_api_authori
     "1:1" "Bearer ${API_WRITE_TOKEN}";
 }
 
-# Track whether auth mode is effectively disabled for fallback behavior.
-map "${RACKULA_AUTH_MODE}" $rackula_auth_mode_none {
-    default 0;
-    "" 1;
-    ~*^none$ 1;
-}
-
 server {
     listen ${RACKULA_LISTEN_PORT};
     listen [::]:${RACKULA_LISTEN_PORT};
@@ -55,7 +48,7 @@ server {
     # Use variable to defer DNS resolution to request time (allows nginx to start without API)
     # Using $uri$is_args$args for normalized path+query (safer than $request_uri)
     # Configure via environment variables: API_HOST (default: rackula-api), API_PORT (default: 3001), API_WRITE_TOKEN (optional)
-    # Note: NGINX_ENVSUBST_FILTER in Dockerfile restricts substitution to runtime variables only
+    # Note: NGINX_ENVSUBST_FILTER in Dockerfile restricts substitution to API_HOST, API_PORT, API_WRITE_TOKEN, and RACKULA_LISTEN_PORT only
     
     # API health check - used by frontend to detect persistence API availability
     # Returns 502/503 if API is unavailable (intentional - signals API is down)
@@ -68,34 +61,6 @@ server {
         proxy_connect_timeout 3s;
         proxy_read_timeout 3s;
         # No fallback - let it fail to signal API unavailability
-    }
-
-    # Public auth bootstrap endpoints.
-    # When auth mode is enabled, these remain reachable for login/callback flow.
-    location = /auth/login {
-        resolver 127.0.0.11 valid=30s;
-        set $api_upstream ${API_HOST};
-        proxy_pass http://$api_upstream:${API_PORT}/auth/login$is_args$args;
-        proxy_http_version 1.1;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_connect_timeout 3s;
-        proxy_read_timeout 15s;
-    }
-
-    location = /auth/callback {
-        resolver 127.0.0.11 valid=30s;
-        set $api_upstream ${API_HOST};
-        proxy_pass http://$api_upstream:${API_PORT}/auth/callback$is_args$args;
-        proxy_http_version 1.1;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_connect_timeout 3s;
-        proxy_read_timeout 15s;
     }
     
     # Handle /api and /api/ edge cases - return JSON error, not SPA fallback (#1010)
@@ -141,37 +106,6 @@ server {
         return 503 '{"error": "Persistence API unavailable"}';
     }
 
-    # Internal auth probe for app-route protection.
-    # API validates the signed session cookie and returns 204 (ok) or 401 (unauthorized).
-    location = /_rackula_auth_check {
-        internal;
-        resolver 127.0.0.11 valid=30s;
-        set $api_upstream ${API_HOST};
-        proxy_pass http://$api_upstream:${API_PORT}/auth/check;
-        proxy_http_version 1.1;
-        proxy_connect_timeout 3s;
-        proxy_read_timeout 3s;
-        proxy_pass_request_body off;
-        proxy_set_header Content-Length "";
-        proxy_set_header Cookie $http_cookie;
-        proxy_set_header X-Original-URI $request_uri;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_intercept_errors on;
-        error_page 502 503 504 = @auth_check_upstream_error;
-    }
-
-    # If API is unavailable, fail open only when auth mode is explicitly disabled.
-    location @auth_check_upstream_error {
-        if ($rackula_auth_mode_none) {
-            return 204;
-        }
-        return 401;
-    }
-
-    location @auth_login_redirect {
-        return 302 /auth/login;
-    }
-
     # Container health check - used by Docker/K8s for liveness/readiness probes
     # Always returns 200 OK because nginx can serve the frontend even without API
     # This endpoint checks the frontend container health, not API availability
@@ -183,9 +117,6 @@ server {
 
     # SPA fallback - all routes to index.html
     location / {
-        auth_request /_rackula_auth_check;
-        error_page 401 = @auth_login_redirect;
-        error_page 403 = @auth_login_redirect;
         try_files $uri $uri/ /index.html;
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@
 #   RACKULA_API_IMAGE: API image override (default: ghcr.io/rackulalives/rackula-api:latest)
 #   CORS_ORIGIN: Allowed browser origin(s) for API CORS (default: http://localhost:8080)
 #   RACKULA_API_WRITE_TOKEN: Optional token protecting API PUT/DELETE routes
-#   RACKULA_AUTH_MODE: Auth mode toggle (none|oidc|local, default: none)
-#   RACKULA_AUTH_SESSION_SECRET: Required when auth mode != none (min 32 chars)
 #   ALLOW_INSECURE_CORS: Explicit insecure fallback for wildcard CORS in production (default: false)
 
 services:
@@ -39,8 +37,6 @@ services:
       - RACKULA_LISTEN_PORT=${RACKULA_LISTEN_PORT:-8080}
       # Optional: token forwarded to API for PUT/DELETE route auth
       - API_WRITE_TOKEN=${RACKULA_API_WRITE_TOKEN:-}
-      # Auth gate mode for app-route checks in nginx
-      - RACKULA_AUTH_MODE=${RACKULA_AUTH_MODE:-none}
     restart: unless-stopped
     stop_grace_period: 10s
 
@@ -92,10 +88,6 @@ services:
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:8080}
       # Optional (recommended): protects PUT/DELETE routes via Bearer token
       - RACKULA_API_WRITE_TOKEN=${RACKULA_API_WRITE_TOKEN:-}
-      # Optional auth mode model: none | oidc | local
-      - RACKULA_AUTH_MODE=${RACKULA_AUTH_MODE:-none}
-      # Required when auth mode is enabled (oidc/local)
-      - RACKULA_AUTH_SESSION_SECRET=${RACKULA_AUTH_SESSION_SECRET:-}
       # Explicit insecure fallback (use only for isolated/local testing)
       - ALLOW_INSECURE_CORS=${ALLOW_INSECURE_CORS:-false}
 


### PR DESCRIPTION
## **User description**
## Summary
- Revert auth-gate/no-anonymous merge introduced via #1182
- Targeted the requested commit basis (`bb8a44a3`) for the revert patch

## Verification
- [x] npm run lint


___

## **CodeAnt-AI Description**
Revert centralized auth gate; restore anonymous access by default

### What Changed
- Removed the global authentication gate and related auth endpoints; the app no longer blocks anonymous requests or exposes /auth/login, /auth/callback, or /auth/check.
- Removed signed session token handling and auth configuration flags; deployments no longer require auth session secret or auth-mode settings.
- Nginx and Docker deployment files, README, and env examples no longer reference or proxy auth checks; SPA routes are no longer gated by an internal auth probe.
- Write-route bearer token enforcement remains in place (PUT/DELETE still require the configured write token), and health endpoints still respond as before.

### Impact
`✅ Anonymous access restored for app routes`
`✅ Fewer startup failures when auth is not configured`
`✅ Simpler deployment with no auth-mode/session-secret requirements`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
