### PR TITLE
fix: batch auto-import with placement for undo/redo (#1470)

### DIFF
--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -2981,23 +2981,28 @@ function moveDeviceRecorded(
   const history = getHistoryStore();
   const adapter = getCommandStoreAdapter();
 
-  const command = createMoveDeviceCommand(
+  const moveCommand = createMoveDeviceCommand(
     deviceIndex,
     oldPositionInternal,
     newPositionInternal,
     adapter,
     deviceName,
   );
-  history.execute(command);
-  isDirty = true;
 
-  // Update slot_position if changed (not tracked by move command undo/redo)
-  if (newSlotPosition && newSlotPosition !== device.slot_position) {
-    const freshRack = getRackById(rackId);
-    if (freshRack && freshRack.devices[deviceIndex]) {
-      freshRack.devices[deviceIndex]!.slot_position = newSlotPosition;
-    }
+  if (newSlotPosition && newSlotPosition !== (device.slot_position ?? "full")) {
+    const slotCommand = createUpdateDeviceSlotPositionCommand(
+      deviceIndex,
+      device.slot_position ?? "full",
+      newSlotPosition,
+      adapter,
+      deviceName,
+    );
+    const batchCommand = createBatchCommand(`Move ${deviceName}`, [moveCommand, slotCommand]);
+    history.execute(batchCommand);
+  } else {
+    history.execute(moveCommand);
   }
+  isDirty = true;
 
   debug.deviceMove({
     index: deviceIndex,

--- a/src/tests/commands-device.test.ts
+++ b/src/tests/commands-device.test.ts
@@ -4,9 +4,15 @@ import {
   createMoveDeviceCommand,
   createRemoveDeviceCommand,
   createUpdateDeviceFaceCommand,
+  createUpdateDeviceSlotPositionCommand,
   type DeviceCommandStore,
 } from "$lib/stores/commands/device";
-import { createTestDevice } from "./factories";
+import {
+  createAddDeviceTypeCommand,
+  type DeviceTypeCommandStore,
+} from "$lib/stores/commands/device-type";
+import { createBatchCommand } from "$lib/stores/commands/types";
+import { createTestDevice, createTestDeviceType } from "./factories";
 import { toInternalUnits } from "$lib/utils/position";
 
 function createMockStore(): DeviceCommandStore & {
@@ -15,6 +21,7 @@ function createMockStore(): DeviceCommandStore & {
   moveDeviceRaw: ReturnType<typeof vi.fn>;
   updateDeviceFaceRaw: ReturnType<typeof vi.fn>;
   updateDeviceNameRaw: ReturnType<typeof vi.fn>;
+  updateDeviceSlotPositionRaw: ReturnType<typeof vi.fn>;
   getDeviceAtIndex: ReturnType<typeof vi.fn>;
 } {
   return {
@@ -23,6 +30,7 @@ function createMockStore(): DeviceCommandStore & {
     moveDeviceRaw: vi.fn().mockReturnValue(true),
     updateDeviceFaceRaw: vi.fn(),
     updateDeviceNameRaw: vi.fn(),
+    updateDeviceSlotPositionRaw: vi.fn(),
     getDeviceAtIndex: vi.fn(),
   };
 }
@@ -194,6 +202,170 @@ describe("Device Commands", () => {
       expect(store.placeDeviceRaw).toHaveBeenCalledWith(
         expect.objectContaining({ position: toInternalUnits(15) }),
       );
+    });
+  });
+
+  describe("batch move + slot-position command", () => {
+    it("undo reverses both position and slot_position", () => {
+      const store = createMockStore();
+
+      const moveCmd = createMoveDeviceCommand(0, 10, 20, store, "Server");
+      const slotCmd = createUpdateDeviceSlotPositionCommand(
+        0,
+        "left",
+        "right",
+        store,
+        "Server",
+      );
+      const batch = createBatchCommand("Move Server", [moveCmd, slotCmd]);
+
+      batch.execute();
+
+      expect(store.moveDeviceRaw).toHaveBeenCalledWith(0, 20);
+      expect(store.updateDeviceSlotPositionRaw).toHaveBeenCalledWith(
+        0,
+        "right",
+      );
+
+      batch.undo();
+
+      // Undo reverses in reverse order: slot first, then position
+      expect(store.updateDeviceSlotPositionRaw).toHaveBeenLastCalledWith(
+        0,
+        "left",
+      );
+      expect(store.moveDeviceRaw).toHaveBeenLastCalledWith(0, 10);
+    });
+
+    it("redo restores both position and slot_position", () => {
+      const store = createMockStore();
+
+      const moveCmd = createMoveDeviceCommand(0, 10, 20, store, "Server");
+      const slotCmd = createUpdateDeviceSlotPositionCommand(
+        0,
+        "left",
+        "right",
+        store,
+        "Server",
+      );
+      const batch = createBatchCommand("Move Server", [moveCmd, slotCmd]);
+
+      batch.execute();
+      batch.undo();
+      batch.execute(); // redo
+
+      // Last calls should be the forward direction again
+      expect(store.moveDeviceRaw).toHaveBeenLastCalledWith(0, 20);
+      expect(store.updateDeviceSlotPositionRaw).toHaveBeenLastCalledWith(
+        0,
+        "right",
+      );
+    });
+
+    it("move without slot change uses simple move command", () => {
+      const store = createMockStore();
+
+      const moveCmd = createMoveDeviceCommand(0, 10, 20, store, "Server");
+      moveCmd.execute();
+
+      expect(store.moveDeviceRaw).toHaveBeenCalledWith(0, 20);
+      expect(store.updateDeviceSlotPositionRaw).not.toHaveBeenCalled();
+
+      moveCmd.undo();
+
+      expect(store.moveDeviceRaw).toHaveBeenLastCalledWith(0, 10);
+      expect(store.updateDeviceSlotPositionRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("batch auto-import + placement", () => {
+    function createCombinedMockStore(): DeviceCommandStore &
+      DeviceTypeCommandStore & {
+        placeDeviceRaw: ReturnType<typeof vi.fn>;
+        removeDeviceAtIndexRaw: ReturnType<typeof vi.fn>;
+        moveDeviceRaw: ReturnType<typeof vi.fn>;
+        updateDeviceFaceRaw: ReturnType<typeof vi.fn>;
+        updateDeviceNameRaw: ReturnType<typeof vi.fn>;
+        updateDeviceSlotPositionRaw: ReturnType<typeof vi.fn>;
+        getDeviceAtIndex: ReturnType<typeof vi.fn>;
+        addDeviceTypeRaw: ReturnType<typeof vi.fn>;
+        removeDeviceTypeRaw: ReturnType<typeof vi.fn>;
+        updateDeviceTypeRaw: ReturnType<typeof vi.fn>;
+        getPlacedDevicesForType: ReturnType<typeof vi.fn>;
+      } {
+      return {
+        placeDeviceRaw: vi.fn().mockReturnValue(0),
+        removeDeviceAtIndexRaw: vi.fn(),
+        moveDeviceRaw: vi.fn().mockReturnValue(true),
+        updateDeviceFaceRaw: vi.fn(),
+        updateDeviceNameRaw: vi.fn(),
+        updateDeviceSlotPositionRaw: vi.fn(),
+        getDeviceAtIndex: vi.fn(),
+        addDeviceTypeRaw: vi.fn(),
+        removeDeviceTypeRaw: vi.fn(),
+        updateDeviceTypeRaw: vi.fn(),
+        getPlacedDevicesForType: vi.fn().mockReturnValue([]),
+      };
+    }
+
+    it("undo removes both device type and placed device", () => {
+      const store = createCombinedMockStore();
+      const device = createTestDevice();
+      const deviceType = createTestDeviceType({ slug: "test-server" });
+
+      const importCmd = createAddDeviceTypeCommand(deviceType, store);
+      const placeCmd = createPlaceDeviceCommand(device, store, "Test Server");
+      const batch = createBatchCommand("Place Test Server", [
+        importCmd,
+        placeCmd,
+      ]);
+
+      batch.execute();
+
+      expect(store.addDeviceTypeRaw).toHaveBeenCalledWith(deviceType);
+      expect(store.placeDeviceRaw).toHaveBeenCalledWith(device);
+
+      batch.undo();
+
+      // Undo reverses in order: placement undone first, then import undone
+      expect(store.removeDeviceAtIndexRaw).toHaveBeenCalledTimes(1);
+      expect(store.removeDeviceTypeRaw).toHaveBeenCalledWith("test-server");
+    });
+
+    it("redo restores both device type and placed device", () => {
+      const store = createCombinedMockStore();
+      const device = createTestDevice();
+      const deviceType = createTestDeviceType({ slug: "test-server" });
+
+      const importCmd = createAddDeviceTypeCommand(deviceType, store);
+      const placeCmd = createPlaceDeviceCommand(device, store, "Test Server");
+      const batch = createBatchCommand("Place Test Server", [
+        importCmd,
+        placeCmd,
+      ]);
+
+      batch.execute();
+      batch.undo();
+      batch.execute(); // redo
+
+      // After redo, both should be called again
+      expect(store.addDeviceTypeRaw).toHaveBeenCalledTimes(2);
+      expect(store.placeDeviceRaw).toHaveBeenCalledTimes(2);
+    });
+
+    it("place without import uses simple place command (no import side effects)", () => {
+      const store = createCombinedMockStore();
+      const device = createTestDevice();
+
+      const placeCmd = createPlaceDeviceCommand(device, store, "Test Server");
+      placeCmd.execute();
+
+      expect(store.placeDeviceRaw).toHaveBeenCalledWith(device);
+      expect(store.addDeviceTypeRaw).not.toHaveBeenCalled();
+
+      placeCmd.undo();
+
+      expect(store.removeDeviceTypeRaw).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -2121,6 +2121,26 @@ describe("Layout Store", () => {
       // But should still contain all original items plus the new one
       expect(store.device_types.length).toBe(originalDeviceTypes.length + 1);
     });
+
+    it("failed placement does not auto-import or mark dirty (#1470)", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42);
+
+      // Place a brand device at position 5 to create a collision target
+      store.placeDevice(rack!.id, "ubiquiti-unifi-switch-24-pro", 5);
+      store.markClean();
+      expect(store.isDirty).toBe(false);
+
+      const typeCountBefore = store.device_types.length;
+
+      // Place a different brand device at the same position (collision)
+      const result = store.placeDevice(rack!.id, "ubiquiti-unifi-dream-machine-pro", 5);
+
+      // Placement failed — nothing should have been imported or dirtied
+      expect(result).toBe(false);
+      expect(store.isDirty).toBe(false);
+      expect(store.device_types.length).toBe(typeCountBefore);
+    });
   });
 
   describe("placeDevice face defaults based on depth", () => {


### PR DESCRIPTION
## **User description**
## Summary
- **Auto-import now batched with placement:** Device types from starter/brand packs are auto-imported using `BatchCommand`, making the import+placement atomic and fully undoable/redoable
- **Failed placements no longer leave orphan types:** Auto-import is deferred until after collision check succeeds, so collisions import nothing
- **Deduplicated pattern:** Extracted `getAutoImportDeviceType()` helper used by both `placeDeviceRecorded()` and `placeInContainer()`
- **Includes prior fix:** Clears `containerHoverInfo` on native DnD drop (#1397)

## Test plan
- [x] 1945/1945 unit tests passing (3 new batch import+placement tests added)
- [x] Updated existing `#1470` test to verify correct behaviour (no dirty on failed placement)
- [x] ESLint clean
- [x] Production build successful
- [x] CodeRabbit local review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Batch auto-import and placement; make moves include slot-position in undo/redo

### What Changed
- Auto-import of device types (from starter/brand packs) is performed together with placement as a single undoable action; failed placements no longer import types or mark the layout dirty
- Moving a device now groups position change and slot-position change into one undoable action so undo/redo restores both position and slot position; moves that don't change slot position still use the simple move action
- Tests added/updated to verify batch undo/redo for import+place and move+slot-position, and to ensure failed placements leave the store clean

### Impact
`✅ No orphaned device types after failed placement`
`✅ Undo/redo restores both device position and slot alignment`
`✅ Fewer unintended "dirty" marks after collision placements`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
