### PR TITLE
feat: move compatible-only toggle to Settings menu (#1361)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -65,10 +65,7 @@
   import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { createKonamiDetector } from "$lib/utils/konami";
   import type { ImageData } from "$lib/types/images";
-  import {
-    downloadArchive,
-    generateArchiveFilename,
-  } from "$lib/utils/archive";
+  import { downloadArchive, generateArchiveFilename } from "$lib/utils/archive";
   import {
     generateExportSVG,
     exportAsSVG,
@@ -1540,6 +1537,7 @@
       displayMode={uiStore.displayMode}
       showAnnotations={uiStore.showAnnotations}
       showBanana={uiStore.showBanana}
+      compatibleOnly={uiStore.compatibleOnly}
       warnOnUnsavedChanges={uiStore.warnOnUnsavedChanges}
       promptCleanupOnSave={uiStore.promptCleanupOnSave}
       {partyMode}
@@ -1558,6 +1556,7 @@
       ontoggledisplaymode={handleToggleDisplayMode}
       ontoggleannotations={handleToggleAnnotations}
       ontogglebanana={() => uiStore.toggleBanana()}
+      ontogglecompatibleonly={() => uiStore.toggleCompatibleOnly()}
       ontogglewarnunsaved={() => uiStore.toggleWarnOnUnsavedChanges()}
       ontogglepromptcleanup={() => uiStore.togglePromptCleanupOnSave()}
       onopencleanup={handleOpenCleanupDialog}

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -20,10 +20,9 @@
   import {
     loadGroupingModeFromStorage,
     saveGroupingModeToStorage,
-    loadCompatibleOnlyFromStorage,
-    saveCompatibleOnlyToStorage,
     type DeviceGroupingMode,
   } from "$lib/utils/deviceGrouping";
+  import { getUIStore } from "$lib/stores/ui.svelte";
   import { debounce } from "$lib/utils/debounce";
   import { truncateWithEllipsis } from "$lib/utils/searchHighlight";
   import { getBrandPacks, getBrandSlugs } from "$lib/data/brandPacks";
@@ -44,6 +43,7 @@
 
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
+  const uiStore = getUIStore();
 
   // Search state with debouncing
   let searchQueryRaw = $state("");
@@ -52,8 +52,6 @@
 
   // Grouping mode state with localStorage persistence
   let groupingMode = $state<DeviceGroupingMode>(loadGroupingModeFromStorage());
-  // Palette visibility toggle: default to safe mode showing compatible devices only
-  let compatibleOnly = $state(loadCompatibleOnlyFromStorage());
 
   // Grouping mode options for SegmentedControl
   const groupingModeOptions: { value: DeviceGroupingMode; label: string }[] = [
@@ -99,10 +97,6 @@
     accordionMultipleValue = [defaultValue];
     preSearchSingleValue = defaultValue;
     accordionMode = "single";
-  });
-
-  $effect(() => {
-    saveCompatibleOnlyToStorage(compatibleOnly);
   });
 
   // Debounce search input
@@ -254,7 +248,10 @@
     > = {};
 
     for (const device of allPaletteDevices) {
-      const compatible = isDeviceCompatibleWithRackWidth(device, activeRackWidth);
+      const compatible = isDeviceCompatibleWithRackWidth(
+        device,
+        activeRackWidth,
+      );
       compatibility[device.slug] = {
         isCompatible: compatible,
         incompatibilityReason: compatible
@@ -270,14 +267,11 @@
     filterPaletteDevicesByRackWidth(
       allGenericDevices,
       activeRackWidth,
-      compatibleOnly,
+      uiStore.compatibleOnly,
     ),
   );
   const filteredGenericDevices = $derived(
-    searchDevices(
-      visibleGenericDevices,
-      searchQuery,
-    ),
+    searchDevices(visibleGenericDevices, searchQuery),
   );
   const groupedGenericDevices = $derived(
     groupDevicesByCategory(filteredGenericDevices),
@@ -291,7 +285,7 @@
         filterPaletteDevicesByRackWidth(
           pack.devices,
           activeRackWidth,
-          compatibleOnly,
+          uiStore.compatibleOnly,
         ),
         searchQuery,
       ),
@@ -310,7 +304,7 @@
     filterPaletteDevicesByRackWidth(
       allPaletteDevices,
       activeRackWidth,
-      compatibleOnly,
+      uiStore.compatibleOnly,
     ),
   );
   const filteredAllDevices = $derived(
@@ -469,7 +463,9 @@
   }
 
   function incompatibilityReason(device: DeviceType): string | null {
-    return deviceCompatibilityBySlug[device.slug]?.incompatibilityReason ?? null;
+    return (
+      deviceCompatibilityBySlug[device.slug]?.incompatibilityReason ?? null
+    );
   }
 </script>
 
@@ -506,14 +502,6 @@
         </Tooltip>
       {/if}
     </div>
-    <label class="compatibility-toggle">
-      <input
-        type="checkbox"
-        bind:checked={compatibleOnly}
-        aria-label="Show compatible devices only"
-      />
-      <span>Compatible only</span>
-    </label>
   </div>
 
   <!-- Device List -->
@@ -645,22 +633,6 @@
     display: flex;
     gap: var(--space-2);
     align-items: center;
-  }
-
-  .compatibility-toggle {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    font-size: var(--font-size-xs);
-    color: var(--colour-text-muted);
-    user-select: none;
-    width: fit-content;
-    cursor: pointer;
-  }
-
-  .compatibility-toggle input {
-    margin: 0;
-    cursor: pointer;
   }
 
   .search-input {

--- a/src/lib/components/SettingsMenu.svelte
+++ b/src/lib/components/SettingsMenu.svelte
@@ -20,11 +20,13 @@
     theme?: "dark" | "light";
     showAnnotations?: boolean;
     showBanana?: boolean;
+    compatibleOnly?: boolean;
     warnOnUnsavedChanges?: boolean;
     promptCleanupOnSave?: boolean;
     ontoggletheme?: () => void;
     ontoggleannotations?: () => void;
     ontogglebanana?: () => void;
+    ontogglecompatibleonly?: () => void;
     ontogglewarnunsaved?: () => void;
     ontogglepromptcleanup?: () => void;
     onopencleanup?: () => void;
@@ -34,11 +36,13 @@
     theme = "dark",
     showAnnotations = false,
     showBanana = false,
+    compatibleOnly = true,
     warnOnUnsavedChanges = true,
     promptCleanupOnSave = true,
     ontoggletheme,
     ontoggleannotations,
     ontogglebanana,
+    ontogglecompatibleonly,
     ontogglewarnunsaved,
     ontogglepromptcleanup,
     onopencleanup,
@@ -112,6 +116,23 @@
             {/if}
           </span>
           <span class="menu-label">Banana for Scale</span>
+        {/snippet}
+      </DropdownMenu.CheckboxItem>
+
+      <DropdownMenu.CheckboxItem
+        class="menu-item"
+        checked={compatibleOnly}
+        onCheckedChange={handleSelect(ontogglecompatibleonly)}
+      >
+        {#snippet children({ checked })}
+          <span class="menu-checkbox">
+            {#if checked}
+              <IconSquareFilled size={ICON_SIZE.sm} />
+            {:else}
+              <IconSquare size={ICON_SIZE.sm} />
+            {/if}
+          </span>
+          <span class="menu-label">Compatible Devices Only</span>
         {/snippet}
       </DropdownMenu.CheckboxItem>
 

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -35,6 +35,7 @@
     displayMode?: DisplayMode;
     showAnnotations?: boolean;
     showBanana?: boolean;
+    compatibleOnly?: boolean;
     warnOnUnsavedChanges?: boolean;
     promptCleanupOnSave?: boolean;
     partyMode?: boolean;
@@ -53,6 +54,7 @@
     ontoggledisplaymode?: () => void;
     ontoggleannotations?: () => void;
     ontogglebanana?: () => void;
+    ontogglecompatibleonly?: () => void;
     ontogglewarnunsaved?: () => void;
     ontogglepromptcleanup?: () => void;
     onopencleanup?: () => void;
@@ -65,6 +67,7 @@
     displayMode = "label",
     showAnnotations = false,
     showBanana = false,
+    compatibleOnly = true,
     warnOnUnsavedChanges = true,
     promptCleanupOnSave = true,
     partyMode = false,
@@ -83,6 +86,7 @@
     ontoggledisplaymode,
     ontoggleannotations,
     ontogglebanana,
+    ontogglecompatibleonly,
     ontogglewarnunsaved,
     ontogglepromptcleanup,
     onopencleanup,
@@ -184,6 +188,11 @@
   function handleToggleBanana() {
     analytics.trackToolbarClick("banana");
     ontogglebanana?.();
+  }
+
+  function handleToggleCompatibleOnly() {
+    analytics.trackToolbarClick("compatible-only");
+    ontogglecompatibleonly?.();
   }
 
   function handleToggleWarnUnsaved() {
@@ -340,11 +349,13 @@
         {theme}
         {showAnnotations}
         {showBanana}
+        {compatibleOnly}
         {warnOnUnsavedChanges}
         {promptCleanupOnSave}
         ontoggletheme={handleToggleTheme}
         ontoggleannotations={handleToggleAnnotations}
         ontogglebanana={handleToggleBanana}
+        ontogglecompatibleonly={handleToggleCompatibleOnly}
         ontogglewarnunsaved={handleToggleWarnUnsaved}
         ontogglepromptcleanup={handleTogglePromptCleanup}
         onopencleanup={handleOpenCleanup}

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -22,6 +22,7 @@ export type SidebarTab = "devices" | "racks";
 const SIDEBAR_TAB_KEY = "Rackula_sidebar_tab";
 const WARN_UNSAVED_KEY = "Rackula_warn_unsaved";
 const PROMPT_CLEANUP_KEY = "Rackula_prompt_cleanup";
+const COMPATIBLE_ONLY_KEY = "Rackula-device-compatible-only";
 
 /**
  * Valid sidebar tab values for runtime validation
@@ -94,6 +95,31 @@ function saveWarnUnsavedToStorage(warn: boolean): void {
 }
 
 /**
+ * Load compatible-only preference from localStorage
+ */
+function loadCompatibleOnlyFromStorage(): boolean {
+  try {
+    const stored = localStorage.getItem(COMPATIBLE_ONLY_KEY);
+    if (stored === "true") return true;
+    if (stored === "false") return false;
+  } catch {
+    // localStorage not available
+  }
+  return true; // default to compatible-only enabled
+}
+
+/**
+ * Save compatible-only preference to localStorage
+ */
+function saveCompatibleOnlyToStorage(value: boolean): void {
+  try {
+    localStorage.setItem(COMPATIBLE_ONLY_KEY, String(value));
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
  * Load prompt cleanup on save setting from localStorage
  */
 function loadPromptCleanupFromStorage(): boolean {
@@ -130,6 +156,7 @@ const initialSidebarWidth = loadSidebarWidthFromStorage();
 const initialSidebarTab = loadSidebarTabFromStorage();
 const initialWarnUnsaved = loadWarnUnsavedFromStorage();
 const initialPromptCleanup = loadPromptCleanupFromStorage();
+const initialCompatibleOnly = loadCompatibleOnlyFromStorage();
 
 // Module-level state (using $state rune)
 let theme = $state<Theme>(initialTheme);
@@ -144,6 +171,7 @@ let sidebarWidth = $state<number | null>(initialSidebarWidth);
 let sidebarTab = $state<SidebarTab>(initialSidebarTab);
 let warnOnUnsavedChanges = $state(initialWarnUnsaved);
 let promptCleanupOnSave = $state(initialPromptCleanup);
+let compatibleOnly = $state(initialCompatibleOnly);
 
 // Derived values (using $derived rune)
 const canZoomIn = $derived(zoom < ZOOM_MAX);
@@ -171,6 +199,7 @@ export function resetUIStore(): void {
   sidebarTab = loadSidebarTabFromStorage();
   warnOnUnsavedChanges = loadWarnUnsavedFromStorage();
   promptCleanupOnSave = loadPromptCleanupFromStorage();
+  compatibleOnly = loadCompatibleOnlyFromStorage();
   applyThemeToDocument(theme);
 }
 
@@ -241,6 +270,9 @@ export function getUIStore() {
     get promptCleanupOnSave() {
       return promptCleanupOnSave;
     },
+    get compatibleOnly() {
+      return compatibleOnly;
+    },
 
     // Theme actions
     toggleTheme,
@@ -282,6 +314,9 @@ export function getUIStore() {
     // Cleanup prompt actions
     togglePromptCleanupOnSave,
     setPromptCleanupOnSave,
+
+    // Compatible-only filter action
+    toggleCompatibleOnly,
   };
 }
 
@@ -499,4 +534,12 @@ function togglePromptCleanupOnSave(): void {
 function setPromptCleanupOnSave(prompt: boolean): void {
   promptCleanupOnSave = prompt;
   savePromptCleanupToStorage(prompt);
+}
+
+/**
+ * Toggle compatible-only device filter
+ */
+function toggleCompatibleOnly(): void {
+  compatibleOnly = !compatibleOnly;
+  saveCompatibleOnlyToStorage(compatibleOnly);
 }

--- a/src/lib/utils/deviceGrouping.ts
+++ b/src/lib/utils/deviceGrouping.ts
@@ -4,8 +4,6 @@
  */
 
 const GROUPING_STORAGE_KEY = "Rackula-device-grouping";
-const COMPATIBLE_ONLY_STORAGE_KEY = "Rackula-device-compatible-only";
-
 /**
  * Device grouping mode for the DevicePalette
  * - 'brand': Generic section with category sub-groups + brand pack sections (default)
@@ -47,37 +45,5 @@ export function saveGroupingModeToStorage(mode: DeviceGroupingMode): void {
     localStorage.setItem(GROUPING_STORAGE_KEY, mode);
   } catch (e) {
     console.warn("[Rackula] Failed to save grouping mode to localStorage:", e);
-  }
-}
-
-/**
- * Load the saved compatible-only preference from localStorage.
- * @returns Stored boolean value, or true by default.
- */
-export function loadCompatibleOnlyFromStorage(): boolean {
-  try {
-    const stored = localStorage.getItem(COMPATIBLE_ONLY_STORAGE_KEY);
-    if (stored === "true") return true;
-    if (stored === "false") return false;
-  } catch (e) {
-    console.warn(
-      "[Rackula] Failed to load compatible-only mode from localStorage:",
-      e,
-    );
-  }
-  return true;
-}
-
-/**
- * Save compatible-only preference to localStorage.
- */
-export function saveCompatibleOnlyToStorage(value: boolean): void {
-  try {
-    localStorage.setItem(COMPATIBLE_ONLY_STORAGE_KEY, String(value));
-  } catch (e) {
-    console.warn(
-      "[Rackula] Failed to save compatible-only mode to localStorage:",
-      e,
-    );
   }
 }


### PR DESCRIPTION
## **User description**
## Summary
- Lift `compatibleOnly` state from DevicePalette's local state into the UI store (`ui.svelte.ts`), matching the `warnOnUnsavedChanges` pattern
- Add "Compatible Devices Only" checkbox item to the Settings gear menu (after "Banana for Scale")
- Remove the inline checkbox from DevicePalette panel
- Preserve the existing localStorage key (`Rackula-device-compatible-only`) so user preferences carry over

## Files Changed
- `src/lib/stores/ui.svelte.ts` — Add `compatibleOnly` state, getter, `toggleCompatibleOnly()` action
- `src/lib/components/SettingsMenu.svelte` — Add `DropdownMenu.CheckboxItem` for compatible-only
- `src/lib/components/Toolbar.svelte` — Wire new prop/callback through to SettingsMenu
- `src/App.svelte` — Connect `uiStore.compatibleOnly` to Toolbar
- `src/lib/components/DevicePalette.svelte` — Read from `uiStore` instead of local state, remove inline toggle + CSS
- `src/lib/utils/deviceGrouping.ts` — Remove relocated localStorage functions

## CodeRabbit Note
The localStorage key uses hyphens (`Rackula-device-compatible-only`) rather than underscores to preserve backward compatibility with existing user preferences from PR #1342.

## Test Plan
- [x] `npm run lint` — passes
- [x] `npm run test:run` — 90 files, 1909 tests pass
- [x] `npm run build` — production build succeeds
- [ ] Manual: Settings menu shows "Compatible Devices Only" checkbox
- [ ] Manual: Toggle filters palette correctly
- [ ] Manual: Setting persists across page reload
- [ ] Manual: No checkbox visible in device palette panel

Closes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Move "Compatible Devices Only" filter into Settings and apply it globally

### What Changed
- A "Compatible Devices Only" checkbox is added to the Settings (gear) menu and can be toggled there.
- The inline "Compatible only" checkbox was removed from the Device Library panel; filtering is now controlled by the Settings checkbox.
- The preference is stored using the existing localStorage key so the choice persists across page reloads and continues to filter devices in the palette and brand packs.

### Impact
`✅ Can toggle compatible-only from Settings menu`
`✅ No inline compatibility toggle in device palette`
`✅ Setting persists across reloads and continues filtering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
