### PR TITLE
feat: rewrite /release skill for CalVer computation (#1804)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,21 +1,24 @@
-# Release Workflow v1
+# Release Workflow v2 (CalVer)
 
 Create a new release with changelog entry, version bump, and tag push.
-CHANGELOG.md is the single source of truth - GitHub releases derive from it.
+CHANGELOG.md is the single source of truth — GitHub releases derive from it.
 
-**Arguments:** `$ARGUMENTS` (required: `patch`, `minor`, `major`, or explicit version like `0.7.0`)
+**Arguments:** `$ARGUMENTS` (optional)
+
+- No argument → auto-compute next CalVer version via `scripts/next-version.sh --dry-run`
+- Explicit version → use the given version string (e.g., `26.7.0`)
 
 ---
 
 ## Permissions
 
-| Action | Scope |
-|--------|-------|
-| Git | add, commit, tag, push (to main) |
-| npm | version (no-git-tag-version) |
+| Action | Scope                                         |
+| ------ | --------------------------------------------- |
+| Git    | add, commit, tag, push (to main)              |
+| npm    | version (no-git-tag-version)                  |
 | GitHub | None (GitHub Action handles release creation) |
 
-**Commands allowed:** `git log`, `git tag`, `gh pr list`, `gh issue list`, `npm version`
+**Commands allowed:** `git log`, `git tag`, `gh pr list`, `gh issue list`, `npm version`, `scripts/next-version.sh`
 
 ---
 
@@ -24,7 +27,9 @@ CHANGELOG.md is the single source of truth - GitHub releases derive from it.
 ```text
 START
   │
-  ├─ Parse $ARGUMENTS → determine version type
+  ├─ Parse $ARGUMENTS → determine version source
+  │   (empty: auto-compute via next-version.sh)
+  │   (explicit: use given version string)
   │
   ├─ PHASE 1: Gather Changes
   │   - git log since last tag
@@ -43,9 +48,10 @@ START
   ├─ PHASE 4: Execute Release
   │   - Update CHANGELOG.md
   │   - Update SECURITY.md (supported version)
-  │   - npm version [type] --no-git-tag-version
+  │   - Compute or validate version
+  │   - npm version $NEW_VERSION --no-git-tag-version
   │   - git add && git commit
-  │   - git tag vX.Y.Z
+  │   - git tag v$NEW_VERSION
   │   - git push && git push --tags
   │
   └─ PHASE 5: Monitor
@@ -99,15 +105,15 @@ gh issue list --state closed --search "closed:>$LAST_DATE" \
 
 ### Categories (Keep a Changelog)
 
-| Category | Use For |
-|----------|---------|
-| **Added** | New features |
-| **Changed** | Changes to existing functionality |
-| **Deprecated** | Soon-to-be removed features |
-| **Removed** | Removed features |
-| **Fixed** | Bug fixes |
-| **Security** | Vulnerability fixes |
-| **Technical** | Internal changes (CI, tests, refactoring) |
+| Category       | Use For                                   |
+| -------------- | ----------------------------------------- |
+| **Added**      | New features                              |
+| **Changed**    | Changes to existing functionality         |
+| **Deprecated** | Soon-to-be removed features               |
+| **Removed**    | Removed features                          |
+| **Fixed**      | Bug fixes                                 |
+| **Security**   | Vulnerability fixes                       |
+| **Technical**  | Internal changes (CI, tests, refactoring) |
 
 ### Formatting Rules
 
@@ -120,7 +126,7 @@ gh issue list --state closed --search "closed:>$LAST_DATE" \
 ### Entry Template
 
 ```markdown
-## [X.Y.Z] - YYYY-MM-DD
+## [YY.M.MICRO] - YYYY-MM-DD
 
 ### Added
 
@@ -142,6 +148,7 @@ gh issue list --state closed --search "closed:>$LAST_DATE" \
 ### Present Draft to User
 
 Show the draft entry and ask:
+
 ```
 === CHANGELOG DRAFT ===
 
@@ -167,7 +174,7 @@ Changes:
 - Update CHANGELOG.md with new entry
 - Update SECURITY.md supported version
 - Bump version in package.json
-- Create git tag vX.Y.Z
+- Create git tag v$NEW_VERSION
 - Push to origin (triggers GitHub Action)
 
 Proceed? [y/n]:
@@ -179,17 +186,45 @@ Proceed? [y/n]:
 
 ## Phase 4: Execute Release
 
-### 4a. Calculate New Version
+### 4a. Compute New Version
+
+**No argument (auto-compute):**
+
+```bash
+NEW_VERSION=$(scripts/next-version.sh --dry-run)
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to compute next version. Check scripts/next-version.sh output."
+  exit 1
+fi
+```
+
+**Explicit version:**
+
+```bash
+NEW_VERSION="$ARGUMENTS"
+# Validate format: YY.M.MICRO (three numeric segments, unpadded month)
+if ! echo "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "ERROR: Version '$NEW_VERSION' is not valid CalVer format (expected YY.M.MICRO, e.g., 26.6.0)"
+  exit 1
+fi
+# Reject zero-padded month (e.g., 26.06.0 is invalid; 26.6.0 is valid)
+MONTH_PART=$(echo "$NEW_VERSION" | cut -d. -f2)
+if [ "$MONTH_PART" != "$(echo "$MONTH_PART" | sed 's/^0//')" ]; then
+  echo "ERROR: Month component must be unpadded (got $MONTH_PART, expected $(echo "$MONTH_PART" | sed 's/^0//'))"
+  exit 1
+fi
+# Check for duplicate tag
+if git tag -l "v$NEW_VERSION" | grep -q .; then
+  echo "ERROR: Tag v$NEW_VERSION already exists."
+  exit 1
+fi
+```
+
+Show version transition:
 
 ```bash
 CURRENT=$(node -p "require('./package.json').version")
-
-case "$ARGUMENTS" in
-  patch) NEW_VERSION=$(echo $CURRENT | awk -F. '{print $1"."$2"."$3+1}') ;;
-  minor) NEW_VERSION=$(echo $CURRENT | awk -F. '{print $1"."$2+1".0"}') ;;
-  major) NEW_VERSION=$(echo $CURRENT | awk -F. '{print $1+1".0.0"}') ;;
-  *) NEW_VERSION="$ARGUMENTS" ;;  # Explicit version
-esac
+echo "Version: $CURRENT → $NEW_VERSION"
 ```
 
 ### 4b. Update CHANGELOG.md
@@ -205,8 +240,8 @@ Update the supported versions table in SECURITY.md to reflect the new release ve
 Use the Edit tool to replace the version table:
 
 ```markdown
