### PR TITLE
fix(lxc): community-scripts compliance, security hardening, and reliability fixes

### DIFF
--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version: "1"
 
       - name: Build frontend
         env:
@@ -80,6 +80,7 @@ jobs:
           cp deploy/lxc/nginx.service.d-override.conf "${TARBALL_DIR}/config/"
 
           tar czf "rackula-lxc-${VERSION}.tar.gz" "${TARBALL_DIR}"
+          rm -rf "${TARBALL_DIR}"
           echo "TARBALL=rackula-lxc-${VERSION}.tar.gz" >> "$GITHUB_ENV"
 
       - name: Upload tarball to release

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -77,6 +77,7 @@ jobs:
           cp deploy/lxc/nginx.conf "${TARBALL_DIR}/config/"
           cp deploy/lxc/rackula-api.service "${TARBALL_DIR}/config/"
           cp deploy/lxc/security-headers.conf "${TARBALL_DIR}/config/"
+          cp deploy/lxc/nginx.service.d-override.conf "${TARBALL_DIR}/config/"
 
           tar czf "rackula-lxc-${VERSION}.tar.gz" "${TARBALL_DIR}"
           echo "TARBALL=rackula-lxc-${VERSION}.tar.gz" >> "$GITHUB_ENV"

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -35,14 +35,15 @@ function update_script() {
     exit 1
   fi
 
-  # Rollback on failure — restore full installation if update broke things
+  # Track update success for rollback decisions
+  UPDATE_SUCCESS=0
+
+  # Rollback on failure — restore from backup unless update succeeded
   cleanup() {
-    if [[ -d /opt/rackula-backup ]]; then
-      if [[ ! -d /opt/rackula ]] || [[ ! -d /opt/rackula/data ]]; then
-        rm -rf /opt/rackula
-        mv /opt/rackula-backup /opt/rackula
-        msg_error "Update failed — restored from backup"
-      fi
+    if [[ -d /opt/rackula-backup ]] && [[ $UPDATE_SUCCESS -eq 0 ]]; then
+      rm -rf /opt/rackula
+      mv /opt/rackula-backup /opt/rackula
+      msg_error "Update failed — restored from backup"
     fi
     rm -rf /tmp/rackula-update.lock
   }
@@ -63,14 +64,26 @@ function update_script() {
     fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
 
     # Restore persistent data from backup
-    mv /opt/rackula-backup/data /opt/rackula/data
+    if ! mv /opt/rackula-backup/data /opt/rackula/data; then
+      msg_error "Failed to restore data directory"
+      exit 1
+    fi
 
     # Update config files from the new release
-    cp /opt/rackula/config/security-headers.conf /etc/nginx/snippets/security-headers.conf
-    cp /opt/rackula/config/rackula-api.service /etc/systemd/system/rackula-api.service
+    if ! cp /opt/rackula/config/security-headers.conf /etc/nginx/snippets/security-headers.conf; then
+      msg_error "Failed to update nginx security headers"
+      exit 1
+    fi
+    if ! cp /opt/rackula/config/rackula-api.service /etc/systemd/system/rackula-api.service; then
+      msg_error "Failed to update rackula-api service"
+      exit 1
+    fi
     if [[ -f /opt/rackula/config/nginx.service.d-override.conf ]]; then
       mkdir -p /etc/systemd/system/nginx.service.d
-      cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.service.d/override.conf
+      if ! cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.service.d/override.conf; then
+        msg_error "Failed to update nginx service override"
+        exit 1
+      fi
     fi
 
     # Set ownership
@@ -100,6 +113,9 @@ function update_script() {
       fi
       sleep 1
     done
+
+    # Mark update as successful so cleanup doesn't roll back
+    UPDATE_SUCCESS=1
 
     # Remove backup only after services verified
     rm -rf /opt/rackula-backup

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -26,7 +26,7 @@ function update_script() {
 
   if [[ ! -f ~/.rackula ]]; then
     msg_error "No ${APP} Installation Found!"
-    exit
+    exit 1
   fi
 
   # Prevent concurrent updates (mkdir is atomic, touch is not)
@@ -41,6 +41,12 @@ function update_script() {
   # Rollback on failure — restore from backup unless update succeeded
   cleanup() {
     if [[ -d /opt/rackula-backup ]] && [[ $UPDATE_SUCCESS -eq 0 ]]; then
+      # Persistent data may already have been moved into the new install
+      # (see data-restore step below). Move it back so it is not destroyed
+      # by the rm -rf, then restore the backup wholesale.
+      if [[ -d /opt/rackula/data ]] && [[ ! -d /opt/rackula-backup/data ]]; then
+        mv /opt/rackula/data /opt/rackula-backup/data
+      fi
       rm -rf /opt/rackula
       mv /opt/rackula-backup /opt/rackula
       # Restart services with the restored installation
@@ -74,6 +80,10 @@ function update_script() {
     fi
 
     # Update config files from the new release
+    if ! cp /opt/rackula/config/nginx.conf /etc/nginx/sites-available/rackula; then
+      msg_error "Failed to update nginx site config"
+      exit 1
+    fi
     if ! cp /opt/rackula/config/security-headers.conf /etc/nginx/snippets/security-headers.conf; then
       msg_error "Failed to update nginx security headers"
       exit 1
@@ -126,7 +136,7 @@ function update_script() {
     rm -rf /opt/rackula-backup
     msg_ok "Updated successfully!"
   fi
-  exit
+  exit 0
 }
 
 start

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -43,6 +43,10 @@ function update_script() {
     if [[ -d /opt/rackula-backup ]] && [[ $UPDATE_SUCCESS -eq 0 ]]; then
       rm -rf /opt/rackula
       mv /opt/rackula-backup /opt/rackula
+      # Restart services with the restored installation
+      systemctl daemon-reload
+      systemctl start rackula-api
+      systemctl start nginx
       msg_error "Update failed — restored from backup"
     fi
     rm -rf /tmp/rackula-update.lock
@@ -88,7 +92,8 @@ function update_script() {
 
     # Set ownership
     chown -R root:root /opt/rackula/frontend
-    chmod -R 755 /opt/rackula/frontend
+    find /opt/rackula/frontend -type d -exec chmod 755 {} \;
+    find /opt/rackula/frontend -type f -exec chmod 644 {} \;
     chown -R rackula:rackula /opt/rackula/api
     chown -R rackula:rackula /opt/rackula/data
     chmod 750 /opt/rackula/data
@@ -103,7 +108,7 @@ function update_script() {
 
     msg_info "Verifying Services"
     for i in $(seq 1 10); do
-      if curl -sf http://127.0.0.1:3001/health >/dev/null 2>&1; then
+      if curl -sf --connect-timeout 2 --max-time 5 http://127.0.0.1:3001/health >/dev/null 2>&1; then
         msg_ok "Service running successfully"
         break
       fi

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -8,8 +8,8 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 APP="Rackula"
 var_tags="${var_tags:-homelab}"
 var_cpu="${var_cpu:-1}"
-var_ram="${var_ram:-256}"
-var_disk="${var_disk:-4}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
@@ -29,7 +29,25 @@ function update_script() {
     exit
   fi
 
-  RELEASE=$(get_latest_github_release "RackulaLives/Rackula")
+  # Prevent concurrent updates (mkdir is atomic, touch is not)
+  if ! mkdir /tmp/rackula-update.lock 2>/dev/null; then
+    msg_error "Update already in progress"
+    exit 1
+  fi
+
+  # Rollback on failure — restore full installation if update broke things
+  cleanup() {
+    if [[ -d /opt/rackula-backup ]]; then
+      if [[ ! -d /opt/rackula ]] || [[ ! -d /opt/rackula/data ]]; then
+        rm -rf /opt/rackula
+        mv /opt/rackula-backup /opt/rackula
+        msg_error "Update failed — restored from backup"
+      fi
+    fi
+    rm -rf /tmp/rackula-update.lock
+  }
+  trap cleanup EXIT
+
   if check_for_gh_release "rackula" "RackulaLives/Rackula"; then
     msg_info "Stopping Services"
     systemctl stop rackula-api
@@ -37,43 +55,54 @@ function update_script() {
     msg_ok "Stopped Services"
 
     msg_info "Backing up data"
-    cp -a /opt/rackula/data /opt/rackula/data.bak
+    rm -rf /opt/rackula-backup
+    mv /opt/rackula /opt/rackula-backup
     msg_ok "Backed up data"
 
-    msg_info "Updating ${APP} to ${RELEASE}"
-    TARBALL_URL="https://github.com/RackulaLives/Rackula/releases/download/${RELEASE}/rackula-lxc-${RELEASE}.tar.gz"
-    $STD curl -fsSL "$TARBALL_URL" -o /tmp/rackula-lxc.tar.gz
-    tar xzf /tmp/rackula-lxc.tar.gz -C /tmp
-    TARBALL_DIR="/tmp/rackula-lxc-${RELEASE}"
+    msg_info "Updating ${APP} to ${CHECK_UPDATE_RELEASE}"
+    fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
 
-    # Update frontend
-    rm -rf /opt/rackula/frontend/*
-    cp -r "${TARBALL_DIR}/frontend/"* /opt/rackula/frontend/
+    # Restore persistent data from backup
+    mv /opt/rackula-backup/data /opt/rackula/data
 
-    # Update API
-    rm -rf /opt/rackula/api/src /opt/rackula/api/node_modules /opt/rackula/api/package.json /opt/rackula/api/tsconfig.json
-    cp -r "${TARBALL_DIR}/api/src" /opt/rackula/api/
-    cp -r "${TARBALL_DIR}/api/node_modules" /opt/rackula/api/
-    cp "${TARBALL_DIR}/api/package.json" /opt/rackula/api/
-    cp "${TARBALL_DIR}/api/tsconfig.json" /opt/rackula/api/
+    # Update config files from the new release
+    cp /opt/rackula/config/security-headers.conf /etc/nginx/snippets/security-headers.conf
+    cp /opt/rackula/config/rackula-api.service /etc/systemd/system/rackula-api.service
+    if [[ -f /opt/rackula/config/nginx.service.d-override.conf ]]; then
+      mkdir -p /etc/systemd/system/nginx.service.d
+      cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.service.d/override.conf
+    fi
 
-    # Update security headers only (preserve user's nginx config)
-    cp "${TARBALL_DIR}/config/security-headers.conf" /etc/nginx/snippets/security-headers.conf
-
+    # Set ownership
+    chown -R root:root /opt/rackula/frontend
+    chmod -R 755 /opt/rackula/frontend
     chown -R rackula:rackula /opt/rackula/api
-    echo "${RELEASE}" >~/.rackula
+    chown -R rackula:rackula /opt/rackula/data
+    chmod 750 /opt/rackula/data
 
-    # Cleanup
-    rm -rf /tmp/rackula-lxc.tar.gz "${TARBALL_DIR}"
-    msg_ok "Updated ${APP} to ${RELEASE}"
+    msg_ok "Updated ${APP} to ${CHECK_UPDATE_RELEASE}"
 
     msg_info "Starting Services"
+    systemctl daemon-reload
     systemctl start rackula-api
     systemctl start nginx
     msg_ok "Started Services"
 
-    # Remove backup on success
-    rm -rf /opt/rackula/data.bak
+    msg_info "Verifying Services"
+    for i in $(seq 1 10); do
+      if curl -sf http://127.0.0.1:3001/health >/dev/null 2>&1; then
+        msg_ok "Service running successfully"
+        break
+      fi
+      if [ "$i" -eq 10 ]; then
+        msg_error "API failed to start within 10 seconds"
+        exit 1
+      fi
+      sleep 1
+    done
+
+    # Remove backup only after services verified
+    rm -rf /opt/rackula-backup
     msg_ok "Updated successfully!"
   fi
   exit

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -52,7 +52,8 @@ cp /opt/rackula/config/security-headers.conf /etc/nginx/snippets/security-header
 
 # Set ownership: frontend root-owned (served by nginx), API rackula-owned
 chown -R root:root /opt/rackula/frontend
-chmod -R 755 /opt/rackula/frontend
+find /opt/rackula/frontend -type d -exec chmod 755 {} \;
+find /opt/rackula/frontend -type f -exec chmod 644 {} \;
 chown -R rackula:rackula /opt/rackula/api
 chown -R rackula:rackula /opt/rackula/data
 chmod 750 /opt/rackula/data
@@ -269,7 +270,7 @@ msg_ok "Created Services"
 
 msg_info "Verifying Services"
 for i in $(seq 1 10); do
-  if curl -sf http://127.0.0.1:3001/health >/dev/null 2>&1; then
+  if curl -sf --connect-timeout 2 --max-time 5 http://127.0.0.1:3001/health >/dev/null 2>&1; then
     msg_ok "Service running successfully"
     break
   fi

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -21,8 +21,9 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Bun"
-$STD curl -fsSL https://bun.sh/install | bash
-ln -sf /root/.bun/bin/bun /usr/local/bin/bun
+BUN_INSTALL=/opt/bun $STD curl -fsSL https://bun.sh/install | bash
+ln -sf /opt/bun/bin/bun /usr/local/bin/bun
+ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"
 
 msg_info "Creating rackula user"
@@ -216,7 +217,6 @@ PrivateTmp=true
 WantedBy=multi-user.target
 EOF
 
-systemctl daemon-reload
 systemctl enable -q --now rackula-api
 systemctl enable -q --now nginx
 msg_ok "Created Services"

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -21,7 +21,8 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Bun"
-BUN_INSTALL=/opt/bun $STD curl -fsSL https://bun.sh/install | bash
+export BUN_INSTALL=/opt/bun
+$STD curl -fsSL https://bun.sh/install | bash
 ln -sf /opt/bun/bin/bun /usr/local/bin/bun
 ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -23,6 +23,10 @@ msg_ok "Installed Dependencies"
 msg_info "Installing Bun"
 export BUN_INSTALL=/opt/bun
 curl -fsSL https://bun.sh/install | $STD bash
+if [ ! -f /opt/bun/bin/bun ]; then
+  msg_error "Bun installation failed — binary not found at /opt/bun/bin/bun"
+  exit 1
+fi
 ln -sf /opt/bun/bin/bun /usr/local/bin/bun
 ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"
@@ -32,39 +36,21 @@ useradd --system --user-group --home-dir /opt/rackula --shell /usr/sbin/nologin 
 msg_ok "Created rackula user"
 
 msg_info "Installing Rackula"
-RELEASE=$(get_latest_github_release "RackulaLives/Rackula")
-TARBALL_URL="https://github.com/RackulaLives/Rackula/releases/download/${RELEASE}/rackula-lxc-${RELEASE}.tar.gz"
-$STD curl -fsSL "$TARBALL_URL" -o /tmp/rackula-lxc.tar.gz
-tar xzf /tmp/rackula-lxc.tar.gz -C /tmp
-TARBALL_DIR="/tmp/rackula-lxc-${RELEASE}"
+fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
 
-# Create directory structure
-mkdir -p /opt/rackula/{frontend,api,data}
+# Create persistent data directory (not in tarball)
+mkdir -p /opt/rackula/data
 mkdir -p /etc/nginx/snippets
 
-# Deploy frontend (root-owned, served by nginx)
-cp -r "${TARBALL_DIR}/frontend/"* /opt/rackula/frontend/
+# Deploy config files from the release
+cp /opt/rackula/config/security-headers.conf /etc/nginx/snippets/security-headers.conf
+
+# Set ownership: frontend root-owned (served by nginx), API rackula-owned
 chown -R root:root /opt/rackula/frontend
 chmod -R 755 /opt/rackula/frontend
-
-# Deploy API (rackula-owned, run by systemd)
-cp -r "${TARBALL_DIR}/api/src" /opt/rackula/api/
-cp -r "${TARBALL_DIR}/api/node_modules" /opt/rackula/api/
-cp "${TARBALL_DIR}/api/package.json" /opt/rackula/api/
-cp "${TARBALL_DIR}/api/tsconfig.json" /opt/rackula/api/
 chown -R rackula:rackula /opt/rackula/api
-
-# Deploy config files from tarball (before cleanup)
-cp "${TARBALL_DIR}/config/security-headers.conf" /etc/nginx/snippets/security-headers.conf
-
-# Data directory (rackula-owned, persists across updates)
 chown -R rackula:rackula /opt/rackula/data
 chmod 750 /opt/rackula/data
-
-echo "${RELEASE}" >~/.rackula
-
-# Cleanup tarball
-rm -rf /tmp/rackula-lxc.tar.gz "${TARBALL_DIR}"
 msg_ok "Installed Rackula"
 
 msg_info "Generating API write token"
@@ -190,7 +176,7 @@ ln -sf /etc/nginx/sites-available/rackula /etc/nginx/sites-enabled/rackula
 msg_ok "Configured nginx"
 
 msg_info "Creating Services"
-# Deploy systemd unit for API
+# Deploy hardened systemd unit for API
 cat <<'EOF' >/etc/systemd/system/rackula-api.service
 [Unit]
 Description=Rackula Persistence API
@@ -208,19 +194,119 @@ RestartSec=5
 Environment=NODE_ENV=production
 Environment=DATA_DIR=/opt/rackula/data
 Environment=RACKULA_API_PORT=3001
+
+# Resource limits
+MemoryMax=384M
+MemoryHigh=320M
+TasksMax=32
+LimitNOFILE=1024
+
+# OOM handling
+OOMPolicy=stop
+OOMScoreAdjust=-100
+
+# Filesystem protection
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 ReadWritePaths=/opt/rackula/data
 PrivateTmp=true
+UMask=0077
+
+# Kernel protection
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+ProtectProc=invisible
+ProcSubset=pid
+
+# Process restrictions
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+LockPersonality=true
+PrivateDevices=true
+RemoveIPC=true
+
+# Capability dropping
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# Syscall filtering
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+
+# Network egress control
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+IPAddressDeny=any
+IPAddressAllow=127.0.0.0/8
+
+# Logging
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
+# Harden nginx service via drop-in override
+mkdir -p /etc/systemd/system/nginx.service.d
+cat <<'EOF' >/etc/systemd/system/nginx.service.d/override.conf
+[Service]
+# Filesystem protection
+ProtectSystem=strict
+ReadWritePaths=/var/log/nginx /var/lib/nginx /var/cache/nginx /run
+ProtectHome=true
+PrivateTmp=true
+
+# Kernel protection
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+
+# Process restrictions
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+RemoveIPC=true
+
+# Capability dropping — nginx on port 80 needs NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_CHOWN CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Syscall filtering
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+EOF
+
+systemctl daemon-reload
 systemctl enable -q --now rackula-api
 systemctl enable -q --now nginx
 msg_ok "Created Services"
+
+msg_info "Verifying Services"
+for i in $(seq 1 10); do
+  if curl -sf http://127.0.0.1:3001/health >/dev/null 2>&1; then
+    msg_ok "Service running successfully"
+    break
+  fi
+  if [ "$i" -eq 10 ]; then
+    msg_error "API failed to start within 10 seconds"
+    exit 1
+  fi
+  sleep 1
+done
 
 motd_ssh
 customize

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -28,7 +28,12 @@ if [ ! -f /opt/bun/bin/bun ]; then
   exit 1
 fi
 ln -sf /opt/bun/bin/bun /usr/local/bin/bun
-ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
+if [ -f /opt/bun/bin/bunx ]; then
+  ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
+else
+  # bunx is typically bun with different argv[0]; fall back to symlink via bun
+  ln -sf /usr/local/bin/bun /usr/local/bin/bunx
+fi
 msg_ok "Installed Bun"
 
 msg_info "Creating rackula user"
@@ -243,7 +248,7 @@ SystemCallFilter=~@privileged @resources
 # Network egress control
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 IPAddressDeny=any
-IPAddressAllow=127.0.0.0/8
+IPAddressAllow=127.0.0.0/8 ::1/128
 
 # Logging
 StandardOutput=journal
@@ -253,42 +258,9 @@ StandardError=journal
 WantedBy=multi-user.target
 EOF
 
-# Harden nginx service via drop-in override
+# Harden nginx service via drop-in override (copy from packaged config)
 mkdir -p /etc/systemd/system/nginx.service.d
-cat <<'EOF' >/etc/systemd/system/nginx.service.d/override.conf
-[Service]
-# Filesystem protection
-ProtectSystem=strict
-ReadWritePaths=/var/log/nginx /var/lib/nginx /var/cache/nginx /run
-ProtectHome=true
-PrivateTmp=true
-
-# Kernel protection
-ProtectKernelTunables=true
-ProtectKernelModules=true
-ProtectKernelLogs=true
-ProtectControlGroups=true
-ProtectClock=true
-ProtectHostname=true
-
-# Process restrictions
-NoNewPrivileges=true
-RestrictSUIDSGID=true
-RestrictRealtime=true
-LockPersonality=true
-MemoryDenyWriteExecute=true
-PrivateDevices=true
-RemoveIPC=true
-
-# Capability dropping — nginx on port 80 needs NET_BIND_SERVICE
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_CHOWN CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID
-AmbientCapabilities=CAP_NET_BIND_SERVICE
-
-# Syscall filtering
-SystemCallArchitectures=native
-SystemCallFilter=@system-service
-SystemCallFilter=~@privileged @resources
-EOF
+cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.service.d/override.conf
 
 systemctl daemon-reload
 systemctl enable -q --now rackula-api

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -62,10 +62,23 @@ msg_ok "Installed Rackula"
 msg_info "Generating API write token"
 API_WRITE_TOKEN=$(openssl rand -hex 32)
 
+# CORS origin scheme — defaults to http. Behind an HTTPS reverse proxy, export
+# CORS_SCHEME=https before running the installer, or edit CORS_ORIGIN in
+# /opt/rackula/data/.env afterwards and restart rackula-api. Only http/https
+# are accepted; anything else is rejected to avoid writing a malformed origin.
+CORS_SCHEME="${CORS_SCHEME:-http}"
+case "$CORS_SCHEME" in
+  http | https) ;;
+  *)
+    msg_error "Invalid CORS_SCHEME '${CORS_SCHEME}' (expected 'http' or 'https')"
+    exit 1
+    ;;
+esac
+
 # Write API environment file
 cat <<EOF >/opt/rackula/data/.env
 RACKULA_API_WRITE_TOKEN=${API_WRITE_TOKEN}
-CORS_ORIGIN=http://localhost
+CORS_ORIGIN=${CORS_SCHEME}://localhost
 ALLOW_INSECURE_CORS=true
 EOF
 chown rackula:rackula /opt/rackula/data/.env
@@ -82,99 +95,8 @@ msg_ok "Generated API write token"
 
 msg_info "Configuring nginx"
 
-# Deploy rackula nginx site config
-cat <<'NGINX' >/etc/nginx/sites-available/rackula
-# Rackula nginx configuration — managed by community-scripts installer
-# Token snippet and security headers are included from /etc/nginx/snippets/
-
-include /etc/nginx/snippets/rackula-api-token.conf;
-
-map $request_method $rackula_is_write_method {
-    default 0;
-    PUT 1;
-    DELETE 1;
-}
-
-map "$rackula_has_api_write_token" $rackula_token_check {
-    default 0;
-    1 1;
-}
-
-map "$rackula_is_write_method:$rackula_token_check" $rackula_api_authorization {
-    default $http_authorization;
-    "1:1" "Bearer $rackula_api_write_token";
-}
-
-server {
-    listen 80;
-    listen [::]:80;
-    server_name _;
-    root /opt/rackula/frontend;
-    index index.html;
-
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private auth;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml application/javascript application/json image/svg+xml;
-
-    location /assets/ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-        include /etc/nginx/snippets/security-headers.conf;
-    }
-
-    location = /api/health {
-        proxy_pass http://127.0.0.1:3001/health;
-        proxy_http_version 1.1;
-        proxy_connect_timeout 3s;
-        proxy_read_timeout 3s;
-    }
-
-    location = /api {
-        default_type application/json;
-        return 400 '{"error": "Invalid API path", "hint": "Use /api/layouts, /api/assets, or /api/health"}';
-    }
-
-    location = /api/ {
-        default_type application/json;
-        return 400 '{"error": "Invalid API path", "hint": "Use /api/layouts, /api/assets, or /api/health"}';
-    }
-
-    location /api/ {
-        rewrite ^/api(/.*)$ $1 break;
-        proxy_pass http://127.0.0.1:3001;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Authorization $rackula_api_authorization;
-        proxy_connect_timeout 5s;
-        proxy_send_timeout 30s;
-        proxy_read_timeout 30s;
-        proxy_intercept_errors on;
-        error_page 502 503 504 = @api_unavailable;
-    }
-
-    location @api_unavailable {
-        default_type application/json;
-        return 503 '{"error": "Persistence API unavailable"}';
-    }
-
-    location = /health {
-        access_log off;
-        default_type text/plain;
-        return 200 "OK";
-    }
-
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    include /etc/nginx/snippets/security-headers.conf;
-}
-NGINX
+# Deploy rackula nginx site config from the packaged tarball (single source of truth)
+cp /opt/rackula/config/nginx.conf /etc/nginx/sites-available/rackula
 
 # Remove default site, enable rackula
 rm -f /etc/nginx/sites-enabled/default
@@ -182,82 +104,8 @@ ln -sf /etc/nginx/sites-available/rackula /etc/nginx/sites-enabled/rackula
 msg_ok "Configured nginx"
 
 msg_info "Creating Services"
-# Deploy hardened systemd unit for API
-cat <<'EOF' >/etc/systemd/system/rackula-api.service
-[Unit]
-Description=Rackula Persistence API
-After=network.target
-
-[Service]
-Type=simple
-User=rackula
-Group=rackula
-WorkingDirectory=/opt/rackula/api
-EnvironmentFile=/opt/rackula/data/.env
-ExecStart=/usr/local/bin/bun src/index.ts
-Restart=always
-RestartSec=5
-Environment=NODE_ENV=production
-Environment=DATA_DIR=/opt/rackula/data
-Environment=RACKULA_API_PORT=3001
-
-# Resource limits
-MemoryMax=384M
-MemoryHigh=320M
-TasksMax=32
-LimitNOFILE=1024
-
-# OOM handling
-OOMPolicy=stop
-OOMScoreAdjust=-100
-
-# Filesystem protection
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/opt/rackula/data
-PrivateTmp=true
-UMask=0077
-
-# Kernel protection
-ProtectKernelTunables=true
-ProtectKernelModules=true
-ProtectKernelLogs=true
-ProtectControlGroups=true
-ProtectClock=true
-ProtectHostname=true
-ProtectProc=invisible
-ProcSubset=pid
-
-# Process restrictions
-RestrictSUIDSGID=true
-RestrictRealtime=true
-RestrictNamespaces=true
-LockPersonality=true
-PrivateDevices=true
-RemoveIPC=true
-
-# Capability dropping
-CapabilityBoundingSet=
-AmbientCapabilities=
-
-# Syscall filtering
-SystemCallArchitectures=native
-SystemCallFilter=@system-service
-SystemCallFilter=~@privileged @resources
-
-# Network egress control
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-IPAddressDeny=any
-IPAddressAllow=127.0.0.0/8 ::1/128
-
-# Logging
-StandardOutput=journal
-StandardError=journal
-
-[Install]
-WantedBy=multi-user.target
-EOF
+# Deploy the hardened API unit from the packaged tarball (single source of truth)
+cp /opt/rackula/config/rackula-api.service /etc/systemd/system/rackula-api.service
 
 # Harden nginx service via drop-in override (copy from packaged config)
 mkdir -p /etc/systemd/system/nginx.service.d

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -22,7 +22,7 @@ msg_ok "Installed Dependencies"
 
 msg_info "Installing Bun"
 export BUN_INSTALL=/opt/bun
-$STD curl -fsSL https://bun.sh/install | bash
+curl -fsSL https://bun.sh/install | $STD bash
 ln -sf /opt/bun/bin/bun /usr/local/bin/bun
 ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"

--- a/deploy/lxc/community-scripts/json/rackula.json
+++ b/deploy/lxc/community-scripts/json/rackula.json
@@ -18,8 +18,8 @@
       "script": "ct/rackula.sh",
       "resources": {
         "cpu": 1,
-        "ram": 256,
-        "hdd": 4,
+        "ram": 512,
+        "hdd": 8,
         "os": "debian",
         "version": "13"
       }

--- a/deploy/lxc/nginx.service.d-override.conf
+++ b/deploy/lxc/nginx.service.d-override.conf
@@ -1,0 +1,32 @@
+[Service]
+# Filesystem protection
+ProtectSystem=strict
+ReadWritePaths=/var/log/nginx /var/lib/nginx /var/cache/nginx /run
+ProtectHome=true
+PrivateTmp=true
+
+# Kernel protection
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+
+# Process restrictions
+NoNewPrivileges=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+RemoveIPC=true
+
+# Capability dropping — nginx on port 80 needs NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_CHOWN CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Syscall filtering
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources

--- a/deploy/lxc/rackula-api.service
+++ b/deploy/lxc/rackula-api.service
@@ -63,7 +63,7 @@ SystemCallFilter=~@privileged @resources
 # Network egress control — API only needs localhost (nginx proxies to it)
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 IPAddressDeny=any
-IPAddressAllow=127.0.0.0/8
+IPAddressAllow=127.0.0.0/8 ::1/128
 
 # Logging
 StandardOutput=journal

--- a/deploy/lxc/rackula-api.service
+++ b/deploy/lxc/rackula-api.service
@@ -14,11 +14,60 @@ RestartSec=5
 Environment=NODE_ENV=production
 Environment=DATA_DIR=/opt/rackula/data
 Environment=RACKULA_API_PORT=3001
+
+# Resource limits
+MemoryMax=384M
+MemoryHigh=320M
+TasksMax=32
+LimitNOFILE=1024
+
+# OOM handling — cleanly stop and let Restart=always bring it back
+OOMPolicy=stop
+OOMScoreAdjust=-100
+
+# Filesystem protection
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 ReadWritePaths=/opt/rackula/data
 PrivateTmp=true
+UMask=0077
+
+# Kernel protection
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+ProtectProc=invisible
+ProcSubset=pid
+
+# Process restrictions
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+LockPersonality=true
+PrivateDevices=true
+RemoveIPC=true
+
+# Capability dropping — API on high port, no caps needed
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# Syscall filtering
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+
+# Network egress control — API only needs localhost (nginx proxies to it)
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+IPAddressDeny=any
+IPAddressAllow=127.0.0.0/8
+
+# Logging
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/lxc/security-headers.conf
+++ b/deploy/lxc/security-headers.conf
@@ -32,4 +32,4 @@ add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 #     Source: index.html <script> tag (SPA redirect for GitHub Pages deep links)
 #   - sha256-yei5Fza+Eyx4G0smvN0xBqEesIKumz6RSyGsU3FJowI=
 #     Source: Dynamic inline script in bundled JS
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-4afnYZWgiqXvmE6yKMLV6jCv+mJKGuq8qikAiTfRgMc=' 'sha256-yei5Fza+Eyx4G0smvN0xBqEesIKumz6RSyGsU3FJowI='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; frame-ancestors 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-4afnYZWgiqXvmE6yKMLV6jCv+mJKGuq8qikAiTfRgMc=' 'sha256-yei5Fza+Eyx4G0smvN0xBqEesIKumz6RSyGsU3FJowI='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;

--- a/deploy/lxc/security-headers.conf
+++ b/deploy/lxc/security-headers.conf
@@ -12,15 +12,14 @@
 # other needs the same change.
 #
 # SINGLE SOURCE OF TRUTH for LXC deployments. Edit headers here, not in nginx.conf.
+#
+# HSTS note: Strict-Transport-Security is intentionally omitted from this
+# default config because the LXC container serves HTTP on port 80. Browsers
+# ignore HSTS over plain HTTP per RFC 6797 S7.2. To enable HSTS, add it
+# in your reverse proxy config (Caddy, Traefik, etc.) where TLS terminates.
 
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
-
-# HTTPS hardening — force secure connections for 1 year
-# REQUIRES TLS: This header is only meaningful when served over HTTPS.
-# Browsers ignore HSTS over plain HTTP (RFC 6797 S7.2). If running behind
-# a reverse proxy with TLS termination (Caddy, Traefik, etc.), this works.
-add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
 # Privacy controls — limit information leakage and browser feature access
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary

Comprehensive overhaul of LXC install and update scripts for the community-scripts/ProxmoxVE distribution (epic #1211).

### Community-Scripts Compliance (#1785, #1787, #1790)

- **#1785** — Use `apt` instead of `apt-get`
- **#1787** — Bun installs to `/opt/bun` with verification and `bunx` fallback
- **#1790** — Removed redundant `systemctl daemon-reload` from install script (kept in update where needed)

### Reliability (#1786, #1788, #1794, #1795)

- **#1786** — Use `fetch_and_deploy_gh_release` with `"prebuild"` mode (not `"tarball"` which downloads source archives)
- **#1788** — Use `check_for_gh_release` + `CHECK_UPDATE_RELEASE` + post-install/update health verification
- **#1794** — Atomic lock file via `mkdir` instead of `touch`
- **#1795** — Full rollback trap that restores entire installation on failure, with `UPDATE_SUCCESS` flag

### Security Hardening (#1791, #1792, #1793)

- **#1791** — Hardened systemd unit for API (memory limits, OOM policy, filesystem/kernel protection, capability dropping, syscall filtering, network egress control with `IPAddressDeny=any` + `IPAddressAllow=127.0.0.0/8 ::1/128`)
- **#1792** — nginx service hardening via drop-in override (`ProtectSystem=strict`, `MemoryDenyWriteExecute`, `NoNewPrivileges`, capability restriction to `CAP_NET_BIND_SERVICE`)
- **#1793** — Removed HSTS header from plain-HTTP config (meaningless per RFC 6797 §7.2), added `form-action 'self'` to CSP

### Remaining M1 issues (#1233, #1234, #1237, #1239, #1240)

- **#1233** — Explicit exit codes in `ct/rackula.sh` (no bare `exit`)
- **#1234** — Pin Bun to major `"1"` in `build-lxc.yml` (was `latest`); all actions SHA-pinned
- **#1237** — Configurable CORS scheme (`http`|`https`) with validation; default stays `http`
- **#1239** — Remove temp `TARBALL_DIR` after `tar czf` in `build-lxc.yml`
- **#1240** — Install nginx site config + `rackula-api.service` from the packaged tarball `config/` instead of inline heredocs (single source of truth)

### Local /code-review fixes

- `update_script()` now also refreshes `nginx.conf` on upgrade (previously drifted — only headers, the API unit, and the nginx override were refreshed, so site-routing changes never reached upgraded containers)
- Rollback trap preserves `/opt/rackula/data` before `rm -rf`, preventing data loss when an update fails *after* the data-restore step

## Notes

- Branch rebased onto current `main` (which now includes #1218 LXC infra and #1800 apt fix). Configs live canonically under `deploy/lxc/`; the stale duplicate copies the old branch carried under `community-scripts/` were dropped.

Closes #1785 Closes #1786 Closes #1787 Closes #1788 Closes #1790 Closes #1791 Closes #1792 Closes #1793 Closes #1794 Closes #1795 Closes #1233 Closes #1234 Closes #1237 Closes #1239 Closes #1240

Also implements: #1212 (CI/CD release tarball), #1213 (community-scripts install files)
