### PR TITLE
feat: add MVP admin authorization for write routes (#1105)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -61,7 +61,7 @@ export function createApp(env: EnvMap = process.env): Hono<AppEnv> {
     "*",
     cors({
       origin: securityConfig.corsOrigin,
-      allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
       allowHeaders: ["Content-Type", "Authorization"],
     }),
   );

--- a/api/src/authorization.ts
+++ b/api/src/authorization.ts
@@ -1,12 +1,9 @@
 import type { MiddlewareHandler } from "hono";
-import type { AuthSessionClaims } from "./security";
+import { STATE_CHANGING_METHODS, type AuthSessionClaims } from "./security";
 
 // Role constants — single admin role for MVP.
 // Future roles (editor, viewer) can be added here without changing middleware shape.
 export const ROLE_ADMIN = "admin";
-
-// Matches STATE_CHANGING_METHODS in security.ts for consistent coverage.
-const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 /**
  * Checks whether session claims carry admin privileges.
@@ -16,7 +13,7 @@ export function isAdmin(claims: AuthSessionClaims | null | undefined): boolean {
 }
 
 /**
- * Creates middleware that requires admin role for write operations.
+ * Creates middleware that requires admin role for state-changing operations.
  *
  * Expects `authClaims` to be set on the Hono context by the auth gate.
  * Passes through for safe methods (GET, HEAD, OPTIONS) so any authenticated user can read.
@@ -31,6 +28,9 @@ export function createRequireAdminMiddleware(): MiddlewareHandler {
 
     const claims = c.get("authClaims") as AuthSessionClaims | undefined;
 
+    // Defensive: in normal wiring the auth gate (registered when authEnabled=true)
+    // rejects unauthenticated requests before this middleware runs. This guard
+    // exists for safety if the middleware is used standalone or wiring changes.
     if (!claims) {
       return c.json(
         {

--- a/api/src/security.test.ts
+++ b/api/src/security.test.ts
@@ -34,6 +34,9 @@ function buildAuthEnabledEnv(overrides: EnvMap = {}): EnvMap {
   });
 }
 
+// Default cookie carries role: "admin" so existing integration tests covering
+// the auth gate and CSRF layer also pass the admin authorization check on write
+// routes. Override role explicitly when testing non-admin behaviour.
 function buildAuthCookie(
   overrides: Partial<AuthSessionClaimsInput> = {},
 ): string {
@@ -864,7 +867,7 @@ describe("authorization", () => {
     const response = await app.request("/layouts/not-a-uuid", {
       method: "PUT",
       headers: {
-        Cookie: buildAuthCookie({ role: "admin" }),
+        Cookie: buildAuthCookie(),
         Origin: "https://rack.example.com",
         "Content-Type": "text/plain",
       },
@@ -958,5 +961,29 @@ describe("authorization", () => {
 
     // No auth gate, no admin check, hits route validation
     expect(response.status).toBe(400);
+  });
+
+  it("writeAuth accepts token but requireAdmin blocks non-admin", async () => {
+    const app = createApp(
+      buildAuthEnabledEnv({ RACKULA_API_WRITE_TOKEN: TEST_TOKEN }),
+    );
+
+    const response = await app.request("/layouts/not-a-uuid", {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${TEST_TOKEN}`,
+        Cookie: buildAuthCookie({ role: "viewer", sid: "non-admin-token-session" }),
+        Origin: "https://rack.example.com",
+        "Content-Type": "text/plain",
+      },
+      body: "version: 1.0.0",
+    });
+
+    // writeAuth passes (valid token), requireAdmin rejects (not admin)
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "Forbidden",
+      message: "Admin role required.",
+    });
   });
 });

--- a/api/src/security.ts
+++ b/api/src/security.ts
@@ -59,7 +59,7 @@ export interface ApiSecurityConfig {
 export type EnvMap = Record<string, string | undefined>;
 
 const WRITE_METHODS = new Set(["PUT", "DELETE"]);
-const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+export const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const AUTH_MODES = new Set<AuthMode>(["none", "oidc", "local"]);
 const AUTH_PUBLIC_PATHS = new Set([
   "/health",


### PR DESCRIPTION
## **User description**
## Summary
- Adds centralized admin authorization middleware for write operations (PUT/DELETE)
- New `api/src/authorization.ts` with `isAdmin()` helper and `createRequireAdminMiddleware()`
- Auth gate now sets `authClaims` on Hono context for downstream authorization
- Returns 403 for authenticated-but-unauthorized users (distinct from 401)
- Read operations remain accessible to any authenticated user
- Clean extension path for future roles (editor/viewer) via role constants

## Files Changed
- `api/src/authorization.ts` — new authorization module
- `api/src/security.ts` — auth gate sets `authClaims` on context
- `api/src/app.ts` — wires admin middleware to write routes
- `api/src/security.test.ts` — 6 new authorization integration tests

## Test plan
- [x] Admin can write layouts (passes through to route validation)
- [x] Non-admin authenticated user gets 403 on write
- [x] User with no role gets 403 on write
- [x] Non-admin can still read (GET passes authorization)
- [x] Unauthenticated write gets 401 (auth gate blocks first)
- [x] Auth-disabled mode skips authorization entirely
- [x] All 53 security tests pass, 73 total API tests pass

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Enforce admin-only writes for state-changing routes and tighten method coverage

### What Changed
- State-changing requests (POST/PUT/PATCH/DELETE) to layouts and assets now require an authenticated session with the admin role; authenticated non-admins receive 403 with "Admin role required."
- Safe/read requests (GET/HEAD/OPTIONS) remain accessible to any authenticated user and are not blocked by the admin check.
- When authentication is disabled, previous token-based write behavior continues and the admin check is skipped.
- CSRF and CORS handling now consistently include PATCH as a state-changing method.
- Added integration tests covering admin write success, authenticated non-admin and no-role 403 responses, unauthenticated 401 on write, read access for non-admins, and interactions between token-based write auth and admin checks.

### Impact
`✅ Fewer unauthorized state changes`
`✅ Clearer forbidden errors for non-admin users`
`✅ Consistent PATCH handling in CORS and CSRF`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
