### PR TITLE
fix: replace deprecated coderabbit --prompt-only with --agent

### DIFF
--- a/.claude/commands/dev-issue.md
+++ b/.claude/commands/dev-issue.md
@@ -390,12 +390,12 @@ If failures: see Error Recovery section.
 **ALWAYS run CodeRabbit CLI before pushing any PR.** This catches issues early and improves PR success rate.
 
 ```bash
-(cd "$WORKTREE_DIR" && coderabbit --prompt-only --type committed)
+(cd "$WORKTREE_DIR" && coderabbit --agent --type committed)
 ```
 
 **Flags:**
 
-- `--prompt-only` — Token-efficient output optimized for Claude Code
+- `--agent` — Token-efficient output optimized for Claude Code
 - `--type committed` — Reviews committed changes on current branch
 
 **If CodeRabbit suggests changes:**

--- a/.claude/skills/gh-dev/SKILL.md
+++ b/.claude/skills/gh-dev/SKILL.md
@@ -263,7 +263,7 @@ If not configured, skip or ask user.
 **Step 1: Run CodeRabbit**
 
 ```bash
-(cd "$WORKTREE_DIR" && coderabbit --prompt-only --type uncommitted 2>&1)
+(cd "$WORKTREE_DIR" && coderabbit --agent --type uncommitted 2>&1)
 ```
 
 **Step 2: Parse Output**

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,10 +1,10 @@
 # Run CodeRabbit review before pushing
-# Uses --prompt-only for token-efficient output (optimized for AI review)
+# Uses --agent for token-efficient output (optimized for AI review)
 # Compares against origin/main to review commits being pushed
 # Blocks push if CodeRabbit finds issues
 
 echo "Running CodeRabbit review on committed changes..."
-if ! coderabbit review --prompt-only --type committed --base origin/main; then
+if ! coderabbit review --agent --type committed --base origin/main; then
   echo ""
   echo "CodeRabbit found issues. Push blocked."
   echo "Fix the issues above or use 'git push --no-verify' to skip."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,13 +143,13 @@ Run local review before pushing to catch issues early:
 
 ```bash
 # Review uncommitted changes (token-efficient output for AI)
-coderabbit --prompt-only --type uncommitted
+coderabbit --agent --type uncommitted
 
 # Review committed changes on current branch
-coderabbit --prompt-only --type committed
+coderabbit --agent --type committed
 ```
 
-Always use `--prompt-only` — provides concise, token-efficient output optimized for Claude Code.
+Always use `--agent` — provides concise, token-efficient output optimized for Claude Code.
 
 ### PR Monitoring
 


### PR DESCRIPTION
## **User description**
CodeRabbit deprecated `--prompt-only` in favour of `--agent`. Update all invocation sites:

- `.husky/pre-push` — hook comment + flag
- `CLAUDE.md` — both CLI examples + the "always use" note
- `.claude/commands/dev-issue.md` — command + flag description
- `.claude/skills/gh-dev/SKILL.md` — command
- `.claude/settings.local.json` — permission allowlist pattern (not committed, updated locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Switch CodeRabbit review commands to the supported `--agent` flag**

### What Changed
- Replaced the deprecated `--prompt-only` flag with `--agent` in the CodeRabbit commands used before pushing and in Claude guidance files
- Updated the surrounding notes so the instructions match the supported review command

### Impact
`✅ Fewer broken pre-push reviews`
`✅ Cleaner CodeRabbit instructions`
`✅ Lower risk of follow-up failures from outdated commands`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
