### PR TITLE
chore(security): fix escape order in netbox importer and scope CodeQL (#1595)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "Rackula CodeQL config"
+
+# Dev-time tooling under scripts/ (e.g. NetBox import utilities) performs
+# fetch -> writeFile by design. These utilities target trusted upstreams
+# and are not shipped with the app, so exclude them from analysis to stop
+# spurious alerts for js/http-to-file-access and similar patterns.
+paths-ignore:
+  - "scripts/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,7 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/scripts/bulk-import-netbox.ts
+++ b/scripts/bulk-import-netbox.ts
@@ -646,7 +646,7 @@ function generateDeviceEntry(device: ImportedDevice): string {
 }
 
 function escapeString(str: string): string {
-  return str.replace(/'/g, "\\'").replace(/\\/g, "\\\\");
+  return str.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 
 // Generic devices to keep from existing library


### PR DESCRIPTION
## **User description**
## Summary

- Fix the escape order in `scripts/bulk-import-netbox.ts::escapeString`: escape backslash before single-quote so the backslash added by the first replace doesn't get doubled by the second (resolves `js/double-escaping` / `js/incomplete-sanitization`).
- Add `.github/codeql/codeql-config.yml` with `paths-ignore: ['scripts/**']` and wire it into `codeql.yml` via `config-file`. The dev-time NetBox import utilities under `scripts/` perform `fetch → writeFile` by design against a trusted upstream — those `js/http-to-file-access` alerts are expected behaviour, not a vulnerability in shipped code.

## Files Changed

- `scripts/bulk-import-netbox.ts` — swap `replace` order in `escapeString`
- `.github/codeql/codeql-config.yml` — new config, scripts excluded
- `.github/workflows/codeql.yml` — reference the config via `config-file`

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 1959/1959 pass
- [x] `npm run build` — succeeds
- [x] `npx tsx scripts/bulk-import-netbox.ts --dry-run` — imports 1500 devices (same as before)
- [x] CodeRabbit CLI: no findings
- [ ] Next scheduled CodeQL run reports 0 alerts in `scripts/`

Closes #1595


___

## **CodeAnt-AI Description**
**Fix NetBox import escaping and stop CodeQL from flagging trusted scripts**

### What Changed
- NetBox import output now escapes backslashes before single quotes, preventing doubled backslashes in generated device data.
- CodeQL no longer scans the `scripts/` import tools, which removes expected alerts from trusted, dev-only utilities.
- The CodeQL workflow now uses the shared ignore list so the exclusion is applied consistently.

### Impact
`✅ Correct NetBox import output`
`✅ Fewer false security alerts`
`✅ Cleaner CodeQL reports`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=Sp7zBkYrfikKlkknfnbxsv_dXdGbSnJHSgfM7Fm1m5Q&org=RackulaLives)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