-| Version | Supported          |
-| ------- | ------------------ |
+| Version        | Supported          |
+| -------------- | ------------------ |
 | $NEW_VERSION   | :white_check_mark: |
 | < $NEW_VERSION | :x:                |
 ```
@@ -265,13 +300,16 @@ gh run watch
 
 ## Error Handling
 
-| Scenario | Response |
-|----------|----------|
-| No changes since last release | "No changes found. Nothing to release." |
-| Uncommitted changes | "Error: Working directory not clean. Commit or stash changes first." |
-| Not on main branch | "Error: Must be on main branch to release." |
-| Tag already exists | "Error: Tag vX.Y.Z already exists." |
-| Push fails | "Error: Push failed. Check permissions and try again." |
+| Scenario                      | Response                                                                             |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| No changes since last release | "No changes found. Nothing to release."                                              |
+| Uncommitted changes           | "Error: Working directory not clean. Commit or stash changes first."                 |
+| Not on main branch            | "Error: Must be on main branch to release."                                          |
+| Tag already exists            | "Error: Tag vX.Y.Z already exists."                                                  |
+| next-version.sh fails         | "Error: Failed to compute next version. Check scripts/next-version.sh output."       |
+| Invalid explicit version      | "Error: Version 'X' is not valid CalVer format (expected YY.M.MICRO, e.g., 26.6.0)." |
+| Zero-padded month             | "Error: Month must be unpadded (e.g., 26.6.0 not 26.06.0)."                          |
+| Push fails                    | "Error: Push failed. Check permissions and try again."                               |
 
 ---
 
@@ -280,11 +318,11 @@ gh run watch
 ### Success
 
 ```
