### PR TITLE
fix: update stale E2E selectors (#1263)

### DIFF
--- a/e2e/custom-device.spec.ts
+++ b/e2e/custom-device.spec.ts
@@ -15,7 +15,7 @@ test.describe("Custom Device Height (Issue #166)", () => {
     page,
   }) => {
     // 1. Open Add Device form
-    const addDeviceButton = page.locator('[aria-label="Add custom device"]');
+    const addDeviceButton = page.locator('[data-testid="btn-create-custom-device"]');
     await addDeviceButton.click();
 
     // 2. Fill in custom device details
@@ -24,7 +24,7 @@ test.describe("Custom Device Height (Issue #166)", () => {
     await page.selectOption("#device-category", "server");
 
     // 3. Submit the form
-    await page.click('button:has-text("Add Device")');
+    await page.click('button:has-text("Add")');
 
     // 4. Verify custom device appears in palette
     const customDevice = page.locator(
@@ -52,7 +52,7 @@ test.describe("Custom Device Height (Issue #166)", () => {
     page,
   }) => {
     // 1. Open Add Device form
-    const addDeviceButton = page.locator('[aria-label="Add custom device"]');
+    const addDeviceButton = page.locator('[data-testid="btn-create-custom-device"]');
     await addDeviceButton.click();
 
     // 2. Create a custom 2U device
@@ -61,7 +61,7 @@ test.describe("Custom Device Height (Issue #166)", () => {
     await page.selectOption("#device-category", "storage");
 
     // 3. Submit the form
-    await page.click('button:has-text("Add Device")');
+    await page.click('button:has-text("Add")');
 
     // 4. Drag device to rack (new device is last in list)
     const deviceCount = await page.locator(".device-palette-item").count();

--- a/e2e/device-images.spec.ts
+++ b/e2e/device-images.spec.ts
@@ -46,7 +46,7 @@ test.describe("Device Images", () => {
 
   test("can upload front image when adding device", async ({ page }) => {
     // Click add device button in sidebar
-    await page.click('button:has-text("Add Device")');
+    await page.click('button:has-text("Add")');
 
     const dialog = page.locator(".dialog");
     await expect(dialog).toBeVisible();

--- a/e2e/device-name.spec.ts
+++ b/e2e/device-name.spec.ts
@@ -11,8 +11,8 @@ test.describe("Device Custom Names", () => {
     await dragDeviceToRack(page);
     await expect(page.locator(".rack-device").first()).toBeVisible();
 
-    // Click on the device to select it (use the foreignObject drag-handle inside)
-    await page.locator(".rack-device .drag-handle").first().click();
+    // Click on the device to select it
+    await page.locator(".rack-device").first().click();
 
     // Wait for edit panel drawer to open
     await expect(page.locator("aside.drawer-right.open")).toBeVisible();

--- a/e2e/migration.spec.ts
+++ b/e2e/migration.spec.ts
@@ -39,12 +39,12 @@ test.describe("Position Migration", () => {
     );
 
     // Verify rack is visible with devices
-    await expect(page.locator(".placed-device").first()).toBeVisible();
+    await expect(page.locator(".rack-device").first()).toBeVisible();
 
     // The server at U10 should now be at internal position 60
     // The switch at U1 should now be at internal position 6
     // Visual verification: both devices should be visible in the rack
-    const devices = await page.locator(".placed-device").count();
+    const devices = await page.locator(".rack-device").count();
     expect(devices).toBe(2);
   });
 
@@ -121,7 +121,7 @@ test.describe("Position Migration", () => {
     });
 
     // Verify devices are still in correct positions (not double-migrated)
-    const devices = await page.locator(".placed-device").count();
+    const devices = await page.locator(".rack-device").count();
     expect(devices).toBe(2);
 
     // Layout name should still be preserved


### PR DESCRIPTION
## **User description**
## Summary
- Updates 4 stale CSS selectors across 4 E2E spec files to match current DOM structure
- `.placed-device` → `.rack-device` (class renamed in RackDevice.svelte)
- `.drag-handle` removed — click `.rack-device` directly
- `[aria-label="Add custom device"]` → `[data-testid="btn-create-custom-device"]`
- `button:has-text("Add Device")` → `button:has-text("Add")`

Closes #1263

## Test plan
- [ ] `npx playwright test migration --project=chromium` passes
- [ ] `npx playwright test device-name --project=chromium` passes
- [ ] `npx playwright test custom-device --project=chromium` passes
- [ ] `npx playwright test device-images --project=chromium` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Update E2E test selectors to match current UI for reliable device flows

### What Changed
- Test interactions now target the visible rack device element instead of the removed/renamed selectors (tests click the device element directly and count ".rack-device" entries)
- Test flows that open the Add Device dialog use the new test id button and the shorter "Add" button label, so creating custom devices in tests matches the real UI
- Assertions that inspect device rendering (height and image upload flows) and migration behavior now operate on the current DOM structure

### Impact
`✅ Fewer flaky UI test failures`
`✅ Stable device creation and placement tests`
`✅ Accurate migration and rendering checks in E2E runs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
