### PR TITLE
feat: CalVer cutover — v0.10.1 → v26.5.0 (#1808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Calendar Versioning](https://calver.org/).
+
+## [26.5.0] - 2026-05-30
+
+### Changed
+
+- Migrated from SemVer (`0.MINOR.PATCH`) to CalVer (`YY.M.MICRO`) versioning
+- Version format is now `YY.M.MICRO` where `YY` = 2-digit year, `M` = unpadded month, `MICRO` = release counter
 
 ## [0.10.1] - 2026-05-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — Rackula
 
 **Project:** Rackula — Rack Layout Designer for Homelabbers
-**Version:** 0.10.1
+**Version:** 26.5.0
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Rackula is currently in active development. Security updates are applied to the 
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 0.10.1   | :white_check_mark: |
-| < 0.10.1 | :x:                |
+| 26.5.0   | :white_check_mark: |
+| < 26.5.0 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rackula/api",
-  "version": "0.1.0",
+  "version": "26.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rackula/api",
-      "version": "0.1.0",
+      "version": "26.5.0",
       "dependencies": {
         "@node-rs/argon2": "^2.0.2",
         "better-auth": "^1.6.2",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rackula/api",
-  "version": "0.1.0",
+  "version": "26.5.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rackula",
-  "version": "0.10.1",
+  "version": "26.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rackula",
-      "version": "0.10.1",
+      "version": "26.5.0",
       "license": "MIT",
       "dependencies": {
         "@lucide/svelte": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rackula",
-  "version": "0.10.1",
+  "version": "26.5.0",
   "description": "Drag and drop rack visualizer",
   "author": "ggfevans",
   "license": "MIT",


### PR DESCRIPTION
## **User description**
## Summary

This is the single atomic commit switching from SemVer to CalVer (`YY.M.MICRO`).

Part of the CalVer migration epic #1802. Depends on all Phase 1 PRs (#1810, #1811, #1812, #1813, #1814) which are already merged.

## Changes

| File | Change |
|------|--------|
| `package.json` | `0.10.1` → `26.5.0` |
| `api/package.json` | `0.1.0` → `26.5.0` (unified with root) |
| `CHANGELOG.md` | Add `[26.5.0]` entry; header changed from Semantic Versioning to Calendar Versioning |
| `SECURITY.md` | Version table updated to `26.5.0` / `< 26.5.0` |
| `CLAUDE.md` | Version field updated to `26.5.0` |

## Verification

- `node -p "require('./package.json').version"` → `26.5.0` ✅
- `node -p "require('./api/package.json').version"` → `26.5.0` ✅
- `grep "^## \[26.5.0\]" CHANGELOG.md` → found ✅
- `scripts/next-version.sh --dry-run` → `26.5.1` (next micro) ✅
- CalVer `26.5.0` > SemVer `0.7.0` (migration thresholds safe) ✅

## Rollback Plan

If the CalVer tag causes unexpected CI failures:
1. Delete the CalVer tag and GitHub Release
2. Revert this commit
3. Re-tag with SemVer `v0.10.2`
4. Phase 1 changes are backward-compatible and need no reverting

Closes #1808

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Switch the project to CalVer release numbering**

### What Changed
- The project version is now `26.5.0` across the main package, API package, and lockfiles
- The changelog now uses Calendar Versioning and adds the new `26.5.0` release entry
- The security policy now marks `26.5.0` as the current supported version
- Project docs now reflect the new version number

### Impact
`✅ Clearer release numbering`
`✅ Updated security support guidance`
`✅ Consistent version shown across project files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
