### PR TITLE
feat: add compatible-only palette override for narrow racks (#1330)

### DIFF
--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -13,11 +13,15 @@
     getCategoryDisplayName,
     sortDevicesByBrandThenModel,
     sortDevicesAlphabetically,
-    filterDevicesByRackWidth,
+    filterPaletteDevicesByRackWidth,
+    isDeviceCompatibleWithRackWidth,
+    getRackWidthIncompatibilityReason,
   } from "$lib/utils/deviceFilters";
   import {
     loadGroupingModeFromStorage,
     saveGroupingModeToStorage,
+    loadCompatibleOnlyFromStorage,
+    saveCompatibleOnlyToStorage,
     type DeviceGroupingMode,
   } from "$lib/utils/deviceGrouping";
   import { debounce } from "$lib/utils/debounce";
@@ -48,6 +52,8 @@
 
   // Grouping mode state with localStorage persistence
   let groupingMode = $state<DeviceGroupingMode>(loadGroupingModeFromStorage());
+  // Palette visibility toggle: default to safe mode showing compatible devices only
+  let compatibleOnly = $state(loadCompatibleOnlyFromStorage());
 
   // Grouping mode options for SegmentedControl
   const groupingModeOptions: { value: DeviceGroupingMode; label: string }[] = [
@@ -93,6 +99,10 @@
     accordionMultipleValue = [defaultValue];
     preSearchSingleValue = defaultValue;
     accordionMode = "single";
+  });
+
+  $effect(() => {
+    saveCompatibleOnlyToStorage(compatibleOnly);
   });
 
   // Debounce search input
@@ -233,9 +243,39 @@
   });
 
   // Filter and search generic devices - only show devices compatible with active rack
+  const allPaletteDevices = $derived([
+    ...allGenericDevices,
+    ...brandPacks.flatMap((pack) => pack.devices),
+  ]);
+  const deviceCompatibilityBySlug = $derived.by(() => {
+    const compatibility: Record<
+      string,
+      { isCompatible: boolean; incompatibilityReason: string | null }
+    > = {};
+
+    for (const device of allPaletteDevices) {
+      const compatible = isDeviceCompatibleWithRackWidth(device, activeRackWidth);
+      compatibility[device.slug] = {
+        isCompatible: compatible,
+        incompatibilityReason: compatible
+          ? null
+          : getRackWidthIncompatibilityReason(device, activeRackWidth),
+      };
+    }
+
+    return compatibility;
+  });
+
+  const visibleGenericDevices = $derived(
+    filterPaletteDevicesByRackWidth(
+      allGenericDevices,
+      activeRackWidth,
+      compatibleOnly,
+    ),
+  );
   const filteredGenericDevices = $derived(
     searchDevices(
-      filterDevicesByRackWidth(allGenericDevices, activeRackWidth),
+      visibleGenericDevices,
       searchQuery,
     ),
   );
@@ -248,7 +288,11 @@
     brandPacks.map((pack) => ({
       ...pack,
       devices: searchDevices(
-        filterDevicesByRackWidth(pack.devices, activeRackWidth),
+        filterPaletteDevicesByRackWidth(
+          pack.devices,
+          activeRackWidth,
+          compatibleOnly,
+        ),
         searchQuery,
       ),
     })),
@@ -263,9 +307,10 @@
 
   // All devices combined (for category and flat modes) - filtered by rack width
   const allDevicesCombined = $derived(
-    filterDevicesByRackWidth(
-      [...allGenericDevices, ...brandPacks.flatMap((p) => p.devices)],
+    filterPaletteDevicesByRackWidth(
+      allPaletteDevices,
       activeRackWidth,
+      compatibleOnly,
     ),
   );
   const filteredAllDevices = $derived(
@@ -418,6 +463,14 @@
     }
     return accordionSingleValue === sectionId;
   }
+
+  function isCompatible(device: DeviceType): boolean {
+    return deviceCompatibilityBySlug[device.slug]?.isCompatible ?? true;
+  }
+
+  function incompatibilityReason(device: DeviceType): string | null {
+    return deviceCompatibilityBySlug[device.slug]?.incompatibilityReason ?? null;
+  }
 </script>
 
 <div class="device-palette">
@@ -453,6 +506,14 @@
         </Tooltip>
       {/if}
     </div>
+    <label class="compatibility-toggle">
+      <input
+        type="checkbox"
+        bind:checked={compatibleOnly}
+        aria-label="Show compatible devices only"
+      />
+      <span>Compatible only</span>
+    </label>
   </div>
 
   <!-- Device List -->
@@ -517,6 +578,10 @@
                             <DevicePaletteItem
                               {device}
                               searchQuery={isSearchActive ? searchQuery : ""}
