### PR TITLE
feat(lxc): bundle arm64 native binary in release tarball (#1850)

### DIFF
--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -53,16 +53,14 @@ jobs:
       - name: Install API production dependencies
         run: |
           cd api
-          bun install --frozen-lockfile --production
-
-          # The tarball is built on x86 but runs on any arch (LXC supports arm64).
+          # The tarball is built on x86 but installs on any LXC arch (incl. arm64).
           # @node-rs/argon2 (the only native dep) ships per-platform binaries as
-          # os/cpu-gated optional deps, so the host install pulls x64 only. Inject the
-          # arm64 glibc binary alongside it, pinned to the exact resolved version so it
-          # cannot drift. The runtime loader picks the binary by file presence, not by
-          # the os/cpu manifest fields, so this loads correctly on arm64.
-          ARGON2_VER=$(node -p "require('./node_modules/@node-rs/argon2-linux-x64-gnu/package.json').version")
-          bun add --no-save "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}" --cpu=arm64 --os=linux
+          # os/cpu-gated optional deps, so a normal host install pulls x64 only.
+          # --cpu='*' --os=linux materialises every linux variant (x64 + arm64, gnu and
+          # musl) in one production install, so the bundled node_modules runs on both
+          # architectures. --production keeps devDependencies out of the tarball. The
+          # runtime loader selects the binary by file presence, not the os/cpu manifest.
+          bun install --frozen-lockfile --production --cpu='*' --os=linux
 
           # Fail the build if either native binary is missing.
           test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -55,6 +55,19 @@ jobs:
           cd api
           bun install --frozen-lockfile --production
 
+          # The tarball is built on x86 but runs on any arch (LXC supports arm64).
+          # @node-rs/argon2 (the only native dep) ships per-platform binaries as
+          # os/cpu-gated optional deps, so the host install pulls x64 only. Inject the
+          # arm64 glibc binary alongside it, pinned to the exact resolved version so it
+          # cannot drift. The runtime loader picks the binary by file presence, not by
+          # the os/cpu manifest fields, so this loads correctly on arm64.
+          ARGON2_VER=$(node -p "require('./node_modules/@node-rs/argon2-linux-x64-gnu/package.json').version")
+          bun add --no-save "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}" --cpu=arm64 --os=linux
+
+          # Fail the build if either native binary is missing.
+          test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node
+          test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
+
       - name: Assemble tarball
         run: |
           VERSION="${{ steps.version.outputs.version }}"

--- a/docs/research/1850-arm64-native-bundling.md
+++ b/docs/research/1850-arm64-native-bundling.md
@@ -32,13 +32,13 @@ Bun's native cross-platform flags (added in Bun 1.2.23, present in the workflow'
 cd api
 bun install --frozen-lockfile --production
 
-# Pass 2 (new): inject the arm64 glibc binary alongside x64, pinned to the resolved version
-ARGON2_VER=$(bun pm ls 2>/dev/null | grep -oE '@node-rs/argon2@[0-9.]+' | head -1 | cut -d@ -f3)
-ARGON2_VER="${ARGON2_VER:-2.0.2}"
+# Pass 2 (new): inject the arm64 glibc binary alongside x64, pinned to the exact
+# version resolved for the host (x64) package so it cannot drift.
+ARGON2_VER=$(node -p "require('./node_modules/@node-rs/argon2-linux-x64-gnu/package.json').version")
 bun add --no-save "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}" --cpu=arm64 --os=linux
-# Verify both binaries are present before tarring
-test -d node_modules/@node-rs/argon2-linux-x64-gnu
-test -d node_modules/@node-rs/argon2-linux-arm64-gnu
+# Fail the build if either native binary is missing
+test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node
+test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
 ```
 
 Notes:

--- a/docs/research/1850-arm64-native-bundling.md
+++ b/docs/research/1850-arm64-native-bundling.md
@@ -1,0 +1,87 @@
+# Spike #1850: arm64 support for the LXC release tarball
+
+**Date:** 2026-06-01
+**Implementation issue:** #1850
+**Related:** community-scripts/ProxmoxVED#1883, held PR branch `feat/add-rackula`
+**Detailed external research:** [1850-external.md](./1850-external.md)
+
+## Problem
+
+`build-lxc.yml` runs `bun install --frozen-lockfile --production` once on `ubuntu-latest`
+(x86) and tars up `api/node_modules`. The API's only native dependency,
+`@node-rs/argon2`, ships per-platform `.node` binaries as `os`/`cpu`-gated
+`optionalDependencies`, so the x86 build pulls only `@node-rs/argon2-linux-x64-gnu`. The
+tarball therefore crashes on arm64. Docker is unaffected (built per-arch via buildx).
+
+## Key finding (verified against `@node-rs/argon2@2.0.2`, Bun 1.3.x)
+
+The loader (`@node-rs/argon2/index.js`) selects the binary at runtime by probing
+`process.platform`/`arch` and a glibc-vs-musl check, then `require()`-ing the matching
+`@node-rs/argon2-<platform>` package. **It never checks the `os`/`cpu`/`libc` manifest
+fields** (those gate only the installer). So if the arm64-gnu package files are present in
+`node_modules`, they load fine on a Debian 13 arm64 host even though the tarball was
+assembled on x86. Injection is safe.
+
+## Decision: Pattern A - Bun two-pass injection, single universal tarball
+
+In `build-lxc.yml`, after the normal production install, add the arm64-gnu package using
+Bun's native cross-platform flags (added in Bun 1.2.23, present in the workflow's Bun 1.x):
+
+```bash
+# Pass 1 (existing): host-arch production deps
+cd api
+bun install --frozen-lockfile --production
+
+# Pass 2 (new): inject the arm64 glibc binary alongside x64, pinned to the resolved version
+ARGON2_VER=$(bun pm ls 2>/dev/null | grep -oE '@node-rs/argon2@[0-9.]+' | head -1 | cut -d@ -f3)
+ARGON2_VER="${ARGON2_VER:-2.0.2}"
+bun add --no-save "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}" --cpu=arm64 --os=linux
+# Verify both binaries are present before tarring
+test -d node_modules/@node-rs/argon2-linux-x64-gnu
+test -d node_modules/@node-rs/argon2-linux-arm64-gnu
+```
+
+Notes:
+
+- `--no-save` keeps `package.json`/lockfile untouched; `--cpu/--os` avoid the npm
+  `EBADPLATFORM` error (no `--force` needed).
+- Pin the injected version to the resolved `@node-rs/argon2` version so it never drifts.
+  Portable fallback if `bun pm ls` parsing is brittle: download the `.tgz` from the npm
+  registry and extract into `node_modules/@node-rs/argon2-linux-arm64-gnu/`.
+- Debian 13 is glibc, so `-linux-arm64-gnu` is the correct variant (not `-musl`).
+
+### Why not the alternatives
+
+- **Per-arch matrix tarballs (Pattern B):** two native builds + arch-selected asset at
+  install. More CI machinery (matrix/QEMU) and a second asset + selector in build.func for
+  one small native dep. Reconsider only if more/larger native deps appear.
+- **In-container `bun install` (Pattern C):** abandons the prebuilt/offline model and adds
+  an install-time network + toolchain dependency. Against the design intent.
+
+## Scope of the implementation (#1850)
+
+1. `build-lxc.yml`: add the pass-2 injection + presence assertions (above).
+2. `ct/rackula.sh`: `var_arm64="${var_arm64:-no}"` -> `yes`.
+3. `json/rackula.json`: `"has_arm": false` -> `true`.
+4. ProxmoxVED #1883 + held PR: flip arm64 back to supported.
+5. Guard: assert the injected version matches the resolved argon2 version (drift-proofing).
+
+## Verification
+
+- **Done (emulation, 2026-06-01):** built the bundle on `docker --platform linux/amd64`
+  (host install pulls x64; `bun add --no-save ...-linux-arm64-gnu --cpu=arm64 --os=linux`
+  injects arm64), tarred `node_modules`, then extracted and ran it under
+  `docker --platform linux/arm64`. `require('@node-rs/argon2')` loaded and
+  `hashSync`/`verifySync` executed: `LOADED_ON_ARM64 true $argon2id$v=1`. The inject also
+  pulls the arm64-musl variant, so both glibc and musl arm64 are covered. Injection
+  commands and the asserted `.node` paths were verified against `@node-rs/argon2@2.0.2`,
+  Bun 1.3.10. Audit confirms argon2 is the _only_ native dep (better-auth/hono/js-yaml/zod
+  are pure JS).
+- **Final sign-off (hardware-gated):** real `curl|bash` install on an arm64 Proxmox/LXC
+  host - same gate as #1214. Flip `var_arm64`/`has_arm` only after this passes.
+
+## Dependencies / order
+
+Blocked behind the separate "tarball not publishing on latest release" fix (build-lxc not
+triggering on recent releases) for real end-to-end testing, but the workflow change itself
+can be written and emulation-verified independently.

--- a/docs/research/1850-arm64-native-bundling.md
+++ b/docs/research/1850-arm64-native-bundling.md
@@ -22,20 +22,15 @@ fields** (those gate only the installer). So if the arm64-gnu package files are 
 `node_modules`, they load fine on a Debian 13 arm64 host even though the tarball was
 assembled on x86. Injection is safe.
 
-## Decision: Pattern A - Bun two-pass injection, single universal tarball
+## Decision: single production install targeting all linux CPUs
 
-In `build-lxc.yml`, after the normal production install, add the arm64-gnu package using
-Bun's native cross-platform flags (added in Bun 1.2.23, present in the workflow's Bun 1.x):
+In `build-lxc.yml`, change the one install command to materialise every linux variant of
+the optional native deps in a single production install, using Bun's cross-platform flags
+(added in Bun 1.2.23, present in the workflow's Bun 1.x):
 
 ```bash
-# Pass 1 (existing): host-arch production deps
 cd api
-bun install --frozen-lockfile --production
-
-# Pass 2 (new): inject the arm64 glibc binary alongside x64, pinned to the exact
-# version resolved for the host (x64) package so it cannot drift.
-ARGON2_VER=$(node -p "require('./node_modules/@node-rs/argon2-linux-x64-gnu/package.json').version")
-bun add --no-save "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}" --cpu=arm64 --os=linux
+bun install --frozen-lockfile --production --cpu='*' --os=linux
 # Fail the build if either native binary is missing
 test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node
 test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
@@ -43,12 +38,21 @@ test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
 
 Notes:
 
-- `--no-save` keeps `package.json`/lockfile untouched; `--cpu/--os` avoid the npm
-  `EBADPLATFORM` error (no `--force` needed).
-- Pin the injected version to the resolved `@node-rs/argon2` version so it never drifts.
-  Portable fallback if `bun pm ls` parsing is brittle: download the `.tgz` from the npm
-  registry and extract into `node_modules/@node-rs/argon2-linux-arm64-gnu/`.
-- Debian 13 is glibc, so `-linux-arm64-gnu` is the correct variant (not `-musl`).
+- `--cpu='*' --os=linux` installs all linux platform binaries (x64 + arm64, gnu and musl)
+  for every optional dep, scoped to linux only (no darwin/win32). For argon2 that is the
+  only native dep, so the extra files are a couple of small `.node` binaries.
+- `--production` keeps devDependencies out of the bundled `node_modules`.
+- No version-pinning logic needed: the lockfile already pins `@node-rs/argon2` and its
+  platform sub-packages, so frozen-install resolves the matching versions for every arch.
+- Debian 13 is glibc, so `-linux-arm64-gnu` is the variant that loads on the target;
+  the musl variant ships too but is unused there (and covers Alpine-based hosts for free).
+
+### Why this over the earlier two-pass `bun add` idea
+
+A second `bun add --no-save --cpu=arm64` after a `--production` install re-reconciles the
+tree: without `--production` it leaks devDependencies into the tarball, and with
+`--production` it prunes the host's x64 binary (reconciles to the command's arm64 target).
+The single `--cpu='*'` install sidesteps both failure modes - verified empirically.
 
 ### Why not the alternatives
 
