### PR TITLE
fix: restore Trivy scan gating in deploy-prod workflow (#1360)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -241,8 +241,6 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:buildcache,mode=max
 
   scan-images:
-    # TODO: remove continue-on-error once aquasecurity/setup-trivy git clone bug is fixed
-    continue-on-error: true
     needs: [build-and-deploy, build-persist, build-api]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -288,10 +286,8 @@ jobs:
           limit-severities-for-sarif: true
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          # TODO: restore exit-code: 1 once aquasecurity/setup-trivy git clone bug is fixed
-          exit-code: 0
-          # Pin trivy version to avoid setup-trivy git clone failures
-          version: "v0.69.1"
+          exit-code: 1
+          version: "v0.69.2"
 
       - name: Upload scan results
         if: always()


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` workaround from `scan-images` job
- Restore `exit-code: 1` so HIGH/CRITICAL CVEs block production deploys again
- Bump pinned Trivy from v0.69.1 to v0.69.2 (v0.69.1 release artifacts were [removed upstream](https://github.com/aquasecurity/trivy-action/issues/516))

## Context
During v0.8.5, `aquasecurity/setup-trivy` had a git clone bug that broke the scan job on tag pushes. Workarounds were added to unblock deploys. The root cause (missing v0.69.1 artifacts + setup-trivy instability) is resolved by bumping to v0.69.2.

## Test plan
- [ ] Verify `scan-images` job runs successfully on next tag push
- [ ] Confirm HIGH/CRITICAL findings would block deploy (exit-code: 1 restored)

Closes #1360

🤖 Generated with [Claude Code](https://claude.com/claude-code)