### PR TITLE
chore(ts): Enable TypeScript strict mode on frontend (#1609)

### DIFF
--- a/docs/plans/typescript-strict-burndown.md
+++ b/docs/plans/typescript-strict-burndown.md
@@ -1,0 +1,84 @@
+# TypeScript Strict Mode Burndown
+
+> Baseline created: 2026-05-19
+> Issue: #1609
+> Config: `strict: true`, `noUnusedLocals: true`, `noUnusedParameters: true`, `noUncheckedIndexedAccess: true`
+
+## Summary
+
+- Total files with `@ts-nocheck`: **25**
+- `.svelte` files: **9**
+- `.ts` files: **14**
+- `.svelte.ts` files: **2**
+- Total type errors suppressed: **84**
+
+## Progress Tracker
+
+- [ ] **Batch 1: Types, constants, schemas** (0 files — already strict)
+- [ ] **Batch 2: Utils** (11 files)
+- [ ] **Batch 3: Data** (0 files — already strict)
+- [ ] **Batch 4: Stores** (3 files)
+- [ ] **Batch 5: Icon components** (0 files — already strict)
+- [ ] **Batch 6: Top-level components** (9 files)
+- [ ] **Batch 7: Root and config** (1 file + 2 test helpers)
+
+## File Checklist
+
+### Batch 2: Utils (11 files, 48 errors)
+
+- [ ] `src/lib/utils/export.ts` — strictNullChecks, noUncheckedIndexedAccess (17 errors)
+- [ ] `src/lib/utils/persistence-manager.svelte.ts` — string vs literal types, SVGElement cast, noUnusedLocals (12 errors)
+- [ ] `src/lib/utils/gestures.ts` — PointerEvent vs EventListener type narrowing (8 errors)
+- [ ] `src/lib/utils/generate-bundled-images.ts` — strictNullChecks, noUncheckedIndexedAccess (3 errors)
+- [ ] `src/lib/utils/canvas.ts` — strictNullChecks, noUncheckedIndexedAccess (2 errors)
+- [ ] `src/lib/utils/deviceFilters.ts` — strictNullChecks, undefined vs null (2 errors)
+- [ ] `src/lib/utils/netbox-import.ts` — noUncheckedIndexedAccess (1 error)
+- [ ] `src/lib/utils/qrcode.ts` — missing type declaration (1 error)
+- [ ] `src/lib/utils/rack-context-actions.ts` — noUnusedLocals (1 error)
+- [ ] `src/lib/utils/rack-interaction-handlers.ts` — DeviceFace vs literal type (1 error)
+- [ ] `src/lib/utils/yaml.ts` — noUncheckedIndexedAccess, string vs undefined (1 error)
+
+### Batch 4: Stores (3 files, 8 errors)
+
+- [ ] `src/lib/stores/layout/rack-actions.ts` — strictNullChecks, Rack \| undefined (5 errors)
+- [ ] `src/lib/stores/cables.svelte.ts` — strictNullChecks, null (2 errors)
+- [ ] `src/lib/stores/layout/command-adapters.ts` — strictNullChecks, return type (1 error)
+
+### Batch 6: Top-level components (9 files, 19 errors)
+
+- [ ] `src/lib/components/ExportDialog.svelte` — strictNullChecks, unknown prop (2 errors)
+- [ ] `src/lib/components/DialogOrchestrator.svelte` — type mismatch, union type (2 errors)
+- [ ] `src/lib/components/DevicePalette.svelte` — strictNullChecks, null vs undefined (4 errors)
+- [ ] `src/lib/components/Rack.svelte` — noUnusedLocals, strictNullChecks (4 errors)
+- [ ] `src/lib/components/RackList.svelte` — strictNullChecks (4 errors)
+- [ ] `src/lib/components/Toolbar.svelte` — string literal type mismatch (3 errors)
+- [ ] `src/lib/components/DevicePaletteItem.svelte` — unknown prop (1 error)
+- [ ] `src/lib/components/ImportFromNetBoxDialog.svelte` — noUnusedLocals (1 error)
+- [ ] `src/App.svelte` — strictNullChecks, null (2 errors)
+
+### Batch 7: Root and config (3 files, 4 errors)
+
+- [ ] `src/tests/factories.ts` — noUncheckedIndexedAccess (2 errors)
+- [ ] `src/tests/setup.ts` — callback type mismatch (2 errors)
+
+## Error Categories Reference
+
+| Category                 | Description                                               | Typical Fix                                             |
+| ------------------------ | --------------------------------------------------------- | ------------------------------------------------------- |
+| strictNullChecks         | Possibly null/undefined values                            | Add null checks, optional chaining, non-null assertions |
+| noUncheckedIndexedAccess | Array/object index access returns T \| undefined          | Add bounds checks or type guards                        |
+| noUnusedLocals           | Declared but unread variables                             | Remove or prefix with `_`                               |
+| noUnusedParameters       | Unused function parameters                                | Prefix with `_`                                         |
+| type mismatch            | Incompatible types (string vs literal, null vs undefined) | Fix type annotations, use type assertions               |
+| missing types            | Implicit any, missing declarations                        | Add type annotations or declaration files               |
+| unknown prop             | Unknown component property                                | Add prop to interface                                   |
+
+## How to Remove @ts-nocheck
+
+For each file in the burndown:
+
+1. Remove the `// @ts-nocheck` line
+2. Run `npx svelte-check --tsconfig ./tsconfig.json` to see remaining errors
+3. Fix each error according to its category (see table above)
+4. Run `npm run lint && npm run build && npm run test:run` to verify
+5. Commit in a separate PR with title: `chore(ts): Remove @ts-nocheck from [module]`

--- a/docs/plans/typescript-strict-burndown.md
+++ b/docs/plans/typescript-strict-burndown.md
@@ -15,16 +15,16 @@
 ## Progress Tracker
 
 - [ ] **Batch 1: Types, constants, schemas** (0 files — already strict)
-- [ ] **Batch 2: Utils** (11 files)
+- [ ] **Batch 2: Utils** (11 files, 49 errors)
 - [ ] **Batch 3: Data** (0 files — already strict)
-- [ ] **Batch 4: Stores** (3 files)
+- [ ] **Batch 4: Stores** (3 files, 8 errors)
 - [ ] **Batch 5: Icon components** (0 files — already strict)
-- [ ] **Batch 6: Top-level components** (9 files)
-- [ ] **Batch 7: Root and config** (1 file + 2 test helpers)
+- [ ] **Batch 6: Top-level components** (9 files, 23 errors)
+- [ ] **Batch 7: Test helpers** (2 files, 4 errors)
 
 ## File Checklist
 
-### Batch 2: Utils (11 files, 48 errors)
+### Batch 2: Utils (11 files, 49 errors)
 
 - [ ] `src/lib/utils/export.ts` — strictNullChecks, noUncheckedIndexedAccess (17 errors)
 - [ ] `src/lib/utils/persistence-manager.svelte.ts` — string vs literal types, SVGElement cast, noUnusedLocals (12 errors)
@@ -44,7 +44,7 @@
 - [ ] `src/lib/stores/cables.svelte.ts` — strictNullChecks, null (2 errors)
 - [ ] `src/lib/stores/layout/command-adapters.ts` — strictNullChecks, return type (1 error)
 
-### Batch 6: Top-level components (9 files, 19 errors)
+### Batch 6: Top-level components (9 files, 23 errors)
 
 - [ ] `src/lib/components/ExportDialog.svelte` — strictNullChecks, unknown prop (2 errors)
 - [ ] `src/lib/components/DialogOrchestrator.svelte` — type mismatch, union type (2 errors)
@@ -56,7 +56,7 @@
 - [ ] `src/lib/components/ImportFromNetBoxDialog.svelte` — noUnusedLocals (1 error)
 - [ ] `src/App.svelte` — strictNullChecks, null (2 errors)
 
-### Batch 7: Root and config (3 files, 4 errors)
+### Batch 7: Test helpers (2 files, 4 errors)
 
 - [ ] `src/tests/factories.ts` — noUncheckedIndexedAccess (2 errors)
 - [ ] `src/tests/setup.ts` — callback type mismatch (2 errors)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,16 @@ export default defineConfig(
       // typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
       // see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
       "no-undef": "off",
+      // Allow @ts-nocheck during strict mode burndown (see #1609)
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          "ts-nocheck": false,
+          "ts-check": false,
+          "ts-expect-error": "allow-with-description",
+          "ts-ignore": "allow-with-description",
+        },
+      ],
       // Allow unused variables that start with underscore
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,6 +3,7 @@
   Main application component
 -->
 <script lang="ts">
