### PR TITLE
fix(ci): add job names and concurrency to project-status-transitions

### DIFF
--- a/.github/workflows/project-status-transitions.yml
+++ b/.github/workflows/project-status-transitions.yml
@@ -8,8 +8,13 @@ on:
 
 permissions: {} # Uses PAT for project access, not GITHUB_TOKEN
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   set-in-progress:
+    name: Set Issue to In Progress
     if: ${{ github.event_name == 'issues' }}
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +48,7 @@ jobs:
           || echo "Warning: Could not update issue (may already be in target status)"
 
   set-in-review:
+    name: Set Linked Issues to In Review
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## **User description**
## Summary

Addresses CodeRabbit review feedback on #1864:

- Add human-readable job names (, ) for Actions UI clarity
- Add  group keyed on workflow + event + item number to serialize runs per target item while allowing parallel runs for different items

## Test Plan

- [ ] Verify job names display correctly in GitHub Actions UI
- [ ] Verify concurrent runs for the same issue/PR are serialized
- [ ] Verify runs for different items still execute in parallel


___

## **CodeAnt-AI Description**
**Make project status transition runs easier to follow and prevent overlapping updates**

### What Changed
- GitHub Actions jobs now show clear names for issue and pull request status updates.
- Runs for the same issue or pull request are now serialized, so rapid repeat events do not update the same item at the same time.
- Runs for different issues or pull requests can still happen in parallel.

### Impact
`✅ Clearer GitHub Actions runs`
`✅ Fewer conflicting status updates`
`✅ Safer issue and PR state changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
