### PR TITLE
fix: anchor right-click context menus to cursor via customAnchor (#1725)

### DIFF
--- a/e2e/context-menu-position.spec.ts
+++ b/e2e/context-menu-position.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "./helpers/base-test";
+import { gotoWithRack, RACK_WITH_DEVICE_SHARE, locators } from "./helpers";
+
+/**
+ * Regression test for #1725 (and the original #1193).
+ *
+ * Right-clicking a placed device must open its context menu at the cursor
+ * location, not pinned to the top-left origin. The menu is rendered inside the
+ * panzoom container, whose CSS `transform` re-bases `position: fixed`, so the
+ * menu must be positioned via a `customAnchor` Measurable rather than a fixed
+ * trigger element. This test guards against the menu collapsing back to (0,0).
+ */
+test("device context menu opens at the cursor, not the top-left origin", async ({
+  page,
+}) => {
+  await gotoWithRack(page, RACK_WITH_DEVICE_SHARE);
+
+  const device = page.locator(locators.rack.device).first();
+  await expect(device).toBeVisible();
+  const deviceBox = await device.boundingBox();
+  if (!deviceBox) throw new Error("device has no bounding box");
+
+  // Right-click the centre of the device — well away from the viewport origin.
+  await device.click({
+    button: "right",
+    position: { x: deviceBox.width / 2, y: deviceBox.height / 2 },
+  });
+
+  const menu = page.locator(locators.contextMenu.content);
+  await expect(menu).toBeVisible();
+  const menuBox = await menu.boundingBox();
+  if (!menuBox) throw new Error("context menu has no bounding box");
+
+  // The menu must appear near the right-clicked device, not at top-left (0,0).
+  // Horizontal position tracks the cursor (bits-ui may flip vertically to keep
+  // the menu inside the viewport, so we assert X against the click and only a
+  // lower bound on Y).
+  const clickX = deviceBox.x + deviceBox.width / 2;
+  expect(Math.abs(menuBox.x - clickX)).toBeLessThan(40);
+  expect(menuBox.x).toBeGreaterThan(50);
+  expect(menuBox.y).toBeGreaterThan(50);
+});

--- a/src/lib/components/DeviceContextMenu.svelte
+++ b/src/lib/components/DeviceContextMenu.svelte
@@ -66,6 +66,17 @@
   // Virtual trigger mode: x and y are provided, children is not
   const useVirtualTrigger = $derived(x !== undefined && y !== undefined);
 
+  // Anchor the menu to the cursor's viewport coordinates via a Measurable
+  // virtual element. We can't anchor to a positioned DOM element here: the
+  // menu is rendered inside the panzoom container whose CSS `transform`
+  // re-bases `position: fixed`, so a fixed trigger div lands in the wrong
+  // place (and bits-ui otherwise defaults the menu to the top-left origin).
+  const virtualAnchor = $derived(
+    useVirtualTrigger
+      ? { getBoundingClientRect: () => new DOMRect(x ?? 0, y ?? 0, 0, 0) }
+      : null,
+  );
+
   function handleSelect(action?: () => void) {
     return () => {
       action?.();
@@ -81,12 +92,9 @@
 
 <ContextMenu.Root {open} onOpenChange={handleOpenChange}>
   {#if useVirtualTrigger}
-    <!-- Virtual trigger at cursor position for SVG elements -->
-    <ContextMenu.Trigger>
-      <div
-        style="position: fixed; left: {x}px; top: {y}px; width: 1px; height: 1px; pointer-events: none;"
-      ></div>
-    </ContextMenu.Trigger>
+    <!-- Virtual trigger mode: the menu is opened programmatically and
+         positioned via customAnchor below, so no trigger element is needed. -->
+    <ContextMenu.Trigger />
   {:else if children}
     <ContextMenu.Trigger>
       {@render children()}
@@ -94,7 +102,11 @@
   {/if}
 
   <ContextMenu.Portal>
-    <ContextMenu.Content class="context-menu-content" sideOffset={5}>
+    <ContextMenu.Content
+      class="context-menu-content"
+      sideOffset={5}
+      customAnchor={virtualAnchor}
+    >
       <ContextMenu.Item
         class="context-menu-item"
         onSelect={handleSelect(onedit)}

--- a/src/lib/components/PaletteDeviceContextMenu.svelte
+++ b/src/lib/components/PaletteDeviceContextMenu.svelte
@@ -14,7 +14,7 @@
     /** Callback when open state changes */
     onOpenChange?: (open: boolean) => void;
     /** Delete device callback */
-    onDelete?: () => void;
+    ondelete?: () => void;
     /** X coordinate for virtual trigger (screen position) */
     x?: number;
     /** Y coordinate for virtual trigger (screen position) */
@@ -24,10 +24,18 @@
   let {
     open = $bindable(false),
     onOpenChange,
-    onDelete,
+    ondelete,
     x = 0,
     y = 0,
   }: Props = $props();
+
+  // Anchor the menu to the cursor's viewport coordinates via a Measurable
+  // virtual element. The menu is opened programmatically (the real right-click
+  // lands on the palette item, not on a bits-ui trigger), so without an anchor
+  // bits-ui positions the menu at the top-left origin.
+  const virtualAnchor = $derived({
+    getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
+  });
 
   function handleOpenChange(newOpen: boolean) {
     open = newOpen;
@@ -36,18 +44,19 @@
 </script>
 
 <ContextMenu.Root {open} onOpenChange={handleOpenChange}>
-  <ContextMenu.Trigger>
-    <div
-      style="position: fixed; left: {x}px; top: {y}px; width: 1px; height: 1px; pointer-events: none;"
-    ></div>
-  </ContextMenu.Trigger>
+  <!-- Virtual trigger mode: opened programmatically, positioned via customAnchor. -->
+  <ContextMenu.Trigger />
 
   <ContextMenu.Portal>
-    <ContextMenu.Content class="context-menu-content" sideOffset={5}>
+    <ContextMenu.Content
+      class="context-menu-content"
+      sideOffset={5}
+      customAnchor={virtualAnchor}
+    >
       <ContextMenu.Item
         class="context-menu-item context-menu-item--destructive"
         onSelect={() => {
-          onDelete?.();
+          ondelete?.();
           open = false;
         }}
       >

--- a/src/lib/components/PaletteDeviceContextMenu.svelte
+++ b/src/lib/components/PaletteDeviceContextMenu.svelte
@@ -15,18 +15,20 @@
     onOpenChange?: (open: boolean) => void;
     /** Delete device callback */
     ondelete?: () => void;
-    /** X coordinate for virtual trigger (screen position) */
-    x?: number;
-    /** Y coordinate for virtual trigger (screen position) */
-    y?: number;
+    /** X coordinate for the menu anchor (cursor screen position). Required: a
+     *  default would silently pin the menu to the top-left origin. */
+    x: number;
+    /** Y coordinate for the menu anchor (cursor screen position). Required: a
+     *  default would silently pin the menu to the top-left origin. */
+    y: number;
   }
 
   let {
     open = $bindable(false),
     onOpenChange,
     ondelete,
-    x = 0,
-    y = 0,
+    x,
+    y,
   }: Props = $props();
 
   // Anchor the menu to the cursor's viewport coordinates via a Measurable


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1725 — right-click context menus opened pinned to the **top-left origin** instead of at the cursor (a regression of #1193). Reproduced on Chrome 148, Firefox 151, and Safari 26.4.

## Root cause (verified by reproduction)

The menus used a `position: fixed` virtual-trigger `<div>`. A Playwright repro showed the menu rendering at ~(0,0) while the click was at (733, 651), and the trigger div's rect was at (1078, 446) — not its style coords (733, 651). Two compounding bugs:

1. **bits-ui doesn't anchor `ContextMenu.Content` to the trigger div** when the menu is opened programmatically (no `contextmenu` event reaches the bits-ui trigger), so it defaults to the (0,0) origin.
2. The device menu renders inside the **`.panzoom-container`**, whose CSS `transform` re-bases `position: fixed`, so the fixed trigger lands far from the cursor anyway.

## Fix

- Replace the fixed-div trigger with a **`customAnchor` Measurable** virtual element whose `getBoundingClientRect()` returns the cursor's viewport coordinates, in both `DeviceContextMenu` and `PaletteDeviceContextMenu`. This is the bits-ui-documented pattern for arbitrary positioning and is immune to transformed ancestors.
- Restore the `ondelete` prop name on `PaletteDeviceContextMenu` — a stray CodeQL autofix (#1703) had renamed it to `onDelete`, silently breaking the palette's "Delete from Library" action since the caller passes `ondelete`.

## Verification

Both menus confirmed via Playwright to open at the cursor (device menu: click (733,651) → menu (740,477), flipping up at the viewport edge; palette menu: click (159,916) → menu (166,454), Delete item present).

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 2000 unit tests pass
- [x] `npm run build` — succeeds
- [x] New e2e regression test `e2e/context-menu-position.spec.ts` (asserts menu opens at cursor, not origin)
- [x] CodeRabbit CLI — 0 findings

## Files Changed

- `src/lib/components/DeviceContextMenu.svelte` — customAnchor Measurable
- `src/lib/components/PaletteDeviceContextMenu.svelte` — customAnchor + `ondelete` prop fix
- `e2e/context-menu-position.spec.ts` — regression test (new)

Closes #1725

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Right-click menus now open at the cursor and the palette delete action works again**

### What Changed
- Device and palette context menus now appear where you right-click instead of opening at the top-left corner
- The device menu keeps working correctly inside the zoomed/positioned canvas area
- The palette menu once again triggers “Delete from Library” as expected
- Added a regression test to confirm the device context menu opens near the clicked item, not at the page origin

### Impact
`✅ Correct menu placement on right-click`
`✅ Fewer broken delete actions in the device palette`
`✅ Prevents context menu regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
