### PR TITLE
fix(devices): add chassis to palette category order and drift-proof against omissions (#1839)

### DIFF
--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -17,6 +17,7 @@
     filterPaletteDevicesByRackWidth,
     isDeviceCompatibleWithRackWidth,
     getRackWidthIncompatibilityReason,
+    categoryOrder,
   } from "$lib/utils/deviceFilters";
   import {
     loadGroupingModeFromStorage,
@@ -311,23 +312,6 @@
   const filteredAllDevices = $derived(
     searchDevices(allDevicesCombined, searchQuery),
   );
-
-  // Category order for consistent display
-  const categoryOrder: import("$lib/types").DeviceCategory[] = [
-    "server",
-    "network",
-    "firewall",
-    "patch-panel",
-    "power",
-    "storage",
-    "kvm",
-    "av-media",
-    "cooling",
-    "shelf",
-    "blank",
-    "cable-management",
-    "other",
-  ];
 
   // Sections for brand mode - filter out empty sections (no compatible devices)
   const brandModeSections = $derived<DeviceSection[]>(

--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -43,6 +43,15 @@ if (import.meta.env.DEV) {
         "Add them to categoryOrder in deviceFilters.ts.",
     );
   }
+  const extra = categoryOrder.filter(
+    (cat) => !DeviceCategorySchema.options.includes(cat),
+  );
+  if (extra.length > 0) {
+    throw new Error(
+      `categoryOrder has unknown categories: ${extra.join(", ")}. ` +
+        "Remove them from categoryOrder in deviceFilters.ts.",
+    );
+  }
 }
 
 /**

--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -13,6 +13,8 @@ const DEFAULT_RACK_WIDTHS = [19];
 
 /**
  * Display order for device categories in the palette.
+ * Ordered by typical usage frequency: common equipment first (servers, network),
+ * utility/structural items last (blanks, cable management, other).
  * Every DeviceCategory value MUST appear here; a dev-only assertion
  * enforces this so new categories cannot be silently dropped.
  */

--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -7,8 +7,43 @@
 import Fuse from "fuse.js";
 import type { IFuseOptions } from "fuse.js";
 import type { DeviceType, DeviceCategory } from "$lib/types";
+import { DeviceCategorySchema } from "$lib/schemas";
 
 const DEFAULT_RACK_WIDTHS = [19];
+
+/**
+ * Display order for device categories in the palette.
+ * Every DeviceCategory value MUST appear here; a dev-only assertion
+ * enforces this so new categories cannot be silently dropped.
+ */
+export const categoryOrder: DeviceCategory[] = [
+  "server",
+  "network",
+  "firewall",
+  "patch-panel",
+  "power",
+  "storage",
+  "kvm",
+  "av-media",
+  "cooling",
+  "shelf",
+  "blank",
+  "cable-management",
+  "chassis",
+  "other",
+];
+
+if (import.meta.env.DEV) {
+  const missing = DeviceCategorySchema.options.filter(
+    (cat) => !categoryOrder.includes(cat),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `categoryOrder is missing categories: ${missing.join(", ")}. ` +
+        "Add them to categoryOrder in deviceFilters.ts.",
+    );
+  }
+}
 
 /**
  * Fuse.js configuration for fuzzy search.

--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -54,6 +54,15 @@ if (import.meta.env.DEV) {
         "Remove them from categoryOrder in deviceFilters.ts.",
     );
   }
+  const unique = new Set(categoryOrder);
+  if (unique.size !== categoryOrder.length) {
+    const duplicates = categoryOrder.filter(
+      (cat, i) => categoryOrder.indexOf(cat) !== i,
+    );
+    throw new Error(
+      `categoryOrder has duplicate entries: ${duplicates.join(", ")}.`,
+    );
+  }
 }
 
 /**

--- a/src/tests/device-palette-categories.test.ts
+++ b/src/tests/device-palette-categories.test.ts
@@ -8,8 +8,4 @@ describe("DevicePalette category grouping", () => {
       expect(categoryOrder).toContain(cat);
     }
   });
-
-  it("includes chassis devices in category-grouped sections", () => {
-    expect(categoryOrder).toContain("chassis");
-  });
 });

--- a/src/tests/device-palette-categories.test.ts
+++ b/src/tests/device-palette-categories.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { DeviceCategorySchema } from "$lib/schemas";
+import { categoryOrder } from "$lib/utils/deviceFilters";
+
+describe("DevicePalette category grouping", () => {
+  it("includes all DeviceCategory values in categoryOrder", () => {
+    for (const cat of DeviceCategorySchema.options) {
+      expect(categoryOrder).toContain(cat);
+    }
+  });
+
+  it("includes chassis devices in category-grouped sections", () => {
+    expect(categoryOrder).toContain("chassis");
+  });
+});

--- a/src/tests/device-palette-categories.test.ts
+++ b/src/tests/device-palette-categories.test.ts
@@ -3,9 +3,12 @@ import { DeviceCategorySchema } from "$lib/schemas";
 import { categoryOrder } from "$lib/utils/deviceFilters";
 
 describe("DevicePalette category grouping", () => {
-  it("includes all DeviceCategory values in categoryOrder", () => {
+  it("categoryOrder is in sync with DeviceCategorySchema", () => {
     for (const cat of DeviceCategorySchema.options) {
       expect(categoryOrder).toContain(cat);
+    }
+    for (const cat of categoryOrder) {
+      expect(DeviceCategorySchema.options).toContain(cat);
     }
   });
 });

--- a/src/tests/device-palette-categories.test.ts
+++ b/src/tests/device-palette-categories.test.ts
@@ -10,5 +10,6 @@ describe("DevicePalette category grouping", () => {
     for (const cat of categoryOrder) {
       expect(DeviceCategorySchema.options).toContain(cat);
     }
+    expect(categoryOrder.length).toBe(new Set(categoryOrder).size);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

- Extract `categoryOrder` from `DevicePalette.svelte` to `deviceFilters.ts` alongside the other category utilities
- Add `"chassis"` to `categoryOrder` so chassis devices appear in the category-grouped palette view
- Add bidirectional dev-only assertion: verifies every `DeviceCategorySchema` option appears in `categoryOrder` AND every `categoryOrder` entry exists in the schema
- Add behavioural test verifying `categoryOrder` stays in sync with `DeviceCategorySchema`

## Root Cause

`categoryOrder` in `DevicePalette.svelte` listed 13 of 14 `DeviceCategory` values, omitting `"chassis"`. The `categoryModeSections` derivation iterates over `categoryOrder`, so any category not in the array was silently dropped from the grouped display. This is a drift-prone pattern: adding a new category to the schema causes no compile error, just a silent omission.

## Test Plan

- [x] Unit test: `categoryOrder` contains all `DeviceCategorySchema` options and vice versa
- [x] All existing tests pass (2050/2050)
- [x] Lint clean
- [x] Build succeeds
- [ ] Manual: open device palette in category mode, verify "Chassis" section appears with blade chassis devices

Closes #1839


___

## **CodeAnt-AI Description**
**Keep chassis devices visible in the grouped device palette**

### What Changed
- Chassis devices now appear in the category-grouped palette instead of being skipped
- Category ordering is moved into shared palette utilities so the list is used consistently
- Added checks and a test to catch missing or extra device categories before they affect the palette

### Impact
`✅ Chassis devices show up in category view`
`✅ Fewer missing device categories`
`✅ Safer palette updates for new device types`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
