### PR TITLE
fix: unskip device-name undo/redo and cross-rack metadata tests (#1405)

### DIFF
--- a/e2e/device-metadata.spec.ts
+++ b/e2e/device-metadata.spec.ts
@@ -5,6 +5,8 @@ import {
   dragDeviceToRack,
   selectDevice,
   deselectDevice,
+  clickNewRack,
+  completeWizardWithClicks,
 } from "./helpers";
 
 /**
@@ -288,14 +290,33 @@ test.describe("Device Metadata Persistence", () => {
       expect(ip).toBe("");
     });
 
-    // Skip multi-rack test for now - complex UI interaction with rack list button
-    // The core metadata persistence is tested by the other tests
-    test.skip("metadata persists across different racks", async ({
-      page: _page,
-    }) => {
-      // This test requires clicking the "New Rack" button in the rack list
-      // which has a different selector than expected. Skipping for now.
-      // The core metadata persistence behavior is validated by the other tests.
+    test("metadata persists across different racks", async ({ page }) => {
+      // Add a device to the first rack and set metadata
+      await dragDeviceToRack(page);
+      await expect(page.locator(".rack-device").first()).toBeVisible();
+
+      await selectDevice(page, 0);
+      await setDeviceIp(page, TEST_METADATA.ip);
+      await setDeviceName(page, TEST_METADATA.name);
+      await deselectDevice(page);
+
+      // Create a second rack via replace flow (single-rack mode)
+      await clickNewRack(page);
+      await page.click('[data-testid="btn-replace-rack"]');
+      await completeWizardWithClicks(page, { name: "Second Rack", height: 24 });
+
+      // Add a device to the second rack
+      await dragDeviceToRack(page);
+      await expect(page.locator(".rack-device").first()).toBeVisible();
+
+      await selectDevice(page, 0);
+      await setDeviceIp(page, TEST_METADATA_2.ip);
+      await setDeviceName(page, TEST_METADATA_2.name);
+
+      // Verify the second rack's device has its own metadata
+      const metadata = await getDeviceMetadata(page);
+      expect(metadata.ip).toBe(TEST_METADATA_2.ip);
+      expect(metadata.name).toBe(TEST_METADATA_2.name);
     });
   });
 

--- a/e2e/device-name.spec.ts
+++ b/e2e/device-name.spec.ts
@@ -89,7 +89,7 @@ test.describe("Device Custom Names", () => {
     );
   });
 
-  test.skip("undo/redo works for display name changes", async ({ page }) => {
+  test("undo/redo works for display name changes", async ({ page }) => {
     // Place a device
     await dragDeviceToRack(page);
     await expect(page.locator(".rack-device").first()).toBeVisible();
@@ -117,8 +117,9 @@ test.describe("Device Custom Names", () => {
       "Custom Name",
     );
 
-    // Click on canvas area to ensure keyboard shortcuts work (not in input)
-    await page.locator(".canvas").first().click();
+    // Deselect device to ensure keyboard shortcuts target the app, not the edit panel
+    await page.keyboard.press("Escape");
+    await expect(page.locator("aside.drawer-right.open")).not.toBeVisible();
 
     // Undo (Ctrl+Z)
     await page.keyboard.press("Control+z");


### PR DESCRIPTION
## **User description**
## Summary
- Unskips undo/redo test in `device-name.spec.ts` by using Escape to close edit panel before keyboard shortcuts (canvas click left focus ambiguous)
- Implements cross-rack metadata test in `device-metadata.spec.ts` using existing `clickNewRack` and `completeWizardWithClicks` helpers

Closes #1405

## Test plan
- [ ] `npm run test:e2e` — both unskipped tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Unskip undo/redo test and add cross-rack metadata E2E coverage

### What Changed
- Re-enabled the device display-name undo/redo end-to-end test by deselecting the edit panel with Escape before issuing keyboard undo/redo, ensuring shortcuts target the app rather than the input.
- Implemented a cross-rack metadata end-to-end test: creates a second rack, places devices in each rack, sets distinct IP and name metadata, and verifies each rack’s device retains its own metadata.
- Added helpers-driven flow to create/replace racks and complete the rack wizard so the cross-rack behavior and saved metadata serialization are validated.

### Impact
`✅ Fewer flaky undo/redo test failures`
`✅ Verifies metadata isolation across racks`
`✅ Catches regressions in saved device metadata`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
