### PR TITLE
feat(api): explicit mutating-request origin policy (#1779)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -398,12 +398,13 @@ export async function createApp(
 
   // Origin policy: enforce trusted origins on mutating requests (POST, PUT, PATCH, DELETE).
   // Fills the gap between CSRF (session-auth only) and write-token auth (no origin check).
-  // Non-browser clients with Bearer auth bypass origin checks.
+  // Non-browser clients with valid write auth tokens bypass origin checks.
   app.use(
     "*",
     createOriginPolicyMiddleware({
       originPolicyEnabled: securityConfig.originPolicyEnabled,
       csrfTrustedOrigins: securityConfig.csrfTrustedOrigins,
+      writeAuthToken: securityConfig.writeAuthToken,
     }),
   );
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -10,6 +10,7 @@ import {
   createAuthGateMiddleware,
   createCsrfProtectionMiddleware,
   createExpiredAuthSessionCookieHeader,
+  createOriginPolicyMiddleware,
   createRefreshedAuthSessionCookieHeader,
   createWriteAuthMiddleware,
   invalidateAuthSession,
@@ -392,6 +393,17 @@ export async function createApp(
       csrfProtectionEnabled: securityConfig.csrfProtectionEnabled,
       csrfTrustedOrigins: securityConfig.csrfTrustedOrigins,
       authSessionCookieName: securityConfig.authSessionCookieName,
+    }),
+  );
+
+  // Origin policy: enforce trusted origins on mutating requests (POST, PUT, PATCH, DELETE).
+  // Fills the gap between CSRF (session-auth only) and write-token auth (no origin check).
+  // Non-browser clients with Bearer auth bypass origin checks.
+  app.use(
+    "*",
+    createOriginPolicyMiddleware({
+      originPolicyEnabled: securityConfig.originPolicyEnabled,
+      csrfTrustedOrigins: securityConfig.csrfTrustedOrigins,
     }),
   );
 

--- a/api/src/security/config.ts
+++ b/api/src/security/config.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomBytes } from "node:crypto";
 import { MIN_AUTH_LOG_HASH_KEY_LENGTH } from "../auth-logger";
-import { normalizeOrigin } from "./csrf";
+import { normalizeOrigin } from "./request-utils";
 import type {
   ApiSecurityConfig,
   AuthMode,
@@ -365,6 +365,11 @@ export function resolveApiSecurityConfig(
     );
   }
 
+  // Origin policy is enabled when auth is enabled and CSRF protection is active
+  // (both require explicit trusted origins). When disabled (no auth or wildcard
+  // CORS), origin checks are redundant — write-token auth alone protects write routes.
+  const originPolicyEnabled = authEnabled && csrfProtectionEnabled;
+
   return {
     corsOrigin,
     allowInsecureCors,
@@ -383,5 +388,6 @@ export function resolveApiSecurityConfig(
     authLoginPath,
     csrfProtectionEnabled,
     csrfTrustedOrigins,
+    originPolicyEnabled,
   };
 }

--- a/api/src/security/csrf.ts
+++ b/api/src/security/csrf.ts
@@ -1,5 +1,9 @@
 import type { MiddlewareHandler } from "hono";
 import { extractCookieValue } from "./cookies";
+import {
+  resolveRequestOrigin,
+  isTrustedOrigin,
+} from "./request-utils";
 import { STATE_CHANGING_METHODS, type ApiSecurityConfig } from "./types";
 
 // Paths that bypass CSRF validation — only safe GET-like auth bootstrap endpoints.
@@ -15,54 +19,8 @@ const CSRF_EXEMPT_AUTH_PATHS = new Set([
   "/api/auth/check",
 ]);
 
