### PR TITLE
fix: skip CodeRabbit pre-push hook for tag-only pushes (#1861)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,6 +3,24 @@
 # Compares against origin/main to review commits being pushed
 # Blocks push if CodeRabbit finds issues
 
+# Skip the review for tag-only pushes. A tag ref has no diff against origin/main,
+# so CodeRabbit exits with "No files found for review" and the push is wrongly
+# blocked (e.g. `git push origin v26.6.0` during a release). Git feeds the ref
+# updates on stdin as "<local ref> <local sha> <remote ref> <remote sha>" lines.
+has_branch_ref=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    refs/tags/*) ;; # tag push: nothing to review
+    "") ;;          # ref deletion: nothing to review
+    *) has_branch_ref=1 ;;
+  esac
+done
+
+if [ "$has_branch_ref" -eq 0 ]; then
+  echo "Tag-only push detected; skipping CodeRabbit review."
+  exit 0
+fi
+
 echo "Running CodeRabbit review on committed changes..."
 if ! coderabbit review --agent --type committed --base origin/main; then
   echo ""

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,21 +3,26 @@
 # Compares against origin/main to review commits being pushed
 # Blocks push if CodeRabbit finds issues
 
-# Skip the review for tag-only pushes. A tag ref has no diff against origin/main,
-# so CodeRabbit exits with "No files found for review" and the push is wrongly
-# blocked (e.g. `git push origin v26.6.0` during a release). Git feeds the ref
-# updates on stdin as "<local ref> <local sha> <remote ref> <remote sha>" lines.
+# Skip the review when there is nothing to review against origin/main: tag pushes
+# and ref deletions. A tag ref has no branch diff, so CodeRabbit exits with "No
+# files found for review" and the push is wrongly blocked (e.g. `git push origin
+# v26.6.0` during a release). A deletion removes a ref rather than adding commits;
+# git signals it with an all-zero local object id (see .git/hooks/pre-push.sample).
+# Git feeds ref updates on stdin as "<local ref> <local sha> <remote ref> <remote sha>".
+zero=$(git hash-object --stdin </dev/null | tr '0-9a-f' '0')
 has_branch_ref=0
 while read -r local_ref local_sha remote_ref remote_sha; do
   case "$remote_ref" in
-    refs/tags/*) ;; # tag push: nothing to review
-    "") ;;          # ref deletion: nothing to review
-    *) has_branch_ref=1 ;;
+    refs/tags/*) continue ;; # tag push: nothing to review
   esac
+  if [ "$local_sha" = "$zero" ]; then
+    continue # ref deletion: nothing to review
+  fi
+  has_branch_ref=1
 done
 
 if [ "$has_branch_ref" -eq 0 ]; then
-  echo "Tag-only push detected; skipping CodeRabbit review."
+  echo "Tag-only or deletion push detected; skipping CodeRabbit review."
   exit 0
 fi
 


### PR DESCRIPTION
## **User description**
## Summary

The `.husky/pre-push` hook ran `coderabbit review --type committed --base origin/main` on
every push, including tag pushes. A tag ref has no diff against `origin/main`, so CodeRabbit
exits with "No files found for review" and the hook blocked the push. This broke
`git push origin <tag>`, the `/release` step that triggers the production deploy (worked
around with `--no-verify` during the v26.6.0 release).

The hook now reads the ref updates git feeds on stdin and exits 0 early when every updated
ref is a tag (or a deletion). Branch pushes still run the review unchanged.

## Test Plan

Guard logic verified against simulated stdin:

- [x] tag-only push (`refs/tags/v26.6.0`) -> skips review
- [x] branch push (`refs/heads/main`) -> runs review
- [x] feature-branch push -> runs review
- [x] mixed branch + tag in one push -> runs review (safe default)
- [x] `sh -n` syntax check passes

Closes #1861


___

## **CodeAnt-AI Description**
Skip CodeRabbit review for tag-only pushes so release tags can be pushed without being blocked

### What Changed
- Tag-only pushes now skip the pre-push review instead of failing with “No files found for review”
- Branch pushes still run the review and can still block the push if issues are found
- Ref deletions also skip the review

### Impact
`✅ Unblocked release tag pushes`
`✅ Fewer failed production deploys`
`✅ Less need for --no-verify on tag releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