@@ -60,21 +64,19 @@ Notes:
 
 ## Scope of the implementation (#1850)
 
-1. `build-lxc.yml`: add the pass-2 injection + presence assertions (above).
+1. `build-lxc.yml`: change the install to `--cpu='*' --os=linux` + presence assertions.
 2. `ct/rackula.sh`: `var_arm64="${var_arm64:-no}"` -> `yes`.
 3. `json/rackula.json`: `"has_arm": false` -> `true`.
 4. ProxmoxVED #1883 + held PR: flip arm64 back to supported.
-5. Guard: assert the injected version matches the resolved argon2 version (drift-proofing).
 
 ## Verification
 
 - **Done (emulation, 2026-06-01):** built the bundle on `docker --platform linux/amd64`
-  (host install pulls x64; `bun add --no-save ...-linux-arm64-gnu --cpu=arm64 --os=linux`
-  injects arm64), tarred `node_modules`, then extracted and ran it under
-  `docker --platform linux/arm64`. `require('@node-rs/argon2')` loaded and
-  `hashSync`/`verifySync` executed: `LOADED_ON_ARM64 true $argon2id$v=1`. The inject also
-  pulls the arm64-musl variant, so both glibc and musl arm64 are covered. Injection
-  commands and the asserted `.node` paths were verified against `@node-rs/argon2@2.0.2`,
+  with `bun install --frozen-lockfile --production --cpu='*' --os=linux`, tarred
+  `node_modules`, then extracted and ran it under `docker --platform linux/arm64`.
+  `require('@node-rs/argon2')` loaded and `hashSync`/`verifySync` executed:
+  `ARM64_RUN true`. Confirmed no devDependencies leaked into the bundle, and both x64-gnu
+  and arm64-gnu `.node` binaries are present. Verified against `@node-rs/argon2@2.0.2`,
   Bun 1.3.10. Audit confirms argon2 is the _only_ native dep (better-auth/hono/js-yaml/zod
   are pure JS).
 - **Final sign-off (hardware-gated):** real `curl|bash` install on an arm64 Proxmox/LXC

