### PR TITLE
fix: canvas fills full window in mobile mode (#1764)

### DIFF
--- a/src/lib/components/CanvasContextMenu.svelte
+++ b/src/lib/components/CanvasContextMenu.svelte
@@ -99,9 +99,17 @@
 <style>
   /*
    * bits-ui ContextMenu.Trigger creates a wrapper div that must fill its parent.
-   * Target by DOM position: any div between .main-pane and .canvas
+   * Target by DOM position: the trigger div directly wrapping .canvas.
+   *
+   * Desktop: .main-pane > div > .canvas
+   * Mobile:  .app-main > div > .canvas (Canvas is a direct child of <main>)
+   *
+   * Without this, the wrapper collapses to its content's intrinsic size and
+   * .canvas { flex: 1 } resolves against the small wrapper instead of the
+   * full parent, so the canvas does not fill the window.
    */
-  :global(.main-pane > div:has(> .canvas)) {
+  :global(.main-pane > div:has(> .canvas)),
+  :global(.app-main > div:has(> .canvas)) {
     display: flex;
     flex: 1 1 0;
     min-height: 0;


### PR DESCRIPTION
## **User description**
## Root cause

In mobile mode (`viewport ≤1024px`) the Canvas is rendered as a **direct child** of `<main class="app-main mobile">` (`src/App.svelte` mobile branch, ~line 651).

bits-ui's `ContextMenu.Trigger` (in `CanvasContextMenu.svelte`) wraps `.canvas` in an unstyled `<div data-context-menu-trigger>`. The component's CSS only stretched that wrapper for the **desktop** layout:

```css
:global(.main-pane > div:has(> .canvas)) { display:flex; flex:1 1 0; min-height:0; height:100%; }
```

In mobile the wrapper's parent is `.app-main` (not `.main-pane`), so `.main-pane > div:has(> .canvas)` does not match. The wrapper therefore collapsed to its content's intrinsic size, and `.canvas { flex: 1 }` resolved against that small wrapper instead of `<main>` — so the canvas was smaller than the window.

The absolutely-positioned `.mobile-history-controls` (`position: absolute`) does **not** consume flow space, so it is not part of the cause. The default `flex-direction: row` on `.app-main` is also harmless here: with a single in-flow flex child given `flex: 1 1 0`, the wrapper fills the cross axis via the default `align-items: stretch` and the main axis via the flex grow, so the canvas fills both dimensions. No `flex-direction` change is needed.

## The change

`src/lib/components/CanvasContextMenu.svelte` — extend the wrapper-stretch selector to also match the mobile parent. No magic heights.

Before:
```css
:global(.main-pane > div:has(> .canvas)) {
  display: flex;
  flex: 1 1 0;
  min-height: 0;
  height: 100%;
}
```

After:
```css
:global(.main-pane > div:has(> .canvas)),
:global(.app-main > div:has(> .canvas)) {
  display: flex;
  flex: 1 1 0;
  min-height: 0;
  height: 100%;
}
```

## Test plan

- [ ] Visual at ≤1024px (mobile): `.canvas` / `.panzoom-container` fill `<main class="app-main mobile">` (window height minus bottom nav + safe area); rack uses full space.
- [ ] Visual at >1024px (desktop): layout unchanged (selector `.main-pane > div:has(> .canvas)` is preserved).
- [ ] Bottom-nav / safe-area `padding-bottom` on `.app-main.mobile` still respected (the wrapper stretches inside `<main>`'s content box, which already excludes the padding).
- [ ] Optional E2E (per #1762/#1764): assert `.canvas` bounding box ≈ `<main class="app-main mobile">` within tolerance.

## ⚠️ Not verified locally

**This change was NOT run or visually verified locally — there is no Node runtime in the authoring environment.** It needs visual confirmation at ≤1024px (mobile) and >1024px (desktop), plus CI (lint/build/tests), before merge. The fix is derived from reading the source and DOM structure only.

Closes #1764

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the canvas fill the window in mobile mode**

### What Changed
- The canvas now stretches to the full available space on mobile, matching desktop behavior.
- The wrapper around the canvas is now sized correctly in both desktop and mobile layouts, preventing the canvas from shrinking to its content.
- The fix removes the mobile layout gap that caused the drawing area to appear smaller than the screen.

### Impact
`✅ Full-screen canvas on mobile`
`✅ Fewer layout issues in the drawing area`
`✅ Consistent canvas sizing across devices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
