### PR TITLE
fix: clear containerHoverInfo on native DnD drop (#1397)

### DIFF
--- a/src/lib/utils/rack-interaction-handlers.ts
+++ b/src/lib/utils/rack-interaction-handlers.ts
@@ -7,12 +7,7 @@
  * reactive getters for the values they need from the component.
  */
 
-import type {
-  Rack,
-  DeviceType,
-  DeviceFace,
-  SlotPosition,
-} from "$lib/types";
+import type { Rack, DeviceType, DeviceFace, SlotPosition } from "$lib/types";
 import {
   parseDragData,
   getCurrentDragData,
@@ -123,12 +118,10 @@ export function handleDragLeave(
 /**
  * Handle native drop events on the rack SVG.
  */
-export function handleDrop(
-  event: DragEvent,
-  ctx: RackHandlerContext,
-): void {
+export function handleDrop(event: DragEvent, ctx: RackHandlerContext): void {
   event.preventDefault();
   ctx.setDropPreview(null);
+  ctx.setContainerHoverInfo(null);
 
   if (!event.dataTransfer) return;
 


### PR DESCRIPTION
## **User description**
## Summary

- `handleDrop` in `rack-interaction-handlers.ts` cleared `dropPreview` but not `containerHoverInfo`, leaving container slot highlighting stuck after a native drag-and-drop
- The pointer-drag path already clears both correctly (lines 73-74 in `rack-pointer-drag.ts`), this aligns the native DnD path

## Test plan

- [x] Lint passes
- [x] Build passes
- [x] All 1938 unit tests pass
- [x] CodeRabbit pre-push review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Clear rack container highlight after native drag-and-drop

### What Changed
- When a native drag-and-drop ends on the rack, the container slot highlight is cleared so slots no longer remain visually stuck
- The drop preview is still cleared, and native drop behavior now matches pointer-drag behavior for clearing hover state

### Impact
`✅ Fewer stuck slot highlights after native drag-and-drop`
`✅ Consistent visual state between pointer and native drag actions`
`✅ Clearer drop completion feedback for users`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
