### PR TITLE
refactor(api): introduce mountWithAlias helper for /api/* aliases (#1020)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -779,13 +779,17 @@ export async function createApp(
   app.use("/layouts/*", layoutBodyLimit);
   app.use("/api/layouts/*", layoutBodyLimit);
 
-  // Mount routes at root paths (nginx strips /api prefix when proxying)
-  app.route("/layouts", layouts);
-  app.route("/assets", assets);
+  // Mount each router at the root path (nginx strips /api when proxying) and
+  // at the /api/* alias for direct access. Using a helper keeps the two
+  // mounts adjacent so a new router can't be added at one path and silently
+  // missed at the other.
+  const mountWithAlias = (path: `/${string}`, router: Hono) => {
+    app.route(path, router);
+    app.route(`/api${path}`, router);
+  };
 
-  // Compatibility aliases for direct API access (without nginx proxy)
-  app.route("/api/layouts", layouts);
-  app.route("/api/assets", assets);
+  mountWithAlias("/layouts", layouts);
+  mountWithAlias("/assets", assets);
 
   // 404 handler
   app.notFound((c) => c.json({ error: "Not found" }, 404));


### PR DESCRIPTION
## **User description**
## Summary

- Introduces a local `mountWithAlias(path, router)` helper inside `createApp` that mounts each router at both the root path and the `/api/<path>` alias in one call.
- Refactors the `layouts` and `assets` mounts to use the helper.
- No functional change. The auth dual-mount block and the inline `/health` + `/api/health` lines are out of scope per the issue body (the issue example also lists health as "inline is acceptable") — happy to fold them in if reviewers prefer one consistent treatment.

## Why

Following #1009 we have dual-mounted user routers — one mount at the root path (nginx strips `/api` before forwarding) and one at `/api/<path>` (direct access without the proxy). Maintaining the two mounts by hand made it easy to add a new router at the root and silently miss the alias. Wrapping the dual mount in a one-line helper keeps the two `app.route` calls structurally adjacent, so a new router only has to be added once.

## Test Plan

- [x] `bun run typecheck` (in `api/`)
- [x] `bun test` (in `api/`) — 140 pass, 0 fail
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Reviewer: hit `GET /layouts` and `GET /api/layouts` against the API container; both should return the same response (existing behaviour, this PR is a refactor)

Closes #1020


___

## **CodeAnt-AI Description**
**Keep root and /api aliases in sync for layout and asset routes**

### What Changed
- Layout and asset pages are now mounted through one shared pattern, so each route is available at both its root path and its `/api/...` alias
- The change keeps the existing access paths working the same for users behind the proxy and for direct API access
- No user-facing behavior changed

### Impact
`✅ Fewer missing route aliases`
`✅ Consistent access to layouts and assets`
`✅ Safer route additions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
