### PR TITLE
ci: disable binfmt cache to fix parallel save collisions (#1029)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -93,6 +93,10 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          # Disable binfmt image caching to avoid post-job cache-save collisions
+          # across parallel build-* jobs that share the same cache key.
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -151,6 +155,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -205,6 +211,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0


### PR DESCRIPTION
## **User description**
## Summary

Closes #1029.

Three parallel jobs in `.github/workflows/deploy-prod.yml` (`build-prod`, `build-persist`, `build-api`) each call `docker/setup-qemu-action@v4.0.0` with default cache settings, racing to save the same `docker.io--tonistiigi--binfmt-latest-linux-x64` cache key. Whichever job loses the race logs:

```
Failed to save: Unable to reserve cache with key docker.io--tonistiigi--binfmt-latest-linux-x64, another job may be creating this cache.
```

No functional failure, but it adds noise to every prod deploy. Setting `cache-image: false` on each invocation disables the binfmt image cache save, removing the collision. The binfmt image is small, so the time savings from the cache were negligible to begin with.

## Test plan

- [ ] Workflow YAML is valid (verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Cut a `v*` tag (or trigger via `workflow_dispatch`) and confirm:
  - all three `build-*` jobs still succeed
  - no `Failed to save: Unable to reserve cache with key ...binfmt...` warnings appear in any job log
- [ ] Confirm overall job runtime is not meaningfully worse (expected: within seconds — the binfmt image is tiny)

## Triage context

This PR was authored as part of a triage pass over the 21 open bugs in the repo. Effort-assessment comments have been added to each open bug; #1029 was the smallest well-defined fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoM4h1NiCDWGBEgZkF6eov)_


___

## **CodeAnt-AI Description**
**Stop cache-save warnings during prod deploys**

### What Changed
- Disabled QEMU binfmt image caching in all three parallel production build jobs
- Production deploys no longer log cache-save collision warnings when the jobs run at the same time
- Deployment behavior stays the same; only the noisy cache step is removed

### Impact
`✅ Cleaner production deploy logs`
`✅ Fewer confusing cache warnings`
`✅ No change to release output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