+  // @ts-nocheck
   import { onMount, untrack } from "svelte";
   import AnimationDefs from "$lib/components/AnimationDefs.svelte";
   import Toolbar from "$lib/components/Toolbar.svelte";

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -4,6 +4,7 @@
   Uses exclusive accordion (only one section open at a time)
 -->
 <script lang="ts">
+  // @ts-nocheck
   import { Accordion } from "bits-ui";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -4,6 +4,7 @@
   Draggable for placement into racks
 -->
 <script lang="ts">
+  // @ts-nocheck
   import type { DeviceType } from "$lib/types";
   import IconGrip from "./icons/IconGrip.svelte";
   import IconTrash from "./icons/IconTrash.svelte";

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -5,6 +5,7 @@
   All dependencies are accessed via module imports and singleton stores (zero props).
 -->
 <script lang="ts">
+  // @ts-nocheck
   import { NewRackWizard, type CreateRackData } from "$lib/components/wizard";
   import AddDeviceForm from "$lib/components/AddDeviceForm.svelte";
   import ImportFromNetBoxDialog from "$lib/components/ImportFromNetBoxDialog.svelte";

--- a/src/lib/components/ExportDialog.svelte
+++ b/src/lib/components/ExportDialog.svelte
@@ -4,6 +4,7 @@
   Features LogoLoader during export, shimmer preview, rack selection for multi-rack exports
 -->
 <script lang="ts">
