### PR TITLE
fix: restore deny-by-default auth gate (#1333)

### DIFF
--- a/api/src/auth-logger.test.ts
+++ b/api/src/auth-logger.test.ts
@@ -291,19 +291,12 @@ describe("auth event integration", () => {
       },
     });
 
-    const allOutput = writeSpy.mock.calls.map((c) => c[0] as string).join("");
-    const authLines = allOutput.split("\n").filter((line) => {
-      try {
-        const parsed = JSON.parse(line);
-        return parsed.event?.startsWith("auth.");
-      } catch {
-        return false;
-      }
-    });
+    const authEvents = extractAuthEvents(writeSpy);
 
-    for (const line of authLines) {
-      expect(line).not.toContain(tokenValue);
-      expect(line).not.toContain("rackula_auth_session=");
+    for (const event of authEvents) {
+      const serialized = JSON.stringify(event);
+      expect(serialized).not.toContain(tokenValue);
+      expect(serialized).not.toContain("rackula_auth_session=");
     }
   });
 });

--- a/api/src/security.ts
+++ b/api/src/security.ts
@@ -67,6 +67,20 @@ export interface ApiSecurityConfig {
 export type EnvMap = Record<string, string | undefined>;
 
 const WRITE_METHODS = new Set(["PUT", "DELETE"]);
+/**
+ * HTTP methods that are considered to change server state.
+ *
+ * Used by CSRF protection middleware and validation logic to determine
+ * whether a request requires origin verification. Exported and immutable.
+ *
+ * @constant
+ * @type {Set<string>}
+ * @example
+ * ```ts
+ * // Methods are stored as uppercase strings — normalize input before checking:
+ * if (STATE_CHANGING_METHODS.has(method.toUpperCase())) { ... }
+ * ```
+ */
 export const STATE_CHANGING_METHODS = new Set([
   "POST",
   "PUT",


### PR DESCRIPTION
## **User description**
## Summary
- mount the auth gate middleware in auth-enabled mode so protected routes deny anonymous access
- restore explicit auth contract endpoints (`/auth/login`, `/auth/callback`, `/auth/check`, `/auth/logout`) and API aliases for compatibility
- wire signed-session check/logout behavior to use existing security helpers and refresh/expire cookies correctly
- update auth logger integration expectations to match session-check event semantics

## Test Plan
- [x] `cd api && bun test src/security.test.ts src/auth-logger.test.ts`
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npm run build`
- [x] `codeant static-analysis --uncommitted --fail-on INFO`
- [x] `codeant security-analysis --uncommitted --fail-on INFO`
- [x] `codeant secrets --uncommitted --fail-on all`
- [x] `coderabbit --prompt-only --type uncommitted`

Closes #1333


___

## **CodeAnt-AI Description**
Restore deny-by-default auth gate and public auth endpoints; ensure CSRF and auth logging behave correctly

### What Changed
- Anonymous requests to protected API paths are now blocked and return 401 (tests updated to assert this)
- Re-introduced public auth routes and API aliases (/auth/* and /api/auth/*) including /auth/logout so auth flows are reachable; logout remains a state-changing POST and is not exempt from CSRF
- Introduced a separate CSRF-exempt set for safe auth bootstrap endpoints so only non-state-changing auth endpoints bypass CSRF checks
- /auth/check responses are asserted by tests (204 for valid session, 401 for invalid) and auth logger tests updated to match emitted session events

### Impact
`✅ Deny anonymous requests (401) when auth is enabled`
`✅ Logout keeps CSRF protection while auth bootstrap endpoints bypass CSRF`
`✅ Clearer auth check outcomes (204/401) and consistent auth event logging`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
