### PR TITLE
feat: add Layouts navigation to File Menu and mobile toolbar

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -314,6 +314,15 @@
     }
   });
 
+  function handleShowLayouts() {
+    if (uiStore.warnOnUnsavedChanges && layoutStore.isDirty) {
+      if (!window.confirm("You have unsaved changes. Leave anyway?")) {
+        return;
+      }
+    }
+    showStartScreen = true;
+  }
+
   function handleStartScreenClose(options?: StartScreenCloseOptions) {
     showStartScreen = false;
 
@@ -536,6 +545,7 @@
       onimportdevices={handleImportDevices}
       onimportnetbox={handleImportFromNetBox}
       onnewcustomdevice={handleAddDevice}
+      onlayouts={handleShowLayouts}
       onfitall={handleFitAll}
       ontoggletheme={handleToggleTheme}
       ontoggledisplaymode={handleToggleDisplayMode}

--- a/src/lib/components/FileMenu.svelte
+++ b/src/lib/components/FileMenu.svelte
@@ -20,6 +20,7 @@
     onimportdevices?: () => void;
     onimportnetbox?: () => void;
     onnewcustomdevice?: () => void;
+    onlayouts?: () => void;
     hasRacks?: boolean;
   }
 
@@ -33,6 +34,7 @@
     onimportdevices,
     onimportnetbox,
     onnewcustomdevice,
+    onlayouts,
     hasRacks = false,
   }: Props = $props();
 
@@ -66,19 +68,35 @@
       sideOffset={4}
       align="end"
     >
-      <DropdownMenu.Item class="menu-item" data-testid="menu-save" onSelect={handleSelect(onsave)}>
+      <DropdownMenu.Item
+        class="menu-item"
+        data-testid="menu-save"
+        onSelect={handleSelect(onsave)}
+      >
         <span class="menu-label">Save</span>
         <span class="menu-shortcut">{shortcuts.save}</span>
       </DropdownMenu.Item>
-      <DropdownMenu.Item class="menu-item" data-testid="menu-save-as" onSelect={handleSelect(onsaveas)}>
+      <DropdownMenu.Item
+        class="menu-item"
+        data-testid="menu-save-as"
+        onSelect={handleSelect(onsaveas)}
+      >
         <span class="menu-label">Save As...</span>
         <span class="menu-shortcut">{shortcuts.saveAs}</span>
       </DropdownMenu.Item>
-      <DropdownMenu.Item class="menu-item" data-testid="menu-load" onSelect={handleSelect(onload)}>
+      <DropdownMenu.Item
+        class="menu-item"
+        data-testid="menu-load"
+        onSelect={handleSelect(onload)}
+      >
         <span class="menu-label">Load</span>
         <span class="menu-shortcut">{shortcuts.load}</span>
       </DropdownMenu.Item>
-      <DropdownMenu.Item class="menu-item" data-testid="menu-export" onSelect={handleSelect(onexport)}>
+      <DropdownMenu.Item
+        class="menu-item"
+        data-testid="menu-export"
+        onSelect={handleSelect(onexport)}
+      >
         <span class="menu-label">Export</span>
         <span class="menu-shortcut">{shortcuts.export}</span>
       </DropdownMenu.Item>
@@ -116,6 +134,16 @@
       >
         <span class="menu-label">New Custom Device</span>
       </DropdownMenu.Item>
+      {#if onlayouts}
+        <DropdownMenu.Separator class="menu-separator" />
+        <DropdownMenu.Item
+          class="menu-item"
+          data-testid="menu-layouts"
+          onSelect={handleSelect(onlayouts)}
+        >
+          <span class="menu-label">Layouts...</span>
+        </DropdownMenu.Item>
+      {/if}
     </DropdownMenu.Content>
   </DropdownMenu.Portal>
 </DropdownMenu.Root>

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -59,6 +59,7 @@
     ontogglepromptcleanup?: () => void;
     onopencleanup?: () => void;
     onhelp?: () => void;
+    onlayouts?: () => void;
   }
 
   let {
@@ -91,6 +92,7 @@
     ontogglepromptcleanup,
     onopencleanup,
     onhelp,
+    onlayouts,
   }: Props = $props();
 
   const layoutStore = getLayoutStore();
@@ -167,6 +169,11 @@
   function handleNewCustomDevice() {
     analytics.trackToolbarClick("new-custom-device");
     onnewcustomdevice?.();
+  }
+
+  function handleLayouts() {
+    analytics.trackToolbarClick("layouts");
+    onlayouts?.();
   }
 
   function handleFitAll() {
@@ -284,7 +291,15 @@
           data-testid="layout-name-display"
         >
           <span class="toolbar-name-text">{layoutStore.layout.name}</span>
-          <svg class="toolbar-name-pencil" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <svg
+            class="toolbar-name-pencil"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
             <path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
           </svg>
         </button>
@@ -402,6 +417,7 @@
         onimportdevices={handleImportDevices}
         onimportnetbox={handleImportNetBox}
         onnewcustomdevice={handleNewCustomDevice}
+        onlayouts={onlayouts ? handleLayouts : undefined}
         {hasRacks}
       />
 
@@ -455,6 +471,17 @@
       >
         Export
       </button>
+      {#if onlayouts}
+        <button
+          class="toolbar-mobile-action-btn"
+          type="button"
+          aria-label="Go to Layouts"
+          onclick={handleLayouts}
+          data-testid="btn-mobile-layouts"
+        >
+          Layouts
+        </button>
+      {/if}
     </div>
   {/if}
 </header>


### PR DESCRIPTION
## **User description**
## Summary

- Adds a **"Layouts..."** item at the bottom of the File Menu dropdown (desktop) so users can return to the Start Screen without a hard page reload
- Adds a **"Layouts"** quick-action button to the mobile toolbar (alongside Save / Load / Export)
- When `warnOnUnsavedChanges` is enabled and the layout is dirty, a browser `confirm()` prompt asks the user before discarding unsaved work; cancelling preserves the current layout

## Why

Once a user opens a layout and enters the canvas view there is no in-app way to switch layouts or create a new one — the only workaround was a hard reload. This was reported by @timothystewart6 in PR #1001.

The "Layouts..." item follows the issue's recommended design option 1 (File Menu), consistent with existing patterns. The mobile button matches the existing Save/Load/Export pattern in the mobile toolbar.

Both the desktop menu item and the mobile button are conditional on `onlayouts` being provided, so the components remain backwards-compatible when used standalone.

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] Unit tests pass — 1995 tests across 97 files (`npm run test:run`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: open File Menu → "Layouts..." appears at the bottom → clicking opens Start Screen
- [ ] Manual: with unsaved changes + warnOnUnsavedChanges enabled → confirm prompt appears; Cancel stays on canvas, OK shows Start Screen
- [ ] Manual: mobile viewport → "Layouts" button visible in toolbar quick-actions

Closes #1004

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8AdHxFQV1j4756x5uFNJT)_


___

## **CodeAnt-AI Description**
**Add Layouts navigation in the toolbar and File menu**

### What Changed
- Added a “Layouts...” option in the desktop File menu and a “Layouts” button in the mobile toolbar so users can return to the start screen without reloading the page
- When unsaved changes are present and unsaved-change warnings are enabled, leaving for Layouts now shows a confirmation prompt; cancelling keeps the current layout open
- The new Layouts action appears only when the app provides layout navigation, so it does not show up in standalone use

### Impact
`✅ Fewer hard reloads to switch layouts`
`✅ Clearer warning before losing unsaved work`
`✅ Consistent layout switching on desktop and mobile`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
