### PR TITLE
docs: versioning policy decision — CalVer app, SemVer packages (#1315)

### DIFF
--- a/docs/superpowers/specs/2026-05-29-versioning-policy-calver-design.md
+++ b/docs/superpowers/specs/2026-05-29-versioning-policy-calver-design.md
@@ -1,0 +1,96 @@
+---
+created: 2026-05-29
+issue: 1315
+status: decided
+---
+
+# Versioning Policy Decision — CalVer for the App, SemVer for Packages
+
+## Context
+
+Rackula currently uses pre-1.0 SemVer (`0.MINOR.PATCH`). Issue
+[#1315](https://github.com/RackulaLives/Rackula/issues/1315) raised switching to CalVer to
+remove the friction of deciding minor-vs-patch on every release. The original analysis
+assumed *"Rackula is an application, no downstream consumers need compatibility signals."*
+
+That premise is now in question: the [#1758 NPM library feasibility spike](../../research/1758-npm-library-feasibility.md)
+(completed 2026-05-28) recommends eventually publishing **`@rackula/core`** to npm + JSR.
+A published package on those registries effectively *must* follow SemVer, because consumer
+version ranges (`^`/`~`), Dependabot, and JSR tooling all assume it. The library is
+**still exploratory** (no commitment), so the policy must not foreclose it.
+
+**Goals (confirmed with maintainer):** (1) eliminate the minor-vs-patch decision, and
+(2) have the version itself convey recency.
+
+## Decision
+
+**Version by artifact, because the version number is a message to a specific reader:**
+
+| Artifact | Audience | Cares about | Scheme | Example |
+| --- | --- | --- | --- | --- |
+| **Rackula app** (web / Docker / LXC) | end users | recency | **CalVer `YY.M.MICRO`** | `v26.5.0`, `v26.5.1`, `v26.6.0` |
+| **`@rackula/core`** (if/when published) | developers | compatibility | **SemVer** | `core/v0.4.0` |
+
+The app and the library are **two different artifacts for two different people**, so giving
+them two version schemes is not a contradiction — it is the standard monorepo pattern
+(any project using `changesets`/`release-please` versions a private app separately from its
+published packages). This is **one static rule**, not a "revisit-when-X" conditional.
+
+### App format: `YY.M.MICRO`
+
+- `YY` = two-digit year (`26`). `M` = month, **unpadded** (`5`, `12`). `MICRO` = release
+  counter within the month.
+- **MICRO rule:** same calendar month as the last release → `MICRO++`; new month →
+  `MICRO = 0`. This is fully mechanical — no human judgement on bump type, ever.
+- **Month MUST be unpadded.** SemVer forbids leading zeroes in numeric identifiers, so
+  `26.05.0` is *invalid* semver and breaks tooling; `26.5.0` is valid-semver-*shaped*.
+  Keeping the shape valid is the entire reason this 3-segment format was chosen over the
+  4-segment `YY.MM.DD.MICRO` originally proposed in #1315.
+- Ordering stays monotonic across the migration: `0.10.0 → 26.5.0` only ever increases, so
+  npm/semver comparison and "is this newer?" checks keep working.
+
+## Why not the alternatives
+
+- **Full CalVer `YY.MM.DD.MICRO`** (the #1315 proposal): 4 segments are not valid semver and
+  risk breaking `package.json`/npm/CI even for a private package; also contaminates the
+  future library option. Rejected.
+- **Stay SemVer + patch-by-default:** solves goal 1 but not goal 2 (no recency in the
+  number). Rejected as insufficient against the "both equally" goal.
+- **Keep one shared version for app + library:** forces a single scheme onto two audiences;
+  this is the actual source of CalVer-vs-SemVer conflict. Avoided by decoupling.
+
+## Consequences
+
+### What changes when implemented
+
+- **`/release` skill** — compute the version from the date + month-counter instead of a
+  semver bump argument.
+- **`package.json`** `version` → e.g. `26.5.0`.
+- **CI** — the `v*` tag → prod-deploy trigger continues to work (CalVer tags are still
+  `v26.5.0`). A future `@rackula/core` uses a **separate tag namespace** (`core/v*`) so
+  package releases don't trip the app's deploy.
+- **`CHANGELOG.md`** — Keep a Changelog format unchanged; headings become
+  `## [26.5.0] - 2026-05-29`.
+- **`CLAUDE.md`** — the Versioning Policy section is rewritten for CalVer.
+
+### Knock-on effects
+
+- The **`v1.0.0` milestone name** no longer maps to a version. Milestones should be named
+  by **theme or target month** (e.g. "26.6 — LXC release"), not by semver. This unblocks
+  the milestone-roadmap naming question.
+- The **"0.x = unstable API" signal is dropped** — but that signal only matters to code
+  consumers, which the app does not have. No real loss.
+
+### Migration timing
+
+The **decision stands now.** The retooling lands at a clean release boundary; the **LXC
+release is the designated "first CalVer release"** (`v26.<month>.0`), which is also a
+natural release-pipeline touch point — satisfying both the "anchor it to a real release"
+and the "do it when migration is nearly free" considerations from #1315. If the LXC release
+slips, the next minor-worthy release becomes the anchor instead.
+
+## Resolution of #1315
+
+> **Decided** — Rackula app adopts CalVer `YY.M.MICRO`; SemVer is reserved for any future
+> published packages (`@rackula/core`). Implement at the LXC release boundary. Close #1315
+> referencing this decision record.


### PR DESCRIPTION
## **User description**
## Summary

Decision record resolving #1315 — Rackula's versioning policy, decoupled by artifact:

| Artifact | Audience | Scheme | Example |
|---|---|---|---|
| **Rackula app** (web / Docker / LXC) | end users → recency | **CalVer `YY.M.MICRO`** | `v26.5.0` |
| **`@rackula/core`** (if/when published) | developers → compatibility | **SemVer** | `core/v0.4.0` |

Driven by the [#1758 NPM library spike](https://github.com/RackulaLives/Rackula/blob/main/docs/research/1758-npm-library-feasibility.md): since a published `@rackula/core` would *require* SemVer, the app and any future package are versioned independently (standard monorepo pattern) rather than forcing one scheme onto two audiences.

## Key points

- App format **`YY.M.MICRO`** with **unpadded month** (`26.5.0`, not `26.05.0`) so it stays valid-semver-shaped and tooling-safe — the reason it was chosen over the original 4-segment `YY.MM.DD.MICRO`.
- MICRO is a mechanical per-month counter → **no more minor-vs-patch decision**.
- Migration anchored to the **LXC release** as the first CalVer release; decision stands regardless of timing.
- Unblocks milestone naming (theme/month-based, e.g. *"26.6 — LXC release"*, instead of `v1.0.0`).

Docs-only change — no code or pipeline changes in this PR (implementation deferred to the release-pipeline touch at the LXC milestone).

Closes #1315 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the versioning policy for the app and future packages**

### What Changed
- Records the decision that the Rackula app will use CalVer in the form `YY.M.MICRO`, so release numbers reflect the month and release order
- Keeps any future published `@rackula/core` package on SemVer, so package users still get compatibility-based versioning
- Explains that app releases will move away from manual minor-vs-patch decisions and use a fixed monthly counter instead
- Notes the expected rollout points for release tags, changelog headings, and milestone naming

### Impact
`✅ Clearer release numbering`
`✅ Fewer versioning decisions per release`
`✅ Cleaner path for future package publishing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