-=== Release v0.6.11 Complete ===
+=== Release v26.6.0 Complete ===
 
 Changelog: Updated with 3 entries
-Version: 0.6.10 → 0.6.11
-Tag: v0.6.11
+Version: 0.10.1 → 26.6.0
+Tag: v26.6.0
 
 GitHub Actions triggered:
 - Release workflow: Creating GitHub release from CHANGELOG.md
@@ -305,15 +343,9 @@ No changes were made.
 ## Quick Reference
 
 ```bash
-# Patch release (bug fixes)
-/release patch
+# Auto-compute next CalVer version (most common)
+/release
 
-# Minor release (new features)
-/release minor
-
-# Major release (breaking changes)
-/release major
-
-# Explicit version
-/release 1.0.0
+# Explicit version (override computed version)
+/release 26.7.0
 ```

--- a/docs/superpowers/specs/2026-05-29-calver-implementation-design.md
+++ b/docs/superpowers/specs/2026-05-29-calver-implementation-design.md
@@ -1,0 +1,301 @@
+---
+created: 2026-05-29
+issue: epic
+status: approved
+depends-on: 1315
+---
+
+# CalVer Implementation Design — YY.M.MICRO Migration
+
+## Context
+
+Issue #1315 decided that the Rackula app adopts CalVer `YY.M.MICRO` (e.g., `v26.6.0`), while
+reserving SemVer for any future published packages (`@rackula/core`). The decision record
+(`docs/superpowers/specs/2026-05-29-versioning-policy-calver-design.md`) is merged. This spec
+covers the implementation: what changes, in what order, and how to verify it.
+
+**Why now?** The LXC release is the designated anchor point. The current SemVer pipeline
+requires a minor-vs-patch decision on every release; CalVer eliminates that friction.
+
+## Key Decisions (Confirmed)
+
+| Decision                | Choice                           | Rationale                                      |
+| ----------------------- | -------------------------------- | ---------------------------------------------- |
+| CalVer format           | `YY.M.MICRO` (e.g., `v26.6.0`)   | Valid-semver-shaped, 3-segment, unpadded month |
+| First CalVer release    | LXC milestone                    | Natural pipeline touch-point                   |
+| Docker rolling tags     | `YY.M` (e.g., `26.6`) + `latest` | Same pattern as current `major.minor`          |
+| Migration thresholds    | Leave `0.7.0` as-is              | Any CalVer > `0.7.0`, no code changes needed   |
+| `api/package.json`      | Track same version as root       | Unify for simplicity                           |
+| Implementation approach | Staged prep + single cutover     | Validate CI before committing to CalVer        |
+
+## What Changes
+
+### Must Change (Preparation Phase — backward-compatible)
+
+1. **New: `scripts/next-version.sh`** — computes next CalVer version from date + existing tags
+2. **Rewrite: `.claude/commands/release.md`** — replace SemVer bump logic with CalVer computation
+3. **Update: `.github/workflows/deploy-prod.yml`** — accept CalVer tags, Docker `YY.M` rolling tags
+4. **Update: `.github/workflows/release.yml`** — update comments/docs (functional: format-agnostic)
+5. **Rewrite: `CLAUDE.md` versioning policy section** — replace Cargo SemVer with CalVer YY.M.MICRO
+
+### Must Change (Cutover Phase — at LXC release)
+
+6. **Update: `package.json` + `api/package.json`** — version fields to first CalVer (e.g., `26.6.0`)
+7. **Update: `CHANGELOG.md`** — add first CalVer heading
+8. **Update: `SECURITY.md`** — version table format
+9. **Git tag** — create and push `v26.6.0` (or whatever month the LXC release lands)
+
+### Must Change (Post-Cutover)
+
+10. **Rename GitHub milestones** — theme-based names instead of SemVer
+
+### Does NOT Need Changes
+
+- `compareVersions()` and `0.7.0` thresholds — CalVer is 3-segment numeric, `26.6.0 > 0.7.0`
+- `vite.config.ts` — reads `pkg.version`, format-agnostic
+- `api/src/app.ts` — reads `APP_VERSION` env var, format-agnostic
+- `verify-version-alignment.sh` — accepts any version string
+- `build-lxc.yml` — uses version string in tarball name directly
+- `version.json` runtime endpoint — format-agnostic
+- `src/lib/version.ts`, `src/lib/types/index.ts` — `VERSION` is a string, format-agnostic
+- `src/lib/schemas/share.ts` — `v` field is a string, format-agnostic
+
+## Issue Breakdown
+
+### Issue 1: Create CalVer version utility script
+
+**What:** Create `scripts/next-version.sh` that computes the next CalVer version.
+
+**Why:** Both the `/release` skill and CI workflows need to compute `YY.M.MICRO` from the current
+date and existing git tags. A single script prevents drift between them.
+
+**Requirements:**
+
+- Read the most recent `v*` git tag
+- If current YY.M matches the tag's YY.M: `MICRO = tag.MICRO + 1`
+- If current YY.M is different: `MICRO = 0`
+- Output the computed version (e.g., `26.6.0`)
+- Support `--dry-run` flag for testing without side effects
+- Support `--tag` flag to also create and push the git tag
+- Validate that the computed version doesn't already exist as a tag
+- Exit non-zero on any error (no tag found, invalid format, duplicate tag)
+
+**Acceptance criteria:**
+
+- `scripts/next-version.sh` exists and is executable
+- `scripts/next-version.sh --dry-run` outputs the correct next version without side effects
+- Works correctly when the most recent tag is SemVer (during prep phase) and CalVer (after cutover)
+- Works correctly for month rollovers (e.g., June → July resets MICRO to 0)
+- Testable via `bats` or manual invocation
+
+**Files:** `scripts/next-version.sh` (new)
+
+---
+
+### Issue 2: Rewrite `/release` skill for CalVer computation
+
+**What:** Replace SemVer bump logic in `.claude/commands/release.md` with CalVer computation.
+
+**Why:** The release skill currently accepts `patch`/`minor`/`major` and does SemVer arithmetic.
+CalVer eliminates bump types — version is computed from date + tag counter.
+
+**Requirements:**
+
+- Remove `patch`/`minor`/`major` arguments
+- Accept no argument (auto-compute via `scripts/next-version.sh`) or an explicit version string
+- Phase 1 (gather), Phase 2 (draft), Phase 3 (confirm) remain unchanged
+- Phase 4 now calls `scripts/next-version.sh` for version computation
+- Phase 4 still runs `npm version $NEW_VERSION --no-git-tag-version`
+- Update output format to show `0.10.1 → 26.6.0` style transitions
+- Update error messages to remove SemVer terminology
+- Update SECURITY.md format to CalVer
+
+**Acceptance criteria:**
+
+- `/release` (no argument) computes the next CalVer version
+- `/release 26.7.0` uses the explicit version
+- `npm version` still works (CalVer `26.6.0` is valid semver for npm)
+- SECURITY.md updated to CalVer format
+
+**Files:** `.claude/commands/release.md`
+
+---
+
+### Issue 3: Update `deploy-prod.yml` for CalVer tag format
+
+**What:** Update the production deployment workflow to handle CalVer tags and Docker tags.
+
+**Why:** The current workflow validates strict SemVer (`^v[0-9]+\.[0-9]+\.[0-9]+$`) and uses
+`type=semver` Docker metadata patterns. CalVer `v26.6.0` technically matches this regex (it's
+still 3 numeric segments), but the semantics of `major.minor` change to `YY.M`, and the
+Docker metadata action's `type=semver` pattern needs review.
+
+**Requirements:**
+
+- Update the validate job's regex comment to clarify it accepts CalVer (the pattern `^v[0-9]+\.[0-9]+\.[0-9]+$` already matches `v26.6.0`)
+- Replace `type=semver,pattern={{version}}` with `type=raw,value=${{ needs.validate.outputs.version }}` for all three images (frontend, persist, API)
+- Replace `type=semver,pattern={{major}}.{{minor}}` with a `YY.M` rolling tag derived from the validated version
+- Add `year_month` output to the validate job (extracted from version: `26.6.0` → `26.6`)
+- Use `year_month` for Docker rolling tags instead of `major_minor`
+- Update `major_minor` references to `year_month` throughout
+- Update persist image tagging pattern from `v{{version}}-persist` to `v{version}-persist` (raw)
+- Keep `latest` tag on all images
+- Verify-version-alignment job stays format-agnostic (no changes needed)
+
+**Acceptance criteria:**
+
+- A `v26.6.0` tag passes validation
+- Docker images get tagged: `26.6.0`, `26.6`, `latest`
+- Persist image gets tagged: `v26.6.0-persist`, `persist`
+- API image gets tagged: `26.6.0`, `26.6`, `latest`
+- Existing SemVer tags (`v0.10.1`) still pass validation (during prep phase)
+- Smoke test verifies the live frontend version matches the CalVer tag
+
+**Files:** `.github/workflows/deploy-prod.yml`
+
+---
+
+### Issue 4: Update `release.yml` for CalVer
+
+**What:** Minor documentation updates to the release creation workflow.
+
+**Why:** The changelog validation is format-agnostic (just greps for `## [VERSION]`), but comments
+reference "semver".
+
+**Requirements:**
+
+- Update comments that reference "semver" to reference "CalVer" or "version"
+- No functional changes to the workflow logic needed
+
+**Acceptance criteria:**
+
+- Comments accurately reflect CalVer versioning
+- No functional regression in changelog validation or GitHub release creation
+
+**Files:** `.github/workflows/release.yml`
+
+---
+
+### Issue 5: Rewrite `CLAUDE.md` versioning policy section
+
+**What:** Replace the Cargo SemVer policy (lines 8–59) with the CalVer `YY.M.MICRO` policy.
+
+**Why:** CLAUDE.md is the AI assistant's primary reference for project conventions. It currently
+describes SemVer bump types and Cargo conventions that are no longer accurate.
+
+**Requirements:**
+
+- Replace the "Versioning Policy" section with CalVer `YY.M.MICRO` format rules
+- Document the format: `YY` = 2-digit year, `M` = unpadded month, `MICRO` = release counter
+- Document the MICRO rule: same month → MICRO++, new month → MICRO 0
+- Document dual-artifact policy: app = CalVer, `@rackula/core` = SemVer
+- Remove references to `patch`/`minor`/`major` bump types
+- Update the release command reference to `/release` (no argument) or `/release 26.7.0`
+- Update the milestone section to reference theme-based names instead of SemVer targets
+- Keep the tag format (`v` prefix) documentation
+
+**Acceptance criteria:**
+
+- CLAUDE.md versioning policy accurately describes CalVer
+- No references to SemVer bump types remain in the versioning section
+- `/release` command documentation matches the updated skill
+
+**Files:** `CLAUDE.md`
+
+---
+
+### Issue 6: Execute CalVer cutover
+
+**What:** The single commit that switches from SemVer to CalVer.
+
+**Why:** All preparation is done; this is the point of no return. Anchored to the LXC release.
+
+**Requirements:**
+
+- Change `package.json` version from `0.10.1` to the first CalVer version (e.g., `26.6.0`)
+- Change `api/package.json` version to match
+- Add a CalVer heading to `CHANGELOG.md` (e.g., `## [26.6.0] - 2026-06-XX`)
+- Update `CHANGELOG.md` header from "Semantic Versioning" to "Calendar Versioning"
+- Update `SECURITY.md` version table to CalVer format
+- Commit as `v26.6.0`
+- Create git tag `v26.6.0`
+- Push to main and push the tag
+
+**Acceptance criteria:**
+
+- `package.json` and `api/package.json` both have the same CalVer version
+- CHANGELOG.md has a `## [YY.M.MICRO] - YYYY-MM-DD` entry
+- SECURITY.md shows the new CalVer version as supported
+- Git tag `vYY.M.MICRO` exists on the cutover commit
+- CI pipeline passes with the CalVer tag
+
+**Files:** `package.json`, `api/package.json`, `CHANGELOG.md`, `SECURITY.md`
+
+---
+
+### Issue 7: Rename GitHub milestones to theme-based names
+
+**What:** Rename GitHub milestones from SemVer names to theme-based names with CalVer ranges.
+
+**Why:** Under CalVer, a milestone named `v1.0.0` no longer maps to a version. Milestones should
+reflect theme and target date instead.
+
+**Requirements:**
+
+- Rename existing milestones (e.g., `v1.0.0` → `M1 — LXC Build & Hardening, v26.6.x`)
+- Create new milestones with CalVer range format (`v26.7.x`, `v26.8.x`, etc.)
+- Update ROADMAP.md milestone references if needed
+- Close or migrate any issues in old milestones
+
+**Acceptance criteria:**
+
+- No SemVer-named milestones remain on GitHub
+- All milestones have theme-based names with CalVer ranges
+
+**Files:** GitHub (milestones), `.planning/ROADMAP.md`
+
+## Migration Safety
+
+### Monotonic ordering
+
+The transition `0.10.1 → 26.6.0` only ever increases. `compareVersions("26.6.0", "0.7.0")` returns
+`1` (greater), so all existing migration thresholds work correctly. No data migration needed.
+
+### Docker tag safety
+
+CalVer tags (`26.6.0`, `26.6`, `latest`) don't collide with existing SemVer tags (`0.10.1`,
+`0.10`, `latest`). The `latest` tag will be overwritten as expected on the first CalVer release.
+
+### CI validation
+
+The regex `^v[0-9]+\.[0-9]+\.[0-9]+$` already matches `v26.6.0`. No regex change is strictly
+required, but the error message should reference "CalVer" instead of "semver".
+
+### Rollback
+
+If the CalVer tag causes unexpected CI failures:
+
+1. Delete the CalVer tag and release from GitHub
+2. Revert the cutover commit
+3. Re-tag with a SemVer `v0.10.2` fix release
+4. The prep changes are backward-compatible and don't need reverting
+
+## Verification Plan
+
+### Phase 1 Verification (Preparation)
+
+1. **`scripts/next-version.sh`**: Run with `--dry-run` on current repo. Should compute a valid
+   CalVer version based on current date and existing tags.
+2. **`/release` skill**: Dry-run with no argument. Should propose the correct CalVer version.
+3. **`deploy-prod.yml`**: Push a test tag (or use `workflow_dispatch`) to validate the regex and
+   Docker tag generation with a CalVer-format tag.
+4. **`CLAUDE.md`**: Review the versioning policy section for accuracy.
+
+### Phase 2 Verification (Cutover)
+
+1. **`package.json`**: `node -p "require('./package.json').version"` returns `26.6.0` (or similar).
+2. **`api/package.json`**: Same version.
+3. **CHANGELOG.md**: `grep -q "^## \[26.6.0\]" CHANGELOG.md` passes.
+4. **Git tag**: `git tag -l 'v26.*'` shows the tag.
+5. **CI pipeline**: The `release.yml` and `deploy-prod.yml` workflows both pass.
+6. **Live version**: `curl https://count.racku.la/version.json | jq .version` returns the CalVer.


