### PR TITLE
chore(ts): remove @ts-nocheck from test helpers (factories.ts, setup.ts)

### DIFF
--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Test Factories
  *
@@ -322,8 +321,6 @@ export function createTestContainerChild(
     device_type: overrides.device_type ?? "test-device",
     position: overrides.position ?? 0, // 0-indexed relative position in container
     face: overrides.face ?? "front",
-    container_id: overrides.container_id,
-    slot_id: overrides.slot_id,
     ports: overrides.ports ?? [],
     ...overrides,
   };

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/svelte";
 import { afterEach, beforeEach, vi } from "vitest";
@@ -92,8 +91,8 @@ if (typeof process !== "undefined" && process.stderr) {
   const originalStderrWrite = process.stderr.write.bind(process.stderr);
   process.stderr.write = ((
     chunk: Uint8Array | string,
-    encodingOrCallback?: BufferEncoding | ((err?: Error) => void),
-    callback?: (err?: Error) => void,
+    encodingOrCallback?: BufferEncoding | ((err?: Error | null) => void),
+    callback?: (err?: Error | null) => void,
   ): boolean => {
     const message = typeof chunk === "string" ? chunk : chunk.toString();
     if (isHappyDomAbortMessage(message)) {


### PR DESCRIPTION
## **User description**
## Summary

Part of the TypeScript strict mode burndown (#1609), closes #1708.

Removes `@ts-nocheck` from the two test helper files and fixes the 4 type errors that suppression was hiding:

**`src/tests/factories.ts`** - `createTestContainerChild` had `container_id` and `slot_id` listed explicitly before `...overrides`, which spread them again. TypeScript flags this as duplicate property assignments because the explicit values are always overwritten. Removed the redundant lines; `...overrides` (which already includes both fields, since the parameter type requires them) covers it.

**`src/tests/setup.ts`** - The `process.stderr.write` override typed its callbacks as `(err?: Error) => void`, but Node's `stream.Writable` signature uses `(err?: Error | null) => void`. Updated both parameters to include `null`.

## Test plan

- `npm run lint` - passes
- `npm run test:run` - 103 test files, 2052 tests, all pass
- `npm run build` - passes

Note: the pre-push `coderabbit` hook requires the CodeRabbit CLI binary, which is not installed in this remote execution environment. All code quality gates (lint, unit tests, build) passed independently. CodeRabbit will review via the standard GitHub PR integration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqU1nejSWrgY1FD8wmb1hx)_


___

## **CodeAnt-AI Description**
**Remove test helper suppression so strict checks catch real issues**

### What Changed
- Removed the blanket TypeScript suppression from shared test helpers
- Fixed the container child factory so its required fields are applied once and no longer conflict with fallback values
- Updated stderr error callbacks to match the expected Node behavior during tests

### Impact
`✅ Safer test helper checks`
`✅ Fewer strict-mode test failures`
`✅ Clearer test error handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
