### PR TITLE
fix: bust apk-upgrade layer cache to patch libxml2 CVE-2026-6732 (#1841)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -136,6 +136,7 @@ jobs:
             VITE_UMAMI_ENABLED=true
             VITE_UMAMI_SCRIPT_URL=${{ vars.UMAMI_SCRIPT_URL }}
             VITE_UMAMI_WEBSITE_ID=${{ vars.UMAMI_PROD_WEBSITE_ID }}
+            APK_CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
 
   build-persist:
     needs: [validate]
@@ -192,6 +193,7 @@ jobs:
           build-args: |
             VITE_ENV=production
             VITE_PERSIST_ENABLED=true
+            APK_CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
 
   build-api:
     needs: [validate]
@@ -262,6 +264,7 @@ jobs:
             APP_VERSION=${{ needs.validate.outputs.version }}
             APP_COMMIT=${{ env.BUILD_COMMIT }}
             APP_BUILD_TIME=${{ env.BUILD_TIME }}
+            APK_CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
 
   verify-version-alignment:
     name: "Verify Version Alignment"

--- a/.github/workflows/rebuild-images.yml
+++ b/.github/workflows/rebuild-images.yml
@@ -17,6 +17,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Read-only default; jobs that push images or upload SARIF elevate explicitly.
+permissions:
+  contents: read
+
 concurrency:
   group: rebuild-images
   cancel-in-progress: false
@@ -37,6 +41,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Determine latest release tag
         id: rel
@@ -45,7 +50,7 @@ jobs:
         run: |
           TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Latest release tag '$TAG' is not a valid version (expected vYY.M.MICRO)."
+            echo "::error::Latest release tag '$TAG' is not a valid CalVer version (expected e.g. v26.6.0)."
             exit 1
           fi
           VERSION="${TAG#v}"
@@ -70,6 +75,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.resolve.outputs.tag }}
+          persist-credentials: false
 
       - name: Set lowercase image name
         run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
@@ -119,6 +125,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.resolve.outputs.tag }}
+          persist-credentials: false
 
       - name: Set lowercase image name
         run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
@@ -163,6 +170,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.resolve.outputs.tag }}
+          persist-credentials: false
 
       - name: Set lowercase image name
         run: echo "API_IMAGE_NAME=${GITHUB_REPOSITORY,,}-api" >> "$GITHUB_ENV"

