### PR TITLE
fix: sync layout.name to first rack on creation (#1481, #1482)

### DIFF
--- a/src/lib/stores/commands/rack.ts
+++ b/src/lib/stores/commands/rack.ts
@@ -22,23 +22,67 @@ export interface RackCommandStore {
 }
 
 /**
+ * Snapshot of the previous layout-level names captured before a first-rack
+ * sync, used to restore them on undo.
+ */
+export interface LayoutNameSnapshot {
+  /** Previous value of `layout.name`. */
+  previousLayoutName: string;
+  /** Previous value of `layout.metadata.name`, if metadata exists. */
+  previousMetadataName?: string;
+}
+
+/**
+ * Optional layout-name sync directive for createAddRackCommand. When provided,
+ * the command will update `layout.name` and `layout.metadata.name` to the new
+ * rack's name on execute(), and restore the previous values on undo().
+ */
+export interface AddRackLayoutNameSync {
+  /** Whether the previous layout had a metadata block at the time of capture. */
+  hasMetadata: boolean;
+  /** Snapshot of names to restore on undo. */
+  snapshot: LayoutNameSnapshot;
+}
+
+/**
  * Interface for layout store operations needed by rack add/delete commands
  */
 export interface RackLifecycleCommandStore {
   addRackRaw(rack: Rack): void;
-  deleteRackRaw(id: string): { rack: Rack; index: number; groups: RackGroup[] } | undefined;
+  deleteRackRaw(
+    id: string,
+  ): { rack: Rack; index: number; groups: RackGroup[] } | undefined;
   restoreRackRaw(rack: Rack, groups: RackGroup[], originalIndex?: number): void;
   setActiveRackId(id: string | null): void;
+  /**
+   * Write both `layout.name` and `layout.metadata.name` directly (bypasses
+   * history and dirty tracking). Used by createAddRackCommand to sync the
+   * layout name when the first rack is added, and to restore it on undo.
+   *
+   * - `name` is written verbatim (no trimming, no empty-skip guard) so undo
+   *   can restore arbitrary previous values exactly.
+   * - When `metadataName` is `undefined`, `layout.metadata.name` is left
+   *   untouched (e.g., layouts without metadata).
+   */
+  setLayoutNamesRaw(name: string, metadataName: string | undefined): void;
 }
 
 /**
  * Create a command to add a rack
+ *
+ * When `layoutNameSync` is provided, this command also syncs
+ * `layout.name` and `layout.metadata.name` to the new rack's name on
+ * `execute()` and restores the previous values on `undo()`. This is used
+ * to keep the layout's display name in sync with the first rack a user
+ * creates (#1482), while preserving full undo correctness.
  */
 export function createAddRackCommand(
   rack: Rack,
   store: RackLifecycleCommandStore,
   /** When true, execute() will also set this rack as active (for redo) */
   setActive = false,
+  /** Optional sync of layout-level names (#1482). */
+  layoutNameSync?: AddRackLayoutNameSync,
 ): Command {
   // Deep copy to avoid mutation issues
   const rackCopy = JSON.parse(JSON.stringify(rack)) as Rack;
@@ -52,9 +96,19 @@ export function createAddRackCommand(
       if (setActive) {
         store.setActiveRackId(rackCopy.id);
       }
+      if (layoutNameSync) {
+        const newName = rackCopy.name;
+        const metadataName = layoutNameSync.hasMetadata ? newName : undefined;
+        store.setLayoutNamesRaw(newName, metadataName);
+      }
     },
     undo() {
       store.deleteRackRaw(rackCopy.id);
+      if (layoutNameSync) {
+        const { previousLayoutName, previousMetadataName } =
+          layoutNameSync.snapshot;
+        store.setLayoutNamesRaw(previousLayoutName, previousMetadataName);
+      }
     },
   };
 }

