### PR TITLE
feat: port type categorization (network / power / console)

### DIFF
--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -17,6 +17,7 @@
     showPortTooltip,
     hidePortTooltip,
   } from "$lib/stores/portTooltip.svelte";
+  import { getPortCategory } from "$lib/utils/port-utils";
 
   interface Props {
     interfaces: InterfaceTemplate[];
@@ -61,8 +62,11 @@
     "100gbase-x-qsfp28": "var(--colour-port-qsfp28)", // Pink - QSFP28
   };
 
-  // Default color for unknown types
-  const DEFAULT_COLOR = "var(--colour-port-default)";
+  const CATEGORY_COLORS = {
+    network: "var(--colour-port-default)",
+    console: "var(--colour-port-console)",
+    power: "var(--colour-port-power)",
+  };
 
   // Constants for port rendering
   const PORT_RADIUS = 3;
@@ -77,9 +81,8 @@
   const BADGE_HEIGHT = 8;
   const BADGE_SPACING = 4;
 
-  // Get color for interface type
   function getInterfaceColor(type: InterfaceType): string {
-    return INTERFACE_COLORS[type] ?? DEFAULT_COLOR;
+    return INTERFACE_COLORS[type] ?? CATEGORY_COLORS[getPortCategory(type)];
   }
 
   // Filter interfaces for current view

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -573,6 +573,9 @@
   --colour-dnd-invalid-bg: rgba(203, 58, 42, 0.1);
   --colour-dnd-dragging: var(--alucard-cyan);
 
+  /* Port/Interface Indicators - light theme overrides */
+  --colour-port-power: var(--alucard-orange);
+
   /* Airflow Visualization */
   --colour-airflow-intake: var(--alucard-cyan);
   --colour-airflow-exhaust: var(--alucard-red);

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -281,6 +281,8 @@
   --colour-port-sfp28: var(--amber-500);
   --colour-port-qsfpp: var(--red-500);
   --colour-port-qsfp28: var(--pink-500);
+  --colour-port-console: var(--neutral-400);
+  --colour-port-power: var(--dracula-orange);
   --colour-port-default: var(--neutral-500);
   --colour-port-stroke: rgba(0, 0, 0, 0.3);
   --colour-port-indicator: white;

--- a/src/lib/utils/port-utils.ts
+++ b/src/lib/utils/port-utils.ts
@@ -6,6 +6,28 @@
 import type { DeviceType, PlacedPort } from "$lib/types";
 import { generateId } from "$lib/utils/device";
 
+export type PortCategory = "network" | "power" | "console";
+
+/**
+ * Categorize an interface type string into network, power, or console.
+ * Uses string matching so it handles future types (e.g. power-inlet-*) even
+ * before they are added to the InterfaceType enum.
+ */
+export function getPortCategory(type: string): PortCategory {
+  if (
+    type === "console" ||
+    type.includes("usb") ||
+    type.includes("serial") ||
+    type.includes("de-9")
+  ) {
+    return "console";
+  }
+  if (type.includes("power") || type.includes("iec") || type.includes("nema")) {
+    return "power";
+  }
+  return "network";
+}
+
 /**
  * Instantiate ports from a DeviceType's interface templates
  * Creates PlacedPort instances with stable UUIDs for each interface


### PR DESCRIPTION
## **User description**
## Summary

- Adds `getPortCategory(type: string): PortCategory` utility to `port-utils.ts`, classifying interface type strings into `network`, `power`, or `console` buckets via string-pattern matching.
- Uses string-based matching (not enum membership) so future power types added by #368 (power-inlet-iec-c14, etc.) are handled without touching this function.
- Updates `PortIndicators.svelte` to fall back to a category color when no specific per-type color exists: console ports get neutral gray, power ports get orange, network ports get the existing neutral default.
- Adds two new design tokens: `--colour-port-console` and `--colour-port-power`.

## Why

Issue #276 requested a `getPortCategory` utility to enable category-aware visual styling and filtering of port indicators. Previously all unrecognised types (console, USB, future power) silently fell through to the same neutral gray. Now console and power categories have distinct colors.

## Test Plan

- [x] `npm run lint` - clean
- [x] `npm run test:run` - all 884 unit tests pass
- [x] `npm run build` - builds successfully
- No new unit tests: `getPortCategory` is simple string matching; TypeScript validates the return type.

Closes #276

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqwfM23x5CRSPoA9SPFQkG)_


___

## **CodeAnt-AI Description**
**Show console and power ports with distinct colors**

### What Changed
- Ports that are not matched by a specific type color now fall back to a category color instead of the same generic default
- Console ports display in neutral gray, and power ports display in orange
- Port types are now grouped into network, power, or console so future power and console variants are colored correctly without extra updates

### Impact
`✅ Clearer port identification`
`✅ Fewer confusing “unknown” port colors`
`✅ Correct colors for new power and console port types`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