--- a/.github/workflows/rebuild-images.yml
+++ b/.github/workflows/rebuild-images.yml
@@ -1,0 +1,255 @@
+name: Rebuild Images (OS patch)
+
+# Proactively refresh OS packages in the published rolling image tags between
+# releases. Rebuilds the latest release's source with a busted apk-upgrade layer
+# cache (APK_CACHEBUST), republishes only the rolling tags (latest / persist /
+# api latest), and rescans. Complements deploy-prod.yml, which only patches at
+# release time. Does NOT deploy to prod.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Monthly, 1st at 06:18 UTC. Multi-arch (arm64 via QEMU) rebuilds are slow,
+    # so monthly balances freshness against CI cost. Offset from CodeQL/Trivy.
+    - cron: "18 6 1 * *"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: rebuild-images
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: "Resolve latest release"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.rel.outputs.tag }}
+      version: ${{ steps.rel.outputs.version }}
+      commit: ${{ steps.rel.outputs.commit }}
+      build_time: ${{ steps.rel.outputs.build_time }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine latest release tag
+        id: rel
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Latest release tag '$TAG' is not a valid version (expected vYY.M.MICRO)."
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          COMMIT=$(git rev-parse --short "${TAG}^{commit}")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          {
+            printf 'tag=%s\n' "$TAG"
+            printf 'version=%s\n' "$VERSION"
+            printf 'commit=%s\n' "$COMMIT"
+            printf 'build_time=%s\n' "$BUILD_TIME"
+          } >> "$GITHUB_OUTPUT"
+          echo "Rebuilding rolling tags from $TAG (version $VERSION, commit $COMMIT)"
+
+  build-frontend:
+    needs: [resolve]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          cache-image: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rebuild and push latest
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest
+          # Full no-cache rebuild: guarantees apk upgrade re-fetches current Alpine
+          # secfixes regardless of whether the resolved release tag's Dockerfile
+          # carries the APK_CACHEBUST arg, and avoids sharing (and racing on)
+          # deploy-prod's release buildcache.
+          no-cache: true
+          build-args: |
+            VITE_ENV=production
+            VITE_UMAMI_ENABLED=true
+            VITE_UMAMI_SCRIPT_URL=${{ vars.UMAMI_SCRIPT_URL }}
+            VITE_UMAMI_WEBSITE_ID=${{ vars.UMAMI_PROD_WEBSITE_ID }}
+
+  build-persist:
+    needs: [resolve]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          cache-image: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rebuild and push persist
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:persist
+          # Full no-cache rebuild (see build-frontend rationale).
+          no-cache: true
+          build-args: |
+            VITE_ENV=production
+            VITE_PERSIST_ENABLED=true
+
+  build-api:
+    needs: [resolve]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Set lowercase image name
+        run: echo "API_IMAGE_NAME=${GITHUB_REPOSITORY,,}-api" >> "$GITHUB_ENV"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          cache-image: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rebuild and push API latest
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ./api
+          file: ./api/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:latest
+          # Full no-cache rebuild (see build-frontend rationale).
+          no-cache: true
+          # Preserve the released version metadata so api:latest keeps reporting
+          # the same version at GET /version after an OS-only rebuild.
+          build-args: |
+            APP_VERSION=${{ needs.resolve.outputs.version }}
+            APP_COMMIT=${{ needs.resolve.outputs.commit }}
+            APP_BUILD_TIME=${{ needs.resolve.outputs.build_time }}
+
+  scan-images:
+    needs: [build-frontend, build-persist, build-api]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - repo_suffix: ""
+            tag: latest
+          - repo_suffix: ""
+            tag: persist
+          - repo_suffix: "-api"
+            tag: latest
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image ref
+        run: |
+          IMAGE_NAME_LC=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_REF="${REGISTRY}/${IMAGE_NAME_LC}${{ matrix.image.repo_suffix }}:${{ matrix.image.tag }}"
+          IMAGE_CATEGORY=$(echo "${IMAGE_REF}" | tr '/:' '--' | tr -cd '[:alnum:]._-')
+          echo "IMAGE_REF=${IMAGE_REF}" >> "$GITHUB_ENV"
+          echo "IMAGE_CATEGORY=${IMAGE_CATEGORY}" >> "$GITHUB_ENV"
+
+      - name: Scan image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_REF }}
+          format: sarif
+          output: trivy-results.sarif
+          limit-severities-for-sarif: true
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: 0
+          version: "v0.70.0"
+
+      - name: Upload scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          sarif_file: trivy-results.sarif
+          # Match deploy-prod/trivy categories so a rebuild refreshes the same
+          # alert set instead of creating duplicates.
+          category: trivy-${{ env.IMAGE_CATEGORY }}

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,8 +12,9 @@ RUN bun install --frozen-lockfile --production
 FROM base AS runner
 WORKDIR /app
 
-# Patch system packages to resolve known CVEs (libssl3/libcrypto3 CVE-2026-31789,
-# libxml2 CVE-2026-6732 et al.). Mirrors the pattern in deploy/Dockerfile.
+# Patch system packages to resolve known CVEs (e.g. libssl3/libcrypto3
+# CVE-2026-31789). The oven/bun:1.3.10-alpine base does not ship libxml2, so
+# CVE-2026-6732 does not apply here; this mirrors deploy/Dockerfile's pattern.
 # APK_CACHEBUST is fed a per-build value so the buildcache for this layer is
 # invalidated each build and apk upgrade re-fetches current Alpine secfixes.
 ARG APK_CACHEBUST=0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,9 +12,12 @@ RUN bun install --frozen-lockfile --production
 FROM base AS runner
 WORKDIR /app
 
-# Patch system packages to resolve known CVEs (libssl3/libcrypto3
-# CVE-2026-31789 et al.). Mirrors the pattern in deploy/Dockerfile.
-RUN apk upgrade --no-cache
+# Patch system packages to resolve known CVEs (libssl3/libcrypto3 CVE-2026-31789,
+# libxml2 CVE-2026-6732 et al.). Mirrors the pattern in deploy/Dockerfile.
+# APK_CACHEBUST is fed a per-build value so the buildcache for this layer is
+# invalidated each build and apk upgrade re-fetches current Alpine secfixes.
+ARG APK_CACHEBUST=0
+RUN echo "apk-cachebust=${APK_CACHEBUST}" && apk upgrade --no-cache
 
 # Create non-root user with matching group
 RUN addgroup --system --gid 1001 rackula && \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -28,9 +28,13 @@ RUN npm run build
 
 # Production stage - non-root nginx
 FROM nginxinc/nginx-unprivileged:alpine
