### PR TITLE
fix(persistence): surface storage quota rejections with clear messaging (#1390)

### DIFF
--- a/src/lib/utils/persistence-manager.svelte.ts
+++ b/src/lib/utils/persistence-manager.svelte.ts
@@ -127,7 +127,25 @@ export function handlePersistenceError(
   const toastStore = getToastStore();
   const action = onRetry ? { label: "Retry", onClick: onRetry } : undefined;
   if (e instanceof PersistenceError) {
-    if (
+    // Storage quota rejections (507 asset limit, 429 layout limit). The server is
+    // reachable and the data is intact, so this is a recoverable error state, not
+    // offline: do not flip to offline or trip the circuit breaker, and 507 must
+    // not fall through to the >= 500 branch. 429 is also used by the API rate
+    // limiter ("Too Many Requests"), so the layout-quota case is distinguished by
+    // the server error text; 507 is only ever the asset quota.
+    const isStorageQuota =
+      e.statusCode === 507 ||
+      (e.statusCode === 429 && /quota/i.test(e.message));
+    if (isStorageQuota) {
+      _saveStatus = "error";
+      if (notify) {
+        const message =
+          e.statusCode === 507
+            ? "Storage full: asset limit reached for this layout. Remove existing assets to add new ones."
+            : "Storage full: layout limit reached. Delete existing layouts to save new ones.";
+        toastStore.showToast(message, "error", undefined, action);
+      }
+    } else if (
       e.statusCode === undefined ||
       e.statusCode === 404 ||
       (typeof e.statusCode === "number" && e.statusCode >= 500)

--- a/src/tests/persistence-manager-quota.test.ts
+++ b/src/tests/persistence-manager-quota.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  handlePersistenceError,
+  getSaveStatus,
+  setSaveStatus,
+  getConsecutiveSaveFailures,
+} from "$lib/utils/persistence-manager.svelte";
+import { PersistenceError } from "$lib/utils/persistence-api";
+import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
+import { setApiAvailable } from "$lib/stores/persistence.svelte";
+
+/**
+ * Storage quota rejections (429 layout limit, 507 asset limit) come from a
+ * reachable server with intact data, so they must surface as a recoverable
+ * "error" state with quota-specific messaging, not as "offline". 507 in
+ * particular must not fall through to the >= 500 offline branch.
+ */
+describe("handlePersistenceError quota rejections", () => {
+  beforeEach(() => {
+    resetToastStore();
+    setSaveStatus("idle");
+    setApiAvailable(true);
+  });
+
+  it("treats 429 as a layout-quota error, not offline", () => {
+    handlePersistenceError(
+      new PersistenceError("Storage quota exceeded", 429),
+      true,
+    );
+    expect(getSaveStatus()).toBe("error");
+    const latest = getToastStore().toasts.at(-1);
+    expect(latest?.type).toBe("error");
+    expect(latest?.message).toContain("layout limit");
+  });
+
+  it("treats 507 as an asset-quota error without tripping the offline circuit breaker", () => {
+    const failuresBefore = getConsecutiveSaveFailures();
+    handlePersistenceError(
+      new PersistenceError("Storage quota exceeded", 507),
+      true,
+    );
+    expect(getSaveStatus()).toBe("error");
+    const latest = getToastStore().toasts.at(-1);
+    expect(latest?.type).toBe("error");
+    expect(latest?.message).toContain("asset limit");
+    // 507 must not be treated as offline, so the circuit breaker stays put.
+    expect(getConsecutiveSaveFailures()).toBe(failuresBefore);
+  });
+
+  it("offers a retry action on quota errors when a retry handler is given", () => {
+    let retried = false;
+    handlePersistenceError(
+      new PersistenceError("Storage quota exceeded", 429),
+      true,
+      () => {
+        retried = true;
+      },
+    );
+    const action = getToastStore().toasts.at(-1)?.action;
+    expect(action?.label).toBe("Retry");
+    action?.onClick();
+    expect(retried).toBe(true);
+  });
+
+  it("does not mistake a rate-limit 429 for a storage quota", () => {
+    // The API rate limiter also returns 429 but with a different error body.
+    handlePersistenceError(
+      new PersistenceError("Too Many Requests", 429),
+      true,
+    );
+    expect(getSaveStatus()).toBe("error");
+    const message = getToastStore().toasts.at(-1)?.message ?? "";
+    expect(message).not.toContain("Storage full");
+  });
+
+  it("still routes genuine 5xx server errors to offline", () => {
+    handlePersistenceError(new PersistenceError("boom", 503), true);
+    expect(getSaveStatus()).toBe("offline");
+  });
+});

--- a/src/tests/persistence-manager-quota.test.ts
+++ b/src/tests/persistence-manager-quota.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   handlePersistenceError,
   getSaveStatus,
-  setSaveStatus,
   getConsecutiveSaveFailures,
+  resetPersistenceManager,
 } from "$lib/utils/persistence-manager.svelte";
 import { PersistenceError } from "$lib/utils/persistence-api";
 import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
@@ -18,7 +18,7 @@ import { setApiAvailable } from "$lib/stores/persistence.svelte";
 describe("handlePersistenceError quota rejections", () => {
   beforeEach(() => {
     resetToastStore();
-    setSaveStatus("idle");
+    resetPersistenceManager();
     setApiAvailable(true);
   });
 


### PR DESCRIPTION
## **User description**
## Summary

When the API rejects a save with a storage quota error (429 layout limit / 507 asset limit, added in #1780/#1875), the UI now shows a clear, recoverable error with quota-specific copy instead of mislabelling it as offline or showing a generic failure.

Closes #1390. Depends on the 429/507 contract from #1875 (merged).

## The bug

`handlePersistenceError` routed any status `>= 500` to the offline path. 507 (Insufficient Storage) fell into that bucket, so an asset-quota rejection from a fully-reachable server was shown as "working offline" and tripped the auto-save circuit breaker. 429 fell through to a generic "Save failed".

## Fix

- 507 (asset quota, unambiguous) and 429 (layout quota) now map to a recoverable `error` state with specific copy ("Storage full: ... limit reached ..."), without flipping to offline or tripping the circuit breaker.
- 429 is also used by the API rate limiter (`Too Many Requests`), so the layout-quota case is distinguished by the server error text (only quota responses carry `Storage quota exceeded`); a rate-limit 429 keeps the generic path.

## Already in place (verified, not rebuilt)

The error state, the toast Retry action (`handleSaveToServer` passes a retry closure), clear-on-success (`_saveStatus = "saved"`), and load-failure toasts (`loadFromApi`) already existed. The startup auto-restore intentionally degrades to localStorage silently, so it is left unchanged.

## Tests

`src/tests/persistence-manager-quota.test.ts` (behavioural): 429 to layout-quota error, 507 to asset-quota error without circuit-breaker trip, retry action wiring, rate-limit 429 not mistaken for quota, and a 5xx-stays-offline regression guard.

## Verification
- [x] New tests pass (5)
- [x] `npm run test:run` (2057 pass)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix quota-related save errors so they show the right message instead of looking like offline failures

### What Changed
- Storage quota rejections now stay in a recoverable error state instead of switching the app to offline
- Layout quota and asset quota errors now show specific messages that tell users what storage limit was reached and how to recover
- The retry action still appears on these errors, and normal server failures still go to the offline path
- Added coverage for quota errors, retry behavior, rate-limit 429 responses, and genuine 5xx offline handling

### Impact
`✅ Clearer storage full errors`
`✅ Fewer mistaken offline states`
`✅ Reliable retry on quota failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
