### PR TITLE
fix: guard preset shortcuts when custom-height input is focused (#1580)

### DIFF
--- a/e2e/rack-configuration.spec.ts
+++ b/e2e/rack-configuration.spec.ts
@@ -105,4 +105,21 @@ test.describe("Rack Configuration", () => {
     await expect(lastLabel).toHaveText("1");
   });
 
+  test("custom height accepts digits that collide with preset shortcuts", async ({ page }) => {
+    await openWizardStep2(page, "Custom 32 Rack");
+
+    await page.click('[data-testid="btn-height-custom"]');
+
+    const customInput = page.locator("#custom-height");
+    await expect(customInput).toBeVisible();
+
+    // pressSequentially fires real keydown events; fill() would bypass the
+    // form's keyboard handler and miss the preset-shortcut collision.
+    await customInput.fill("");
+    await customInput.pressSequentially("32");
+
+    await expect(customInput).toBeVisible();
+    await expect(customInput).toHaveValue("32");
+  });
+
 });

--- a/src/lib/components/wizard/NewRackWizard.svelte
+++ b/src/lib/components/wizard/NewRackWizard.svelte
@@ -13,6 +13,7 @@
 <script lang="ts">
   import Dialog from "$lib/components/Dialog.svelte";
   import LayoutTypeCard from "./LayoutTypeCard.svelte";
+  import { shouldIgnoreKeyboard } from "$lib/utils/keyboard";
   import {
     COMMON_RACK_HEIGHTS,
     MIN_RACK_HEIGHT,
@@ -336,6 +337,9 @@
 
     // Step 2: Height presets with number keys
     if (currentStep === 2) {
+      // Digits must reach the custom-height input when it has focus.
+      if (shouldIgnoreKeyboard(event)) return;
+
       const presetMap: Record<string, number> = {
         "1": availableHeights[0] ?? 12,
         "2": availableHeights[1] ?? 18,


### PR DESCRIPTION
## **User description**
## Summary

- In the **New Rack** wizard on Step 2, keys `1`–`4` were mapped to the preset-height buttons and fired unconditionally, so typing a height like `32` into the **Custom** input got swallowed: `3` selected the 3rd preset (24U) and collapsed the input.
- Reuse the existing `shouldIgnoreKeyboard` helper (already used by the global `KeyboardHandler`) to skip the preset shortcut when focus is in an input/textarea/select/contenteditable.
- Scope of the fix is intentionally narrow — Backspace's existing ad-hoc check is left alone.

Fixes #1580.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:run` (1959 unit tests passing)
- [x] `npm run build`
- [x] `npx playwright test e2e/rack-configuration.spec.ts e2e/keyboard.spec.ts e2e/basic-workflow.spec.ts e2e/single-rack.spec.ts` — all passing, new regression test passes on Chromium + WebKit
- [x] `coderabbit --prompt-only --type uncommitted` — no findings
- [ ] Manual: open wizard → Custom → type `32`, `14`, `41`, `23` — all must type into the field; presets (clicked by mouse) still work.

## Regression test

`e2e/rack-configuration.spec.ts` gains one Playwright test that drives real keystrokes via `pressSequentially("32")` (not `fill`, which would bypass the keyboard handler and miss this bug) and asserts the input stays visible with value `32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop preset height shortcuts from interrupting custom height entry**

### What Changed
- Typing numbers in the Custom height field on Step 2 now stays in the field instead of triggering preset height choices.
- Number shortcuts still work when focus is not inside an input field.
- Added a browser test that types `32` into the Custom field and confirms the value remains visible.

### Impact
`✅ Reliable custom height entry`
`✅ Fewer accidental preset selections`
`✅ Clearer Step 2 keyboard behavior`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=IMZSJrjhqAwt3qRbFqL5PJX17G5vEsbLENo_Yin0mZg&org=RackulaLives)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