--- a/docs/research/1850-external.md
+++ b/docs/research/1850-external.md
@@ -235,34 +235,47 @@ host during LXC/app install.
 
 ---
 
-## Recommended pattern
+## Recommended pattern (implemented)
 
-**Pattern A, Bun two-pass injection (A.0), producing one universal `node_modules` tarball.**
-
-Rationale:
-
-1. The project already uses Bun in `/api` and Bun has first-class `--cpu/--os` support for
-   exactly this scenario — no `--force`, no manual registry juggling.
-2. One artifact, one CI job. No matrix, no QEMU, no arm64 runner, no install-time network
-   dependency. Fits the "build on x86, ship a tarball, untar on Debian arm64" model already in
-   place.
-3. Frozen-lockfile and version pinning are preserved: pass 1 is the normal frozen production
-   install; pass 2 derives the version from the lockfile and adds only the arm64-gnu binary via
-   `--no-save`, so the two arches can never drift and the lockfile contract is intact.
-4. Minimal tarball bloat: targeted single extra `.node` (~0.5 MB) vs `--cpu='*' --os='*'` which
-   drags in musl/windows/android binaries.
-
-Concrete CI step:
+**Single-pass production install scoped to all linux CPUs**, producing one universal
+`node_modules` tarball:
 
 ```bash
-bun install --frozen-lockfile --production
-ARGON2_VER=$(grep -oE '@node-rs/argon2@[0-9]+\.[0-9]+\.[0-9]+' bun.lock | head -1 | cut -d@ -f3)
-bun add --no-save "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}" --cpu=arm64 --os=linux
+bun install --frozen-lockfile --production --cpu='*' --os=linux
 tar czf app.tar.gz node_modules <app files>
 ```
 
