### PR TITLE
ci(trivy): on-demand security scan aligned with deploy-prod

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,44 +1,137 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+name: Trivy Security Scan
 
-name: trivy
+# On-demand Trivy vulnerability scan that complements the release-time scan
+# in deploy-prod.yml. Lets us re-scan published images and the current repo
+# state without cutting a release. Image categories match deploy-prod's scan
+# so findings refresh the same alert set instead of stacking duplicates.
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   schedule:
-    - cron: '18 19 * * 0'
+    # Weekly Sunday 19:18 UTC — offset from CodeQL (Sundays 11:35 UTC)
+    # to spread scheduler load.
+    - cron: "18 19 * * 0"
 
 permissions:
   contents: read
 
+env:
+  REGISTRY: ghcr.io
+  TRIVY_VERSION: "v0.70.0"
+
+concurrency:
+  group: trivy-scan-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Build
+  scan-filesystem:
+    name: Scan filesystem (${{ matrix.target.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - name: app
+            path: "."
+            category: filesystem-app
+          - name: api
+            path: ./api
+            category: filesystem-api
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Build an image from Dockerfile
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        with:
+          scan-type: fs
+          scan-ref: ${{ matrix.target.path }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          # Without this, SARIF can include severities below the filter.
+          limit-severities-for-sarif: true
+          exit-code: 0
+          version: ${{ env.TRIVY_VERSION }}
+
+      - name: Upload SARIF to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-${{ matrix.target.category }}
+
+  scan-images:
+    name: Scan image (${{ matrix.image.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: app-latest
+            repo_suffix: ""
+            tag: latest
+          - name: app-persist
+            repo_suffix: ""
+            tag: persist
+          - name: api-latest
+            repo_suffix: "-api"
+            tag: latest
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image reference
+        env:
+          IMAGE_NAME: ${{ github.repository }}
+          REPO_SUFFIX: ${{ matrix.image.repo_suffix }}
+          TAG: ${{ matrix.image.tag }}
         run: |
-          docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
+          IMAGE_NAME_LC=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+          IMAGE_REF="${REGISTRY}/${IMAGE_NAME_LC}${REPO_SUFFIX}:${TAG}"
+          IMAGE_CATEGORY=$(echo "$IMAGE_REF" | tr '/:' '--' | tr -cd '[:alnum:]._-')
+          {
+            echo "IMAGE_REF=${IMAGE_REF}"
+            echo "IMAGE_CATEGORY=${IMAGE_CATEGORY}"
+          } >> "$GITHUB_ENV"
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+      - name: Run Trivy image scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
-          image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          image-ref: ${{ env.IMAGE_REF }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          limit-severities-for-sarif: true
+          exit-code: 0
+          version: ${{ env.TRIVY_VERSION }}
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+      - name: Upload SARIF to Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: trivy-results.sarif
+          # Match deploy-prod's category so on-demand runs refresh the
+          # release-time alert set rather than creating duplicates.
+          category: trivy-${{ env.IMAGE_CATEGORY }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: trivy
+
+on:
+  workflow_dispatch: 
+  schedule:
+    - cron: '18 19 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe
+        with:
+          image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## **User description**
## Summary

Replaces the CodeAnt-AI starter template with a project-aligned on-demand Trivy scan. The previous version targeted a non-existent root `Dockerfile` and used a placeholder image name, so it never produced useful results.

The reworked workflow has two parallel jobs:

- **`scan-filesystem`** — Trivy scans `.` and `./api` for HIGH/CRITICAL CVEs in dependencies (npm + bun lockfiles). Useful for catching transitive-dep issues without waiting for an image build.
- **`scan-images`** — Trivy scans the three published images on `ghcr.io` (`rackula:latest`, `rackula:persist`, `rackula-api:latest`) that match the matrix used by `deploy-prod.yml`'s `scan-images` job.

Both jobs upload SARIF to the Security tab using the same category convention as `deploy-prod.yml`, so on-demand runs refresh the existing alert set instead of stacking duplicates.

## Changes vs. PR's first commit

| Issue | Before | After |
|---|---|---|
| Image ref | Placeholder `docker.io/my-organization/my-app` | Real published `ghcr.io/${repo}` images via matrix |
| Build step | `docker build … .` (no root `Dockerfile` exists) | Removed — scans already-published images |
| `trivy-action` pin | `7b7aa264…` (Jun 2022, Trivy 0.29.1) | `ed142fd0…` (v0.36.0) — matches `deploy-prod.yml` |
| `codeql-action/upload-sarif` pin | `@v3` (mutable) | `68bde559…` v4 — matches `deploy-prod.yml` |
| SARIF format | `template: '@/contrib/sarif.tpl'` (pre-v0.30 workaround) | Native `format: sarif` with `limit-severities-for-sarif` |
| Filesystem scan | Not present | Added — covers source dependency CVEs |
| Timeouts | None | 15 min (fs), 20 min (image) |
| Concurrency | None | Group + cancel-in-progress |
| Categories | Single default | Distinct per-target categories, image categories match deploy-prod |

## CodeRabbit's earlier feedback

All three actionable comments from the first review are addressed:

- ✅ `codeql-action/upload-sarif` now SHA-pinned (`68bde559…` v4).
- ✅ Placeholder image name replaced with real `ghcr.io` references.
- ✅ Outdated `trivy-action` SHA replaced with the v0.36.0 SHA already in use by deploy-prod.

The remaining nitpick about handling missing images is intentional: this workflow is for re-scanning *published* images, so a missing tag failing loudly is the right behaviour for this repo. `fail-fast: false` keeps other matrix entries running.

## Test plan

- [ ] After merge, trigger via `gh workflow run "Trivy Security Scan"` and confirm both jobs succeed.
- [ ] Confirm Security tab shows results categorised per target (`trivy-filesystem-app`, `trivy-filesystem-api`, and per-image categories matching deploy-prod's slugging).
- [ ] Sanity check that an existing alert set (e.g. the open CVEs on `rackula-api`) refreshes rather than duplicating after a manual run.

## Related

The five open Trivy alerts on `rackula-api`'s `node_modules` (lodash, kysely, effect, drizzle-orm, defu) are transitive deps of `better-auth`. Worth tracking as a separate issue once we can verify which are fixed by the latest `better-auth` and which need `overrides` in `api/package.json`.


___

## **CodeAnt-AI Description**
**Run Trivy scans on demand and on a weekly schedule**

### What Changed
- Trivy scans can now be started manually and also run automatically once a week
- The scan now checks both the app source and API source for high and critical dependency issues
- Published container images are scanned directly, including the app, persisted app, and API images
- Scan results are uploaded under the same Security tab grouping as release scans, so findings update the existing alerts instead of creating duplicates

### Impact
`✅ Fewer duplicate security alerts`
`✅ Earlier detection of dependency CVEs`
`✅ Weekly security coverage without a release`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
