### PR TITLE
fix: add text/plain fallback for Safari drag-and-drop

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -587,8 +587,10 @@
     if (!event.dataTransfer) return;
 
     // Try dataTransfer first (works in drop), fall back to shared state (needed for dragover)
+    // Safari compatibility: try application/json first, fall back to text/plain
     let dragData = parseDragData(
-      event.dataTransfer.getData("application/json"),
+      event.dataTransfer.getData("application/json") ||
+        event.dataTransfer.getData("text/plain"),
     );
     if (!dragData) {
       // getData() blocked during dragover in most browsers - use shared state
@@ -843,7 +845,10 @@
 
     if (!event.dataTransfer) return;
 
-    const data = event.dataTransfer.getData("application/json");
+    // Safari compatibility: try application/json first, fall back to text/plain
+    const data =
+      event.dataTransfer.getData("application/json") ||
+      event.dataTransfer.getData("text/plain");
     const dragData = parseDragData(data);
     if (!dragData) return;
 


### PR DESCRIPTION
## **User description**
## Summary
- Adds `text/plain` fallback to both `getData()` calls in Rack.svelte's drag event handlers
- The SET side (DevicePaletteItem) already writes both `application/json` and `text/plain`, but the GET side (Rack drop handlers) only read `application/json` — Safari blocks custom MIME types in some cases, causing silent drop failures
- Now both dragover and drop handlers try `application/json` first, falling back to `text/plain`

Fixes #1200

## Test plan
- [ ] Drag a device from the palette to a rack in Safari — verify it drops correctly
- [ ] Drag a device from the palette to a rack in Chrome/Firefox — verify no regression
- [ ] Drag a device between racks in Safari — verify cross-rack moves work

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix Safari drag-and-drop failures by falling back to text/plain in Rack handlers

### What Changed
- Drag-and-drop into racks now reads drag data as application/json and falls back to text/plain when needed
- Both dragover (preview) and drop (final placement) handlers use the fallback so drops that were previously blocked in Safari succeed
- Internal moves and cross-rack drops behave the same across Chrome, Firefox, and Safari

### Impact
`✅ Fewer drag-and-drop failures in Safari`
`✅ Consistent device placement across browsers`
`✅ Reliable rack device moves and previews`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
