### PR TITLE
fix: skip pointer drag events outside rack SVG bounds (#1467)

### DIFF
--- a/src/lib/utils/rack-pointer-drag.ts
+++ b/src/lib/utils/rack-pointer-drag.ts
@@ -38,15 +38,35 @@ export interface PointerDragContext {
   toastStore: ReturnType<typeof getToastStore>;
 }
 
+// Document-level drag events fire on every rack listener. Without a bounds
+// check, racks process events whose pointer is over a sibling rack, causing
+// stale previews and incorrect drop dispatch in multi-rack layouts (#1467).
+function isPointerOutsideSvg(
+  svg: SVGSVGElement,
+  clientX: number,
+  clientY: number,
+): boolean {
+  const rect = svg.getBoundingClientRect();
+  return (
+    clientX < rect.left ||
+    clientX > rect.right ||
+    clientY < rect.top ||
+    clientY > rect.bottom
+  );
+}
+
 /**
  * Create and attach pointer drag event listeners.
  * Returns a cleanup function that removes the listeners.
  */
-export function attachPointerDragListeners(ctx: PointerDragContext): () => void {
+export function attachPointerDragListeners(
+  ctx: PointerDragContext,
+): () => void {
   function handleDragMove(event: CustomEvent) {
     const svgElement = ctx.getSvgElement();
     if (!svgElement) return;
     const { clientX, clientY, device } = event.detail;
+    if (isPointerOutsideSvg(svgElement, clientX, clientY)) return;
     const rack = ctx.getRack();
     const isInternalMove = event.detail.rackId === rack.id;
     const excludeIndex = isInternalMove ? event.detail.deviceIndex : undefined;
@@ -68,11 +88,27 @@ export function attachPointerDragListeners(ctx: PointerDragContext): () => void 
   function handleDragEnd(event: CustomEvent) {
     const svgElement = ctx.getSvgElement();
     if (!svgElement) return;
-    const { clientX, clientY, device, rackId: sourceRackId, deviceIndex } = event.detail;
+    const {
+      clientX,
+      clientY,
+      device,
+      rackId: sourceRackId,
+      deviceIndex,
+    } = event.detail;
 
+    // Always clear this rack's local drag state, even if the drop landed
+    // elsewhere — the source rack still needs its dragging-index cleared.
     ctx.setDropPreview(null);
     ctx.setContainerHoverInfo(null);
     ctx.clearDraggingIndex();
+
+    // Only the rack containing the pointer at drop time should dispatch the
+    // drop action. Other racks must skip dispatch to avoid duplicate/incorrect
+    // drops in multi-rack layouts (#1467).
+    if (isPointerOutsideSvg(svgElement, clientX, clientY)) {
+      ctx.onDragFinished();
+      return;
+    }
 
     // Preserve existing slot_position for pointer-based moves
     const sourceRack = ctx.layoutStore.getRackById(sourceRackId);
@@ -109,11 +145,20 @@ export function attachPointerDragListeners(ctx: PointerDragContext): () => void 
     ctx.onDragFinished();
   }
 
-  document.addEventListener("rackula:dragmove", handleDragMove as EventListener);
+  document.addEventListener(
+    "rackula:dragmove",
+    handleDragMove as EventListener,
+  );
   document.addEventListener("rackula:dragend", handleDragEnd as EventListener);
 
   return () => {
-    document.removeEventListener("rackula:dragmove", handleDragMove as EventListener);
-    document.removeEventListener("rackula:dragend", handleDragEnd as EventListener);
+    document.removeEventListener(
+      "rackula:dragmove",
+      handleDragMove as EventListener,
+    );
+    document.removeEventListener(
+      "rackula:dragend",
+      handleDragEnd as EventListener,
+    );
   };
 }

--- a/src/lib/utils/rack-pointer-drag.ts
+++ b/src/lib/utils/rack-pointer-drag.ts
@@ -66,7 +66,14 @@ export function attachPointerDragListeners(
     const svgElement = ctx.getSvgElement();
     if (!svgElement) return;
     const { clientX, clientY, device } = event.detail;
-    if (isPointerOutsideSvg(svgElement, clientX, clientY)) return;
+    if (isPointerOutsideSvg(svgElement, clientX, clientY)) {
+      // Pointer left this rack — clear any preview/hover state we set earlier.
+      // Otherwise a stale drop preview remains visible while the user drags
+      // over a sibling rack.
+      ctx.setContainerHoverInfo(null);
+      ctx.setDropPreview(null);
+      return;
+    }
     const rack = ctx.getRack();
     const isInternalMove = event.detail.rackId === rack.id;
     const excludeIndex = isInternalMove ? event.detail.deviceIndex : undefined;


### PR DESCRIPTION
## **User description**
## Summary

Closes #1467.

Document-level `rackula:dragmove` and `rackula:dragend` listeners (Safari pointer-drag workaround) fire on every rack instance. Without a bounds check, racks process drag events whose pointer is physically over a sibling rack — stale drop previews and incorrect drop dispatch in multi-rack layouts.

Adds an `isPointerOutsideSvg` helper using `getBoundingClientRect()` and gates both handlers:

- **`handleDragMove`**: early return when pointer is outside this rack's SVG.
- **`handleDragEnd`**: always clears this rack's local drag state (the *source* rack still needs its dragging-index cleared even when the drop lands elsewhere), then skips drop dispatch when the pointer is outside.

## Test plan

- [x] `npm run check` — 0 new errors (16 pre-existing on `main`, all unrelated to this file)
- [x] `npm run test:run` — 1922/1922 pass
- [ ] Manual verification in a multi-rack layout:
  - drag a device from rack A while pointer is over rack B → rack A's preview should not flicker / rack B should show the preview
  - drop in rack B → only one drop dispatched; rack A's dragging-index cleared

## Triage context

Part of the open-bugs triage pass. #1467 was the next smallest concrete code fix after #1029 (merged in #1688).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoM4h1NiCDWGBEgZkF6eov)_


___

## **CodeAnt-AI Description**
**Skip drag events that belong to another rack**

### What Changed
- Rack drag previews now update only for the rack currently under the pointer, preventing stale highlights in multi-rack layouts
- When a drag ends outside a rack, that rack still clears its local drag state, but it no longer sends a drop action
- This avoids duplicate or incorrect drops when dragging between adjacent racks

### Impact
`✅ Fewer wrong drops in multi-rack layouts`
`✅ No stale drag previews on neighboring racks`
`✅ Clearer drag-and-drop behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
