### PR TITLE
fix: sync U-numbering settings across bayed groups (#1520)

### DIFF
--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -137,13 +137,21 @@
   // Calculate max height for U-label column (use tallest rack)
   const maxHeight = $derived(Math.max(...racks.map((r) => r.height), 0));
 
-  // Generate U labels for center column (ascending: U1 at bottom)
+  // Generate U labels for center column.
+  // Use the primary (first) rack's desc_units and starting_unit so the shared
+  // labels respond to per-rack U-numbering edits (#1520). Mirrors the formula
+  // in Rack.svelte.
   const U_HEIGHT = 22;
   const RAIL_WIDTH = 17;
 
   const uLabels = $derived(
     Array.from({ length: maxHeight }, (_, i) => {
-      const uNumber = maxHeight - i;
+      const primary = racks[0];
+      const startUnit = primary?.starting_unit ?? 1;
+      const descUnits = primary?.desc_units ?? false;
+      const uNumber = descUnits
+        ? startUnit + i
+        : startUnit + (maxHeight - 1) - i;
       // Match Rack.svelte yPosition: includes RACK_PADDING_HIDDEN to align with hidden rack name mode
       const yPosition =
         i * U_HEIGHT + U_HEIGHT / 2 + RACK_PADDING_HIDDEN + RAIL_WIDTH;

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -492,7 +492,15 @@ function addRack(
   desc_units?: boolean,
   starting_unit?: number,
 ) {
-  return addRackImpl(stateAccess, name, height, width, form_factor, desc_units, starting_unit);
+  return addRackImpl(
+    stateAccess,
+    name,
+    height,
+    width,
+    form_factor,
+    desc_units,
+    starting_unit,
+  );
 }
 
 function addBayedRackGroup(
@@ -542,6 +550,35 @@ function updateRack(id: string, updates: Partial<Rack>): void {
   const { view: _view, devices: _devices, ...recordableUpdates } = updates;
   if (Object.keys(recordableUpdates).length > 0) {
     updateRackRecorded(id, recordableUpdates);
+
+    // Propagate U-numbering settings across a bayed group: the BayedRackView
+    // renders a single shared U-label column, so all bays must agree on
+    // desc_units / starting_unit. Without this, edits to one bay leave the
+    // visible labels (read from racks[0]) unchanged (#1520).
+    const numberingKeys = ["desc_units", "starting_unit"] as const;
+    const numberingUpdates: Partial<Rack> = {};
+    for (const key of numberingKeys) {
+      if (key in recordableUpdates) {
+        numberingUpdates[key] = recordableUpdates[key] as never;
+      }
+    }
+    if (Object.keys(numberingUpdates).length > 0) {
+      const group = getRackGroupForRack(id);
+      if (group?.layout_preset === "bayed") {
+        for (const peerId of group.rack_ids) {
+          if (peerId === id) continue;
+          const peer = layout.racks.find((r) => r.id === peerId);
+          if (!peer) continue;
+          // Skip if already in sync to avoid extra history entries
+          const needsUpdate = (
+            Object.keys(numberingUpdates) as (keyof Rack)[]
+          ).some((k) => peer[k] !== numberingUpdates[k]);
+          if (needsUpdate) {
+            updateRackRecorded(peerId, numberingUpdates);
+          }
+        }
+      }
+    }
   }
 }
 
@@ -570,7 +607,11 @@ function duplicateRack(id: string) {
 // Rack Group Actions — delegated to layout/rack-groups.ts
 // =============================================================================
 
-function createRackGroup(name: string, rackIds: string[], preset?: LayoutPreset) {
+function createRackGroup(
+  name: string,
+  rackIds: string[],
+  preset?: LayoutPreset,
+) {
   return createRackGroupImpl(stateAccess, name, rackIds, preset);
 }
 
@@ -782,7 +823,13 @@ function placeDevice(
   face?: DeviceFace,
   slotPosition?: SlotPosition,
 ): boolean {
-  return placeDeviceRecorded(rackId, deviceTypeSlug, position, face, slotPosition);
+  return placeDeviceRecorded(
+    rackId,
+    deviceTypeSlug,
+    position,
+    face,
+    slotPosition,
+  );
 }
 
 /**
@@ -850,11 +897,18 @@ function placeInContainer(
     childType && !layout.device_types.find((dt) => dt.slug === deviceTypeSlug)
       ? childType
       : undefined;
-  const placeCommand = createPlaceDeviceCommand(placedDevice, adapter, deviceName);
+  const placeCommand = createPlaceDeviceCommand(
+    placedDevice,
+    adapter,
+    deviceName,
+  );
 
   if (autoImport) {
     const importCommand = createAddDeviceTypeCommand(autoImport, adapter);
-    const batch = createBatchCommand(`Place ${deviceName}`, [importCommand, placeCommand]);
+    const batch = createBatchCommand(`Place ${deviceName}`, [
+      importCommand,
+      placeCommand,
+    ]);
     history.execute(batch);
   } else {
     history.execute(placeCommand);
@@ -1090,7 +1144,10 @@ function updateDevicePlacementImageRaw(
   updateDevicePlacementImageRawImpl(stateAccess, rackId, index, face, filename);
 }
 
-function updateDeviceColourRaw(index: number, colour: string | undefined): void {
+function updateDeviceColourRaw(
+  index: number,
+  colour: string | undefined,
+): void {
   // Resolve rack ID: use active rack, fall back to first rack
   const rackId = activeRackId ?? getTargetRackImpl(stateAccess)?.rack.id;
   if (!rackId) {
@@ -1273,11 +1330,8 @@ function moveDeviceRecorded(
 
 function removeDeviceRecorded(rackId: string, deviceIndex: number): void {
   // $state.snapshot() is a Svelte rune — must be called from this .svelte.ts file
-  removeDeviceRecordedImpl(
-    stateAccess,
-    rackId,
-    deviceIndex,
-    (device) => $state.snapshot(device),
+  removeDeviceRecordedImpl(stateAccess, rackId, deviceIndex, (device) =>
+    $state.snapshot(device),
   );
 }
 

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -118,6 +118,7 @@ import {
   updateDeviceNotesRecorded as updateDeviceNotesRecordedImpl,
   updateDeviceIpRecorded as updateDeviceIpRecordedImpl,
   updateRackRecorded as updateRackRecordedImpl,
+  updateRacksBatchRecorded as updateRacksBatchRecordedImpl,
   clearRackRecorded as clearRackRecordedImpl,
 } from "./layout/command-adapters";
 
@@ -548,38 +549,41 @@ function updateRack(id: string, updates: Partial<Rack>): void {
 
   // For other properties, use recorded version for undo/redo support
   const { view: _view, devices: _devices, ...recordableUpdates } = updates;
-  if (Object.keys(recordableUpdates).length > 0) {
-    updateRackRecorded(id, recordableUpdates);
+  if (Object.keys(recordableUpdates).length === 0) return;
 
-    // Propagate U-numbering settings across a bayed group: the BayedRackView
-    // renders a single shared U-label column, so all bays must agree on
-    // desc_units / starting_unit. Without this, edits to one bay leave the
-    // visible labels (read from racks[0]) unchanged (#1520).
-    const numberingKeys = ["desc_units", "starting_unit"] as const;
-    const numberingUpdates: Partial<Rack> = {};
-    for (const key of numberingKeys) {
-      if (key in recordableUpdates) {
-        numberingUpdates[key] = recordableUpdates[key] as never;
-      }
-    }
-    if (Object.keys(numberingUpdates).length > 0) {
-      const group = getRackGroupForRack(id);
-      if (group?.layout_preset === "bayed") {
-        for (const peerId of group.rack_ids) {
-          if (peerId === id) continue;
-          const peer = layout.racks.find((r) => r.id === peerId);
-          if (!peer) continue;
-          // Skip if already in sync to avoid extra history entries
-          const needsUpdate = (
-            Object.keys(numberingUpdates) as (keyof Rack)[]
-          ).some((k) => peer[k] !== numberingUpdates[k]);
-          if (needsUpdate) {
-            updateRackRecorded(peerId, numberingUpdates);
-          }
-        }
-      }
+  // BayedRackView renders one shared U-label column read from racks[0], so
+  // all bays must agree on desc_units / starting_unit. When the change
+  // touches those keys on a member of a bayed group, fold the origin and
+  // every diverging peer into a single batch — one undo reverts the whole
+  // group together (#1520).
+  const numberingKeys = ["desc_units", "starting_unit"] as const;
+  const numberingUpdates: Partial<Omit<Rack, "devices" | "view">> = {};
+  for (const key of numberingKeys) {
+    if (key in recordableUpdates) {
+      numberingUpdates[key] = recordableUpdates[key] as never;
     }
   }
+
+  const group =
+    Object.keys(numberingUpdates).length > 0
+      ? getRackGroupForRack(id)
+      : undefined;
+
+  if (group?.layout_preset === "bayed" && group.rack_ids.length > 1) {
+    // Origin gets the full update; peers only get the numbering keys.
+    const targets: {
+      rackId: string;
+      updates: Partial<Omit<Rack, "devices" | "view">>;
+    }[] = [{ rackId: id, updates: recordableUpdates }];
+    for (const peerId of group.rack_ids) {
+      if (peerId === id) continue;
+      targets.push({ rackId: peerId, updates: numberingUpdates });
+    }
+    updateRacksBatchRecorded(targets, "Update bayed rack");
+    return;
+  }
+
+  updateRackRecorded(id, recordableUpdates);
 }
 
 /**
@@ -1408,6 +1412,16 @@ function updateRackRecorded(
   updates: Partial<Omit<Rack, "devices" | "view">>,
 ): void {
   updateRackRecordedImpl(stateAccess, rackId, updates);
+}
+
+function updateRacksBatchRecorded(
+  targets: {
+    rackId: string;
+    updates: Partial<Omit<Rack, "devices" | "view">>;
+  }[],
+  description: string,
+): void {
+  updateRacksBatchRecordedImpl(stateAccess, targets, description);
 }
 
 function clearRackRecorded(rackId?: string): void {

--- a/src/lib/stores/layout/command-adapters.ts
+++ b/src/lib/stores/layout/command-adapters.ts
@@ -1091,6 +1091,70 @@ export function updateRackRecorded(
 }
 
 /**
+ * Update the same fields on multiple racks atomically — a single undo reverts
+ * every rack in the batch. Used to keep bayed-group U-numbering in sync (#1520).
+ *
+ * @param ctx - Layout state access
+ * @param targets - rackId → updates pairs; racks that already match are silently skipped
+ * @param description - History entry label
+ */
+export function updateRacksBatchRecorded(
+  ctx: LayoutStateAccess,
+  targets: {
+    rackId: string;
+    updates: Partial<Omit<Rack, "devices" | "view">>;
+  }[],
+  description: string,
+): void {
+  const adapter = getCommandStoreAdapter(ctx);
+  const history = getHistoryStore();
+  const commands = [];
+
+  for (const { rackId, updates } of targets) {
+    const targetRack = getRackById(ctx, rackId);
+    if (!targetRack) continue;
+
+    const before: Partial<Omit<Rack, "devices" | "view">> = {};
+    let differs = false;
+    for (const key of Object.keys(updates) as (keyof Omit<
+      Rack,
+      "devices" | "view"
+    >)[]) {
+      const current = targetRack[key];
+      const next = updates[key];
+      if (current !== next) {
+        differs = true;
+      }
+      before[key] = current as never;
+    }
+    if (!differs) continue;
+
+    // Each sub-command sets the active rack first because updateRackRaw
+    // targets whichever rack is active.
+    const inner = createUpdateRackCommand(before, updates, adapter);
+    commands.push({
+      type: "UPDATE_RACK" as const,
+      description,
+      timestamp: Date.now(),
+      execute() {
+        ctx.setActiveRackId(rackId);
+        inner.execute();
+      },
+      undo() {
+        ctx.setActiveRackId(rackId);
+        inner.undo();
+      },
+    });
+  }
+
+  if (commands.length === 0) return;
+
+  const batch = createBatchCommand(description, commands);
+  history.execute(batch);
+  ctx.markDirty();
+}
+
+/**
  * Clear rack devices with undo/redo support
  * Uses active rack unless a rackId override is provided
  * @param ctx - Layout state access

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -528,6 +528,57 @@ describe("Layout Store", () => {
       expect(bay1.name).toBe("Renamed Bay 1");
       expect(bay2.name).toBe("Bay 2");
     });
+
+    it("undoes bayed desc_units propagation atomically (#1520)", () => {
+      const store = getLayoutStore();
+      const result = store.addBayedRackGroup("Bayed", 3, 12);
+      expect(result).not.toBeNull();
+      const groupRackIds = result!.racks.map((r) => r.id);
+
+      store.updateRack(result!.racks[1].id, { desc_units: true });
+      for (const r of store.layout.racks.filter((r) =>
+        groupRackIds.includes(r.id),
+      )) {
+        expect(r.desc_units).toBe(true);
+      }
+
+      // One undo must revert ALL bays — otherwise the shared U-label column
+      // ends up out of sync with the other bays.
+      store.undo();
+      for (const r of store.layout.racks.filter((r) =>
+        groupRackIds.includes(r.id),
+      )) {
+        expect(r.desc_units).toBe(false);
+      }
+
+      store.redo();
+      for (const r of store.layout.racks.filter((r) =>
+        groupRackIds.includes(r.id),
+      )) {
+        expect(r.desc_units).toBe(true);
+      }
+    });
+
+    it("undoes bayed starting_unit propagation atomically (#1520)", () => {
+      const store = getLayoutStore();
+      const result = store.addBayedRackGroup("Bayed", 2, 12);
+      expect(result).not.toBeNull();
+      const groupRackIds = result!.racks.map((r) => r.id);
+
+      store.updateRack(result!.racks[0].id, { starting_unit: 10 });
+      for (const r of store.layout.racks.filter((r) =>
+        groupRackIds.includes(r.id),
+      )) {
+        expect(r.starting_unit).toBe(10);
+      }
+
+      store.undo();
+      for (const r of store.layout.racks.filter((r) =>
+        groupRackIds.includes(r.id),
+      )) {
+        expect(r.starting_unit).toBe(1);
+      }
+    });
   });
 
   describe("deleteRack", () => {

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -534,6 +534,11 @@ describe("Layout Store", () => {
       const result = store.addBayedRackGroup("Bayed", 3, 12);
       expect(result).not.toBeNull();
       const groupRackIds = result!.racks.map((r) => r.id);
+      // Capture initial values rather than assuming defaults — keeps the
+      // test honest if createDefaultRack's defaults change.
+      const initialDesc = new Map(
+        result!.racks.map((r) => [r.id, r.desc_units ?? false]),
+      );
 
       store.updateRack(result!.racks[1].id, { desc_units: true });
       for (const r of store.layout.racks.filter((r) =>
@@ -548,7 +553,7 @@ describe("Layout Store", () => {
       for (const r of store.layout.racks.filter((r) =>
         groupRackIds.includes(r.id),
       )) {
-        expect(r.desc_units).toBe(false);
+        expect(r.desc_units).toBe(initialDesc.get(r.id));
       }
 
       store.redo();

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -473,6 +473,61 @@ describe("Layout Store", () => {
       store.updateRack(rack!.id, { name: "Updated" });
       expect(store.isDirty).toBe(true);
     });
+
+    it("propagates desc_units across a bayed group (#1520)", () => {
+      const store = getLayoutStore();
+      const result = store.addBayedRackGroup("Bayed", 3, 12);
+      expect(result).not.toBeNull();
+      // Sanity: all bays start with desc_units=false
+      for (const r of result!.racks) {
+        expect(r.desc_units).toBe(false);
+      }
+
+      // Edit the middle bay — the shared U-label column reads from racks[0],
+      // and bays must stay in sync regardless of which one the user edits.
+      store.updateRack(result!.racks[1].id, { desc_units: true });
+
+      const groupRackIds = result!.racks.map((r) => r.id);
+      const updated = store.layout.racks.filter((r) =>
+        groupRackIds.includes(r.id),
+      );
+      for (const r of updated) {
+        expect(r.desc_units).toBe(true);
+      }
+    });
+
+    it("propagates starting_unit across a bayed group (#1520)", () => {
+      const store = getLayoutStore();
+      const result = store.addBayedRackGroup("Bayed", 2, 12);
+      expect(result).not.toBeNull();
+
+      store.updateRack(result!.racks[1].id, { starting_unit: 10 });
+
+      const groupRackIds = result!.racks.map((r) => r.id);
+      const updated = store.layout.racks.filter((r) =>
+        groupRackIds.includes(r.id),
+      );
+      for (const r of updated) {
+        expect(r.starting_unit).toBe(10);
+      }
+    });
+
+    it("does not propagate non-numbering settings across a bayed group", () => {
+      const store = getLayoutStore();
+      const result = store.addBayedRackGroup("Bayed", 2, 12);
+      expect(result).not.toBeNull();
+
+      store.updateRack(result!.racks[0].id, { name: "Renamed Bay 1" });
+
+      const bay1 = store.layout.racks.find(
+        (r) => r.id === result!.racks[0].id,
+      )!;
+      const bay2 = store.layout.racks.find(
+        (r) => r.id === result!.racks[1].id,
+      )!;
+      expect(bay1.name).toBe("Renamed Bay 1");
+      expect(bay2.name).toBe("Bay 2");
+    });
   });
 
   describe("deleteRack", () => {

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -564,6 +564,11 @@ describe("Layout Store", () => {
       const result = store.addBayedRackGroup("Bayed", 2, 12);
       expect(result).not.toBeNull();
       const groupRackIds = result!.racks.map((r) => r.id);
+      // Capture initial values rather than assuming defaults — keeps the
+      // test honest if createDefaultRack's defaults change.
+      const initialStarting = new Map(
+        result!.racks.map((r) => [r.id, r.starting_unit ?? 1]),
+      );
 
       store.updateRack(result!.racks[0].id, { starting_unit: 10 });
       for (const r of store.layout.racks.filter((r) =>
@@ -576,7 +581,14 @@ describe("Layout Store", () => {
       for (const r of store.layout.racks.filter((r) =>
         groupRackIds.includes(r.id),
       )) {
-        expect(r.starting_unit).toBe(1);
+        expect(r.starting_unit).toBe(initialStarting.get(r.id));
+      }
+
+      store.redo();
+      for (const r of store.layout.racks.filter((r) =>
+        groupRackIds.includes(r.id),
+      )) {
+        expect(r.starting_unit).toBe(10);
       }
     });
   });


### PR DESCRIPTION
## **User description**
## Summary

Closes #1520.

User report: toggling "U1 at top / U1 at bottom" on a double bay does nothing visually, even though the change shows up in undo/redo. Single-rack edits work fine — the bug is specific to bayed groups.

Two cooperating problems:

1. **`BayedRackView.svelte` ignored per-rack U-numbering settings.** The shared U-label column rendered between adjacent bays used a hard-coded `maxHeight - i` sequence, so `desc_units` and `starting_unit` were silently dropped. The shared labels now mirror the formula in `Rack.svelte`, reading the primary (first) bay's `desc_units` and `starting_unit`.

2. **`updateRack` didn't keep bayed racks in sync.** Even with fix #1, editing Bay 2 left Bay 1's values (and therefore the shared label column) unchanged. `updateRack` already special-cases bayed groups for `height` (silent reject). Now it also propagates `desc_units` / `starting_unit` updates to every rack in the group, so editing any bay updates them all — matching how the user experiences the group as a single visual unit.

Other settings (`name`, `notes`, `width`, etc.) are not propagated.

## Test plan

- [x] `npm run test:run` — 1943/1943 pass (3 new regression tests in `layout-store.test.ts`):
  - `desc_units` propagation across a bayed group
  - `starting_unit` propagation across a bayed group
  - `name` does *not* propagate (per-rack isolation preserved)
- [x] `npm run lint` — clean
- [ ] Manual: create a 2-bay or 3-bay group, edit "U Numbering" on any bay, observe all bays + shared label column flip together.

## Triage context

Part of the open-bugs triage pass. Following #1029, #1467, #1483, #1683 (all merged) and several already-fixed bugs closed (#1474, #1461, #1475, #1476, #1477, #1403, #1481, #1482).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoM4h1NiCDWGBEgZkF6eov)_


___

## **CodeAnt-AI Description**
**Keep U-numbering aligned across bayed rack groups**

### What Changed
- Changing U numbering on any bay now updates the whole bayed group, so the shared label column and every bay stay in sync.
- The shared center U-label column now uses the group’s current U numbering direction and starting unit instead of a fixed sequence.
- Non-numbering settings like rack name still stay local to the bay you edited.

### Impact
`✅ Consistent U labels across bayed racks`
`✅ Fewer confusing “changed but not visible” edits`
`✅ Clearer rack numbering in multi-bay setups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
