### PR TITLE
fix: correct unit conversion in rack-resize validator (#1683, #1624)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -259,7 +259,7 @@
         "@babel/helper-optimise-call-expression": "^7.27.1",
         "@babel/helper-replace-supers": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -435,9 +435,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -708,9 +708,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "dev": true,
       "funding": [
         {
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
       "dev": true,
       "funding": [
         {
@@ -749,7 +749,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.0"
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
       "dev": true,
       "funding": [
         {
@@ -1483,25 +1483,39 @@
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1632,6 +1646,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1649,6 +1666,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1666,6 +1686,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1683,6 +1706,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1700,6 +1726,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1717,6 +1746,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1734,6 +1766,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1751,6 +1786,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1768,6 +1806,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1791,6 +1832,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1814,6 +1858,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1837,6 +1884,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1860,6 +1910,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1883,6 +1936,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1906,6 +1962,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1929,6 +1988,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2035,14 +2097,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.3.tgz",
-      "integrity": "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.5.tgz",
+      "integrity": "sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/figures": "^2.0.5",
         "@inquirer/type": "^4.0.5"
       },
@@ -2059,13 +2121,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
-      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+      "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -2081,9 +2143,9 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
-      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+      "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2108,13 +2170,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.0.tgz",
-      "integrity": "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.2.tgz",
+      "integrity": "sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/external-editor": "^3.0.0",
         "@inquirer/type": "^4.0.5"
       },
@@ -2131,13 +2193,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.12.tgz",
-      "integrity": "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.14.tgz",
+      "integrity": "sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -2185,13 +2247,13 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.11.tgz",
-      "integrity": "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.13.tgz",
+      "integrity": "sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -2207,13 +2269,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.11.tgz",
-      "integrity": "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.13.tgz",
+      "integrity": "sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -2229,14 +2291,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.11.tgz",
-      "integrity": "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.13.tgz",
+      "integrity": "sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -2252,22 +2314,22 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.1.tgz",
-      "integrity": "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.3.tgz",
+      "integrity": "sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.1.3",
-        "@inquirer/confirm": "^6.0.11",
-        "@inquirer/editor": "^5.1.0",
-        "@inquirer/expand": "^5.0.12",
-        "@inquirer/input": "^5.0.11",
-        "@inquirer/number": "^4.0.11",
-        "@inquirer/password": "^5.0.11",
-        "@inquirer/rawlist": "^5.2.7",
-        "@inquirer/search": "^4.1.7",
-        "@inquirer/select": "^5.1.3"
+        "@inquirer/checkbox": "^5.1.5",
+        "@inquirer/confirm": "^6.0.13",
+        "@inquirer/editor": "^5.1.2",
+        "@inquirer/expand": "^5.0.14",
+        "@inquirer/input": "^5.0.13",
+        "@inquirer/number": "^4.0.13",
+        "@inquirer/password": "^5.0.13",
+        "@inquirer/rawlist": "^5.2.9",
+        "@inquirer/search": "^4.1.9",
+        "@inquirer/select": "^5.1.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -2282,13 +2344,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.7.tgz",
-      "integrity": "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w==",
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.9.tgz",
+      "integrity": "sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -2304,13 +2366,13 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.7.tgz",
-      "integrity": "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.9.tgz",
+      "integrity": "sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/figures": "^2.0.5",
         "@inquirer/type": "^4.0.5"
       },
@@ -2327,14 +2389,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.3.tgz",
-      "integrity": "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.5.tgz",
+      "integrity": "sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.10",
         "@inquirer/figures": "^2.0.5",
         "@inquirer/type": "^4.0.5"
       },
@@ -2570,6 +2632,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2587,6 +2652,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2604,6 +2672,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2621,6 +2692,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2638,6 +2712,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2655,6 +2732,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2847,6 +2927,19 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@stryker-mutator/util": {
@@ -3070,9 +3163,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/js-yaml": {
@@ -3738,9 +3831,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.10.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+      "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3791,9 +3884,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3884,9 +3977,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -4346,9 +4439,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
-      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.4.tgz",
+      "integrity": "sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4370,9 +4463,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.338",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.338.tgz",
-      "integrity": "sha512-KVQQ3xko9/coDX3qXLUEEbqkKT8L+1DyAovrtu0Khtrt9wjSZ+7CZV4GVzxFy9Oe1NbrIU1oVXCwHJruIA1PNg==",
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
       "dev": true,
       "license": "ISC"
     },
@@ -4430,9 +4523,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4683,9 +4776,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4770,9 +4863,9 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
-      "integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -4968,9 +5061,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/figures": {
@@ -5247,9 +5340,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5604,9 +5697,9 @@
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5895,6 +5988,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5916,6 +6012,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5937,6 +6036,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5958,6 +6060,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6024,9 +6129,9 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.4.tgz",
-      "integrity": "sha512-+rU9lSUyVOZ/hDUmRLVGzyS2v73cDdQjX+XQz1AaOdIE4RysLq0HoPW2HrrgeNCLklkhi904VBU1bmgWLHVnkA==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
+      "integrity": "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6209,13 +6314,13 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
+        "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
@@ -6406,9 +6511,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6893,9 +6998,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -7272,9 +7377,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7461,9 +7566,9 @@
       }
     },
     "node_modules/simple-icons": {
-      "version": "16.19.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.19.0.tgz",
-      "integrity": "sha512-muxcz/FDvWFPrKJdsjaz79qsBjtZeVKUVIFl7wLVOwb+yqAag8FPe8+hFlMVRnmAXYQIm4eUDDm2+dhOj0cFgQ==",
+      "version": "16.20.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.20.0.tgz",
+      "integrity": "sha512-2b7Xu+Zy+iwLiuLSAcWuxnM1ETNFy7JmxWSjh0Y/A8P3KGjFFcokbpWbUf/IivMNbR9WuZ/QQlirh5bGh3Q2vA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7718,9 +7823,9 @@
       }
     },
     "node_modules/svelte-eslint-parser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.6.0.tgz",