-/**
- * Normalizes a URL string to its `origin` form (`scheme://host[:port]`).
- *
- * @throws Error when the input is not a parseable URL.
- */
-export function normalizeOrigin(input: string): string {
-  try {
-    const url = new URL(input);
-    return url.origin;
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    throw new Error(`Invalid CORS origin "${input}": ${reason}`, {
-      cause: error,
-    });
-  }
-}
-
 function isStateChangingMethod(method: string): boolean {
   return STATE_CHANGING_METHODS.has(method.toUpperCase());
-}
-
-function resolveRequestOrigin(request: Request): string | null {
-  const originHeader = request.headers.get("origin");
-  if (originHeader && originHeader !== "null") {
-    try {
-      return normalizeOrigin(originHeader);
-    } catch {
-      return null;
-    }
-  }
-
-  const refererHeader = request.headers.get("referer");
-  if (!refererHeader) {
-    return null;
-  }
-
-  try {
-    return new URL(refererHeader).origin;
-  } catch {
-    return null;
-  }
-}
-
-function isTrustedOrigin(
-  requestOrigin: string,
-  trustedOrigins: string[],
-): boolean {
-  return trustedOrigins.includes(requestOrigin);
 }
 
 /**

--- a/api/src/security/index.ts
+++ b/api/src/security/index.ts
@@ -29,9 +29,13 @@ export {
 
 export { createCsrfProtectionMiddleware } from "./csrf";
 
+export { normalizeOrigin } from "./request-utils";
+
 export {
   createAuthGateMiddleware,
   createWriteAuthMiddleware,
 } from "./middleware";
+
+export { createOriginPolicyMiddleware } from "./origin-policy";
 
 export { resolveApiSecurityConfig } from "./config";

--- a/api/src/security/index.ts
+++ b/api/src/security/index.ts
@@ -34,6 +34,7 @@ export { normalizeOrigin } from "./request-utils";
 export {
   createAuthGateMiddleware,
   createWriteAuthMiddleware,
+  AUTH_PUBLIC_PATHS,
 } from "./middleware";
 
 export { createOriginPolicyMiddleware } from "./origin-policy";

--- a/api/src/security/middleware.ts
+++ b/api/src/security/middleware.ts
@@ -8,7 +8,7 @@ import {
 import type { ApiSecurityConfig, AuthSessionClaims } from "./types";
 
 const WRITE_METHODS = new Set(["PUT", "DELETE"]);
-const AUTH_PUBLIC_PATHS = new Set([
+const _AUTH_PUBLIC_PATHS = new Set([
   "/health",
   "/api/health",
   "/version",
@@ -22,6 +22,8 @@ const AUTH_PUBLIC_PATHS = new Set([
   "/api/auth/check",
   "/api/auth/logout",
 ]);
+/** Immutable set of paths exempt from auth and rate limiting. */
+export const AUTH_PUBLIC_PATHS: ReadonlySet<string> = _AUTH_PUBLIC_PATHS;
 const API_ROUTE_PREFIXES = ["/api", "/layouts", "/assets"];
 
 function timingSafeTokenCompare(
@@ -40,7 +42,7 @@ function isApiRequestPath(pathname: string): boolean {
 }
 
 function isAuthPublicPath(pathname: string): boolean {
-  return AUTH_PUBLIC_PATHS.has(pathname);
+  return _AUTH_PUBLIC_PATHS.has(pathname);
 }
 
 function buildLoginRedirectUrl(requestUrl: string, loginPath: string): string {

--- a/api/src/security/origin-policy.test.ts
+++ b/api/src/security/origin-policy.test.ts
@@ -3,12 +3,15 @@ import { Hono } from "hono";
 import { createOriginPolicyMiddleware } from "./origin-policy";
 import type { ApiSecurityConfig } from "./types";
 
+const TEST_WRITE_TOKEN = "test-secret-token-32chars-long!!";
+
 function makeConfig(
-  overrides: Partial<Pick<ApiSecurityConfig, "originPolicyEnabled" | "csrfTrustedOrigins">> = {},
-): Pick<ApiSecurityConfig, "originPolicyEnabled" | "csrfTrustedOrigins"> {
+  overrides: Partial<Pick<ApiSecurityConfig, "originPolicyEnabled" | "csrfTrustedOrigins" | "writeAuthToken">> = {},
+): Pick<ApiSecurityConfig, "originPolicyEnabled" | "csrfTrustedOrigins" | "writeAuthToken"> {
   return {
     originPolicyEnabled: true,
     csrfTrustedOrigins: ["https://racku.la", "https://count.racku.la"],
+    writeAuthToken: TEST_WRITE_TOKEN,
     ...overrides,
   };
 }
@@ -43,23 +46,42 @@ describe("createOriginPolicyMiddleware", () => {
     expect(getRes.status).toBe(200);
   });
 
-  it("allows PUT/DELETE with no Origin when Bearer token is present", async () => {
+  it("allows PUT/DELETE with no Origin when valid Bearer token is present", async () => {
     const app = createTestApp(makeConfig());
     const res = await app.request("/layouts/1", {
       method: "PUT",
-      headers: { Authorization: "Bearer test-token" },
+      headers: { Authorization: `Bearer ${TEST_WRITE_TOKEN}` },
     });
     // No Origin header but valid auth -> allowed
     expect(res.status).toBe(200);
   });
 
-  it("allows POST with no Origin when Bearer token is present", async () => {
+  it("allows POST with no Origin when valid Bearer token is present", async () => {
     const app = createTestApp(makeConfig());
     const res = await app.request("/layouts", {
       method: "POST",
-      headers: { Authorization: "Bearer test-token" },
+      headers: { Authorization: `Bearer ${TEST_WRITE_TOKEN}` },
     });
     expect(res.status).toBe(200);
+  });
+
+  it("blocks PUT with invalid Bearer token", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Authorization: "Bearer wrong-token" },
+    });
+    // Invalid token does not bypass origin check
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks PUT with no write auth token configured and no Origin", async () => {
+    const app = createTestApp(makeConfig({ writeAuthToken: undefined }));
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+    });
+    // No writeAuthToken -> no Bearer bypass -> no Origin -> block
+    expect(res.status).toBe(403);
   });
 
   // --- Origin validation on mutating routes ---
