### PR TITLE
fix: use unique SVG pattern IDs per rack instance (#1466)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -429,6 +429,7 @@
   >
     <!-- Layer 1: Static rack frame -->
     <RackFrame
+      rackId={rack.id}
       rackWidth={RACK_WIDTH}
       {interiorWidth}
       railWidth={RAIL_WIDTH}

--- a/src/lib/components/RackFrame.svelte
+++ b/src/lib/components/RackFrame.svelte
@@ -39,6 +39,8 @@
     nameYOffset: number;
     /** Whether Shift key is held (shows half-U grid lines) */
     shiftKeyHeld?: boolean;
+    /** Unique rack identifier for SVG pattern IDs */
+    rackId: string;
     /** Blocked slot ranges for crosshatch overlay */
     blockedSlots?: URange[];
     /** Drop preview data for highlighting drop target U slots */
@@ -67,6 +69,7 @@
     rackName,
     viewLabel,
     nameYOffset,
+    rackId,
     shiftKeyHeld = false,
     blockedSlots = [],
     dropPreview = null,
@@ -253,7 +256,7 @@
   <!-- Crosshatch pattern for blocked slots - uses two overlapping diagonal line sets
        for better visibility and accessibility (not relying solely on color) -->
   <pattern
-    id="blocked-crosshatch-pattern"
+    id="blocked-crosshatch-{rackId}"
     patternUnits="userSpaceOnUse"
     width="8"
     height="8"
@@ -314,7 +317,7 @@
         y={slotY(slot)}
         width={slotW}
         height={slotHeight(slot)}
-        fill="url(#blocked-crosshatch-pattern)"
+        fill="url(#blocked-crosshatch-{rackId})"
       />
     {/each}
   </g>


### PR DESCRIPTION
## **User description**
## Summary

- RackFrame used a hardcoded `id="blocked-crosshatch-pattern"` for its SVG pattern, creating duplicate DOM IDs in multi-rack layouts
- SVG `url()` references resolved to the first matching element, so crosshatch overlays didn't render on non-first racks
- Added `rackId` prop to RackFrame and use it to generate unique pattern IDs (`blocked-crosshatch-{rackId}`)

## Test Plan

- [x] ESLint passes
- [x] All 1959 unit tests pass
- [x] Production build succeeds
- [x] CodeRabbit local review: no findings

Closes #1466

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Blocked slot patterns now render correctly on every rack**

### What Changed
- Each rack now uses its own blocked-slot pattern, so the crosshatch overlay shows up correctly in multi-rack layouts
- Blocked slots keep their visual texture on every rack instead of reusing the first rack’s pattern

### Impact
`✅ Clearer blocked-slot indicators`
`✅ Correct rack overlays in multi-rack views`
`✅ Fewer missing pattern displays`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
