### PR TITLE
fix: add circuit breaker for persistence auto-save retries (#1088)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -133,6 +133,11 @@
   let _currentLayoutId = $state<string | undefined>(undefined);
   let saveStatus = $state<SaveStatusType>("idle");
 
+  // Circuit breaker: stops auto-save retries after consecutive failures (#1088)
+  // Prevents infinite bounce when health check passes but layout endpoints fail.
+  const MAX_SAVE_FAILURES = 3;
+  let _consecutiveSaveFailures = 0;
+
   // Dialog state - now managed by dialogStore
   // Legacy local aliases for gradual migration
   let newRackFormOpen = $derived(dialogStore.isOpen("newRack"));
@@ -608,6 +613,36 @@
   }
 
   /**
+   * Mark API as unavailable and open circuit breaker after repeated failures.
+   * Shared by both PersistenceError and unknown error branches.
+   */
+  function handleSaveFailure(
+    notify: boolean,
+    action?: { label: string; onClick: () => void },
+  ) {
+    _consecutiveSaveFailures++;
+    setApiAvailable(false);
+    saveStatus = "offline";
+    if (_consecutiveSaveFailures >= MAX_SAVE_FAILURES) {
+      persistenceDebug.api(
+        "circuit breaker open after %d consecutive failures — auto-save paused",
+        _consecutiveSaveFailures,
+      );
+      toastStore.showToast(
+        "Server save unavailable — working offline. Use Ctrl+S to retry.",
+        "warning",
+      );
+    } else if (notify) {
+      toastStore.showToast(
+        "Save failed — backend unavailable",
+        "error",
+        undefined,
+        action,
+      );
+    }
+  }
+
+  /**
    * Classify a persistence error and update saveStatus / API availability.
    * @param e - The caught error (unknown type from catch block)
    * @param notify - Show toast messages (true for manual saves, false for auto-save)
@@ -624,30 +659,14 @@
         e.statusCode === 404 ||
         (typeof e.statusCode === "number" && e.statusCode >= 500)
       ) {
-        setApiAvailable(false);
-        saveStatus = "offline";
-        if (notify)
-          toastStore.showToast(
-            "Save failed — backend unavailable",
-            "error",
-            undefined,
-            action,
-          );
+        handleSaveFailure(notify, action);
       } else {
         saveStatus = "error";
         if (notify)
           toastStore.showToast("Save failed", "error", undefined, action);
       }
     } else {
-      setApiAvailable(false);
-      saveStatus = "offline";
-      if (notify)
-        toastStore.showToast(
-          "Save failed — backend unavailable",
-          "error",
-          undefined,
-          action,
-        );
+      handleSaveFailure(notify, action);
     }
   }
 
@@ -666,6 +685,7 @@
       const snapshot = structuredClone($state.snapshot(layoutStore.layout));
       const newId = await saveLayoutToServer(snapshot);
       _currentLayoutId = newId;
+      _consecutiveSaveFailures = 0; // Reset circuit breaker on success
       saveStatus = "saved";
       layoutStore.markClean();
       clearSession();
@@ -1501,6 +1521,10 @@
     // Check runtime API availability instead of build-time flag
     if (!isApiAvailable()) return;
 
+    // Circuit breaker: stop auto-saving after repeated failures (#1088)
+    // Manual save (Ctrl+S) bypasses this and resets the counter on success.
+    if (_consecutiveSaveFailures >= MAX_SAVE_FAILURES) return;
+
     const layout = layoutStore.layout;
     if (!layout.name) return;
 
@@ -1527,6 +1551,7 @@
         // UUID comes from layout metadata now, not passed as parameter
         const newId = await saveLayoutToServer(snapshot);
         _currentLayoutId = newId;
+        _consecutiveSaveFailures = 0; // Reset circuit breaker on success
         saveStatus = "saved";
 
         // Clear localStorage after successful server save to prevent stale data (#1012)
@@ -1559,11 +1584,15 @@
     // hasEverConnectedToApi() in future code paths, so check both signals.
     if (saveStatus === "disabled") return;
 
+    // Don't poll if circuit breaker is open — user must retry manually (#1088)
+    if (_consecutiveSaveFailures >= MAX_SAVE_FAILURES) return;
+
     persistenceDebug.health("API offline, starting health check interval");
     const intervalId = setInterval(async () => {
       const healthy = await checkApiHealth();
       if (healthy) {
         persistenceDebug.health("API health check passed, marking available");
+        _consecutiveSaveFailures = 0; // Reset circuit breaker on recovery
         setApiAvailable(true);
         saveStatus = "idle";
       } else {


### PR DESCRIPTION
## **User description**
## Summary
- Adds a circuit breaker that stops auto-save retries after 3 consecutive failures
- Prevents infinite bounce cycle when health check passes but layout endpoints fail (e.g., nginx misconfiguration causing 404 on `/api/layouts/:uuid`)
- Manual save (Ctrl+S) bypasses the circuit breaker and resets it on success
- Health check polling stops when the breaker is open to avoid wasted requests
- Extracts duplicated failure handling into `handleSaveFailure()` helper

## How It Works
1. Each save failure (404, 5xx, network error) increments `_consecutiveSaveFailures`
2. After 3 failures, auto-save stops and user gets a one-time warning toast
3. Health check polling also stops (no point polling if saves keep failing)
4. User can manually retry with Ctrl+S — success resets the counter
5. Successful auto-save also resets the counter

## Test Plan
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds  
- [x] `npm run test:run` — all 1931 tests pass
- [x] CodeRabbit local review — addressed nitpick (DRY refactor)

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Stop auto-save retries after repeated server failures; require manual retry

### What Changed
- Auto-save pauses after 3 consecutive server/save failures and shows a one-time warning: "Server save unavailable — working offline. Use Ctrl+S to retry."
- Manual save (Ctrl+S) still attempts a server save, bypasses the pause, and on success clears the paused state so auto-save resumes.
- While paused, health-check polling and further auto-save attempts are suppressed to avoid repeated failing requests; a successful health check or a successful save resets the pause.
- Successful server saves reset the failure counter and clear the local session to prevent stale local data.

### Impact
`✅ Fewer repeated save retry loops`
`✅ Fewer wasted health-check requests when server save is failing`
`✅ Clearer offline behavior with a single, actionable retry (Ctrl+S)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
