### PR TITLE
feat: add multi-rack share URL support (v2 schema) (#1207)

### DIFF
--- a/src/lib/schemas/share.ts
+++ b/src/lib/schemas/share.ts
@@ -126,6 +126,47 @@ export const MinimalLayoutSchema = z.object({
 });
 
 // =============================================================================
+// V2 Multi-Rack Schemas
+// =============================================================================
+
+/**
+ * Minimal rack schema with short ID for multi-rack support
+ */
+export const MinimalRackV2Schema = MinimalRackSchema.extend({
+  /** Short sequential rack ID (e.g., "0", "1", "2") */
+  i: z.string(),
+});
+
+/**
+ * Minimal rack group schema for bayed/linked rack configurations
+ */
+export const MinimalRackGroupSchema = z.object({
+  /** Short rack IDs referencing MinimalRackV2.i values */
+  rs: z.array(z.string()),
+  /** Optional group name */
+  n: z.string().optional(),
+  /** Layout preset */
+  p: z.enum(["bayed", "row"]).optional(),
+});
+
+/**
+ * Minimal layout schema v2 (multi-rack)
+ * Detected by presence of `rs` field (vs `r` for v1)
+ */
+export const MinimalLayoutV2Schema = z.object({
+  /** version */
+  v: z.string(),
+  /** name */
+  n: z.string(),
+  /** racks array (v2) */
+  rs: z.array(MinimalRackV2Schema),
+  /** rack groups (optional) */
+  rg: z.array(MinimalRackGroupSchema).optional(),
+  /** device_types (only used ones) */
+  dt: z.array(MinimalDeviceTypeSchema),
+});
+
+// =============================================================================
 // Type Exports
 // =============================================================================
 
@@ -133,3 +174,6 @@ export type MinimalLayout = z.infer<typeof MinimalLayoutSchema>;
 export type MinimalDevice = z.infer<typeof MinimalDeviceSchema>;
 export type MinimalDeviceType = z.infer<typeof MinimalDeviceTypeSchema>;
 export type MinimalRack = z.infer<typeof MinimalRackSchema>;
+export type MinimalRackV2 = z.infer<typeof MinimalRackV2Schema>;
+export type MinimalRackGroup = z.infer<typeof MinimalRackGroupSchema>;
+export type MinimalLayoutV2 = z.infer<typeof MinimalLayoutV2Schema>;

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -6,17 +6,30 @@
  * - Internal state uses internal units (1/6U): position 9 = U1.5
  * - Share links use human U-values for readability: position 1.5 = U1.5
  * - Conversion happens on encode (internal→U) and decode (U→internal)
+ *
+ * Schema versions:
+ * - v1: Single rack (`r` field) — legacy, decode-only
+ * - v2: Multi-rack (`rs` field) with optional rack groups (`rg`)
  */
 
 import pako from "pako";
-import type { Layout, DeviceType, PlacedDevice } from "$lib/types";
+import type {
+  Layout,
+  DeviceType,
+  PlacedDevice,
+  RackGroup,
+} from "$lib/types";
 import {
   MinimalLayoutSchema,
+  MinimalLayoutV2Schema,
   CATEGORY_TO_ABBREV,
   ABBREV_TO_CATEGORY,
   type MinimalLayout,
+  type MinimalLayoutV2,
   type MinimalDeviceType,
   type MinimalDevice,
+  type MinimalRackV2,
+  type MinimalRackGroup,
 } from "$lib/schemas/share";
 import { generateId } from "./device";
 import { createDefaultRack } from "./serialization";
@@ -34,24 +47,72 @@ function normalizeRackWidth(width: number): 10 | 19 {
   return width === 10 ? 10 : 19;
 }
 
+/**
+ * Convert a rack's devices to minimal format
+ */
+function convertDevices(devices: PlacedDevice[]): MinimalDevice[] {
+  return devices.map((d) => ({
+    t: d.device_type,
+    p: toHumanUnits(d.position),
+    f: d.face,
+    ...(d.name ? { n: d.name } : {}),
+  }));
+}
+
+/**
+ * Convert minimal device types back to full DeviceType[]
+ */
+function convertDeviceTypes(dt: MinimalDeviceType[]): DeviceType[] {
+  return dt.map((item) => ({
+    slug: item.s,
+    u_height: item.h,
+    ...(item.mf ? { manufacturer: item.mf } : {}),
+    ...(item.m ? { model: item.m } : {}),
+    colour: item.c,
+    category: ABBREV_TO_CATEGORY[item.x] ?? "other",
+  }));
+}
+
+/**
+ * Convert minimal devices back to full PlacedDevice[]
+ */
+function convertMinimalDevices(devices: MinimalDevice[]): PlacedDevice[] {
+  return devices.map((d) => ({
+    id: generateId(),
+    device_type: d.t,
+    position: toInternalUnits(d.p),
+    face: d.f,
+    ...(d.n ? { name: d.n } : {}),
+  }));
+}
+
 // =============================================================================
 // Layout Conversion Functions
 // =============================================================================
 
 /**
- * Convert Layout to MinimalLayout
- * Only includes device types that are actually placed in the rack
- * Note: Multi-rack layouts use the first rack for sharing
+ * Convert Layout to MinimalLayoutV2 (multi-rack)
+ * Always encodes as v2 format, even for single-rack layouts.
+ * Only includes device types that are actually placed in racks.
  */
-export function toMinimalLayout(layout: Layout): MinimalLayout {
-  // For multi-rack layouts, use the first rack
-  const rack = layout.racks[0];
-  if (!rack) {
+export function toMinimalLayout(layout: Layout): MinimalLayoutV2 {
+  if (layout.racks.length === 0) {
     throw new Error("Layout must have at least one rack");
   }
 
-  // Get unique device type slugs from placed devices
-  const usedSlugs = new Set(rack.devices.map((d) => d.device_type));
+  // Build rack ID map: real UUID -> short sequential ID
+  const rackIdMap = new Map<string, string>();
+  layout.racks.forEach((rack, index) => {
+    rackIdMap.set(rack.id, String(index));
+  });
+
+  // Collect used device type slugs from ALL racks (deduplicated)
+  const usedSlugs = new Set<string>();
+  for (const rack of layout.racks) {
+    for (const device of rack.devices) {
+      usedSlugs.add(device.device_type);
+    }
+  }
 
   // Validate all used slugs exist in device_types
   const availableSlugs = new Set(layout.device_types.map((t) => t.slug));
@@ -62,7 +123,7 @@ export function toMinimalLayout(layout: Layout): MinimalLayout {
     );
   }
 
-  // Filter and convert device types (only used ones)
+  // Filter and convert device types (only used ones, deduplicated by slug)
   const dt: MinimalDeviceType[] = layout.device_types
     .filter((deviceType) => usedSlugs.has(deviceType.slug))
     .map((deviceType) => ({
@@ -74,61 +135,62 @@ export function toMinimalLayout(layout: Layout): MinimalLayout {
       x: CATEGORY_TO_ABBREV[deviceType.category] ?? "o",
     }));
 
-  // Convert devices (position: internal units → human U-values for URL readability)
-  const devices: MinimalDevice[] = rack.devices.map((d) => ({
-    t: d.device_type,
-    p: toHumanUnits(d.position),
-    f: d.face,
-    ...(d.name ? { n: d.name } : {}),
+  // Convert all racks to MinimalRackV2
+  const rs: MinimalRackV2[] = layout.racks.map((rack) => ({
+    i: rackIdMap.get(rack.id)!,
+    n: rack.name,
+    h: rack.height,
+    w: normalizeRackWidth(rack.width),
+    d: convertDevices(rack.devices),
   }));
+
+  // Convert rack groups (if present)
+  const rg: MinimalRackGroup[] | undefined =
+    layout.rack_groups && layout.rack_groups.length > 0
+      ? layout.rack_groups.map((group, groupIndex) => {
+          const missingIds = group.rack_ids.filter(
+            (id) => !rackIdMap.has(id),
+          );
+          if (missingIds.length > 0) {
+            console.warn(
+              `Share encode: rack group ${group.name ?? `#${groupIndex}`} references unknown rack IDs: ${missingIds.join(", ")}`,
+            );
+          }
+          return {
+            rs: group.rack_ids
+              .map((id) => rackIdMap.get(id))
+              .filter((id): id is string => id !== undefined),
+            ...(group.name ? { n: group.name } : {}),
+            ...(group.layout_preset ? { p: group.layout_preset } : {}),
+          };
+        })
+      : undefined;
 
   return {
     v: layout.version,
     n: layout.name,
-    r: {
-      n: rack.name,
-      h: rack.height,
-      w: normalizeRackWidth(rack.width),
-      d: devices,
-    },
+    rs,
+    ...(rg ? { rg } : {}),
     dt,
   };
 }
 
 /**
- * Convert MinimalLayout back to full Layout
- * Generates IDs for devices, adds default settings
+ * Convert v1 MinimalLayout (single rack) back to full Layout
  */
-export function fromMinimalLayout(minimal: MinimalLayout): Layout {
-  // Convert device types
-  const device_types: DeviceType[] = minimal.dt.map((dt) => ({
-    slug: dt.s,
-    u_height: dt.h,
-    ...(dt.mf ? { manufacturer: dt.mf } : {}),
-    ...(dt.m ? { model: dt.m } : {}),
-    colour: dt.c,
-    category: ABBREV_TO_CATEGORY[dt.x] ?? "other",
-  }));
+function fromMinimalLayoutV1(minimal: MinimalLayout): Layout {
+  const device_types = convertDeviceTypes(minimal.dt);
+  const devices = convertMinimalDevices(minimal.r.d);
 
-  // Convert devices with generated UUIDs (position: human U-values → internal units)
-  const devices: PlacedDevice[] = minimal.r.d.map((d) => ({
-    id: generateId(),
-    device_type: d.t,
-    position: toInternalUnits(d.p),
-    face: d.f,
-    ...(d.n ? { name: d.n } : {}),
-  }));
-
-  // Create rack using factory to centralize defaults
   const rack = createDefaultRack(
-    minimal.r.n, // name
-    minimal.r.h, // height
-    normalizeRackWidth(minimal.r.w), // width (validated)
-    "4-post-cabinet", // form_factor (default)
-    false, // desc_units (default)
-    1, // starting_unit (default)
-    true, // show_rear (default)
-    generateId(), // id
+    minimal.r.n,
+    minimal.r.h,
+    normalizeRackWidth(minimal.r.w),
+    "4-post-cabinet",
+    false,
+    1,
+    true,
+    generateId(),
   );
   rack.devices = devices;
 
@@ -144,6 +206,82 @@ export function fromMinimalLayout(minimal: MinimalLayout): Layout {
   };
 }
 
+/**
+ * Convert v2 MinimalLayoutV2 (multi-rack) back to full Layout
+ */
+function fromMinimalLayoutV2(minimal: MinimalLayoutV2): Layout {
+  const device_types = convertDeviceTypes(minimal.dt);
+
+  // Build reverse map: shortId -> generated UUID
+  const shortIdToUuid = new Map<string, string>();
+
+  const racks = minimal.rs.map((minRack) => {
+    const rackId = generateId();
+    shortIdToUuid.set(minRack.i, rackId);
+
+    const rack = createDefaultRack(
+      minRack.n,
+      minRack.h,
+      normalizeRackWidth(minRack.w),
+      "4-post-cabinet",
+      false,
+      1,
+      true,
+      rackId,
+    );
+    rack.devices = convertMinimalDevices(minRack.d);
+    return rack;
+  });
+
+  // Convert rack groups (translate short IDs back to UUIDs)
+  const rack_groups: RackGroup[] | undefined =
+    minimal.rg && minimal.rg.length > 0
+      ? minimal.rg.map((group, groupIndex) => {
+          const unknownIds = group.rs.filter(
+            (shortId) => !shortIdToUuid.has(shortId),
+          );
+          if (unknownIds.length > 0) {
+            console.warn(
+              `Share decode: rack group ${group.n ?? `#${groupIndex}`} references unknown short IDs: ${unknownIds.join(", ")}`,
+            );
+          }
+          return {
+            id: generateId(),
+            rack_ids: group.rs
+              .map((shortId) => shortIdToUuid.get(shortId))
+              .filter((id): id is string => id !== undefined),
+            ...(group.n ? { name: group.n } : {}),
+            ...(group.p ? { layout_preset: group.p } : {}),
+          };
+        })
+      : undefined;
+
+  return {
+    version: minimal.v,
+    name: minimal.n,
+    racks,
+    ...(rack_groups ? { rack_groups } : {}),
+    device_types,
+    settings: {
+      display_mode: "label",
+      show_labels_on_images: false,
+    },
+  };
+}
+
+/**
+ * Convert MinimalLayout back to full Layout
+ * Public wrapper kept for backward compatibility with existing callers
+ */
+export function fromMinimalLayout(
+  minimal: MinimalLayout | MinimalLayoutV2,
+): Layout {
+  if ("rs" in minimal) {
+    return fromMinimalLayoutV2(minimal as MinimalLayoutV2);
+  }
+  return fromMinimalLayoutV1(minimal as MinimalLayout);
+}
+
 // =============================================================================
 // Encoding/Decoding Functions
 // =============================================================================
@@ -151,7 +289,7 @@ export function fromMinimalLayout(minimal: MinimalLayout): Layout {
 /**
  * Base64url encode (URL-safe base64)
  */
-function base64UrlEncode(data: Uint8Array): string {
+export function base64UrlEncode(data: Uint8Array): string {
   let binary = "";
   const chunkSize = 8192;
   for (let i = 0; i < data.length; i += chunkSize) {
@@ -173,6 +311,7 @@ function base64UrlDecode(str: string): Uint8Array {
 
 /**
  * Encode Layout to URL-safe compressed string
+ * Always encodes as v2 format.
  * Returns null if encoding fails (e.g., empty racks, missing device types)
  */
 export function encodeLayout(layout: Layout): string | null {
@@ -194,7 +333,9 @@ export interface DecodeResult {
 
 /**
  * Decode URL-safe compressed string to Layout
- * Returns DecodeResult with layout and optional error context
+ * Supports both v1 (single rack) and v2 (multi-rack) formats.
+ * Detects version by field presence: `r` = v1, `rs` = v2.
+ * Returns DecodeResult with layout and optional error context.
  */
 export function decodeLayout(encoded: string): DecodeResult {
   try {
@@ -202,14 +343,23 @@ export function decodeLayout(encoded: string): DecodeResult {
     const json = pako.inflate(compressed, { to: "string" });
     const parsed = JSON.parse(json);
 
-    // Validate with Zod
-    const result = MinimalLayoutSchema.safeParse(parsed);
-    if (!result.success) {
-      console.warn("Share link validation failed:", result.error);
-      return { layout: null, error: "Layout format is invalid or outdated" };
+    // Detect v1 vs v2 by field presence
+    if ("rs" in parsed) {
+      const result = MinimalLayoutV2Schema.safeParse(parsed);
+      if (!result.success) {
+        console.warn("Share link v2 validation failed:", result.error);
+        return { layout: null, error: "Layout format is invalid or outdated" };
+      }
+      return { layout: fromMinimalLayoutV2(result.data) };
     }
 
-    return { layout: fromMinimalLayout(result.data) };
+    // v1 fallback
+    const result = MinimalLayoutSchema.safeParse(parsed);
+    if (!result.success) {
+      console.warn("Share link v1 validation failed:", result.error);
+      return { layout: null, error: "Layout format is invalid or outdated" };
+    }
+    return { layout: fromMinimalLayoutV1(result.data) };
   } catch (error) {
     console.warn("Share link decode failed:", error);
     return { layout: null, error: "Could not decode share link" };

--- a/src/tests/share.test.ts
+++ b/src/tests/share.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import pako from "pako";
 import {
   encodeLayout,
   decodeLayout,
@@ -11,6 +12,7 @@ import {
   generateShareUrl,
   getShareParam,
   clearShareParam,
+  base64UrlEncode,
 } from "$lib/utils/share";
 import {
   createTestLayout,
@@ -91,9 +93,9 @@ describe("toMinimalLayout", () => {
 
     expect(minimal.v).toBe(layout.version);
     expect(minimal.n).toBe(layout.name);
-    expect(minimal.r.n).toBe(layout.racks[0].name);
-    expect(minimal.r.h).toBe(layout.racks[0].height);
-    expect(minimal.r.w).toBe(19);
+    expect(minimal.rs[0].n).toBe(layout.racks[0].name);
+    expect(minimal.rs[0].h).toBe(layout.racks[0].height);
+    expect(minimal.rs[0].w).toBe(19);
   });
 
   it("normalizes rack width 10 to 10", () => {
@@ -102,7 +104,7 @@ describe("toMinimalLayout", () => {
     });
     const minimal = toMinimalLayout(layout);
 
-    expect(minimal.r.w).toBe(10);
+    expect(minimal.rs[0].w).toBe(10);
   });
 
   it("normalizes rack width 19 to 19", () => {
@@ -111,7 +113,7 @@ describe("toMinimalLayout", () => {
     });
     const minimal = toMinimalLayout(layout);
 
-    expect(minimal.r.w).toBe(19);
+    expect(minimal.rs[0].w).toBe(19);
   });
 
   it("normalizes non-standard rack width 21 to 19", () => {
@@ -121,7 +123,7 @@ describe("toMinimalLayout", () => {
     });
     const minimal = toMinimalLayout(layout);
 
-    expect(minimal.r.w).toBe(19);
+    expect(minimal.rs[0].w).toBe(19);
   });
 
   it("normalizes non-standard rack width 23 to 19", () => {
@@ -131,7 +133,7 @@ describe("toMinimalLayout", () => {
     });
     const minimal = toMinimalLayout(layout);
 
-    expect(minimal.r.w).toBe(19);
+    expect(minimal.rs[0].w).toBe(19);
   });
 
   it("only includes device types that are placed", () => {
@@ -192,7 +194,7 @@ describe("toMinimalLayout", () => {
 
     const minimal = toMinimalLayout(layout);
 
-    expect(minimal.r.d[0].n).toBe("Primary DB");
+    expect(minimal.rs[0].d[0].n).toBe("Primary DB");
   });
 });
 
@@ -568,5 +570,232 @@ describe("share integration", () => {
 
     // Output should still be reasonable for QR codes
     expect(encoded.length).toBeLessThan(1600);
+  });
+});
+
+// =============================================================================
+// Multi-Rack Tests (v2 schema)
+// =============================================================================
+
+describe("multi-rack share", () => {
+  it("round-trips multi-rack layout with devices", () => {
+    const serverType = createTestDeviceType({
+      slug: "server-1u",
+      u_height: 1,
+      category: "server",
+    });
+    const switchType = createTestDeviceType({
+      slug: "switch-1u",
+      u_height: 1,
+      category: "network",
+    });
+
+    const rack1 = createTestRack({
+      id: "rack-a",
+      name: "Rack A",
+      height: 42,
+      devices: [
+        createTestDevice({
+          device_type: "server-1u",
+          position: 1,
+          face: "front",
+        }),
+      ],
+    });
+    const rack2 = createTestRack({
+      id: "rack-b",
+      name: "Rack B",
+      height: 24,
+      devices: [
+        createTestDevice({
+          device_type: "switch-1u",
+          position: 3,
+          face: "front",
+        }),
+      ],
+    });
+
+    const layout = createTestLayout({
+      name: "Multi-Rack Layout",
+      racks: [rack1, rack2],
+      device_types: [serverType, switchType],
+    });
+
+    const encoded = requireEncoded(layout);
+    const decoded = requireDecoded(encoded);
+
+    // eslint-disable-next-line no-restricted-syntax -- round-trip must preserve exact rack count
+    expect(decoded.racks).toHaveLength(2);
+    expect(decoded.racks[0].name).toBe("Rack A");
+    expect(decoded.racks[0].height).toBe(42);
+    expect(decoded.racks[1].name).toBe("Rack B");
+    expect(decoded.racks[1].height).toBe(24);
+    expect(
+      decoded.racks[0].devices.find((d) => d.device_type === "server-1u"),
+    ).toBeDefined();
+    expect(
+      decoded.racks[1].devices.find((d) => d.device_type === "switch-1u"),
+    ).toBeDefined();
+  });
+
+  it("round-trips bayed rack group", () => {
+    const deviceType = createTestDeviceType({ slug: "device-1u" });
+    const rack1 = createTestRack({
+      id: "bay-1",
+      name: "Bay 1",
+      height: 42,
+      devices: [createTestDevice({ device_type: "device-1u", position: 1 })],
+    });
+    const rack2 = createTestRack({
+      id: "bay-2",
+      name: "Bay 2",
+      height: 42,
+      devices: [createTestDevice({ device_type: "device-1u", position: 2 })],
+    });
+
+    const layout = createTestLayout({
+      name: "Bayed Layout",
+      racks: [rack1, rack2],
+      rack_groups: [
+        {
+          id: "group-1",
+          name: "Server Bay",
+          rack_ids: ["bay-1", "bay-2"],
+          layout_preset: "bayed",
+        },
+      ],
+      device_types: [deviceType],
+    });
+
+    const encoded = requireEncoded(layout);
+    const decoded = requireDecoded(encoded);
+
+    // eslint-disable-next-line no-restricted-syntax -- round-trip must preserve exact rack count
+    expect(decoded.racks).toHaveLength(2);
+    expect(decoded.rack_groups).toBeDefined();
+    // eslint-disable-next-line no-restricted-syntax -- round-trip must preserve exact group count
+    expect(decoded.rack_groups).toHaveLength(1);
+    const group = decoded.rack_groups![0];
+    expect(group.name).toBe("Server Bay");
+    expect(group.layout_preset).toBe("bayed");
+    // eslint-disable-next-line no-restricted-syntax -- round-trip must preserve exact rack_ids count
+    expect(group.rack_ids).toHaveLength(2);
+    expect(group.rack_ids).toContain(decoded.racks[0].id);
+    expect(group.rack_ids).toContain(decoded.racks[1].id);
+  });
+
+  it("deduplicates device types used across multiple racks", () => {
+    const sharedType = createTestDeviceType({ slug: "shared-device" });
+    const rack1 = createTestRack({
+      id: "r1",
+      name: "Rack 1",
+      devices: [
+        createTestDevice({ device_type: "shared-device", position: 1 }),
+      ],
+    });
+    const rack2 = createTestRack({
+      id: "r2",
+      name: "Rack 2",
+      devices: [
+        createTestDevice({ device_type: "shared-device", position: 2 }),
+      ],
+    });
+
+    const layout = createTestLayout({
+      racks: [rack1, rack2],
+      device_types: [sharedType],
+    });
+
+    const minimal = toMinimalLayout(layout);
+
+    // Should have exactly one device type entry despite being used in both racks
+    const matchingTypes = minimal.dt.filter((dt) => dt.s === "shared-device");
+    // eslint-disable-next-line no-restricted-syntax -- deduplication behavioral invariant
+    expect(matchingTypes).toHaveLength(1);
+  });
+
+  it("preserves rack ordering across round-trip", () => {
+    const deviceType = createTestDeviceType({ slug: "generic" });
+    const racks = ["Alpha", "Beta", "Gamma"].map((name, i) =>
+      createTestRack({
+        id: `rack-${i}`,
+        name,
+        devices: [createTestDevice({ device_type: "generic", position: 1 })],
+      }),
+    );
+
+    const layout = createTestLayout({
+      racks,
+      device_types: [deviceType],
+    });
+
+    const encoded = requireEncoded(layout);
+    const decoded = requireDecoded(encoded);
+
+    expect(decoded.racks[0].name).toBe("Alpha");
+    expect(decoded.racks[1].name).toBe("Beta");
+    expect(decoded.racks[2].name).toBe("Gamma");
+  });
+
+  it("decodes v1 share links (backward compatibility)", () => {
+    // Manually construct a v1 payload (single rack with `r` field)
+    const v1Payload = {
+      v: "1.0",
+      n: "Legacy Layout",
+      r: {
+        n: "Old Rack",
+        h: 42,
+        w: 19,
+        d: [{ t: "legacy-server", p: 5, f: "front" as const }],
+      },
+      dt: [{ s: "legacy-server", h: 2, c: "#336699", x: "s" }],
+    };
+
+    const json = JSON.stringify(v1Payload);
+    const compressed = pako.deflate(json);
+    const encoded = base64UrlEncode(compressed);
+
+    const { layout: decoded } = decodeLayout(encoded);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded!.name).toBe("Legacy Layout");
+    expect(decoded!.racks[0].name).toBe("Old Rack");
+    expect(decoded!.racks[0].height).toBe(42);
+    expect(
+      decoded!.racks[0].devices.find((d) => d.device_type === "legacy-server"),
+    ).toBeDefined();
+    expect(
+      decoded!.device_types.find((dt) => dt.slug === "legacy-server"),
+    ).toBeDefined();
+  });
+
+  it("assigns sequential short IDs to racks in minimal format", () => {
+    const deviceType = createTestDeviceType({ slug: "test-dev" });
+    const racks = [0, 1, 2].map((i) =>
+      createTestRack({
+        id: `rack-${i}`,
+        name: `Rack ${i}`,
+        devices: [createTestDevice({ device_type: "test-dev", position: 1 })],
+      }),
+    );
+
+    const layout = createTestLayout({
+      racks,
+      device_types: [deviceType],
+    });
+
+    const minimal = toMinimalLayout(layout);
+
+    expect(minimal.rs[0].i).toBe("0");
+    expect(minimal.rs[1].i).toBe("1");
+    expect(minimal.rs[2].i).toBe("2");
+  });
+
+  it("omits rack_groups when layout has none", () => {
+    const layout = createLayoutWithDevices();
+    const encoded = requireEncoded(layout);
+    const decoded = requireDecoded(encoded);
+
+    expect(decoded.rack_groups).toBeUndefined();
   });
 });


### PR DESCRIPTION
## **User description**
## Summary
- Extends share URL encoding to support multi-rack layouts (v2 schema)
- Encodes all racks and rack group relationships in the share URL
- Backward compatible: v1 share links still decode correctly
- Shared bayed rack URLs now reconstruct the full bayed configuration

## Changes
- `src/lib/schemas/share.ts`: Added `MinimalLayoutV2Schema`, `MinimalRackV2`, `MinimalRackGroup` types
- `src/lib/utils/share.ts`: `toMinimalLayout` now encodes all racks + groups; `decodeLayout` detects v1 vs v2 by field presence
- `src/tests/share.test.ts`: Added 7 new tests for multi-rack encode/decode, rack groups, deduplication, and v1 backward compatibility

## Test Plan
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test:run` — all 1938 tests pass (including 7 new share tests)
- [x] CodeRabbit local review — no findings

Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add multi-rack share URLs (v2) that encode multiple racks and rack groups while keeping v1 links supported

### What Changed
- Share URLs now encode the full layout of all racks (v2) including optional rack groups, instead of only the first rack; encoded rack entries get short sequential IDs to reference groups
- Device types are collected from all racks and stored once (deduplicated); rack order and device placements round-trip through encode/decode
- Decoder accepts both v2 (multi-rack) and legacy v1 (single-rack) links by detecting fields, and warnings are logged when groups reference unknown racks
- Public encoding/decoding preserves user-visible layout name, rack names/heights, devices, and rack groups; existing v1 share links continue to decode

### Impact
`✅ Share multiple racks via URL`
`✅ Preserves bay/group layouts in shared links`
`✅ Backward-compatible decoding of legacy single-rack links`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
