### PR TITLE
fix: reduce text stroke-width and remove unsupported paint-order

### DIFF
--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -954,11 +954,10 @@ export function generateExportSVG(
       deviceNameEl.setAttribute("dominant-baseline", "middle");
       deviceNameEl.setAttribute("font-family", "system-ui, sans-serif");
       if (showImage) {
-        // Text halo for visibility over images (stroke works in svg2pdf.js)
+        // Thin stroke outline for text visibility over images
         deviceNameEl.setAttribute("stroke", "rgba(0,0,0,0.7)");
-        deviceNameEl.setAttribute("stroke-width", "3");
+        deviceNameEl.setAttribute("stroke-width", "1.5");
         deviceNameEl.setAttribute("stroke-linejoin", "round");
-        deviceNameEl.setAttribute("paint-order", "stroke");
       }
       deviceNameEl.textContent = fittedLabel.text;
       rackGroup.appendChild(deviceNameEl);


### PR DESCRIPTION
## **User description**
## Summary

svg2pdf.js v2.7.0 does not support the `paint-order` SVG attribute. With the default fill-then-stroke order, a 3px stroke rendered on top of white fill obscures glyphs at small font sizes. Reduce to 1.5px for a subtle outline that enhances readability without blocking the fill.

## Root Cause

`svg2pdf.js` has zero support for SVG `<filter>` elements (open issue #82 since 2019) and zero support for `paint-order`. At 3px stroke-width with default fill→stroke ordering, the black stroke covers the white fill, turning the intended halo into an illegible blob.

## Fix

- Reduce `stroke-width` from `"3"` to `"1.5"` — thin enough to act as a readable outline
- Remove `paint-order="stroke"` — silently ignored by svg2pdf.js, so the line had no effect
- Update comment to reflect the actual approach

Follow-up to #1731 / PR #1734.

## Test Plan

- [x] Lint passes
- [x] Export tests pass (6/6)
- [ ] Manual: Verify text labels on images are readable in PDF viewer


___

## **CodeAnt-AI Description**
**Make text labels stay readable in PDF exports**

### What Changed
- Text labels over images now use a thinner outline so the white text is less likely to get covered in exported PDFs
- The unsupported stroke ordering setting was removed, leaving a simpler outline that works in export
- The note for this label styling was updated to match the exported result

### Impact
`✅ Clearer text in PDF exports`
`✅ Fewer unreadable labels on images`
`✅ More reliable export appearance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
