### PR TITLE
fix: harden LXC update_script rollback and install idempotency (#1851)

### DIFF
--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -49,6 +49,9 @@ function update_script() {
 
   # Track update success for rollback decisions
   UPDATE_SUCCESS=0
+  # Set once this run owns the backup/swap, so rollback never acts on a stale
+  # /opt/rackula-backup left behind by a previously killed run.
+  SWAP_STARTED=0
 
   # Rollback on failure. Runs as the EXIT trap under errexit, so every step is
   # guarded: a failure here must not abort the trap before recovery completes.
@@ -63,36 +66,41 @@ function update_script() {
         echo "$OLD_VERSION" >~/.rackula
       fi
 
-      # Restore the /etc unit + nginx files that were overwritten this run, before
-      # the backup tree is moved back into place.
-      if [[ -d /opt/rackula-etc-backup ]]; then
-        cp -a /opt/rackula-etc-backup/rackula /etc/nginx/sites-available/rackula 2>/dev/null || true
-        cp -a /opt/rackula-etc-backup/security-headers.conf /etc/nginx/snippets/security-headers.conf 2>/dev/null || true
-        cp -a /opt/rackula-etc-backup/rackula-api.service /etc/systemd/system/rackula-api.service 2>/dev/null || true
-        if [[ -f /opt/rackula-etc-backup/nginx-override.conf ]]; then
-          mkdir -p /etc/systemd/system/nginx.service.d
-          cp -a /opt/rackula-etc-backup/nginx-override.conf /etc/systemd/system/nginx.service.d/override.conf 2>/dev/null || true
-        fi
-      fi
-
-      if [[ -d /opt/rackula-backup ]]; then
-        # Persistent data may already have been moved into the new install. Move
-        # it back before restoring the backup, but only destroy the live tree once
-        # the data move has succeeded, so user data is never lost.
-        local data_safe=1
-        if [[ -d /opt/rackula/data ]] && [[ ! -d /opt/rackula-backup/data ]]; then
-          if ! mv /opt/rackula/data /opt/rackula-backup/data; then
-            data_safe=0
-            msg_error "Rollback: could not preserve data; leaving /opt/rackula intact to avoid data loss"
+      # Only undo on-disk changes when THIS run started the swap. A stale
+      # /opt/rackula-backup or -etc-backup left by a previously killed run must
+      # never be restored over a good install.
+      if [[ $SWAP_STARTED -eq 1 ]]; then
+        # Restore the /etc unit + nginx files that were overwritten this run,
+        # before the backup tree is moved back into place.
+        if [[ -d /opt/rackula-etc-backup ]]; then
+          cp -a /opt/rackula-etc-backup/rackula /etc/nginx/sites-available/rackula 2>/dev/null || true
+          cp -a /opt/rackula-etc-backup/security-headers.conf /etc/nginx/snippets/security-headers.conf 2>/dev/null || true
+          cp -a /opt/rackula-etc-backup/rackula-api.service /etc/systemd/system/rackula-api.service 2>/dev/null || true
+          if [[ -f /opt/rackula-etc-backup/nginx-override.conf ]]; then
+            mkdir -p /etc/systemd/system/nginx.service.d
+            cp -a /opt/rackula-etc-backup/nginx-override.conf /etc/systemd/system/nginx.service.d/override.conf 2>/dev/null || true
           fi
         fi
-        if [[ $data_safe -eq 1 ]]; then
-          rm -rf /opt/rackula
-          mv /opt/rackula-backup /opt/rackula
-          systemctl daemon-reload
-          systemctl start rackula-api || true
-          systemctl start nginx || true
-          msg_error "Update failed, restored from backup"
+
+        if [[ -d /opt/rackula-backup ]]; then
+          # Persistent data may already have been moved into the new install. Move
+          # it back before restoring the backup, but only destroy the live tree once
+          # the data move has succeeded, so user data is never lost.
+          local data_safe=1
+          if [[ -d /opt/rackula/data ]] && [[ ! -d /opt/rackula-backup/data ]]; then
+            if ! mv /opt/rackula/data /opt/rackula-backup/data; then
+              data_safe=0
+              msg_error "Rollback: could not preserve data; leaving /opt/rackula intact to avoid data loss"
+            fi
+          fi
+          if [[ $data_safe -eq 1 ]]; then
+            rm -rf /opt/rackula
+            mv /opt/rackula-backup /opt/rackula
+            systemctl daemon-reload
+            systemctl start rackula-api || true
+            systemctl start nginx || true
+            msg_error "Update failed, restored from backup"
+          fi
         fi
       fi
     fi
@@ -122,8 +130,10 @@ function update_script() {
     systemctl stop nginx
     msg_ok "Stopped Services"
 
-    # Swap the staged release into place. From here the EXIT trap can roll back.
+    # Swap the staged release into place. Mark that this run owns the backup so
+    # the EXIT trap will only roll back a backup we created; from here it can.
     msg_info "Installing ${APP} ${CHECK_UPDATE_RELEASE}"
+    SWAP_STARTED=1
     rm -rf /opt/rackula-backup
     mv /opt/rackula /opt/rackula-backup
     mv /opt/rackula.new /opt/rackula
@@ -135,13 +145,23 @@ function update_script() {
     fi
 
     # Back up the current /etc unit + nginx files before overwriting them, so the
-    # rollback can restore a fully working previous install.
+    # rollback can restore a fully working previous install. A missing source is
+    # fine (skip it), but a real copy failure must abort so we never overwrite
+    # /etc without a usable backup.
     rm -rf /opt/rackula-etc-backup
     mkdir -p /opt/rackula-etc-backup
-    cp -a /etc/nginx/sites-available/rackula /opt/rackula-etc-backup/rackula 2>/dev/null || true
-    cp -a /etc/nginx/snippets/security-headers.conf /opt/rackula-etc-backup/security-headers.conf 2>/dev/null || true
-    cp -a /etc/systemd/system/rackula-api.service /opt/rackula-etc-backup/rackula-api.service 2>/dev/null || true
-    cp -a /etc/systemd/system/nginx.service.d/override.conf /opt/rackula-etc-backup/nginx-override.conf 2>/dev/null || true
+    while IFS='|' read -r etc_src etc_dest; do
+      [[ -e "$etc_src" ]] || continue
+      if ! cp -a "$etc_src" "/opt/rackula-etc-backup/${etc_dest}"; then
+        msg_error "Failed to back up ${etc_src} before update"
+        exit 1
+      fi
+    done <<'ETC_FILES'
+/etc/nginx/sites-available/rackula|rackula
+/etc/nginx/snippets/security-headers.conf|security-headers.conf
+/etc/systemd/system/rackula-api.service|rackula-api.service
+/etc/systemd/system/nginx.service.d/override.conf|nginx-override.conf
+ETC_FILES
 
     # Update config files from the new release
     if ! cp /opt/rackula/config/nginx.conf /etc/nginx/sites-available/rackula; then

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -67,40 +67,39 @@ function update_script() {
       fi
 
       # Only undo on-disk changes when THIS run started the swap. A stale
-      # /opt/rackula-backup or -etc-backup left by a previously killed run must
-      # never be restored over a good install.
-      if [[ $SWAP_STARTED -eq 1 ]]; then
-        # Restore the /etc unit + nginx files that were overwritten this run,
-        # before the backup tree is moved back into place.
-        if [[ -d /opt/rackula-etc-backup ]]; then
-          cp -a /opt/rackula-etc-backup/rackula /etc/nginx/sites-available/rackula 2>/dev/null || true
-          cp -a /opt/rackula-etc-backup/security-headers.conf /etc/nginx/snippets/security-headers.conf 2>/dev/null || true
-          cp -a /opt/rackula-etc-backup/rackula-api.service /etc/systemd/system/rackula-api.service 2>/dev/null || true
-          if [[ -f /opt/rackula-etc-backup/nginx-override.conf ]]; then
-            mkdir -p /etc/systemd/system/nginx.service.d
-            cp -a /opt/rackula-etc-backup/nginx-override.conf /etc/systemd/system/nginx.service.d/override.conf 2>/dev/null || true
+      # /opt/rackula-backup left by a previously killed run must never be
+      # restored over a good install.
+      if [[ $SWAP_STARTED -eq 1 ]] && [[ -d /opt/rackula-backup ]]; then
+        # Persistent data may already have been moved into the new install. Move
+        # it back before restoring the backup, but only destroy the live tree once
+        # the data move has succeeded, so user data is never lost.
+        local data_safe=1
+        if [[ -d /opt/rackula/data ]] && [[ ! -d /opt/rackula-backup/data ]]; then
+          if ! mv /opt/rackula/data /opt/rackula-backup/data; then
+            data_safe=0
+            msg_error "Rollback: could not preserve data; leaving /opt/rackula intact to avoid data loss"
           fi
         fi
-
-        if [[ -d /opt/rackula-backup ]]; then
-          # Persistent data may already have been moved into the new install. Move
-          # it back before restoring the backup, but only destroy the live tree once
-          # the data move has succeeded, so user data is never lost.
-          local data_safe=1
-          if [[ -d /opt/rackula/data ]] && [[ ! -d /opt/rackula-backup/data ]]; then
-            if ! mv /opt/rackula/data /opt/rackula-backup/data; then
-              data_safe=0
-              msg_error "Rollback: could not preserve data; leaving /opt/rackula intact to avoid data loss"
+        if [[ $data_safe -eq 1 ]]; then
+          rm -rf /opt/rackula
+          mv /opt/rackula-backup /opt/rackula
+          # Restore the /etc unit + nginx files overwritten this run together with
+          # the old code, so config and code stay matched, before reloading and
+          # starting services. (If data could not be preserved above we keep the
+          # new install in place, so the new /etc is left to match it.)
+          if [[ -d /opt/rackula-etc-backup ]]; then
+            cp -a /opt/rackula-etc-backup/rackula /etc/nginx/sites-available/rackula 2>/dev/null || true
+            cp -a /opt/rackula-etc-backup/security-headers.conf /etc/nginx/snippets/security-headers.conf 2>/dev/null || true
+            cp -a /opt/rackula-etc-backup/rackula-api.service /etc/systemd/system/rackula-api.service 2>/dev/null || true
+            if [[ -f /opt/rackula-etc-backup/nginx-override.conf ]]; then
+              mkdir -p /etc/systemd/system/nginx.service.d
+              cp -a /opt/rackula-etc-backup/nginx-override.conf /etc/systemd/system/nginx.service.d/override.conf 2>/dev/null || true
             fi
           fi
-          if [[ $data_safe -eq 1 ]]; then
-            rm -rf /opt/rackula
-            mv /opt/rackula-backup /opt/rackula
-            systemctl daemon-reload
-            systemctl start rackula-api || true
-            systemctl start nginx || true
-            msg_error "Update failed, restored from backup"
-          fi
+          systemctl daemon-reload
+          systemctl start rackula-api || true
+          systemctl start nginx || true
+          msg_error "Update failed, restored from backup"
         fi
       fi
     fi
@@ -130,12 +129,13 @@ function update_script() {
     systemctl stop nginx
     msg_ok "Stopped Services"
 
-    # Swap the staged release into place. Mark that this run owns the backup so
-    # the EXIT trap will only roll back a backup we created; from here it can.
+    # Swap the staged release into place.
     msg_info "Installing ${APP} ${CHECK_UPDATE_RELEASE}"
-    SWAP_STARTED=1
     rm -rf /opt/rackula-backup
     mv /opt/rackula /opt/rackula-backup
+    # The live tree is now the backup, so arm rollback: only from here can the
+    # EXIT trap restore /opt/rackula-backup, and only this run could have created it.
+    SWAP_STARTED=1
     mv /opt/rackula.new /opt/rackula
 
     # Restore persistent data from backup

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -29,55 +29,116 @@ function update_script() {
     exit 1
   fi
 
-  # Prevent concurrent updates (mkdir is atomic, touch is not)
-  if ! mkdir /tmp/rackula-update.lock 2>/dev/null; then
+  # Prevent concurrent updates with an fd-based advisory lock. flock releases the
+  # lock automatically when the process exits (including a crash or host reboot),
+  # so a stale lock can never permanently block future updates.
+  exec 9>/tmp/rackula-update.lock || {
+    msg_error "Cannot open update lock file"
+    exit 1
+  }
+  if ! flock -n 9; then
     msg_error "Update already in progress"
     exit 1
   fi
 
+  # Currently-installed version, captured so rollback can restore the marker.
+  OLD_VERSION="$(cat ~/.rackula 2>/dev/null || true)"
+
   # Track update success for rollback decisions
   UPDATE_SUCCESS=0
 
-  # Rollback on failure — restore from backup unless update succeeded
+  # Rollback on failure. Runs as the EXIT trap under errexit, so every step is
+  # guarded: a failure here must not abort the trap before recovery completes.
+  # shellcheck disable=SC2329 # invoked indirectly via 'trap cleanup EXIT' below
   cleanup() {
-    if [[ -d /opt/rackula-backup ]] && [[ $UPDATE_SUCCESS -eq 0 ]]; then
-      # Persistent data may already have been moved into the new install
-      # (see data-restore step below). Move it back so it is not destroyed
-      # by the rm -rf, then restore the backup wholesale.
-      if [[ -d /opt/rackula/data ]] && [[ ! -d /opt/rackula-backup/data ]]; then
-        mv /opt/rackula/data /opt/rackula-backup/data
+    if [[ $UPDATE_SUCCESS -eq 0 ]]; then
+      # The release fetch advances ~/.rackula to the new version before the swap,
+      # so restore the marker on every rollback path (including pre-swap failures
+      # and an aborted data move). Otherwise the install reports "up to date" on
+      # the next run while still running the old code.
+      if [[ -n "$OLD_VERSION" ]]; then
+        echo "$OLD_VERSION" >~/.rackula
       fi
-      rm -rf /opt/rackula
-      mv /opt/rackula-backup /opt/rackula
-      # Restart services with the restored installation
-      systemctl daemon-reload
-      systemctl start rackula-api
-      systemctl start nginx
-      msg_error "Update failed — restored from backup"
+
+      # Restore the /etc unit + nginx files that were overwritten this run, before
+      # the backup tree is moved back into place.
+      if [[ -d /opt/rackula-etc-backup ]]; then
+        cp -a /opt/rackula-etc-backup/rackula /etc/nginx/sites-available/rackula 2>/dev/null || true
+        cp -a /opt/rackula-etc-backup/security-headers.conf /etc/nginx/snippets/security-headers.conf 2>/dev/null || true
+        cp -a /opt/rackula-etc-backup/rackula-api.service /etc/systemd/system/rackula-api.service 2>/dev/null || true
+        if [[ -f /opt/rackula-etc-backup/nginx-override.conf ]]; then
+          mkdir -p /etc/systemd/system/nginx.service.d
+          cp -a /opt/rackula-etc-backup/nginx-override.conf /etc/systemd/system/nginx.service.d/override.conf 2>/dev/null || true
+        fi
+      fi
+
+      if [[ -d /opt/rackula-backup ]]; then
+        # Persistent data may already have been moved into the new install. Move
+        # it back before restoring the backup, but only destroy the live tree once
+        # the data move has succeeded, so user data is never lost.
+        local data_safe=1
+        if [[ -d /opt/rackula/data ]] && [[ ! -d /opt/rackula-backup/data ]]; then
+          if ! mv /opt/rackula/data /opt/rackula-backup/data; then
+            data_safe=0
+            msg_error "Rollback: could not preserve data; leaving /opt/rackula intact to avoid data loss"
+          fi
+        fi
+        if [[ $data_safe -eq 1 ]]; then
+          rm -rf /opt/rackula
+          mv /opt/rackula-backup /opt/rackula
+          systemctl daemon-reload
+          systemctl start rackula-api || true
+          systemctl start nginx || true
+          msg_error "Update failed, restored from backup"
+        fi
+      fi
     fi
-    rm -rf /tmp/rackula-update.lock
+    # Drop transient staging/backup dirs (no-ops if absent or already consumed).
+    rm -rf /opt/rackula.new /opt/rackula-etc-backup 2>/dev/null || true
   }
   trap cleanup EXIT
 
   if check_for_gh_release "rackula" "RackulaLives/Rackula"; then
+    # Stage the new release into a scratch dir first. Services stay up and the
+    # live install is untouched, so a missing asset or no-op deploy fails here
+    # with the running install fully intact.
+    msg_info "Fetching ${APP} ${CHECK_UPDATE_RELEASE}"
+    rm -rf /opt/rackula.new
+    if ! fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula.new" "rackula-lxc-*.tar.gz"; then
+      msg_error "Failed to fetch release ${CHECK_UPDATE_RELEASE}"
+      exit 1
+    fi
+    if [[ ! -d /opt/rackula.new/config ]] || [[ ! -d /opt/rackula.new/api ]]; then
+      msg_error "Release did not populate config/ and api/, aborting before touching live install"
+      exit 1
+    fi
+    msg_ok "Fetched ${APP} ${CHECK_UPDATE_RELEASE}"
+
     msg_info "Stopping Services"
     systemctl stop rackula-api
     systemctl stop nginx
     msg_ok "Stopped Services"
 
-    msg_info "Backing up data"
+    # Swap the staged release into place. From here the EXIT trap can roll back.
+    msg_info "Installing ${APP} ${CHECK_UPDATE_RELEASE}"
     rm -rf /opt/rackula-backup
     mv /opt/rackula /opt/rackula-backup
-    msg_ok "Backed up data"
-
-    msg_info "Updating ${APP} to ${CHECK_UPDATE_RELEASE}"
-    fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
+    mv /opt/rackula.new /opt/rackula
 
     # Restore persistent data from backup
     if ! mv /opt/rackula-backup/data /opt/rackula/data; then
       msg_error "Failed to restore data directory"
       exit 1
     fi
+
+    # Back up the current /etc unit + nginx files before overwriting them, so the
+    # rollback can restore a fully working previous install.
+    rm -rf /opt/rackula-etc-backup
+    mkdir -p /opt/rackula-etc-backup
+    cp -a /etc/nginx/sites-available/rackula /opt/rackula-etc-backup/rackula 2>/dev/null || true
+    cp -a /etc/nginx/snippets/security-headers.conf /opt/rackula-etc-backup/security-headers.conf 2>/dev/null || true
+    cp -a /etc/systemd/system/rackula-api.service /opt/rackula-etc-backup/rackula-api.service 2>/dev/null || true
+    cp -a /etc/systemd/system/nginx.service.d/override.conf /opt/rackula-etc-backup/nginx-override.conf 2>/dev/null || true
 
     # Update config files from the new release
     if ! cp /opt/rackula/config/nginx.conf /etc/nginx/sites-available/rackula; then
@@ -132,8 +193,8 @@ function update_script() {
     # Mark update as successful so cleanup doesn't roll back
     UPDATE_SUCCESS=1
 
-    # Remove backup only after services verified
-    rm -rf /opt/rackula-backup
+    # Remove transient backups only after services verified
+    rm -rf /opt/rackula-backup /opt/rackula-etc-backup
     msg_ok "Updated successfully!"
   fi
   exit 0

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -31,8 +31,11 @@ function update_script() {
 
   # Prevent concurrent updates with an fd-based advisory lock. flock releases the
   # lock automatically when the process exits (including a crash or host reboot),
-  # so a stale lock can never permanently block future updates.
-  exec 9>/tmp/rackula-update.lock || {
+  # so a stale lock can never permanently block future updates. The lock lives
+  # under root-owned /run (not world-writable like /tmp) so a local user cannot
+  # pre-plant a symlink there and have this root process truncate its target.
+  mkdir -p /run/rackula
+  exec 9>/run/rackula/update.lock || {
     msg_error "Cannot open update lock file"
     exit 1
   }

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -37,7 +37,9 @@ fi
 msg_ok "Installed Bun"
 
 msg_info "Creating rackula user"
-useradd --system --user-group --home-dir /opt/rackula --shell /usr/sbin/nologin rackula
+if ! id -u rackula >/dev/null 2>&1; then
+  useradd --system --user-group --home-dir /opt/rackula --shell /usr/sbin/nologin rackula
+fi
 msg_ok "Created rackula user"
 
 msg_info "Installing Rackula"


### PR DESCRIPTION
## **User description**
## Summary

Hardens the community-scripts LXC update and install path against five integrity bugs (plus one related latent bug found in review). These scripts have never run on a real host (#1214), so the update path was entirely unexercised.

- Staging deploy: fetch the release into `/opt/rackula.new` and assert `config/` + `api/` exist before stopping services or moving data, so a missing asset or no-op deploy fails with the running install fully intact (no downtime, backup never created). Finding 3.
- Rollback restores `/etc` units + nginx config: the unit/site/snippet/override files are backed up before overwrite and restored on rollback, so a failed update no longer leaves new units pointing at old code. Finding 1.
- Data-loss guard: the `rm -rf` of the live tree is gated on the data `mv` succeeding, so user layout data is never destroyed by a failed move. Finding 2.
- Lock via `flock`: replaces the `mkdir` sentinel with an fd-based advisory lock that auto-releases on process exit, so a crash or reboot mid-update cannot permanently block future updates. Finding 4.
- Idempotent `useradd`: guarded by `id -u rackula`, so a re-run of the installer does not abort on an existing user. Finding 5.
- Version marker restore (found in code review): `fetch_and_deploy_gh_release` advances `~/.rackula` to the new version on a successful staging fetch, before the swap. Rollback now restores the marker on every failure path, so a rolled-back install re-offers the update instead of reporting "up to date".

## Acceptance criteria

- [x] A failed update restores a fully working previous install (code AND /etc units/config AND version marker).
- [x] No code path can `rm -rf` the live data dir after a failed/skipped data move.
- [x] A missing/non-populated deploy fails before services are stopped and data is moved, with the backup intact.
- [x] A stale lock from a crashed run does not permanently block future updates.
- [x] Re-running the installer does not abort on an existing `rackula` user.
- [ ] Covered by the real-host test in #1214.

## Test plan

These scripts source the remote community-scripts framework, so they cannot fully execute locally; the real-host run is tracked by #1214. Local gates run:

- `bash -n` on both scripts: pass
- `shellcheck -e SC1090,SC1091` on both scripts: clean
- Per-AC logic trace against the framework contract in ProxmoxVE `misc/tools.func` / `misc/error_handler.func` (errexit + EXIT/ERR traps, `fetch_and_deploy_gh_release` return codes and marker write).

Follow-up: re-sync the held ProxmoxVED submission branch (`feat/add-rackula`, #1215) after this lands.

Closes #1851


___

## **CodeAnt-AI Description**
**Harden LXC updates so failed installs roll back cleanly and safe retries work**

### What Changed
- Updates now stage the new release first and stop services only after the release is confirmed to contain the needed files, so missing or empty releases fail without touching the running install.
- Failed updates now restore the previous app files, system service files, nginx settings, and version marker, so the next update behaves correctly and the old install comes back intact.
- The installer no longer fails if the `rackula` user already exists, which allows rerunning setup on the same container.
- Update locking now clears itself after crashes or reboots, preventing a stuck lock from blocking future updates.

### Impact
`✅ Fewer broken updates`
`✅ Safer rollback after failed deploys`
`✅ Shorter recovery after interrupted updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
