### PR TITLE
fix(ci): revert claude review to pull_request, skip fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,22 +1,15 @@
 name: Claude Code Review
 
-# SECURITY NOTE:
-# This workflow uses `pull_request_target` so secrets (ANTHROPIC_API_KEY) and
-# `id-token: write` are available for fork PRs — fork PRs are the ones that most
-# need automated review. The safety contract is:
-#   1. Checkout pins to the PR head SHA (not a mutable ref) so a force-push
-#      mid-run cannot swap the code being reviewed.
-#   2. `persist-credentials: false` — no GITHUB_TOKEN left in .git/config that
-#      fork-controlled code could read.
-#   3. We never run `npm install`, build, or test steps on the PR's code in
-#      this workflow. Only the action's own pinned dependencies execute.
-#   4. Claude is denied Bash/Write/Edit/NotebookEdit, so it can read the diff
-#      but cannot execute fork code or modify anything.
-# Residual risk: prompt injection in the diff could produce a misleading review
-# comment, but cannot exfiltrate secrets without an execution tool.
+# Fork PRs are skipped: GitHub strips secrets and `id-token: write` from
+# `pull_request` runs triggered by forks, so the action cannot authenticate.
+# `pull_request_target` would expose secrets but Anthropic's app-token exchange
+# rejects OIDC tokens with `event_name: pull_request_target`
+# (see https://github.com/anthropics/claude-code-action/issues/713). Until that
+# is fixed upstream, fork PRs go unreviewed by this workflow — use the
+# `@claude` comment trigger in claude.yml for on-demand review of fork PRs.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
@@ -33,8 +26,11 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    # Skip drafts and Dependabot PRs (no access to secrets)
-    if: github.event.pull_request.draft != true && github.actor != 'dependabot[bot]'
+    # Skip drafts, Dependabot PRs, and fork PRs (no access to secrets/OIDC).
+    if: >-
+      github.event.pull_request.draft != true
+      && github.actor != 'dependabot[bot]'
+      && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
@@ -47,12 +43,11 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout PR head (pinned to SHA, no credentials persisted)
+      - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
     # Skip drafts, Dependabot PRs, and fork PRs (no access to secrets/OIDC).
     if: >-
       github.event.pull_request.draft != true
-      && github.actor != 'dependabot[bot]'
+      && github.event.pull_request.user.login != 'dependabot[bot]'
       && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           persist-credentials: false
 


### PR DESCRIPTION
## **User description**
## Summary

Reverts PR #1670. That change unblocked OIDC permissions but ran into a deeper backend rejection: Anthropic's app-token exchange does not accept OIDC tokens with \`event_name: pull_request_target\` (see [anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713), open with no upstream fix). Net effect of #1670: every Claude review run failed, including the internal-branch PRs that previously worked.

This restores \`pull_request\` and explicitly skips fork PRs (\`head.repo.fork == false\`) so the workflow no longer attempts runs it cannot authenticate.

- Internal-branch PRs: reviewed as before.
- Fork PRs: skipped. Use the \`@claude\` comment trigger in \`claude.yml\` for on-demand review while #713 is open.

## Defence-in-depth retained from #1670

- \`persist-credentials: false\` on checkout
- \`--disallowedTools "Bash,Write,Edit,NotebookEdit"\` on Claude

## Test Plan

- [ ] After merge, confirm an internal-branch PR triggers a green Claude review run
- [ ] Confirm a fork PR (e.g. on a re-sync of #1662) skips this workflow cleanly with no failed checks


___

## **CodeAnt-AI Description**
Restore Claude review for internal PRs and skip fork PRs

### What Changed
- Claude review now runs on regular pull request events again, so internal PRs are reviewed as before
- Fork PRs are skipped in this workflow because they cannot authenticate here
- The workflow keeps a note directing fork PRs to use the `@claude` comment trigger for on-demand review

### Impact
`✅ Restored reviews for internal PRs`
`✅ Fewer failed Claude checks on fork PRs`
`✅ Clearer fork review path`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
