### PR TITLE
feat(ci): add project board automation for assigned issues and opened PRs

### DIFF
--- a/.github/workflows/project-status-transitions.yml
+++ b/.github/workflows/project-status-transitions.yml
@@ -39,7 +39,8 @@ jobs:
             --id "$ITEM_ID" \
             --project-id "$PROJECT_ID" \
             --field-id "$STATUS_FIELD_ID" \
-            --single-select-option-id "$IN_PROGRESS_OPTION_ID"
+            --single-select-option-id "$IN_PROGRESS_OPTION_ID" \
+          || echo "Warning: Could not update issue (may already be in target status)"
 
   set-in-review:
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}

--- a/.github/workflows/project-status-transitions.yml
+++ b/.github/workflows/project-status-transitions.yml
@@ -50,7 +50,9 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          ISSUES=$(echo "$PR_BODY" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | grep -oE '[0-9]+' | sort -u || echo "")
+          ISSUES=$(echo "$PR_BODY" \
+            | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' \
+            | grep -oE '[0-9]+' | sort -u | tr '\n' ' ')
           echo "issue_numbers=$ISSUES" >> "$GITHUB_OUTPUT"
 
       - name: Move linked issues to In Review

--- a/.github/workflows/project-status-transitions.yml
+++ b/.github/workflows/project-status-transitions.yml
@@ -1,0 +1,81 @@
+name: Project Status Transitions
+
+on:
+  issues:
+    types: [assigned]
+  pull_request:
+    types: [opened]
+
+permissions: {} # Uses PAT for project access, not GITHUB_TOKEN
+
+jobs:
+  set-in-progress:
+    if: ${{ github.event_name == 'issues' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find project item for issue
+        id: find-item
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PROJECT_ID: ${{ vars.PROJECT_ID || 'PVT_kwDODv3FSs4BLc_R' }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          ITEM_ID=$(gh project item-list "$PROJECT_ID" \
+            --format json \
+            --jq ".[] | select(.content.number == $ISSUE_NUMBER) | .id" \
+            2>/dev/null | head -1 || echo "")
+          echo "item_id=$ITEM_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Set status to In Progress
+        if: ${{ steps.find-item.outputs.item_id != '' }}
+        env:
+          PROJECT_ID: ${{ vars.PROJECT_ID || 'PVT_kwDODv3FSs4BLc_R' }}
+          STATUS_FIELD_ID: ${{ vars.STATUS_FIELD_ID || 'PVTSSF_lADODv3FSs4BLc_Rzg7BbqY' }}
+          IN_PROGRESS_OPTION_ID: ${{ vars.IN_PROGRESS_OPTION_ID || '47fc9ee4' }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ITEM_ID: ${{ steps.find-item.outputs.item_id }}
+        run: |
+          gh project item-edit \
+            --id "$ITEM_ID" \
+            --project-id "$PROJECT_ID" \
+            --field-id "$STATUS_FIELD_ID" \
+            --single-select-option-id "$IN_PROGRESS_OPTION_ID"
+
+  set-in-review:
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract linked issue numbers from PR body
+        id: extract-issues
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ISSUES=$(echo "$PR_BODY" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | grep -oE '[0-9]+' | sort -u || echo "")
+          echo "issue_numbers=$ISSUES" >> "$GITHUB_OUTPUT"
+
+      - name: Move linked issues to In Review
+        if: ${{ steps.extract-issues.outputs.issue_numbers != '' }}
+        env:
+          PROJECT_ID: ${{ vars.PROJECT_ID || 'PVT_kwDODv3FSs4BLc_R' }}
+          STATUS_FIELD_ID: ${{ vars.STATUS_FIELD_ID || 'PVTSSF_lADODv3FSs4BLc_Rzg7BbqY' }}
+          IN_REVIEW_OPTION_ID: ${{ vars.IN_REVIEW_OPTION_ID || 'fe785116' }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NUMBERS: ${{ steps.extract-issues.outputs.issue_numbers }}
+        run: |
+          for ISSUE_NUM in $ISSUE_NUMBERS; do
+            ITEM_ID=$(gh project item-list "$PROJECT_ID" \
+              --format json \
+              --jq ".[] | select(.content.number == $ISSUE_NUM) | .id" \
+              2>/dev/null | head -1 || echo "")
+
+            if [ -n "$ITEM_ID" ]; then
+              gh project item-edit \
+                --id "$ITEM_ID" \
+                --project-id "$PROJECT_ID" \
+                --field-id "$STATUS_FIELD_ID" \
+                --single-select-option-id "$IN_REVIEW_OPTION_ID" \
+              || echo "Warning: Could not update issue #$ISSUE_NUM (may already be in target status)"
+            else
+              echo "Info: Issue #$ISSUE_NUM not found in project, skipping"
+            fi
+          done


### PR DESCRIPTION
## **User description**
## Summary

- Add `project-status-transitions.yml` workflow with two jobs:
  - **set-in-progress**: triggers on issue assigned, moves project item to "In Progress"
  - **set-in-review**: triggers on PR opened, parses body for Closes/Fixes/Resolves keywords, moves linked issues to "In Review"
- Both jobs use `secrets.PROJECT_TOKEN` PAT for org project access
- PR job skips fork PRs (no access to secrets)
- All untrusted inputs passed via env vars (actionlint-safe, no script injection)
- Case-insensitive keyword matching: close/closed/closes, fix/fixed/fixes, resolve/resolved/resolves
- Idempotent: re-running does not cause errors; issues not in project are skipped

## Test Plan

- [ ] Assign an issue and verify it moves to "In Progress" on the project board
- [ ] Open a PR with `Closes #N` in the body and verify linked issues move to "In Review"
- [ ] Re-run both workflows to confirm idempotency
- [ ] Open a PR from a fork and verify the set-in-review job is skipped

Closes #1863


___

## **CodeAnt-AI Description**
**Move assigned issues into the project board and link PRs to review status**

### What Changed
- Assigned issues are now moved to the project’s “In Progress” status automatically
- Opening a PR now moves any linked issues mentioned with close/fix/resolve wording into “In Review”
- PRs from forks are skipped, so the automation only runs where it has access to update the project
- The issue-matching text now recognizes more close/fix/resolve variations, making linked issues easier to detect
- If an issue is already in the right place or cannot be found, the workflow logs a warning and keeps going

### Impact
`✅ Faster issue triage`
`✅ Fewer manual board updates`
`✅ More reliable PR-to-issue linking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