### PR DESCRIPTION
## **User description**
## Summary

Rewrite `.claude/commands/release.md` to replace SemVer bump logic (patch/minor/major) with CalVer computation via `scripts/next-version.sh`.

Part of the CalVer migration epic #1802. Depends on #1803 (next-version.sh).

## Changes

- Remove `patch`/`minor`/`major` arguments
- Accept no argument (auto-compute via `scripts/next-version.sh --dry-run`) or explicit version string
- Add CalVer format validation for explicit versions (YY.M.MICRO, no zero-padded month)
- Add version transition display (`0.10.1 → 26.6.0`)
- Update SECURITY.md template for CalVer format
- Update error messages and examples to CalVer terminology
- Update quick reference to `/release` (auto) and `/release 26.7.0` (explicit)
- Add `scripts/next-version.sh` to allowed commands

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Switch the release workflow to CalVer**

### What Changed
- The `/release` command now uses CalVer instead of patch/minor/major release types
- Running `/release` with no argument now computes the next version automatically, and explicit CalVer versions are accepted
- Release output now shows the version change in `old → new` form and tags releases with the new CalVer version
- Validation and error messages now cover CalVer rules, including rejection of invalid or zero-padded month versions
- The quick reference and release notes now reflect CalVer versioning and the new release format

### Impact
`✅ Shorter release steps`
`✅ Fewer invalid version entries`
`✅ Clearer release version output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
