### PR TITLE
feat: persist viewport (zoom/pan) across page reloads

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -276,7 +276,9 @@
           );
 
           requestAnimationFrame(() => {
-            canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
+            if (!canvasStore.restoreViewport()) {
+              canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
+            }
           });
           return;
         }
@@ -302,9 +304,11 @@
       // Mark as dirty since this is an autosaved session (not explicitly saved)
       layoutStore.markDirty();
       // Don't show new rack dialog - user has work in progress
-      // Reset view to center the loaded rack after DOM updates
+      // Restore saved viewport if available, otherwise fit all racks
       requestAnimationFrame(() => {
-        canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
+        if (!canvasStore.restoreViewport()) {
+          canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
+        }
       });
       return;
     }

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -21,11 +21,18 @@ import {
   DUAL_VIEW_EXTRA_HEIGHT,
 } from "$lib/constants/layout";
 import { toHumanUnits } from "$lib/utils/position";
+import {
+  safeGetItem,
+  safeSetItem,
+  safeRemoveItem,
+} from "$lib/utils/safe-storage";
 
 // Panzoom constants
 export const ZOOM_MIN = 0.25; // 25% - allows fitting 6+ large racks
 export const ZOOM_MAX = 2; // 200%
 export const ZOOM_STEP = 0.25; // 25%
+
+const VIEWPORT_KEY = "Rackula:viewport";
 
 type PanzoomInstance = ReturnType<typeof panzoom>;
 
@@ -34,6 +41,8 @@ let panzoomInstance = $state<PanzoomInstance | null>(null);
 let currentZoom = $state(1); // 1 = 100%
 let canvasElement = $state<HTMLElement | null>(null);
 let isPanning = $state(false);
+let viewportSaveTimer: ReturnType<typeof setTimeout> | null = null;
+let suppressViewportSave = false;
 
 // Derived values
 const canZoomIn = $derived(currentZoom < ZOOM_MAX);