+                              isCompatible={isCompatible(device)}
+                              incompatibilityReason={incompatibilityReason(
+                                device,
+                              )}
                               canDelete={canDeleteDevice(device)}
                               onselect={handleDeviceSelect}
                               ondelete={handleDeviceDelete}
@@ -533,6 +598,8 @@
                       <DevicePaletteItem
                         {device}
                         searchQuery={isSearchActive ? searchQuery : ""}
+                        isCompatible={isCompatible(device)}
+                        incompatibilityReason={incompatibilityReason(device)}
                         canDelete={canDeleteDevice(device)}
                         onselect={handleDeviceSelect}
                         ondelete={handleDeviceDelete}
@@ -578,6 +645,22 @@
     display: flex;
     gap: var(--space-2);
     align-items: center;
+  }
+
+  .compatibility-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-size-xs);
+    color: var(--colour-text-muted);
+    user-select: none;
+    width: fit-content;
+    cursor: pointer;
+  }
+
+  .compatibility-toggle input {
+    margin: 0;
+    cursor: pointer;
   }
 
   .search-input {

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -31,7 +31,7 @@
     /** Whether device is compatible with current rack width. Defaults to true. */
     isCompatible?: boolean;
     /** Tooltip text to show when device is incompatible */
-    incompatibilityReason?: string;
+    incompatibilityReason?: string | null;
     /** Whether this device type can be deleted (unused custom type) */
     canDelete?: boolean;
     onselect?: (event: CustomEvent<{ device: DeviceType }>) => void;
@@ -44,7 +44,7 @@
     librarySelected = false,
     searchQuery = "",
     isCompatible = true,
-    incompatibilityReason = "",
+    incompatibilityReason = null,
     canDelete = false,
     onselect,
     ondelete,
@@ -149,7 +149,7 @@
   tabindex="0"
   draggable={isCompatible}
   data-testid="device-palette-item"
-  title={!isCompatible ? incompatibilityReason : undefined}
+  title={!isCompatible ? (incompatibilityReason ?? undefined) : undefined}
   onclick={handleClick}
   onkeydown={handleKeyDown}
   ondragstart={handleDragStart}

--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -7,6 +7,8 @@ import Fuse from "fuse.js";
 import type { IFuseOptions } from "fuse.js";
 import type { DeviceType, DeviceCategory } from "$lib/types";
 
+const DEFAULT_RACK_WIDTHS = [19];
+
 /**
  * Fuse.js configuration for fuzzy search.
  * Threshold of 0.3 balances typo tolerance with precision.
@@ -216,8 +218,7 @@ export function isDeviceCompatibleWithRackWidth(
   device: DeviceType,
   rackWidth: number,
 ): boolean {
-  // Devices without rack_widths are assumed to be 19" compatible
-  const deviceWidths = device.rack_widths?.length ? device.rack_widths : [19];
+  const deviceWidths = resolveDeviceRackWidths(device);
 
   // Device is compatible if rack width >= any of the device's supported widths
   return deviceWidths.some((deviceWidth) => rackWidth >= deviceWidth);
@@ -239,4 +240,38 @@ export function filterDevicesByRackWidth(
   return devices.filter((device) =>
     isDeviceCompatibleWithRackWidth(device, rackWidth),
   );
+}
+
+/**
+ * Filter palette devices by compatibility mode.
+ * When compatibleOnly is false, returns all devices for discoverability.
+ */
+export function filterPaletteDevicesByRackWidth(
+  devices: DeviceType[],
+  rackWidth: number,
+  compatibleOnly: boolean,
+): DeviceType[] {
+  return compatibleOnly ? filterDevicesByRackWidth(devices, rackWidth) : devices;
+}
+
+/**
+ * Get a user-facing incompatibility message for palette items.
+ * Returns null when device is compatible with the active rack width.
+ */
+export function getRackWidthIncompatibilityReason(
+  device: DeviceType,
+  rackWidth: number,
+): string | null {
+  if (isDeviceCompatibleWithRackWidth(device, rackWidth)) {
+    return null;
+  }
+
+  const supportedWidths = resolveDeviceRackWidths(device);
+  const minRequiredWidth = Math.min(...supportedWidths);
+
+  return `Requires at least ${minRequiredWidth}" rack width (current: ${rackWidth}")`;
+}
+
+function resolveDeviceRackWidths(device: DeviceType): number[] {
+  return device.rack_widths?.length ? device.rack_widths : DEFAULT_RACK_WIDTHS;
 }

--- a/src/lib/utils/deviceGrouping.ts
+++ b/src/lib/utils/deviceGrouping.ts
@@ -4,6 +4,7 @@
  */
 
 const GROUPING_STORAGE_KEY = "Rackula-device-grouping";
+const COMPATIBLE_ONLY_STORAGE_KEY = "Rackula-device-compatible-only";
 
 /**
  * Device grouping mode for the DevicePalette
@@ -46,5 +47,37 @@ export function saveGroupingModeToStorage(mode: DeviceGroupingMode): void {
     localStorage.setItem(GROUPING_STORAGE_KEY, mode);
   } catch (e) {
     console.warn("[Rackula] Failed to save grouping mode to localStorage:", e);
+  }
+}
+
+/**
+ * Load the saved compatible-only preference from localStorage.
+ * @returns Stored boolean value, or true by default.
+ */
+export function loadCompatibleOnlyFromStorage(): boolean {
+  try {
+    const stored = localStorage.getItem(COMPATIBLE_ONLY_STORAGE_KEY);
+    if (stored === "true") return true;
+    if (stored === "false") return false;
+  } catch (e) {
+    console.warn(
+      "[Rackula] Failed to load compatible-only mode from localStorage:",
+      e,
+    );
+  }
+  return true;
+}
+
+/**
+ * Save compatible-only preference to localStorage.
+ */
+export function saveCompatibleOnlyToStorage(value: boolean): void {
+  try {
+    localStorage.setItem(COMPATIBLE_ONLY_STORAGE_KEY, String(value));
+  } catch (e) {
+    console.warn(
+      "[Rackula] Failed to save compatible-only mode to localStorage:",
+      e,
+    );
   }
 }

--- a/src/tests/rack-width-filter.test.ts
+++ b/src/tests/rack-width-filter.test.ts
@@ -10,6 +10,8 @@ import { describe, it, expect } from "vitest";
 import {
   isDeviceCompatibleWithRackWidth,
   filterDevicesByRackWidth,
+  filterPaletteDevicesByRackWidth,
+  getRackWidthIncompatibilityReason,
 } from "$lib/utils/deviceFilters";
 import { createTestDeviceType } from "./factories";
 
@@ -240,5 +242,47 @@ describe("filterDevicesByRackWidth", () => {
 
     // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: empty input produces empty output
     expect(result).toHaveLength(0);
+  });
+});
+
+describe("filterPaletteDevicesByRackWidth", () => {
+  const compatibleDevice = createTestDeviceType({
+    slug: "compatible-10",
+    rack_widths: [10],
+  });
+  const incompatibleInTenInchRack = createTestDeviceType({
+    slug: "incompatible-19",
+    rack_widths: [19],
+  });
+  const devices = [compatibleDevice, incompatibleInTenInchRack];
+
+  it("keeps current behavior when compatible-only mode is enabled", () => {
+    const result = filterPaletteDevicesByRackWidth(devices, 10, true);
+    const slugs = result.map((d) => d.slug);
+
+    expect(slugs).toContain("compatible-10");
+    expect(slugs).not.toContain("incompatible-19");
+  });
+
+  it("shows all devices when compatible-only mode is disabled", () => {
+    const result = filterPaletteDevicesByRackWidth(devices, 10, false);
+    const slugs = result.map((d) => d.slug);
+
+    expect(slugs).toContain("compatible-10");
+    expect(slugs).toContain("incompatible-19");
+  });
+});
+
+describe("getRackWidthIncompatibilityReason", () => {
+  it("returns null for compatible devices", () => {
+    const device = createTestDeviceType({ rack_widths: [10] });
+    expect(getRackWidthIncompatibilityReason(device, 10)).toBeNull();
+  });
+
+  it("explains minimum required rack width for incompatible devices", () => {
+    const device = createTestDeviceType({ rack_widths: [19, 23] });
+    expect(getRackWidthIncompatibilityReason(device, 10)).toContain(
+      'Requires at least 19" rack width',
+    );
   });
 });


