### PR TITLE
feat(mobile): refit canvas on device orientation change

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -68,6 +68,7 @@
     handleShare,
     handleFitAll,
   } from "$lib/utils/persistence-manager.svelte";
+  import { debounce } from "$lib/utils/debounce";
 
   // Sidebar size configuration (in pixels)
   interface Props {
@@ -313,6 +314,33 @@
       });
       return;
     }
+  });
+
+  // Refit canvas on orientation change (mobile/tablet only).
+  // Debounced 300ms to let the rotation animation complete before measuring the new viewport.
+  onMount(() => {
+    const onOrientationChange = debounce(() => {
+      if (!viewportStore.isMobile) return;
+      canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
+    }, 300);
+
+    if (typeof screen?.orientation?.addEventListener === "function") {
+      screen.orientation.addEventListener("change", onOrientationChange);
+      return () =>
+        screen.orientation.removeEventListener("change", onOrientationChange);
+    }
+
+    // Fallback: detect orientation flip via resize event
+    let lastIsLandscape = window.innerWidth > window.innerHeight;
+    const onResize = () => {
+      const isLandscape = window.innerWidth > window.innerHeight;
+      if (isLandscape !== lastIsLandscape) {
+        lastIsLandscape = isLandscape;
+        onOrientationChange();
+      }
+    };
+    window.addEventListener("resize", onResize, { passive: true });
+    return () => window.removeEventListener("resize", onResize);
   });
 
   function handleShowLayouts() {


### PR DESCRIPTION
## **User description**
## Summary

- Rotating a phone or tablet left the canvas at stale viewport dimensions — racks could end up off-screen or poorly zoomed.
- Adds a debounced (300 ms) `onMount` listener in `App.svelte` that calls `canvasStore.fitAll()` whenever the device orientation flips portrait ↔ landscape.
- Uses `screen.orientation.change` as the primary event, falling back to a `window.resize` listener that detects an aspect-ratio flip for browsers without the Screen Orientation API.
- Gated behind `viewportStore.isMobile` (≤ 1024 px) so desktop behaviour is unchanged.

## Why

Orientation change updates the viewport dimensions but nothing was triggering a canvas refit. `fitAll()` already exists and handles this correctly — it just wasn't wired to orientation events.

## Test Plan

- [ ] Rotate a phone/tablet portrait → landscape: canvas should refit to fill the new viewport.
- [ ] Rotate back landscape → portrait: canvas refits again.
- [ ] Desktop resize (not an orientation flip): no refit triggered by the fallback path.
- [ ] All 2015 unit tests pass (`npm run test:run`).
- [ ] `npm run lint` clean.
- [ ] `npm run build` succeeds.

Closes #1051

---
_Generated by [Claude Code](https://claude.ai/code/session_017PNHDcsFhJVSG8uaMkFUAa)_


___

## **CodeAnt-AI Description**
**Refit the canvas after phone or tablet orientation changes**

### What Changed
- The canvas now refits automatically when a mobile device switches between portrait and landscape
- The refit waits briefly so the screen rotation can finish before the layout is recalculated
- Devices without built-in orientation change support still refit when a true orientation flip is detected during resize
- Desktop behavior stays unchanged

### Impact
`✅ Fewer off-screen racks after rotation`
`✅ Correct canvas fit on mobile and tablet`
`✅ No extra refits during desktop resizing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