-# Patch system packages to resolve known CVEs (e.g. libpng)
+# Patch system packages to resolve known CVEs (e.g. libpng, libxml2 CVE-2026-6732).
+# APK_CACHEBUST is fed a per-build value (release version / date) so this layer's
+# buildcache is invalidated each build and apk upgrade re-fetches current Alpine
+# secfixes instead of reusing a stale cached layer.
+ARG APK_CACHEBUST=0
 USER root
-RUN apk upgrade --no-cache
+RUN echo "apk-cachebust=${APK_CACHEBUST}" && apk upgrade --no-cache
 USER nginx
 
 # OCI labels


### PR DESCRIPTION
## **User description**
## What

Fixes Trivy code-scanning alert [#67](https://github.com/RackulaLives/Rackula/security/code-scanning/67) (**CVE-2026-6732**, HIGH): a libxml2 DoS via crafted XSD-validated documents. The vulnerable Alpine OS package `libxml2 2.13.9-r0` ships in `ghcr.io/rackulalives/rackula:latest`.

Closes #1841.

## Root cause

Both prod Dockerfiles already run `apk upgrade --no-cache`, but the published `latest` kept `libxml2 2.13.9-r0`. The prod build uses registry buildcache with `mode=max`; because the `nginx-unprivileged:alpine` base digest had not changed since before the secfix landed, BuildKit replayed the cached `apk upgrade` layer and never re-fetched `2.13.9-r1`. Pinning the base by digest would freeze secfixes further, so the fix is to bust the cache on the upgrade layer.

## Changes

- `deploy/Dockerfile`, `api/Dockerfile`: add `ARG APK_CACHEBUST`, referenced in the `apk upgrade` RUN so a changing value invalidates that layer's cache.
- `deploy-prod.yml`: feed all three build jobs `APK_CACHEBUST=<run_id>-<run_attempt>`, so every release build (and re-run) re-patches OS packages.
- `rebuild-images.yml` (new): monthly scheduled rebuild + Trivy rescan of the rolling tags (`latest`/`persist`/api `latest`) from the latest release's source, keeping published images patched between releases. Builds with `no-cache` (independent of the resolved tag's Dockerfile and without sharing/racing the release buildcache) and does not deploy to prod.

## Verification

Built the edited `deploy/Dockerfile` locally:

```
$ docker run --rm --entrypoint sh rackula-fe-verify -c 'apk list --installed | grep "^libxml2-2"'
libxml2-2.13.9-r1 aarch64 {libxml2} (MIT) [installed]
```

- nginx base `apk upgrade`: `2.13.9-r0` -> `2.13.9-r1` confirmed.
- api image builds clean; libxml2 is not present there, so the CVE does not apply to the api image.
- `actionlint` clean on the new workflow.

Alert #67 clears once `latest` is rebuilt and rescanned by the next release (a patch release will be cut after merge).

## Notes

Deliberately out of scope (per design discussion): base-image digest pinning, Dependabot `docker` ecosystem, and auto-redeploying prod after scheduled rebuilds. `rebuild-images.yml` intentionally mirrors `deploy-prod.yml`'s build jobs and `trivy.yml`'s scan job rather than extracting a `workflow_call` (avoids refactoring the release/scan path; the default `GITHUB_TOKEN` also cannot reliably dispatch `trivy.yml` cross-workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep published images patched between releases**

### What Changed
- Release builds now force the OS package refresh step to run on every build, so images pick up current Alpine security fixes instead of reusing a stale cached layer.
- The frontend, persistent site, and API release images all get the same cache-busting behavior.
- A new monthly rebuild job republishes and rescans the rolling image tags (`latest`, `persist`, and API `latest`) from the most recent release, without deploying anything to production.
- The API image keeps reporting the same version details after an OS-only rebuild.

### Impact
`✅ Fewer vulnerable images in release builds`
`✅ Faster recovery from Alpine security advisories`
`✅ Updated rolling tags without a prod redeploy` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
