### PR TITLE
fix(nginx): fix OIDC auth redirect port when behind reverse proxy

### DIFF
--- a/deploy/docker-compose.persist.yml
+++ b/deploy/docker-compose.persist.yml
@@ -25,8 +25,11 @@ services:
       - RACKULA_ENABLE_IPV6=${RACKULA_ENABLE_IPV6:-auto}
       # DNS resolver for nginx upstream resolution (override for Kubernetes)
       - NGINX_RESOLVER=${NGINX_RESOLVER:-127.0.0.11}
-      # Set to 1 when Rackula is behind a trusted reverse proxy that sets
-      # X-Forwarded-Proto. Enables correct https:// scheme in auth redirects.
+      # Set to 1 when Rackula is behind a trusted reverse proxy.
+      # Required for correct https:// scheme in auth redirects (reads X-Forwarded-Proto).
+      # Your proxy must also forward the original Host header unchanged — including any
+      # non-standard external port — because auth redirects use the Host header for
+      # the redirect authority (e.g. proxy_set_header Host $host in nginx).
       # Leave at 0 (default) for direct access — prevents open-redirect abuse.
       - RACKULA_TRUST_PROXY=${RACKULA_TRUST_PROXY:-0}
     restart: unless-stopped

--- a/deploy/docker-compose.persist.yml
+++ b/deploy/docker-compose.persist.yml
@@ -25,6 +25,10 @@ services:
       - RACKULA_ENABLE_IPV6=${RACKULA_ENABLE_IPV6:-auto}
       # DNS resolver for nginx upstream resolution (override for Kubernetes)
       - NGINX_RESOLVER=${NGINX_RESOLVER:-127.0.0.11}
+      # Set to 1 when Rackula is behind a trusted reverse proxy that sets
+      # X-Forwarded-Proto. Enables correct https:// scheme in auth redirects.
+      # Leave at 0 (default) for direct access — prevents open-redirect abuse.
+      - RACKULA_TRUST_PROXY=${RACKULA_TRUST_PROXY:-0}
     restart: unless-stopped
     stop_grace_period: 10s
     depends_on:

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -40,6 +40,19 @@ map "$request_method:$rackula_auth_mode_local" $rackula_serve_local_login_page {
     "GET:1" 1;
 }
 
+# When behind a reverse proxy, use X-Forwarded-Proto/Host for the correct
+# external scheme and hostname in auth redirects. Falls back to nginx's own
+# $scheme/$http_host when no forwarded headers are present (direct access).
+map "$http_x_forwarded_proto" $real_scheme {
+    default $scheme;
+    ~^(\w+) $1;
+}
+
+map "$http_x_forwarded_host" $real_host {
+    default $http_host;
+    ~^([^,\s]+) $1;
+}
+
 log_format rackula_auth_upstream_failure
     'auth_upstream_unavailable '
     'remote_addr=$remote_addr request_uri=$request_uri '
@@ -222,7 +235,9 @@ server {
         # Limitation: if $args contains & characters, nginx will split them into
         # separate query params. Only the first segment stays in next=.
         # Full URI-encoding requires OpenResty (set_escape_uri), unavailable here.
-        return 302 /auth/login?next=$uri$is_args$args;
+        # Use $real_scheme/$real_host (resolved from X-Forwarded-* headers above)
+        # so the absolute redirect URL is correct when nginx is behind a reverse proxy.
+        return 302 $real_scheme://$real_host/auth/login?next=$uri$is_args$args;
     }
 
     # Container health check - used by Docker/K8s for liveness/readiness probes

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -40,17 +40,19 @@ map "$request_method:$rackula_auth_mode_local" $rackula_serve_local_login_page {
     "GET:1" 1;
 }
 
