### PR TITLE
fix: clean up cables when a device type is deleted (#1483)

### DIFF
--- a/src/lib/stores/commands/device-type.ts
+++ b/src/lib/stores/commands/device-type.ts
@@ -123,12 +123,15 @@ export function createDeleteDeviceTypeCommand(
       // Restore devices to their original racks
       const previousActiveRack = store.getActiveRackId();
       const imgStore = getImageStore();
+      // Track old→new device IDs so we can rewrite cable endpoints below
+      // (placeDeviceRaw may remap the ID — see #1363 dedup guard).
+      const deviceIdMap = new Map<string, string>();
       for (const { rackId, device } of deviceData) {
         store.setActiveRackId(rackId);
         const placedIdx = store.placeDeviceRaw(device);
-        // Read back actual device — placeDeviceRaw may remap the ID (#1363 dedup guard)
         const placed = store.getDeviceAtIndex(placedIdx);
         const actualId = placed?.id ?? device.id;
+        deviceIdMap.set(device.id, actualId);
         // Restore placement images under the (possibly remapped) key
         const originalKey = `placement-${device.id}`;
         const snap = placementSnapshots.get(originalKey);
@@ -155,9 +158,14 @@ export function createDeleteDeviceTypeCommand(
             typeImageCopy.rear,
           );
       }
-      // Restore cables once their endpoint devices are back in the layout.
+      // Restore cables, rewriting endpoint IDs through the remap map so any
+      // device whose id was changed by placeDeviceRaw stays reachable.
       for (const cable of cableData) {
-        store.addCableRaw(cable);
+        store.addCableRaw({
+          ...cable,
+          a_device_id: deviceIdMap.get(cable.a_device_id) ?? cable.a_device_id,
+          b_device_id: deviceIdMap.get(cable.b_device_id) ?? cable.b_device_id,
+        });
       }
     },
   };

--- a/src/lib/stores/commands/device-type.ts
+++ b/src/lib/stores/commands/device-type.ts
@@ -2,136 +2,163 @@
  * Device Type Commands for Undo/Redo
  */
 