--- a/src/lib/stores/layout/mutators.ts
+++ b/src/lib/stores/layout/mutators.ts
@@ -472,11 +472,13 @@ export function getPlacedDevicesWithRackForType(
   ctx: LayoutStateAccess,
   slug: string,
 ): { rackId: string; device: PlacedDevice }[] {
-  return ctx.getLayout().racks.flatMap((rack) =>
-    rack.devices
-      .filter((d) => d.device_type === slug)
-      .map((d) => ({ rackId: rack.id, device: d })),
-  );
+  return ctx
+    .getLayout()
+    .racks.flatMap((rack) =>
+      rack.devices
+        .filter((d) => d.device_type === slug)
+        .map((d) => ({ rackId: rack.id, device: d })),
+    );
 }
 
 // =============================================================================
@@ -563,6 +565,42 @@ export function restoreRackDevicesRaw(
     ...rack,
     devices: [...safeDevices],
   }));
+}
+
+// =============================================================================
+// Layout-Level Raw Mutators
+// =============================================================================
+
+/**
+ * Write both `layout.name` and `layout.metadata.name` directly (raw).
+ *
+ * This bypasses the `setLayoutName` action's trim/empty-skip guard so that
+ * undo can faithfully restore any previously-captured value (including
+ * pre-trimmed names). Used by `createAddRackCommand` when syncing the
+ * layout name on first-rack creation (#1482).
+ *
+ * @param ctx - Layout state access
+ * @param name - New value for `layout.name` (written verbatim)
+ * @param metadataName - New value for `layout.metadata.name`. When
+ *   `undefined` or when the layout has no metadata block, `metadata.name`
+ *   is left untouched.
+ */
+export function setLayoutNamesRaw(
+  ctx: LayoutStateAccess,
+  name: string,
+  metadataName: string | undefined,
+): void {
+  const layout = ctx.getLayout();
+  const nextMetadata =
+    metadataName !== undefined && layout.metadata
+      ? { ...layout.metadata, name: metadataName }
+      : layout.metadata;
+
+  ctx.setLayout({
+    ...layout,
+    name,
+    metadata: nextMetadata,
+  });
 }
 
 // =============================================================================

--- a/src/lib/stores/layout/rack-actions.ts
+++ b/src/lib/stores/layout/rack-actions.ts
@@ -22,6 +22,7 @@ import {
 } from "../commands";
 import type { LayoutStateAccess } from "./types";
 import { getRackGroupCommandAdapter } from "./rack-groups";
+import { setLayoutNamesRaw } from "./mutators";
 
 // =============================================================================
 // Raw Mutators (for undo/redo system — bypass history)
