### PR TITLE
fix: rewrite responsive e2e tests to match current toolbar UI (#1347)

### DIFF
--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -69,8 +69,10 @@ test.describe("Responsive Layout", () => {
       await expect(exportBtn).toBeVisible();
     });
 
-    test("bottom navigation is visible", async ({ page }) => {
-      const bottomNav = page.getByRole("button", { name: /devices/i });
+    test("mobile bottom navigation is visible", async ({ page }) => {
+      const bottomNav = page.getByRole("navigation", {
+        name: /mobile navigation/i,
+      });
       await expect(bottomNav).toBeVisible();
     });
 
@@ -154,7 +156,7 @@ test.describe("Responsive Layout", () => {
     test("reset view via keyboard shortcut", async ({ page }) => {
       const panzoomContainer = page.locator(".panzoom-container");
 
-      // Pan the view to a non-default position
+      // Set a non-default transform (matches pattern in view-reset.spec.ts)
       await page.evaluate(() => {
         const container = document.querySelector(".panzoom-container");
         if (container) {


### PR DESCRIPTION
## **User description**
## Summary

- Rewrote `e2e/responsive.spec.ts` to match the current toolbar implementation (no hamburger menu/drawer — mobile uses direct Save/Load/Export buttons + bottom navigation)
- Replaced all broken class-based selectors (`.brand-name`, `aside.sidebar`, `.hamburger-icon`, `.toolbar-drawer`, `.drawer-item`) with stable, user-visible signals (`aria-label`, `role`, existing classes)
- Removed the phone viewport dialog test that depended entirely on defunct drawer UI
- Net: -195 lines, +41 lines (removed dead test code)

## Test plan
- [x] All 16 responsive tests pass on Chromium locally
- [ ] CI passes on WebKit (the originally failing browser)
- [ ] No regressions in adjacent E2E specs

Closes #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Update responsive end-to-end tests to match the current toolbar UI

### What Changed
- Replaced assertions that expected a hamburger/drawer navigation with checks for visible toolbar center, direct Save/Load/Export action buttons on narrow viewports, and a bottom navigation button
- Switched brand and sidebar checks to use stable, user-visible labels so tests verify the Rackula brand image and the sidebar pane are visible
- Removed phone-dialog and drawer-opening tests that relied on the old hamburger/drawer interaction
- Adjusted pan/zoom reset test to use a keyboard shortcut and verify the canvas container is interactive

### Impact
`✅ Fewer flaky responsive tests`
`✅ Tests reflect current mobile toolbar behavior (Save/Load/Export and bottom nav visible)`
`✅ Clearer test failures for branding and sidebar visibility`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
