### PR TITLE
test: stabilize App.startScreen and App.cleanupPrompt full-suite flake (#1846)

### DIFF
--- a/src/tests/App.cleanupPrompt.test.ts
+++ b/src/tests/App.cleanupPrompt.test.ts
@@ -158,7 +158,12 @@ function resetHoistedMocks(): void {
   archiveMocks.extractFolderArchive.mockReset();
 }
 
-describe("App cleanup prompt flow", () => {
+// These suites render the full App component. Under full-suite memory pressure
+// the worker GC-thrashes, so a render + waitFor can exceed the default 10s and
+// the test fails with "Test timed out". A generous per-suite timeout absorbs the
+// slow renders, and retry covers any residual transient failures. The tests pass
+// in isolation; the failing test varies run to run. See issue #1846.
+describe("App cleanup prompt flow", { retry: 2, timeout: 30000 }, () => {
   const layoutStore = getLayoutStore();
   const uiStore = getUIStore();
 

--- a/src/tests/App.startScreen.test.ts
+++ b/src/tests/App.startScreen.test.ts
@@ -96,7 +96,12 @@ vi.mock("$lib/utils/session-storage", () => ({
   isServerNewer: sessionStorageMocks.isServerNewer,
 }));
 
-describe("App Start Screen integration", () => {
+// Full-App renders flake under full-suite memory pressure: the worker GC-thrashes
+// and a render + waitFor can exceed the default 10s ("Test timed out"). A generous
+// per-suite timeout absorbs the slow renders, and retry covers residual transient
+// failures. The tests pass in isolation. See issue #1846 (and the matching note in
+// App.cleanupPrompt.test.ts).
+describe("App Start Screen integration", { retry: 2, timeout: 30000 }, () => {
   beforeEach(() => {
     resetLayoutStore();
     resetSelectionStore();


### PR DESCRIPTION
## **User description**
## Summary

`App.startScreen.test.ts` and `App.cleanupPrompt.test.ts` render the full App component and
fail intermittently in the full suite (~2052 tests, forks pool) while always passing in
isolation.

## Root cause

Under full-suite memory pressure the fork worker GC-thrashes, so a `render(App)` + `waitFor`
occasionally exceeds the default 10s `testTimeout` and the test fails with `Test timed out in
10000ms` (Svelte also logs `derived_inert` warnings as the slow teardown races). The failing
test varies run to run, confirming pressure-induced slowness rather than deterministic
breakage.

Diagnosis path (each verified by repeated full-suite runs): clearing the persistence manager's
real timers per-file and globally, and extending setup.ts's teardown-error suppression, each
only reduced the flake. Capturing the actual failure showed plain `Test timed out`, which
pointed at the tight 10s budget under load.

## Fix

Add `{ retry: 2, timeout: 30000 }` to both suites:
- 30s per-suite timeout absorbs slow full-App renders under memory pressure.
- `retry: 2` is a backstop for any residual transient failure.

Scoped to the two affected suites; no change to test logic or the global config.

## Verification

- Isolated run: 7/7 pass.
- Full suite: green across 6 consecutive runs (previously failed ~1 in 3-5 runs).

Closes #1846


___

## **CodeAnt-AI Description**
**Stabilize two full-App test suites that were timing out under heavy suite load**

### What Changed
- Increased the time allowed for the App start screen and cleanup prompt test suites so they can finish when the full test run is under memory pressure
- Added automatic retries for those two suites to handle rare run-to-run failures without changing the test behavior
- Kept the change limited to the two affected suites

### Impact
`✅ Fewer flaky test failures in full-suite runs`
`✅ Fewer timeout errors in App integration tests`
`✅ More reliable CI test results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
