### PR TITLE
fix: skip CodeRabbit pre-push review for tag-only pushes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,28 +3,15 @@
 # Compares against origin/main to review commits being pushed
 # Blocks push if CodeRabbit finds issues
 
-# Skip the review when there is nothing to review against origin/main: tag pushes
-# and ref deletions. A tag ref has no branch diff, so CodeRabbit exits with "No
-# files found for review" and the push is wrongly blocked (e.g. `git push origin
-# v26.6.0` during a release). A deletion removes a ref rather than adding commits;
-# git signals it with an all-zero local object id (see .git/hooks/pre-push.sample).
-# Git feeds ref updates on stdin as "<local ref> <local sha> <remote ref> <remote sha>".
-zero=$(git hash-object --stdin </dev/null | tr '0-9a-f' '0')
-has_branch_ref=0
-while read -r local_ref local_sha remote_ref remote_sha; do
-  case "$remote_ref" in
-    refs/tags/*) continue ;; # tag push: nothing to review
+# Skip review for tag-only pushes (tags have no file diff to review)
+has_branch=0
+while IFS=' ' read -r local_ref _rest; do
+  case "$local_ref" in
+    refs/tags/*) ;;
+    *) has_branch=1 ;;
   esac
-  if [ "$local_sha" = "$zero" ]; then
-    continue # ref deletion: nothing to review
-  fi
-  has_branch_ref=1
 done
-
-if [ "$has_branch_ref" -eq 0 ]; then
-  echo "Tag-only or deletion push detected; skipping CodeRabbit review."
-  exit 0
-fi
+[ "$has_branch" -eq 0 ] && exit 0
 
 echo "Running CodeRabbit review on committed changes..."
 if ! coderabbit review --agent --type committed --base origin/main; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,11 +3,14 @@
 # Compares against origin/main to review commits being pushed
 # Blocks push if CodeRabbit finds issues
 
-# Skip review for tag-only pushes (tags have no file diff to review)
+# Skip review for tag-only or deletion pushes (no file diff to review)
 has_branch=0
-while IFS=' ' read -r local_ref _rest; do
-  case "$local_ref" in
-    refs/tags/*) ;;
+while IFS=' ' read -r local_ref local_sha remote_ref _rest; do
+  if [ "$local_ref" = "(delete)" ] || [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    continue
+  fi
+  case "$local_ref$remote_ref" in
+    *refs/tags/*) ;;
     *) has_branch=1 ;;
   esac
 done

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,10 +3,13 @@
 # Compares against origin/main to review commits being pushed
 # Blocks push if CodeRabbit finds issues
 
+# Match the repository's object format (sha1, sha256, ...)
+zero=$(git hash-object --stdin </dev/null | tr '[:xdigit:]' '0')
+
 # Skip review for tag-only or deletion pushes (no file diff to review)
 has_branch=0
 while IFS=' ' read -r local_ref local_sha remote_ref _rest; do
-  if [ "$local_ref" = "(delete)" ] || [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+  if [ "$local_ref" = "(delete)" ] || [ "$local_sha" = "$zero" ]; then
     continue
   fi
   case "$local_ref$remote_ref" in


### PR DESCRIPTION
## **User description**
## Summary

- Tag refs have no file diff against `origin/main`, causing CodeRabbit to exit with "No files found for review" and block the push.
- Add tag-push detection at the top of `.husky/pre-push`: read the refs from stdin and exit 0 early if every ref being pushed matches `refs/tags/*`.
- Branch pushes continue to run the full CodeRabbit review as before.

## Why

Observed during the v26.6.0 release: `git push origin v26.6.0` was blocked by the hook. The release workflow had to work around it with `--no-verify`. This fix makes tag pushes transparent to the hook so future releases work without workarounds.

## Test Plan

- [x] Lint passes (`npm run lint`)
- [x] Unit tests pass (`npm run test:run` - 2052 tests, 0 failures)
- [x] Build succeeds (`npm run build`)
- Manual: simulate a tag push by piping `refs/tags/v99.0.0 abc123 refs/tags/v99.0.0 000000` to the hook - it should exit 0 without running coderabbit
- Manual: simulate a branch push - it should still run coderabbit review

Closes #1861

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVrgB5DcsvQt8p9edFS1WN)_


___

## **CodeAnt-AI Description**
**Skip CodeRabbit review for tag-only pushes**

### What Changed
- Pushing only tags now skips the pre-push CodeRabbit review instead of blocking the push with a “no files found” error
- Pushes that include at least one branch still run the full review as before
- Ref deletions are no longer treated as changes that need review

### Impact
`✅ Tag-only releases no longer need a manual bypass`
`✅ Fewer blocked pushes during version publishing`
`✅ Branch pushes still get review checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