### PR DESCRIPTION
## **User description**
## Summary
- add a `Compatible only` palette toggle (default on) to allow optional visibility of all device types in narrow racks
- keep incompatible devices visually marked and non-draggable when shown via override
- apply toggle behavior consistently across brand, category, flat, and search views
- persist compatibility-toggle preference in localStorage
- add rack-width filter helper coverage for compatibility override + incompatibility messaging

## Test Plan
- [x] npm run lint
- [x] npm run test:run
- [x] npm run build
- [x] coderabbit --prompt-only --type uncommitted

Closes #1330


___

## **CodeAnt-AI Description**
**Add "Compatible only" toggle to device palette and persistence for the preference**

### What Changed
- Device palette now includes a "Compatible only" checkbox (enabled by default) that, when turned off, shows all device types even if they don't fit the active rack width.
- Incompatible devices shown via the override remain visually marked and non-draggable, and show a clear message explaining the minimum required rack width.
- The compatibility preference is saved to and loaded from localStorage so the toggle state persists across sessions.
- Devices without explicit rack widths continue to default to 19" compatibility; unit tests were added/updated to cover the new filtering and incompatibility messaging functions.

### Impact
`✅ Can view incompatible devices in the palette for discovery`
`✅ Clearer incompatibility messages for non-fitting devices`
`✅ Preference persists across sessions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
