### PR TITLE
test: harden false-positive e2e assertions (#1229)

### DIFF
--- a/e2e/keyboard.spec.ts
+++ b/e2e/keyboard.spec.ts
@@ -80,18 +80,14 @@ test.describe("Keyboard Shortcuts", () => {
 
   test("Ctrl+S triggers save", async ({ page }) => {
     // Set up download listener
-    const downloadPromise = page
-      .waitForEvent("download", { timeout: 5000 })
-      .catch(() => null);
+    const downloadPromise = page.waitForEvent("download", { timeout: 5000 });
 
     // Press Ctrl+S
     await page.keyboard.press("Control+s");
 
     // Should trigger download
     const download = await downloadPromise;
-    if (download) {
-      expect(download.suggestedFilename()).toContain(".Rackula.zip");
-    }
+    expect(download.suggestedFilename()).toMatch(/\.zip$/);
   });
 
   test("Escape closes dialogs", async ({ page }) => {
@@ -107,19 +103,27 @@ test.describe("Keyboard Shortcuts", () => {
   });
 
   test("Arrow keys move device in rack", async ({ page }) => {
-    // Add a device to the rack
-    await dragDeviceToRack(page);
+    // Add a device lower in the rack so ArrowUp can move it.
+    await dragDeviceToRack(page, { yOffsetPercent: 70 });
 
-    // Wait for device
-    await expect(page.locator(".rack-device").first()).toBeVisible();
+    const device = page.locator(".rack-front .rack-device").first();
+    await expect(device).toBeVisible();
 
-    // Select the device (first one in dual-view)
-    await page.locator(".rack-device").first().click();
+    await device.click();
+    const beforePosition = await device.boundingBox();
+    expect(beforePosition).not.toBeNull();
+    if (!beforePosition) {
+      throw new Error("Could not determine device position before ArrowUp");
+    }
 
     // Press Arrow Up
     await page.keyboard.press("ArrowUp");
 
-    // Note: This test verifies the key is handled, actual movement depends on implementation
-    await expect(page.locator(".rack-device").first()).toBeVisible();
+    await expect
+      .poll(async () => {
+        const afterPosition = await device.boundingBox();
+        return afterPosition?.y ?? beforePosition.y;
+      })
+      .not.toBe(beforePosition.y);
   });
 });

--- a/e2e/rack-context-menu-focus.spec.ts
+++ b/e2e/rack-context-menu-focus.spec.ts
@@ -17,6 +17,15 @@ async function getPanzoomTransform(page: Page) {
   });
 }
 
+async function setPanzoomTransform(page: Page, transform: string) {
+  await page.evaluate((nextTransform) => {
+    const panzoomContainer = document.querySelector(".panzoom-container");
+    if (panzoomContainer) {
+      (panzoomContainer as HTMLElement).style.transform = nextTransform;
+    }
+  }, transform);
+}
+
 test.describe("Rack Context Menu Focus", () => {
   test.beforeEach(async ({ page }) => {
     await gotoWithRack(page);
@@ -28,12 +37,23 @@ test.describe("Rack Context Menu Focus", () => {
     // Rack should be visible
     await expect(page.locator(".rack-container").first()).toBeVisible();
 
-    // Get the initial transform
+    // Force a non-focused transform so Focus must change it.
+    await setPanzoomTransform(page, "matrix(0.4, 0, 0, 0.4, 0, 0)");
     const transformBefore = await getPanzoomTransform(page);
     expect(transformBefore).toBeTruthy();
+    expect(transformBefore?.scale).toBe(0.4);
 
-    // Right-click on the rack-svg (inside the dual view)
-    await page.locator(".rack-svg").first().click({ button: "right" });
+    // Open the canvas context menu directly on the rack element.
+    await page.evaluate(() => {
+      const rack = document.querySelector(".rack-svg");
+      if (!rack) throw new Error("Could not find rack svg");
+      rack.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
 
     // Wait for context menu to appear
     await expect(page.locator(".context-menu-content")).toBeVisible();
@@ -43,21 +63,29 @@ test.describe("Rack Context Menu Focus", () => {
     await expect(focusItem).toBeVisible();
     await focusItem.click();
 
-    // Focus recalculates and applies optimal zoom/pan for the rack.
-    // Even from the initial position, Focus will center the rack.
-    // Wait for transform to potentially change (animation may take time)
-    await expect(async () => {
-      const transformAfter = await getPanzoomTransform(page);
-      expect(transformAfter).toBeTruthy();
-      expect(transformAfter?.scale).toBeDefined();
-      expect(transformAfter?.x).toBeDefined();
-      expect(transformAfter?.y).toBeDefined();
-    }).toPass({ timeout: 1000 });
+    await expect
+      .poll(async () => {
+        const transformAfter = await getPanzoomTransform(page);
+        if (!transformBefore || !transformAfter) return false;
+
+        return (
+          transformAfter.scale !== transformBefore.scale ||
+          transformAfter.x !== transformBefore.x ||
+          transformAfter.y !== transformBefore.y
+        );
+      })
+      .toBe(true);
   });
 
   test("Focus option in Racks panel context menu works", async ({ page }) => {
     // Rack should be visible
     await expect(page.locator(".rack-container").first()).toBeVisible();
+
+    // Force a non-focused transform so Focus must change it.
+    await setPanzoomTransform(page, "matrix(0.4, 0, 0, 0.4, 0, 0)");
+    const transformBefore = await getPanzoomTransform(page);
+    expect(transformBefore).toBeTruthy();
+    expect(transformBefore?.scale).toBe(0.4);
 
     // Switch to the Racks tab in the sidebar
     // This test requires the sidebar to be visible (desktop viewport)
@@ -81,13 +109,17 @@ test.describe("Rack Context Menu Focus", () => {
     // Click Focus - this triggers the focusRack function via callback chain
     await focusItem.click();
 
-    // Verify the transform exists (Focus was applied)
-    await expect(async () => {
-      const transformAfter = await getPanzoomTransform(page);
-      expect(transformAfter).toBeTruthy();
-      expect(transformAfter?.scale).toBeDefined();
-      expect(transformAfter?.x).toBeDefined();
-      expect(transformAfter?.y).toBeDefined();
-    }).toPass({ timeout: 1000 });
+    await expect
+      .poll(async () => {
+        const transformAfter = await getPanzoomTransform(page);
+        if (!transformBefore || !transformAfter) return false;
+
+        return (
+          transformAfter.scale !== transformBefore.scale ||
+          transformAfter.x !== transformBefore.x ||
+          transformAfter.y !== transformBefore.y
+        );
+      })
+      .toBe(true);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary
- make `Ctrl+S` keyboard test require a real download event (removed swallowed timeout path)
- make ArrowUp keyboard test compare device Y position before/after keypress
- make rack context-menu Focus tests assert panzoom transform changes after clicking Focus

## Test Plan
- [x] `npx playwright test --config playwright.dev.config.ts e2e/keyboard.spec.ts e2e/rack-context-menu-focus.spec.ts --grep "Ctrl\+S|Arrow keys move device|Focus option"`
- [ ] `npm run test:e2e` (blocked locally: production build startup exceeds Playwright webServer 60s timeout and WebKit browser is not installed)
- [ ] `npm run lint` (fails on pre-existing unrelated repo lint errors)

Closes #1229


___

## **CodeAnt-AI Description**
Harden e2e keyboard and rack-focus tests to avoid false positives

### What Changed
- Ctrl+S test now waits for a real download and asserts the saved filename ends with .zip instead of silently passing when no download occurs
- Arrow key test places a device lower in the rack, captures its Y position before and after pressing ArrowUp, and requires an actual position change rather than only confirming the element exists
- Focus-from-context-menu tests force a non-focused pan/zoom state, open the canvas or panel context menu reliably, click "Focus", and assert the pan/zoom transform values change by polling until they differ from the initial values
- Added a helper to set the pan/zoom transform so tests can reliably start from a known, non-focused state

### Impact
`✅ Fewer false-positive e2e failures`
`✅ Fewer flaky keyboard tests`
`✅ Fewer flaky focus/context-menu tests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
