### PR TITLE
chore(ts): remove @ts-nocheck from stores

### DIFF
--- a/src/lib/stores/cables.svelte.ts
+++ b/src/lib/stores/cables.svelte.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Cable Store
  * CRUD operations for cable connections between device interfaces
@@ -57,6 +56,10 @@ export function validateCable(
   const layoutStore = getLayoutStore();
   const rack = layoutStore.rack;
   const device_types = layoutStore.device_types;
+
+  if (!rack) {
+    return { valid: false, errors: ["No active rack"] };
+  }
 
   // Check A-side device exists
   const aDevice = rack.devices.find((d) => d.id === cable.a_device_id);

--- a/src/lib/stores/layout/command-adapters.ts
+++ b/src/lib/stores/layout/command-adapters.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Command Adapters for Layout Store
  *
@@ -215,7 +214,7 @@ export function getCommandStoreAdapter(
       if (!target && layout.racks.length === 0) {
         throw new Error("No rack available in RackCommandStore");
       }
-      return target?.rack ?? layout.racks[0];
+      return target?.rack ?? layout.racks[0]!;
     },
   };
 }

--- a/src/lib/stores/layout/rack-actions.ts
+++ b/src/lib/stores/layout/rack-actions.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Rack Actions Domain Module
  *
@@ -56,7 +55,7 @@ export function deleteRackRaw(
   const layout = ctx.getLayout();
   const rackIndex = layout.racks.findIndex((r) => r.id === id);
   if (rackIndex === -1) return undefined;
-  const rack = layout.racks[rackIndex];
+  const rack = layout.racks[rackIndex]!;
 
   // Find groups that contain this rack (capture their state before modification)
   const affectedGroups = (layout.rack_groups ?? [])
@@ -225,7 +224,7 @@ export function getTargetRack(
   if (rackId) {
     const index = ctx.findRackIndex(rackId);
     if (index !== -1) {
-      return { rack: layout.racks[index], index };
+      return { rack: layout.racks[index]!, index };
     }
     return undefined;
   }
@@ -235,13 +234,13 @@ export function getTargetRack(
   if (activeId) {
     const index = ctx.findRackIndex(activeId);
     if (index !== -1) {
-      return { rack: layout.racks[index], index };
+      return { rack: layout.racks[index]!, index };
     }
   }
 
   // Fall back to first rack
   if (layout.racks.length > 0) {
-    return { rack: layout.racks[0], index: 0 };
+    return { rack: layout.racks[0]!, index: 0 };
   }
 
   return undefined;
@@ -470,7 +469,7 @@ export function reorderRacks(
   }
 
   const newRacks = [...layout.racks];
-  const [removed] = newRacks.splice(fromIndex, 1);
+  const [removed] = newRacks.splice(fromIndex, 1) as [Rack];
   newRacks.splice(toIndex, 0, removed);
 
   // Update position field to match new array indices


### PR DESCRIPTION
## **User description**
Removes `@ts-nocheck` from 3 store files and fixes the 8 underlying TypeScript errors.

## Changes

- `rack-actions.ts`: non-null assertions on guarded array accesses (5 errors)
- `cables.svelte.ts`: early return guard when no active rack (2 errors)
- `command-adapters.ts`: non-null assertion on guarded `racks[0]` access (1 error)

## Testing

`svelte-check` reports 0 errors in the modified files.

Closes #1706

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Tighten rack and cable handling when no active rack is available

### What Changed
- Cable validation now stops early with a clear “No active rack” error instead of continuing when nothing is selected
- Rack lookups now use safer fallbacks when choosing the current rack, reducing cases where actions could fail on an empty or missing selection
- Rack reordering and deletion now handle selected racks more reliably

### Impact
`✅ Fewer crashes when no rack is selected`
`✅ Clearer cable validation errors`
`✅ More reliable rack actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