-**Fallback if you ever drop Bun from the artifact step:** use A.2 (`npm pack` + `tar
---strip-components=1`), which has zero platform-validation surface and works from any host.
+Rationale:
+
+1. The project already uses Bun in `/api`, which has first-class `--cpu/--os` support for
+   exactly this scenario - no `--force`, no manual registry juggling.
+2. One artifact, one CI job. No matrix, no QEMU, no arm64 runner, no install-time network
+   dependency. Fits the "build on x86, ship a tarball, untar on Debian arm64" model already in
+   place.
+3. Frozen-lockfile and pinning are preserved: a single frozen production install resolves the
+   matching versions for every linux platform binary, so the arches cannot drift.
+4. `--os=linux` scopes the extra binaries to linux only (x64 + arm64, gnu + musl) - no
+   darwin/windows/android. For this project that is a couple of small `@node-rs/argon2` `.node`
+   files; the bloat is negligible.
+
+### Considered and rejected: two-pass `bun add` injection
+
+The original idea was to inject only the arm64-gnu binary after the production install:
+
+```bash
+bun install --frozen-lockfile --production
+bun add --no-save "@node-rs/argon2-linux-arm64-gnu@<ver>" --cpu=arm64 --os=linux
+```
+
+This breaks in practice: the second `bun add` re-reconciles `node_modules` to the install
+command's view. Without `--production` it pulls devDependencies back into the tarball; with
+`--production` it reconciles to the `--cpu=arm64` target and prunes the host x64 binary. The
+single-pass `--cpu='*'` install sidesteps both failure modes (verified empirically), at the
+cost of a couple of extra small linux binaries (musl, arm) instead of one.
+
+**Fallback if you ever drop Bun from the artifact step:** `npm pack` + `tar
+--strip-components=1` to extract the platform package into `node_modules`, which has zero
+platform-validation surface and works from any host.
 
 **Escalate to Pattern B** only if the app later gains additional native deps or needs musl +
 glibc across multiple arches, where per-arch native builds become cleaner than injecting N