@@ -142,18 +164,31 @@ describe("createOriginPolicyMiddleware", () => {
 
   // --- Edge cases ---
 
-  it("treats literal 'null' Origin header as absent", async () => {
+  it("treats literal 'null' Origin header as absent, falls through to Referer", async () => {
     const app = createTestApp(makeConfig());
-    // "null" Origin is a known attack vector — should fall through to Referer or reject
+    // "null" Origin is a known attack vector — should fall through to Referer
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: {
+        Origin: "null",
+        Referer: "https://racku.la/layouts",
+      },
+    });
+    // Falls through to Referer, which is trusted -> allowed
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks when 'null' Origin and no Referer", async () => {
+    const app = createTestApp(makeConfig());
     const res = await app.request("/layouts/1", {
       method: "PUT",
       headers: { Origin: "null" },
     });
-    // No Referer either, no Bearer token -> block
+    // No Referer either, no valid Bearer token -> block
     expect(res.status).toBe(403);
   });
 
-  it("blocks mutating request with no Origin, no Referer, and no Bearer token", async () => {
+  it("blocks mutating request with no Origin, no Referer, and no valid Bearer token", async () => {
     const app = createTestApp(makeConfig());
     const res = await app.request("/layouts/1", {
       method: "PUT",
@@ -167,11 +202,24 @@ describe("createOriginPolicyMiddleware", () => {
       method: "PUT",
       headers: {
         Origin: "https://evil.example.com",
-        Authorization: "Bearer test-token",
+        Authorization: `Bearer ${TEST_WRITE_TOKEN}`,
       },
     });
-    // Bearer token overrides origin check — non-browser clients may not send Origin
+    // Valid Bearer token overrides origin check
     expect(res.status).toBe(200);
+  });
+
+  it("blocks mutating request with untrusted Origin and invalid Bearer token", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: {
+        Origin: "https://evil.example.com",
+        Authorization: "Bearer wrong-token",
+      },
+    });
+    // Invalid Bearer token does not override origin check
+    expect(res.status).toBe(403);
   });
 
   it("blocks PATCH requests with untrusted origin (PATCH is a state-changing method)", async () => {
@@ -180,7 +228,6 @@ describe("createOriginPolicyMiddleware", () => {
       method: "PATCH",
       headers: { Origin: "https://evil.example.com" },
     });
-    // PATCH is in STATE_CHANGING_METHODS, so origin policy applies
     expect(res.status).toBe(403);
   });
 
@@ -191,5 +238,15 @@ describe("createOriginPolicyMiddleware", () => {
       headers: { Origin: "https://racku.la" },
     });
     expect(res.status).toBe(200);
+  });
+
+  it("blocks mutating request with malformed Origin header", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Origin: "not a url" },
+    });
+    // Malformed Origin fails parsing, falls through to Referer (absent) -> block
+    expect(res.status).toBe(403);
   });
 });

