### PR TITLE
feat: right-click context menu for custom devices in DevicePalette

### DIFF
--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -105,9 +105,9 @@
   }
 
   function handleContextMenu(event: MouseEvent) {
-    if (!canDelete) return;
     event.preventDefault();
     event.stopPropagation();
+    if (!canDelete) return;
     contextMenuX = event.clientX;
     contextMenuY = event.clientY;
     contextMenuOpen = true;

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -23,6 +23,8 @@
     hideDragTooltip,
   } from "$lib/stores/dragTooltip.svelte";
   import { highlightMatch } from "$lib/utils/searchHighlight";
+  import PaletteDeviceContextMenu from "./PaletteDeviceContextMenu.svelte";
+  import ConfirmDialog from "./ConfirmDialog.svelte";
 
   interface Props {
     device: DeviceType;
@@ -71,6 +73,12 @@
   // Track dragging state for visual feedback
   let isDragging = $state(false);
 
+  // Context menu state (right-click for custom devices)
+  let contextMenuOpen = $state(false);
+  let contextMenuX = $state(0);
+  let contextMenuY = $state(0);
+  let showConfirmDelete = $state(false);
+
   function handleClick() {
     onselect?.(new CustomEvent("select", { detail: { device } }));
   }
@@ -94,6 +102,25 @@
       event.stopPropagation();
       ondelete?.(new CustomEvent("delete", { detail: { device } }));
     }
+  }
+
+  function handleContextMenu(event: MouseEvent) {
+    if (!canDelete) return;
+    event.preventDefault();
+    event.stopPropagation();
+    contextMenuX = event.clientX;
+    contextMenuY = event.clientY;
+    contextMenuOpen = true;
+  }
+
+  function handleContextMenuDelete() {
+    contextMenuOpen = false;
+    showConfirmDelete = true;
+  }
+
+  function handleConfirmDelete() {
+    showConfirmDelete = false;
+    ondelete?.(new CustomEvent("delete", { detail: { device } }));
   }
 
   // Tracks whether this instance owns the current drag session.
@@ -186,6 +213,7 @@
   title={!isCompatible ? (incompatibilityReason ?? undefined) : undefined}
   onclick={handleClick}
   onkeydown={handleKeyDown}
+  oncontextmenu={handleContextMenu}
   ondragstart={handleDragStart}
   ondragend={handleDragEnd}
   aria-label={ariaDescription}
@@ -242,6 +270,24 @@
     </Tooltip>
   {/if}
 </div>
+
+{#if canDelete}
+  <PaletteDeviceContextMenu
+    bind:open={contextMenuOpen}
+    x={contextMenuX}
+    y={contextMenuY}
+    ondelete={handleContextMenuDelete}
+  />
+
+  <ConfirmDialog
+    open={showConfirmDelete}
+    title="Delete Device Type"
+    message={`Delete "${deviceName}"? This will remove the device from your library.`}
+    confirmLabel="Delete"
+    onconfirm={handleConfirmDelete}
+    oncancel={() => (showConfirmDelete = false)}
+  />
+{/if}
 
 <style>
   .device-palette-item {

--- a/src/lib/components/PaletteDeviceContextMenu.svelte
+++ b/src/lib/components/PaletteDeviceContextMenu.svelte
@@ -1,0 +1,58 @@
+<!--
+  PaletteDeviceContextMenu Component
+  Right-click context menu for custom device types in the device palette.
+  Shows a "Delete from Library" action for custom (user-defined) devices.
+  Uses bits-ui ContextMenu in virtual trigger mode.
+-->
+<script lang="ts">
+  import { ContextMenu } from "bits-ui";
+  import "$lib/styles/context-menus.css";
+
+  interface Props {
+    /** Whether the menu is open */
+    open?: boolean;
+    /** Callback when open state changes */
+    onOpenChange?: (open: boolean) => void;
+    /** Delete device callback */
+    ondelete?: () => void;
+    /** X coordinate for virtual trigger (screen position) */
+    x?: number;
+    /** Y coordinate for virtual trigger (screen position) */
+    y?: number;
+  }
+
+  let {
+    open = $bindable(false),
+    onOpenChange,
+    ondelete,
+    x = 0,
+    y = 0,
+  }: Props = $props();
+
+  function handleOpenChange(newOpen: boolean) {
+    open = newOpen;
+    onOpenChange?.(newOpen);
+  }
+</script>
+
+<ContextMenu.Root {open} onOpenChange={handleOpenChange}>
+  <ContextMenu.Trigger>
+    <div
+      style="position: fixed; left: {x}px; top: {y}px; width: 1px; height: 1px; pointer-events: none;"
+    ></div>
+  </ContextMenu.Trigger>
+
+  <ContextMenu.Portal>
+    <ContextMenu.Content class="context-menu-content" sideOffset={5}>
+      <ContextMenu.Item
+        class="context-menu-item context-menu-item--destructive"
+        onSelect={() => {
+          ondelete?.();
+          open = false;
+        }}
+      >
+        <span class="context-menu-label">Delete from Library</span>
+      </ContextMenu.Item>
+    </ContextMenu.Content>
+  </ContextMenu.Portal>
+</ContextMenu.Root>


### PR DESCRIPTION
## **User description**
## Summary

- Adds `PaletteDeviceContextMenu.svelte` — a minimal bits-ui ContextMenu (virtual trigger mode) with a single "Delete from Library" action styled as a destructive item.
- Modifies `DevicePaletteItem.svelte` to capture right-click (`oncontextmenu`) and, when `canDelete` is true, open the context menu at the cursor position followed by a `ConfirmDialog` before firing the existing `ondelete` callback.
- Non-custom devices (starter / brand pack) are unaffected — right-click has no effect when `canDelete` is false.

## Why

The existing hover trash icon is easy to miss; a right-click context menu gives users a more discoverable and keyboard-accessible path to delete custom device types, consistent with the pattern already used for placed devices (`DeviceContextMenu`) and racks (`RackContextMenu`).

## Test plan

- [ ] Right-click a custom (unused) device in the palette → context menu appears at cursor with "Delete from Library"
- [ ] Clicking "Delete from Library" → ConfirmDialog appears matching the EditPanel style
- [ ] Confirming → device removed from library (undo with Ctrl+Z works)
- [ ] Cancelling → device stays, no side effects
- [ ] Pressing Escape while menu is open → menu closes
- [ ] Right-clicking a starter or brand device → no context menu
- [ ] Keyboard nav in menu (arrow keys, Enter) works via bits-ui

Closes #167

https://claude.ai/code/session_011LKAvmm4qYMePby2g2btdt

---
_Generated by [Claude Code](https://claude.ai/code/session_011LKAvmm4qYMePby2g2btdt)_


___

## **CodeAnt-AI Description**
**Add a right-click delete menu for custom devices in the palette**

### What Changed
- Right-clicking a custom device in the palette now opens a menu at the cursor with a “Delete from Library” action
- Choosing delete opens a confirmation dialog before the device is removed from the library
- Starter and brand devices still ignore right-click, so they cannot be deleted from this menu
- The existing delete button still works as before

### Impact
`✅ Easier custom device removal`
`✅ Fewer missed delete actions`
`✅ Clearer delete confirmation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