@@ -51,6 +60,11 @@ export function resetCanvasStore(): void {
   currentZoom = 1;
   canvasElement = null;
   isPanning = false;
+  if (viewportSaveTimer) {
+    clearTimeout(viewportSaveTimer);
+    viewportSaveTimer = null;
+  }
+  suppressViewportSave = false;
 }
 
 /**
@@ -93,7 +107,59 @@ export function getCanvasStore() {
     fitAll,
     focusRack,
     zoomToDevice,
+    restoreViewport,
   };
+}
+
+function scheduleViewportSave(): void {
+  if (suppressViewportSave || !panzoomInstance) return;
+  if (viewportSaveTimer) clearTimeout(viewportSaveTimer);
+  viewportSaveTimer = setTimeout(() => {
+    if (panzoomInstance) {
+      const t = panzoomInstance.getTransform();
+      safeSetItem(
+        VIEWPORT_KEY,
+        JSON.stringify({ x: t.x, y: t.y, scale: t.scale }),
+      );
+    }
+    viewportSaveTimer = null;
+  }, 500);
+}
+
+function clearSavedViewport(): void {
+  if (viewportSaveTimer) {
+    clearTimeout(viewportSaveTimer);
+    viewportSaveTimer = null;
+  }
+  safeRemoveItem(VIEWPORT_KEY);
+}
+
+/**
+ * Restore the saved viewport transform from localStorage.
+ * Returns true if a saved viewport was found and applied.
+ * Used on page load to resume where the user left off.
+ */
+function restoreViewport(): boolean {
+  if (!panzoomInstance) return false;
+  const raw = safeGetItem(VIEWPORT_KEY);
+  if (!raw) return false;
+  try {
+    const saved = JSON.parse(raw) as { x: number; y: number; scale: number };
+    if (
+      typeof saved.x !== "number" ||
+      typeof saved.y !== "number" ||
+      typeof saved.scale !== "number"
+    ) {
+      return false;
+    }
+    const scale = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, saved.scale));
+    panzoomInstance.zoomAbs(0, 0, scale);
+    panzoomInstance.moveTo(saved.x, saved.y);
+    currentZoom = scale;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -102,10 +168,11 @@ export function getCanvasStore() {
 function setPanzoomInstance(instance: PanzoomInstance): void {
   panzoomInstance = instance;
 
-  // Listen for zoom changes to keep state in sync
+  // Listen for zoom changes to keep state in sync, and debounce-save viewport
   instance.on("zoom", () => {
     const transform = instance.getTransform();
     currentZoom = transform.scale;
+    scheduleViewportSave();
   });
 
   // Track panning state to prevent accidental selection after pan
@@ -117,6 +184,7 @@ function setPanzoomInstance(instance: PanzoomInstance): void {
     setTimeout(() => {
       isPanning = false;
     }, 50);
+    scheduleViewportSave();
   });
 
   // Initialize currentZoom from panzoom
@@ -178,8 +246,11 @@ function setZoom(scale: number): void {
 function resetZoom(): void {
   if (!panzoomInstance) return;
 
+  suppressViewportSave = true;
+  clearSavedViewport();
   panzoomInstance.zoomAbs(0, 0, 1);
   panzoomInstance.moveTo(0, 0);
+  suppressViewportSave = false;
 }
 
 /**
@@ -250,6 +321,9 @@ function fitAll(
 ): void {
   if (!panzoomInstance || !canvasElement || racks.length === 0) return;
 
+  suppressViewportSave = true;
+  clearSavedViewport();
+
   // Get viewport dimensions, accounting for any right-side overlay
   const viewportWidth = canvasElement.clientWidth - rightOffset;
   const viewportHeight = canvasElement.clientHeight;
@@ -275,6 +349,8 @@ function fitAll(
   panzoomInstance.moveTo(panX, panY);
 
   canvasDebug.transform("fitAll applied: %o", panzoomInstance.getTransform());
+
+  suppressViewportSave = false;
 }
 
 /**

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -60,10 +60,7 @@ export function resetCanvasStore(): void {
   currentZoom = 1;
   canvasElement = null;
   isPanning = false;
-  if (viewportSaveTimer) {
-    clearTimeout(viewportSaveTimer);
-    viewportSaveTimer = null;
-  }
+  cancelViewportSave();
   suppressViewportSave = false;
 }
 
@@ -117,6 +114,11 @@ function scheduleViewportSave(): void {
   viewportSaveTimer = setTimeout(() => {
     if (panzoomInstance) {
       const t = panzoomInstance.getTransform();
+      canvasDebug.transform("viewport save: %o", {
+        x: t.x,
+        y: t.y,
+        scale: t.scale,
+      });
       safeSetItem(
         VIEWPORT_KEY,
         JSON.stringify({ x: t.x, y: t.y, scale: t.scale }),
@@ -126,12 +128,11 @@ function scheduleViewportSave(): void {
   }, 500);
 }
 
-function clearSavedViewport(): void {
+function cancelViewportSave(): void {
   if (viewportSaveTimer) {
     clearTimeout(viewportSaveTimer);
     viewportSaveTimer = null;
   }
-  safeRemoveItem(VIEWPORT_KEY);
 }
 
 /**
@@ -146,18 +147,27 @@ function restoreViewport(): boolean {
   try {
     const saved = JSON.parse(raw) as { x: number; y: number; scale: number };
     if (
-      typeof saved.x !== "number" ||
-      typeof saved.y !== "number" ||
-      typeof saved.scale !== "number"
+      !Number.isFinite(saved.x) ||
+      !Number.isFinite(saved.y) ||
+      !Number.isFinite(saved.scale)
     ) {
+      // Remove corrupted entry so future saves can work correctly
+      safeRemoveItem(VIEWPORT_KEY);
       return false;
     }
     const scale = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, saved.scale));
+    canvasDebug.transform("viewport restore: %o", {
+      x: saved.x,
+      y: saved.y,
+      scale,
+    });
     panzoomInstance.zoomAbs(0, 0, scale);
     panzoomInstance.moveTo(saved.x, saved.y);
     currentZoom = scale;
     return true;
   } catch {
+    // Remove unparseable entry so it doesn't block future restores
+    safeRemoveItem(VIEWPORT_KEY);
     return false;
   }
 }
@@ -247,7 +257,7 @@ function resetZoom(): void {
   if (!panzoomInstance) return;
 
   suppressViewportSave = true;
-  clearSavedViewport();
+  cancelViewportSave();
   panzoomInstance.zoomAbs(0, 0, 1);
   panzoomInstance.moveTo(0, 0);
   suppressViewportSave = false;
@@ -322,7 +332,7 @@ function fitAll(
   if (!panzoomInstance || !canvasElement || racks.length === 0) return;
 
   suppressViewportSave = true;
-  clearSavedViewport();
+  cancelViewportSave();
 
   // Get viewport dimensions, accounting for any right-side overlay
   const viewportWidth = canvasElement.clientWidth - rightOffset;

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -105,6 +105,7 @@ export function getCanvasStore() {
     focusRack,
     zoomToDevice,
     restoreViewport,
+    clearSavedViewport,
   };
 }
 
@@ -133,6 +134,11 @@ function cancelViewportSave(): void {
     clearTimeout(viewportSaveTimer);
     viewportSaveTimer = null;
   }
+}
+
+function clearSavedViewport(): void {
+  cancelViewportSave();
+  safeRemoveItem(VIEWPORT_KEY);
 }
 
 /**
@@ -206,6 +212,7 @@ function setPanzoomInstance(instance: PanzoomInstance): void {
  * Dispose panzoom instance (called from Canvas component on unmount)
  */
 function disposePanzoom(): void {
+  cancelViewportSave();
   if (panzoomInstance) {
     panzoomInstance.dispose();
     panzoomInstance = null;
@@ -257,7 +264,7 @@ function resetZoom(): void {
   if (!panzoomInstance) return;
 
   suppressViewportSave = true;
-  cancelViewportSave();
+  clearSavedViewport();
   panzoomInstance.zoomAbs(0, 0, 1);
   panzoomInstance.moveTo(0, 0);
   suppressViewportSave = false;

--- a/src/lib/utils/persistence-manager.svelte.ts
+++ b/src/lib/utils/persistence-manager.svelte.ts
@@ -65,6 +65,7 @@ export function handleFitAll(): void {
   const uiStore = getUIStore();
   const canvasStore = getCanvasStore();
   const rightOffset = uiStore.rightDrawerOpen ? DRAWER_WIDTH : 0;
+  canvasStore.clearSavedViewport();
   canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups, rightOffset);
 }
 


### PR DESCRIPTION
## **User description**
## Summary

- Saves the panzoom transform (`x`, `y`, `scale`) to `localStorage` under `Rackula:viewport` after every zoom or `panend` event, debounced 500 ms
- On page load, when restoring a local autosave session, tries `restoreViewport()` first and falls back to `fitAll()` if no saved state exists
- Clicking **Reset View** (fit-all) or **Reset Zoom** clears the saved viewport so the next reload returns to a clean fit-all view
- Front/rear view per rack was already persisted as part of the layout autosave — no additional work needed

## Why

Fixes #118 — users lost their zoom level and pan position on every page reload and had to click "Fit All" each time. This change makes the canvas resume exactly where the user left off.

## Implementation notes

- `canvas.svelte.ts`: added `scheduleViewportSave` (debounced), `clearSavedViewport`, and `restoreViewport` helpers; `fitAll` and `resetZoom` clear the saved state so "Reset View" gives a fresh fit-all on next load; `suppressViewportSave` flag prevents the programmatic panzoom events inside `fitAll`/`resetZoom` from re-saving the cleared state
- `App.svelte`: the two local-session restore paths (local-newer-than-server and offline-local) now call `restoreViewport()` before falling back to `fitAll()`. Share-link and server-newer paths keep `fitAll()` since they load a different/fresh layout.

## Test plan

- [ ] Pan/zoom in app → reload page → viewport is restored to same position
- [ ] Click Reset View (F) → reload page → page shows fit-all view (not previous pan/zoom)
- [ ] Click Reset Zoom → reload page → page shows 100% zoom centered
- [ ] Load from share link → fit-all applied (not stale viewport)
- [ ] First load (no autosave) → fit-all applied normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUNC8Z1GFmBnXR4UDsocvH)_


___

## **CodeAnt-AI Description**
**Keep zoom and pan after reloading a local session**

### What Changed
- When reopening unsaved work, the canvas now returns to the last zoom and pan position instead of always starting with a full fit
- If no saved view exists, the canvas still opens in a fit-all view
- Reset View and Reset Zoom now clear the saved view, so the next reload starts clean

### Impact
`✅ Resumes the same canvas view after refresh`
`✅ Fewer repeat fit-all clicks after reload`
`✅ Clean restart after resetting the view`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