-# When behind a reverse proxy, use X-Forwarded-Proto/Host for the correct
-# external scheme and hostname in auth redirects. Falls back to nginx's own
-# $scheme/$http_host when no forwarded headers are present (direct access).
-map "$http_x_forwarded_proto" $real_scheme {
-    default $scheme;
-    ~^(\w+) $1;
+# When RACKULA_TRUST_PROXY=1 (or true/yes), X-Forwarded-Proto is honoured so
+# the auth redirect uses the external scheme (https) rather than the internal
+# one (http). Disabled by default — only enable when nginx is behind a trusted
+# reverse proxy that sets this header. Only http/https are accepted.
+map "${RACKULA_TRUST_PROXY}" $rackula_trust_proxy {
+    default 0;
+    ~*^(1|true|yes)$ 1;
 }
 
-map "$http_x_forwarded_host" $real_host {
-    default $http_host;
-    ~^([^,\s]+) $1;
+map "$rackula_trust_proxy:$http_x_forwarded_proto" $real_scheme {
+    default        $scheme;
+    "1:http"       http;
+    "1:https"      https;
 }
 
 log_format rackula_auth_upstream_failure
@@ -235,9 +237,11 @@ server {
         # Limitation: if $args contains & characters, nginx will split them into
         # separate query params. Only the first segment stays in next=.
         # Full URI-encoding requires OpenResty (set_escape_uri), unavailable here.
-        # Use $real_scheme/$real_host (resolved from X-Forwarded-* headers above)
-        # so the absolute redirect URL is correct when nginx is behind a reverse proxy.
-        return 302 $real_scheme://$real_host/auth/login?next=$uri$is_args$args;
+        # Explicit absolute URL avoids nginx appending $server_port to $http_host
+        # when the Host header has no port (the root cause of #1713).
+        # $real_scheme honours X-Forwarded-Proto when RACKULA_TRUST_PROXY=1.
+        # $http_host (not X-Forwarded-Host) is used to prevent open-redirect.
+        return 302 $real_scheme://$http_host/auth/login?next=$uri$is_args$args;
     }
 
     # Container health check - used by Docker/K8s for liveness/readiness probes


### PR DESCRIPTION
## **User description**
## Summary

- `return 302 /auth/login?...` in `@auth_login_redirect` caused nginx to construct the Location header using `$server_port` (RACKULA_LISTEN_PORT, e.g. 8080) when the Host header had no port
- Behind a reverse proxy the client-visible port is different (443/HTTPS or a custom port), so the redirect landed on the wrong port and broke the OIDC login flow
- Fix adds two `map` blocks (`$real_scheme`, `$real_host`) that prefer `X-Forwarded-Proto` / `X-Forwarded-Host` headers when set, falling back to nginx's own `$scheme`/`$http_host` for direct-access deployments
- Redirect is now `$real_scheme://$real_host/auth/login?...` — always reflects the address the client actually used

## Why

When Nginx Proxy Manager (or any reverse proxy) sits in front of Rackula and the internal and external ports differ, the OIDC callback loop was broken because nginx was redirecting to e.g. `http://rackula.example.com:8080/auth/login` instead of `https://rackula.example.com/auth/login`.

## Test Plan

- [ ] Direct access (no proxy): verify login redirect uses the correct host/port from the `Host` header
- [ ] Behind a reverse proxy with HTTPS: set `X-Forwarded-Proto: https` and `X-Forwarded-Host: rackula.example.com`; verify Location header is `https://rackula.example.com/auth/login?next=...`
- [ ] Behind a reverse proxy on a non-standard port: set `X-Forwarded-Host: rackula.example.com:8443`; verify port is preserved
- [ ] No forwarded headers at all: verify fallback to `$scheme/$http_host` works (unchanged from prior behaviour)

Closes #1713

---
_Generated by [Claude Code](https://claude.ai/code/session_0114nzhugWdDB1N2GBpdLkYY)_


___

## **CodeAnt-AI Description**
**Fix OIDC login redirects behind reverse proxies**

### What Changed
- Login redirects now keep the client-facing scheme and host when Rackula is behind a reverse proxy
- The redirect falls back to the direct-access address when no forwarded headers are present
- The `next=` path and query string are still preserved in the login redirect

### Impact
`✅ Correct login redirects behind reverse proxies`
`✅ Fewer broken OIDC sign-ins`
`✅ Preserved direct-access login behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
