### PR TITLE
fix: recover slot_position and slot_width for half-width pairs on load (#1602)

### DIFF
--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -7,6 +7,7 @@ import { z } from "../zod";
 import { nanoid } from "nanoid";
 import { UNITS_PER_U } from "$lib/types/constants";
 import { VERSION } from "$lib/version";
+import { layoutDebug } from "$lib/utils/debug";
 
 /**
  * Slug pattern: lowercase alphanumeric with hyphens, no leading/trailing/consecutive hyphens
@@ -874,12 +875,87 @@ function migrateDevicePositions<
 }
 
 /**
+ * Recover slot_position for pairs of devices at the same position and face
+ * that are both missing slot_position.
+ *
+ * Layouts saved by the broken serializer introduced in dd25f4c (PR #1324, YAML
+ * editor panel) accidentally stripped both slot_position and slot_width from
+ * the output. Without recovery the two devices are indistinguishable after load
+ * and Svelte throws each_key_duplicate (#1248, #1602).
+ *
+ * A valid layout cannot have two full-width devices at the same position, so
+ * exactly-2 co-located devices with no slot_position unambiguously indicates
+ * a half-width pair that lost its placement data. slot_width is not required
+ * on the device type because that field may also be missing from the same
+ * broken save.
+ *
+ * Recovery is best-effort: the original left/right order is lost, so we
+ * assign "left" to the first device in the array and "right" to the second.
+ * Returns the recovered devices and the set of device_type slugs that were
+ * recovered, so the caller can also restore slot_width on those device types.
+ */
+function recoverSlotPositions<
+  T extends {
+    id: string;
+    device_type: string;
+    position: number;
+    face: string;
+    container_id?: string;
+    slot_position?: string;
+  },
+>(devices: T[]): { devices: T[]; recoveredSlugs: Set<string> } {
+  // Group rack-level devices by position+face to find co-located pairs.
+  // Container children are excluded: they share relative position/face values
+  // and are disambiguated by slot_id, not slot_position, so they must never
+  // be treated as half-width rack pairs.
+  const groups = new Map<string, T[]>();
+  for (const d of devices) {
+    if (d.container_id !== undefined) continue;
+    const key = `${d.position}:${d.face}`;
+    const group = groups.get(key) ?? [];
+    group.push(d);
+    groups.set(key, group);
+  }
+
+  const recovery = new Map<string, "left" | "right">();
+  const recoveredSlugs = new Set<string>();
+  for (const group of groups.values()) {
+    if (
+      group.length === 2 &&
+      group.every((d) => d.slot_position === undefined)
+    ) {
+      recovery.set(group[0].id, "left");
+      recovery.set(group[1].id, "right");
+      for (const d of group) recoveredSlugs.add(d.device_type);
+    }
+  }
+
+  if (recovery.size === 0) return { devices, recoveredSlugs };
+
+  const affectedGroups = recovery.size / 2;
+  layoutDebug.schema(
+    "Recovered slot_position for %d device(s) in %d half-width pair(s) — layout was saved without slot_position (dd25f4c regression)",
+    recovery.size,
+    affectedGroups,
+  );
+
+  return {
+    devices: devices.map((d) => {
+      const assigned = recovery.get(d.id);
+      return assigned ? { ...d, slot_position: assigned } : d;
+    }),
+    recoveredSlugs,
+  };
+}
+
+/**
  * Complete layout schema (base, with migration transform)
  * Uses racks array for multi-rack support
  * Transform handles:
  * - Legacy rack → racks[0] migration
  * - Generating nanoid for racks missing id field
  * - Position migration from U values to internal units (v0.7.0)
+ * - slot_position recovery for half-width device pairs missing the field (#1248, #1602)
  */
 const LayoutSchemaBase = LayoutSchemaInput.transform((data) => {
   // Determine the racks array
@@ -902,7 +978,9 @@ const LayoutSchemaBase = LayoutSchemaInput.transform((data) => {
   // Check if positions need migration (pre-0.7.0 format)
   const migratePositions = needsPositionMigration(data.version, allDevices);
 
-  // Generate IDs for racks missing them, deduplicate device IDs, and migrate positions if needed
+  // Generate IDs for racks missing them, deduplicate device IDs, and migrate positions if needed.
+  // Also collect device type slugs that need slot_width recovery (#1248, #1602).
+  const allRecoveredSlugs = new Set<string>();
   const racksWithIds = racks.map((rack) => {
     // Deduplicate device IDs to prevent Svelte each_key_duplicate errors (#1363)
     const seenDeviceIds = new Set<string>();
@@ -926,14 +1004,30 @@ const LayoutSchemaBase = LayoutSchemaInput.transform((data) => {
         : { ...d, id: nextId, container_id: nextContainerId };
     });
 
+    // Recover slot_position for half-width device pairs missing it (#1248, #1602)
+    const { devices: recoveredDevices, recoveredSlugs } =
+      recoverSlotPositions(deduplicatedDevices);
+    for (const slug of recoveredSlugs) allRecoveredSlugs.add(slug);
+
     return {
       ...rack,
       id: rack.id ?? nanoid(),
       devices: migratePositions
-        ? migrateDevicePositions(deduplicatedDevices)
-        : deduplicatedDevices,
+        ? migrateDevicePositions(recoveredDevices)
+        : recoveredDevices,
     };
   });
+
+  // Recover slot_width: 1 on device types whose slot_width was also stripped
+  // by the same broken serializer (#1248, #1602)
+  const fixedDeviceTypes =
+    allRecoveredSlugs.size === 0
+      ? data.device_types
+      : data.device_types.map((dt) =>
+          allRecoveredSlugs.has(dt.slug) && dt.slot_width === undefined
+            ? { ...dt, slot_width: 1 }
+            : dt,
+        );
 
   // Build the output without the legacy 'rack' field
   const { rack: _legacyRack, racks: _inputRacks, ...rest } = data;
@@ -945,6 +1039,7 @@ const LayoutSchemaBase = LayoutSchemaInput.transform((data) => {
     // After migration, stamp with current app version
     version: migratePositions ? VERSION : data.version,
     racks: racksWithIds,
+    device_types: fixedDeviceTypes,
   };
 });
 

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -901,16 +901,24 @@ function recoverSlotPositions<
     position: number;
     face: string;
     container_id?: string;
+    parent_device?: string;
+    device_bay?: string;
     slot_position?: string;
   },
 >(devices: T[]): { devices: T[]; recoveredSlugs: Set<string> } {
   // Group rack-level devices by position+face to find co-located pairs.
-  // Container children are excluded: they share relative position/face values
-  // and are disambiguated by slot_id, not slot_position, so they must never
-  // be treated as half-width rack pairs.
+  // Nested children are excluded — container children (container_id) and
+  // parent/bay children (parent_device, device_bay) all legitimately share
+  // their parent's position/face and are disambiguated by slot_id/bay, not
+  // slot_position, so they must never be treated as half-width rack pairs.
   const groups = new Map<string, T[]>();
   for (const d of devices) {
-    if (d.container_id !== undefined) continue;
+    if (
+      d.container_id !== undefined ||
+      d.parent_device !== undefined ||
+      d.device_bay !== undefined
+    )
+      continue;
     const key = `${d.position}:${d.face}`;
     const group = groups.get(key) ?? [];
     group.push(d);

--- a/src/lib/utils/debug.ts
+++ b/src/lib/utils/debug.ts
@@ -24,6 +24,7 @@ export const layoutDebug = {
   state: Debug("rackula:layout:state"),
   device: Debug("rackula:layout:device"),
   group: Debug("rackula:layout:group"),
+  schema: Debug("rackula:layout:schema"),
 };
 
 export const canvasDebug = {

--- a/src/tests/slot-position-recovery.test.ts
+++ b/src/tests/slot-position-recovery.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { serializeLayoutToYaml, parseLayoutYaml } from "$lib/utils/yaml";
+import {
+  createTestDevice,
+  createTestDeviceType,
+  createTestLayout,
+  createTestRack,
+} from "./factories";
+
+/**
+ * Strip slot_position and slot_width lines from a YAML string to simulate
+ * layouts saved by the broken serializer introduced in dd25f4c (#1324) and
+ * fixed in #1564. The serializer dropped both fields for half-width pairs.
+ */
+function stripHalfWidthFields(yaml: string): string {
+  return yaml
+    .split("\n")
+    .filter(
+      (line) => !line.includes("slot_position") && !line.includes("slot_width"),
+    )
+    .join("\n");
+}
+
+/**
+ * Regression tests for layouts saved without slot_position/slot_width (#1602).
+ * Two half-width devices at the same position with no slot_position would
+ * crash on load with each_key_duplicate. The schema transform must recover
+ * by assigning "left"/"right" automatically.
+ */
+describe("slot_position recovery on load", () => {
+  it("assigns left/right to two half-width devices at the same position when slot_position is missing", async () => {
+    const halfWidth = createTestDeviceType({
+      slug: "half-width-device",
+      u_height: 1,
+      slot_width: 1,
+    });
+
+    const layout = createTestLayout({
+      racks: [
+        createTestRack({
+          devices: [
+            createTestDevice({
+              id: "device-a",
+              device_type: halfWidth.slug,
+              position: 10,
+              slot_position: "left",
+            }),
+            createTestDevice({
+              id: "device-b",
+              device_type: halfWidth.slug,
+              position: 10,
+              slot_position: "right",
+            }),
+          ],
+        }),
+      ],
+      device_types: [halfWidth],
+    });
+
+    // Strip slot_position and slot_width to simulate the broken serializer
+    const yaml = await serializeLayoutToYaml(layout);
+    const brokenYaml = stripHalfWidthFields(yaml);
+
+    const restored = await parseLayoutYaml(brokenYaml);
+    const devices = restored.racks[0]?.devices ?? [];
+
+    // eslint-disable-next-line no-restricted-syntax -- Behavioral invariant: recovery must preserve device count (2 in -> 2 out)
+    expect(devices).toHaveLength(2);
+
+    const slots = devices.map((d) => d.slot_position);
+    // Both devices must have a slot_position assigned
+    expect(slots).not.toContain(undefined);
+    // One must be "left" and one must be "right"
+    expect(slots).toContain("left");
+    expect(slots).toContain("right");
+
+    // slot_width must also be recovered on the device type so it renders correctly
+    expect(restored.device_types[0]?.slot_width).toBe(1);
+  });
+
+  it("does not assign slot_position to a single half-width device with no pair", async () => {
+    // A single device at a position is ambiguous — recovery only fires for
+    // exactly-2 co-located devices, so a solo device must be left untouched.
+    const halfWidth = createTestDeviceType({
+      slug: "half-width-device",
+      u_height: 1,
+      slot_width: 1,
+    });
+
+    const layout = createTestLayout({
+      racks: [
+        createTestRack({
+          devices: [
+            createTestDevice({
+              id: "device-a",
+              device_type: halfWidth.slug,
+              position: 10,
+              slot_position: "left",
+            }),
+          ],
+        }),
+      ],
+      device_types: [halfWidth],
+    });
+
+    // Strip both fields to simulate the broken serializer
+    const yaml = await serializeLayoutToYaml(layout);
+    const brokenYaml = stripHalfWidthFields(yaml);
+
+    const restored = await parseLayoutYaml(brokenYaml);
+    const device = restored.racks[0]?.devices[0];
+
+    // No pair → recovery must not assign a slot_position
+    expect(device?.slot_position).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Layouts saved by the broken serializer introduced in dd25f4c (#1324) and fixed in #1564 had `slot_position` stripped from devices and `slot_width` stripped from device types. Two co-located half-width devices became indistinguishable on reload, triggering Svelte `each_key_duplicate` and crashing the app (#1248, #1602).

This PR implements **option 1** from #1602 — auto-recover in the schema transform — so existing broken files just work on load.

## Approach

`LayoutSchemaBase.transform()` runs a recovery pass after device-ID deduplication and before position migration:

1. Group rack-level devices by `position`+`face` (container children excluded — they use `slot_id`, not `slot_position`).
2. For any group of **exactly 2** devices where **both** are missing `slot_position`, assign `left` to the first and `right` to the second. This is unambiguous because a valid layout cannot have two full-width devices at the same position.
3. Restore `slot_width: 1` on the matching device types (stripped by the same broken serializer).
4. Any other arrangement is left untouched; single devices stay untouched.

Recovery is best-effort — original left/right order is lost. The transform emits a `rackula:layout:schema` debug log when it fires.

## Notes

- Replays the approach from closed PR #1565 (which never merged).
- Aligns with the maintainer comment on #1602 that fix-and-report-on-load is not a violation of the no-migration rule — corrupted YAML (legacy formats, hand editing) is a normal input class.
- CodeRabbit local review: clean (no findings).

## Test plan

- [x] `npm run test:run -- slot-position-recovery` — 2/2 passing
- [x] `npm run test:run` — 1997/1997 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Reviewer: load a layout saved without `slot_position`/`slot_width` (or a hand-stripped YAML) — should render correctly instead of crashing

Closes #1602


___

## **CodeAnt-AI Description**
**Recover broken half-width layouts when they are opened**

### What Changed
- Layouts saved without `slot_position` now open correctly instead of crashing when two half-width devices share the same rack position
- The app restores the missing left/right placement for those device pairs and brings back the missing half-width sizing so they render properly
- Nested devices inside containers, bays, or parent devices are left unchanged, and single unmatched devices are not assigned a slot
- Added regression tests for pair recovery and the single-device case

### Impact
`✅ Fewer layout load crashes`
`✅ Correct rendering of recovered half-width devices`
`✅ Safer loading of previously broken saved layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
