### PR TITLE
chore(ci): add post-release version-alignment test across published images (#1728)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -214,7 +214,8 @@ jobs:
         # which on workflow_dispatch points at the dispatch ref rather than the tag.
         run: |
           echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
-          echo "BUILD_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          # Short hash to match the frontend's commit format (rev-parse --short).
+          echo "BUILD_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Set lowercase image name
         run: echo "API_IMAGE_NAME=${GITHUB_REPOSITORY,,}-api" >> $GITHUB_ENV
 
+      - name: Set build timestamp
+        run: echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
@@ -247,6 +250,49 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:buildcache,mode=max
+          # Inject the release version so the API reports it at GET /version.
+          # The git tag is the single source of truth; api/package.json is only a
+          # local-dev fallback.
+          build-args: |
+            APP_VERSION=${{ needs.validate.outputs.version }}
+            APP_COMMIT=${{ github.sha }}
+            APP_BUILD_TIME=${{ env.BUILD_TIME }}
+
+  verify-version-alignment:
+    name: "Verify Version Alignment"
+    needs: [validate, build-and-deploy, build-persist, build-api]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+          sparse-checkout: |
+            scripts/verify-version-alignment.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify all published images report the release version
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          chmod +x scripts/verify-version-alignment.sh
+          FRONTEND_IMAGE="${REGISTRY}/${IMAGE_NAME_LC}:${VERSION}" \
+          PERSIST_IMAGE="${REGISTRY}/${IMAGE_NAME_LC}:v${VERSION}-persist" \
+          API_IMAGE="${REGISTRY}/${IMAGE_NAME_LC}-api:${VERSION}" \
+            scripts/verify-version-alignment.sh "$VERSION"
 
   scan-images:
     needs: [build-and-deploy, build-persist, build-api]
@@ -309,7 +355,15 @@ jobs:
     # `scan-images` then scans those pushed tags before deploy executes.
     # Trade-off: scan failures block `deploy`, but already-pushed images remain published.
     # (Alternative future flow: scan tar/filesystem artifacts before push.)
-    needs: [validate, build-and-deploy, build-persist, build-api, scan-images]
+    needs:
+      [
+        validate,
+        build-and-deploy,
+        build-persist,
+        build-api,
+        verify-version-alignment,
+        scan-images,
+      ]
     runs-on: [self-hosted, vps-rackula]
     timeout-minutes: 20
     permissions:
@@ -341,7 +395,7 @@ jobs:
           docker compose up -d --remove-orphans
 
   smoke-test:
-    needs: deploy
+    needs: [validate, deploy]
     runs-on: [self-hosted, vps-rackula]
     timeout-minutes: 5
     permissions: {}
@@ -352,9 +406,37 @@ jobs:
           sleep 5
           curl -sf --retry 5 --retry-delay 3 https://count.racku.la
 
+      - name: Verify live version alignment
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          # Extract .version from JSON without depending on jq being installed
+          # on the self-hosted runner.
+          extract_version() {
+            grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' \
+              | head -n1 \
+              | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/'
+          }
+          fe="$(curl -sf --retry 5 --retry-delay 3 https://count.racku.la/version.json | extract_version)"
+          api="$(curl -sf --retry 5 --retry-delay 3 https://count.racku.la/api/version | extract_version)"
+          echo "frontend=${fe} api=${api} expected=${VERSION}"
+          [ "$fe" = "$VERSION" ] || { echo "::error::Live frontend version '${fe}' != '${VERSION}'"; exit 1; }
+          [ "$api" = "$VERSION" ] || { echo "::error::Live API version '${api}' != '${VERSION}'"; exit 1; }
+          echo "✓ Live stack reports ${VERSION}"
+
   notify-failure:
     if: ${{ always() && (failure() || cancelled()) }}
-    needs: [validate, build-and-deploy, build-persist, build-api, scan-images, deploy, smoke-test]
+    needs:
+      [
+        validate,
+        build-and-deploy,
+        build-persist,
+        build-api,
+        verify-version-alignment,
+        scan-images,
+        deploy,
+        smoke-test,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -209,8 +209,12 @@ jobs:
       - name: Set lowercase image name
         run: echo "API_IMAGE_NAME=${GITHUB_REPOSITORY,,}-api" >> $GITHUB_ENV
 
-      - name: Set build timestamp
-        run: echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+      - name: Set build metadata
+        # Derive the commit from the checked-out tag (ref above), not github.sha,
+        # which on workflow_dispatch points at the dispatch ref rather than the tag.
+        run: |
+          echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+          echo "BUILD_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -255,7 +259,7 @@ jobs:
           # local-dev fallback.
           build-args: |
             APP_VERSION=${{ needs.validate.outputs.version }}
-            APP_COMMIT=${{ github.sha }}
+            APP_COMMIT=${{ env.BUILD_COMMIT }}
             APP_BUILD_TIME=${{ env.BUILD_TIME }}
 
   verify-version-alignment:
@@ -270,6 +274,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.validate.outputs.tag }}
+          persist-credentials: false
           sparse-checkout: |
             scripts/verify-version-alignment.sh
           sparse-checkout-cone-mode: false

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -36,6 +36,16 @@ LABEL org.opencontainers.image.title="Rackula API"
 
 USER rackula
 