-import type { Command } from './types';
-import type { DeviceType, PlacedDevice } from '$lib/types';
-import { getImageStore } from '../images.svelte';
-import type { DeviceImageData } from '$lib/types/images';
+import type { Command } from "./types";
+import type { Cable, DeviceType, PlacedDevice } from "$lib/types";
+import { getImageStore } from "../images.svelte";
+import type { DeviceImageData } from "$lib/types/images";
 
 /**
  * Interface for layout store operations needed by device type commands
  */
 export interface DeviceTypeCommandStore {
-	addDeviceTypeRaw(deviceType: DeviceType): void;
-	removeDeviceTypeRaw(slug: string): void;
-	updateDeviceTypeRaw(slug: string, updates: Partial<DeviceType>): void;
-	placeDeviceRaw(device: PlacedDevice): number;
-	removeDeviceAtIndexRaw(index: number): void;
-	getPlacedDevicesForType(slug: string): PlacedDevice[];
-	getDeviceAtIndex(index: number): PlacedDevice | undefined;
-	setActiveRackId(id: string | null): void;
-	getActiveRackId(): string | null;
+  addDeviceTypeRaw(deviceType: DeviceType): void;
+  removeDeviceTypeRaw(slug: string): void;
+  updateDeviceTypeRaw(slug: string, updates: Partial<DeviceType>): void;
+  placeDeviceRaw(device: PlacedDevice): number;
+  removeDeviceAtIndexRaw(index: number): void;
+  getPlacedDevicesForType(slug: string): PlacedDevice[];
+  getDeviceAtIndex(index: number): PlacedDevice | undefined;
+  setActiveRackId(id: string | null): void;
+  getActiveRackId(): string | null;
+  addCableRaw(cable: Cable): void;
+  removeCableRaw(id: string): void;
 }
 
 /**
  * Create a command to add a device type
  */
 export function createAddDeviceTypeCommand(
-	deviceType: DeviceType,
-	store: DeviceTypeCommandStore
+  deviceType: DeviceType,
+  store: DeviceTypeCommandStore,
 ): Command {
-	return {
-		type: 'ADD_DEVICE_TYPE',
-		description: `Add ${deviceType.model ?? deviceType.slug}`,
-		timestamp: Date.now(),
-		execute() {
-			store.addDeviceTypeRaw(deviceType);
-		},
-		undo() {
-			store.removeDeviceTypeRaw(deviceType.slug);
-		}
-	};
+  return {
+    type: "ADD_DEVICE_TYPE",
+    description: `Add ${deviceType.model ?? deviceType.slug}`,
+    timestamp: Date.now(),
+    execute() {
+      store.addDeviceTypeRaw(deviceType);
+    },
+    undo() {
+      store.removeDeviceTypeRaw(deviceType.slug);
+    },
+  };
 }
 
 /**
  * Create a command to update a device type
  */
 export function createUpdateDeviceTypeCommand(
-	slug: string,
-	before: Partial<DeviceType>,
-	after: Partial<DeviceType>,
-	store: DeviceTypeCommandStore
+  slug: string,
+  before: Partial<DeviceType>,
+  after: Partial<DeviceType>,
+  store: DeviceTypeCommandStore,
 ): Command {
-	return {
-		type: 'UPDATE_DEVICE_TYPE',
-		description: `Update ${slug}`,
-		timestamp: Date.now(),
-		execute() {
-			store.updateDeviceTypeRaw(slug, after);
-		},
-		undo() {
-			store.updateDeviceTypeRaw(slug, before);
-		}
-	};
+  return {
+    type: "UPDATE_DEVICE_TYPE",
+    description: `Update ${slug}`,
+    timestamp: Date.now(),
+    execute() {
+      store.updateDeviceTypeRaw(slug, after);
+    },
+    undo() {
+      store.updateDeviceTypeRaw(slug, before);
+    },
+  };
 }
 
 /**
  * Create a command to delete a device type (including placed instances)
  * Accepts rack-aware device data so undo restores devices to their original racks.
+ * Accepts connected cables so undo restores the cable topology too.
  */
 export function createDeleteDeviceTypeCommand(
-	deviceType: DeviceType,
-	placedDevices: { rackId: string; device: PlacedDevice }[],
-	store: DeviceTypeCommandStore
+  deviceType: DeviceType,
+  placedDevices: { rackId: string; device: PlacedDevice }[],
+  store: DeviceTypeCommandStore,
+  connectedCables: Cable[] = [],
 ): Command {
-	const deviceData = placedDevices.map((d) => ({
-		rackId: d.rackId,
-		device: JSON.parse(JSON.stringify(d.device)) as PlacedDevice,
-	}));
-	const deviceTypeCopy = JSON.parse(JSON.stringify(deviceType)) as DeviceType;
+  const deviceData = placedDevices.map((d) => ({
+    rackId: d.rackId,
+    device: JSON.parse(JSON.stringify(d.device)) as PlacedDevice,
+  }));
+  const deviceTypeCopy = JSON.parse(JSON.stringify(deviceType)) as DeviceType;
+  const cableData = connectedCables.map((c) => structuredClone(c));
 
-	// Snapshot all images associated with this device type
-	const imageStore = getImageStore();
-	const typeImageSnapshot = imageStore.getAllImages().get(deviceType.slug);
-	const typeImageCopy = typeImageSnapshot ? structuredClone(typeImageSnapshot) : undefined;
+  // Snapshot all images associated with this device type
+  const imageStore = getImageStore();
+  const typeImageSnapshot = imageStore.getAllImages().get(deviceType.slug);
+  const typeImageCopy = typeImageSnapshot
+    ? structuredClone(typeImageSnapshot)
+    : undefined;
 
-	// Snapshot placement-specific images for each placed device
-	const placementSnapshots = new Map<string, DeviceImageData>();
-	for (const d of placedDevices) {
-		const key = `placement-${d.device.id}`;
-		const snap = imageStore.getAllImages().get(key);
-		if (snap) placementSnapshots.set(key, structuredClone(snap));
-	}
+  // Snapshot placement-specific images for each placed device
+  const placementSnapshots = new Map<string, DeviceImageData>();
+  for (const d of placedDevices) {
+    const key = `placement-${d.device.id}`;
+    const snap = imageStore.getAllImages().get(key);
+    if (snap) placementSnapshots.set(key, structuredClone(snap));
+  }
 
-	return {
-		type: 'DELETE_DEVICE_TYPE',
-		description: `Delete ${deviceType.model ?? deviceType.slug}`,
-		timestamp: Date.now(),
-		execute() {
-			// Clean up images (moved from raw mutator)
-			const imgStore = getImageStore();
-			imgStore.removeAllDeviceImages(deviceTypeCopy.slug);
-			// Remove placement images — check both original and potentially remapped keys
-			for (const { device } of deviceData) {
-				imgStore.removeAllDeviceImages(`placement-${device.id}`);
-			}
-			store.removeDeviceTypeRaw(deviceTypeCopy.slug);
-		},
-		undo() {
-			store.addDeviceTypeRaw(deviceTypeCopy);
-			// Restore devices to their original racks
-			const previousActiveRack = store.getActiveRackId();
-			const imgStore = getImageStore();
-			for (const { rackId, device } of deviceData) {
-				store.setActiveRackId(rackId);
-				const placedIdx = store.placeDeviceRaw(device);
-				// Read back actual device — placeDeviceRaw may remap the ID (#1363 dedup guard)
-				const placed = store.getDeviceAtIndex(placedIdx);
-				const actualId = placed?.id ?? device.id;
-				// Restore placement images under the (possibly remapped) key
-				const originalKey = `placement-${device.id}`;
-				const snap = placementSnapshots.get(originalKey);
-				if (snap) {
-					const actualKey = `placement-${actualId}`;
-					if (snap.front) imgStore.setDeviceImage(actualKey, 'front', snap.front);
-					if (snap.rear) imgStore.setDeviceImage(actualKey, 'rear', snap.rear);
-				}
-			}
-			store.setActiveRackId(previousActiveRack);
-			// Restore type-level images
-			if (typeImageCopy) {
-				if (typeImageCopy.front) imgStore.setDeviceImage(deviceTypeCopy.slug, 'front', typeImageCopy.front);
-				if (typeImageCopy.rear) imgStore.setDeviceImage(deviceTypeCopy.slug, 'rear', typeImageCopy.rear);
-			}
-		}
-	};
+  return {
+    type: "DELETE_DEVICE_TYPE",
+    description: `Delete ${deviceType.model ?? deviceType.slug}`,
+    timestamp: Date.now(),
+    execute() {
+      // Clean up cables connected to the placed devices before removing them,
+      // otherwise their endpoint device IDs become orphan references (#1483).
+      for (const cable of cableData) {
+        store.removeCableRaw(cable.id);
+      }
+      // Clean up images (moved from raw mutator)
+      const imgStore = getImageStore();
+      imgStore.removeAllDeviceImages(deviceTypeCopy.slug);
+      // Remove placement images — check both original and potentially remapped keys
+      for (const { device } of deviceData) {
+        imgStore.removeAllDeviceImages(`placement-${device.id}`);
+      }
+      store.removeDeviceTypeRaw(deviceTypeCopy.slug);
+    },
+    undo() {
+      store.addDeviceTypeRaw(deviceTypeCopy);
+      // Restore devices to their original racks
+      const previousActiveRack = store.getActiveRackId();
+      const imgStore = getImageStore();
+      for (const { rackId, device } of deviceData) {
+        store.setActiveRackId(rackId);
+        const placedIdx = store.placeDeviceRaw(device);
+        // Read back actual device — placeDeviceRaw may remap the ID (#1363 dedup guard)
+        const placed = store.getDeviceAtIndex(placedIdx);
+        const actualId = placed?.id ?? device.id;
+        // Restore placement images under the (possibly remapped) key
+        const originalKey = `placement-${device.id}`;
+        const snap = placementSnapshots.get(originalKey);
+        if (snap) {
+          const actualKey = `placement-${actualId}`;
+          if (snap.front)
+            imgStore.setDeviceImage(actualKey, "front", snap.front);
+          if (snap.rear) imgStore.setDeviceImage(actualKey, "rear", snap.rear);
+        }
+      }
+      store.setActiveRackId(previousActiveRack);
+      // Restore type-level images
+      if (typeImageCopy) {
+        if (typeImageCopy.front)
+          imgStore.setDeviceImage(
+            deviceTypeCopy.slug,
+            "front",
+            typeImageCopy.front,
+          );
+        if (typeImageCopy.rear)
+          imgStore.setDeviceImage(
+            deviceTypeCopy.slug,
+            "rear",
+            typeImageCopy.rear,
+          );
+      }
+      // Restore cables once their endpoint devices are back in the layout.
+      for (const cable of cableData) {
+        store.addCableRaw(cable);
+      }
+    },
+  };
 }

