### PR TITLE
feat(api): adopt pino as the logging standard with levels (#1888)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  api:
+    name: api (typecheck + tests)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1"
+
+      - name: Install API dependencies
+        working-directory: api
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck API
+        working-directory: api
+        run: bun run typecheck
+
+      - name: Run API tests
+        working-directory: api
+        run: bun test
+
   validate:
     name: validate
     runs-on: ubuntu-latest

--- a/api/.env.example
+++ b/api/.env.example
@@ -70,6 +70,10 @@ PORT=3000
 # Node environment (development, production, test)
 NODE_ENV=development
 
+# Log verbosity: trace, debug, info, warn, error, fatal, or silent (default: info)
+# debug is off by default in production; raise to debug for verbose tracing.
+# LOG_LEVEL=info
+
 # ========================================
 # Storage Quotas
 # ========================================

--- a/api/bun.lock
+++ b/api/bun.lock
@@ -9,11 +9,13 @@
         "better-auth": "^1.6.2",
         "hono": "^4.12.19",
         "js-yaml": "^4.1.1",
+        "pino": "^10.3.1",
         "zod": "^3.24.1",
       },
       "devDependencies": {
         "@types/bun": "^1.2.21",
         "@types/js-yaml": "^4.0.9",
+        "pino-pretty": "^13.1.3",
         "typescript": "^5.8.3",
       },
     },