--- a/api/src/security/origin-policy.test.ts
+++ b/api/src/security/origin-policy.test.ts
@@ -249,4 +249,17 @@ describe("createOriginPolicyMiddleware", () => {
     // Malformed Origin fails parsing, falls through to Referer (absent) -> block
     expect(res.status).toBe(403);
   });
+
+  it("falls through to Referer when Origin is malformed", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: {
+        Origin: "not a url",
+        Referer: "https://racku.la/layouts",
+      },
+    });
+    // Malformed Origin is ignored, Referer origin is trusted -> allowed
+    expect(res.status).toBe(200);
+  });
 });

--- a/api/src/security/origin-policy.test.ts
+++ b/api/src/security/origin-policy.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { createOriginPolicyMiddleware } from "./origin-policy";
+import type { ApiSecurityConfig } from "./types";
+
+function makeConfig(
+  overrides: Partial<Pick<ApiSecurityConfig, "originPolicyEnabled" | "csrfTrustedOrigins">> = {},
+): Pick<ApiSecurityConfig, "originPolicyEnabled" | "csrfTrustedOrigins"> {
+  return {
+    originPolicyEnabled: true,
+    csrfTrustedOrigins: ["https://racku.la", "https://count.racku.la"],
+    ...overrides,
+  };
+}
+
+function createTestApp(config: ReturnType<typeof makeConfig>) {
+  const app = new Hono();
+  app.use("*", createOriginPolicyMiddleware(config));
+  app.put("/layouts/:id", (c) => c.json({ ok: true }));
+  app.delete("/layouts/:id", (c) => c.json({ ok: true }));
+  app.post("/layouts", (c) => c.json({ ok: true }));
+  app.patch("/layouts/:id", (c) => c.json({ ok: true }));
+  app.get("/layouts", (c) => c.json({ ok: true }));
+  return app;
+}
+
+describe("createOriginPolicyMiddleware", () => {
+  // --- Skip behaviour ---
+
+  it("skips origin checks when origin policy is disabled", async () => {
+    const app = createTestApp(makeConfig({ originPolicyEnabled: false }));
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Origin: "https://evil.example.com" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("skips non-mutating methods (GET)", async () => {
+    const app = createTestApp(makeConfig());
+
+    const getRes = await app.request("/layouts");
+    expect(getRes.status).toBe(200);
+  });
+
+  it("allows PUT/DELETE with no Origin when Bearer token is present", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Authorization: "Bearer test-token" },
+    });
+    // No Origin header but valid auth -> allowed
+    expect(res.status).toBe(200);
+  });
+
+  it("allows POST with no Origin when Bearer token is present", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-token" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  // --- Origin validation on mutating routes ---
+
+  it("blocks PUT with untrusted Origin", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Origin: "https://evil.example.com" },
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("blocks DELETE with untrusted Origin", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "DELETE",
+      headers: { Origin: "https://evil.example.com" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks POST with untrusted Origin", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts", {
+      method: "POST",
+      headers: { Origin: "https://evil.example.com" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows PUT with trusted Origin", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Origin: "https://racku.la" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows DELETE with trusted Origin", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "DELETE",
+      headers: { Origin: "https://count.racku.la" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows POST with trusted Origin", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts", {
+      method: "POST",
+      headers: { Origin: "https://racku.la" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  // --- Referer fallback ---
+
+  it("uses Referer header as fallback when Origin is absent", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Referer: "https://racku.la/layouts" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks when Referer origin is untrusted", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Referer: "https://evil.example.com/page" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  // --- Edge cases ---
+
+  it("treats literal 'null' Origin header as absent", async () => {
+    const app = createTestApp(makeConfig());
+    // "null" Origin is a known attack vector — should fall through to Referer or reject
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: { Origin: "null" },
+    });
+    // No Referer either, no Bearer token -> block
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks mutating request with no Origin, no Referer, and no Bearer token", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows mutating request with untrusted Origin but valid Bearer token", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PUT",
+      headers: {
+        Origin: "https://evil.example.com",
+        Authorization: "Bearer test-token",
+      },
+    });
+    // Bearer token overrides origin check — non-browser clients may not send Origin
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks PATCH requests with untrusted origin (PATCH is a state-changing method)", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PATCH",
+      headers: { Origin: "https://evil.example.com" },
+    });
+    // PATCH is in STATE_CHANGING_METHODS, so origin policy applies
+    expect(res.status).toBe(403);
+  });
+
+  it("allows PATCH requests with trusted origin", async () => {
+    const app = createTestApp(makeConfig());
+    const res = await app.request("/layouts/1", {
+      method: "PATCH",
+      headers: { Origin: "https://racku.la" },
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/api/src/security/origin-policy.ts
+++ b/api/src/security/origin-policy.ts
@@ -1,0 +1,81 @@
+/**
+ * Origin policy middleware for mutating (write) API routes.
+ *
+ * Enforces that state-changing requests (POST, PUT, PATCH, DELETE) originate
+ * from a trusted origin. This fills the gap between CSRF protection (which
+ * only covers session-authenticated requests) and write-token auth (which
+ * only validates bearer tokens without checking origin).
+ *
+ * Non-browser clients (curl, API tools) that send a valid `Authorization`
+ * header bypass origin checks, since they may not include an `Origin` header.
+ *
+ * @module origin-policy
+ */
+
+import type { MiddlewareHandler } from "hono";
+import { resolveRequestOrigin, isTrustedOrigin } from "./request-utils";
+import { STATE_CHANGING_METHODS, type ApiSecurityConfig } from "./types";
+
+/**
+ * Creates middleware that enforces an origin policy on mutating requests.
+ *
+ * @param securityConfig - Origin policy enablement and trusted origins.
+ * @returns Hono middleware that returns `403` JSON for origin policy violations.
+ * @remarks
+ * - Skips entirely when `originPolicyEnabled` is false.
+ * - Skips non-mutating methods (GET, HEAD, OPTIONS).
+ * - Allows requests with a valid `Authorization: Bearer` header regardless of origin.
+ * - Falls back from `Origin` to `Referer` header for origin resolution.
+ * - Blocks mutating requests with no origin and no auth token.
+ */
+export function createOriginPolicyMiddleware(
+  securityConfig: Pick<
+    ApiSecurityConfig,
+    "originPolicyEnabled" | "csrfTrustedOrigins"
+  >,
+): MiddlewareHandler {
+  return async (c, next): Promise<void | Response> => {
+    if (!securityConfig.originPolicyEnabled) {
+      await next();
+      return;
+    }
+
+    if (!STATE_CHANGING_METHODS.has(c.req.method.toUpperCase())) {
+      await next();
+      return;
+    }
+
+    // Non-browser clients with bearer auth bypass origin checks.
+    const authorization = c.req.header("Authorization");
+    if (authorization?.match(/^Bearer\s+\S+$/i)) {
+      await next();
+      return;
+    }
+
+    const requestOrigin = resolveRequestOrigin(c.req.raw);
+
+    // No origin and no auth token: block the request.
+    if (!requestOrigin) {
+      return c.json(
+        {
+          error: "Forbidden",
+          message:
+            "Origin policy: mutating requests require an Origin or Referer header, or a Bearer authorization token.",
+        },
+        403,
+      );
+    }
+
+    if (!isTrustedOrigin(requestOrigin, securityConfig.csrfTrustedOrigins)) {
+      return c.json(
+        {
+          error: "Forbidden",
+          message: "Origin policy: request origin is not allowed.",
+        },
+        403,
+      );
+    }
+
+    await next();
+  };
+}

--- a/api/src/security/origin-policy.ts
+++ b/api/src/security/origin-policy.ts
@@ -6,32 +6,45 @@
  * only covers session-authenticated requests) and write-token auth (which
  * only validates bearer tokens without checking origin).
  *
- * Non-browser clients (curl, API tools) that send a valid `Authorization`
- * header bypass origin checks, since they may not include an `Origin` header.
+ * Non-browser clients (curl, API tools) that present a valid write auth
+ * bearer token bypass origin checks, since they may not include an Origin
+ * header. The token is validated via timing-safe comparison against the
+ * configured write auth token.
  *
  * @module origin-policy
  */
 
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { MiddlewareHandler } from "hono";
 import { resolveRequestOrigin, isTrustedOrigin } from "./request-utils";
 import { STATE_CHANGING_METHODS, type ApiSecurityConfig } from "./types";
 
 /**
+ * Timing-safe comparison of two strings using SHA-256 hashing.
+ * Returns true if the strings are equal.
+ */
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const aHash = createHash("sha256").update(a).digest();
+  const bHash = createHash("sha256").update(b).digest();
+  return timingSafeEqual(aHash, bHash);
+}
+
+/**
  * Creates middleware that enforces an origin policy on mutating requests.
  *
- * @param securityConfig - Origin policy enablement and trusted origins.
+ * @param securityConfig - Origin policy enablement, trusted origins, and write auth token.
  * @returns Hono middleware that returns `403` JSON for origin policy violations.
  * @remarks
  * - Skips entirely when `originPolicyEnabled` is false.
  * - Skips non-mutating methods (GET, HEAD, OPTIONS).
- * - Allows requests with a valid `Authorization: Bearer` header regardless of origin.
+ * - Allows requests with a valid write auth bearer token regardless of origin.
  * - Falls back from `Origin` to `Referer` header for origin resolution.
- * - Blocks mutating requests with no origin and no auth token.
+ * - Blocks mutating requests with no origin and no valid auth token.
  */
 export function createOriginPolicyMiddleware(
   securityConfig: Pick<
     ApiSecurityConfig,
-    "originPolicyEnabled" | "csrfTrustedOrigins"
+    "originPolicyEnabled" | "csrfTrustedOrigins" | "writeAuthToken"
   >,
 ): MiddlewareHandler {
   return async (c, next): Promise<void | Response> => {
@@ -45,22 +58,25 @@ export function createOriginPolicyMiddleware(
       return;
     }
 
-    // Non-browser clients with bearer auth bypass origin checks.
-    const authorization = c.req.header("Authorization");
-    if (authorization?.match(/^Bearer\s+\S+$/i)) {
-      await next();
-      return;
+    // Non-browser clients with a valid write auth bearer token bypass origin checks.
+    if (securityConfig.writeAuthToken) {
+      const authorization = c.req.header("Authorization");
+      const match = authorization?.match(/^Bearer\s+(.+)$/i);
+      if (match?.[1] && timingSafeStringEqual(match[1].trim(), securityConfig.writeAuthToken)) {
+        await next();
+        return;
+      }
     }
 
     const requestOrigin = resolveRequestOrigin(c.req.raw);
 
-    // No origin and no auth token: block the request.
+    // No origin and no valid auth token: block the request.
     if (!requestOrigin) {
       return c.json(
         {
           error: "Forbidden",
           message:
-            "Origin policy: mutating requests require an Origin or Referer header, or a Bearer authorization token.",
+            "Origin policy: mutating requests require an Origin or Referer header, or a valid Bearer authorization token.",
         },
         403,
       );

--- a/api/src/security/origin-policy.ts
+++ b/api/src/security/origin-policy.ts
@@ -17,6 +17,7 @@
 import { createHash, timingSafeEqual } from "node:crypto";
 import type { MiddlewareHandler } from "hono";
 import { resolveRequestOrigin, isTrustedOrigin } from "./request-utils";
+import { AUTH_PUBLIC_PATHS } from "./middleware";
 import { STATE_CHANGING_METHODS, type ApiSecurityConfig } from "./types";
 
 /**
@@ -54,6 +55,14 @@ export function createOriginPolicyMiddleware(
     }
 
     if (!STATE_CHANGING_METHODS.has(c.req.method.toUpperCase())) {
+      await next();
+      return;
+    }
+
+    // Auth and health endpoints are exempt from origin checks.
+    // Login forms must be accessible without an Origin header.
+    const { pathname } = new URL(c.req.url);
+    if (AUTH_PUBLIC_PATHS.has(pathname)) {
       await next();
       return;
     }

--- a/api/src/security/request-utils.ts
+++ b/api/src/security/request-utils.ts
@@ -28,6 +28,11 @@ export function normalizeOrigin(input: string): string {
  * to the `Referer` header's origin. Returns `null` when neither header is
  * present or parseable. Treats the literal string `"null"` as absent
  * (a known CSRF attack vector).
+ *
+ * When `Origin` is present but malformed, falls through to `Referer` rather
+ * than rejecting immediately. This avoids false 403s for requests that
+ * include a valid Referer but a garbled Origin (e.g., from misconfigured
+ * proxies).
  */
 export function resolveRequestOrigin(request: Request): string | null {
   const originHeader = request.headers.get("origin");
@@ -35,7 +40,7 @@ export function resolveRequestOrigin(request: Request): string | null {
     try {
       return normalizeOrigin(originHeader);
     } catch {
-      return null;
+      // Malformed Origin: fall through to Referer rather than rejecting.
     }
   }
 

--- a/api/src/security/request-utils.ts
+++ b/api/src/security/request-utils.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared request utilities used by CSRF and origin-policy middleware.
+ *
+ * @module request-utils
+ */
+
+/**
+ * Normalizes a URL string to its `origin` form (`scheme://host[:port]`).
+ *
+ * @throws Error when the input is not a parseable URL.
+ */
+export function normalizeOrigin(input: string): string {
+  try {
+    const url = new URL(input);
+    return url.origin;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid CORS origin "${input}": ${reason}`, {
+      cause: error,
+    });
+  }
+}
+
+/**
+ * Resolves the origin of a request from `Origin` or `Referer` headers.
+ *
+ * Checks the `Origin` header first (standard for CORS/CSRF), then falls back
+ * to the `Referer` header's origin. Returns `null` when neither header is
+ * present or parseable. Treats the literal string `"null"` as absent
+ * (a known CSRF attack vector).
+ */
+export function resolveRequestOrigin(request: Request): string | null {
+  const originHeader = request.headers.get("origin");
+  if (originHeader && originHeader !== "null") {
+    try {
+      return normalizeOrigin(originHeader);
+    } catch {
+      return null;
+    }
+  }
+
+  const refererHeader = request.headers.get("referer");
+  if (!refererHeader) {
+    return null;
+  }
+
+  try {
+    return new URL(refererHeader).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks whether an origin string is in the list of trusted origins.
+ */
+export function isTrustedOrigin(
+  requestOrigin: string,
+  trustedOrigins: string[],
+): boolean {
+  return trustedOrigins.includes(requestOrigin);
+}

--- a/api/src/security/types.ts
+++ b/api/src/security/types.ts
@@ -54,6 +54,7 @@ export interface ApiSecurityConfig {
   authLoginPath: string;
   csrfProtectionEnabled: boolean;
   csrfTrustedOrigins: string[];
+  originPolicyEnabled: boolean;
   localCredentials?: LocalCredentials;
 }
 

--- a/docs/deployment/AUTHENTICATION.md
+++ b/docs/deployment/AUTHENTICATION.md
@@ -557,7 +557,7 @@ Rackula includes structured authentication event logging via `auth-logger.ts`:
 
 ## Origin Policy for Mutating Requests
 
-When authentication and CSRF protection are both enabled, Rackula enforces an origin policy on state-changing requests (POST, PUT, PATCH, DELETE). This ensures that even if a session cookie is not present (e.g., API-only access), mutating requests must originate from a trusted domain.
+When authentication and CSRF protection are both enabled, Rackula enforces an origin policy on state-changing requests (POST, PUT, PATCH, DELETE). This ensures that even if a session cookie is not present (e.g., API-only access), mutating requests must originate from a trusted domain unless they carry a valid write auth bearer token.
 
 ### How It Works
 

--- a/docs/deployment/AUTHENTICATION.md
+++ b/docs/deployment/AUTHENTICATION.md
@@ -555,6 +555,38 @@ Rackula includes structured authentication event logging via `auth-logger.ts`:
 - **Privacy:** User identifiers are pseudonymized via HMAC (configurable with `RACKULA_AUTH_LOG_HASH_KEY`)
 - **Security:** Sensitive headers (e.g., `Authorization`, `Cookie`) are automatically redacted
 
+## Origin Policy for Mutating Requests
+
+When authentication and CSRF protection are both enabled, Rackula enforces an origin policy on state-changing requests (POST, PUT, PATCH, DELETE). This ensures that even if a session cookie is not present (e.g., API-only access), mutating requests must originate from a trusted domain.
+
+### How It Works
+
+1. For every state-changing request, the middleware checks the `Origin` header (or falls back to the `Referer` header's origin)
+2. If the origin is not in the trusted origins list (derived from `CORS_ORIGIN`), the request is rejected with `403 Forbidden`
+3. If neither `Origin` nor `Referer` is present and the request has no `Authorization: Bearer` header, it is rejected with `403 Forbidden`
+
+### Non-Browser Client Access
+
+API clients (curl, scripting tools, monitoring systems) that send a valid `Authorization: Bearer` header bypass origin checks entirely. This allows automated tools to make mutating requests without needing to set an `Origin` header:
+
+```bash
+# Allowed: Bearer token bypasses origin check
+curl -X PUT https://racku.la/api/layouts/my-layout \
+  -H "Authorization: Bearer $RACKULA_API_WRITE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my layout"}'
+
+# Blocked: no origin and no auth token
+curl -X PUT https://racku.la/api/layouts/my-layout \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my layout"}'
+# Returns 403: Origin policy: mutating requests require an Origin or Referer header, or a Bearer authorization token.
+```
+
+### When Origin Policy Is Active
+
+Origin policy is active when both `RACKULA_AUTH_MODE` is not `none` and `RACKULA_AUTH_CSRF_PROTECTION` is true (the default when auth is enabled). When auth is disabled (`RACKULA_AUTH_MODE=none`), origin policy is also disabled since there are no trusted origins to validate against.
+
 ## Reverse Proxy Defense-in-Depth
 
 Rackula's production deployment uses nginx as a reverse proxy with `auth_request` to enforce authentication at the edge — before requests reach the API. This section documents the architecture for operators who need to understand or customise the proxy layer.


### PR DESCRIPTION
## **User description**
## Summary

Add origin policy middleware that enforces trusted origins on state-changing requests (POST, PUT, PATCH, DELETE). This fills the gap between CSRF protection (session-authenticated only) and write-token auth (bearer token only, no origin check).

### Changes
- **`request-utils.ts`**: Extract `resolveRequestOrigin`, `normalizeOrigin`, `isTrustedOrigin` from csrf.ts into a shared module
- **`origin-policy.ts`**: New `createOriginPolicyMiddleware` that checks Origin/Referer on mutating requests
- **`origin-policy.test.ts`**: 17 tests covering skip conditions, origin validation, Referer fallback, null Origin handling, and Bearer auth bypass
- **`config.ts`**: Add `originPolicyEnabled` (derived from `authEnabled && csrfProtectionEnabled`)
- **`types.ts`**: Add `originPolicyEnabled` to `ApiSecurityConfig`
- **`csrf.ts`**: Import from shared `request-utils.ts` instead of local definitions
- **`app.ts`**: Wire origin policy middleware after CSRF, before write-auth

### Design decisions
- Non-browser clients (curl, API tools) with valid `Authorization: Bearer` headers bypass origin checks
- Requests with no Origin/Referer and no Bearer token are blocked (403)
- Origin policy is automatically enabled when auth + CSRF are both active
- Uses the same trusted origins list (`CORS_ORIGIN`) as CSRF protection

### Test plan
- [x] 17 unit tests pass (origin-policy.test.ts)
- [x] Full test suite passes (2026 tests)
- [x] Lint passes
- [x] Build passes
- [ ] CodeRabbit review

Closes #1779


___

## **CodeAnt-AI Description**
**Enforce trusted origins for state-changing API requests**

### What Changed
- Mutating requests now require a trusted `Origin` or `Referer` header unless they use a Bearer token
- Requests from untrusted origins, or with no origin information and no Bearer token, are rejected with `403 Forbidden`
- The same trusted origin list is reused across CSRF and origin checks, and the policy is only active when authentication and CSRF protection are enabled
- Documentation now explains when the policy applies and how API clients can bypass it with Bearer authentication

### Impact
`✅ Fewer cross-site write requests`
`✅ Clearer protection for session-based API actions`
`✅ Fewer blocked API tool requests when using Bearer tokens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