--- a/src/lib/stores/commands/device-type.ts
+++ b/src/lib/stores/commands/device-type.ts
@@ -83,6 +83,10 @@ export function createDeleteDeviceTypeCommand(
   }));
   const deviceTypeCopy = JSON.parse(JSON.stringify(deviceType)) as DeviceType;
   const cableData = connectedCables.map((c) => structuredClone(c));
+  // Populated by undo() so a subsequent redo can clean up placement images and
+  // restore cables under the (possibly remapped) device ids — placeDeviceRaw
+  // can change the id if it collides with another rack device (#1363).
+  const restoredDeviceIdMap = new Map<string, string>();
 
   // Snapshot all images associated with this device type
   const imageStore = getImageStore();
@@ -112,9 +116,14 @@ export function createDeleteDeviceTypeCommand(
       // Clean up images (moved from raw mutator)
       const imgStore = getImageStore();
       imgStore.removeAllDeviceImages(deviceTypeCopy.slug);
-      // Remove placement images — check both original and potentially remapped keys
+      // Remove placement images at both the snapshot id and any remapped id
+      // left over from a prior undo (otherwise redo leaks an orphan key).
       for (const { device } of deviceData) {
         imgStore.removeAllDeviceImages(`placement-${device.id}`);
+        const remapped = restoredDeviceIdMap.get(device.id);
+        if (remapped && remapped !== device.id) {
+          imgStore.removeAllDeviceImages(`placement-${remapped}`);
+        }
       }
       store.removeDeviceTypeRaw(deviceTypeCopy.slug);
     },