--- a/docs/research/1850-external.md
+++ b/docs/research/1850-external.md
@@ -1,0 +1,285 @@
+# Research: Multi-arch distribution of a Bun app depending on `@node-rs/argon2`
+
+**Issue:** #1850
+**Date:** 2026-06-01
+**Context:** CI runs `bun install --frozen-lockfile --production` on `ubuntu-latest` (x86-64),
+tars `node_modules`, ships it. Target host is Debian 13, linux/arm64, glibc. The x86 install
+only pulls `@node-rs/argon2-linux-x64-gnu`, so the arm64 binary is missing and the app crashes
+at load on the target.
+
+All claims below were verified empirically against the locked version `@node-rs/argon2@2.0.2`
+(from `api/bun.lock`) and Bun `1.3.10`, unless marked otherwise.
+
+---
+
+## 1. Runtime resolution (verified)
+
+`@node-rs/argon2` is the standard NAPI-RS layout. `index.js` (`"main": "index.js"`, no
+`exports`) runs a `requireNative()` chain that branches on `process.platform`, `process.arch`,
+and a libc probe, then for each case tries a **local `.node` file first**, falling back to the
+**per-platform npm package**. The relevant linux/arm64 block:
+
+```js
+} else if (process.arch === 'arm64') {
+  if (isMusl()) {
+    try { return require('./argon2.linux-arm64-musl.node') } catch (e) { loadErrors.push(e) }
+    try { return require('@node-rs/argon2-linux-arm64-musl') } catch (e) { loadErrors.push(e) }
+  } else {
+    try { return require('./argon2.linux-arm64-gnu.node') } catch (e) { loadErrors.push(e) }
+    try { return require('@node-rs/argon2-linux-arm64-gnu') } catch (e) { loadErrors.push(e) }
+  }
+}
+```
+
+`isMusl()` probes (in order) `/usr/bin/ldd` contents, `process.report`, then `ldd --version`.
+On Debian 13 glibc this returns `false`, so the loader takes the **gnu** branch.
+
+**What must be present for arm64-gnu to load on Debian:** either
+
+- `node_modules/@node-rs/argon2/argon2.linux-arm64-gnu.node` (local file, tried first), **or**
+- `node_modules/@node-rs/argon2-linux-arm64-gnu/` containing `argon2.linux-arm64-gnu.node` +
+  its `package.json` (`"main": "argon2.linux-arm64-gnu.node"`).
+
+The per-platform package is trivial: `package.json` + `README.md` + the single `.node` file.
+Its `package.json` carries `"os": ["linux"]`, `"cpu": ["arm64"]` (and on the registry,
+`libc: ["glibc"]`) — this gating is the root cause of why a normal x64 install skips it, and the
+key gotcha for Pattern A injection (see below).
+
+Note: `require('@node-rs/argon2-linux-arm64-gnu')` resolves via normal `node_modules` walk, so
+the package just needs to exist anywhere on the resolution path. The `os`/`cpu` fields are only
+checked by the **installer**, never by the loader — once the files are on disk, the loader does
+not re-validate platform. This is what makes injection safe.
+
+---
+
+## 2. Pattern A — inject the foreign-arch package during the x86 build
+
+### A.0 Bun's native `--cpu`/`--os` flags (recommended within Pattern A)
+
+Bun (>= ~1.2.23, present in 1.3.10) supports `--cpu` and `--os` on `bun install`/`bun add` to
+override the target platform for optional-dependency selection. Per Bun docs, **the lockfile is
+unchanged across platforms even though the set of installed packages changes** — so version
+pinning to the resolved `2.0.2` is automatic and frozen-lockfile-safe.
+
+Accepted: `--cpu` = `arm64,x64,ia32,ppc64,s390x`; `--os` = `linux,darwin,win32,freebsd,...`;
+wildcard `*` = all.
+
+Verified behaviours on a darwin host:
+
+- `bun install --cpu='*' --os='*'` on a project depending on `@node-rs/argon2` installed **all
+  14** per-platform packages (incl. `argon2-linux-arm64-gnu` with its `.node`) in one pass.
+- `bun add --no-save @node-rs/argon2-linux-arm64-gnu@2.0.2 --cpu=arm64 --os=linux` installed the
+  leaf package **with the binary** and, unlike npm, **without `--force`** and without
+  `EBADPLATFORM`.
+- `bun install --frozen-lockfile --production --cpu=x64 --os=linux` works; on the x64 target it
+  pulls both `linux-x64-gnu` and `linux-x64-musl` (Bun matches on cpu/os, not libc).
+
+**Recommended A approach (two-pass, frozen-safe):**
+
+```bash
+# Pass 1: normal frozen production install for the build host (x64 glibc)
+bun install --frozen-lockfile --production
+
+# Pass 2: additively inject the arm64-gnu binary, pinned to the locked version.
+#   --no-save keeps package.json/lockfile untouched (frozen contract preserved)
+#   reads the exact version from the lockfile so the two archs never drift
+ARGON2_VER=$(grep -oE '"@node-rs/argon2@[0-9.]+"' bun.lock | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+bun add --no-save "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}" --cpu=arm64 --os=linux
+```
+
+This leaves a single `node_modules` tree containing **both** `argon2-linux-x64-gnu` (build host)
+and `argon2-linux-arm64-gnu` (target). The same tarball boots on both arches; the loader picks
+the right one at runtime. Version drift is impossible because pass 2 reads the version the
+lockfile already resolved.
+
+Alternative single-pass: replace pass 1 with `bun install --frozen-lockfile --cpu='*' --os='*'`
+to grab every platform at once. Simpler, but `--production` + `*` will include musl/windows/etc.
+binaries you do not need, bloating the tarball by ~2-4 MB per extra `.node`. Prefer the targeted
+two-pass for a lean artifact.
+
+### A.1 npm foreign-arch trick (fallback if not using Bun for this step)
+
+`npm install --cpu=arm64 --os=linux --libc=glibc @node-rs/argon2-linux-arm64-gnu@<v>` **fails**
+with `EBADPLATFORM` because npm validates the leaf package's own `os`/`cpu`/`libc` against the
+(overridden) target — and the leaf declares exactly those, yet npm still rejects installing a
+package whose platform != current host without override acceptance. Adding `--force` makes it
+work:
+
+```bash
+npm install --no-save --force --cpu=arm64 --os=linux --libc=glibc \
+  @node-rs/argon2-linux-arm64-gnu@2.0.2
+```
+
+Verified: this places `node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node`.
+Downsides: `--force` disables other protections; version must be passed manually (no automatic
+pin to the resolved parent version unless you script it).
+
+### A.2 `npm pack` + extract (most portable, zero install-time platform logic)
+
+```bash
+ARGON2_VER=2.0.2   # read from lockfile
+npm pack "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}"   # -> node-rs-argon2-linux-arm64-gnu-2.0.2.tgz
+mkdir -p node_modules/@node-rs/argon2-linux-arm64-gnu
+tar xzf node-rs-argon2-linux-arm64-gnu-${ARGON2_VER}.tgz \
+  --strip-components=1 -C node_modules/@node-rs/argon2-linux-arm64-gnu
+```
+
+Verified the tgz contains `package/{package.json,README.md,argon2.linux-arm64-gnu.node}`
+(hence `--strip-components=1`). No `--force`, no platform validation, works from any host. This
+is the most robust and least magical option; pins via the explicit `@${ARGON2_VER}`.
+
+### A.3 Direct `.tgz` download (no npm/bun needed)
+
+`curl -sL https://registry.npmjs.org/@node-rs/argon2-linux-arm64-gnu/-/argon2-linux-arm64-gnu-${VER}.tgz`
+then the same `tar --strip-components=1` extract as A.2. Equivalent result; useful in minimal
+images. Same manual-pin requirement.
+
+### Which keeps the version pinned automatically
+
+Only the **Bun two-pass (A.0)** reads the version straight from the lockfile via `--no-save`
+semantics tied to the resolved tree; the others (A.1/A.2/A.3) require you to inject
+`${ARGON2_VER}` extracted from `bun.lock`. All can be made drift-proof by deriving the version
+from the lockfile in one place.
+
+### Bun-specific gotchas
+
+- Bun **does not strip** "unused" optional deps you add via `bun add --no-save` into an existing
+  tree — verified the arm64 package persists. So the inject-after-install pattern is safe.
+- `--frozen-lockfile` forbids lockfile changes; combine it only with `--no-save` secondary
+  passes, or with `--cpu/--os` on the primary pass (lockfile is platform-invariant, so frozen is
+  satisfied).
+- `--production` omits devDependencies but does **not** prune already-present platform packages.
+
+---
+
+## 3. Pattern B — per-arch artifacts via CI matrix
+
+Build two tarballs, one per arch, and select at install time.
+
+```yaml
+strategy:
+  matrix:
+    include:
+      - arch: amd64
+        runner: ubuntu-latest # native x64
+      - arch: arm64
+        runner: ubuntu-24.04-arm # native arm64 runner (GA), or buildx+QEMU
+```
+
+Each job runs `bun install --frozen-lockfile --production` natively, tars to
+`app-linux-${arch}.tar.gz`. Installer on the host picks:
+
+```bash
+case "$(dpkg --print-architecture)" in
+  amd64) A=amd64 ;; arm64) A=arm64 ;; *) echo "unsupported"; exit 1 ;;
+esac
+curl -fsSL ".../app-linux-${A}.tar.gz" | tar xz
+# (uname -m gives x86_64 / aarch64 if dpkg unavailable)
+```
+
+**Trade-offs vs A:**
+
+- Pro: each tarball is native, no foreign-arch trickery, smallest per-arch size, catches any
+  arch-specific issue at build time. Naturally extends to musl, other native deps, etc.
+- Con: two build jobs (arm64 native runners or QEMU, which is slow); a release-time selection
+  step; two artifacts to publish/track. For a single native dep this is heavier than A.
+- Pattern A gives **one** universal tarball; Pattern B gives N tarballs + a selector. A wins for
+  "one artifact" simplicity when the only native dep is argon2; B wins if you accumulate more
+  native deps or need musl + glibc + multiple arches.
+
+---
+
+## 4. Pattern C — install deps inside the target at install time
+
+Ship source + lockfile, run `bun install --frozen-lockfile --production` on the Debian arm64
+host during LXC/app install.
+
+**Trade-offs:**
+
+- Pro: always correct binary for the actual host (incl. libc), no cross-arch logic, lockfile is
+  the single source of truth.
+- Con: requires network + registry reachability at install time (offline/airgapped installs
+  break); adds Bun as an install-time dependency on the target; slower installs; non-hermetic
+  (registry availability becomes a runtime install risk). `@node-rs/argon2` ships **prebuilt**
+  binaries, so no Rust/compiler toolchain is needed — but this is not guaranteed for arbitrary
+  future native deps.
+- For a community-scripts-style LXC where the install pulls a release tarball, C reintroduces a
+  network dependency the prebuilt-tarball model was meant to avoid.
+
+---
+
+## 5. Prior art
+
+- **NAPI-RS itself** (and `@node-rs/*`, `@napi-rs/*`) deliberately does **not** ship multi-arch
+  in one package: the main package is JS-only and declares per-platform `optionalDependencies`
+  gated by `os`/`cpu`/`libc`. Multi-arch bundling is explicitly an installer-side concern, which
+  is exactly why the `--cpu/--os` / inject approach is the intended escape hatch.
+  (https://napi.rs/docs/deep-dive/release, https://napi.rs/docs/deep-dive/native-module)
+- **Bun** added `--cpu`/`--os` specifically for this Docker/CI cross-target case (Jarred Sumner
+  announcement; Bun v1.2.23 blog). Docs state the lockfile is platform-invariant, which is the
+  guarantee that makes frozen cross-target installs safe.
+  (https://bun.com/docs/pm/cli/install, https://bun.com/blog/bun-v1.2.23)
+- **esbuild** faces the identical problem (per-platform optional dep packages). Its maintainer's
+  guidance is essentially Pattern C ("don't copy node_modules across platforms; run install on
+  the destination") or use the `*-wasm` fallback; Yarn users use `supportedArchitectures` (the
+  Yarn analogue of Bun's `--cpu/--os`). (esbuild issues #2597, #2617)
+- **prebuildify / prebuild-install** (better-sqlite3 and many node-gyp modules) take the opposite
+  tack: bundle **all** prebuilt `.node` files inside the **single main package** under
+  `prebuilds/<platform>-<arch>/` and select at runtime via `node-gyp-build`. That yields a true
+  single universal artifact but requires the package author to opt into prebuildify; `@node-rs`
+  does not, so we cannot rely on it here. (https://github.com/prebuild/prebuildify)
+- **Yarn `supportedArchitectures`** in `.yarnrc.yml` is the closest npm-ecosystem analogue to
+  Bun's flags (declaratively pulls extra platform binaries into the install). Not applicable
+  since this project uses Bun in `/api`, but confirms the inject-extra-binaries pattern is
+  mainstream.
+
+---
+
+## Recommended pattern
+
+**Pattern A, Bun two-pass injection (A.0), producing one universal `node_modules` tarball.**
+
+Rationale:
+
+1. The project already uses Bun in `/api` and Bun has first-class `--cpu/--os` support for
+   exactly this scenario — no `--force`, no manual registry juggling.
+2. One artifact, one CI job. No matrix, no QEMU, no arm64 runner, no install-time network
+   dependency. Fits the "build on x86, ship a tarball, untar on Debian arm64" model already in
+   place.
+3. Frozen-lockfile and version pinning are preserved: pass 1 is the normal frozen production
+   install; pass 2 derives the version from the lockfile and adds only the arm64-gnu binary via
+   `--no-save`, so the two arches can never drift and the lockfile contract is intact.
+4. Minimal tarball bloat: targeted single extra `.node` (~0.5 MB) vs `--cpu='*' --os='*'` which
+   drags in musl/windows/android binaries.
+
+Concrete CI step:
+
+```bash
+bun install --frozen-lockfile --production
+ARGON2_VER=$(grep -oE '@node-rs/argon2@[0-9]+\.[0-9]+\.[0-9]+' bun.lock | head -1 | cut -d@ -f3)
+bun add --no-save "@node-rs/argon2-linux-arm64-gnu@${ARGON2_VER}" --cpu=arm64 --os=linux
+tar czf app.tar.gz node_modules <app files>
+```
+
+**Fallback if you ever drop Bun from the artifact step:** use A.2 (`npm pack` + `tar
+--strip-components=1`), which has zero platform-validation surface and works from any host.
+
+**Escalate to Pattern B** only if the app later gains additional native deps or needs musl +
+glibc across multiple arches, where per-arch native builds become cleaner than injecting N
+foreign binaries.
+
+---
+
+## Sources
+
+- https://bun.com/docs/pm/cli/install
+- https://bun.com/blog/bun-v1.2.23
+- https://x.com/jarredsumner/status/1970073696745496892
+- https://napi.rs/docs/deep-dive/release
+- https://napi.rs/docs/deep-dive/native-module
+- https://napi.rs/docs/cross-build.en
+- https://github.com/prebuild/prebuildify
+- https://github.com/evanw/esbuild/issues/2597
+- https://github.com/evanw/esbuild/issues/2617
+- Local verification: `@node-rs/argon2@2.0.2` `index.js` loader; npm/bun install experiments on
+  darwin host, Bun 1.3.10.


### PR DESCRIPTION
## **User description**
## Summary

Makes the LXC release tarball arch-complete so the community-scripts install works on arm64, not just x86. The tarball is assembled once on x86 CI, but `@node-rs/argon2` (the API's only native dep) ships per-platform binaries as os/cpu-gated optional deps, so a normal host install bundled the x64 binary only and the API would fail to start on an arm64 LXC.

Change: the API production install in `build-lxc.yml` now uses
`bun install --frozen-lockfile --production --cpu='*' --os=linux`, which materialises every linux platform binary (x64 + arm64, gnu + musl) in one production install, plus assertions that both `.node` binaries are present before tarring. The runtime loader selects the binary by file presence, so the x86-assembled bundle loads on arm64.

Docker is unaffected (already multi-arch via buildx). Spike + rationale in `docs/research/1850-arm64-native-bundling.md`.

## Verification

Verified by emulation (`docs/research/1850-arm64-native-bundling.md` has the details):
- Built the bundle on `docker --platform linux/amd64` with the new command.
- No devDependencies in the bundled `node_modules`; both x64-gnu and arm64-gnu `.node` binaries present.
- Extracted under `docker --platform linux/arm64` and ran `require('@node-rs/argon2')` + `hashSync`/`verifySync`: passes (`ARM64_RUN true`).

## Test Plan

- [ ] CI `build-lxc.yml` produces a tarball whose `api/node_modules` contains both `argon2-linux-x64-gnu` and `argon2-linux-arm64-gnu` and no devDependencies.
- [ ] Real arm64 Proxmox/LXC host: `curl|bash` install starts the API successfully (hardware-gated, tracked with #1214).

## Notes

- Final arm64 sign-off (flipping `var_arm64`/`has_arm` to supported in `ct/rackula.sh` / `json/rackula.json` / ProxmoxVED#1883) is held until the real-host test passes, so this PR does not change those flags.
- End-to-end testing also depends on the separate fix to publish the LXC tarball on the latest release (build-lxc not triggering on recent releases).

Part of #1850 (tarball change only; arm64 host sign-off and the var_arm64/has_arm flip remain on the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the LXC release tarball run on arm64 hosts**

### What Changed
- The LXC tarball now includes both x64 and arm64 Linux binaries for the native argon2 dependency, so the same release archive can start on arm64 as well as x86.
- The build now checks that both native binaries are present before publishing the tarball, preventing broken releases.
- Added research notes explaining the arm64 packaging issue and the chosen approach.

### Impact
`✅ Arm64 LXC installs`
`✅ Fewer startup failures on Debian arm64`
`✅ Clearer release validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
