### PR TITLE
fix: half-width devices independently selectable at same U (#1680)

### DIFF
--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -56,7 +56,12 @@
     /** Callback when the entire group is selected (bayed racks select as a unit) */
     ongroupselect?: (event: CustomEvent<{ groupId: string }>) => void;
     ondeviceselect?: (
-      event: CustomEvent<{ rackId: string; slug: string; position: number }>,
+      event: CustomEvent<{
+        rackId: string;
+        deviceId?: string;
+        slug: string;
+        position: number;
+      }>,
     ) => void;
     ondevicedrop?: (
       event: CustomEvent<{
@@ -325,12 +330,13 @@
   // Handle device select - inject the correct rackId into the event
   function handleDeviceSelect(
     rackId: string,
-    event: CustomEvent<{ slug: string; position: number }>,
+    event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
   ) {
     ondeviceselect?.(
       new CustomEvent("deviceselect", {
         detail: {
           rackId,
+          deviceId: event.detail.deviceId,
           slug: event.detail.slug,
           position: event.detail.position,
         },

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -31,6 +31,7 @@
   import WelcomeScreen from "./WelcomeScreen.svelte";
   import CanvasContextMenu from "./CanvasContextMenu.svelte";
   import type { DeviceFace, SlotPosition } from "$lib/types";
+  import { resolveSelectedDevice } from "$lib/utils/device-selection";
   // Note: PlacementIndicator removed - placement UI now integrated into Rack.svelte
 
   // Multi-rack mode: use active rack ID from store
@@ -46,7 +47,7 @@
     ontoggletheme?: () => void;
     onrackselect?: (event: CustomEvent<{ rackId: string }>) => void;
     ondeviceselect?: (
-      event: CustomEvent<{ slug: string; position: number }>,
+      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
     ) => void;
     ondevicedrop?: (
       event: CustomEvent<{
@@ -414,16 +415,15 @@
 
   function handleDeviceSelect(
     rackId: string,
-    event: CustomEvent<{ slug: string; position: number }>,
+    event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
   ) {
-    // Find the device by slug and position, then select by ID (UUID-based tracking)
+    // Resolve the placed device by its UUID when available. The legacy
+    // (slug, position) fallback is ambiguous for two half-width devices sharing
+    // the same U (#1680), where it always resolved to the left device and left
+    // the right one unselectable.
     const targetRack = layoutStore.getRackById(rackId);
     if (targetRack) {
-      const device = targetRack.devices.find(
-        (d) =>
-          d.device_type === event.detail.slug &&
-          d.position === event.detail.position,
-      );
+      const device = resolveSelectedDevice(targetRack, event.detail);
       if (device) {
         layoutStore.setActiveRack(rackId);
         selectionStore.selectDevice(rackId, device.id);

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -95,7 +95,7 @@
     partyMode?: boolean;
     onselect?: (event: CustomEvent<{ rackId: string }>) => void;
     ondeviceselect?: (
-      event: CustomEvent<{ slug: string; position: number }>,
+      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
     ) => void;
     ondevicedrop?: (
       event: CustomEvent<{

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -81,7 +81,9 @@
     dragTargetSlotId?: string | null;
     /** Whether the current drag target slot is valid for the dragged device */
     isDragTargetValid?: boolean;
-    onselect?: (event: CustomEvent<{ slug: string; position: number }>) => void;
+    onselect?: (
+      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+    ) => void;
     ondragstart?: (
       event: CustomEvent<{ rackId: string; deviceIndex: number }>,
     ) => void;
@@ -318,7 +320,9 @@
       event.preventDefault();
       event.stopPropagation();
       onselect?.(
-        new CustomEvent("select", { detail: { slug: device.slug, position } }),
+        new CustomEvent("select", {
+          detail: { deviceId: placedDeviceId, slug: device.slug, position },
+        }),
       );
     }
 
@@ -429,7 +433,9 @@
       // No significant movement - this is a click
       event.stopPropagation();
       onselect?.(
-        new CustomEvent("select", { detail: { slug: device.slug, position } }),
+        new CustomEvent("select", {
+          detail: { deviceId: placedDeviceId, slug: device.slug, position },
+        }),
       );
     } else if (pointerState === "dragging") {
       // Complete the drag operation

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -43,7 +43,7 @@
     enableLongPress?: boolean;
     onselect?: (event: CustomEvent<{ rackId: string }>) => void;
     ondeviceselect?: (
-      event: CustomEvent<{ slug: string; position: number }>,
+      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
     ) => void;
     ondevicedrop?: (
       event: CustomEvent<{

--- a/src/lib/utils/device-selection.ts
+++ b/src/lib/utils/device-selection.ts
@@ -1,0 +1,39 @@
+import type { PlacedDevice, Rack } from "$lib/types";
+
+/**
+ * Identifying detail carried by a device-selection event.
+ *
+ * `deviceId` (the placed device's UUID) is the preferred, unambiguous
+ * identifier. `slug`/`position` are kept as a fallback for compatibility.
+ */
+export interface DeviceSelectionDetail {
+  /** UUID of the placed device (preferred, unambiguous identifier) */
+  deviceId?: string;
+  /** device_type slug (fallback identifier) */
+  slug: string;
+  /** position in internal units (fallback identifier) */
+  position: number;
+}
+
+/**
+ * Resolve which placed device a selection event refers to.
+ *
+ * Prefers the stable UUID when present. The legacy `(device_type, position)`
+ * fallback is AMBIGUOUS for two half-width devices sharing the same U (#1680):
+ * both share an identical pair, so `.find()` always returns the left one and
+ * the right device becomes structurally unselectable. Matching on the UUID
+ * first removes that ambiguity.
+ */
+export function resolveSelectedDevice(
+  rack: Rack,
+  detail: DeviceSelectionDetail,
+): PlacedDevice | undefined {
+  if (detail.deviceId) {
+    const byId = rack.devices.find((d) => d.id === detail.deviceId);
+    if (byId) return byId;
+  }
+
+  return rack.devices.find(
+    (d) => d.device_type === detail.slug && d.position === detail.position,
+  );
+}

--- a/src/tests/device-selection.test.ts
+++ b/src/tests/device-selection.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveSelectedDevice } from "$lib/utils/device-selection";
+import { createTestRack, createTestDevice } from "./factories";
+
+/**
+ * Regression tests for #1680: a half-width device on the right side is
+ * unselectable when paired with a same-type device at the same U.
+ *
+ * Root cause: the selection event identified a device by (device_type, position)
+ * only. Two half-width devices sharing a U have an identical pair, so the
+ * resolver's `.find()` always returned the first (left) device, making the
+ * right device structurally unselectable.
+ */
+describe("resolveSelectedDevice (#1680)", () => {
+  it("resolves the clicked device when two half-width devices share device type and position", () => {
+    const left = createTestDevice({
+      id: "uuid-left",
+      device_type: "rackmate-2u",
+      position: 54,
+      slot_position: "left",
+    });
+    const right = createTestDevice({
+      id: "uuid-right",
+      device_type: "rackmate-2u",
+      position: 54,
+      slot_position: "right",
+    });
+    const rack = createTestRack({ devices: [left, right] });
+
+    // Clicking the RIGHT device must resolve to the right device, not the
+    // first (left) device that happens to share the same (slug, position).
+    const resolved = resolveSelectedDevice(rack, {
+      deviceId: "uuid-right",
+      slug: "rackmate-2u",
+      position: 54,
+    });
+
+    expect(resolved?.id).toBe("uuid-right");
+  });
+
+  it("falls back to (slug, position) when no deviceId is supplied", () => {
+    const device = createTestDevice({
+      id: "uuid-1",
+      device_type: "server",
+      position: 12,
+    });
+    const rack = createTestRack({ devices: [device] });
+
+    const resolved = resolveSelectedDevice(rack, {
+      slug: device.device_type,
+      position: device.position,
+    });
+
+    expect(resolved?.id).toBe("uuid-1");
+  });
+
+  it("returns undefined when the deviceId is not present in the rack", () => {
+    const device = createTestDevice({ id: "uuid-1", device_type: "server" });
+    const rack = createTestRack({ devices: [device] });
+
+    const resolved = resolveSelectedDevice(rack, {
+      deviceId: "missing",
+      slug: "nonexistent",
+      position: 999,
+    });
+
+    expect(resolved).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Fixes #1680 — a half-width device on the right side was unselectable when paired with a same-type device at the same U (in both regular and bayed racks).

## Root cause

Two half-width devices placed left/right at the same U share an identical `(device_type, position)` pair. The device-selection event identified a device by that pair only, and `Canvas.handleDeviceSelect` resolved it with:

```js
targetRack.devices.find(d => d.device_type === slug && d.position === position)
```

`.find()` always returns the **first** match (the left device), so clicking the right device resolved to the left one — the right device was structurally unselectable. The known workaround (move the left device ±1U) worked only because it made `position` unique again.

Confirmed from live DOM: both side-by-side devices render with identical `data-device-id` + `data-device-position`, at correct non-overlapping geometry — so this is a device-identity bug, **not** an SVG hit-testing / pointer-events issue.

## Fix

Thread the placed device's stable UUID through the selection event chain (`RackDevice → Rack → BayedRackView`/`RackDualView → Canvas`) as an optional `deviceId`, and resolve by it via a new `resolveSelectedDevice()` helper — falling back to `(slug, position)` for compatibility. UUID-based selection is already the convention everywhere else (`selectedDeviceId`); the select event simply wasn't carrying it.

This is a distinct root cause from #1522 (rack-level event routing), so they are fixed independently — the earlier "shared fix" triage theory was disproved.

## Test plan

- [x] New unit test `src/tests/device-selection.test.ts` (red before fix, green after): two same-type half-width devices at the same position → the clicked device resolves correctly; `(slug, position)` fallback preserved.
- [x] `npm run check` (svelte-check) — no new errors in touched files
- [x] `npm run lint` — clean
- [x] `npm run test:run` — 2020 passed
- [x] `npm run build` — success
- [x] CodeRabbit local review — 0 findings

Closes #1680

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make same-position half-width devices selectable by their own ID**

### What Changed
- Clicking a half-width device now selects the exact device you clicked, even when another device of the same type sits at the same U
- Selection still works with the older position-based fallback when a device ID is not available
- Added tests that cover the right-side device case, the fallback path, and missing device IDs

### Impact
`✅ Fixed selection for side-by-side half-width devices`
`✅ Fewer misclicks in rack editing`
`✅ Correct device selection in regular and bayed racks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