@@ -104,7 +105,11 @@ export function restoreRackRaw(
 
   // Insert the rack at its original position (or append if no index given)
   const racks = [...layout.racks];
-  if (originalIndex !== undefined && originalIndex >= 0 && originalIndex <= racks.length) {
+  if (
+    originalIndex !== undefined &&
+    originalIndex >= 0 &&
+    originalIndex <= racks.length
+  ) {
     racks.splice(originalIndex, 0, rack);
   } else {
     racks.push(rack);
@@ -154,6 +159,8 @@ export function getRackLifecycleCommandAdapter(
     restoreRackRaw: (rack: Rack, groups: RackGroup[], originalIndex?: number) =>
       restoreRackRaw(ctx, rack, groups, originalIndex),
     setActiveRackId: (id: string | null) => ctx.setActiveRackId(id),
+    setLayoutNamesRaw: (name: string, metadataName: string | undefined) =>
+      setLayoutNamesRaw(ctx, name, metadataName),
   };
 }
 
@@ -179,10 +186,7 @@ export function getRackById(
  * @param ctx - Layout state access
  * @param id - Rack ID to make active (null to clear)
  */
-export function setActiveRack(
-  ctx: LayoutStateAccess,
-  id: string | null,
-): void {
+export function setActiveRack(ctx: LayoutStateAccess, id: string | null): void {
   if (id === null) {
     ctx.setActiveRackId(null);
     return;
@@ -201,10 +205,7 @@ export function setActiveRack(
  * @param rackId - Rack ID to find
  * @returns Index in layout.racks or -1 if not found
  */
-export function getRackIndex(
-  ctx: LayoutStateAccess,
-  rackId: string,
-): number {
+export function getRackIndex(ctx: LayoutStateAccess, rackId: string): number {
   return ctx.findRackIndex(rackId);
 }
 
@@ -251,8 +252,15 @@ export function getTargetRack(
 
 /**
  * Add a new rack to the layout
- * Layout name is managed independently via setLayoutName
- * Uses undo/redo support via command pattern
+ *
+ * When this is the **first** rack added to the layout, both `layout.name`
+ * and `layout.metadata.name` are synced to the new rack's name (#1482).
+ * The sync is captured inside the command so undo restores the previous
+ * layout-level names exactly. Subsequent racks do not touch the layout
+ * name; it can still be changed via `setLayoutName` independently.
+ *
+ * Uses undo/redo support via command pattern.
+ *
  * @param ctx - Layout state access
  * @param name - Rack name
  * @param height - Rack height in U
@@ -278,6 +286,19 @@ export function addRack(
     return null;
   }
 
+  // Snapshot layout-level names before creating the first rack so that
+  // undo can restore them exactly (#1482).
+  const wasFirstRack = layout.racks.length === 0;
+  const layoutNameSync = wasFirstRack
+    ? {
+        hasMetadata: layout.metadata !== undefined,
+        snapshot: {
+          previousLayoutName: layout.name,
+          previousMetadataName: layout.metadata?.name,
+        },
+      }
+    : undefined;
+
   const newRack = createDefaultRack(
     name,
     height,
@@ -293,7 +314,7 @@ export function addRack(
   // setActive: true ensures redo also restores the active rack selection
   const history = getHistoryStore();
   const adapter = getRackLifecycleCommandAdapter(ctx);
-  const command = createAddRackCommand(newRack, adapter, true);
+  const command = createAddRackCommand(newRack, adapter, true, layoutNameSync);
   history.execute(command);
   ctx.markDirty();
 
@@ -375,10 +396,15 @@ export function addBayedRackGroup(
   const groupAdapter = getRackGroupCommandAdapter(ctx);
 
   const commands: Command[] = [
-    ...newRacks.map((rack, i) => createAddRackCommand(rack, rackAdapter, i === 0)),
+    ...newRacks.map((rack, i) =>
+      createAddRackCommand(rack, rackAdapter, i === 0),
+    ),
     createCreateRackGroupCommand(group, groupAdapter),
   ];
-  const batch = createBatchCommand(`Create bayed group "${groupName}"`, commands);
+  const batch = createBatchCommand(
+    `Create bayed group "${groupName}"`,
+    commands,
+  );
   history.execute(batch);
   ctx.markDirty();
 

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -28,7 +28,8 @@ import type {
 } from "$lib/types";
 import type { Command, CommandType } from "$lib/stores/commands/types";
 import { toInternalUnits } from "$lib/utils/position";
-import { getLayoutStore } from "$lib/stores/layout.svelte";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
 import { generateId } from "$lib/utils/device";
 
 // =============================================================================
@@ -385,6 +386,45 @@ export function setupStoreWithRack(height: number = 42): {
   }
 
   return { store, rack };
+}
+
+// =============================================================================
+// Layout Store Factory
+// =============================================================================
+
+export interface CreateTestLayoutStoreOptions {
+  /**
+   * Optional layout name to pre-set on the freshly-reset store.
+   * When omitted, the default name from createLayout() ("My Layout") is used.
+   */
+  layoutName?: string;
+}
+
+/**
+ * Reset the singleton layout store and (optionally) seed it with a layout name.
+ * Also resets the history store so undo/redo tests start clean.
+ *
+ * Use this when a test needs a known, named layout without any racks yet
+ * (e.g., verifying that the first rack creation syncs `layout.name`).
+ *
+ * @example
+ * const store = createTestLayoutStore({ layoutName: "My Lab" });
+ * store.addRack("Server Rack A", 42);
+ * expect(store.layout.name).toBe("Server Rack A");
+ */
+export function createTestLayoutStore(
+  options: CreateTestLayoutStoreOptions = {},
+) {
+  resetLayoutStore();
+  resetHistoryStore();
+  const store = getLayoutStore();
+  if (!store) {
+    throw new Error("createTestLayoutStore: getLayoutStore() returned null");
+  }
+  if (options.layoutName !== undefined) {
+    store.setLayoutName(options.layoutName);
+  }
+  return store;
 }
 
 // =============================================================================

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -8,6 +8,7 @@ import {
   setupStoreWithDevice,
   createTestDevice,
   createTestDeviceType,
+  createTestLayoutStore,
 } from "./factories";
 
 describe("Layout Store", () => {
@@ -172,16 +173,46 @@ describe("Layout Store", () => {
             starting_unit: 1,
             position: 0,
             devices: [
-              { id: "same-id", device_type: "server-a", position: 100, face: "front" as const },
-              { id: "same-id", device_type: "server-b", position: 200, face: "front" as const },
-              { id: "ok-id", device_type: "server-c", position: 300, face: "front" as const },
+              {
+                id: "same-id",
+                device_type: "server-a",
+                position: 100,
+                face: "front" as const,
+              },
+              {
+                id: "same-id",
+                device_type: "server-b",
+                position: 200,
+                face: "front" as const,
+              },
+              {
+                id: "ok-id",
+                device_type: "server-c",
+                position: 300,
+                face: "front" as const,
+              },
             ],
           },
         ],
         device_types: [
-          { slug: "server-a", u_height: 1, colour: "#4A90A4", category: "server" as const },
-          { slug: "server-b", u_height: 1, colour: "#4A90A4", category: "server" as const },
-          { slug: "server-c", u_height: 1, colour: "#4A90A4", category: "server" as const },
+          {
+            slug: "server-a",
+            u_height: 1,
+            colour: "#4A90A4",
+            category: "server" as const,
+          },
+          {
+            slug: "server-b",
+            u_height: 1,
+            colour: "#4A90A4",
+            category: "server" as const,
+          },
+          {
+            slug: "server-c",
+            u_height: 1,
+            colour: "#4A90A4",
+            category: "server" as const,
+          },
         ],
         settings: {
           display_mode: "label",
@@ -215,14 +246,34 @@ describe("Layout Store", () => {
             starting_unit: 1,
             position: 0,
             devices: [
-              { id: "", device_type: "server-a", position: 100, face: "front" as const },
-              { id: "valid-id", device_type: "server-b", position: 200, face: "front" as const },
+              {
+                id: "",
+                device_type: "server-a",
+                position: 100,
+                face: "front" as const,
+              },
+              {
+                id: "valid-id",
+                device_type: "server-b",
+                position: 200,
+                face: "front" as const,
+              },
             ],
           },
         ],
         device_types: [
-          { slug: "server-a", u_height: 1, colour: "#4A90A4", category: "server" as const },
-          { slug: "server-b", u_height: 1, colour: "#4A90A4", category: "server" as const },
+          {
+            slug: "server-a",
+            u_height: 1,
+            colour: "#4A90A4",
+            category: "server" as const,
+          },
+          {
+            slug: "server-b",
+            u_height: 1,
+            colour: "#4A90A4",
+            category: "server" as const,
+          },
         ],
         settings: {
           display_mode: "label",
@@ -2134,7 +2185,11 @@ describe("Layout Store", () => {
       const typeCountBefore = store.device_types.length;
 
       // Place a different brand device at the same position (collision)
-      const result = store.placeDevice(rack!.id, "ubiquiti-unifi-dream-machine-pro", 5);
+      const result = store.placeDevice(
+        rack!.id,
+        "ubiquiti-unifi-dream-machine-pro",
+        5,
+      );
 
       // Placement failed — nothing should have been imported or dirtied
       expect(result).toBe(false);
@@ -2405,5 +2460,85 @@ describe("Layout Store", () => {
       const ids = new Set(devices.map((d) => d.id));
       expect(ids.size).toBe(3);
     });
+  });
+});
+
+describe("Layout name sync on first rack creation (#1482)", () => {
+  it("syncs layout.name and metadata.name to the first rack's name", () => {
+    const store = createTestLayoutStore({ layoutName: "My Layout" });
+    expect(store.layout.name).toBe("My Layout");
+    expect(store.layout.metadata?.name).toBe("My Layout");
+
+    store.addRack("Server Rack A", 42);
+
+    expect(store.layout.name).toBe("Server Rack A");
+    expect(store.layout.metadata?.name).toBe("Server Rack A");
+  });
+
+  it("does NOT change layout.name when adding subsequent racks", () => {
+    const store = createTestLayoutStore({ layoutName: "My Layout" });
+    store.addRack("Server Rack A", 42);
+
+    store.addRack("Server Rack B", 24);
+
+    expect(store.layout.name).toBe("Server Rack A");
+    expect(store.layout.metadata?.name).toBe("Server Rack A");
+  });
+
+  it("restores the original layout name when undoing the first rack creation", () => {
+    const store = createTestLayoutStore({ layoutName: "Original Layout" });
+    expect(store.layout.name).toBe("Original Layout");
+
+    store.addRack("First Rack", 42);
+    expect(store.layout.name).toBe("First Rack");
+
+    store.undo();
+
+    expect(store.layout.name).toBe("Original Layout");
+    expect(store.layout.metadata?.name).toBe("Original Layout");
+    expect(store.layout.racks.length).toBe(0);
+  });
+
+  it("does not touch layout.name when undoing a subsequent rack creation", () => {
+    const store = createTestLayoutStore({ layoutName: "Original Layout" });
+    store.addRack("First Rack", 42);
+    const layoutNameAfterFirstRack = store.layout.name;
+    expect(layoutNameAfterFirstRack).toBe("First Rack");
+
+    store.addRack("Second Rack", 24);
+    store.undo();
+
+    // Undoing the second rack should leave layout.name as "First Rack",
+    // not revert further back to "Original Layout"
+    expect(store.layout.name).toBe(layoutNameAfterFirstRack);
+    expect(store.layout.metadata?.name).toBe(layoutNameAfterFirstRack);
+  });
+});
+
+describe("Raw mutators do not have layout-name side effects (#1481)", () => {
+  it("updateRackRaw does not change layout.name", () => {
+    const store = createTestLayoutStore({ layoutName: "Original Layout" });
+    store.addRack("First Rack", 42);
+    const beforeName = store.layout.name;
+
+    // Call updateRackRaw directly (bypass recorded path)
+    store.updateRackRaw({ name: "Renamed Rack" });
+
+    expect(store.layout.name).toBe(beforeName);
+    expect(store.layout.metadata?.name).toBe(beforeName);
+  });
+
+  it("undo of a rack settings change does not change layout.name", () => {
+    const store = createTestLayoutStore({ layoutName: "My Layout" });
+    store.addRack("First Rack", 42);
+    const layoutNameBeforeUndo = store.layout.name;
+    const activeRackId = store.activeRackId;
+    expect(activeRackId).not.toBeNull();
+
+    store.updateRack(activeRackId!, { height: 24 });
+    store.undo();
+
+    expect(store.layout.name).toBe(layoutNameBeforeUndo);
+    expect(store.layout.metadata?.name).toBe(layoutNameBeforeUndo);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

- **#1482 (fixed in PR):** When the very first rack is added to a layout, both \`layout.name\` and \`layout.metadata.name\` now sync to the new rack's name. Subsequent racks do not touch the layout name.
- **#1481 (verified already fixed):** \`updateRackRaw\` and sibling raw mutators in \`src/lib/stores/layout/mutators.ts\` no longer touch \`layout.name\` or \`metadata.name\`. The side effect described in the issue was removed in a prior refactor. Added regression tests to lock the boundary.
- **Undo correctness:** The sync is captured **inside** \`createAddRackCommand\` (not inline in \`addRack\`), so undoing the first rack restores the original layout-level names exactly. Undoing a *second* rack does not regress past the first rack's name.

## Why folding the sync into the command (Option 2)

Option 1 (sync inline after \`history.execute\`) would have left undo asymmetric: undoing the first rack would delete it but the layout would still bear that rack's name. Option 2 captures \`{ previousLayoutName, previousMetadataName }\` as a snapshot inside the command closure, writes the new name on \`execute()\`, and restores the snapshot on \`undo()\` — keeping the history fully reversible.

To avoid the empty-name guard in \`setLayoutName\`, this PR adds a small raw mutator \`setLayoutNamesRaw\` that writes both \`layout.name\` and \`layout.metadata.name\` verbatim so undo can restore any prior value (including the factory default "My Layout"). It is wired through \`RackLifecycleCommandStore\` so only the rack-lifecycle command path can call it.

## Files changed

- \`src/lib/stores/commands/rack.ts\` — extends \`RackLifecycleCommandStore\` interface with \`setLayoutNamesRaw\`, adds optional \`AddRackLayoutNameSync\` arg to \`createAddRackCommand\`, captures execute/undo paths.
- \`src/lib/stores/layout/mutators.ts\` — new \`setLayoutNamesRaw\` raw mutator.
- \`src/lib/stores/layout/rack-actions.ts\` — \`addRack\` now snapshots the layout-level names if it's the first rack and passes them through to the command; adapter wires \`setLayoutNamesRaw\`.
- \`src/tests/factories.ts\` — new \`createTestLayoutStore({ layoutName })\` helper; also resets the history store so undo tests start clean.
- \`src/tests/layout-store.test.ts\` — 6 new tests (4 for #1482, 2 boundary tests for #1481).

## Test plan

- [x] Unit: \`npm run test:run -- src/tests/layout-store.test.ts\` — 137/137 pass (6 new tests + existing layout-store tests)
- [x] Unit: full suite \`npm run test:run\` — 1975/1975 pass
- [x] Lint: \`npm run lint\` — clean
- [x] Build: \`npm run build\` — clean
- [x] CodeRabbit local review (\`coderabbit --prompt-only --type uncommitted\` and pre-push) — **No findings**

### Manual smoke checklist (for human reviewer)

The orchestrator instructed me to skip the browser-based manual smoke. Please verify:

1. **First rack syncs:** Fresh load (layout shows "My Layout"). Create first rack named "Server Rack" via the wizard — left sidebar / layout title and the exported layout's \`metadata.name\` should both become "Server Rack".
2. **Subsequent rack does not sync:** Add a second rack named "Networking" — layout name stays "Server Rack".
3. **Undo of first rack restores original layout name:** With a fresh load, create the first rack, press Ctrl+Z — layout name returns to "My Layout" and the rack is gone.
4. **Undo of rack settings does NOT touch layout name:** Open the first rack's settings, rename it or resize it, then undo — \`layout.name\` is unchanged (this is the #1481 boundary).

## Issue verification (#1481)

\`\`\`bash
grep -rn "layout\.name\|metadata\.name" src/lib/stores/layout/mutators.ts
# (no hits — confirmed clean)

grep -rn "layout\.name\|metadata\.name" src/lib/stores/layout/
# (no hits in any file under the layout store directory)
\`\`\`

The only raw-mutator-side reference to \`.name\` is a debug log of \`rack.name\` (not a write). \`updateRackRaw\` (lines 492–500 of \`mutators.ts\`) does not mutate layout-level names. The two new regression tests (\`updateRackRaw does not change layout.name\`, \`undo of a rack settings change does not change layout.name\`) lock this in.

Closes #1481
Closes #1482


___

## **CodeAnt-AI Description**
**Keep the layout name in sync with the first rack, and restore it on undo**

### What Changed
- When the first rack is created, the layout name and layout metadata name now change to match that rack’s name.
- Adding more racks no longer changes the layout name.
- Undoing the first rack creation restores the original layout name exactly.
- Undoing later rack changes does not roll the layout name back past the first rack.
- Direct rack updates no longer change the layout name, and undoing a rack settings change leaves the layout name untouched.

### Impact
`✅ Clearer layout naming after first rack setup`
`✅ Correct undo for layout names`
`✅ Fewer unexpected layout name changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
