### PR TITLE
feat: share URL warning at 1800 chars + download layout file fallback

### DIFF
--- a/src/lib/components/ShareDialog.svelte
+++ b/src/lib/components/ShareDialog.svelte
@@ -19,6 +19,8 @@
   import { analytics } from "$lib/utils/analytics";
   import type { Layout } from "$lib/types";
 
+  // Threshold is checked against the full URL (encoded payload + ~30-char static prefix),
+  // consistent with how canFitInQR() measures the share URL.
   const URL_LENGTH_WARNING = 1800;
 
   interface Props {
@@ -57,6 +59,13 @@
     } else {
       qrDataUrl = null;
       qrError = null;
+    }
+  });
+
+  // Clear stale QR image if layout grows too large while dialog is open
+  $effect(() => {
+    if (isTooLong) {
+      qrDataUrl = null;
     }
   });
 

--- a/src/lib/components/ShareDialog.svelte
+++ b/src/lib/components/ShareDialog.svelte
@@ -6,15 +6,20 @@
   import Dialog from "./Dialog.svelte";
   import { IconCopy, IconDownload } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
-  import { generateShareUrl, encodeLayout } from "$lib/utils/share";
+  import { generateShareUrl } from "$lib/utils/share";
   import {
     generateQRCode,
     canFitInQR,
     QR_MIN_PRINT_CM,
   } from "$lib/utils/qrcode";
+  import { serializeLayoutToYaml } from "$lib/utils/yaml";
+  import { downloadBlob } from "$lib/utils/export";
+  import { buildYamlFilename } from "$lib/utils/folder-structure";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { analytics } from "$lib/utils/analytics";
   import type { Layout } from "$lib/types";
+
+  const URL_LENGTH_WARNING = 1800;
 
   interface Props {
     open: boolean;
@@ -33,7 +38,8 @@
 
   // Generate share URL
   const shareUrl = $derived(generateShareUrl(layout));
-  const encodedLength = $derived(encodeLayout(layout)?.length ?? 0);
+  const urlLength = $derived(shareUrl?.length ?? 0);
+  const isTooLong = $derived(urlLength > URL_LENGTH_WARNING);
   const fitsInQR = $derived(shareUrl ? canFitInQR(shareUrl) : false);
 
   // QR code generation state
@@ -94,6 +100,17 @@
     link.download = `${layout.name.replace(/[^a-zA-Z0-9]/g, "-")}-qr.png`;
     link.click();
   }
+
+  async function downloadLayoutFile() {
+    try {
+      const yaml = await serializeLayoutToYaml(layout);
+      const blob = new Blob([yaml], { type: "text/yaml" });
+      downloadBlob(blob, buildYamlFilename(layout.name));
+      toastStore.showToast("Layout file downloaded", "success", 3000);
+    } catch {
+      toastStore.showToast("Failed to download layout", "error");
+    }
+  }
 </script>
 
 <Dialog
@@ -128,9 +145,11 @@
         </button>
       </div>
       <p class="url-info">
-        {encodedLength} characters
-        {#if encodedLength > 2000}
-          <span class="warning"> (may be too long for some browsers)</span>
+        {urlLength} characters
+        {#if isTooLong}
+          <span class="warning">
+            &mdash; too long for some browsers; download the file instead</span
+          >
         {/if}
       </p>
     </div>
@@ -173,7 +192,17 @@
       <button type="button" class="btn btn-secondary" onclick={onclose}>
         Cancel
       </button>
-      {#if qrDataUrl}
+      {#if isTooLong}
+        <button
+          type="button"
+          class="btn btn-primary"
+          onclick={downloadLayoutFile}
+          data-testid="layout-download-btn"
+        >
+          <IconDownload size={ICON_SIZE.sm} />
+          Download Layout File
+        </button>
+      {:else if qrDataUrl}
         <button
           type="button"
           class="btn btn-primary"


### PR DESCRIPTION
## **User description**
## Summary

- Lower the share URL warning threshold from 2000 → **1800 characters** (full URL length, consistent with the existing QR code limit check)
- Add a **"Download Layout File"** button that appears when the URL is too long, giving users a reliable offline fallback
- Character count in the info line now shows the full URL length rather than the encoded parameter length

## Why

The previous warning fired at 2000 characters but offered no escape hatch. Older browsers (Edge/IE) historically cap URLs around 2000 chars, so by the time users saw the warning it may already have been too late. Showing the warning at 1800 gives a buffer, and the download button lets them share the layout via file instead.

## Test Plan

- [ ] Open Share dialog with a small layout — no warning, QR download shown as before
- [ ] Open Share dialog with a layout large enough to exceed 1800 chars — warning appears, "Download Layout File" button shown in place of QR download
- [ ] Click "Download Layout File" — `.rackula.yaml` file downloads successfully
- [ ] Layout still fits in QR at < 1588 chars — QR generates normally

Closes #819

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyf1ArFTGnR6GK3ZymHaZE)_


___

## **CodeAnt-AI Description**
**Warn earlier when a share link is too long and offer a file download instead**

### What Changed
- The share dialog now warns when the full link reaches 1800 characters and shows the full link length in the info line.
- When the link is too long, the QR download option is replaced with a “Download Layout File” button so users can share the layout as a YAML file instead.
- Downloading the layout file now shows a success or failure message.

### Impact
`✅ Fewer share links that fail in older browsers`
`✅ Clearer guidance when a layout link is too long`
`✅ Reliable fallback for sharing large layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
