### PR TITLE
feat: move mini-PC devices from Generic into brand packs (#1840)

### DIFF
--- a/docs/superpowers/specs/2026-05-31-device-metadata-design.md
+++ b/docs/superpowers/specs/2026-05-31-device-metadata-design.md
@@ -110,10 +110,10 @@ read the instance value first and fall back to the template value:
 - `serial`: `placedDevice.serial_number ?? deviceType.serial_number`
 - `asset_tag`: `placedDevice.asset_tag ?? deviceType.asset_tag`
 
-Add `"mac_address"` to `AnnotationField`, resolving from the device's ports (first port with
-a MAC, or a documented selection rule). Typed custom-field defs become selectable annotation
-fields, keyed by def `name`. The annotation column already drives SVG display and exports, so
-no separate export wiring is required.
+Add `"mac_address"` to `AnnotationField`, resolving to the MAC of the device's first port
+(lowest port index) that has a `mac_address` set, or blank if none. Typed custom-field defs
+become selectable annotation fields, keyed by def `name`. The annotation column already drives
+SVG display and exports, so no separate export wiring is required.
 
 ## Store actions - `stores/layout.svelte.ts`
 

--- a/docs/superpowers/specs/2026-05-31-device-metadata-design.md
+++ b/docs/superpowers/specs/2026-05-31-device-metadata-design.md
@@ -51,7 +51,7 @@ field from NetBox imports"). We follow the NetBox object model rather than inven
 | DeviceType (template) | (NetBox has no serial/asset_tag here)       | existing template defaults |
 
 Naming decision: NetBox's instance field is `serial`, but Rackula's existing DeviceType key
-is `serial_number` and `AnnotationField` already uses `"serial"`. We use **`serial_number`**
+is `serial_number` and `AnnotationField` already uses `"serial"`. We use `serial_number`
 on `PlacedDevice` so instance and template share one key for annotation fallback. A future
 NetBox adapter maps `serial` <-> `serial_number`, consistent with the other name mappings it
 already performs.

