### PR TITLE
test: harden e2e rack-setup helpers (#756)

### DIFF
--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -26,7 +26,6 @@ export {
 export {
   completeWizardWithKeyboard,
   completeWizardWithClicks,
-  fillRackForm,
 } from "./rack-setup";
 
 // Toolbar actions

--- a/e2e/helpers/rack-setup.ts
+++ b/e2e/helpers/rack-setup.ts
@@ -49,12 +49,14 @@ async function selectHeight(
 
   // Slider fallback: a range input silently clamps out-of-range values, which
   // would let a test pass with the wrong height. Validate against the slider's
-  // own min/max so the test fails fast instead.
+  // own min/max/step so the test fails fast instead.
   const slider = page.locator('[data-testid="slider-height"]');
   const minAttr = await slider.getAttribute("min");
   const maxAttr = await slider.getAttribute("max");
+  const stepAttr = await slider.getAttribute("step");
   const min = Number(minAttr);
   const max = Number(maxAttr);
+  const step = stepAttr === null ? NaN : Number(stepAttr);
   if (
     minAttr === null ||
     maxAttr === null ||
@@ -65,9 +67,21 @@ async function selectHeight(
       `selectHeight: could not read slider range (min=${minAttr}, max=${maxAttr})`,
     );
   }
+  if (stepAttr !== "any" && (Number.isNaN(step) || step <= 0)) {
+    throw new Error(
+      `selectHeight: could not read slider step (step=${stepAttr})`,
+    );
+  }
   if (height < min || height > max) {
     throw new Error(
       `selectHeight: height ${height}U is outside the slider range [${min}, ${max}]`,
+    );
+  }
+  // A range input also snaps in-range values to the nearest step (the bayed
+  // slider uses step=2), which would silently coerce e.g. 13U to 12U.
+  if (stepAttr !== "any" && (height - min) % step !== 0) {
+    throw new Error(
+      `selectHeight: height ${height}U does not align to slider step ${step}U from min ${min}U`,
     );
   }
 

--- a/e2e/helpers/rack-setup.ts
+++ b/e2e/helpers/rack-setup.ts
@@ -47,7 +47,31 @@ async function selectHeight(
     return;
   }
 
-  await page.locator('[data-testid="slider-height"]').fill(String(height));
+  // Slider fallback: a range input silently clamps out-of-range values, which
+  // would let a test pass with the wrong height. Validate against the slider's
+  // own min/max so the test fails fast instead.
+  const slider = page.locator('[data-testid="slider-height"]');
+  const minAttr = await slider.getAttribute("min");
+  const maxAttr = await slider.getAttribute("max");
+  const min = Number(minAttr);
+  const max = Number(maxAttr);
+  if (
+    minAttr === null ||
+    maxAttr === null ||
+    Number.isNaN(min) ||
+    Number.isNaN(max)
+  ) {
+    throw new Error(
+      `selectHeight: could not read slider range (min=${minAttr}, max=${maxAttr})`,
+    );
+  }
+  if (height < min || height > max) {
+    throw new Error(
+      `selectHeight: height ${height}U is outside the slider range [${min}, ${max}]`,
+    );
+  }
+
+  await slider.fill(String(height));
 }
 
 /**
@@ -148,16 +172,4 @@ export async function completeWizardWithClicks(
     .locator(locators.rack.container)
     .first()
     .waitFor({ state: "visible" });
-}
-
-/**
- * Fill rack form fields (legacy helper for tests that open wizard themselves)
- */
-export async function fillRackForm(
-  page: Page,
-  name: string,
-  height: number,
-): Promise<void> {
-  await page.fill("#rack-name", name);
-  await selectHeight(page, height);
 }


### PR DESCRIPTION
## **User description**
## Summary

Post-merge follow-up addressing CodeRabbit feedback on the now-merged PR #1865 (rack height slider, #756). Both findings were verified against current code before fixing.

- **`selectHeight` slider clamp:** A range input silently clamps out-of-range values, which would let an E2E test pass with the wrong height. The slider fallback now reads the slider's own `min`/`max` attributes and throws a clear range error if they're missing/non-numeric or if the requested height is out of range, so tests fail fast. The preset-button/column branch is unchanged.
- **`fillRackForm` removed:** The helper was exported through the barrel but never called by any spec. Per project policy (delete unused code, no legacy/deprecation shims), it was removed along with its barrel export rather than marked `@deprecated`.

## Test Plan

- [x] `npm run lint` passes
- [x] `tsc --noEmit` clean for touched files
- [ ] CodeRabbit review

Refs #756


___

## **CodeAnt-AI Description**
Harden rack setup helpers so E2E tests fail when a height is out of range

### What Changed
- Height selection now checks the slider’s allowed range before entering a custom value, instead of silently accepting a clamped result
- Tests now stop with a clear error if the slider range cannot be read or if the requested height is outside the allowed limits
- Removed an unused rack form helper and its export from the test helper bundle

### Impact
`✅ Fewer false-positive E2E test passes`
`✅ Clearer test failures for invalid rack heights`
`✅ Smaller test helper surface`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