@@ -88,6 +90,8 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
@@ -100,27 +104,77 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "better-auth": ["better-auth@1.6.2", "", { "dependencies": { "@better-auth/core": "1.6.2", "@better-auth/drizzle-adapter": "1.6.2", "@better-auth/kysely-adapter": "1.6.2", "@better-auth/memory-adapter": "1.6.2", "@better-auth/mongo-adapter": "1.6.2", "@better-auth/prisma-adapter": "1.6.2", "@better-auth/telemetry": "1.6.2", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.14", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-5nqDAIj5xexmnk+GjjdrBknJCabi1mlvsVWJbxs4usHreao4vNdxIxINWDzCyDF9iDR1ildRZdXWSiYPAvTHhA=="],
 
     "better-call": ["better-call@1.3.5", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "fast-copy": ["fast-copy@4.0.3", "", {}, "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
     "hono": ["hono@4.12.19", "", {}, "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
     "nanostores": ["nanostores@1.3.0", "", {}, "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
     "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -128,10 +182,14 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@better-auth/core/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "better-auth/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -22,11 +22,13 @@
     "better-auth": "^1.6.2",
     "hono": "^4.12.19",
     "js-yaml": "^4.1.1",
+    "pino": "^10.3.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/bun": "^1.2.21",
     "@types/js-yaml": "^4.0.9",
+    "pino-pretty": "^13.1.3",
     "typescript": "^5.8.3"
   }
 }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
-import { logger } from "hono/logger";
+import { logger as honoLogger } from "hono/logger";
 import { bodyLimit } from "hono/body-limit";
 import layouts from "./routes/layouts";
 import assets from "./routes/assets";
@@ -34,6 +34,7 @@ import {
   verifyCredentials,
 } from "./local-auth";
 import pkg from "../package.json";
+import { logger } from "./logger";
 
 const DEFAULT_MAX_ASSET_SIZE = 5 * 1024 * 1024; // 5MB
 const DEFAULT_MAX_LAYOUT_SIZE = 1 * 1024 * 1024; // 1MB
@@ -208,7 +209,7 @@ function mapFallbackSessionClaims(
   const fallbackSubject =
     session.user.email?.trim() || session.user.id?.trim() || "oidc-user";
   if (fallbackSubject === "oidc-user") {
-    console.warn(
+    logger.warn(
       "auth: OIDC session missing user identity (email and id), using generic subject",
     );
   }
@@ -290,31 +291,31 @@ export async function createApp(
       securityConfig.isProduction &&
       !securityConfig.authSessionCookieSecure
     ) {
-      console.warn(
+      logger.warn(
         "⚠ Local auth mode in production without Secure cookies. Set RACKULA_AUTH_SESSION_COOKIE_SECURE=true.",
       );
     }
   }
 
   if (securityConfig.isProduction && securityConfig.allowInsecureCors) {
-    console.warn(
+    logger.warn(
       "⚠ Running with wildcard CORS in production because ALLOW_INSECURE_CORS=true.",
     );
   }
 
   if (securityConfig.isProduction && !securityConfig.writeAuthToken) {
-    console.warn(
+    logger.warn(
       "⚠ Write-route auth token is not configured. Set RACKULA_API_WRITE_TOKEN to protect PUT/DELETE routes.",
     );
   }
 
   if (securityConfig.authEnabled) {
-    console.warn(
+    logger.warn(
       `🔒 Authentication gate enabled (mode=${securityConfig.authMode}). Anonymous access is blocked by default.`,
     );
   }
 
-  app.use("*", logger());
+  app.use("*", honoLogger());
   app.use(
     "*",
     cors({
@@ -390,7 +391,7 @@ export async function createApp(
         ? validateFallbackSessionClaims(mappedFallbackClaims, authSessionConfig)
         : null;
     } catch (error) {
-      console.debug("auth: fallback session check failed", error);
+      logger.debug({ err: error }, "auth: fallback session check failed");
       return null;
     }
   };
@@ -499,7 +500,7 @@ export async function createApp(
 
         return c.redirect(redirectUrl, 302);
       } catch (error) {
-        console.error("OIDC login initiation failed:", error);
+        logger.error({ err: error }, "OIDC login initiation failed");
         return c.json(
           {
             error: "Authentication failed",
@@ -603,7 +604,7 @@ export async function createApp(
           });
           appendSetCookieHeaders(c, signOutResult.headers);
         } catch (error) {
-          console.debug("auth: provider sign-out failed", error);
+          logger.debug({ err: error }, "auth: provider sign-out failed");
         }
       }
 
@@ -889,7 +890,7 @@ export async function createApp(
 
   // Error handler
   app.onError((err, c) => {
-    console.error("Unhandled error:", err);
+    logger.error({ err }, "Unhandled error");
     return c.json({ error: "Internal server error" }, 500);
   });
 

--- a/api/src/auth-logger.ts
+++ b/api/src/auth-logger.ts
@@ -5,6 +5,7 @@
  * All sensitive fields (tokens, passwords, session IDs) are redacted.
  */
 import { createHmac } from "node:crypto";
+import { logger } from "./logger";
 
 export type AuthEventType =
   | "auth.login.success"
@@ -58,14 +59,14 @@ export function configureAuthLogHashKey(hashKey: string | undefined): void {
   ) {
     // Primary validation lives in resolveApiSecurityConfig(security.ts); this is a
     // defensive fallback for direct caller usage that bypasses config resolution.
-    console.warn(
+    logger.warn(
       `[auth-logger] Ignoring auth log hash key shorter than ${MIN_AUTH_LOG_HASH_KEY_LENGTH} characters. This fallback applies only when resolveApiSecurityConfig is not used.`,
     );
     authLogHashKey = undefined;
   } else {
     authLogHashKey = normalizedLength > 0 ? normalized : undefined;
     if (authLogHashKey) {
-      console.debug(
+      logger.debug(
         `[auth-logger] Auth log hash key configured (>=${MIN_AUTH_LOG_HASH_KEY_LENGTH} chars).`,
       );
     }
@@ -79,7 +80,7 @@ function getAuthLogHashKey(): string {
   }
 
   if (!hasWarnedDefaultHashKey) {
-    console.warn(
+    logger.warn(
       "[auth-logger] No auth log hash key configured. Falling back to default auth log hash key; configure RACKULA_AUTH_LOG_HASH_KEY to avoid predictable cross-instance pseudonyms.",
     );
     hasWarnedDefaultHashKey = true;
@@ -211,6 +212,6 @@ export function safeLogAuthEvent(
   try {
     logAuthEvent(eventType, request, extra);
   } catch (err) {
-    console.error("[auth-logger] Failed to log auth event:", err);
+    logger.error({ err }, "[auth-logger] Failed to log auth event");
   }
 }

--- a/api/src/auth/config.ts
+++ b/api/src/auth/config.ts
@@ -3,6 +3,7 @@ import { genericOAuth } from "better-auth/plugins";
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 
 import type { EnvMap } from "../security";
+import { logger } from "../logger";
 
 const DEFAULT_BASE_URL = "http://localhost:3000";
 const DEFAULT_AUTH_SESSION_COOKIE_NAME = "rackula_auth_session";
@@ -288,7 +289,7 @@ function createOidcUserInfoResolver(options: {
 
       return mapVerifiedOidcPayload(payload);
     } catch (error) {
-      console.warn("OIDC ID token validation failed:", error);
+      logger.warn({ err: error }, "OIDC ID token validation failed");
       return null;
     }
   };

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -4,6 +4,7 @@
  */
 import { createApp } from "./app";
 import { ensureDataDir } from "./storage/filesystem";
+import { logger } from "./logger";
 
 const app = await createApp();
 
@@ -15,8 +16,8 @@ const port = Number.isNaN(parsedPort) ? 3001 : parsedPort;
 
 await ensureDataDir();
 
-console.log(`Rackula API listening on port ${port}`);
-console.log(`Data directory: ${process.env.DATA_DIR ?? "./data"}`);
+logger.info(`Rackula API listening on port ${port}`);
+logger.info(`Data directory: ${process.env.DATA_DIR ?? "./data"}`);
 
 export default {
   port,

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -6,13 +6,14 @@
  * environment via the LOG_LEVEL environment variable.
  *
  * - level: LOG_LEVEL (default "info") so debug tracing is opt-in
- * - interactive terminal (TTY): pino-pretty transport for readable output
+ * - non-production interactive terminal (TTY): pino-pretty transport for readable output
  * - everywhere else (production, CI, systemd, Docker): structured JSON to stdout
  *
- * Pretty output is gated on stdout being a TTY rather than on NODE_ENV, so CI,
- * test runs, and non-interactive production launches never spawn the pino-pretty
- * worker thread or require pino-pretty (a devDependency absent from production
- * installs).
+ * Pretty output requires both a non-production environment and an interactive
+ * TTY. The TTY check keeps CI, test runs, and non-interactive launches on JSON
+ * (no pino-pretty worker thread), while the NODE_ENV check ensures production
+ * never attempts pino-pretty (a devDependency absent from production installs)
+ * even when attached to a terminal, e.g. `docker run -it`.
  *
  * Usage:
  *   import { logger } from "./logger";

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared application logger for the API.
+ *
+ * Built on pino, which gives real log levels (debug/info/warn/error), so debug
+ * output is off by default in production and verbosity is controllable per
+ * environment via the LOG_LEVEL environment variable.
+ *
+ * - level: LOG_LEVEL (default "info") so debug tracing is opt-in
+ * - interactive terminal (TTY): pino-pretty transport for readable output
+ * - everywhere else (production, CI, systemd, Docker): structured JSON to stdout
+ *
+ * Pretty output is gated on stdout being a TTY rather than on NODE_ENV, so CI,
+ * test runs, and non-interactive production launches never spawn the pino-pretty
+ * worker thread or require pino-pretty (a devDependency absent from production
+ * installs).
+ *
+ * Usage:
+ *   import { logger } from "./logger";
+ *   logger.warn("quota exceeded");
+ *   logger.error({ err }, "Failed to save layout");
+ */
+import pino from "pino";
+
+const usePrettyOutput =
+  process.env.NODE_ENV !== "production" && Boolean(process.stdout.isTTY);
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
+  ...(usePrettyOutput
+    ? {
+        transport: {
+          target: "pino-pretty",
+          options: { colorize: true, ignore: "pid,hostname" },
+        },
+      }
+    : {}),
+});

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -22,6 +22,7 @@ import {
   isValidDeviceSlug,
   MAX_SIZE,
 } from "../storage/assets";
+import { logger } from "../logger";
 
 const assets = new Hono();
 
@@ -58,7 +59,7 @@ assets.get("/:layoutId/:deviceSlug/:face", async (c) => {
       "Cache-Control": "public, max-age=3600, must-revalidate",
     });
   } catch (error) {
-    console.error(`Failed to get asset:`, error);
+    logger.error({ err: error }, `Failed to get asset`);
     return c.json({ error: "Failed to get asset" }, 500);
   }
 });
@@ -112,7 +113,7 @@ assets.put("/:layoutId/:deviceSlug/:face", async (c) => {
 
     return c.json({ message: "Asset uploaded" }, 200);
   } catch (error) {
-    console.error(`Failed to save asset:`, error);
+    logger.error({ err: error }, `Failed to save asset`);
 
     if (error instanceof Error && error.message.includes("too large")) {
       return c.json({ error: error.message }, 413);
@@ -147,7 +148,7 @@ assets.delete("/:layoutId/:deviceSlug/:face", async (c) => {
 
     return c.json({ message: "Asset deleted" }, 200);
   } catch (error) {
-    console.error(`Failed to delete asset:`, error);
+    logger.error({ err: error }, `Failed to delete asset`);
     return c.json({ error: "Failed to delete asset" }, 500);
   }
 });

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -23,6 +23,7 @@ import {
   deleteLayout,
 } from "../storage/filesystem";
 import { deleteLayoutAssets } from "../storage/assets";
+import { logger } from "../logger";
 
 const layouts = new Hono();
 
@@ -32,7 +33,7 @@ layouts.get("/", async (c) => {
     const items = await listLayouts();
     return c.json({ layouts: items });
   } catch (error) {
-    console.error("Failed to list layouts:", error);
+    logger.error({ err: error }, "Failed to list layouts");
     return c.json({ error: "Failed to list layouts" }, 500);
   }
 });
@@ -54,7 +55,7 @@ layouts.get("/:uuid", async (c) => {
 
     return c.text(content, 200, { "Content-Type": "text/yaml" });
   } catch (error) {
-    console.error(`Failed to get layout ${uuidResult.data}:`, error);
+    logger.error({ err: error }, `Failed to get layout ${uuidResult.data}`);
     return c.json({ error: "Failed to get layout" }, 500);
   }
 });
@@ -113,7 +114,7 @@ layouts.put("/:uuid", async (c) => {
       result.isNew ? 201 : 200,
     );
   } catch (error) {
-    console.error(`Failed to save layout ${uuidResult.data}:`, error);
+    logger.error({ err: error }, `Failed to save layout ${uuidResult.data}`);
 
     // saveLayout throws Error with message prefixes for validation failures
     if (error instanceof Error) {
@@ -150,15 +151,15 @@ layouts.delete("/:uuid", async (c) => {
     try {
       await deleteLayoutAssets(uuidResult.data);
     } catch (assetError) {
-      console.warn(
-        `Failed to delete assets for layout ${uuidResult.data}:`,
-        assetError,
+      logger.warn(
+        { err: assetError },
+        `Failed to delete assets for layout ${uuidResult.data}`,
       );
     }
 
     return c.json({ message: "Layout deleted" }, 200);
   } catch (error) {
-    console.error(`Failed to delete layout ${uuidResult.data}:`, error);
+    logger.error({ err: error }, `Failed to delete layout ${uuidResult.data}`);
     return c.json({ error: "Failed to delete layout" }, 500);
   }
 });

--- a/api/src/security/config.ts
+++ b/api/src/security/config.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomBytes } from "node:crypto";
 import { MIN_AUTH_LOG_HASH_KEY_LENGTH } from "../auth-logger";
+import { logger } from "../logger";
 import { normalizeOrigin } from "./request-utils";
 import type {
   ApiSecurityConfig,
@@ -53,7 +54,7 @@ function resolveAuthLogHashKey(options: {
   }
 
   if (options.isProduction) {
-    console.warn(
+    logger.warn(
       "⚠ Auth log hash key is not configured and no auth session secret is available. Generating an ephemeral per-process key. Set RACKULA_AUTH_LOG_HASH_KEY in production for stable pseudonymization.",
     );
   }

--- a/api/src/security/storage-quota-middleware.ts
+++ b/api/src/security/storage-quota-middleware.ts
@@ -18,6 +18,7 @@ import type { MiddlewareHandler } from "hono";
 import { checkLayoutQuota, checkAssetQuota } from "../storage/quota";
 import { findFolderByUuid } from "../storage/filesystem";
 import { isUuid } from "../schemas/layout";
+import { logger } from "../logger";
 
 /**
  * Configuration for the storage quota middleware.
@@ -74,7 +75,7 @@ export function createStorageQuotaMiddleware(
       if (uuid && isUuid(uuid)) {
         const existingFolder = await findFolderByUuid(uuid, dataDir);
         if (existingFolder) {
-          console.debug(`quota: layout update for ${uuid}, skipping check`);
+          logger.debug(`quota: layout update for ${uuid}, skipping check`);
           await next();
           return;
         }
@@ -87,7 +88,7 @@ export function createStorageQuotaMiddleware(
       // Adding file locks would introduce complexity not justified by the threat model.
       const quota = await checkLayoutQuota(dataDir, maxLayouts);
       if (!quota.allowed) {
-        console.warn(
+        logger.warn(
           `quota: layout quota exceeded ${quota.current}/${quota.max}`,
         );
         return c.json(
@@ -115,7 +116,7 @@ export function createStorageQuotaMiddleware(
         if (layoutFolder) {
           const quota = await checkAssetQuota(layoutFolder, maxAssetsPerLayout);
           if (!quota.allowed) {
-            console.warn(
+            logger.warn(
               `quota: asset quota exceeded for layout ${layoutId}: ${quota.current}/${quota.max}`,
             );
             return c.json(
@@ -130,7 +131,7 @@ export function createStorageQuotaMiddleware(
           }
         } else {
           // Layout doesn't exist — the route handler will return 404
-          console.debug(
+          logger.debug(
             `quota: layout ${layoutId} not found, skipping asset check`,
           );
         }

--- a/api/src/storage/assets.ts
+++ b/api/src/storage/assets.ts
@@ -18,6 +18,7 @@ import { join, dirname } from "node:path";
 import { z } from "zod";
 import { getLayoutAssetsDir } from "./filesystem";
 import { isUuid } from "../schemas/layout";
+import { logger } from "../logger";
 
 // Allowed image types
 const ALLOWED_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
@@ -82,7 +83,7 @@ export function getContentTypeFromExt(ext: string): string {
     case "webp":
       return "image/webp";
     default:
-      console.warn(`Unknown extension for content type lookup: ${ext}`);
+      logger.warn(`Unknown extension for content type lookup: ${ext}`);
       return "application/octet-stream";
   }
 }

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -22,6 +22,7 @@ import {
   slugify,
   type LayoutListItem,
 } from "../schemas/layout";
+import { logger } from "../logger";
 
 function getDataDir(): string {
   return process.env.DATA_DIR ?? "./data";
@@ -136,7 +137,7 @@ async function readLegacyLayout(
   } catch (e) {
     const slug = filename.replace(/\.ya?ml$/i, "");
     const stats = await stat(filepath).catch(() => ({ mtime: new Date() }));
-    console.warn(`Failed to read legacy layout: ${filename}`, e);
+    logger.warn({ err: e }, `Failed to read legacy layout: ${filename}`);
     return {
       id: slug,
       name: slug,
@@ -199,7 +200,7 @@ async function readLayoutFromFolder(
   } catch (e) {
     // File read/parse error - include with error flag
     const stats = await stat(folderPath).catch(() => ({ mtime: new Date() }));
-    console.warn(`Failed to read layout from folder: ${folderName}`, e);
+    logger.warn({ err: e }, `Failed to read layout from folder: ${folderName}`);
     return {
       id: uuid,
       name: folderName.replace(`-${uuid}`, ""),
@@ -401,9 +402,9 @@ async function migrateLegacyLayout(
         await mkdir(join(dataDir, "assets"), { recursive: true });
         await rename(newAssetsDir, oldAssetsDir);
       } catch (restoreError) {
-        console.warn(
+        logger.warn(
+          { err: restoreError },
           `Failed to restore legacy assets for ${oldSlug}`,
-          restoreError,
         );
       }
     }
@@ -519,9 +520,9 @@ export async function saveLayout(
         await rm(join(folderPath, oldYamlFilename));
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          console.warn(
+          logger.warn(
+            { err: error },
             `Failed to delete stale YAML file "${oldYamlFilename}" in "${folderPath}"`,
-            error,
           );
         }
       }

--- a/api/src/storage/quota.ts
+++ b/api/src/storage/quota.ts
@@ -10,6 +10,7 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { extractUuidFromFolderName } from "../schemas/layout";
+import { logger } from "../logger";
 
 /**
  * Result of a storage quota check.
@@ -39,7 +40,7 @@ export async function checkLayoutQuota(
   maxLayouts: number,
 ): Promise<QuotaCheckResult> {
   if (maxLayouts === 0) {
-    console.debug("quota: layout quota unlimited, skipping check");
+    logger.debug("quota: layout quota unlimited, skipping check");
     return { allowed: true, current: 0, max: 0 };
   }
 
@@ -75,7 +76,7 @@ export async function checkLayoutQuota(
   }
 
   const allowed = layoutCount < maxLayouts;
-  console.debug(
+  logger.debug(
     `quota: layout check ${layoutCount}/${maxLayouts} ${allowed ? "allowed" : "exceeded"}`,
   );
 
@@ -99,7 +100,7 @@ export async function checkAssetQuota(
   maxAssetsPerLayout: number,
 ): Promise<QuotaCheckResult> {
   if (maxAssetsPerLayout === 0) {
-    console.debug("quota: asset quota unlimited, skipping check");
+    logger.debug("quota: asset quota unlimited, skipping check");
     return { allowed: true, current: 0, max: 0 };
   }
 
@@ -115,7 +116,7 @@ export async function checkAssetQuota(
       err instanceof Error &&
       (err as NodeJS.ErrnoException).code === "ENOENT"
     ) {
-      console.debug(`quota: no assets directory, 0/${maxAssetsPerLayout}`);
+      logger.debug(`quota: no assets directory, 0/${maxAssetsPerLayout}`);
       return { allowed: true, current: 0, max: maxAssetsPerLayout };
     }
     throw err;
@@ -144,7 +145,7 @@ export async function checkAssetQuota(
   }
 
   const allowed = assetCount < maxAssetsPerLayout;
-  console.debug(
+  logger.debug(
     `quota: asset check for ${layoutDir} ${assetCount}/${maxAssetsPerLayout} ${allowed ? "allowed" : "exceeded"}`,
   );
 

--- a/docs/deployment/SELF-HOSTING.md
+++ b/docs/deployment/SELF-HOSTING.md
@@ -627,6 +627,7 @@ All variables have sensible defaults. Only configure if you need to change somet
 | `RACKULA_OIDC_REDIRECT_URI`          | _derived from BASE_URL_ | Explicit OIDC callback URL; must match the IdP's registered redirect URI exactly                   |
 | `RACKULA_MAX_LAYOUTS`                | `100`                   | Maximum number of stored layouts. Set to `0` for unlimited                                         |
 | `RACKULA_MAX_ASSETS_PER_LAYOUT`      | `50`                    | Maximum number of assets per layout. Set to `0` for unlimited                                      |
+| `LOG_LEVEL`                          | `info`                  | API log verbosity: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, or `silent`                 |
 
 **Port mapping explained:**
 
@@ -844,6 +845,23 @@ When a quota is exceeded:
 - Asset limit reached returns HTTP 507 with a message to remove existing assets
 
 Layout quota only applies to new layouts. Updating an existing layout always succeeds.
+
+### Logging
+
+The API logs through a single pino logger. Verbosity is controlled by the `LOG_LEVEL`
+environment variable (default `info`), so debug tracing is off by default in production.
+
+| `LOG_LEVEL`        | Output                                                |
+| ------------------ | ----------------------------------------------------- |
+| `debug` or `trace` | Verbose tracing plus all info, warnings, and errors   |
+| `info` (default)   | Startup and operational info, warnings, and errors    |
+| `warn`             | Warnings and errors only                              |
+| `error` or `fatal` | Errors only                                           |
+| `silent`           | No output                                             |
+
+In production (`NODE_ENV=production`) logs are emitted as structured JSON, one object per
+line, suitable for log shippers. In other environments they are pretty-printed for
+readability.
 
 ### Single-User Design
 

--- a/docs/deployment/SELF-HOSTING.md
+++ b/docs/deployment/SELF-HOSTING.md
@@ -860,8 +860,9 @@ environment variable (default `info`), so debug tracing is off by default in pro
 | `silent`           | No output                                             |
 
 In production (`NODE_ENV=production`) logs are emitted as structured JSON, one object per
-line, suitable for log shippers. In other environments they are pretty-printed for
-readability.
+line, suitable for log shippers. In non-production interactive terminals (TTY) logs are
+pretty-printed for readability; non-interactive runs (CI, systemd, Docker) still emit
+structured JSON.
 
 ### Single-User Design
 


### PR DESCRIPTION
## **User description**
## Summary

Adopt pino as the API logging standard, replacing every `console.*` call in `api/src/**` with a shared `logger` (`api/src/logger.ts`). Gives real log levels (debug off by default in production) controlled per environment via `LOG_LEVEL`.

Closes #1888.

## What changed

- New `api/src/logger.ts`: pino singleton, `level: LOG_LEVEL ?? "info"`.
- Pretty output (`pino-pretty`) is gated on `stdout` being a **TTY**, not on `NODE_ENV`. So interactive dev terminals get readable colourised logs, while CI, `bun test`, systemd, and Docker all emit structured JSON. This means non-interactive runs never spawn the pino-pretty worker thread or require `pino-pretty` (a devDependency absent from `--production` installs).
- Converted all `console.*` across 11 files. Calls passing a trailing `Error` use pino's merge-object form: `logger.error({ err }, "message")`. Per-file before/after log-call counts match exactly (39 to 39) - no log line dropped.
- The `hono/logger` access-log middleware is retained (request-level access logging is explicitly out of scope per the issue) and its import aliased to `honoLogger` to avoid colliding with the pino `logger`.
- Docs: `LOG_LEVEL` documented in `api/.env.example` and `docs/deployment/SELF-HOSTING.md`.

## CI gate (was: typecheck only)

Discovery during this work: **no CI job ran the API's `bun test` or `bun run typecheck` at all** - the only api/ references in workflows are build/deploy. This is exactly why #1890's typecheck errors landed silently.

This PR adds an `api` job to `test.yml` running `bun install --frozen-lockfile`, `bun run typecheck`, **and** `bun test`. Running the test suite (not just typecheck) is a deliberate extension beyond the originally-scoped typecheck gate, closing a real M2 stability gap. It is consistent with the existing unfiltered `validate` job. Trim to typecheck-only if you'd prefer the minimal change.

## Verification

- `cd api && bun run typecheck` - clean (0 errors)
- `cd api && bun test` - 240 pass / 0 fail
- `LOG_LEVEL=info` suppresses debug; `LOG_LEVEL=debug` shows it; warn/error always fire
- Production smoke: `bun install --frozen-lockfile --production` excludes pino-pretty; `NODE_ENV=production` import emits JSON without requiring it (no startup crash)
- TTY run renders pretty colourised output; non-TTY renders JSON
- Confirmed both production paths set `NODE_ENV=production` (`api/Dockerfile`, `deploy/lxc/rackula-api.service`)

## Test Plan
- [x] Typecheck clean
- [x] API tests pass (240)
- [x] LOG_LEVEL gating verified
- [x] Production bundle smoke (no pino-pretty dependency)
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Standardize API logging and start checking API tests in CI**

### What Changed
- API startup, auth, quota, storage, and route errors now use one shared logger with adjustable log levels
- Debug logs stay off by default in production, while interactive terminals keep readable log output
- Logging errors now include structured error details, and auth/session warnings are handled consistently
- API typechecks and the API test suite now run in CI
- `LOG_LEVEL` is documented in the example env file and self-hosting guide

### Impact
`✅ Clearer API logs`
`✅ Easier production log filtering`
`✅ Fewer missed API test failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
