### PR TITLE
chore: add keyboard viewport coverage for editable controls (#1116)

### DIFF
--- a/src/tests/keyboard-viewport.test.ts
+++ b/src/tests/keyboard-viewport.test.ts
@@ -124,47 +124,71 @@ describe("keyboard viewport adaptation", () => {
     cleanup();
   });
 
-  it("scrolls focused input into view when keyboard is visible", () => {
-    const { viewport, getResizeHandler } = createMockVisualViewport();
-    setVisualViewport(viewport as unknown as VisualViewport);
+  it.each([
+    {
+      name: "input",
+      createElement: () => document.createElement("input"),
+    },
+    {
+      name: "textarea",
+      createElement: () => document.createElement("textarea"),
+    },
+    {
+      name: "contentEditable element",
+      createElement: () => {
+        const editable = document.createElement("div");
+        editable.tabIndex = -1;
+        Object.defineProperty(editable, "isContentEditable", {
+          value: true,
+          configurable: true,
+        });
+        return editable;
+      },
+    },
+  ])(
+    "scrolls focused $name into view when keyboard is visible",
+    ({ createElement }) => {
+      const { viewport, getResizeHandler } = createMockVisualViewport();
+      setVisualViewport(viewport as unknown as VisualViewport);
 
-    const input = document.createElement("input");
-    const scrollIntoView = vi.fn();
-    input.scrollIntoView = scrollIntoView;
-    input.getBoundingClientRect = vi.fn(() => ({
-      x: 0,
-      y: 700,
-      width: 200,
-      height: 32,
-      top: 700,
-      right: 200,
-      bottom: 732,
-      left: 0,
-      toJSON: () => ({}),
-    }));
-    document.body.appendChild(input);
-    input.focus();
+      const element = createElement();
+      const scrollIntoView = vi.fn();
+      element.scrollIntoView = scrollIntoView;
+      element.getBoundingClientRect = vi.fn(() => ({
+        x: 0,
+        y: 700,
+        width: 200,
+        height: 80,
+        top: 700,
+        right: 200,
+        bottom: 780,
+        left: 0,
+        toJSON: () => ({}),
+      }));
+      document.body.appendChild(element);
+      element.focus();
 
-    const cleanup = setupKeyboardViewportAdaptation({
-      isMobile: () => true,
-      debounceMs: 0,
-      keyboardThresholdPx: 0,
-    });
+      const cleanup = setupKeyboardViewportAdaptation({
+        isMobile: () => true,
+        debounceMs: 0,
+        keyboardThresholdPx: 0,
+      });
 
-    viewport.height = 560;
-    const resizeHandler = getResizeHandler();
-    resizeHandler(new Event("resize"));
-    vi.runAllTimers();
+      viewport.height = 560;
+      const resizeHandler = getResizeHandler();
+      resizeHandler(new Event("resize"));
+      vi.runAllTimers();
 
-    expect(scrollIntoView).toHaveBeenCalledWith({
-      block: "center",
-      inline: "nearest",
-      behavior: "smooth",
-    });
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: "center",
+        inline: "nearest",
+        behavior: "smooth",
+      });
 
-    cleanup();
-    input.remove();
-  });
+      cleanup();
+      element.remove();
+    },
+  );
 
   it("does not scroll focused select elements into view", () => {
     const { viewport, getResizeHandler } = createMockVisualViewport();


### PR DESCRIPTION
## **User description**
## Summary
- add keyboard viewport regression coverage for `input`, `textarea`, and `contentEditable` controls using a parameterized test
- preserve the existing regression asserting focused `select` elements do not trigger `scrollIntoView`
- keep all scroll assertions aligned with current keyboard-aware behavior

## Test Plan
- [x] npm run test:run -- src/tests/keyboard-viewport.test.ts
- [x] codeant static-analysis --uncommitted --fail-on INFO
- [x] codeant security-analysis --uncommitted --fail-on INFO
- [x] codeant secrets --uncommitted --fail-on all
- [x] coderabbit --prompt-only --type uncommitted
- [x] codeant static-analysis --last-commit --fail-on INFO
- [x] codeant security-analysis --last-commit --fail-on INFO
- [x] codeant secrets --last-commit --fail-on all

Closes #1116


___

## **CodeAnt-AI Description**
Add keyboard-viewport tests for textarea and contentEditable focus scrolling

### What Changed
- Added parameterized tests that verify focused inputs, textareas, and contentEditable elements are scrolled into view when the on-screen keyboard appears
- Kept the existing regression test that focused select elements are not scrolled into view
- Ensures the scroll-into-view behavior is asserted for multiple editable control types using the same test flow

### Impact
`✅ Fewer keyboard-scroll regressions`
`✅ Clearer test coverage for editable controls`
`✅ Fewer unexpected select-element scrolls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
