### PR TITLE
fix: PDF export rendering regressions (#1738, #1739, #1740)

### DIFF
--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -571,6 +571,7 @@ export function generateExportSVG(
     yOffset: number,
     faceFilter: "front" | "rear" | undefined,
     viewLabel?: string,
+    suppressName = false,
   ): SVGGElement {
     const rackGroup = document.createElementNS(
       "http://www.w3.org/2000/svg",
@@ -981,8 +982,10 @@ export function generateExportSVG(
     }
 
     // Rack name (positioned above rack) - only for non-dual-view
-    // In dual-view, the name is rendered separately above both front/rear views
-    if (includeNames && !viewLabel) {
+    // In dual-view, the name is rendered separately above both front/rear views.
+    // In bayed groups, the bay label already identifies each bay, so suppress the
+    // rack's own name to avoid drawing it on top of the bay label (#1740).
+    if (includeNames && !viewLabel && !suppressName) {
       const nameText = document.createElementNS(
         "http://www.w3.org/2000/svg",
         "text",
@@ -1091,7 +1094,14 @@ export function generateExportSVG(
     groupRacks.forEach((rack, bayIndex) => {
       const bayX = bayIndex * RACK_WIDTH;
       const bayY = currentY + (groupMaxHeight - rack.height) * U_HEIGHT;
-      const frontView = renderRackView(rack, bayX, bayY, "front");
+      const frontView = renderRackView(
+        rack,
+        bayX,
+        bayY,
+        "front",
+        undefined,
+        true,
+      );
       bayedGroup.appendChild(frontView);
     });
     currentY += singleRowHeight + BAYED_ROW_GAP;
@@ -1142,7 +1152,14 @@ export function generateExportSVG(
     reversedRacks.forEach((rack, reversedIndex) => {
       const bayX = reversedIndex * RACK_WIDTH;
       const bayY = currentY + (groupMaxHeight - rack.height) * U_HEIGHT;
-      const rearView = renderRackView(rack, bayX, bayY, "rear");
+      const rearView = renderRackView(
+        rack,
+        bayX,
+        bayY,
+        "rear",
+        undefined,
+        true,
+      );
       bayedGroup.appendChild(rearView);
     });
 
@@ -1455,6 +1472,43 @@ export async function exportAsJPEG(
 }
 
 /**
+ * Normalise an export SVG so svg2pdf.js renders it faithfully.
+ *
+ * svg2pdf does not implement every SVG/CSS feature the browser does, so the
+ * shared export SVG needs two adjustments before vector PDF conversion (these
+ * are applied to the re-parsed copy only — the PNG path keeps the original):
+ *
+ *  - `dominant-baseline` is ignored by svg2pdf; it reads `alignment-baseline`
+ *    instead. Mirror the value across so vertically-centred text (device names,
+ *    U numbers) stays centred rather than shifting up to the baseline (#1738).
+ *  - Numeric `font-weight` values other than 400/700 yield an invalid jsPDF
+ *    style (e.g. "normal600") and fall back to the serif font (times). Collapse
+ *    weights to the supported 400/700, treating >= 500 as bold (#1739).
+ */
+export function prepareSvgForPdf(svgElement: Element): void {
+  const textLike = [
+    ...Array.from(svgElement.getElementsByTagName("text")),
+    ...Array.from(svgElement.getElementsByTagName("tspan")),
+  ];
+
+  for (const el of textLike) {
+    const dominantBaseline = el.getAttribute("dominant-baseline");
+    if (dominantBaseline && !el.getAttribute("alignment-baseline")) {
+      el.setAttribute("alignment-baseline", dominantBaseline);
+    }
+
+    const fontWeight = el.getAttribute("font-weight");
+    if (fontWeight) {
+      const isBold =
+        fontWeight === "bold" ||
+        fontWeight === "bolder" ||
+        Number(fontWeight) >= 500;
+      el.setAttribute("font-weight", isBold ? "700" : "400");
+    }
+  }
+}
+
+/**
  * Export SVG string as PDF blob (US Letter size, centered)
  */
 export async function exportAsPDF(
@@ -1468,6 +1522,10 @@ export async function exportAsPDF(
   const parser = new DOMParser();
   const svgDoc = parser.parseFromString(svgString, "image/svg+xml");
   const svgElement = svgDoc.documentElement;
+
+  // svg2pdf lacks support for some SVG features the browser renders; normalise
+  // this re-parsed copy so the vector PDF matches the on-screen/PNG output.
+  prepareSvgForPdf(svgElement);
 
   const imgWidth = parseInt(svgElement.getAttribute("width") || "0", 10);
   const imgHeight = parseInt(svgElement.getAttribute("height") || "0", 10);

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -1835,6 +1835,10 @@ export async function exportAsMultiPagePDF(
     pdf.setFont("helvetica", "bold");
     pdf.text(rack.name, pageWidth / 2, margin + 20, { align: "center" });
 
+    // Normalise SVG for svg2pdf before conversion (baseline + font-weight).
+    // This SVG is generated per page and not shared with the PNG path.
+    prepareSvgForPdf(svg);
+
     // Convert SVG to vector PDF
     await pdf.svg(svg, { x, y, width: scaledWidth, height: scaledHeight });
   }

--- a/src/tests/export-pdf-rendering.test.ts
+++ b/src/tests/export-pdf-rendering.test.ts
@@ -1,0 +1,118 @@
+/**
+ * PDF export rendering regressions (#1738, #1739, #1740)
+ *
+ * The vector PDF path (#1731) renders the shared export SVG through svg2pdf.js,
+ * which does not support every SVG feature the browser-rendered PNG path does:
+ *   - It ignores `dominant-baseline`, so vertically-centred text shifts up (#1738).
+ *   - Numeric `font-weight` other than 400/700 produces an invalid jsPDF style
+ *     (e.g. "normal600") and falls back to a serif font (times) (#1739).
+ * `prepareSvgForPdf` normalises a *copy* of the SVG so the PNG path stays intact.
+ *
+ * Separately, bayed groups labelled each bay both via the explicit "Bay N" label
+ * and via the bay rack's own name (defaulted to "Bay N"), overlapping them (#1740).
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateExportSVG, prepareSvgForPdf } from "$lib/utils/export";
+import type { ExportOptions, RackGroup } from "$lib/types";
+import { createTestRack } from "./factories";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+const baseOptions: ExportOptions = {
+  format: "pdf",
+  scope: "all",
+  exportView: "both",
+  includeNames: true,
+  includeLegend: false,
+  background: "solid",
+  displayMode: "label",
+};
+
+function textNodesWithContent(svg: SVGElement, content: string) {
+  return Array.from(svg.getElementsByTagName("text")).filter(
+    (t) => t.textContent === content,
+  );
+}
+
+describe("bayed export labels (#1740)", () => {
+  it("does not render a bay's rack name on top of its bay label", () => {
+    const rack1 = createTestRack({ id: "r1", name: "Bay 1", height: 12 });
+    const rack2 = createTestRack({ id: "r2", name: "Bay 2", height: 12 });
+    const group: RackGroup = {
+      id: "g1",
+      name: "Bayoncé",
+      rack_ids: ["r1", "r2"],
+      layout_preset: "bayed",
+    };
+
+    const svg = generateExportSVG([rack1, rack2], [], baseOptions, undefined, [
+      group,
+    ]);
+
+    // "Bay 1" is a legitimate bay label once per row (front + rear) = 2.
+    // Before the fix the bay rack's own name added two more, overlapping the labels.
+    // eslint-disable-next-line no-restricted-syntax -- bayed export must label each bay once per row, never duplicate via rack name
+    expect(textNodesWithContent(svg, "Bay 1")).toHaveLength(2);
+    // eslint-disable-next-line no-restricted-syntax -- bayed export must label each bay once per row, never duplicate via rack name
+    expect(textNodesWithContent(svg, "Bay 2")).toHaveLength(2);
+  });
+});
+
+describe("prepareSvgForPdf — svg2pdf compatibility (#1738, #1739)", () => {
+  it("mirrors dominant-baseline to alignment-baseline so text stays vertically centred", () => {
+    const svg = document.createElementNS(SVG_NS, "svg") as SVGElement;
+    const text = document.createElementNS(SVG_NS, "text");
+    text.setAttribute("dominant-baseline", "middle");
+    svg.appendChild(text);
+
+    prepareSvgForPdf(svg);
+
+    expect(text.getAttribute("alignment-baseline")).toBe("middle");
+  });
+
+  it("normalises numeric font-weight to a jsPDF-supported style (700) on text and tspan", () => {
+    const svg = document.createElementNS(SVG_NS, "svg") as SVGElement;
+    const text = document.createElementNS(SVG_NS, "text");
+    text.setAttribute("font-weight", "600");
+    const tspan = document.createElementNS(SVG_NS, "tspan");
+    tspan.setAttribute("font-weight", "500");
+    text.appendChild(tspan);
+    svg.appendChild(text);
+
+    prepareSvgForPdf(svg);
+
+    expect(text.getAttribute("font-weight")).toBe("700");
+    expect(tspan.getAttribute("font-weight")).toBe("700");
+  });
+
+  it("leaves normal-weight text unbolded", () => {
+    const svg = document.createElementNS(SVG_NS, "svg") as SVGElement;
+    const text = document.createElementNS(SVG_NS, "text");
+    text.setAttribute("font-weight", "400");
+    svg.appendChild(text);
+
+    prepareSvgForPdf(svg);
+
+    expect(text.getAttribute("font-weight")).toBe("400");
+  });
+
+  it("normalises the keyword weights bold/bolder/normal", () => {
+    const svg = document.createElementNS(SVG_NS, "svg") as SVGElement;
+    const make = (weight: string) => {
+      const t = document.createElementNS(SVG_NS, "text");
+      t.setAttribute("font-weight", weight);
+      svg.appendChild(t);
+      return t;
+    };
+    const bold = make("bold");
+    const bolder = make("bolder");
+    const normal = make("normal");
+
+    prepareSvgForPdf(svg);
+
+    expect(bold.getAttribute("font-weight")).toBe("700");
+    expect(bolder.getAttribute("font-weight")).toBe("700");
+    expect(normal.getAttribute("font-weight")).toBe("400");
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Fixes three rendering regressions in the vector PDF export introduced by #1731, where the shared export SVG is run through `svg2pdf.js`. svg2pdf lacks several SVG/CSS features the browser-rendered PNG path relies on.

| Issue | Symptom | Root cause |
| --- | --- | --- |
| #1738 | Device names (and U numbers) shifted **up** from centre | svg2pdf ignores `dominant-baseline`; it reads `alignment-baseline` instead |
| #1739 | FRONT/REAR labels, bay-group titles, and the QR "Rackula" title render in **serif** | Numeric `font-weight` ≠ 400/700 produces an invalid jsPDF style (e.g. `"normal600"`), so svg2pdf falls back to its hardcoded `times` font |
| #1740 | Bay labels **duplicated/overlapping** on bayed racks | Bay racks default-named `Bay N`; the bayed path also drew each rack's own name on top of the explicit `Bay N` label |

## Fix

- **#1738 / #1739** — new `prepareSvgForPdf()` runs on the re-parsed SVG copy inside `exportAsPDF()` (the PNG path keeps the original untouched). It mirrors `dominant-baseline` → `alignment-baseline` and normalises `font-weight` to the jsPDF-supported `400`/`700`.
- **#1740** — `renderRackView` gains a `suppressName` argument; the bayed render path passes `true` since the bay label already identifies each bay. This is a real layout bug that also affected PNG export.

## Verification

- New unit tests in `export-pdf-rendering.test.ts` (bayed dedup invariant + `prepareSvgForPdf` transform).
- End-to-end: generated a PDF through the real `exportAsPDF` pipeline and inspected the `Tf` font operators — **without the fix** text was drawn with `Helvetica` **and `Times-Roman`** (serif leak); **with the fix** only `Helvetica` / `Helvetica-Bold`, no Times.
- Full suite (2004 tests), lint, and typecheck pass.

Closes #1738
Closes #1739
Closes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix PDF export text placement, font styling, and bay label overlap**

### What Changed
- PDF exports now keep centered text in the right place and preserve the intended font weight, avoiding shifted labels and serif fallback in exported files
- Bayed rack exports no longer draw each rack name on top of the bay label, so bay names appear once per row without overlap
- Added tests that cover the PDF text cleanup and the bay label behavior

### Impact
`✅ Clearer PDF exports`
`✅ Fewer overlapping bay labels`
`✅ Consistent text alignment in exported PDFs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
