### PR TITLE
ci(deploy-dev): fail loudly if data dir not writable by uid 1001

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -108,6 +108,17 @@ jobs:
           ALLOW_INSECURE_CORS=false
           EOF
 
+      - name: Verify data dir is writable by API container (uid 1001)
+        run: |
+          DATA_DIR=/opt/rackula/rackula-dev/data
+          mkdir -p "$DATA_DIR"
+          if ! docker run --rm -u 1001:1001 -v "$DATA_DIR":/data busybox \
+              sh -c 'touch /data/.write-test && rm -f /data/.write-test'; then
+            echo "::error::$DATA_DIR is not writable by uid 1001 (rackula-api container user)."
+            echo "::error::Fix once on the host: sudo chown -R 1001:1001 $DATA_DIR"
+            exit 1
+          fi
+
       - name: Deploy to dev
         run: |
           cd /opt/rackula/rackula-dev


### PR DESCRIPTION
## **User description**
## Context

Saving a layout on **d.racku.la** returned HTTP 500 (`{"error":"Failed to save layout"}`). Confirmed from `rackula-api-dev` container logs:

```
EACCES: permission denied, mkdir '/data/Racky McRackface-63f30df1-...'
syscall: "mkdir", errno: -13, code: "EACCES"
```

`deploy-dev.yml` deploys into `/opt/rackula/rackula-dev` and bind-mounts `./data:/data` for the API service. The Docker daemon had auto-created that host dir as `root:root`. The bind mount shadows the image's own `/data` (which the Dockerfile correctly `chown`s to uid 1001), so the container — running as `USER rackula` (**uid 1001**) — could read/list `/data` (`GET /layouts` → 200) but couldn't `mkdir` a new layout folder (`PUT` → 500).

A one-time `sudo chown -R 1001:1001 /opt/rackula/rackula-dev/data` on the host unblocked it. This PR prevents the *silent* regression.

## Change

Adds one preflight step to the `deploy` job, before `docker compose up`: a uid-1001 write probe against the real bind mount. If `/data` isn't writable, the deploy **fails with the exact remediation printed**, instead of shipping a green deploy that 500s on first save.

```yaml
- name: Verify data dir is writable by API container (uid 1001)
  run: |
    DATA_DIR=/opt/rackula/rackula-dev/data
    mkdir -p "$DATA_DIR"
    if ! docker run --rm -u 1001:1001 -v "$DATA_DIR":/data busybox \
        sh -c 'touch /data/.write-test && rm -f /data/.write-test'; then
      echo "::error::$DATA_DIR is not writable by uid 1001 (rackula-api container user)."
      echo "::error::Fix once on the host: sudo chown -R 1001:1001 $DATA_DIR"
      exit 1
    fi
```

Design notes:
- The `docker run -u 1001:1001` write probe exercises the *exact* effective access the API container will have — more accurate than a `stat`-ownership check.
- Chosen over auto-`chown` in CI to avoid granting the deploy runner root/chown powers; the guard fails loud and points to the one-time host fix.
- Reuses the canonical pattern already in `deploy/lxc/community-scripts/install/rackula-install.sh` and documented in `docker-compose.yml`.

## Scope

**Prod is unaffected** — `deploy-prod.yml` runs `docker compose up` without `--profile persist` and deploys no API container, so there's no data mount. No prod change made.

## Verification

- actionlint: zero new warnings (only pre-existing `vps-rackula` custom-label notes).
- YAML parses cleanly.
- Happy path: dir is already `1001:1001`, so the step passes and deploy proceeds as before.
- Regression sim (on VPS): `sudo chown -R root:root /opt/rackula/rackula-dev/data` → step fails with the remediation; restore ownership → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop dev deploys that break layout saving**

### What Changed
- Before the dev API starts, the deploy now checks that the shared data folder can be written by the API user
- If the folder is not writable, the deploy stops and shows the exact fix needed on the host
- This prevents a successful deploy from later failing when someone tries to save a layout

### Impact
`✅ Fewer layout save failures in dev`
`✅ Earlier deploy failures when file permissions are wrong`
`✅ Clearer setup fix for dev hosts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