-      "integrity": "sha512-qoB1ehychT6OxEtQAqc/guSqLS20SlA53Uijl7x375s8nlUT0lb9ol/gzraEEatQwsyPTJo87s2CmKL9Xab+Uw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.6.1.tgz",
+      "integrity": "sha512-hhvSH6kRj46UzrBVO5TaotD+Iuvruj5ccKBcO4wAhVcPTLmIc/c32D8UllBTYO0on4LzYuM0rNzf1lM/gBlkSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7734,7 +7839,7 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
-        "pnpm": "10.30.3"
+        "pnpm": "10.33.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
@@ -7903,22 +8008,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.30"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7978,9 +8083,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
-      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8045,15 +8150,15 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.0.tgz",
-      "integrity": "sha512-FfBj5tjviexjIus3La4n4s9i+f81Zj7HU+lUlQWK219HMRfmzLsbIf4PZF2+X6EouJKyuANpvvef5VrUWM4AFw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.14.1",
+        "qs": "6.15.1",
         "tunnel": "0.0.6",
         "underscore": "^1.13.8"
       },
@@ -8590,9 +8695,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/lib/utils/rack-resize.test.ts
+++ b/src/lib/utils/rack-resize.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import { canResizeRackTo, getDeviceRangeText } from "./rack-resize";
+import { createTestRack, createTestDeviceType } from "../../tests/factories";
+import { toInternalUnits } from "./position";
+import type { PlacedDevice } from "$lib/types";
+
+/**
+ * Regression tests for the rack-resize unit-mismatch bug.
+ *
+ * Background: `PlacedDevice.position` is stored in internal units (1/6U,
+ * UNITS_PER_U = 6). `DeviceType.u_height` and `Rack.height` are in human U.
+ * The old implementation mixed the two:
+ *   - canResizeRackTo computed `position + uHeight - 1` then compared to
+ *     `newHeight` (human U), producing phantom conflicts (#1624).
+ *   - getDeviceRangeText returned the raw internal position as the bottom U
+ *     label, producing nonsense like "U30" or "U228" (#1683).
+ */
+
+describe("canResizeRackTo — unit-mismatch regression (#1624)", () => {
+  it("allows shrink when devices fit in human-U terms", () => {
+    const deviceType = createTestDeviceType({ slug: "srv-1u", u_height: 1 });
+    const rack = createTestRack({
+      height: 12,
+      devices: [
+        {
+          id: "d1",
+          device_type: "srv-1u",
+          position: toInternalUnits(1),
+          face: "front",
+        },
+        {
+          id: "d2",
+          device_type: "srv-1u",
+          position: toInternalUnits(2),
+          face: "front",
+        },
+        {
+          id: "d3",
+          device_type: "srv-1u",
+          position: toInternalUnits(3),
+          face: "front",
+        },
+      ],
+    });
+
+    const result = canResizeRackTo(rack, 6, [deviceType]);
+    expect(result.allowed).toBe(true);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("correctly rejects shrink when device top exceeds new height", () => {
+    const deviceType = createTestDeviceType({ slug: "srv-2u", u_height: 2 });
+    const rack = createTestRack({
+      height: 12,
+      devices: [
+        {
+          id: "d1",
+          device_type: "srv-2u",
+          position: toInternalUnits(10),
+          face: "front",
+        }, // occupies U10–U11
+      ],
+    });
+
+    const result = canResizeRackTo(rack, 9, [deviceType]);
+    expect(result.allowed).toBe(false);
+    expect(result.conflicts.map((c) => c.id)).toEqual(["d1"]);
+  });
+
+  it("allows shrink that exactly matches the highest device top", () => {
+    const deviceType = createTestDeviceType({ slug: "srv-2u", u_height: 2 });
+    const rack = createTestRack({
+      height: 12,
+      devices: [
+        {
+          id: "d1",
+          device_type: "srv-2u",
+          position: toInternalUnits(9),
+          face: "front",
+        }, // occupies U9–U10
+      ],
+    });
+
+    // New height 10 should fit the device that ends at U10 exactly.
+    const result = canResizeRackTo(rack, 10, [deviceType]);
+    expect(result.allowed).toBe(true);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("treats growing the rack as always allowed", () => {
+    const deviceType = createTestDeviceType({ slug: "srv-1u", u_height: 1 });
+    const rack = createTestRack({
+      height: 12,
+      devices: [
+        {
+          id: "d1",
+          device_type: "srv-1u",
+          position: toInternalUnits(11),
+          face: "front",
+        },
+      ],
+    });
+
+    const result = canResizeRackTo(rack, 42, [deviceType]);
+    expect(result.allowed).toBe(true);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("handles half-U devices on fractional boundaries", () => {
+    // A 0.5U device at U6 occupies the lower half of U6 (positions 36–38
+    // internally). It fits in a 6U rack but not in a 5U one.
+    const deviceType = createTestDeviceType({
+      slug: "srv-half",
+      u_height: 0.5,
+    });
+    const rack = createTestRack({
+      height: 12,
+      devices: [
+        {
+          id: "d1",
+          device_type: "srv-half",
+          position: toInternalUnits(6),
+          face: "front",
+        },
+      ],
+    });
+
+    expect(canResizeRackTo(rack, 6, [deviceType]).allowed).toBe(true);
+    expect(canResizeRackTo(rack, 5, [deviceType]).allowed).toBe(false);
+  });
+});
+
+describe("getDeviceRangeText — display regression (#1683)", () => {
+  it("renders single-U device as human U, not internal units", () => {
+    const deviceType = createTestDeviceType({ slug: "srv-1u", u_height: 1 });
+    const device: PlacedDevice = {
+      id: "d1",
+      device_type: "srv-1u",
+      position: toInternalUnits(5), // internal = 30
+      face: "front",
+    };
+
+    expect(getDeviceRangeText(device, deviceType)).toBe("U5");
+  });
+
+  it("renders multi-U device range as human U", () => {
+    const deviceType = createTestDeviceType({ slug: "srv-2u", u_height: 2 });
+    const device: PlacedDevice = {
+      id: "d1",
+      device_type: "srv-2u",
+      position: toInternalUnits(5),
+      face: "front",
+    };
+
+    expect(getDeviceRangeText(device, deviceType)).toBe("U5-6");
+  });
+
+  it("renders 3U device range correctly", () => {
+    const deviceType = createTestDeviceType({ slug: "srv-3u", u_height: 3 });
+    const device: PlacedDevice = {
+      id: "d1",
+      device_type: "srv-3u",
+      position: toInternalUnits(10),
+      face: "front",
+    };
+
+    expect(getDeviceRangeText(device, deviceType)).toBe("U10-12");
+  });
+
+  it("falls back to 1U when the device type is unknown", () => {
+    const device: PlacedDevice = {
+      id: "d1",
+      device_type: "missing",
+      position: toInternalUnits(7),
+      face: "front",
+    };
+
+    expect(getDeviceRangeText(device, undefined)).toBe("U7");
+  });
+});

--- a/src/lib/utils/rack-resize.ts
+++ b/src/lib/utils/rack-resize.ts
@@ -5,103 +5,115 @@
  * Issue #115: Allow growing always, shrinking only when devices fit.
  */
 
-import type { Rack, DeviceType, PlacedDevice } from '$lib/types';
+import type { Rack, DeviceType, PlacedDevice } from "$lib/types";
+import { UNITS_PER_U } from "$lib/types/constants";
+import { heightToInternalUnits, toHumanUnits } from "./position";
 
 /**
  * Result of resize validation
  */
 export interface ResizeValidationResult {
-	/** Whether the resize is allowed */
-	allowed: boolean;
-	/** List of devices that would exceed new bounds */
-	conflicts: PlacedDevice[];
+  /** Whether the resize is allowed */
+  allowed: boolean;
+  /** List of devices that would exceed new bounds */
+  conflicts: PlacedDevice[];
 }
 
 /**
  * Conflict with enriched device type information
  */
 export interface ConflictInfo {
-	device: PlacedDevice;
-	deviceType: DeviceType | undefined;
+  device: PlacedDevice;
+  deviceType: DeviceType | undefined;
 }
 
 /**
- * Check if a rack can be resized to a new height
+ * Check if a rack can be resized to a new height.
  *
  * Rules:
- * - Growing is always allowed
- * - Shrinking is blocked if any device's top position exceeds new height
- * - Conflict formula: position + u_height - 1 > newHeight
+ * - Growing is always allowed.
+ * - Shrinking is blocked if any device's top exceeds the new height.
+ *
+ * Unit note: `device.position` is stored in internal units (1/6U,
+ * `UNITS_PER_U = 6`), while `rack.height`, `newHeight`, and `u_height`
+ * are in human U. The comparison is performed entirely in internal units
+ * to avoid mixing the two systems.
  *
  * @param rack - The rack to check
- * @param newHeight - The proposed new height
+ * @param newHeight - The proposed new height, in human U
  * @param deviceTypes - Device type library for u_height lookup
  * @returns Validation result with conflicts if any
  */
 export function canResizeRackTo(
-	rack: Rack,
-	newHeight: number,
-	deviceTypes: DeviceType[]
+  rack: Rack,
+  newHeight: number,
+  deviceTypes: DeviceType[],
 ): ResizeValidationResult {
-	// Growing is always allowed
-	if (newHeight >= rack.height) {
-		return { allowed: true, conflicts: [] };
-	}
+  // Growing is always allowed
+  if (newHeight >= rack.height) {
+    return { allowed: true, conflicts: [] };
+  }
 
-	// Shrinking - check each device
-	const conflicts: PlacedDevice[] = [];
+  // Shrinking - compare device top to new height in internal units.
+  // Mirrors the canonical formula in collision.ts:
+  //   topPosition = position + heightInternal - 1
+  //   maxValidTop = rack.height * UNITS_PER_U + (UNITS_PER_U - 1)
+  const maxValidTopInternal = newHeight * UNITS_PER_U + (UNITS_PER_U - 1);
+  const conflicts: PlacedDevice[] = [];
 
-	for (const device of rack.devices) {
-		const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
-		const uHeight = deviceType?.u_height ?? 1; // Default to 1U if unknown
+  for (const device of rack.devices) {
+    const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
+    const uHeight = deviceType?.u_height ?? 1; // Default to 1U if unknown
+    const heightInternal = heightToInternalUnits(uHeight);
+    const deviceTopInternal = device.position + heightInternal - 1;
 
-		// Calculate device top position (accounting for 0.5U devices)
-		const deviceTop = device.position + uHeight - 1;
-		const effectiveTop = Math.ceil(deviceTop); // Round up for fractional U
+    if (deviceTopInternal > maxValidTopInternal) {
+      conflicts.push(device);
+    }
+  }
 
-		if (effectiveTop > newHeight) {
-			conflicts.push(device);
-		}
-	}
-
-	return {
-		allowed: conflicts.length === 0,
-		conflicts
-	};
+  return {
+    allowed: conflicts.length === 0,
+    conflicts,
+  };
 }
 
 /**
- * Get human-readable U range text for a device
+ * Get human-readable U range text for a device.
+ *
+ * Converts the internal-unit position back into human U values for display.
+ * Fractional bottom positions (e.g. half-U devices on 0.5U boundaries) are
+ * rounded up to the nearest whole U so the label remains human-friendly.
  *
  * @example
  * getDeviceRangeText(device, { u_height: 1 }) // "U15"
  * getDeviceRangeText(device, { u_height: 3 }) // "U10-12"
  */
 export function getDeviceRangeText(
-	device: PlacedDevice,
-	deviceType: DeviceType | undefined
+  device: PlacedDevice,
+  deviceType: DeviceType | undefined,
 ): string {
-	const uHeight = deviceType?.u_height ?? 1;
-	const bottom = device.position;
-	const top = Math.ceil(device.position + uHeight - 1);
+  const uHeight = deviceType?.u_height ?? 1;
+  const bottom = Math.ceil(toHumanUnits(device.position));
+  const top = bottom + Math.ceil(uHeight) - 1;
 
-	if (top === bottom) {
-		return `U${bottom}`;
-	}
-	return `U${bottom}-${top}`;
+  if (top === bottom) {
+    return `U${bottom}`;
+  }
+  return `U${bottom}-${top}`;
 }
 
 /**
  * Get detailed conflict information with device types
  */
 export function getConflictDetails(
-	conflicts: PlacedDevice[],
-	deviceTypes: DeviceType[]
+  conflicts: PlacedDevice[],
+  deviceTypes: DeviceType[],
 ): ConflictInfo[] {
-	return conflicts.map((device) => ({
-		device,
-		deviceType: deviceTypes.find((dt) => dt.slug === device.device_type)
-	}));
+  return conflicts.map((device) => ({
+    device,
+    deviceType: deviceTypes.find((dt) => dt.slug === device.device_type),
+  }));
 }
 
 /**
@@ -111,11 +123,12 @@ export function getConflictDetails(
  * formatConflictMessage(conflicts) // "Switch at U40, Storage at U38-40"
  */
 export function formatConflictMessage(conflicts: ConflictInfo[]): string {
-	return conflicts
-		.map(({ device, deviceType }) => {
-			const name = device.name ?? deviceType?.model ?? deviceType?.slug ?? 'Device';
-			const range = getDeviceRangeText(device, deviceType);
-			return `${name} at ${range}`;
-		})
-		.join(', ');
+  return conflicts
+    .map(({ device, deviceType }) => {
+      const name =
+        device.name ?? deviceType?.model ?? deviceType?.slug ?? "Device";
+      const range = getDeviceRangeText(device, deviceType);
+      return `${name} at ${range}`;
+    })
+    .join(", ");
 }

--- a/src/lib/utils/rack-resize.ts
+++ b/src/lib/utils/rack-resize.ts
@@ -63,8 +63,12 @@ export function canResizeRackTo(
 
   for (const device of rack.devices) {
     const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
-    const uHeight = deviceType?.u_height ?? 1; // Default to 1U if unknown
-    const heightInternal = heightToInternalUnits(uHeight);
+    if (!deviceType) {
+      throw new Error(
+        `Cannot validate resize: unknown device type "${device.device_type}" for device ${device.name ?? device.id}`,
+      );
+    }
+    const heightInternal = heightToInternalUnits(deviceType.u_height);
     const deviceTopInternal = device.position + heightInternal - 1;
 
     if (deviceTopInternal > maxValidTopInternal) {
@@ -93,9 +97,13 @@ export function getDeviceRangeText(
   device: PlacedDevice,
   deviceType: DeviceType | undefined,
 ): string {
-  const uHeight = deviceType?.u_height ?? 1;
+  if (!deviceType) {
+    throw new Error(
+      `Cannot format device range: unknown device type "${device.device_type}" for device ${device.name ?? device.id}`,
+    );
+  }
   const bottom = Math.ceil(toHumanUnits(device.position));
-  const top = bottom + Math.ceil(uHeight) - 1;
+  const top = bottom + Math.ceil(deviceType.u_height) - 1;
 
   if (top === bottom) {
     return `U${bottom}`;


### PR DESCRIPTION
## **User description**
## Summary

The rack-resize validator and its display formatter mixed two unit systems:
`PlacedDevice.position` is stored in internal units (1/6U, `UNITS_PER_U = 6`),
but `Rack.height`, `newHeight`, and `DeviceType.u_height` are in human U.

The old code computed `position + uHeight - 1` (mixed units) and compared it
directly to `newHeight` (human U). Symptoms:

- **#1624** Phantom conflicts blocked valid resizes — e.g. a 1U device at U1
  produced a "top" of `6 + 1 - 1 = 6` and falsely tripped the conflict check
  whenever the new height was ≤ 6U.
- **#1683** Error labels showed nonsense U numbers like "U30" or "U228" on a
  42U rack, because `getDeviceRangeText` echoed the raw internal position as
  the bottom U.

## Fix

`canResizeRackTo` now does the comparison entirely in internal units, mirroring
the canonical formula already used in `src/lib/utils/collision.ts`:

```ts
const maxValidTopInternal = newHeight * UNITS_PER_U + (UNITS_PER_U - 1);
const deviceTopInternal = device.position + heightInternal - 1;
```

`getDeviceRangeText` converts `device.position` back to human U with
`toHumanUnits` before building the label.

Function signatures are unchanged — both call sites (`EditPanel.svelte`,
`RackEditSheet.svelte`) already pass human U for `newHeight`, so no caller
changes are required.

## Test plan

- [x] 9 new unit tests in `src/lib/utils/rack-resize.test.ts` covering:
  - shrink-allowed when devices fit in human-U terms (#1624 regression)
  - shrink-blocked when device top exceeds new height
  - exact-fit (device top == new height) is allowed
  - growing is always allowed
  - half-U device on a 0.5U boundary
  - display path for 1U / 2U / 3U / unknown-type cases (#1683 regression)
- [x] `npm run test:run` — 1978 tests pass (97 files), zero regressions
- [x] `npm run lint` clean, `npm run build` green
- [x] CodeRabbit local review (`coderabbit --prompt-only --type uncommitted`): **No findings**

## Manual smoke (recommended for reviewer)

These browser checks were not driven by this agent and should be confirmed
before merge:

1. Create a 12U rack, place three 1U devices at U1, U2, U3. Resize to 6U — must succeed (regression check for #1624).
2. Place a 1U device at U5 in a 12U rack, try to resize to 2U — the conflict toast/inline error should read **"U5"**, not "U30" (regression check for #1683).
3. Place a 2U device occupying U9–U10 in a 42U rack, resize to exactly 10U — should succeed (exact-fit).
4. Place a 0.5U device at U6 in a 12U rack, resize to 6U — should succeed; to 5U — should report a conflict at "U6".
5. Open a rack at its original height, then try to resize down past a device — error message wording is human-readable U numbers.

Closes #1683
Closes #1624


___

## **CodeAnt-AI Description**
**Fix rack resize checks and device labels**

### What Changed
- Shrinking a rack now only blocks devices that truly extend past the new height, so valid downsizes are no longer rejected.
- Device range labels now show the correct human rack units instead of internal position numbers.
- Half-U and exact-fit edge cases are handled consistently in resize checks and displayed ranges.

### Impact
`✅ Fewer blocked rack shrinks`
`✅ Clearer device conflict messages`
`✅ Correct U labels in resize errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