--- a/docs/superpowers/specs/2026-05-31-device-metadata-design.md
+++ b/docs/superpowers/specs/2026-05-31-device-metadata-design.md
@@ -1,0 +1,169 @@
+# Device Metadata: Instance Fields and Layout-Defined Custom Fields
+
+Date: 2026-05-31
+Status: Approved design, pending implementation plan
+Related discussions: #1558 (serial/MAC), #1620 (CMDB custom fields, instance vs template)
+Adjacent: #1556 (brands, separate), #1557 (firewall category, separate), #1398 (EditPanel tab split), #571/#1209 (NetBox interop)
+
+## Problem
+
+Operators want per-instance asset data on the devices they place: serial number, asset
+tag, MAC address, and arbitrary organisation-specific fields (VLAN, cost centre, owner).
+
+Today these have no home at the instance level:
+
+- `serial_number` and `asset_tag` exist only on `DeviceTypeSchema` (the template), not on
+  `PlacedDeviceSchema`. A serial is per physical unit, so storing it on the shared template
+  is the wrong level. This is the core complaint in #1620.
+- MAC address has no field anywhere.
+- The only instance-level custom data is the untyped `custom_fields` Record, edited through
+  a single hardcoded path (`updateDeviceIp` writes `custom_fields.ip`). There is no UI to
+  manage other fields and no consistency across devices.
+
+## Goals
+
+- Promote `serial_number` and `asset_tag` to the placed-device instance.
+- Add `mac_address` at the NetBox-correct level (the port/interface).
+- Let a layout define a consistent, typed set of custom fields that every device can fill in.
+- Surface all of the above in the annotation column and exports.
+
+## Non-goals (explicitly out of scope)
+
+These belong to separate issues and must not expand this spec:
+
+- Site/location tagging, the site browser, and cross-layout device search (rest of #1620).
+- Support-contract date tracking with expiry highlighting (rest of #1620).
+- Editing device brands (#1556).
+- A firewall device category (#1557).
+- A NetBox import/export adapter (#1209/#571) consumes this model but is not built here.
+
+## NetBox alignment
+
+Rackula's schema is deliberately NetBox-compatible (≈25 "NetBox-compatible" annotations in
+`schemas/index.ts` and `types/index.ts`, plus a `comments` field marked "Legacy comments
+field from NetBox imports"). We follow the NetBox object model rather than inventing one:
+
+| NetBox object         | NetBox field                                | Rackula home               |
+| --------------------- | ------------------------------------------- | -------------------------- |
+| Device (instance)     | `serial`, `asset_tag`, `custom_fields`      | `PlacedDevice`             |
+| Interface (component) | `mac_address`                               | `PlacedPort`               |
+| CustomField           | typed: text/integer/boolean/date/url/select | `Layout.custom_field_defs` |
+| DeviceType (template) | (NetBox has no serial/asset_tag here)       | existing template defaults |
+
+Naming decision: NetBox's instance field is `serial`, but Rackula's existing DeviceType key
+is `serial_number` and `AnnotationField` already uses `"serial"`. We use **`serial_number`**
+on `PlacedDevice` so instance and template share one key for annotation fallback. A future
+NetBox adapter maps `serial` <-> `serial_number`, consistent with the other name mappings it
+already performs.
+
+## Data model
+
+### PlacedDevice (instance) - `types/index.ts`, `schemas/index.ts`
+
+Add to `PlacedDevice` and `PlacedDeviceSchema`:
+
+```ts
+serial_number?: string;  // z.string().max(100).optional()
+asset_tag?: string;      // z.string().max(100).optional()
+```
+
+`custom_fields?: Record<string, unknown>` already exists and continues to hold custom-field
+values keyed by definition `name`. IP remains at `custom_fields.ip` unchanged.
+
+Curated fields start blank on placement. They do not pre-fill from the DeviceType template,
+because serial and asset tag are per physical unit and inheriting the template value would
+usually be wrong.
+
+### PlacedPort (component) - `types/index.ts`, `schemas/index.ts`
+
+Add to `PlacedPort` and `PlacedPortSchema`:
+
+```ts
+mac_address?: string;  // z.string().optional()
+```
+
+MAC lives on the port because NetBox models it on the interface. A device with no defined
+ports cannot hold a MAC; that is acceptable and matches the NetBox model.
+
+### Layout - `schemas/index.ts` (`LayoutSchemaBase`)
+
+Add a typed custom-field definition list, mirroring NetBox `CustomField`:
+
+```ts
+custom_field_defs?: {
+  name: string;                 // stable key into PlacedDevice.custom_fields
+  label?: string;               // display label; defaults to name
+  type: 'text' | 'integer' | 'boolean' | 'date' | 'url' | 'select';
+  choices?: string[];           // required when type === 'select'
+}[]
+```
+
+The layout already carries `custom_fields` (record) and `annotation_field`; this sits
+alongside them. Values for each def are stored per device in `PlacedDevice.custom_fields`
+under `name`.
+
+## Annotation and export
+
+`AnnotationField` already includes `"serial"` and `"asset_tag"`. Change their resolution to
+read the instance value first and fall back to the template value:
+
+- `serial`: `placedDevice.serial_number ?? deviceType.serial_number`
+- `asset_tag`: `placedDevice.asset_tag ?? deviceType.asset_tag`
+
+Add `"mac_address"` to `AnnotationField`, resolving from the device's ports (first port with
+a MAC, or a documented selection rule). Typed custom-field defs become selectable annotation
+fields, keyed by def `name`. The annotation column already drives SVG display and exports, so
+no separate export wiring is required.
+
+## Store actions - `stores/layout.svelte.ts`
+
+Follow the existing `updateDeviceIp` pattern exactly: snapshot the layout, locate the device,
+no-op guard if unchanged, dispatch a command for undo/redo, return boolean.
+
+- `updateDeviceSerial(rackId, deviceIndex, value?: string): boolean`
+- `updateDeviceAssetTag(rackId, deviceIndex, value?: string): boolean`
+- `updateDeviceCustomField(rackId, deviceIndex, key: string, value: unknown): boolean`
+- `updatePortMac(rackId, deviceIndex, portId, value?: string): boolean`
+- Layout level: `setCustomFieldDefs(defs)` plus add/remove helpers, each a discrete command.
+
+Each edit is its own command so undo operates per change, matching IP/notes behaviour.
+
+## UI
+
+### EditPanel - `components/EditPanel.svelte`
+
+- Typed inputs for `serial_number` and `asset_tag` beside the existing IP and notes inputs,
+  reusing the saved-indicator + blur-to-save behaviour from `handleDeviceIpBlur`.
+- A custom-fields section that renders one control per `custom_field_defs` entry, with the
+  control chosen by the def `type` (text input, number, checkbox, date picker, url input,
+  select). Values read/write `PlacedDevice.custom_fields[name]`.
+- A small "Manage fields" affordance to edit the layout-level def list (add, rename label,
+  set type, remove, set select choices).
+
+These are added to the panel as it exists today. They do not block on #1398 (the EditPanel
+tab-split refactor); when #1398 lands it reorganises where the inputs sit, but the fields and
+store actions are unaffected.
+
+### Port UI
+
+MAC is edited per port in the existing port editing UI, not in the device panel.
+
+## Staging
+
+The design is one spec; implementation ships in independently mergeable stages.
+
+- Stage 1 (closes #1558 serial; core of #1620): instance `serial_number` + `asset_tag`,
+  their store actions, EditPanel inputs, annotation instance-first fallback. Schema-clean and
+  NetBox-aligned.
+- Stage 2 (#1620 custom-fields slice): typed `custom_field_defs` on the layout, the field
+  manager UI, per-device rendering, and custom-field annotation.
+- Stage 3 (#1558 MAC): `mac_address` on `PlacedPort` and its port UI. Sized to the port work
+  and can be its own issue alongside #71/#362.
+
+## Risks and notes
+
+- EditPanel growth overlaps #1398. Mitigation: add fields now, let #1398 reorganise later.
+- `mac_address` requires defined ports. Mitigation: documented limitation; broader interface
+  work tracked under #71/#362.
+- Annotation fallback must not break existing layouts that rely on template serial/asset_tag.
+  Mitigation: template remains the fallback; instance value only overrides when present.

--- a/src/lib/components/BrandIcon.svelte
+++ b/src/lib/components/BrandIcon.svelte
@@ -20,6 +20,8 @@
     siLenovo,
     siBlackmagicdesign,
     siApple,
+    siIntel,
+    siRaspberrypi,
   } from "simple-icons";
   import { Zap } from "@lucide/svelte";
   import {
@@ -29,6 +31,8 @@
     deskPiPath,
     netgatePath,
     fsPath,
+    beelinkPath,
+    zimaPath,
   } from "./customBrandIcons";
 
   interface Props {
@@ -57,6 +61,8 @@
     lenovo: siLenovo,
     blackmagicdesign: siBlackmagicdesign,
     apple: siApple,
+    intel: siIntel,
+    raspberrypi: siRaspberrypi,
     // Custom brand icons (not in simple-icons)
     arista: { path: aristaPath, hex: "FFFFFF" },
     acinfinity: { path: acInfinityPath, hex: "FFFFFF" },
@@ -64,6 +70,8 @@
     deskpi: { path: deskPiPath, hex: "FFFFFF" },
     netgate: { path: netgatePath, hex: "FFFFFF" },
     fs: { path: fsPath, hex: "E31837" },
+    beelink: { path: beelinkPath, hex: "FFFFFF" },
+    zima: { path: zimaPath, hex: "FFFFFF" },
   };
 
   const icon = $derived(slug ? iconMap[slug] : undefined);

--- a/src/lib/components/customBrandIcons.ts
+++ b/src/lib/components/customBrandIcons.ts
@@ -26,3 +26,10 @@ export const aristaPath =
 // FS.COM - circular emblem with three horizontal bars (traced from brand logo)
 export const fsPath =
   "M12 2A10 10 0 0 1 22 12A10 10 0 0 1 12 22A10 10 0 0 1 2 12A10 10 0 0 1 12 2Z M4 7.5L4 9L19 9L19 7.5Z M4 11L4 12.5L16 12.5L16 11Z M4 14.5L4 16L14 16L14 14.5Z";
+
+// Beelink - simplified "B" monogram for brand section icon
+export const beelinkPath =
+  "M6 3 H13.5 C17 3 17 11 13.5 11 C17.5 11 17.5 21 13 21 H6 Z M9 5.8 V9.4 H13 C14.9 9.4 14.9 5.8 13 5.8 Z M9 12.6 V18.2 H13 C15.4 18.2 15.4 12.6 13 12.6 Z";
+
+// Zima - simplified "Z" monogram for brand section icon
+export const zimaPath = "M5 3 H19 V7 L11 17 H19 V21 H5 V17 L13 7 H5 Z";

--- a/src/lib/data/brandPacks/apple.ts
+++ b/src/lib/data/brandPacks/apple.ts
@@ -5,16 +5,18 @@
  *
  * The Xserve was Apple's rack-mounted server line manufactured 2002-2011.
  * The Xserve RAID was Apple's enterprise storage solution.
+ * The Mac Mini is a compact mini-PC for shelf placement.
  */
 
 import type { DeviceType } from "$lib/types";
 import { CATEGORY_COLOURS } from "$lib/types/constants";
 
 /**
- * Apple device definitions (2 rack-mount devices)
+ * Apple device definitions
  *
  * Xserve: 1U rack-mounted server (PowerPC G4/G5 2002-2006, Intel Xeon 2006-2011)
  * Xserve RAID: 3U rack-mounted storage (14 hot-swappable drives, up to 10.5TB)
+ * Mac Mini: Compact mini-PC for shelf placement
  */
 export const appleDevices: DeviceType[] = [
   {
@@ -38,5 +40,15 @@ export const appleDevices: DeviceType[] = [
     colour: CATEGORY_COLOURS.storage,
     category: "storage",
     front_image: true,
+  },
+  {
+    slug: "apple-mac-mini",
+    u_height: 1,
+    manufacturer: "Apple",
+    model: "Mac Mini",
+    slot_width: 1,
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS.server,
+    category: "server",
   },
 ];

--- a/src/lib/data/brandPacks/beelink.ts
+++ b/src/lib/data/brandPacks/beelink.ts
@@ -1,0 +1,25 @@
+/**
+ * Beelink Brand Pack
+ * Pre-defined device types for Beelink mini-PC equipment
+ */
+
+import type { DeviceType } from "$lib/types";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
+
+/**
+ * Beelink device definitions
+ *
+ * Mini S12 Pro: Compact mini-PC for shelf placement
+ */
+export const beelinkDevices: DeviceType[] = [
+  {
+    slug: "beelink-mini-s12-pro",
+    u_height: 1,
+    manufacturer: "Beelink",
+    model: "Mini S12 Pro",
+    slot_width: 1,
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS.server,
+    category: "server",
+  },
+];

--- a/src/lib/data/brandPacks/index.ts
+++ b/src/lib/data/brandPacks/index.ts
@@ -31,6 +31,10 @@ import { aristaDevices } from "./arista";
 import { juniperDevices } from "./juniper";
 import { vertivDevices } from "./vertiv";
 import { fsDevices } from "./fs";
+import { intelDevices } from "./intel";
+import { beelinkDevices } from "./beelink";
+import { raspberryPiDevices } from "./raspberry-pi";
+import { zimaDevices } from "./zima";
 
 export {
   ubiquitiDevices,
@@ -59,6 +63,10 @@ export {
   juniperDevices,
   vertivDevices,
   fsDevices,
+  intelDevices,
+  beelinkDevices,
+  raspberryPiDevices,
+  zimaDevices,
 };
 
 /**
@@ -262,6 +270,35 @@ export function getBrandPacks(): BrandSection[] {
       defaultExpanded: false,
       icon: "apple",
     },
+    // Mini PCs / SBCs
+    {
+      id: "intel",
+      title: "Intel",
+      devices: intelDevices,
+      defaultExpanded: false,
+      icon: "intel",
+    },
+    {
+      id: "beelink",
+      title: "Beelink",
+      devices: beelinkDevices,
+      defaultExpanded: false,
+      icon: "beelink",
+    },
+    {
+      id: "raspberry-pi",
+      title: "Raspberry Pi",
+      devices: raspberryPiDevices,
+      defaultExpanded: false,
+      icon: "raspberrypi",
+    },
+    {
+      id: "zima",
+      title: "Zima",
+      devices: zimaDevices,
+      defaultExpanded: false,
+      icon: "zima",
+    },
   ];
 }
 
@@ -320,6 +357,14 @@ export function getBrandDevices(brandId: string): DeviceType[] {
       return vertivDevices;
     case "fs":
       return fsDevices;
+    case "intel":
+      return intelDevices;
+    case "beelink":
+      return beelinkDevices;
+    case "raspberry-pi":
+      return raspberryPiDevices;
+    case "zima":
+      return zimaDevices;
     default:
       return [];
   }
@@ -356,6 +401,10 @@ export function getAllBrandDevices(): DeviceType[] {
     ...juniperDevices,
     ...vertivDevices,
     ...fsDevices,
+    ...intelDevices,
+    ...beelinkDevices,
+    ...raspberryPiDevices,
+    ...zimaDevices,
   ];
 }
 

--- a/src/lib/data/brandPacks/intel.ts
+++ b/src/lib/data/brandPacks/intel.ts
@@ -1,0 +1,25 @@
+/**
+ * Intel Brand Pack
+ * Pre-defined device types for Intel mini-PC equipment
+ */
+
+import type { DeviceType } from "$lib/types";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
+
+/**
+ * Intel device definitions
+ *
+ * NUC: Compact mini-PC for shelf placement
+ */
+export const intelDevices: DeviceType[] = [
+  {
+    slug: "intel-nuc",
+    u_height: 1,
+    manufacturer: "Intel",
+    model: "NUC",
+    slot_width: 1,
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS.server,
+    category: "server",
+  },
+];

--- a/src/lib/data/brandPacks/raspberry-pi.ts
+++ b/src/lib/data/brandPacks/raspberry-pi.ts
@@ -1,0 +1,35 @@
+/**
+ * Raspberry Pi Brand Pack
+ * Pre-defined device types for Raspberry Pi single-board computers
+ */
+
+import type { DeviceType } from "$lib/types";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
+
+/**
+ * Raspberry Pi device definitions
+ *
+ * Pi 5, Pi 4: Single-board computers for shelf placement
+ */
+export const raspberryPiDevices: DeviceType[] = [
+  {
+    slug: "raspberry-pi-5",
+    u_height: 0.5,
+    manufacturer: "Raspberry Pi",
+    model: "Pi 5",
+    slot_width: 1,
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS.server,
+    category: "server",
+  },
+  {
+    slug: "raspberry-pi-4",
+    u_height: 0.5,
+    manufacturer: "Raspberry Pi",
+    model: "Pi 4",
+    slot_width: 1,
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS.server,
+    category: "server",
+  },
+];

--- a/src/lib/data/brandPacks/zima.ts
+++ b/src/lib/data/brandPacks/zima.ts
@@ -1,0 +1,25 @@
+/**
+ * Zima Brand Pack
+ * Pre-defined device types for Zima single-board server equipment
+ */
+
+import type { DeviceType } from "$lib/types";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
+
+/**
+ * Zima device definitions
+ *
+ * Zimaboard: Single-board x86 server for shelf placement
+ */
+export const zimaDevices: DeviceType[] = [
+  {
+    slug: "zimaboard",
+    u_height: 0.5,
+    manufacturer: "Zima",
+    model: "Zimaboard",
+    slot_width: 1,
+    is_full_depth: false,
+    colour: CATEGORY_COLOURS.server,
+    category: "server",
+  },
+];

--- a/src/lib/data/starterLibrary.ts
+++ b/src/lib/data/starterLibrary.ts
@@ -308,59 +308,11 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
     ],
   },
 
-  // Mini Devices - for placement on shelf slots (7)
+  // Mini Devices - for placement on shelf slots (1)
   // Note: Brand names in model field, no manufacturer (keeps starter library generic)
   {
     slug: "generic-mini-pc",
     model: "Mini PC",
-    u_height: 1,
-    category: "server",
-    slot_width: 1,
-    is_full_depth: false,
-  },
-  {
-    slug: "intel-nuc",
-    model: "Intel NUC",
-    u_height: 1,
-    category: "server",
-    slot_width: 1,
-    is_full_depth: false,
-  },
-  {
-    slug: "beelink-mini-s12-pro",
-    model: "Beelink Mini S12 Pro",
-    u_height: 1,
-    category: "server",
-    slot_width: 1,
-    is_full_depth: false,
-  },
-  {
-    slug: "raspberry-pi-5",
-    model: "Raspberry Pi 5",
-    u_height: 0.5,
-    category: "server",
-    slot_width: 1,
-    is_full_depth: false,
-  },
-  {
-    slug: "raspberry-pi-4",
-    model: "Raspberry Pi 4",
-    u_height: 0.5,
-    category: "server",
-    slot_width: 1,
-    is_full_depth: false,
-  },
-  {
-    slug: "zimaboard",
-    model: "Zimaboard",
-    u_height: 0.5,
-    category: "server",
-    slot_width: 1,
-    is_full_depth: false,
-  },
-  {
-    slug: "apple-mac-mini",
-    model: "Mac Mini",
     u_height: 1,
     category: "server",
     slot_width: 1,

--- a/src/lib/data/starterLibrary.ts
+++ b/src/lib/data/starterLibrary.ts
@@ -308,8 +308,9 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
     ],
   },
 
-  // Mini Devices - for placement on shelf slots (1)
-  // Note: Brand names in model field, no manufacturer (keeps starter library generic)
+  // Mini Devices - for placement on shelf slots
+  // A single generic entry (generic-mini-pc) with a generic model value.
+  // Branded mini PCs and SBCs live in their own brand packs.
   {
     slug: "generic-mini-pc",
     model: "Mini PC",


### PR DESCRIPTION
## **User description**
Closes #1840

## Summary

Moves six mini-PC / SBC server devices out of the catch-all Generic palette section and into proper brand packs, matching how every other vendor (Dell, Apple, Ubiquiti, etc.) is presented.

| Device (slug)          | Was     | Now                  |
| ---------------------- | ------- | -------------------- |
| `intel-nuc`            | Generic | Intel (new pack)     |
| `beelink-mini-s12-pro` | Generic | Beelink (new pack)   |
| `raspberry-pi-5` / `raspberry-pi-4` | Generic | Raspberry Pi (new pack) |
| `zimaboard`            | Generic | Zima (new pack)      |
| `apple-mac-mini`       | Generic | Apple (existing pack)|

`generic-mini-pc` stays in Generic (it is genuinely generic).

## Details

- Each moved device gains a `manufacturer`, and the brand is stripped from the `model` field (`NUC`, `Pi 5`, etc.) to match the Apple-pack convention.
- Slugs are unchanged, so existing saved layouts keep resolving (placed types are auto-imported into the layout, so there is no rendering regression).
- Logos: Intel and Raspberry Pi come from simple-icons; Beelink and Zima use simple custom monogram glyphs to avoid the generic fallback bolt.

## Reviewer note

The Beelink "B" and Zima "Z" glyphs are placeholder monograms (those brands are not in simple-icons). They render as a mark rather than the fallback bolt; swapping in traced brand logos later is a follow-up.

## Verification

- `npm run test:run` - 2042 passing (brandpacks test is parameterized, auto-covers the new packs)
- `npm run lint` - clean
- `svelte-check` - no new errors in touched files
- `npm run build` - succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Move mini-PC and SBC devices into their own brand sections**

### What Changed
- Intel NUC, Beelink Mini S12 Pro, Raspberry Pi 4/5, ZimaBoard, and Mac Mini now appear under their own brand sections instead of Generic
- These devices now show the correct brand name and shorter model name in the library
- Brand icons were added for Intel and Raspberry Pi, with custom icons for Beelink and Zima
- The Generic starter list no longer includes these brand-specific devices, leaving only the truly generic mini-PC entry

### Impact
`✅ Easier device selection for mini-PCs`
`✅ Clearer brand grouping in the device library`
`✅ Fewer generic listings for branded hardware`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
