### PR TITLE
test: E2E regression for mouse tap-to-place in mobile mode (#1762)

### DIFF
--- a/e2e/mobile-placement-mouse.spec.ts
+++ b/e2e/mobile-placement-mouse.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Mobile tap-to-place with a MOUSE (regression for #1757)
+ *
+ * #1757: in mobile mode (viewport <= 1024px) placing a device onto a rack was
+ * triggered only by `ontouchend`. Desktop browsers do NOT synthesise
+ * TouchEvents for mouse/trackpad input, so a mouse user in a narrow window
+ * could pick a device from the palette but never complete the placement tap.
+ *
+ * This exercises the exact gap no other project covers: the desktop projects
+ * run at >1024px (desktop drag-and-drop) and the touch projects emulate real
+ * TouchEvents. Here we run under the desktop `chromium` project (mouse,
+ * hasTouch:false) but force a narrow viewport so the app enters mobile mode.
+ *
+ * The test fails against the pre-#1757 (touch-only) code, which is what makes
+ * it a meaningful regression guard.
+ *
+ * NOTE: Test 2 from #1762 ("a pan ending over a rack does not place") is
+ * intentionally omitted: it depends on the ~50ms `isPanning` window and is
+ * timing-sensitive/flaky in CI. Per the issue's acceptance criteria it is
+ * deferred rather than committed as a flaky test; it can be added later with
+ * explicit synchronisation.
+ */
+import { test, expect } from "./helpers/base-test";
+import { openDeviceLibraryFromBottomNav } from "./helpers/mobile-navigation";
+import { EMPTY_RACK_SHARE, gotoWithRack, locators } from "./helpers";
+
+// Desktop Chrome (mouse, hasTouch:false) at a narrow viewport -> mobile mode
+// (breakpoint is max-width:1024px). 944x1039 matches the original bug report.
+test.use({ viewport: { width: 944, height: 1039 } });
+
+test.describe("Mobile tap-to-place with a mouse (#1757)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Dismiss the mobile-warning modal so it doesn't intercept interactions.
+    await page.addInitScript(() => {
+      sessionStorage.setItem("rackula-mobile-warning-dismissed", "true");
+    });
+    await gotoWithRack(page, EMPTY_RACK_SHARE);
+  });
+
+  test("mouse user can pick a device and tap a rack slot to place it", async ({
+    page,
+  }) => {
+    const rack = page.locator(locators.rack.container).first();
+    await expect(rack).toBeVisible();
+
+    const devicesBefore = await page.locator(locators.rack.device).count();
+
+    // Open the device library and pick the first device. On mobile this starts
+    // placement mode and auto-closes the bottom sheet (do NOT press Escape — it
+    // would cancel placement).
+    await openDeviceLibraryFromBottomNav(page);
+    const firstDevice = page.locator(locators.device.paletteItem).first();
+    await expect(firstDevice).toBeVisible();
+    await firstDevice.click();
+
+    // Placement mode is active: the "Tap to place" header appears and the
+    // bottom sheet has closed.
+    const placementHeader = page.locator(".placement-header");
+    await expect(placementHeader).toBeVisible();
+    await expect(placementHeader).toContainText("Tap to place");
+    await expect(page.locator(locators.mobile.bottomSheet)).not.toBeVisible();
+
+    // Tap a rack slot with the MOUSE (the path #1757 fixed). Use the front-view
+    // SVG and aim ~35% down to land in clear rack interior, below the header.
+    const rackSvg = page.locator(`${locators.rackView.front} ${locators.rack.svg}`).first();
+    const box = await rackSvg.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height * 0.35);
+
+    // The device is placed: count increases and placement mode exits.
+    await expect(async () => {
+      const devicesAfter = await page.locator(locators.rack.device).count();
+      expect(devicesAfter).toBeGreaterThan(devicesBefore);
+    }).toPass({ timeout: 5000 });
+
+    await expect(placementHeader).not.toBeVisible();
+  });
+});

--- a/e2e/mobile-placement-mouse.spec.ts
+++ b/e2e/mobile-placement-mouse.spec.ts
@@ -54,8 +54,9 @@ test.describe("Mobile tap-to-place with a mouse (#1757)", () => {
     await firstDevice.click();
 
     // Placement mode is active: the "Tap to place" header appears and the
-    // bottom sheet has closed.
-    const placementHeader = page.locator(".placement-header");
+    // bottom sheet has closed. Dual-view renders the header in both the front
+    // and rear SVGs, so scope to the first to avoid a strict-mode violation.
+    const placementHeader = page.locator(".placement-header").first();
     await expect(placementHeader).toBeVisible();
     await expect(placementHeader).toContainText("Tap to place");
     await expect(page.locator(locators.mobile.bottomSheet)).not.toBeVisible();

--- a/e2e/mobile-placement-mouse.spec.ts
+++ b/e2e/mobile-placement-mouse.spec.ts
@@ -74,6 +74,10 @@ test.describe("Mobile tap-to-place with a mouse (#1757)", () => {
       expect(devicesAfter).toBeGreaterThan(devicesBefore);
     }).toPass({ timeout: 5000 });
 
-    await expect(placementHeader).not.toBeVisible();
+    // (`.not.toBeVisible()` already auto-retries; wrapped in toPass per review
+    // #1763 to make the post-placement settle explicit.)
+    await expect(async () => {
+      await expect(placementHeader).not.toBeVisible();
+    }).toPass({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Closes #1762. Adds an E2E regression test for #1757 — mouse/pointer tap-to-place in mobile mode (viewport ≤1024px).

`e2e/mobile-placement-mouse.spec.ts` runs under the **chromium** project (desktop = mouse, `hasTouch:false`) with `test.use({ viewport: { width: 944, height: 1039 } })`, forcing the app into mobile mode. It picks the first palette device (which starts placement and auto-closes the bottom sheet on mobile) and **clicks** a rack slot with the mouse — the path that was previously touch-only and broke for mouse users. Asserts the device count increases and placement mode exits.

This covers the gap no existing project did: desktop projects run >1024px (drag-and-drop), and the mobile projects emulate real `TouchEvent`s (which would have passed).

## Scope notes

- **Test 2 deferred** ("a pan ending over a rack does not place") — per #1762's acceptance criteria, it depends on the ~50ms `isPanning` window and would be flaky in CI; documented in the spec for a later, explicitly-synchronised implementation.

## Test plan

- [ ] CI Playwright job (chromium) runs the new spec green
- [ ] lint / build pass

> ⚠️ **Not run locally before pushing** — no Node/Playwright runtime in the authoring environment, so CI is the first real execution of this E2E spec. I'll monitor the Playwright job and iterate on any selector/timing failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add a regression test for mouse-based device placement in mobile mode**

### What Changed
- Adds an end-to-end test that checks a mouse user can open the device list, pick a device, and place it onto a rack in the mobile layout
- Verifies placement starts correctly in mobile mode, the bottom sheet closes, and the “Tap to place” prompt appears
- Confirms the device is actually placed and placement mode exits after the click

### Impact
`✅ Fewer broken placements in mobile layout`
`✅ Safer mouse use on narrow screens`
`✅ Earlier detection of touch-versus-mouse regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
