### PR TITLE
fix(api): patch Alpine packages to resolve CVE-2026-31789

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,6 +12,10 @@ RUN bun install --frozen-lockfile --production
 FROM base AS runner
 WORKDIR /app
 
+# Patch system packages to resolve known CVEs (libssl3/libcrypto3
+# CVE-2026-31789 et al.). Mirrors the pattern in deploy/Dockerfile.
+RUN apk upgrade --no-cache
+
 # Create non-root user with matching group
 RUN addgroup --system --gid 1001 rackula && \
     adduser --system --uid 1001 --ingroup rackula rackula


### PR DESCRIPTION
## **User description**
## Summary

- Adds `RUN apk upgrade --no-cache` to the runner stage of `api/Dockerfile`
- Mirrors the existing pattern in `deploy/Dockerfile:33`
- Resolves code scanning alerts **#39** (libcrypto3) and **#44** (libssl3) for **CVE-2026-31789** (CRITICAL — OpenSSL heap buffer overflow on 32-bit X.509 parsing)
- Expected to also clear related Alpine HIGH alerts (#45–#51: libssl3, musl, musl-utils, zlib) on the next Trivy scan

## Why broad `apk upgrade` over package pinning

CodeRabbit's local review flagged two trivial nitpicks suggesting we pin specific packages (or bump the Bun base image tag) instead of running a blanket upgrade. We are intentionally choosing the broader approach because:

1. **Consistency** — `deploy/Dockerfile:33` already uses `RUN apk upgrade --no-cache` for the web image. The API image was the inconsistent outlier.
2. **Coverage** — pinning only `libssl3`/`libcrypto3` would close #39/#44 but leave #45–#51 (other Alpine HIGH CVEs on the same image) still failing the `scan-images` Trivy gate in `deploy-prod.yml`.
3. **Maintenance** — explicit package pins would require a Dockerfile edit for every new Alpine CVE; the `apk upgrade` approach lets `oven/bun:1.3.10-alpine` digest updates carry the patches.
4. **Reproducibility** — Trivy's `ignore-unfixed: true` and `exit-code: 1` on every build ensure CI re-verifies the patched state; build digests are pinned per release tag downstream.

The Bun runtime is not an apk package (ships as part of the base image FS), so `apk upgrade` cannot affect it.

## CI gate context

`.github/workflows/deploy-prod.yml` job `scan-images` (lines 243–289):

- `severity: HIGH,CRITICAL`
- `ignore-unfixed: true`
- `exit-code: 1` — failing scans block deploys to `count.racku.la`

These two alerts currently block any future `v*` tag deploy. This PR unblocks the prod deploy gate.

## Test plan

- [ ] CI lint + tests pass (`deploy-prod.yml` build job)
- [ ] CI `scan-images` job passes with no libssl3 / libcrypto3 findings
- [ ] After merge + next scheduled scan: code scanning alerts #39 and #44 transition to `fixed`
- [ ] After merge + next scheduled scan: alerts #45–#51 also expected to transition to `fixed`

## Out of scope

- npm/JS package alerts (#52–#56: lodash, kysely, effect, drizzle-orm, defu) — these need `bun update` in `api/` and are unrelated to OS packages
- Bumping `oven/bun:1.3.10-alpine` to a newer Bun tag

Refs: code scanning alerts #39, #44 on `ghcr.io/rackulalives/rackula-api:latest`


___

## **CodeAnt-AI Description**
Patch Alpine packages in the API image to resolve known OpenSSL CVEs

### What Changed
- The API production image now updates Alpine system packages during build, which addresses the OpenSSL-related security issue in `libssl3` and `libcrypto3`
- This change matches the package update approach already used in the web deployment image

### Impact
`✅ Fewer security scan failures`
`✅ Closed OpenSSL vulnerability alerts`
`✅ Safer API container builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
