### PR TITLE
feat: show onboarding hint when rack has no devices

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -32,7 +32,10 @@
   import CanvasContextMenu from "./CanvasContextMenu.svelte";
   import type { DeviceFace, SlotPosition } from "$lib/types";
   import { resolveSelectedDevice } from "$lib/utils/device-selection";
+  import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
   // Note: PlacementIndicator removed - placement UI now integrated into Rack.svelte
+
+  const ONBOARDING_HINT_KEY = "Rackula_onboarding_hint_dismissed";
 
   // Multi-rack mode: use active rack ID from store
 
@@ -172,6 +175,13 @@
   const activeRackId = $derived(layoutStore.activeRackId);
   const hasRacks = $derived(layoutStore.rackCount > 0);
   const rackGroups = $derived(layoutStore.rack_groups);
+  const allRacksEmpty = $derived(racks.every((r) => r.devices.length === 0));
+  let hintDismissed = $state(safeGetItem(ONBOARDING_HINT_KEY) === "1");
+
+  function dismissOnboardingHint() {
+    safeSetItem(ONBOARDING_HINT_KEY, "1");
+    hintDismissed = true;
+  }
 
   // Organize racks: grouped racks in their groups, then ungrouped racks
   const organizedRacks = $derived.by(() => {
@@ -717,6 +727,20 @@
     {#if deviceListDescription}
       <p id="canvas-device-list" class="sr-only">{deviceListDescription}</p>
     {/if}
+
+    {#if hasRacks && allRacksEmpty && !hintDismissed}
+      <div class="onboarding-hint" role="status" aria-live="polite">
+        <span
+          >Open the Devices tab on the left and drag items into your rack.</span
+        >
+        <button
+          class="hint-dismiss"
+          onclick={dismissOnboardingHint}
+          aria-label="Dismiss hint">x</button
+        >
+      </div>
+    {/if}
+
     {#if hasRacks}
       <div class="panzoom-container" bind:this={panzoomContainer}>
         <!-- Multi-rack mode: render racks with visual grouping -->
@@ -988,5 +1012,39 @@
     .racks-wrapper.swipe-previous {
       animation: none;
     }
+  }
+
+  .onboarding-hint {
+    position: absolute;
+    bottom: var(--space-6, 24px);
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: var(--space-3, 12px);
+    padding: var(--space-3, 12px) var(--space-4, 16px);
+    background: var(--colour-surface, rgba(40, 42, 54, 0.92));
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md, 6px);
+    color: var(--colour-text-muted);
+    font-size: var(--font-size-sm);
+    white-space: nowrap;
+    pointer-events: auto;
+    z-index: 10;
+  }
+
+  .hint-dismiss {
+    background: none;
+    border: none;
+    color: var(--colour-text-muted);
+    cursor: pointer;
+    padding: 0 var(--space-1, 4px);
+    font-size: var(--font-size-base);
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  .hint-dismiss:hover {
+    color: var(--colour-text);
   }
 </style>

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1028,8 +1028,8 @@
     border-radius: var(--radius-md, 6px);
     color: var(--colour-text-muted);
     font-size: var(--font-size-sm);
-    white-space: nowrap;
-    pointer-events: auto;
+    max-width: min(90%, 480px);
+    pointer-events: none;
     z-index: 10;
   }
 
@@ -1042,6 +1042,7 @@
     font-size: var(--font-size-base);
     line-height: 1;
     flex-shrink: 0;
+    pointer-events: auto;
   }
 
   .hint-dismiss:hover {

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1038,11 +1038,15 @@
     border: none;
     color: var(--colour-text-muted);
     cursor: pointer;
-    padding: 0 var(--space-1, 4px);
     font-size: var(--font-size-base);
     line-height: 1;
     flex-shrink: 0;
     pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    min-height: 24px;
   }
 
   .hint-dismiss:hover {


### PR DESCRIPTION
## **User description**
## Summary

- Adds a dismissable hint bar at the bottom of the canvas when a rack exists but has no devices placed in it
- Hint reads: "Open the Devices tab on the left and drag items into your rack."
- Dismissal is stored in localStorage (`Rackula_onboarding_hint_dismissed`) so it never re-appears after the user has seen it
- Hint also disappears automatically the moment any device is placed in any rack

## Why

After creating their first rack, new users see an empty rack with no indication of how to populate it. The Devices tab on the left sidebar is the primary way to add devices, but it's not obvious. This addresses the discovery gap without being intrusive.

## Implementation

Single-file change to `Canvas.svelte`:
- `allRacksEmpty` derived state watches all racks for device count
- `hintDismissed` reads the localStorage flag on mount
- `dismissOnboardingHint()` writes the flag and hides the hint immediately
- The hint renders as an absolutely-positioned bar inside `.canvas` with `pointer-events: auto` so it doesn't block panzoom interactions on the canvas background

## Test plan

- [ ] Create a new rack - hint appears at bottom of canvas
- [ ] Drag a device into the rack - hint disappears immediately
- [ ] Dismiss hint via "x" button - hint gone, localStorage key set
- [ ] Reload page with key set - hint does not reappear
- [ ] User who already has devices in racks - hint never appears

Closes #111

_Generated by [Claude Code](https://claude.ai/code/session_01TRbxwjkJrXQbCDnUUiDyof)_


___

## **CodeAnt-AI Description**
**Show a dismissible onboarding hint for empty racks**

### What Changed
- When a rack exists but none of the racks has devices, the canvas shows a hint telling users to open the Devices tab and drag items into the rack.
- Dismissing the hint hides it for that browser, and it stays hidden after reload.
- The hint also disappears as soon as any device is added to a rack.
- On narrow screens, the hint now wraps instead of overflowing, and the canvas still responds to pan and zoom gestures.
- The dismiss button has a larger touch target so it is easier to tap on mobile.

### Impact
`✅ Clearer first-time rack setup`
`✅ Fewer empty-canvas dead ends`
`✅ Easier mobile hint dismissal`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
