### PR TITLE
fix: enable mouse/pointer tap-to-place in mobile mode (#1757)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -64,6 +64,7 @@
     handleDragLeave as onDragLeave,
     handleDrop as onDrop,
     handleTouchEnd as onTouchEnd,
+    handlePlacementClick as onPlacementClick,
     type RackHandlerContext,
     type DropPreviewState,
   } from "$lib/utils/rack-interaction-handlers";
@@ -370,7 +371,18 @@
     canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
   }
 
-  function handleClick() {
+  function handleClick(event: MouseEvent) {
+    // Mobile tap-to-place via mouse/pointer. Touch input is handled by the
+    // SVG's ontouchend; desktop browsers do NOT synthesise TouchEvents for a
+    // mouse, so without this a mouse user in mobile mode (#1757) could pick a
+    // device from the palette but never complete the placement.
+    if (viewportStore.isMobile && placementStore.isPlacing) {
+      const device = placementStore.pendingDevice;
+      if (device && svgElement) {
+        onPlacementClick(event, svgElement, handlerCtx, device, onplacementtap);
+      }
+      return;
+    }
     if (canvasStore.isPanning) return;
     if (justFinishedDrag) {
       justFinishedDrag = false;

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -374,24 +374,26 @@
   /**
    * Handle a click on the rack container.
    *
-   * In mobile mode (viewport <= 1024px) a click while placing completes
-   * mouse/pointer tap-to-place (#1757); touch input is handled separately by
-   * the SVG's `ontouchend`, and desktop browsers do not synthesise TouchEvents
-   * for a mouse, so without this a mouse user could pick a device from the
-   * palette but never place it. Otherwise the click selects the rack (unless a
-   * pan or drag just finished).
+   * Clicks synthesised at the end of a pan/drag gesture are ignored first
+   * (`isPanning` stays true for ~50ms after `panend`), so neither placement nor
+   * selection fires unintentionally after a pan. Then, in mobile mode (viewport
+   * <= 1024px) a click while placing completes mouse/pointer tap-to-place
+   * (#1757) — desktop browsers do not synthesise TouchEvents for a mouse, so
+   * without this a mouse user could pick a device but never place it; touch
+   * input is handled separately by the SVG's `ontouchend`. Otherwise the click
+   * selects the rack.
    */
   function handleClick(event: MouseEvent) {
+    if (canvasStore.isPanning) return;
+    if (justFinishedDrag) {
+      justFinishedDrag = false;
+      return;
+    }
     if (viewportStore.isMobile && placementStore.isPlacing) {
       const device = placementStore.pendingDevice;
       if (device && svgElement) {
         onPlacementClick(event, svgElement, handlerCtx, device, onplacementtap);
       }
-      return;
-    }
-    if (canvasStore.isPanning) return;
-    if (justFinishedDrag) {
-      justFinishedDrag = false;
       return;
     }
     onselect?.(new CustomEvent("select", { detail: { rackId: rack.id } }));
@@ -442,6 +444,8 @@
     }}
     ontouchend={(e) => {
       if (!viewportStore.isMobile || !placementStore.isPlacing) return;
+      // Don't place when a pan gesture just ended over the rack.
+      if (canvasStore.isPanning) return;
       const device = placementStore.pendingDevice;
       if (!device) return;
       onTouchEnd(e, handlerCtx, device, onplacementtap);

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -371,11 +371,17 @@
     canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
   }
 
+  /**
+   * Handle a click on the rack container.
+   *
+   * In mobile mode (viewport <= 1024px) a click while placing completes
+   * mouse/pointer tap-to-place (#1757); touch input is handled separately by
+   * the SVG's `ontouchend`, and desktop browsers do not synthesise TouchEvents
+   * for a mouse, so without this a mouse user could pick a device from the
+   * palette but never place it. Otherwise the click selects the rack (unless a
+   * pan or drag just finished).
+   */
   function handleClick(event: MouseEvent) {
-    // Mobile tap-to-place via mouse/pointer. Touch input is handled by the
-    // SVG's ontouchend; desktop browsers do NOT synthesise TouchEvents for a
-    // mouse, so without this a mouse user in mobile mode (#1757) could pick a
-    // device from the palette but never complete the placement.
     if (viewportStore.isMobile && placementStore.isPlacing) {
       const device = placementStore.pendingDevice;
       if (device && svgElement) {

--- a/src/lib/utils/rack-interaction-handlers.ts
+++ b/src/lib/utils/rack-interaction-handlers.ts
@@ -197,24 +197,22 @@ export function handleDrop(event: DragEvent, ctx: RackHandlerContext): void {
 }
 
 /**
- * Handle touch end events for mobile tap-to-place workflow.
+ * Resolve the drop target under the given client coordinates and, when valid,
+ * dispatch a `placementtap`. Shared by the touch (handleTouchEnd) and
+ * mouse/pointer (handlePlacementClick) tap-to-place paths.
  */
-export function handleTouchEnd(
-  event: TouchEvent,
+function dispatchPlacementAt(
+  svg: SVGSVGElement,
+  clientX: number,
+  clientY: number,
   ctx: RackHandlerContext,
   device: DeviceType,
   onplacementtap?: (
     event: CustomEvent<{ position: number; face: "front" | "rear" }>,
   ) => void,
 ): void {
-  event.preventDefault();
-
-  const touch = event.changedTouches[0];
-  if (!touch) return;
-
-  const svg = event.currentTarget as SVGSVGElement;
   const result = resolveDropTarget(
-    { svgElement: svg, clientX: touch.clientX, clientY: touch.clientY },
+    { svgElement: svg, clientX, clientY },
     ctx.getRackDims(),
     ctx.getRack(),
     ctx.getDeviceLibrary(),
@@ -234,4 +232,65 @@ export function handleTouchEnd(
   } else {
     hapticError();
   }
+}
+
+/**
+ * Handle touch end events for mobile tap-to-place workflow (touchscreen input).
+ */
+export function handleTouchEnd(
+  event: TouchEvent,
+  ctx: RackHandlerContext,
+  device: DeviceType,
+  onplacementtap?: (
+    event: CustomEvent<{ position: number; face: "front" | "rear" }>,
+  ) => void,
+): void {
+  event.preventDefault();
+
+  const touch = event.changedTouches[0];
+  if (!touch) return;
+
+  dispatchPlacementAt(
+    event.currentTarget as SVGSVGElement,
+    touch.clientX,
+    touch.clientY,
+    ctx,
+    device,
+    onplacementtap,
+  );
+}
+
+/**
+ * Handle mouse/pointer tap-to-place onto the rack.
+ *
+ * The touch flow (handleTouchEnd) only fires for real TouchEvents, which
+ * desktop browsers do NOT synthesise for mouse/trackpad input. In mobile mode
+ * (viewport <= 1024px) a mouse user could pick a device from the palette but
+ * never complete the placement tap (#1757). This mirrors the touch flow for
+ * click input so placement works for any pointing device, in any browser.
+ *
+ * Touch input keeps using handleTouchEnd (whose preventDefault() suppresses the
+ * synthesised click), so this does not double-fire on touchscreens.
+ *
+ * The rack `<svg>` is passed explicitly because this is invoked from the
+ * accessible rack-container click handler, whose `currentTarget` is the
+ * wrapping element rather than the SVG used for coordinate resolution.
+ */
+export function handlePlacementClick(
+  event: MouseEvent,
+  svg: SVGSVGElement,
+  ctx: RackHandlerContext,
+  device: DeviceType,
+  onplacementtap?: (
+    event: CustomEvent<{ position: number; face: "front" | "rear" }>,
+  ) => void,
+): void {
+  dispatchPlacementAt(
+    svg,
+    event.clientX,
+    event.clientY,
+    ctx,
+    device,
+    onplacementtap,
+  );
 }

--- a/src/tests/placement-pointer.test.ts
+++ b/src/tests/placement-pointer.test.ts
@@ -11,6 +11,7 @@ import { handlePlacementClick } from "$lib/utils/rack-interaction-handlers";
 import { resolveDropTarget } from "$lib/utils/rack-drop-coordinator";
 import { hapticError } from "$lib/utils/haptics";
 
+/** Build a minimal RackHandlerContext; only the getters used by placement matter. */
 function makeCtx() {
   return {
     getRack: () => ({}),
@@ -26,6 +27,7 @@ function makeCtx() {
   } as unknown as Parameters<typeof handlePlacementClick>[2];
 }
 
+/** Minimal MouseEvent stand-in carrying just the client coordinates. */
 function makeMouseEvent(clientX: number, clientY: number): MouseEvent {
   return { clientX, clientY } as unknown as MouseEvent;
 }

--- a/src/tests/placement-pointer.test.ts
+++ b/src/tests/placement-pointer.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Control the resolved drop target without a real SVG / geometry.
+vi.mock("$lib/utils/rack-drop-coordinator", () => ({
+  resolveDropTarget: vi.fn(),
+}));
+// Avoid touching navigator.vibrate on the invalid path.
+vi.mock("$lib/utils/haptics", () => ({ hapticError: vi.fn() }));
+
+import { handlePlacementClick } from "$lib/utils/rack-interaction-handlers";
+import { resolveDropTarget } from "$lib/utils/rack-drop-coordinator";
+import { hapticError } from "$lib/utils/haptics";
+
+function makeCtx() {
+  return {
+    getRack: () => ({}),
+    getDeviceLibrary: () => [],
+    getRackDims: () => ({}),
+    getFaceFilter: () => "front",
+    getSelectedDeviceId: () => null,
+    getEventCallbacks: () => ({}),
+    setDropPreview: () => {},
+    setContainerHoverInfo: () => {},
+    layoutStore: {},
+    toastStore: {},
+  } as unknown as Parameters<typeof handlePlacementClick>[2];
+}
+
+function makeMouseEvent(clientX: number, clientY: number): MouseEvent {
+  return { clientX, clientY } as unknown as MouseEvent;
+}
+
+// Stands in for the rack <svg>; the mocked resolver ignores it.
+const svg = {} as unknown as SVGSVGElement;
+const device = { slug: "test-device", slot_width: 2 } as never;
+
+describe("handlePlacementClick — mouse/pointer tap-to-place (#1757)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("dispatches a placement tap at the resolved U for a valid mouse click", () => {
+    (resolveDropTarget as ReturnType<typeof vi.fn>).mockReturnValue({
+      feedback: "valid",
+      targetU: 7,
+    });
+    const onplacementtap = vi.fn();
+
+    handlePlacementClick(
+      makeMouseEvent(120, 240),
+      svg,
+      makeCtx(),
+      device,
+      onplacementtap,
+    );
+
+    // eslint-disable-next-line no-restricted-syntax -- a single click must place exactly once
+    expect(onplacementtap).toHaveBeenCalledTimes(1);
+    expect(onplacementtap.mock.calls[0][0].detail).toEqual({
+      position: 7,
+      face: "front",
+    });
+  });
+
+  it("does not place (and signals an error) when the target is invalid", () => {
+    (resolveDropTarget as ReturnType<typeof vi.fn>).mockReturnValue({
+      feedback: "invalid",
+      targetU: 3,
+    });
+    const onplacementtap = vi.fn();
+
+    handlePlacementClick(
+      makeMouseEvent(0, 0),
+      svg,
+      makeCtx(),
+      device,
+      onplacementtap,
+    );
+
+    expect(onplacementtap).not.toHaveBeenCalled();
+    expect(hapticError).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1757 — tap-to-place fails for mouse/pointer users in mobile mode (viewport ≤1024px).

Originally reported as "clicks not registering in Firefox 150 on macOS", but systematic-debugging traced it to a **browser-agnostic** cause (reproduced in both Firefox and Chrome): placing a device onto a rack in mobile mode was triggered **only** by a `TouchEvent` (`Rack.svelte` `ontouchend` → `handleTouchEnd`, reading `changedTouches`). Desktop browsers do **not** synthesise `TouchEvent`s for mouse/trackpad input, so a mouse user in a narrow window (which the `(max-width: 1024px)` breakpoint classifies as mobile) could pick a device from the palette but never complete the placement tap.

Evidence that pinned it: selecting *placed* devices still worked (pointer-event path), and widening the window past 1024px fixed it (desktop uses HTML5 drag-and-drop, which works with a mouse).

## Changes

- `rack-interaction-handlers.ts`: extract shared `dispatchPlacementAt(svg, clientX, clientY, …)`; add `handlePlacementClick` for mouse/pointer input. `handleTouchEnd` behaviour is unchanged.
- `Rack.svelte`: route mouse/pointer placement through the existing **accessible** rack-container `handleClick` (role="option" + keyboard handler), rather than adding `onclick` to the `<svg>` (which would trip Svelte a11y lint).
- `src/tests/placement-pointer.test.ts`: unit test for the new handler.

## Why no double-fire on touch

On touchscreens, `handleTouchEnd` calls `event.preventDefault()`, which suppresses the synthesised compatibility `click` — so the new click path does not run a second placement.

## Test plan

- [ ] CI: lint → test → build
- [ ] CodeRabbit review
- [ ] Manual: Firefox **and** Chrome at ≤1024px viewport — pick a device from the palette, click a rack slot, device is placed
- [ ] Manual: real touchscreen — tap-to-place still works, no double placement
- [ ] Manual: desktop width >1024px — drag-and-drop unaffected

> ⚠️ Local `test:run`/`lint`/`build` were not run before pushing (no Node.js runtime available in the authoring environment). Relying on CI + CodeRabbit for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Let mouse users place devices on racks in mobile mode

### What Changed
- Clicking a rack now places the selected device in mobile view, not just touchscreens
- Touch placement still works the same way, and touch taps do not place twice
- Added coverage for successful mouse placement and invalid placement errors

### Impact
`✅ Mouse-based rack placement on narrow screens`
`✅ Fewer failed placements in mobile mode`
`✅ Clearer placement behavior across touch and mouse`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
