### PR TITLE
fix: respect per-device face in PNG export filter (#1681)

### DIFF
--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -73,28 +73,19 @@ const DARK_GRID = "#505050";
 const LIGHT_GRID = "#a0a0a0";
 
 /**
- * Filter devices by face for export
- * Full-depth devices are visible from both sides, so they're included on both faces
+ * Filter devices by face for export.
+ *
+ * Mirrors the live preview in Rack.svelte: a device is visible on a face when
+ * its placement face is "both" or matches the requested face. Full-depth
+ * placements are normalised to face: "both" at placement time, so they fall
+ * through the "both" branch without a per-device library lookup.
  */
 function filterDevicesByFace(
   devices: Rack["devices"],
   faceFilter: "front" | "rear" | undefined,
-  deviceLibrary: DeviceType[],
 ): Rack["devices"] {
   if (!faceFilter) return devices;
-  return devices.filter((d) => {
-    // Both-face devices are always visible
-    if (d.face === "both") return true;
-    // Devices on this face are visible
-    if (d.face === faceFilter) return true;
-    // Full-depth devices on the opposite face are also visible
-    const deviceType = deviceLibrary.find((dt) => dt.slug === d.device_type);
-    if (deviceType) {
-      const isFullDepth = deviceType.is_full_depth !== false;
-      if (isFullDepth) return true;
-    }
-    return false;
-  });
+  return devices.filter((d) => d.face === "both" || d.face === faceFilter);
 }
 
 /**
@@ -798,11 +789,7 @@ export function generateExportSVG(
     }
 
     // Filter and render devices
-    const filteredDevices = filterDevicesByFace(
-      rack.devices,
-      faceFilter,
-      deviceLibrary,
-    );
+    const filteredDevices = filterDevicesByFace(rack.devices, faceFilter);
     for (const placedDevice of filteredDevices) {
       const device = deviceLibrary.find(
         (d) => d.slug === placedDevice.device_type,

--- a/src/tests/export-face-filter.test.ts
+++ b/src/tests/export-face-filter.test.ts
@@ -24,6 +24,9 @@ const baseOptions: Omit<ExportOptions, "exportView"> = {
   displayMode: "label",
 };
 
+// Devices are rendered as <rect> elements coloured with the device type's
+// `colour` value, so filtering rects by fill counts how many of a given
+// device type made it into the rendered view.
 function rectsWithFill(svg: SVGElement, fill: string) {
   return Array.from(svg.getElementsByTagName("rect")).filter(
     (r) => r.getAttribute("fill") === fill,

--- a/src/tests/export-face-filter.test.ts
+++ b/src/tests/export-face-filter.test.ts
@@ -1,0 +1,120 @@
+/**
+ * PNG/SVG export — face filtering (#1681)
+ *
+ * Regression coverage: ensures the export renderer respects each placed
+ * device's `face` field so that "front" devices stay out of the rear view
+ * (and vice versa), matching the live builder preview in Rack.svelte.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateExportSVG } from "$lib/utils/export";
+import type { ExportOptions } from "$lib/types";
+import {
+  createTestRack,
+  createTestDeviceType,
+  createTestDevice,
+} from "./factories";
+
+const baseOptions: Omit<ExportOptions, "exportView"> = {
+  format: "png",
+  scope: "all",
+  includeNames: true,
+  includeLegend: false,
+  background: "solid",
+  displayMode: "label",
+};
+
+function rectsWithFill(svg: SVGElement, fill: string) {
+  return Array.from(svg.getElementsByTagName("rect")).filter(
+    (r) => r.getAttribute("fill") === fill,
+  );
+}
+
+describe("PNG export — face filtering (#1681)", () => {
+  it("hides a front-mounted device from the rear export view", () => {
+    const deviceType = createTestDeviceType({
+      slug: "front-only-server",
+      u_height: 2,
+      is_full_depth: true,
+    });
+
+    const rack = createTestRack({
+      devices: [
+        createTestDevice({
+          id: "front-1",
+          device_type: "front-only-server",
+          position: 10,
+          face: "front",
+        }),
+      ],
+    });
+
+    const rearSvg = generateExportSVG([rack], [deviceType], {
+      ...baseOptions,
+      exportView: "rear",
+    });
+
+    // eslint-disable-next-line no-restricted-syntax -- face filter must exclude opposite-face devices entirely
+    expect(rectsWithFill(rearSvg, deviceType.colour!)).toHaveLength(0);
+  });
+
+  it("renders a both-face device in both front and rear export views", () => {
+    const deviceType = createTestDeviceType({
+      slug: "both-face-server",
+      u_height: 2,
+      is_full_depth: true,
+    });
+
+    const rack = createTestRack({
+      devices: [
+        createTestDevice({
+          id: "both-1",
+          device_type: "both-face-server",
+          position: 10,
+          face: "both",
+        }),
+      ],
+    });
+
+    const frontSvg = generateExportSVG([rack], [deviceType], {
+      ...baseOptions,
+      exportView: "front",
+    });
+    const rearSvg = generateExportSVG([rack], [deviceType], {
+      ...baseOptions,
+      exportView: "rear",
+    });
+
+    // eslint-disable-next-line no-restricted-syntax -- one both-face placement must produce exactly one rect per view
+    expect(rectsWithFill(frontSvg, deviceType.colour!)).toHaveLength(1);
+    // eslint-disable-next-line no-restricted-syntax -- one both-face placement must produce exactly one rect per view
+    expect(rectsWithFill(rearSvg, deviceType.colour!)).toHaveLength(1);
+  });
+
+  it("hides a rear-mounted device from the front export view", () => {
+    const deviceType = createTestDeviceType({
+      slug: "rear-only-pdu",
+      u_height: 1,
+      is_full_depth: true,
+    });
+
+    const rack = createTestRack({
+      devices: [
+        createTestDevice({
+          id: "rear-1",
+          device_type: "rear-only-pdu",
+          position: 5,
+          face: "rear",
+        }),
+      ],
+    });
+
+    const frontSvg = generateExportSVG([rack], [deviceType], {
+      ...baseOptions,
+      exportView: "front",
+    });
+
+    // eslint-disable-next-line no-restricted-syntax -- face filter must exclude opposite-face devices entirely
+    expect(rectsWithFill(frontSvg, deviceType.colour!)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Export's `filterDevicesByFace` no longer ignores a placed device's `face` for full-depth device types — it now mirrors `Rack.svelte`'s simple "face is `both` or matches the requested face" rule.
- The unused `deviceLibrary` parameter is removed from the helper since the per-device library lookup is no longer needed.
- Adds `src/tests/export-face-filter.test.ts` covering front-only-stays-out-of-rear, rear-only-stays-out-of-front, and both-face-in-both-views.

## Why

`filterDevicesByFace` (in `src/lib/utils/export.ts`) had an extra branch that returned full-depth devices on the opposite face regardless of their mounted `face`. Most placements get normalised to `face: "both"` at placement time, so this branch was usually unreachable — but data that bypassed normalisation (older saves, NetBox imports, stale device-type metadata) could leak a front-mounted device onto the rear export panel, diverging from the live preview.

Split from #1660 per the original triage; that PR fixed half-width geometry, this one fixes the face filter.

## Test Plan

- [x] `npm run lint`
- [x] `npm run test:run` — all 1969 unit tests pass
- [x] `npm run build`
- [x] New regression tests pass (3 cases)
- [ ] Reviewer: place a front-mounted full-depth device, export Both view, verify it appears only in the Front panel

Closes #1681
Refs #1660


___

## **CodeAnt-AI Description**
**Keep front and rear exports consistent with device face placement**

### What Changed
- Exported PNG/SVG views now hide devices that are placed on the opposite side of the rack
- Devices placed on both sides still appear in both front and rear exports
- Added regression coverage for front-only, rear-only, and both-face devices in export output

### Impact
`✅ Fewer devices appearing on the wrong export side`
`✅ Consistent front and rear preview output`
`✅ Lower risk of incorrect rack exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