@@ -123,15 +132,13 @@ export function createDeleteDeviceTypeCommand(
       // Restore devices to their original racks
       const previousActiveRack = store.getActiveRackId();
       const imgStore = getImageStore();
-      // Track old→new device IDs so we can rewrite cable endpoints below
-      // (placeDeviceRaw may remap the ID — see #1363 dedup guard).
-      const deviceIdMap = new Map<string, string>();
+      restoredDeviceIdMap.clear();
       for (const { rackId, device } of deviceData) {
         store.setActiveRackId(rackId);
         const placedIdx = store.placeDeviceRaw(device);
         const placed = store.getDeviceAtIndex(placedIdx);
         const actualId = placed?.id ?? device.id;
-        deviceIdMap.set(device.id, actualId);
+        restoredDeviceIdMap.set(device.id, actualId);
         // Restore placement images under the (possibly remapped) key
         const originalKey = `placement-${device.id}`;
         const snap = placementSnapshots.get(originalKey);
@@ -163,8 +170,10 @@ export function createDeleteDeviceTypeCommand(
       for (const cable of cableData) {
         store.addCableRaw({
           ...cable,
-          a_device_id: deviceIdMap.get(cable.a_device_id) ?? cable.a_device_id,
-          b_device_id: deviceIdMap.get(cable.b_device_id) ?? cable.b_device_id,
+          a_device_id:
+            restoredDeviceIdMap.get(cable.a_device_id) ?? cable.a_device_id,
+          b_device_id:
+            restoredDeviceIdMap.get(cable.b_device_id) ?? cable.b_device_id,
         });
       }
     },

--- a/src/lib/stores/commands/device-type.ts
+++ b/src/lib/stores/commands/device-type.ts
@@ -20,7 +20,17 @@ export interface DeviceTypeCommandStore {
   getDeviceAtIndex(index: number): PlacedDevice | undefined;
   setActiveRackId(id: string | null): void;
   getActiveRackId(): string | null;
+  /**
+   * Append a cable in place — not recorded by the history system.
+   * `createDeleteDeviceTypeCommand` calls this from its undo path to restore
+   * cables snapshotted at command creation; the surrounding command provides
+   * the redo entry, so this mutator must not record one itself.
+   */
   addCableRaw(cable: Cable): void;
+  /**
+   * Remove the cable with the given id in place — not recorded by the history
+   * system. Counterpart to `addCableRaw`; same non-recording contract.
+   */
   removeCableRaw(id: string): void;
 }
 

--- a/src/lib/stores/layout/command-adapters.ts
+++ b/src/lib/stores/layout/command-adapters.ts
@@ -348,13 +348,22 @@ export function deleteMultipleDeviceTypesRecorded(
   const history = getHistoryStore();
   const adapter = getCommandStoreAdapter(ctx);
   const commands: ReturnType<typeof createDeleteDeviceTypeCommand>[] = [];
+  // A cable connecting devices of two different types would otherwise be
+  // snapshotted by both per-type delete commands, restoring it twice on undo.
+  const claimedCableIds = new Set<string>();
 
   for (const slug of slugs) {
     const existing = findDeviceTypeInArray(layout.device_types, slug);
     if (!existing) continue;
 
     const placedDevices = getPlacedDevicesWithRackForType(ctx, slug);
-    const connectedCables = findCablesForDevices(ctx, placedDevices);
+    const connectedCables = findCablesForDevices(ctx, placedDevices).filter(
+      (cable) => {
+        if (claimedCableIds.has(cable.id)) return false;
+        claimedCableIds.add(cable.id);
+        return true;
+      },
+    );
     const command = createDeleteDeviceTypeCommand(
       existing,
       placedDevices,

--- a/src/lib/stores/layout/command-adapters.ts
+++ b/src/lib/stores/layout/command-adapters.ts
@@ -11,6 +11,7 @@
  */
 
 import type {
+  Cable,
   DeviceFace,
   DeviceType,
   PlacedDevice,
@@ -19,10 +20,7 @@ import type {
 } from "$lib/types";
 import { UNITS_PER_U } from "$lib/types/constants";
 import { toInternalUnits, toHumanUnits } from "$lib/utils/position";
-import {
-  canPlaceDevice,
-  isSlotOccupied,
-} from "$lib/utils/collision";
+import { canPlaceDevice, isSlotOccupied } from "$lib/utils/collision";
 import {
   createDeviceType as createDeviceTypeHelper,
   findDeviceType as findDeviceTypeInArray,
@@ -78,6 +76,8 @@ import {
   replaceRackRaw,
   clearRackDevicesRaw,
   restoreRackDevicesRaw,
+  addCableRaw,
+  removeCableRaw,
 } from "./mutators";
 
 // =============================================================================
@@ -90,14 +90,21 @@ import {
  * Resolve the rack ID for adapter operations.
  * Uses active rack, validates it exists, and warns on fallback.
  */
-function resolveAdapterRackId(ctx: LayoutStateAccess, caller: string): string | undefined {
+function resolveAdapterRackId(
+  ctx: LayoutStateAccess,
+  caller: string,
+): string | undefined {
   const activeId = ctx.getActiveRackId();
   if (activeId) {
     // Validate the active rack still exists
     if (ctx.findRack(activeId)) {
       return activeId;
     }
-    layoutDebug.device("%s: activeRackId '%s' is stale (rack no longer exists), falling back", caller, activeId);
+    layoutDebug.device(
+      "%s: activeRackId '%s' is stale (rack no longer exists), falling back",
+      caller,
+      activeId,
+    );
   }
   // Fall back to first rack
   const target = getTargetRack(ctx);
@@ -145,14 +152,14 @@ export function getCommandStoreAdapter(
     getPlacedDevicesForType: (slug) => getPlacedDevicesForType(ctx, slug),
     setActiveRackId: (id) => ctx.setActiveRackId(id),
     getActiveRackId: () => ctx.getActiveRackId(),
+    addCableRaw: (cable) => addCableRaw(ctx, cable),
+    removeCableRaw: (id) => removeCableRaw(ctx, id),
 
     // DeviceCommandStore
     moveDeviceRaw: (index, newPosition) =>
       moveDeviceRaw(ctx, index, newPosition),
-    updateDeviceFaceRaw: (index, face) =>
-      updateDeviceFaceRaw(ctx, index, face),
-    updateDeviceNameRaw: (index, name) =>
-      updateDeviceNameRaw(ctx, index, name),
+    updateDeviceFaceRaw: (index, face) => updateDeviceFaceRaw(ctx, index, face),
+    updateDeviceNameRaw: (index, name) => updateDeviceNameRaw(ctx, index, name),
     updateDevicePlacementImageRaw: (index, face, filename) => {
       const rackId = resolveAdapterRackId(ctx, "updateDevicePlacementImageRaw");
       if (!rackId) {
@@ -269,6 +276,24 @@ export function updateDeviceTypeRecorded(
 }
 
 /**
+ * Find cables connected to any of the given placed devices.
+ * Used so DELETE_DEVICE_TYPE can clean up dangling cable endpoints (#1483).
+ */
+function findCablesForDevices(
+  ctx: LayoutStateAccess,
+  placedDevices: { rackId: string; device: PlacedDevice }[],
+): Cable[] {
+  const layout = ctx.getLayout();
+  const cables = layout.cables;
+  if (!cables || cables.length === 0) return [];
+  const deviceIds = new Set(placedDevices.map((p) => p.device.id));
+  if (deviceIds.size === 0) return [];
+  return cables.filter(
+    (c) => deviceIds.has(c.a_device_id) || deviceIds.has(c.b_device_id),
+  );
+}
+
+/**
  * Delete a device type with undo/redo support
  * @param ctx - Layout state access
  * @param slug - Device type slug
@@ -282,6 +307,7 @@ export function deleteDeviceTypeRecorded(
   if (!existing) return;
 
   const placedDevices = getPlacedDevicesWithRackForType(ctx, slug);
+  const connectedCables = findCablesForDevices(ctx, placedDevices);
   const history = getHistoryStore();
   const adapter = getCommandStoreAdapter(ctx);
 
@@ -289,6 +315,7 @@ export function deleteDeviceTypeRecorded(
     existing,
     placedDevices,
     adapter,
+    connectedCables,
   );
   history.execute(command);
   ctx.markDirty();
@@ -327,10 +354,12 @@ export function deleteMultipleDeviceTypesRecorded(
     if (!existing) continue;
 
     const placedDevices = getPlacedDevicesWithRackForType(ctx, slug);
+    const connectedCables = findCablesForDevices(ctx, placedDevices);
     const command = createDeleteDeviceTypeCommand(
       existing,
       placedDevices,
       adapter,
+      connectedCables,
     );
     commands.push(command);
   }
@@ -479,7 +508,10 @@ export function placeDeviceRecorded(
 
   if (autoImport) {
     const importCommand = createAddDeviceTypeCommand(autoImport, adapter);
-    const batch = createBatchCommand(`Place ${deviceName}`, [importCommand, placeCommand]);
+    const batch = createBatchCommand(`Place ${deviceName}`, [
+      importCommand,
+      placeCommand,
+    ]);
     history.execute(batch);
   } else {
     history.execute(placeCommand);
@@ -617,7 +649,10 @@ export function moveDeviceRecorded(
       adapter,
       deviceName,
     );
-    const batchCommand = createBatchCommand(`Move ${deviceName}`, [moveCommand, slotCommand]);
+    const batchCommand = createBatchCommand(`Move ${deviceName}`, [
+      moveCommand,
+      slotCommand,
+    ]);
     history.execute(batchCommand);
   } else {
     history.execute(moveCommand);

--- a/src/tests/commands-device-type.test.ts
+++ b/src/tests/commands-device-type.test.ts
@@ -19,6 +19,8 @@ function createMockStore(): DeviceTypeCommandStore & {
   getDeviceAtIndex: ReturnType<typeof vi.fn>;
   setActiveRackId: ReturnType<typeof vi.fn>;
   getActiveRackId: ReturnType<typeof vi.fn>;
+  addCableRaw: ReturnType<typeof vi.fn>;
+  removeCableRaw: ReturnType<typeof vi.fn>;
 } {
   let activeRackId: string | null = null;
   return {
@@ -29,8 +31,12 @@ function createMockStore(): DeviceTypeCommandStore & {
     removeDeviceAtIndexRaw: vi.fn(),
     getPlacedDevicesForType: vi.fn().mockReturnValue([]),
     getDeviceAtIndex: vi.fn().mockReturnValue(undefined),
-    setActiveRackId: vi.fn((id: string | null) => { activeRackId = id; }),
+    setActiveRackId: vi.fn((id: string | null) => {
+      activeRackId = id;
+    }),
     getActiveRackId: vi.fn(() => activeRackId),
+    addCableRaw: vi.fn(),
+    removeCableRaw: vi.fn(),
   };
 }
 
@@ -200,8 +206,17 @@ describe("Device Type Commands", () => {
       const store = createMockStore();
       const deviceType = createTestDeviceType({ slug: "server-type" });
       const placedDevices = [
-        { rackId: "rack-a", device: createTestDevice({ device_type: "server-type", position: 5 }) },
-        { rackId: "rack-b", device: createTestDevice({ device_type: "server-type", position: 10 }) },
+        {
+          rackId: "rack-a",
+          device: createTestDevice({ device_type: "server-type", position: 5 }),
+        },
+        {
+          rackId: "rack-b",
+          device: createTestDevice({
+            device_type: "server-type",
+            position: 10,
+          }),
+        },
       ];
 
       const command = createDeleteDeviceTypeCommand(
@@ -253,6 +268,51 @@ describe("Device Type Commands", () => {
       // Should restore with original position (5 in internal units), not mutated (99)
       expect(store.placeDeviceRaw).toHaveBeenCalledWith(
         expect.objectContaining({ position: toInternalUnits(5) }),
+      );
+    });
+
+    it("removes connected cables on execute and restores them on undo (#1483)", () => {
+      const store = createMockStore();
+      const deviceType = createTestDeviceType({ slug: "switch-type" });
+      const devA = createTestDevice({
+        device_type: "switch-type",
+        position: 1,
+      });
+      const devB = createTestDevice({
+        device_type: "switch-type",
+        position: 2,
+      });
+      const placedDevices = [
+        { rackId: "rack-1", device: devA },
+        { rackId: "rack-1", device: devB },
+      ];
+      const cables = [
+        {
+          id: "cable-1",
+          a_device_id: devA.id,
+          a_interface: "eth0",
+          b_device_id: devB.id,
+          b_interface: "eth1",
+        },
+      ];
+
+      const command = createDeleteDeviceTypeCommand(
+        deviceType,
+        placedDevices,
+        store,
+        cables,
+      );
+
+      command.execute();
+      expect(store.removeCableRaw).toHaveBeenCalledWith("cable-1");
+
+      command.undo();
+      expect(store.addCableRaw).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "cable-1",
+          a_device_id: devA.id,
+          b_device_id: devB.id,
+        }),
       );
     });
   });

--- a/src/tests/commands-device.test.ts
+++ b/src/tests/commands-device.test.ts
@@ -305,6 +305,8 @@ describe("Device Commands", () => {
         removeDeviceTypeRaw: vi.fn(),
         updateDeviceTypeRaw: vi.fn(),
         getPlacedDevicesForType: vi.fn().mockReturnValue([]),
+        addCableRaw: vi.fn(),
+        removeCableRaw: vi.fn(),
       };
     }
 

--- a/src/tests/image-undo.test.ts
+++ b/src/tests/image-undo.test.ts
@@ -7,202 +7,265 @@
  * so undoing a removal lost the images permanently.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { getImageStore, resetImageStore } from '$lib/stores/images.svelte';
-import { createRemoveDeviceCommand } from '$lib/stores/commands/device';
-import { createDeleteDeviceTypeCommand } from '$lib/stores/commands/device-type';
-import type { DeviceCommandStore } from '$lib/stores/commands/device';
-import type { DeviceTypeCommandStore } from '$lib/stores/commands/device-type';
-import { createTestDevice, createTestDeviceType } from './factories';
-import type { PlacedDevice, DeviceType } from '$lib/types';
-import type { ImageData } from '$lib/types/images';
+import { describe, it, expect, beforeEach } from "vitest";
+import { getImageStore, resetImageStore } from "$lib/stores/images.svelte";
+import { createRemoveDeviceCommand } from "$lib/stores/commands/device";
+import { createDeleteDeviceTypeCommand } from "$lib/stores/commands/device-type";
+import type { DeviceCommandStore } from "$lib/stores/commands/device";
+import type { DeviceTypeCommandStore } from "$lib/stores/commands/device-type";
+import { createTestDevice, createTestDeviceType } from "./factories";
+import type { PlacedDevice, DeviceType } from "$lib/types";
+import type { ImageData } from "$lib/types/images";
 
 // Helper to create mock ImageData (user upload)
-function createMockImageData(filename = 'test-front.png'): ImageData {
-	return {
-		blob: new Blob(['test'], { type: 'image/png' }),
-		dataUrl: 'data:image/png;base64,dGVzdA==',
-		filename
-	};
+function createMockImageData(filename = "test-front.png"): ImageData {
+  return {
+    blob: new Blob(["test"], { type: "image/png" }),
+    dataUrl: "data:image/png;base64,dGVzdA==",
+    filename,
+  };
 }
 
 // Minimal mock store that tracks placed devices
 function createMockDeviceStore(devices: PlacedDevice[]): DeviceCommandStore {
-	return {
-		placeDeviceRaw(device: PlacedDevice) {
-			devices.push(device);
-			return devices.length - 1;
-		},
-		removeDeviceAtIndexRaw(index: number) {
-			const removed = devices[index];
-			devices.splice(index, 1);
-			return removed;
-		},
-		moveDeviceRaw() { return true; },
-		updateDeviceFaceRaw() {},
-		updateDeviceNameRaw() {},
-		updateDevicePlacementImageRaw() {},
-		updateDeviceColourRaw() {},
-		updateDeviceSlotPositionRaw() {},
-		updateDeviceNotesRaw() {},
-		updateDeviceIpRaw() {},
-		getDeviceAtIndex(index: number) { return devices[index]; },
-	};
+  return {
+    placeDeviceRaw(device: PlacedDevice) {
+      devices.push(device);
+      return devices.length - 1;
+    },
+    removeDeviceAtIndexRaw(index: number) {
+      const removed = devices[index];
+      devices.splice(index, 1);
+      return removed;
+    },
+    moveDeviceRaw() {
+      return true;
+    },
+    updateDeviceFaceRaw() {},
+    updateDeviceNameRaw() {},
+    updateDevicePlacementImageRaw() {},
+    updateDeviceColourRaw() {},
+    updateDeviceSlotPositionRaw() {},
+    updateDeviceNotesRaw() {},
+    updateDeviceIpRaw() {},
+    getDeviceAtIndex(index: number) {
+      return devices[index];
+    },
+  };
 }
 
 // Minimal mock store for device type commands
 function createMockDeviceTypeStore(
-	deviceTypes: DeviceType[],
-	devices: PlacedDevice[]
+  deviceTypes: DeviceType[],
+  devices: PlacedDevice[],
 ): DeviceTypeCommandStore {
-	let activeRackId: string | null = null;
-	return {
-		addDeviceTypeRaw(dt: DeviceType) {
-			deviceTypes.push(dt);
-		},
-		removeDeviceTypeRaw(slug: string) {
-			const idx = deviceTypes.findIndex((dt) => dt.slug === slug);
-			if (idx >= 0) deviceTypes.splice(idx, 1);
-			// Also remove placed devices of this type
-			for (let i = devices.length - 1; i >= 0; i--) {
-				if (devices[i].device_type === slug) devices.splice(i, 1);
-			}
-		},
-		updateDeviceTypeRaw() {},
-		placeDeviceRaw(device: PlacedDevice) {
-			devices.push(device);
-			return devices.length - 1;
-		},
-		removeDeviceAtIndexRaw() {},
-		getPlacedDevicesForType(slug: string) {
-			return devices.filter((d) => d.device_type === slug);
-		},
-		getDeviceAtIndex(index: number) { return devices[index]; },
-		setActiveRackId(id: string | null) { activeRackId = id; },
-		getActiveRackId() { return activeRackId; },
-	};
+  let activeRackId: string | null = null;
+  return {
+    addDeviceTypeRaw(dt: DeviceType) {
+      deviceTypes.push(dt);
+    },
+    removeDeviceTypeRaw(slug: string) {
+      const idx = deviceTypes.findIndex((dt) => dt.slug === slug);
+      if (idx >= 0) deviceTypes.splice(idx, 1);
+      // Also remove placed devices of this type
+      for (let i = devices.length - 1; i >= 0; i--) {
+        if (devices[i].device_type === slug) devices.splice(i, 1);
+      }
+    },
+    updateDeviceTypeRaw() {},
+    placeDeviceRaw(device: PlacedDevice) {
+      devices.push(device);
+      return devices.length - 1;
+    },
+    removeDeviceAtIndexRaw() {},
+    getPlacedDevicesForType(slug: string) {
+      return devices.filter((d) => d.device_type === slug);
+    },
+    getDeviceAtIndex(index: number) {
+      return devices[index];
+    },
+    setActiveRackId(id: string | null) {
+      activeRackId = id;
+    },
+    getActiveRackId() {
+      return activeRackId;
+    },
+    addCableRaw() {},
+    removeCableRaw() {},
+  };
 }
 
-describe('Image Undo — Device Removal', () => {
-	beforeEach(() => {
-		resetImageStore();
-	});
+describe("Image Undo — Device Removal", () => {
+  beforeEach(() => {
+    resetImageStore();
+  });
 
-	it('removing device with placement image then undoing restores image', () => {
-		const imageStore = getImageStore();
-		const device = createTestDevice({ id: 'dev-1', device_type: 'test-device' });
-		const devices = [device];
-		const store = createMockDeviceStore(devices);
+  it("removing device with placement image then undoing restores image", () => {
+    const imageStore = getImageStore();
+    const device = createTestDevice({
+      id: "dev-1",
+      device_type: "test-device",
+    });
+    const devices = [device];
+    const store = createMockDeviceStore(devices);
 
-		// Set up a placement image for this device
-		const imageKey = `placement-${device.id}`;
-		const frontImage = createMockImageData('dev-1-front.png');
-		imageStore.setDeviceImage(imageKey, 'front', frontImage);
+    // Set up a placement image for this device
+    const imageKey = `placement-${device.id}`;
+    const frontImage = createMockImageData("dev-1-front.png");
+    imageStore.setDeviceImage(imageKey, "front", frontImage);
 
-		// Verify image exists before removal
-		expect(imageStore.hasImage(imageKey, 'front')).toBe(true);
+    // Verify image exists before removal
+    expect(imageStore.hasImage(imageKey, "front")).toBe(true);
 
-		// Create the remove command (should snapshot images)
-		const cmd = createRemoveDeviceCommand(0, device, store, 'Test Device');
+    // Create the remove command (should snapshot images)
+    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device");
 
-		// Execute: removes device and cleans up images
-		cmd.execute();
-		expect(imageStore.hasImage(imageKey, 'front')).toBe(false);
+    // Execute: removes device and cleans up images
+    cmd.execute();
+    expect(imageStore.hasImage(imageKey, "front")).toBe(false);
 
-		// Undo: should restore the device AND its images
-		cmd.undo();
-		expect(imageStore.hasImage(imageKey, 'front')).toBe(true);
-		expect(imageStore.getDeviceImage(imageKey, 'front')?.filename).toBe('dev-1-front.png');
-	});
+    // Undo: should restore the device AND its images
+    cmd.undo();
+    expect(imageStore.hasImage(imageKey, "front")).toBe(true);
+    expect(imageStore.getDeviceImage(imageKey, "front")?.filename).toBe(
+      "dev-1-front.png",
+    );
+  });
 
-	it('removing device with both front and rear images restores both on undo', () => {
-		const imageStore = getImageStore();
-		const device = createTestDevice({ id: 'dev-2', device_type: 'test-device' });
-		const devices = [device];
-		const store = createMockDeviceStore(devices);
+  it("removing device with both front and rear images restores both on undo", () => {
+    const imageStore = getImageStore();
+    const device = createTestDevice({
+      id: "dev-2",
+      device_type: "test-device",
+    });
+    const devices = [device];
+    const store = createMockDeviceStore(devices);
 
-		const imageKey = `placement-${device.id}`;
-		imageStore.setDeviceImage(imageKey, 'front', createMockImageData('dev-2-front.png'));
-		imageStore.setDeviceImage(imageKey, 'rear', createMockImageData('dev-2-rear.png'));
+    const imageKey = `placement-${device.id}`;
+    imageStore.setDeviceImage(
+      imageKey,
+      "front",
+      createMockImageData("dev-2-front.png"),
+    );
+    imageStore.setDeviceImage(
+      imageKey,
+      "rear",
+      createMockImageData("dev-2-rear.png"),
+    );
 
-		const cmd = createRemoveDeviceCommand(0, device, store, 'Test Device');
+    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device");
 
-		cmd.execute();
-		expect(imageStore.hasImage(imageKey, 'front')).toBe(false);
-		expect(imageStore.hasImage(imageKey, 'rear')).toBe(false);
+    cmd.execute();
+    expect(imageStore.hasImage(imageKey, "front")).toBe(false);
+    expect(imageStore.hasImage(imageKey, "rear")).toBe(false);
 
-		cmd.undo();
-		expect(imageStore.hasImage(imageKey, 'front')).toBe(true);
-		expect(imageStore.hasImage(imageKey, 'rear')).toBe(true);
-		expect(imageStore.getDeviceImage(imageKey, 'front')?.filename).toBe('dev-2-front.png');
-		expect(imageStore.getDeviceImage(imageKey, 'rear')?.filename).toBe('dev-2-rear.png');
-	});
+    cmd.undo();
+    expect(imageStore.hasImage(imageKey, "front")).toBe(true);
+    expect(imageStore.hasImage(imageKey, "rear")).toBe(true);
+    expect(imageStore.getDeviceImage(imageKey, "front")?.filename).toBe(
+      "dev-2-front.png",
+    );
+    expect(imageStore.getDeviceImage(imageKey, "rear")?.filename).toBe(
+      "dev-2-rear.png",
+    );
+  });
 
-	it('removing device without images does not fail on undo', () => {
-		const device = createTestDevice({ id: 'dev-3', device_type: 'test-device' });
-		const devices = [device];
-		const store = createMockDeviceStore(devices);
+  it("removing device without images does not fail on undo", () => {
+    const device = createTestDevice({
+      id: "dev-3",
+      device_type: "test-device",
+    });
+    const devices = [device];
+    const store = createMockDeviceStore(devices);
 
-		const cmd = createRemoveDeviceCommand(0, device, store, 'Test Device');
+    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device");
 
-		cmd.execute();
-		// Should not throw
-		expect(() => cmd.undo()).not.toThrow();
-	});
+    cmd.execute();
+    // Should not throw
+    expect(() => cmd.undo()).not.toThrow();
+  });
 });
 
-describe('Image Undo — Device Type Deletion', () => {
-	beforeEach(() => {
-		resetImageStore();
-	});
+describe("Image Undo — Device Type Deletion", () => {
+  beforeEach(() => {
+    resetImageStore();
+  });
 
-	it('deleting device type with images then undoing restores all images', () => {
-		const imageStore = getImageStore();
-		const deviceType = createTestDeviceType({ slug: 'my-server', u_height: 2 });
-		const device1 = createTestDevice({ id: 'placed-1', device_type: 'my-server' });
-		const device2 = createTestDevice({ id: 'placed-2', device_type: 'my-server' });
+  it("deleting device type with images then undoing restores all images", () => {
+    const imageStore = getImageStore();
+    const deviceType = createTestDeviceType({ slug: "my-server", u_height: 2 });
+    const device1 = createTestDevice({
+      id: "placed-1",
+      device_type: "my-server",
+    });
+    const device2 = createTestDevice({
+      id: "placed-2",
+      device_type: "my-server",
+    });
 
-		const deviceTypes = [deviceType];
-		const devices = [device1, device2];
-		const store = createMockDeviceTypeStore(deviceTypes, devices);
+    const deviceTypes = [deviceType];
+    const devices = [device1, device2];
+    const store = createMockDeviceTypeStore(deviceTypes, devices);
 
-		// Set up type-level image
-		imageStore.setDeviceImage('my-server', 'front', createMockImageData('my-server-front.png'));
+    // Set up type-level image
+    imageStore.setDeviceImage(
+      "my-server",
+      "front",
+      createMockImageData("my-server-front.png"),
+    );
 
-		// Set up placement-specific images
-		imageStore.setDeviceImage('placement-placed-1', 'front', createMockImageData('placed-1-front.png'));
-		imageStore.setDeviceImage('placement-placed-2', 'rear', createMockImageData('placed-2-rear.png'));
+    // Set up placement-specific images
+    imageStore.setDeviceImage(
+      "placement-placed-1",
+      "front",
+      createMockImageData("placed-1-front.png"),
+    );
+    imageStore.setDeviceImage(
+      "placement-placed-2",
+      "rear",
+      createMockImageData("placed-2-rear.png"),
+    );
 
-		const cmd = createDeleteDeviceTypeCommand(deviceType, [
-			{ rackId: 'rack-1', device: device1 },
-			{ rackId: 'rack-1', device: device2 },
-		], store);
+    const cmd = createDeleteDeviceTypeCommand(
+      deviceType,
+      [
+        { rackId: "rack-1", device: device1 },
+        { rackId: "rack-1", device: device2 },
+      ],
+      store,
+    );
 
-		// Execute: deletes type, devices, and images
-		cmd.execute();
-		expect(imageStore.hasImage('my-server', 'front')).toBe(false);
-		expect(imageStore.hasImage('placement-placed-1', 'front')).toBe(false);
-		expect(imageStore.hasImage('placement-placed-2', 'rear')).toBe(false);
+    // Execute: deletes type, devices, and images
+    cmd.execute();
+    expect(imageStore.hasImage("my-server", "front")).toBe(false);
+    expect(imageStore.hasImage("placement-placed-1", "front")).toBe(false);
+    expect(imageStore.hasImage("placement-placed-2", "rear")).toBe(false);
 
-		// Undo: should restore everything
-		cmd.undo();
-		expect(imageStore.hasImage('my-server', 'front')).toBe(true);
-		expect(imageStore.getDeviceImage('my-server', 'front')?.filename).toBe('my-server-front.png');
-		expect(imageStore.hasImage('placement-placed-1', 'front')).toBe(true);
-		expect(imageStore.getDeviceImage('placement-placed-1', 'front')?.filename).toBe('placed-1-front.png');
-		expect(imageStore.hasImage('placement-placed-2', 'rear')).toBe(true);
-		expect(imageStore.getDeviceImage('placement-placed-2', 'rear')?.filename).toBe('placed-2-rear.png');
-	});
+    // Undo: should restore everything
+    cmd.undo();
+    expect(imageStore.hasImage("my-server", "front")).toBe(true);
+    expect(imageStore.getDeviceImage("my-server", "front")?.filename).toBe(
+      "my-server-front.png",
+    );
+    expect(imageStore.hasImage("placement-placed-1", "front")).toBe(true);
+    expect(
+      imageStore.getDeviceImage("placement-placed-1", "front")?.filename,
+    ).toBe("placed-1-front.png");
+    expect(imageStore.hasImage("placement-placed-2", "rear")).toBe(true);
+    expect(
+      imageStore.getDeviceImage("placement-placed-2", "rear")?.filename,
+    ).toBe("placed-2-rear.png");
+  });
 
-	it('deleting device type without images does not fail on undo', () => {
-		const deviceType = createTestDeviceType({ slug: 'no-image-device' });
-		const deviceTypes = [deviceType];
-		const devices: PlacedDevice[] = [];
-		const store = createMockDeviceTypeStore(deviceTypes, devices);
+  it("deleting device type without images does not fail on undo", () => {
+    const deviceType = createTestDeviceType({ slug: "no-image-device" });
+    const deviceTypes = [deviceType];
+    const devices: PlacedDevice[] = [];
+    const store = createMockDeviceTypeStore(deviceTypes, devices);
 
-		const cmd = createDeleteDeviceTypeCommand(deviceType, [], store);
+    const cmd = createDeleteDeviceTypeCommand(deviceType, [], store);
 
-		cmd.execute();
-		expect(() => cmd.undo()).not.toThrow();
-	});
+    cmd.execute();
+    expect(() => cmd.undo()).not.toThrow();
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

Closes #1483.

When a device type is deleted, `removeDeviceTypeRaw` removes the device type and all placed devices of that type — but cables connected to those placed devices were silently orphaned. Their `a_device_id` / `b_device_id` would point to nonexistent devices, polluting layout data and potentially breaking cable rendering or export.

Fix at the **command** layer (not the raw mutator) so undo can restore the cables along with the devices and type, per the issue's guidance.

### Changes

- `DeviceTypeCommandStore` gains `addCableRaw(cable)` / `removeCableRaw(id)`
- `createDeleteDeviceTypeCommand` accepts a `Cable[]` snapshot:
  - `execute()` removes the cables before removing devices/type
  - `undo()` re-adds them after devices and type are restored
- `deleteDeviceTypeRecorded` and `deleteMultipleDeviceTypesRecorded` (in `command-adapters.ts`) find cables whose `a_device_id` or `b_device_id` references any placed device of the deleted type
- New regression test in `commands-device-type.test.ts` for execute/undo round-trip with a connected cable
- Mock stores in `commands-device.test.ts` and `image-undo.test.ts` updated for the expanded interface

## Test plan

- [x] `npm run check` — 0 new errors (16 pre-existing on `main`, unrelated)
- [x] `npm run test:run` — 1923/1923 pass (one new regression test: "removes connected cables on execute and restores them on undo")
- [ ] Manual: place two devices, run a cable between them, delete the device type → cable disappears; Ctrl+Z → devices + cable restored

## Triage context

Part of the open-bugs triage pass. Next after #1029 (merged in #1688) and #1467 (merged in #1690).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoM4h1NiCDWGBEgZkF6eov)_


___

## **CodeAnt-AI Description**
**Remove cables when deleting a device type, and restore them on undo**

### What Changed
- Deleting a device type now also removes any cables connected to devices of that type, so no broken cable links are left behind.
- Undo restores the deleted device type, its placed devices, and the connected cables in one step.
- The same cleanup now applies to deleting multiple device types at once.
- Added regression coverage for cable cleanup during delete and restore flows.

### Impact
`✅ Fewer broken cable links after device type deletion`
`✅ Cleaner layout data after bulk deletes`
`✅ Reliable undo for device type cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