+# Version metadata injected at build time from the release tag (single source
+# of truth). Surfaced at runtime via GET /version for cross-image alignment checks.
+# api/package.json's version is only a local-dev fallback (see resolveVersionInfo).
+ARG APP_VERSION=""
+ARG APP_COMMIT=""
+ARG APP_BUILD_TIME=""
+ENV APP_VERSION=${APP_VERSION} \
+    APP_COMMIT=${APP_COMMIT} \
+    APP_BUILD_TIME=${APP_BUILD_TIME}
+
 ENV NODE_ENV=production PORT=3001 DATA_DIR=/data
 
 EXPOSE 3001

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -29,6 +29,7 @@ import {
   MAX_PASSWORD_LENGTH,
   verifyCredentials,
 } from "./local-auth";
+import pkg from "../package.json";
 
 const DEFAULT_MAX_ASSET_SIZE = 5 * 1024 * 1024; // 5MB
 const DEFAULT_MAX_LAYOUT_SIZE = 1 * 1024 * 1024; // 1MB
@@ -39,6 +40,33 @@ const HEALTH_RESPONSE = {
   service: "rackula-persistence-api",
   version: 1,
 } as const;
+
+export interface VersionInfo {
+  /** Release version (e.g. "0.9.5"), used for cross-image version-alignment checks. */
+  version: string;
+  /** Short git commit hash the image was built from, or "" when not injected. */
+  commit: string;
+  /** ISO 8601 build timestamp, or "" when not injected. */
+  buildTime: string;
+}
+
+/**
+ * Resolve the app version reported by `/version`.
+ *
+ * The deployed version is injected at build time via the `APP_VERSION` build
+ * arg (sourced from the release tag — the single source of truth). When unset,
+ * as in local development, it falls back to `api/package.json`'s version.
+ *
+ * @param env - Environment map (defaults to `process.env`).
+ * @returns Version metadata served unauthenticated at `/version` and `/api/version`.
+ */
+export function resolveVersionInfo(env: EnvMap = process.env): VersionInfo {
+  return {
+    version: env.APP_VERSION?.trim() || pkg.version,
+    commit: env.APP_COMMIT?.trim() || "",
+    buildTime: env.APP_BUILD_TIME?.trim() || "",
+  };
+}
 
 type AppEnv = {
   Variables: {
@@ -754,6 +782,14 @@ export async function createApp(
   // Health check
   app.get("/health", (c) => c.json(HEALTH_RESPONSE));
   app.get("/api/health", (c) => c.json(HEALTH_RESPONSE));
+
+  // Version endpoint — public, unauthenticated (see AUTH_PUBLIC_PATHS).
+  // Used by the post-release version-alignment test to confirm every image
+  // published under a release tag reports the same version. Exposes only build
+  // metadata — no secrets, env, or internal paths.
+  const versionInfo = resolveVersionInfo(env);
+  app.get("/version", (c) => c.json(versionInfo));
+  app.get("/api/version", (c) => c.json(versionInfo));
 
   // Apply body size limit to asset uploads (5MB default, configurable via env)
   const parsedMaxAssetSize = Number.parseInt(env.MAX_ASSET_SIZE ?? "", 10);

--- a/api/src/security/middleware.ts
+++ b/api/src/security/middleware.ts
@@ -11,6 +11,8 @@ const WRITE_METHODS = new Set(["PUT", "DELETE"]);
 const AUTH_PUBLIC_PATHS = new Set([
   "/health",
   "/api/health",
+  "/version",
+  "/api/version",
   "/auth/login",
   "/auth/callback",
   "/auth/check",

--- a/api/src/version.test.ts
+++ b/api/src/version.test.ts
@@ -42,14 +42,26 @@ describe("resolveVersionInfo", () => {
 });
 
 describe("version endpoint", () => {
-  it("serves the resolved version at both /version and /api/version", async () => {
-    const app = await createApp(buildEnv({ APP_VERSION: "1.2.3" }));
+  it("serves the full version contract at both /version and /api/version", async () => {
+    const app = await createApp(
+      buildEnv({
+        APP_VERSION: "1.2.3",
+        APP_COMMIT: "deadbee",
+        APP_BUILD_TIME: "2026-05-25T12:00:00.000Z",
+      }),
+    );
 
     for (const path of ["/version", "/api/version"]) {
       const res = await app.request(path);
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { version: string };
+      const body = (await res.json()) as {
+        version: string;
+        commit: string;
+        buildTime: string;
+      };
       expect(body.version).toBe("1.2.3");
+      expect(body.commit).toBe("deadbee");
+      expect(body.buildTime).toBe("2026-05-25T12:00:00.000Z");
     }
   });
 

--- a/api/src/version.test.ts
+++ b/api/src/version.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import pkg from "../package.json";
+import { createApp, resolveVersionInfo } from "./app";
+import type { EnvMap } from "./security";
+
+const TEST_AUTH_SECRET = "rackula-auth-session-secret-for-tests-0123456789";
+
+function buildEnv(overrides: EnvMap = {}): EnvMap {
+  return { NODE_ENV: "test", ...overrides };
+}
+
+describe("resolveVersionInfo", () => {
+  it("reports the injected APP_VERSION build metadata", () => {
+    const info = resolveVersionInfo(
+      buildEnv({
+        APP_VERSION: "0.9.5",
+        APP_COMMIT: "abc1234",
+        APP_BUILD_TIME: "2026-05-25T00:00:00.000Z",
+      }),
+    );
+
+    expect(info.version).toBe("0.9.5");
+    expect(info.commit).toBe("abc1234");
+    expect(info.buildTime).toBe("2026-05-25T00:00:00.000Z");
+  });
+
+  it("falls back to the package.json version when APP_VERSION is unset", () => {
+    expect(resolveVersionInfo(buildEnv()).version).toBe(pkg.version);
+  });
+
+  it("treats a blank APP_VERSION as unset and falls back to package.json", () => {
+    expect(resolveVersionInfo(buildEnv({ APP_VERSION: "   " })).version).toBe(
+      pkg.version,
+    );
+  });
+
+  it("omits commit and buildTime when not injected", () => {
+    const info = resolveVersionInfo(buildEnv());
+    expect(info.commit).toBe("");
+    expect(info.buildTime).toBe("");
+  });
+});
+
+describe("version endpoint", () => {
+  it("serves the resolved version at both /version and /api/version", async () => {
+    const app = await createApp(buildEnv({ APP_VERSION: "1.2.3" }));
+
+    for (const path of ["/version", "/api/version"]) {
+      const res = await app.request(path);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { version: string };
+      expect(body.version).toBe("1.2.3");
+    }
+  });
+
+  it("remains public when the authentication gate is enabled", async () => {
+    const app = await createApp(
+      buildEnv({
+        APP_VERSION: "1.2.3",
+        RACKULA_AUTH_MODE: "oidc",
+        RACKULA_AUTH_SESSION_SECRET: TEST_AUTH_SECRET,
+        CORS_ORIGIN: "https://rack.example.com",
+      }),
+    );
+
+    const res = await app.request("/api/version");
+    expect(res.status).toBe(200);
+  });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -170,16 +170,31 @@ No legacy support or migration code. Features are implemented as if they're the 
 | Dev         | dev.racku.la | Push to `main` | Preview, testing |
 | Prod        | app.racku.la | Git tag `v*`   | Live users       |
 
+### Version Alignment
+
+A single release tag produces three images (default frontend, `:persist`
+frontend, and `rackula-api`). Each reports its version at runtime so they can be
+verified to match:
+
+- **Frontend** (default and `:persist`): `GET /version.json`
+- **API** (`rackula-api`): `GET /api/version`
+
+Both return `{ version, commit, buildTime }`. The git tag is the single source
+of truth - injected into the API via the `APP_VERSION` build arg, and read from
+`package.json` for the frontend. A `verify-version-alignment` CI job runs every
+published image and fails the release if their versions diverge, preventing
+mismatched releases (e.g. a stale `:persist` image, as in discussion #1563).
+
 ## Documentation Map
 
-| Document                            | Purpose                               |
-| ----------------------------------- | ------------------------------------- |
+| Document                            | Purpose                                  |
+| ----------------------------------- | ---------------------------------------- |
 | `docs/reference/SPEC.md`            | Technical overview and design principles |
-| `docs/reference/BRAND.md`           | Design system quick reference         |
-| `docs/reference/GITHUB-WORKFLOW.md` | GitHub Issues workflow                |
-| `docs/guides/TESTING.md`            | Testing patterns and commands         |
-| `docs/guides/ACCESSIBILITY.md`      | A11y compliance checklist             |
-| `docs/planning/ROADMAP.md`          | Version planning and vision           |
+| `docs/reference/BRAND.md`           | Design system quick reference            |
+| `docs/reference/GITHUB-WORKFLOW.md` | GitHub Issues workflow                   |
+| `docs/guides/TESTING.md`            | Testing patterns and commands            |
+| `docs/guides/ACCESSIBILITY.md`      | A11y compliance checklist                |
+| `docs/planning/ROADMAP.md`          | Version planning and vision              |
 
 ### Design Plans
 

--- a/docs/guides/SELF-HOSTING.md
+++ b/docs/guides/SELF-HOSTING.md
@@ -96,7 +96,7 @@ Example pod environment:
 ```yaml
 env:
   - name: NGINX_RESOLVER
-    value: "10.96.0.10"  # Your cluster DNS IP
+    value: "10.96.0.10" # Your cluster DNS IP
   - name: API_HOST
     value: "rackula-api.default.svc.cluster.local"
   - name: API_PORT
@@ -126,6 +126,7 @@ This section adds an interim authentication layer for self-hosted Rackula using 
 It is designed for internal deployments that need immediate protection while first-class app auth is in progress.
 
 Tracking:
+
 - Epic: <https://github.com/RackulaLives/Rackula/issues/1095>
 - Long-term auth docs plan: <https://github.com/RackulaLives/Rackula/issues/1107>
 
@@ -143,6 +144,7 @@ This guide aligns with current public guidance:
 - Add API rate limiting at the proxy to reduce abuse impact (NGINX `limit_req`, OWASP API4:2023).
 
 This section's defaults:
+
 - Protect both `/` and `/api/*`.
 - Block all anonymous API access (read and write).
 - Do not use trusted-IP password bypass.
@@ -166,6 +168,7 @@ Browser
 ```
 
 Hardening goal:
+
 - Only `auth-proxy` is published to host ports.
 - `rackula` and `rackula-api` are internal-only via Docker networking (`expose`, not `ports`).
 
@@ -447,6 +450,7 @@ curl -i http://localhost:3001/health
 ```
 
 Expected:
+
 - `rackula-api` has no `0.0.0.0:3001->...` mapping.
 - direct host call to `:3001` fails.
 
@@ -534,6 +538,7 @@ docker compose up -d --force-recreate auth-proxy
 #### 401 Unauthorized for valid users
 
 Check:
+
 - Username/password typo.
 - Secret file mounted and readable at `/run/secrets/rackula_htpasswd`.
 - NGINX is using the expected config.
@@ -584,22 +589,23 @@ All variables have sensible defaults. Only configure if you need to change somet
 
 ### Runtime Variables
 
-| Variable              | Default       | Description                                     |
-| --------------------- | ------------- | ----------------------------------------------- |
-| `RACKULA_PORT`        | `8080`        | Host port for the web UI                        |
-| `RACKULA_LISTEN_PORT` | `8080`        | Port nginx listens on inside the container      |
-| `RACKULA_API_PORT`    | `3001`        | Port the API listens on                         |
-| `API_HOST`            | `rackula-api` | Hostname of API container (for nginx proxy)     |
-| `API_PORT`            | `3001`        | Port of API container (for nginx proxy)         |
-| `CORS_ORIGIN`         | `http://localhost:8080` | Allowed browser origin(s) for API access (production-safe default) |
-| `RACKULA_API_WRITE_TOKEN` | _unset_    | Optional bearer token required for API `PUT`/`DELETE` |
-| `ALLOW_INSECURE_CORS` | `false`       | Explicitly allow wildcard CORS in production (not recommended) |
-| `NGINX_RESOLVER`      | `127.0.0.11`  | DNS resolver for nginx upstream resolution (override for Kubernetes) |
-| `DATA_DIR`            | `/data`       | Path to data directory inside API container     |
+| Variable                  | Default                 | Description                                                          |
+| ------------------------- | ----------------------- | -------------------------------------------------------------------- |
+| `RACKULA_PORT`            | `8080`                  | Host port for the web UI                                             |
+| `RACKULA_LISTEN_PORT`     | `8080`                  | Port nginx listens on inside the container                           |
+| `RACKULA_API_PORT`        | `3001`                  | Port the API listens on                                              |
+| `API_HOST`                | `rackula-api`           | Hostname of API container (for nginx proxy)                          |
+| `API_PORT`                | `3001`                  | Port of API container (for nginx proxy)                              |
+| `CORS_ORIGIN`             | `http://localhost:8080` | Allowed browser origin(s) for API access (production-safe default)   |
+| `RACKULA_API_WRITE_TOKEN` | _unset_                 | Optional bearer token required for API `PUT`/`DELETE`                |
+| `ALLOW_INSECURE_CORS`     | `false`                 | Explicitly allow wildcard CORS in production (not recommended)       |
+| `NGINX_RESOLVER`          | `127.0.0.11`            | DNS resolver for nginx upstream resolution (override for Kubernetes) |
+| `DATA_DIR`                | `/data`                 | Path to data directory inside API container                          |
 
 **Port mapping explained:**
 
 By default, both `RACKULA_PORT` and `RACKULA_LISTEN_PORT` are `8080`, meaning:
+
 - Host port 8080 → Container port 8080 → nginx listening on 8080
 
 For most users, just set `RACKULA_PORT` to change the host port:
@@ -698,6 +704,38 @@ docker logs rackula-api
 2. Create or modify a layout
 3. Look for `PUT /api/layouts/*` requests
 4. If no API calls appear, you're using the wrong setup - use Option 1 (persistence compose file) not Option 2 (simple docker run)
+
+### Checking the Version
+
+Both the web UI and the API report their version over HTTP:
+
+```bash
+# Frontend (served by nginx) - works for both the default and :persist images
+curl -fsS http://localhost:8080/version.json
+
+# API backend
+curl -fsS http://localhost:8080/api/version
+```
+
+Each returns `{ "version": "...", "commit": "...", "buildTime": "..." }`.
+
+**Version alignment:** every image published for a given release - the default
+frontend, the `:persist` frontend, and `rackula-api` - reports the **same**
+version. If `/version.json` and `/api/version` disagree, your containers are
+from different releases. Pull the matching tags and recreate:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Official images released together are guaranteed to match: a release-time CI
+check runs every published image and fails the release if their versions
+diverge, so a mismatch locally means stale tags rather than a bad release.
+
+> Using the stop-gap auth proxy above? `/version.json` sits behind Basic auth
+> like the rest of `/`, and `/api/version` is not in the API allowlist - add it
+> the same way as `/api/health` if you want to query it through the proxy.
 
 ---
 

--- a/scripts/verify-version-alignment.sh
+++ b/scripts/verify-version-alignment.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that every published Rackula image reports the same release version.
+#
+# Background: a release once shipped the `:persist` image at a stale version
+# (Discussion #1563). This script runs each image and asserts its runtime version
+# endpoint reports the expected release version, so a misaligned image fails the
+# release before it reaches users.
+#
+# Usage:
+#   scripts/verify-version-alignment.sh <expected_version>
+#
+# Image refs are supplied via environment variables (any unset ref is skipped):
+#   FRONTEND_IMAGE  Static frontend image    -> GET /version.json   (.version)
+#   PERSIST_IMAGE   Persist frontend image   -> GET /version.json   (.version)
+#   API_IMAGE       API backend image        -> GET /api/version    (.version)
+#
+# Example:
+#   FRONTEND_IMAGE=ghcr.io/rackulalives/rackula:0.9.5 \
+#   PERSIST_IMAGE=ghcr.io/rackulalives/rackula:v0.9.5-persist \
+#   API_IMAGE=ghcr.io/rackulalives/rackula-api:0.9.5 \
+#   scripts/verify-version-alignment.sh 0.9.5
+
+EXPECTED_VERSION="${1:-}"
+if [[ -z "$EXPECTED_VERSION" ]]; then
+  echo "ERROR: expected version is required (usage: $0 <expected_version>)" >&2
+  exit 2
+fi
+
+for dep in docker curl jq; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "ERROR: required dependency '$dep' not found on PATH" >&2
+    exit 2
+  fi
+done
+
+CONTAINERS=()
+cleanup() {
+  for cid in "${CONTAINERS[@]:-}"; do
+    [[ -n "$cid" ]] && docker rm -f "$cid" >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+failures=0
+checked=0
+
+# verify_image <label> <image_ref> <container_port> <path>
+verify_image() {
+  local label="$1" image="$2" container_port="$3" path="$4"
+
+  echo "→ ${label}: starting ${image}"
+  local cid
+  cid="$(docker run -d -P "$image")"
+  CONTAINERS+=("$cid")
+
+  # Resolve the ephemeral host port Docker mapped to the container port.
+  local hostport
+  hostport="$(docker port "$cid" "${container_port}/tcp" | head -n1 | sed 's/.*://')"
+  if [[ -z "$hostport" ]]; then
+    echo "  ✗ could not resolve published host port for ${container_port}/tcp" >&2
+    failures=$((failures + 1))
+    return
+  fi
+
+  local url="http://127.0.0.1:${hostport}${path}"
+  local body="" actual=""
+  local attempt
+  for attempt in $(seq 1 30); do
+    if body="$(curl -fsS "$url" 2>/dev/null)"; then
+      actual="$(printf '%s' "$body" | jq -r '.version // empty')"
+      [[ -n "$actual" ]] && break
+    fi
+    sleep 1
+  done
+
+  checked=$((checked + 1))
+  if [[ "$actual" == "$EXPECTED_VERSION" ]]; then
+    echo "  ✓ reports ${actual}"
+  else
+    echo "  ✗ expected ${EXPECTED_VERSION}, got '${actual:-<no response>}' from ${path}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+[[ -n "${FRONTEND_IMAGE:-}" ]] && verify_image "frontend (static)" "$FRONTEND_IMAGE" 8080 "/version.json"
+[[ -n "${PERSIST_IMAGE:-}" ]] && verify_image "frontend (persist)" "$PERSIST_IMAGE" 8080 "/version.json"
+[[ -n "${API_IMAGE:-}" ]] && verify_image "api" "$API_IMAGE" 3001 "/api/version"
+
+if [[ "$checked" -eq 0 ]]; then
+  echo "ERROR: no images to check; set FRONTEND_IMAGE, PERSIST_IMAGE, and/or API_IMAGE" >&2
+  exit 2
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "✗ Version alignment FAILED: ${failures} image(s) did not report ${EXPECTED_VERSION}" >&2
+  exit 1
+fi
+
+echo "✓ Version alignment passed: all ${checked} image(s) report ${EXPECTED_VERSION}"

--- a/scripts/verify-version-alignment.sh
+++ b/scripts/verify-version-alignment.sh
@@ -50,6 +50,11 @@ checked=0
 verify_image() {
   local label="$1" image="$2" container_port="$3" path="$4"
 
+  # Count the attempt up front so every exit path (including failures below)
+  # leaves a non-zero "checked" total — otherwise a sole image that fails here
+  # would misreport as "no images to check".
+  checked=$((checked + 1))
+
   echo "→ ${label}: starting ${image}"
   local cid
   cid="$(docker run -d -P "$image")"
@@ -68,14 +73,13 @@ verify_image() {
   local body="" actual=""
   local attempt
   for attempt in $(seq 1 30); do
-    if body="$(curl -fsS "$url" 2>/dev/null)"; then
+    if body="$(curl -fsS --connect-timeout 5 --max-time 10 "$url" 2>/dev/null)"; then
       actual="$(printf '%s' "$body" | jq -r '.version // empty')"
       [[ -n "$actual" ]] && break
     fi
     sleep 1
   done
 
-  checked=$((checked + 1))
   if [[ "$actual" == "$EXPECTED_VERSION" ]]; then
     echo "  ✓ reports ${actual}"
   else

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { svelte } from "@sveltejs/vite-plugin-svelte";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import { existsSync, readFileSync } from "fs";
 import { execFileSync } from "child_process";
 import { resolve } from "path";
@@ -103,13 +103,48 @@ function getGitInfo(): GitInfo {
 
 const gitInfo = getGitInfo();
 
+// Single build timestamp reused by the __BUILD_TIME__ define and version.json
+// so they never drift within one build.
+const buildTime = new Date().toISOString();
+
+/**
+ * Emit a static `version.json` (`{ version, commit, buildTime }`) into the build
+ * output, served at `/version.json`. This makes the frontend's version readable
+ * over HTTP without executing JS, powering the post-release version-alignment
+ * test. Exposes only build metadata — no secrets.
+ */
+function emitVersionJson(info: {
+  version: string;
+  commit: string;
+  buildTime: string;
+}): Plugin {
+  return {
+    name: "rackula:version-json",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "version.json",
+        source: `${JSON.stringify(info, null, 2)}\n`,
+      });
+    },
+  };
+}
+
 export default defineConfig(() => ({
   // VITE_BASE_PATH env var allows different base paths per deployment:
   // - GitHub Pages: /Rackula/ (set in workflow)
   // - Docker/local: / (default)
   base: process.env.VITE_BASE_PATH || "/",
   publicDir: "static",
-  plugins: [svelte()],
+  plugins: [
+    svelte(),
+    emitVersionJson({
+      version: pkg.version,
+      commit: gitInfo.commitHash,
+      buildTime,
+    }),
+  ],
   server: {
     watch: {
       // Ignore git worktrees and other development artifacts
@@ -121,7 +156,7 @@ export default defineConfig(() => ({
     // Inject version at build time
     __APP_VERSION__: JSON.stringify(pkg.version),
     // Inject build timestamp at build time (ISO 8601)
-    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+    __BUILD_TIME__: JSON.stringify(buildTime),
     // Git commit hash (short form, e.g., "e2bf857")
     __COMMIT_HASH__: JSON.stringify(gitInfo.commitHash),
     // Git branch name (e.g., "main", "feat/414-dev-build-info")


### PR DESCRIPTION
## **User description**
## Summary

Guarantees every Docker image published under a release tag `vX.Y.Z` reports `X.Y.Z` at runtime, and **fails the release** if any image is misaligned.

Closes #1728. Addresses [Discussion #1563](https://github.com/RackulaLives/Rackula/discussions/1563), where the `:persist` image shipped stale at `v0.9.1` with no test to catch it.

## What changed

- **Frontend** (`vite.config.ts`): a small build-only Vite plugin emits a static `/version.json` (`{ version, commit, buildTime }`) into the bundle, so both frontend image variants expose their version over HTTP without executing JS. Reuses the existing build metadata; `__BUILD_TIME__` and `version.json` now share one timestamp.
- **API** (`api/src/app.ts`, `api/Dockerfile`): `APP_VERSION` (+ `APP_COMMIT`, `APP_BUILD_TIME`) build args injected from the release tag; new public `GET /version` and `/api/version` endpoints return the same shape. `resolveVersionInfo()` prefers the injected version and falls back to `api/package.json` (`0.1.0`) for local dev. Added to `AUTH_PUBLIC_PATHS` so it stays reachable when the auth gate is on.
- **CI** (`.github/workflows/deploy-prod.yml`): new `verify-version-alignment` job pulls all three published images, runs each, and asserts its reported version equals the release tag — **gates the `deploy` job**. The `smoke-test` job now also confirms the live `count.racku.la` frontend + API report the release version.
- **Script** (`scripts/verify-version-alignment.sh`): reusable image-level checker (runs each image, queries its version endpoint, compares).

## Design notes

- **Git tag is the single source of truth.** `api/package.json` deliberately stays at its independent `0.1.0` — runtime version comes from the injected build arg.
- **Security:** version endpoints are public `GET` (consistent with `/health`) and expose only `version`/`commit`/`buildTime` — no secrets, env, or internal paths.

## Test plan

- [x] API: `resolveVersionInfo` env-override + package.json fallback + blank-string handling; `/version` and `/api/version` return the version and stay public with the auth gate enabled (`api/src/version.test.ts`, 6 tests)
- [x] API: full suite 147/147, typecheck clean
- [x] Frontend: `npm run build` emits `dist/version.json` with the correct version; lint clean; unit tests 1999/2000 (the 1 failure is a pre-existing flaky timeout, passes in isolation)
- [x] Script: error paths (missing version / no images); JSON parsing verified for both pretty + compact shapes
- [ ] Image-level container run — **CI-only** (local Docker daemon was not running); exercised by the `verify-version-alignment` job on the next release
- [ ] Live `/version.json` + `/api/version` check — exercised post-deploy by `smoke-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add release version checks across published images and live deployment**

### What Changed
- The API now exposes its release version at `/version` and `/api/version`, and these paths stay public even when authentication is enabled.
- The frontend build now publishes a `version.json` file so its version can be checked over HTTP without loading the app.
- Release deployment now stops if any published image reports a version different from the git tag, and the live site is checked after deploy to confirm both frontend and API match the release.
- New tests cover version reporting, fallback behavior in development, and access to the public version endpoint.

### Impact
`✅ Fewer mismatched release images`
`✅ Earlier detection of broken version tags`
`✅ Clearer post-deploy release verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
