### PR TITLE
fix(ci): verify live frontend version only on no-API prod (#1770)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -413,10 +413,17 @@ jobs:
           sleep 5
           curl -sf --retry 5 --retry-delay 3 https://count.racku.la
 
-      - name: Verify live version alignment
+      - name: Verify live frontend version
         env:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
+          # Public prod (count.racku.la) serves the static frontend only — it has
+          # no API/persistence backend by design (no user-data storage), so
+          # /api/version intentionally returns 503 "Persistence API unavailable".
+          # We therefore verify the live FRONTEND version here. The published API
+          # image version is validated separately by the verify-version-alignment
+          # job, which runs the image in an ephemeral container.
+          #
           # Extract .version from JSON without depending on jq being installed
           # on the self-hosted runner.
           extract_version() {
@@ -425,11 +432,9 @@ jobs:
               | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/'
           }
           fe="$(curl -sf --retry 5 --retry-delay 3 https://count.racku.la/version.json | extract_version)"
-          api="$(curl -sf --retry 5 --retry-delay 3 https://count.racku.la/api/version | extract_version)"
-          echo "frontend=${fe} api=${api} expected=${VERSION}"
+          echo "frontend=${fe} expected=${VERSION}"
           [ "$fe" = "$VERSION" ] || { echo "::error::Live frontend version '${fe}' != '${VERSION}'"; exit 1; }
-          [ "$api" = "$VERSION" ] || { echo "::error::Live API version '${api}' != '${VERSION}'"; exit 1; }
-          echo "✓ Live stack reports ${VERSION}"
+          echo "✓ Live frontend reports ${VERSION}"
 
   notify-failure:
     if: ${{ always() && (failure() || cancelled()) }}


### PR DESCRIPTION
## **User description**
## Summary

The `smoke-test` job's "Verify live version alignment" step asserted that the **live API** at `count.racku.la/api/version` reports the release version. Public prod serves the **static frontend only** and has no API/persistence backend by design (no user-data storage), so nginx's `@api_unavailable` block correctly returns `503 {"error":"Persistence API unavailable"}`. The assertion could never pass and blocked every production release (e.g. v0.10.0).

This drops the live API version assertion and keeps the meaningful prod checks:

- ✅ Frontend live version (`/version.json` == release version) — retained
- ✅ Reachability curl to `https://count.racku.la` — retained
- ❌ Live `/api/version` assertion — removed (prod runs no API by design)

The published **API image** version remains validated by the separate `verify-version-alignment` job, which runs the image in an ephemeral container — preserving the stale-image guard (Discussion #1563).

## Test Plan

- [x] `deploy-prod.yml` is valid YAML
- [x] No new actionlint/shellcheck findings in the changed step (pre-existing SC2086 / `vps-rackula` runner-label warnings only)
- [x] CodeRabbit local review: 0 findings
- [ ] Confirmed by a successful prod deploy run (next tagged release)

Closes #1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Stop smoke tests from checking a live API that does not exist in public production

### What Changed
- Production smoke tests now verify the live frontend version only, instead of checking both frontend and API versions
- The release check keeps confirming the site is reachable and that the frontend matches the tagged release
- The failing live `/api/version` check was removed because public production serves the static frontend only

### Impact
`✅ Fewer blocked production releases`
`✅ Accurate smoke tests for frontend-only production`
`✅ Clearer deployment checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
