### PR TITLE
feat: validate interface positions on half-depth device types (#254)

### DIFF
--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -43,9 +43,9 @@ Homelabbers planning rack layouts. Desktop browser users for creation/editing, m
 
 Rackula supports two deployment modes:
 
-| Mode       | Backend  | Persistence             | Use Case                   |
-| ---------- | -------- | ----------------------- | -------------------------- |
-| **Static** | None     | File download/upload    | GitHub Pages, simple hosts |
+| Mode        | Backend  | Persistence            | Use Case                   |
+| ----------- | -------- | ---------------------- | -------------------------- |
+| **Static**  | None     | File download/upload   | GitHub Pages, simple hosts |
 | **Persist** | Hono/Bun | API server (save/load) | Self-hosted Docker         |
 
 In static mode, Rackula is a pure client-side SPA with no network dependencies. In persist mode, an optional API server provides layout storage, authentication, and multi-device sync.
@@ -119,6 +119,13 @@ The `face` property is the single source of truth for collision detection:
 - Half-depth devices (`is_full_depth: false`) default to `face: "front"`
 - Users can override face via EditPanel; the override takes precedence for collision detection
 
+**Interface Position Constraints:**
+
+Half-depth device types (`is_full_depth: false`) have a single physical face. Their interface
+templates cannot have mixed `position` values — all explicitly positioned interfaces must use
+the same face (`front` or `rear`). Unpositioned interfaces default to `front`. This constraint
+is enforced by `DeviceTypeSchema`.
+
 **Interaction Consistency:**
 
 Both drag-and-drop and keyboard movement use face-aware validation:
@@ -175,10 +182,10 @@ my-rack.Rackula.zip
 
 ## See Also
 
-| Document                                  | Purpose                           |
-| ----------------------------------------- | --------------------------------- |
-| [ARCHITECTURE.md](../ARCHITECTURE.md)     | Codebase overview and entry points |
-| [SCHEMA.md](./SCHEMA.md)                  | Complete data schema reference    |
-| [BRAND.md](./BRAND.md)                    | Design system and brand colours   |
-| [CLAUDE.md](../../CLAUDE.md)              | Development workflow and commands |
-| [CHANGELOG.md](../../CHANGELOG.md)        | Version history                   |
+| Document                              | Purpose                            |
+| ------------------------------------- | ---------------------------------- |
+| [ARCHITECTURE.md](../ARCHITECTURE.md) | Codebase overview and entry points |
+| [SCHEMA.md](./SCHEMA.md)              | Complete data schema reference     |
+| [BRAND.md](./BRAND.md)                | Design system and brand colours    |
+| [CLAUDE.md](../../CLAUDE.md)          | Development workflow and commands  |
+| [CHANGELOG.md](../../CHANGELOG.md)    | Version history                    |

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -539,15 +539,16 @@ export const DeviceTypeSchema = z
   })
   .passthrough()
   .superRefine((data, ctx) => {
-    // Half-depth devices have one physical face; interfaces cannot span both
+    // Half-depth devices have one physical face; interfaces cannot span both.
+    // Unspecified position defaults to 'front', so implicit-front + explicit-rear is also invalid.
     if (
       data.is_full_depth === false &&
       data.interfaces &&
       data.interfaces.length > 0
     ) {
-      const positions = data.interfaces
-        .filter((iface: { position?: string }) => iface.position != null)
-        .map((iface: { position?: string }) => iface.position);
+      const positions = data.interfaces.map(
+        (iface: { position?: string }) => iface.position ?? "front",
+      );
       const uniquePositions = new Set(positions);
       if (uniquePositions.size > 1) {
         ctx.addIssue({

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -537,7 +537,28 @@ export const DeviceTypeSchema = z
      */
     slots: z.array(SlotSchema).optional(),
   })
-  .passthrough();
+  .passthrough()
+  .superRefine((data, ctx) => {
+    // Half-depth devices have one physical face; interfaces cannot span both
+    if (
+      data.is_full_depth === false &&
+      data.interfaces &&
+      data.interfaces.length > 0
+    ) {
+      const positions = data.interfaces
+        .filter((iface: { position?: string }) => iface.position != null)
+        .map((iface: { position?: string }) => iface.position);
+      const uniquePositions = new Set(positions);
+      if (uniquePositions.size > 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "Half-depth device cannot have interfaces on both front and rear faces",
+          path: ["interfaces"],
+        });
+      }
+    }
+  });
 
 /**
  * Placed device schema - instance in rack

--- a/src/tests/schemas.test.ts
+++ b/src/tests/schemas.test.ts
@@ -480,12 +480,7 @@ describe("DeviceTypeSchema", () => {
 // ============================================================================
 
 describe("DeviceTypeSchema half-depth interface position validation", () => {
-  const validBase = {
-    slug: "test-device",
-    u_height: 1,
-    colour: "#4A90D9",
-    category: "server" as const,
-  };
+  const validBase = createTestDeviceType({ slug: "test-device" });
 
   it("accepts half-depth device with all-front interfaces", () => {
     const device = {
@@ -547,6 +542,22 @@ describe("DeviceTypeSchema half-depth interface position validation", () => {
       interfaces: [
         { name: "eth0", type: "1000base-t", position: "front" },
         { name: "mgmt", type: "console", position: "rear" },
+      ],
+    };
+    const result = DeviceTypeSchema.safeParse(device);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain("interfaces");
+    }
+  });
+
+  it("rejects half-depth device with implicit-front and explicit-rear interfaces", () => {
+    const device = {
+      ...validBase,
+      is_full_depth: false,
+      interfaces: [
+        { name: "eth0", type: "1000base-t", position: "rear" },
+        { name: "eth1", type: "1000base-t" }, // no position = implicit front
       ],
     };
     const result = DeviceTypeSchema.safeParse(device);

--- a/src/tests/schemas.test.ts
+++ b/src/tests/schemas.test.ts
@@ -476,6 +476,88 @@ describe("DeviceTypeSchema", () => {
 });
 
 // ============================================================================
+// DeviceTypeSchema interface position validation
+// ============================================================================
+
+describe("DeviceTypeSchema half-depth interface position validation", () => {
+  const validBase = {
+    slug: "test-device",
+    u_height: 1,
+    colour: "#4A90D9",
+    category: "server" as const,
+  };
+
+  it("accepts half-depth device with all-front interfaces", () => {
+    const device = {
+      ...validBase,
+      is_full_depth: false,
+      interfaces: [
+        { name: "eth0", type: "1000base-t", position: "front" },
+        { name: "eth1", type: "1000base-t", position: "front" },
+      ],
+    };
+    expect(DeviceTypeSchema.safeParse(device).success).toBe(true);
+  });
+
+  it("accepts half-depth device with all-rear interfaces", () => {
+    const device = {
+      ...validBase,
+      is_full_depth: false,
+      interfaces: [
+        { name: "eth0", type: "1000base-t", position: "rear" },
+        { name: "eth1", type: "1000base-t", position: "rear" },
+      ],
+    };
+    expect(DeviceTypeSchema.safeParse(device).success).toBe(true);
+  });
+
+  it("accepts half-depth device with unpositioned interfaces", () => {
+    const device = {
+      ...validBase,
+      is_full_depth: false,
+      interfaces: [
+        { name: "eth0", type: "1000base-t" },
+        { name: "eth1", type: "1000base-t" },
+      ],
+    };
+    expect(DeviceTypeSchema.safeParse(device).success).toBe(true);
+  });
+
+  it("accepts half-depth device with no interfaces", () => {
+    const device = { ...validBase, is_full_depth: false };
+    expect(DeviceTypeSchema.safeParse(device).success).toBe(true);
+  });
+
+  it("accepts full-depth device with mixed front and rear interfaces", () => {
+    const device = {
+      ...validBase,
+      is_full_depth: true,
+      interfaces: [
+        { name: "eth0", type: "1000base-t", position: "front" },
+        { name: "mgmt", type: "console", position: "rear" },
+      ],
+    };
+    expect(DeviceTypeSchema.safeParse(device).success).toBe(true);
+  });
+
+  it("rejects half-depth device with mixed front and rear interfaces", () => {
+    const device = {
+      ...validBase,
+      is_full_depth: false,
+      interfaces: [
+        { name: "eth0", type: "1000base-t", position: "front" },
+        { name: "mgmt", type: "console", position: "rear" },
+      ],
+    };
+    const result = DeviceTypeSchema.safeParse(device);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain("interfaces");
+    }
+  });
+});
+
+// ============================================================================
 // PlacedDeviceSchema Tests
 // ============================================================================
 
@@ -1599,16 +1681,46 @@ describe("LayoutSchema device ID deduplication (#1363)", () => {
           starting_unit: 1,
           position: 0,
           devices: [
-            { id: "dupe-id", device_type: "server-a", position: 100, face: "front" as const },
-            { id: "dupe-id", device_type: "server-b", position: 200, face: "front" as const },
-            { id: "unique-id", device_type: "server-c", position: 300, face: "front" as const },
+            {
+              id: "dupe-id",
+              device_type: "server-a",
+              position: 100,
+              face: "front" as const,
+            },
+            {
+              id: "dupe-id",
+              device_type: "server-b",
+              position: 200,
+              face: "front" as const,
+            },
+            {
+              id: "unique-id",
+              device_type: "server-c",
+              position: 300,
+              face: "front" as const,
+            },
           ],
         },
       ],
       device_types: [
-        { slug: "server-a", u_height: 1, colour: "#4A90A4", category: "server" as const },
-        { slug: "server-b", u_height: 1, colour: "#4A90A4", category: "server" as const },
-        { slug: "server-c", u_height: 1, colour: "#4A90A4", category: "server" as const },
+        {
+          slug: "server-a",
+          u_height: 1,
+          colour: "#4A90A4",
+          category: "server" as const,
+        },
+        {
+          slug: "server-b",
+          u_height: 1,
+          colour: "#4A90A4",
+          category: "server" as const,
+        },
+        {
+          slug: "server-c",
+          u_height: 1,
+          colour: "#4A90A4",
+          category: "server" as const,
+        },
       ],
       settings: baseSettings,
     };
@@ -1644,8 +1756,18 @@ describe("LayoutSchema device ID deduplication (#1363)", () => {
           starting_unit: 1,
           position: 0,
           devices: [
-            { id: "dupe-id", device_type: "server-a", position: 100, face: "front" as const },
-            { id: "dupe-id", device_type: "server-b", position: 200, face: "front" as const },
+            {
+              id: "dupe-id",
+              device_type: "server-a",
+              position: 100,
+              face: "front" as const,
+            },
+            {
+              id: "dupe-id",
+              device_type: "server-b",
+              position: 200,
+              face: "front" as const,
+            },
           ],
         },
         {
@@ -1659,15 +1781,40 @@ describe("LayoutSchema device ID deduplication (#1363)", () => {
           starting_unit: 1,
           position: 1,
           devices: [
-            { id: "dupe-id-2", device_type: "server-a", position: 100, face: "front" as const },
-            { id: "dupe-id-2", device_type: "server-c", position: 200, face: "front" as const },
+            {
+              id: "dupe-id-2",
+              device_type: "server-a",
+              position: 100,
+              face: "front" as const,
+            },
+            {
+              id: "dupe-id-2",
+              device_type: "server-c",
+              position: 200,
+              face: "front" as const,
+            },
           ],
         },
       ],
       device_types: [
-        { slug: "server-a", u_height: 1, colour: "#4A90A4", category: "server" as const },
-        { slug: "server-b", u_height: 1, colour: "#4A90A4", category: "server" as const },
-        { slug: "server-c", u_height: 1, colour: "#4A90A4", category: "server" as const },
+        {
+          slug: "server-a",
+          u_height: 1,
+          colour: "#4A90A4",
+          category: "server" as const,
+        },
+        {
+          slug: "server-b",
+          u_height: 1,
+          colour: "#4A90A4",
+          category: "server" as const,
+        },
+        {
+          slug: "server-c",
+          u_height: 1,
+          colour: "#4A90A4",
+          category: "server" as const,
+        },
       ],
       settings: baseSettings,
     };


### PR DESCRIPTION
## **User description**
## Summary

- Adds a `superRefine` to `DeviceTypeSchema` that rejects half-depth devices (`is_full_depth: false`) whose `interfaces` array mixes `front` and `rear` position values
- A half-depth device has one physical face, so ports physically cannot span both faces
- Documents the constraint in `docs/reference/SPEC.md` under "Interface Position Constraints"

## Why

Part of the network interface visualization track (#71). Closing the gap between #247 (InterfaceTemplate schema merged) and future port visualization work: without this guard a brand-pack author could accidentally define a half-depth device with ports on both front and rear, which would be silently invalid.

## Test Plan

- [x] `npm run lint` — passes
- [x] `npm run test:run` — 1975 tests pass (96 test files)
- [x] `npm run build` — builds successfully
- [x] New `describe("DeviceTypeSchema half-depth interface position validation")` block covers:
  - accepts half-depth + all-front interfaces
  - accepts half-depth + all-rear interfaces
  - accepts half-depth + unpositioned interfaces
  - accepts half-depth + no interfaces
  - accepts full-depth + mixed front/rear (valid)
  - rejects half-depth + mixed front/rear (the new rule)

Closes #254

---
_Generated by [Claude Code](https://claude.ai/code/session_014VGvxGUUHgTwXShx53o3Cx)_


___

## **CodeAnt-AI Description**
**Reject invalid interface layouts on half-depth device types**

### What Changed
- Half-depth device types are now rejected when their interfaces are split across both front and rear faces
- Half-depth devices still allow interfaces on only one face, unpositioned interfaces, or no interfaces at all
- Full-depth devices can still use front and rear interfaces together
- The spec now explains the interface position rule for half-depth devices
- Added tests for valid and invalid half-depth interface layouts

### Impact
`✅ Fewer invalid device definitions`
`✅ Clearer interface layout rules`
`✅ Safer rack visualization data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
