### PR TITLE
fix: convert position from internal units in resize validator (#1683)

### DIFF
--- a/src/lib/utils/rack-resize.ts
+++ b/src/lib/utils/rack-resize.ts
@@ -5,24 +5,25 @@
  * Issue #115: Allow growing always, shrinking only when devices fit.
  */
 
-import type { Rack, DeviceType, PlacedDevice } from '$lib/types';
+import type { Rack, DeviceType, PlacedDevice } from "$lib/types";
+import { toHumanUnits } from "./position";
 
 /**
  * Result of resize validation
  */
 export interface ResizeValidationResult {
-	/** Whether the resize is allowed */
-	allowed: boolean;
-	/** List of devices that would exceed new bounds */
-	conflicts: PlacedDevice[];
+  /** Whether the resize is allowed */
+  allowed: boolean;
+  /** List of devices that would exceed new bounds */
+  conflicts: PlacedDevice[];
 }
 
 /**
  * Conflict with enriched device type information
  */
 export interface ConflictInfo {
-	device: PlacedDevice;
-	deviceType: DeviceType | undefined;
+  device: PlacedDevice;
+  deviceType: DeviceType | undefined;
 }
 
 /**
@@ -34,40 +35,43 @@ export interface ConflictInfo {
  * - Conflict formula: position + u_height - 1 > newHeight
  *
  * @param rack - The rack to check
- * @param newHeight - The proposed new height
+ * @param newHeight - The proposed new height (human U)
  * @param deviceTypes - Device type library for u_height lookup
  * @returns Validation result with conflicts if any
  */
 export function canResizeRackTo(
-	rack: Rack,
-	newHeight: number,
-	deviceTypes: DeviceType[]
+  rack: Rack,
+  newHeight: number,
+  deviceTypes: DeviceType[],
 ): ResizeValidationResult {
-	// Growing is always allowed
-	if (newHeight >= rack.height) {
-		return { allowed: true, conflicts: [] };
-	}
+  // Growing is always allowed
+  if (newHeight >= rack.height) {
+    return { allowed: true, conflicts: [] };
+  }
 
-	// Shrinking - check each device
-	const conflicts: PlacedDevice[] = [];
+  // Shrinking - check each device
+  const conflicts: PlacedDevice[] = [];
 
-	for (const device of rack.devices) {
-		const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
-		const uHeight = deviceType?.u_height ?? 1; // Default to 1U if unknown
+  for (const device of rack.devices) {
+    const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
+    const uHeight = deviceType?.u_height ?? 1; // Default to 1U if unknown
 
-		// Calculate device top position (accounting for 0.5U devices)
-		const deviceTop = device.position + uHeight - 1;
-		const effectiveTop = Math.ceil(deviceTop); // Round up for fractional U
+    // device.position is stored in internal units (UNITS_PER_U per U).
+    // newHeight and u_height are in human U — convert before comparing,
+    // otherwise we read an inflated "U228" for a device actually at U38 (#1683).
+    const positionU = toHumanUnits(device.position);
+    const deviceTop = positionU + uHeight - 1;
+    const effectiveTop = Math.ceil(deviceTop); // Round up for fractional U
 
-		if (effectiveTop > newHeight) {
-			conflicts.push(device);
-		}
-	}
+    if (effectiveTop > newHeight) {
+      conflicts.push(device);
+    }
+  }
 
-	return {
-		allowed: conflicts.length === 0,
-		conflicts
-	};
+  return {
+    allowed: conflicts.length === 0,
+    conflicts,
+  };
 }
 
 /**
@@ -78,30 +82,31 @@ export function canResizeRackTo(
  * getDeviceRangeText(device, { u_height: 3 }) // "U10-12"
  */
 export function getDeviceRangeText(
-	device: PlacedDevice,
-	deviceType: DeviceType | undefined
+  device: PlacedDevice,
+  deviceType: DeviceType | undefined,
 ): string {
-	const uHeight = deviceType?.u_height ?? 1;
-	const bottom = device.position;
-	const top = Math.ceil(device.position + uHeight - 1);
+  const uHeight = deviceType?.u_height ?? 1;
+  // Convert internal units to human U for display (#1683).
+  const bottom = toHumanUnits(device.position);
+  const top = Math.ceil(bottom + uHeight - 1);
 
-	if (top === bottom) {
-		return `U${bottom}`;
-	}
-	return `U${bottom}-${top}`;
+  if (top === bottom) {
+    return `U${bottom}`;
+  }
+  return `U${bottom}-${top}`;
 }
 
 /**
  * Get detailed conflict information with device types
  */
 export function getConflictDetails(
-	conflicts: PlacedDevice[],
-	deviceTypes: DeviceType[]
+  conflicts: PlacedDevice[],
+  deviceTypes: DeviceType[],
 ): ConflictInfo[] {
-	return conflicts.map((device) => ({
-		device,
-		deviceType: deviceTypes.find((dt) => dt.slug === device.device_type)
-	}));
+  return conflicts.map((device) => ({
+    device,
+    deviceType: deviceTypes.find((dt) => dt.slug === device.device_type),
+  }));
 }
 
 /**
@@ -111,11 +116,12 @@ export function getConflictDetails(
  * formatConflictMessage(conflicts) // "Switch at U40, Storage at U38-40"
  */
 export function formatConflictMessage(conflicts: ConflictInfo[]): string {
-	return conflicts
-		.map(({ device, deviceType }) => {
-			const name = device.name ?? deviceType?.model ?? deviceType?.slug ?? 'Device';
-			const range = getDeviceRangeText(device, deviceType);
-			return `${name} at ${range}`;
-		})
-		.join(', ');
+  return conflicts
+    .map(({ device, deviceType }) => {
+      const name =
+        device.name ?? deviceType?.model ?? deviceType?.slug ?? "Device";
+      const range = getDeviceRangeText(device, deviceType);
+      return `${name} at ${range}`;
+    })
+    .join(", ");
 }

--- a/src/tests/rack-resize.test.ts
+++ b/src/tests/rack-resize.test.ts
@@ -23,7 +23,7 @@ describe("rack-resize", () => {
 
       const result = canResizeRackTo(rack, 42, [dt]);
       expect(result.allowed).toBe(true);
-      expect(result.conflicts).toHaveLength(0);
+      expect(result.conflicts).toEqual([]);
     });
 
     it("allows shrinking when all devices fit in the new height (#1683)", () => {
@@ -39,7 +39,7 @@ describe("rack-resize", () => {
 
       const result = canResizeRackTo(rack, 12, [dt]);
       expect(result.allowed).toBe(true);
-      expect(result.conflicts).toHaveLength(0);
+      expect(result.conflicts).toEqual([]);
     });
 
     it("blocks shrinking when a device would exceed the new height", () => {

--- a/src/tests/rack-resize.test.ts
+++ b/src/tests/rack-resize.test.ts
@@ -79,8 +79,8 @@ describe("rack-resize", () => {
 
     it("displays human U, not internal units (#1683)", () => {
       // Without conversion, this would render as "U228" because the device's
-      // internal position is 5 * UNITS_PER_U = 30 and earlier code wrote that
-      // raw value into the U message.
+      // internal position is 38 * UNITS_PER_U = 228 and earlier code wrote
+      // that raw value into the U message.
       const device = createTestDevice({ position: 38 });
       const dt = createTestDeviceType({
         slug: device.device_type,

--- a/src/tests/rack-resize.test.ts
+++ b/src/tests/rack-resize.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  canResizeRackTo,
+  getDeviceRangeText,
+  formatConflictMessage,
+  getConflictDetails,
+} from "$lib/utils/rack-resize";
+import {
+  createTestRack,
+  createTestDevice,
+  createTestDeviceType,
+} from "./factories";
+
+describe("rack-resize", () => {
+  describe("canResizeRackTo", () => {
+    it("allows growing the rack regardless of contents", () => {
+      const device = createTestDevice({ position: 40 });
+      const rack = createTestRack({ height: 24, devices: [device] });
+      const dt = createTestDeviceType({
+        slug: device.device_type,
+        u_height: 1,
+      });
+
+      const result = canResizeRackTo(rack, 42, [dt]);
+      expect(result.allowed).toBe(true);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("allows shrinking when all devices fit in the new height (#1683)", () => {
+      // Repro from #1683: place a device at U5, then attempt resize to 42U.
+      // device.position is stored in internal units; the validator must
+      // convert before comparing against the new (human) height.
+      const device = createTestDevice({ position: 5 });
+      const rack = createTestRack({ height: 42, devices: [device] });
+      const dt = createTestDeviceType({
+        slug: device.device_type,
+        u_height: 1,
+      });
+
+      const result = canResizeRackTo(rack, 12, [dt]);
+      expect(result.allowed).toBe(true);
+      expect(result.conflicts).toHaveLength(0);
+    });
+
+    it("blocks shrinking when a device would exceed the new height", () => {
+      const device = createTestDevice({ position: 20 });
+      const rack = createTestRack({ height: 42, devices: [device] });
+      const dt = createTestDeviceType({
+        slug: device.device_type,
+        u_height: 2,
+      });
+
+      const result = canResizeRackTo(rack, 10, [dt]);
+      expect(result.allowed).toBe(false);
+      expect(result.conflicts).toContain(device);
+    });
+  });
+
+  describe("getDeviceRangeText", () => {
+    it("renders a single-U device as U<position>", () => {
+      const device = createTestDevice({ position: 5 });
+      const dt = createTestDeviceType({
+        slug: device.device_type,
+        u_height: 1,
+      });
+
+      expect(getDeviceRangeText(device, dt)).toBe("U5");
+    });
+
+    it("renders a multi-U device as U<bottom>-<top>", () => {
+      const device = createTestDevice({ position: 10 });
+      const dt = createTestDeviceType({
+        slug: device.device_type,
+        u_height: 3,
+      });
+
+      expect(getDeviceRangeText(device, dt)).toBe("U10-12");
+    });
+
+    it("displays human U, not internal units (#1683)", () => {
+      // Without conversion, this would render as "U228" because the device's
+      // internal position is 5 * UNITS_PER_U = 30 and earlier code wrote that
+      // raw value into the U message.
+      const device = createTestDevice({ position: 38 });
+      const dt = createTestDeviceType({
+        slug: device.device_type,
+        u_height: 1,
+      });
+
+      expect(getDeviceRangeText(device, dt)).toBe("U38");
+    });
+  });
+
+  describe("formatConflictMessage", () => {
+    it("joins multiple conflicts with comma", () => {
+      const d1 = createTestDevice({ device_type: "switch-slug", position: 10 });
+      const d2 = createTestDevice({
+        device_type: "storage-slug",
+        position: 20,
+      });
+      const dt1 = createTestDeviceType({
+        slug: "switch-slug",
+        model: "Switch",
+        u_height: 1,
+      });
+      const dt2 = createTestDeviceType({
+        slug: "storage-slug",
+        model: "Storage",
+        u_height: 3,
+      });
+
+      const conflicts = getConflictDetails([d1, d2], [dt1, dt2]);
+      expect(formatConflictMessage(conflicts)).toBe(
+        "Switch at U10, Storage at U20-22",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Closes #1683. Likely also closes #1624 (same root cause).

`canResizeRackTo` and `getDeviceRangeText` in `src/lib/utils/rack-resize.ts` were reading `device.position` as a human U value, but it's actually stored in **internal units** (`UNITS_PER_U = 6` per U). On a 42U rack with a device at U38, the validator compared `228` (internal) against `42` (human) and rejected every resize with the message:

```
Cannot resize: Patch Panel (24-Port) at U228
```

That's exactly the symptom from #1683: `228 = 38 × 6` — pure internal-unit leak in both the comparison logic and the user-visible message.

### Changes

- `canResizeRackTo`: convert `device.position` via `toHumanUnits()` before computing `deviceTop` and comparing against `newHeight`.
- `getDeviceRangeText`: same conversion before rendering the `U<bottom>-<top>` string.
- New `src/tests/rack-resize.test.ts` with 7 tests including the regression guard `"displays human U, not internal units (#1683)"`.

The issue also shared a root cause with #1624 ("Cannot resize rack after placing devices") — the user there reported devices at U30/U18/U48 on a 24U rack, which match the internal-unit pattern (5×6=30, 3×6=18, 8×6=48). Both issues are resolved by this fix.

## Test plan

- [x] `npm run test:run` — 1943/1943 pass (7 new tests in `rack-resize.test.ts`)
- [x] `npm run check` — 0 new errors (16 pre-existing on `main`, unrelated)
- [ ] Manual: follow the #1683 repro (42U rack, place Patch Panel, move to U30, move back to U5, click 42U preset) → resize succeeds without spurious error.

## Triage context

Part of the open-bugs triage pass. Following #1029, #1467, #1483 (all merged) and several already-fixed-needed-closing bugs (#1474, #1461, #1475, #1476, #1477, #1403).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoM4h1NiCDWGBEgZkF6eov)_


___

## **CodeAnt-AI Description**
**Fix rack resize checks and messages to use the correct rack position values**

### What Changed
- Rack resize validation now compares devices using human rack units, so valid shrink actions are no longer blocked by inflated internal values.
- Device position text in resize conflicts now shows the correct U range, instead of messages like `U228`.
- Added tests for allowed and blocked resize cases, plus a regression test for the wrong U display.

### Impact
`✅ Fewer blocked rack resizes`
`✅ Clearer resize error messages`
`✅ Correct U positions in conflict lists`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