+  // @ts-nocheck
   import type {
     Rack,
     RackGroup,
@@ -389,7 +390,11 @@
   <div class="export-form">
     <div class="form-group">
       <label for="export-format">Format</label>
-      <select id="export-format" data-testid="select-export-format" bind:value={format}>
+      <select
+        id="export-format"
+        data-testid="select-export-format"
+        bind:value={format}
+      >
         <option value="png">PNG</option>
         <option value="jpeg">JPEG</option>
         <option value="svg">SVG</option>
@@ -457,7 +462,11 @@
 
       <div class="form-group">
         <label for="export-view">View</label>
-        <select id="export-view" data-testid="select-export-view" bind:value={exportView}>
+        <select
+          id="export-view"
+          data-testid="select-export-view"
+          bind:value={exportView}
+        >
           <option value="both">Front & Rear (Side-by-Side)</option>
           <option value="front">Front Only</option>
           <option value="rear">Rear Only</option>

--- a/src/lib/components/ImportFromNetBoxDialog.svelte
+++ b/src/lib/components/ImportFromNetBoxDialog.svelte
@@ -4,6 +4,7 @@
   Uses bits-ui Tabs for accessible input mode selection
 -->
 <script lang="ts">
+  // @ts-nocheck
   import Dialog from "./Dialog.svelte";
   import { Tabs } from "$lib/components/ui/Tabs";
   import { IconUpload } from "./icons";

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -17,6 +17,7 @@
   - rack-context-menu-handlers: context menu UI delegation
 -->
 <script lang="ts">
+  // @ts-nocheck
   import type {
     Rack as RackType,
     DeviceType,

--- a/src/lib/components/RackList.svelte
+++ b/src/lib/components/RackList.svelte
@@ -3,6 +3,7 @@
   Displays list of all racks with selection, delete, and context menu actions
 -->
 <script lang="ts">
+  // @ts-nocheck
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -6,6 +6,7 @@
   - Right: Dropdown menus (desktop) / quick file actions (mobile)
 -->
 <script lang="ts">
+  // @ts-nocheck
   import Tooltip from "./Tooltip.svelte";
   import FileMenu from "./FileMenu.svelte";
   import SettingsMenu from "./SettingsMenu.svelte";
@@ -284,7 +285,15 @@
           data-testid="layout-name-display"
         >
           <span class="toolbar-name-text">{layoutStore.layout.name}</span>
-          <svg class="toolbar-name-pencil" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <svg
+            class="toolbar-name-pencil"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
             <path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
           </svg>
         </button>

--- a/src/lib/stores/cables.svelte.ts
+++ b/src/lib/stores/cables.svelte.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Cable Store
  * CRUD operations for cable connections between device interfaces

--- a/src/lib/stores/layout/command-adapters.ts
+++ b/src/lib/stores/layout/command-adapters.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Command Adapters for Layout Store
  *

--- a/src/lib/stores/layout/rack-actions.ts
+++ b/src/lib/stores/layout/rack-actions.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Rack Actions Domain Module
  *

--- a/src/lib/utils/canvas.ts
+++ b/src/lib/utils/canvas.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Canvas Utility Functions
  * Calculations for fit-all zoom and rack positioning

--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Device Filters
  * Utility functions for searching and grouping devices
@@ -251,7 +252,9 @@ export function filterPaletteDevicesByRackWidth(
   rackWidth: number,
   compatibleOnly: boolean,
 ): DeviceType[] {
-  return compatibleOnly ? filterDevicesByRackWidth(devices, rackWidth) : devices;
+  return compatibleOnly
+    ? filterDevicesByRackWidth(devices, rackWidth)
+    : devices;
 }
 
 /**

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Export utilities for generating images from rack layouts
  */

--- a/src/lib/utils/generate-bundled-images.ts
+++ b/src/lib/utils/generate-bundled-images.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Bundled Images Generator
  *

--- a/src/lib/utils/gestures.ts
+++ b/src/lib/utils/gestures.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Touch Gesture Utilities
  * Composable gesture detection for touch interactions

--- a/src/lib/utils/netbox-import.ts
+++ b/src/lib/utils/netbox-import.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * NetBox Device Import Utilities
  * Parses NetBox devicetype-library YAML format and converts to Rackula DeviceType

--- a/src/lib/utils/persistence-manager.svelte.ts
+++ b/src/lib/utils/persistence-manager.svelte.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import {
   isApiAvailable,
   setApiAvailable,

--- a/src/lib/utils/qrcode.ts
+++ b/src/lib/utils/qrcode.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * QR Code Generation Utilities
  * Fixed spec per Issue #88: Version 24, Error Correction L
@@ -20,7 +21,7 @@ export const QR_VERSION = 24;
  * Error correction level (L = 7% recovery)
  * Lower error correction = more data capacity
  */
-export const QR_ERROR_CORRECTION = 'L' as const;
+export const QR_ERROR_CORRECTION = "L" as const;
 
 /**
  * Maximum chars that fit in QR v24 with EC level L
@@ -39,30 +40,33 @@ export const QR_MIN_PRINT_CM = 4.0;
 // =============================================================================
 
 export interface QRCodeOptions {
-	/** Output width in pixels (default: 444 for high quality) */
-	width?: number;
+  /** Output width in pixels (default: 444 for high quality) */
+  width?: number;
 }
 
 /**
  * Generate QR code as PNG data URL
  * Uses fixed Version 24, EC Level L for consistent sizing
  */
-export async function generateQRCode(data: string, options: QRCodeOptions = {}): Promise<string> {
-	const { width = 444 } = options;
+export async function generateQRCode(
+  data: string,
+  options: QRCodeOptions = {},
+): Promise<string> {
+  const { width = 444 } = options;
 
-	// Dynamic import to avoid loading QRCode library on app startup
-	const QRCode = await import('qrcode');
+  // Dynamic import to avoid loading QRCode library on app startup
+  const QRCode = await import("qrcode");
 
-	return QRCode.toDataURL(data, {
-		errorCorrectionLevel: QR_ERROR_CORRECTION,
-		version: QR_VERSION,
-		width,
-		margin: 2,
-		color: {
-			dark: '#000000',
-			light: '#ffffff'
-		}
-	});
+  return QRCode.toDataURL(data, {
+    errorCorrectionLevel: QR_ERROR_CORRECTION,
+    version: QR_VERSION,
+    width,
+    margin: 2,
+    color: {
+      dark: "#000000",
+      light: "#ffffff",
+    },
+  });
 }
 
 // =============================================================================
@@ -73,5 +77,5 @@ export async function generateQRCode(data: string, options: QRCodeOptions = {}):
  * Check if data fits within QR Version 24 capacity
  */
 export function canFitInQR(data: string): boolean {
-	return data.length <= QR_MAX_CHARS;
+  return data.length <= QR_MAX_CHARS;
 }

--- a/src/lib/utils/rack-context-actions.ts
+++ b/src/lib/utils/rack-context-actions.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Rack Context Menu Actions
  * Factory for context menu handlers, extracted from Rack.svelte.

--- a/src/lib/utils/rack-interaction-handlers.ts
+++ b/src/lib/utils/rack-interaction-handlers.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Rack Interaction Handlers
  * Factory for drag-and-drop, touch, and keyboard event handlers.

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * YAML Serialization Utilities
  * For folder-based project format

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Test Factories
  *

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/svelte";
 import { afterEach, beforeEach, vi } from "vitest";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,10 @@
     "noEmit": true,
 
     /* Linting - Strict mode */
-    "strict": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
 


### PR DESCRIPTION
## **User description**
## Summary

- Flip `tsconfig.json` to `strict: true`, `noUnusedLocals: true`, `noUnusedParameters: true`, `noUncheckedIndexedAccess: true`
- Add `@ts-nocheck` escape hatches to 25 files with type errors (84 total errors suppressed)
- Configure ESLint to allow `@ts-nocheck` during the burndown
- Create burndown checklist at `docs/plans/typescript-strict-burndown.md`

This PR does **not** fix any type errors — it only enables strict mode and uses `@ts-nocheck` to keep CI green. The actual type fixes are tracked in follow-up issues.

## Follow-up Issues

- #1705: Remove @ts-nocheck from utils (11 files, 48 errors)
- #1706: Remove @ts-nocheck from stores (3 files, 8 errors)
- #1707: Remove @ts-nocheck from components (9 files, 19 errors)
- #1708: Remove @ts-nocheck from test helpers (2 files, 4 errors)

## Verification

- `npx svelte-check --tsconfig ./tsconfig.json` — 0 errors (all suppressed)
- `npm run lint` — passes
- `npm run build` — passes
- `npm run test:run` — 97 files, 1995 tests pass

Closes #1609


___

## **CodeAnt-AI Description**
**Enable TypeScript strict mode across the frontend without changing app behavior**

### What Changed
- Turned on stricter TypeScript checks for the frontend project
- Added `@ts-nocheck` to files with existing type errors so builds, linting, and tests still pass
- Allowed `@ts-nocheck` in lint rules during the rollout and added a burndown checklist for the remaining fixes

### Impact
`✅ Safer future code changes`
`✅ Fewer type regressions slipping through`
`✅ Keeps the app build and tests passing during the strict-mode rollout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
