### PR TITLE
fix(api): drop legacy AUTH_*/API_* env-var fallbacks

### DIFF
--- a/api/src/security.test.ts
+++ b/api/src/security.test.ts
@@ -97,6 +97,22 @@ describe("resolveApiSecurityConfig", () => {
     ).toThrow("Invalid auth mode");
   });
 
+  it("ignores unprefixed env vars so security config cannot diverge from createAuth", () => {
+    const config = resolveApiSecurityConfig(
+      buildEnv({
+        AUTH_MODE: "oidc",
+        AUTH_SESSION_SECRET: TEST_AUTH_SECRET,
+        AUTH_SESSION_COOKIE_NAME: "shadow_session",
+        AUTH_LOG_HASH_KEY: "rackula-auth-log-key-override",
+        API_WRITE_TOKEN: TEST_TOKEN,
+      }),
+    );
+
+    expect(config.authMode).toBe("none");
+    expect(config.authSessionCookieName).toBe("rackula_auth_session");
+    expect(config.writeAuthToken).toBeUndefined();
+  });
+
   it("requires auth session secret and references RACKULA_AUTH_MODE when auth is enabled", () => {
     const run = () =>
       resolveApiSecurityConfig(

--- a/api/src/security/config.ts
+++ b/api/src/security/config.ts
@@ -257,7 +257,7 @@ export function resolveApiSecurityConfig(
   const isProduction = env.NODE_ENV === "production";
   const allowInsecureCors = parseBoolean(env.ALLOW_INSECURE_CORS);
   const configuredOrigin = env.CORS_ORIGIN?.trim();
-  const authMode = parseAuthMode(env.RACKULA_AUTH_MODE ?? env.AUTH_MODE);
+  const authMode = parseAuthMode(env.RACKULA_AUTH_MODE);
   const authEnabled = authMode !== "none";
 
   let corsOrigin: string | string[];
@@ -280,18 +280,16 @@ export function resolveApiSecurityConfig(
     );
   }
 
-  const writeAuthTokenRaw = env.RACKULA_API_WRITE_TOKEN ?? env.API_WRITE_TOKEN;
+  const writeAuthTokenRaw = env.RACKULA_API_WRITE_TOKEN;
   const writeAuthToken = writeAuthTokenRaw?.trim() || undefined;
 
   const authSessionCookieName = parseAuthCookieName(
-    env.RACKULA_AUTH_SESSION_COOKIE_NAME ?? env.AUTH_SESSION_COOKIE_NAME,
+    env.RACKULA_AUTH_SESSION_COOKIE_NAME,
   );
   const authLoginPath = parseLoginPath(env.RACKULA_AUTH_LOGIN_PATH);
-  const authSessionSecretRaw =
-    env.RACKULA_AUTH_SESSION_SECRET ?? env.AUTH_SESSION_SECRET;
+  const authSessionSecretRaw = env.RACKULA_AUTH_SESSION_SECRET;
   const authSessionSecret = authSessionSecretRaw?.trim() || undefined;
-  const authLogHashKeyRaw =
-    env.RACKULA_AUTH_LOG_HASH_KEY ?? env.AUTH_LOG_HASH_KEY;
+  const authLogHashKeyRaw = env.RACKULA_AUTH_LOG_HASH_KEY;
 
   if (authEnabled && !authSessionSecret) {
     throw new Error(


### PR DESCRIPTION
## **User description**
## Summary

Addresses both CodeAnt-AI findings on the security review by removing the unprefixed `AUTH_*` / `API_*` env-var fallbacks from `resolveApiSecurityConfig`. Per the project's greenfield rule (`CLAUDE.md` — "Do not use migration or legacy support concepts"), `RACKULA_*` is the single source of truth.

## Why

`resolveApiSecurityConfig` was reading:

```ts
env.RACKULA_AUTH_SESSION_COOKIE_NAME ?? env.AUTH_SESSION_COOKIE_NAME
env.RACKULA_AUTH_SESSION_SECRET     ?? env.AUTH_SESSION_SECRET
env.RACKULA_AUTH_MODE               ?? env.AUTH_MODE
env.RACKULA_AUTH_LOG_HASH_KEY       ?? env.AUTH_LOG_HASH_KEY
env.RACKULA_API_WRITE_TOKEN         ?? env.API_WRITE_TOKEN
```

…while `createAuth` only reads the `RACKULA_*` variants. A deployment that set the legacy `AUTH_SESSION_COOKIE_NAME` ended up with:

- security config → custom cookie name
- Better Auth → default `rackula_auth_session`

The CSRF middleware then gated on the wrong cookie name and skipped origin checks for state-changing requests authenticated through Better Auth's fallback session resolver. Dropping the legacy fallbacks collapses the contract to a single canonical name on both sides.

## Test plan

- [x] `bun test src/security.test.ts` → 59/59 pass (including new regression test)
- [x] `bun test` (full API suite) → 141/141 pass
- [x] `npm run lint` clean
- [x] New test `ignores unprefixed env vars so security config cannot diverge from createAuth` asserts none of the legacy names leak into `ApiSecurityConfig`

https://claude.ai/code/session_01HNyH2ysDanaYHJd16yjWZ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNyH2ysDanaYHJd16yjWZ5)_


___

## **CodeAnt-AI Description**
**Use only `RACKULA_*` settings for API security**

### What Changed
- API security settings now ignore legacy `AUTH_*` and `API_*` environment variables
- Auth mode, session cookie name, session secret, log hash key, and write token all come from `RACKULA_*` only
- This keeps security checks aligned with the auth system, avoiding mismatched cookie names and skipped origin checks
- Added a regression test to confirm unprefixed variables no longer affect security config

### Impact
`✅ Fewer security config mismatches`
`✅ Safer state-changing requests`
`✅ Clearer auth environment setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
