### PR TITLE
fix: respect half-width slot_position in PNG export (#1660)

### DIFF
--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -820,14 +820,35 @@ export function generateExportSVG(
         RACK_PADDING +
         RAIL_WIDTH;
       const deviceHeight = device.u_height * U_HEIGHT - 2;
-      const deviceWidth = RACK_WIDTH - RAIL_WIDTH * 2 - 4;
+
+      // Half-width slot geometry (mirrors RackDevice.svelte:218-233).
+      // Only two-slot racks (>10") split into left/right; everything else is full-width.
+      // Outer-rail edges keep the export's 2px padding; the inner midline edges meet
+      // so two half-width devices touch like in the live preview.
+      const fullInteriorWidth = RACK_WIDTH - RAIL_WIDTH * 2;
+      const isHalfWidth = device.slot_width === 1 && rack.width > 10;
+      const effectiveSlotPosition = isHalfWidth
+        ? (placedDevice.slot_position ?? "full")
+        : "full";
+      let deviceX: number;
+      let deviceWidth: number;
+      if (effectiveSlotPosition === "right") {
+        deviceX = RAIL_WIDTH + fullInteriorWidth / 2;
+        deviceWidth = fullInteriorWidth / 2 - 2;
+      } else if (effectiveSlotPosition === "left") {
+        deviceX = RAIL_WIDTH + 2;
+        deviceWidth = fullInteriorWidth / 2 - 2;
+      } else {
+        deviceX = RAIL_WIDTH + 2;
+        deviceWidth = fullInteriorWidth - 4;
+      }
 
       // Always render device rect as background
       const deviceRect = document.createElementNS(
         "http://www.w3.org/2000/svg",
         "rect",
       );
-      deviceRect.setAttribute("x", String(RAIL_WIDTH + 2));
+      deviceRect.setAttribute("x", String(deviceX));
       deviceRect.setAttribute("y", String(deviceY + 1));
       deviceRect.setAttribute("width", String(deviceWidth));
       deviceRect.setAttribute("height", String(deviceHeight));
@@ -855,7 +876,7 @@ export function generateExportSVG(
           "http://www.w3.org/2000/svg",
           "image",
         );
-        imageEl.setAttribute("x", String(RAIL_WIDTH + 2));
+        imageEl.setAttribute("x", String(deviceX));
         imageEl.setAttribute("y", String(deviceY + 1));
         imageEl.setAttribute("width", String(deviceWidth));
         imageEl.setAttribute("height", String(deviceHeight));
@@ -874,7 +895,7 @@ export function generateExportSVG(
           "http://www.w3.org/2000/svg",
           "rect",
         );
-        clipRect.setAttribute("x", String(RAIL_WIDTH + 2));
+        clipRect.setAttribute("x", String(deviceX));
         clipRect.setAttribute("y", String(deviceY + 1));
         clipRect.setAttribute("width", String(deviceWidth));
         clipRect.setAttribute("height", String(deviceHeight));
@@ -887,7 +908,7 @@ export function generateExportSVG(
         // Category icon (only for devices tall enough and with a category)
         if (deviceHeight >= 20 && device.category) {
           const iconSize = 12;
-          const iconX = RAIL_WIDTH + 6;
+          const iconX = deviceX + 4;
           const iconY = deviceY + (deviceHeight - iconSize) / 2 + 1;
 
           const iconSvg = document.createElementNS(
@@ -937,7 +958,7 @@ export function generateExportSVG(
         "http://www.w3.org/2000/svg",
         "text",
       );
-      deviceNameEl.setAttribute("x", String(RACK_WIDTH / 2));
+      deviceNameEl.setAttribute("x", String(deviceX + deviceWidth / 2));
       deviceNameEl.setAttribute("y", String(deviceY + deviceHeight / 2 + 1));
       deviceNameEl.setAttribute("fill", "#ffffff");
       deviceNameEl.setAttribute("font-size", String(fittedLabel.fontSize));

--- a/src/tests/export-half-width.test.ts
+++ b/src/tests/export-half-width.test.ts
@@ -1,0 +1,142 @@
+/**
+ * PNG/SVG export — half-width device geometry (#1660)
+ *
+ * Regression coverage: ensures the export renderer respects `slot_width: 1`
+ * and `slot_position` so two half-width devices end up side-by-side instead
+ * of overlapping at full width.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateExportSVG } from "$lib/utils/export";
+import type { ExportOptions } from "$lib/types";
+import {
+  createTestRack,
+  createTestDeviceType,
+  createTestDevice,
+  TEST_CONSTANTS,
+} from "./factories";
+
+const { RAIL_WIDTH, RACK_WIDTH_19 } = TEST_CONSTANTS;
+const INTERIOR_WIDTH = RACK_WIDTH_19 - RAIL_WIDTH * 2;
+
+const baseOptions: ExportOptions = {
+  format: "png",
+  scope: "all",
+  includeNames: true,
+  includeLegend: false,
+  background: "solid",
+  exportView: "front",
+  displayMode: "label",
+};
+
+function rectsWithFill(svg: SVGElement, fill: string) {
+  return Array.from(svg.getElementsByTagName("rect")).filter(
+    (r) => r.getAttribute("fill") === fill,
+  );
+}
+
+describe("PNG export — half-width device geometry (#1660)", () => {
+  it("places two side-by-side half-width devices in non-overlapping halves of the interior", () => {
+    const halfWidth = createTestDeviceType({
+      slug: "half-server",
+      u_height: 3,
+      slot_width: 1,
+      is_full_depth: false,
+    });
+
+    const rack = createTestRack({
+      width: 19,
+      devices: [
+        createTestDevice({
+          id: "left",
+          device_type: "half-server",
+          position: 10,
+          slot_position: "left",
+        }),
+        createTestDevice({
+          id: "right",
+          device_type: "half-server",
+          position: 10,
+          slot_position: "right",
+        }),
+      ],
+    });
+
+    const svg = generateExportSVG([rack], [halfWidth], baseOptions);
+    const rects = rectsWithFill(svg, halfWidth.colour!);
+
+    // eslint-disable-next-line no-restricted-syntax -- two placed devices must produce exactly two coloured device rects
+    expect(rects).toHaveLength(2);
+
+    const sorted = rects
+      .map((r) => ({
+        x: Number(r.getAttribute("x")),
+        width: Number(r.getAttribute("width")),
+      }))
+      .sort((a, b) => a.x - b.x);
+
+    expect(sorted[0].width).toBeCloseTo(INTERIOR_WIDTH / 2 - 2);
+    expect(sorted[1].width).toBeCloseTo(INTERIOR_WIDTH / 2 - 2);
+    expect(sorted[0].x).toBeCloseTo(RAIL_WIDTH + 2);
+    expect(sorted[1].x).toBeCloseTo(RAIL_WIDTH + INTERIOR_WIDTH / 2);
+
+    // The two rects must not overlap horizontally.
+    expect(sorted[1].x).toBeGreaterThanOrEqual(sorted[0].x + sorted[0].width);
+  });
+
+  it("renders a full-width device across the full interior", () => {
+    const fullWidth = createTestDeviceType({
+      slug: "full-server",
+      u_height: 2,
+    });
+    const rack = createTestRack({
+      width: 19,
+      devices: [
+        createTestDevice({
+          id: "fw",
+          device_type: "full-server",
+          position: 10,
+        }),
+      ],
+    });
+
+    const svg = generateExportSVG([rack], [fullWidth], baseOptions);
+    const rects = rectsWithFill(svg, fullWidth.colour!);
+
+    // eslint-disable-next-line no-restricted-syntax -- one placed device must produce exactly one coloured device rect
+    expect(rects).toHaveLength(1);
+    expect(Number(rects[0].getAttribute("x"))).toBeCloseTo(RAIL_WIDTH + 2);
+    expect(Number(rects[0].getAttribute("width"))).toBeCloseTo(
+      INTERIOR_WIDTH - 4,
+    );
+  });
+
+  it('ignores slot_position on a 10" single-slot rack and renders the device full-width', () => {
+    const halfWidth = createTestDeviceType({
+      slug: "ten-inch",
+      u_height: 1,
+      slot_width: 1,
+    });
+    const rack = createTestRack({
+      width: 10,
+      devices: [
+        createTestDevice({
+          id: "ten",
+          device_type: "ten-inch",
+          position: 5,
+          slot_position: "right",
+        }),
+      ],
+    });
+
+    const svg = generateExportSVG([rack], [halfWidth], baseOptions);
+    const rects = rectsWithFill(svg, halfWidth.colour!);
+
+    // eslint-disable-next-line no-restricted-syntax -- one placed device must produce exactly one coloured device rect
+    expect(rects).toHaveLength(1);
+    expect(Number(rects[0].getAttribute("x"))).toBeCloseTo(RAIL_WIDTH + 2);
+    expect(Number(rects[0].getAttribute("width"))).toBeCloseTo(
+      INTERIOR_WIDTH - 4,
+    );
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- PNG export hardcoded full-width geometry for every device, so a half-width device at `slot_position: right` was drawn across the whole row in the exported image, visually covering its left-side neighbour.
- Mirror the live preview's logic from `RackDevice.svelte:218-233` — derive `deviceX` and `deviceWidth` from `slot_width` + `slot_position`, gated on two-slot racks (`rack.width > 10`).
- Two halves meet at the midline to match the live preview while keeping the export's existing 2px outer-rail padding for full-width devices.

## Out of scope (filed separately)

The original issue body and follow-up comment described two additional bugs that are unrelated to the half-width export geometry. They have their own root causes and are tracked separately so this PR stays focused:

- #1680 — Right-side half-width device unclickable when paired at the same U (live-preview hit testing, not export).
- #1681 — PNG export does not respect "Front Only" view settings (face-filter divergence between export and live preview).

## Test plan

- [x] Added `src/tests/export-half-width.test.ts` covering two side-by-side half-width devices, a full-width control, and a 10" rack (`slot_position` ignored).
- [x] `npm run lint` clean.
- [x] `npm run test:run` — 1966 tests pass.
- [x] `npm run build` clean.
- [x] Local `coderabbit --prompt-only --type uncommitted` — no findings.
- [ ] Manual PNG export of two half-width devices side-by-side in dev to visually confirm geometry.

Closes #1660


___

## **CodeAnt-AI Description**
**Respect half-width device placement in PNG exports**

### What Changed
- PNG exports now place half-width devices in the left or right half of a two-slot rack instead of stretching them across the full row
- Full-width devices still export across the full interior width with the same outer padding as before
- On 10" single-slot racks, half-width positioning is ignored and devices export full-width
- Added regression tests for side-by-side half-width devices, full-width devices, and 10" racks

### Impact
`✅ Correct rack images in PNG exports`
`✅ Fewer overlapping devices in exported diagrams`
`✅ Clearer export results for half-width hardware`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
