### PR TITLE
feat(lxc): add SHA256 verification and harden LXC release workflow (#1891)

### DIFF
--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -5,10 +5,14 @@ name: Build LXC Tarball
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Create Release"]
+    types: [completed]
+    branches: ["v*"]
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g. v0.8.0)"
+        description: "Version tag (e.g. v26.6.0)"
         required: true
 
 permissions:
@@ -17,6 +21,8 @@ permissions:
 jobs:
   build-lxc-tarball:
     runs-on: ubuntu-latest
+    # Only run if the triggering workflow succeeded (skip if release.yml was skipped/failed)
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -26,9 +32,21 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Derive version from the triggering workflow's ref (tag name)
+            echo "version=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
           else
             echo "version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
+            exit 1
+          fi
+          echo "Version: $VERSION"
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -90,7 +108,19 @@ jobs:
           cp deploy/lxc/security-headers.conf "${TARBALL_DIR}/config/"
           cp deploy/lxc/nginx.service.d-override.conf "${TARBALL_DIR}/config/"
 
+          # Verify expected directories exist in the tarball
+          for dir in frontend api config; do
+            if [ ! -d "${TARBALL_DIR}/${dir}" ] || [ -z "$(ls -A "${TARBALL_DIR}/${dir}")" ]; then
+              echo "ERROR: Tarball directory '${dir}' is missing or empty"
+              exit 1
+            fi
+          done
+
           tar czf "rackula-lxc-${VERSION}.tar.gz" "${TARBALL_DIR}"
+
+          # Generate SHA256 checksum for integrity verification
+          sha256sum "rackula-lxc-${VERSION}.tar.gz" > "rackula-lxc-${VERSION}.tar.gz.sha256"
+
           rm -rf "${TARBALL_DIR}"
           echo "TARBALL=rackula-lxc-${VERSION}.tar.gz" >> "$GITHUB_ENV"
 
@@ -99,7 +129,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if ! gh release view "$VERSION" &>/dev/null; then
-            gh release create "$VERSION" --draft --title "$VERSION (LXC test)"
+
+          # Verify the release exists and is published (not a draft)
+          IS_DRAFT=$(gh release view "$VERSION" --json isDraft --jq '.isDraft' 2>/dev/null || echo "missing")
+          if [ "$IS_DRAFT" = "missing" ]; then
+            echo "ERROR: Release $VERSION does not exist. Create it with release.yml first."
+            exit 1
           fi
-          gh release upload "$VERSION" "${TARBALL}" --clobber
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "ERROR: Release $VERSION is a draft. Publish it before uploading tarballs."
+            exit 1
+          fi
+
+          gh release upload "$VERSION" "${TARBALL}" "${TARBALL}.sha256" --clobber
+          echo "Uploaded ${TARBALL} and checksum to release $VERSION"

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -29,19 +29,24 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+          WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
-            # Derive version from the triggering workflow's ref (tag name)
-            echo "version=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "version=$DISPATCH_VERSION" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "workflow_run" ]; then
+            echo "version=$WORKFLOW_BRANCH" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "version=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate version format
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
             exit 1
@@ -85,8 +90,9 @@ jobs:
           test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
 
       - name: Assemble tarball
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           TARBALL_DIR="rackula-lxc-${VERSION}"
 
           mkdir -p "${TARBALL_DIR}/frontend"
@@ -127,8 +133,8 @@ jobs:
       - name: Upload tarball to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
 
           # Verify the release exists and is published (not a draft)
           IS_DRAFT=$(gh release view "$VERSION" --json isDraft --jq '.isDraft' 2>/dev/null || echo "missing")

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -8,7 +8,6 @@ on:
   workflow_run:
     workflows: ["Create Release"]
     types: [completed]
-    branches: ["v*"]
   workflow_dispatch:
     inputs:
       version:
@@ -21,8 +20,11 @@ permissions:
 jobs:
   build-lxc-tarball:
     runs-on: ubuntu-latest
-    # Only run if the triggering workflow succeeded (skip if release.yml was skipped/failed)
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Only run if the triggering workflow succeeded and, for workflow_run events,
+    # the head_branch starts with 'v' (tag-triggered releases only). The branches
+    # filter on workflow_run is unreliable for tag-triggered upstream runs, so we
+    # validate the branch/tag prefix here instead.
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -27,8 +27,9 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
 
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
+      # Extract version before checkout so we can checkout the correct ref.
+      # For workflow_run/workflow_dispatch events, actions/checkout defaults to the
+      # default branch rather than the tag, so we must explicitly specify the ref.
       - name: Extract version
         id: version
         env:
@@ -44,6 +45,10 @@ jobs:
           else
             echo "version=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ steps.version.outputs.version }}
 
       - name: Validate version format
         env:

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -27,9 +27,8 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
 
     steps:
-      # Extract version before checkout so we can checkout the correct ref.
-      # For workflow_run/workflow_dispatch events, actions/checkout defaults to the
-      # default branch rather than the tag, so we must explicitly specify the ref.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Extract version
         id: version
         env:
@@ -45,10 +44,6 @@ jobs:
           else
             echo "version=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           fi
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ steps.version.outputs.version }}
 
       - name: Validate version format
         env:

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -154,10 +154,10 @@ function update_script() {
       exit 1
     }
     # The tarball contains a top-level rackula-lxc-vX.Y.Z/ wrapper directory.
-    # Find and copy its contents into the staging directory.
+    # Find and copy its contents into the staging directory, including dotfiles.
     _UNPACK_DIR=$(find "$_DL_TMPDIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
     if [[ -n "$_UNPACK_DIR" ]]; then
-      cp -r "$_UNPACK_DIR"/* /opt/rackula.new/ || {
+      cp -a "$_UNPACK_DIR"/. /opt/rackula.new/ || {
         msg_error "Failed to copy release files to /opt/rackula.new"
         rm -rf "$_DL_TMPDIR" /opt/rackula.new
         exit 1

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -12,6 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
+var_arm64="${var_arm64:-no}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -103,25 +104,77 @@ function update_script() {
         fi
       fi
     fi
-    # Drop transient staging/backup dirs (no-ops if absent or already consumed).
-    rm -rf /opt/rackula.new /opt/rackula-etc-backup 2>/dev/null || true
+    # Drop transient staging/backup/download dirs (no-ops if absent or already consumed).
+    rm -rf /opt/rackula.new /opt/rackula-etc-backup "${_DL_TMPDIR:-}" 2>/dev/null || true
   }
   trap cleanup EXIT
 
   if check_for_gh_release "rackula" "RackulaLives/Rackula"; then
-    # Stage the new release into a scratch dir first. Services stay up and the
-    # live install is untouched, so a missing asset or no-op deploy fails here
-    # with the running install fully intact.
+    # Stage the new release into a scratch dir first. Download the tarball and
+    # its SHA256 checksum, verify integrity, then extract. Services stay up and
+    # the live install is untouched, so any failure here leaves the running
+    # install fully intact.
     msg_info "Fetching ${APP} ${CHECK_UPDATE_RELEASE}"
     rm -rf /opt/rackula.new
-    if ! fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula.new" "rackula-lxc-*.tar.gz"; then
-      msg_error "Failed to fetch release ${CHECK_UPDATE_RELEASE}"
+
+    _DL_TMPDIR=$(mktemp -d) || { msg_error "Cannot create temp dir for download"; exit 1; }
+    _TARBALL_NAME="rackula-lxc-${CHECK_UPDATE_RELEASE}.tar.gz"
+    _TARBALL_URL="https://github.com/RackulaLives/Rackula/releases/download/${CHECK_UPDATE_RELEASE}/${_TARBALL_NAME}"
+    _CHECKSUM_URL="${_TARBALL_URL}.sha256"
+
+    # Download tarball and SHA256 checksum
+    if ! curl_download "$_DL_TMPDIR/$_TARBALL_NAME" "$_TARBALL_URL"; then
+      msg_error "Failed to download tarball from ${_TARBALL_URL}"
+      rm -rf "$_DL_TMPDIR" /opt/rackula.new
       exit 1
     fi
+    if ! curl_download "$_DL_TMPDIR/${_TARBALL_NAME}.sha256" "$_CHECKSUM_URL"; then
+      msg_error "Failed to download SHA256 checksum"
+      rm -rf "$_DL_TMPDIR" /opt/rackula.new
+      exit 1
+    fi
+
+    # Verify SHA256 integrity before extraction
+    _EXPECTED_HASH=$(awk '{print $1}' "$_DL_TMPDIR/${_TARBALL_NAME}.sha256")
+    _ACTUAL_HASH=$(sha256sum "$_DL_TMPDIR/$_TARBALL_NAME" | awk '{print $1}')
+    if [[ "$_EXPECTED_HASH" != "$_ACTUAL_HASH" ]]; then
+      msg_error "SHA256 verification failed for ${_TARBALL_NAME}"
+      msg_error "Expected: ${_EXPECTED_HASH}"
+      msg_error "Actual:   ${_ACTUAL_HASH}"
+      rm -rf "$_DL_TMPDIR" /opt/rackula.new
+      exit 1
+    fi
+    msg_ok "SHA256 checksum verified"
+
+    # Extract verified tarball to staging directory
+    mkdir -p /opt/rackula.new
+    tar --no-same-owner -xzf "$_DL_TMPDIR/$_TARBALL_NAME" -C "$_DL_TMPDIR" || {
+      msg_error "Failed to extract tarball"
+      rm -rf "$_DL_TMPDIR" /opt/rackula.new
+      exit 1
+    }
+    # The tarball contains a top-level rackula-lxc-vX.Y.Z/ wrapper directory.
+    # Find and copy its contents into the staging directory.
+    _UNPACK_DIR=$(find "$_DL_TMPDIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    if [[ -n "$_UNPACK_DIR" ]]; then
+      cp -r "$_UNPACK_DIR"/* /opt/rackula.new/ || {
+        msg_error "Failed to copy release files to /opt/rackula.new"
+        rm -rf "$_DL_TMPDIR" /opt/rackula.new
+        exit 1
+      }
+    fi
+    rm -rf "$_DL_TMPDIR"
+
+    # Verify structure before touching the live install
     if [[ ! -d /opt/rackula.new/config ]] || [[ ! -d /opt/rackula.new/api ]]; then
       msg_error "Release did not populate config/ and api/, aborting before touching live install"
+      rm -rf /opt/rackula.new
       exit 1
     fi
+
+    # Write version marker (strip leading 'v' for consistency with check_for_gh_release)
+    echo "${CHECK_UPDATE_RELEASE#v}" > ~/.rackula
+
     msg_ok "Fetched ${APP} ${CHECK_UPDATE_RELEASE}"
 
     msg_info "Stopping Services"

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -114,6 +114,11 @@ function update_script() {
     # its SHA256 checksum, verify integrity, then extract. Services stay up and
     # the live install is untouched, so any failure here leaves the running
     # install fully intact.
+    #
+    # NOTE: This deliberately replaces fetch_and_deploy_gh_release (see
+    # docs/research/lxc-best-practices.md) so the SHA256 checksum is verified
+    # BEFORE any live files are touched. The standard helper extracts before we
+    # could verify, which defeats the integrity guarantee.
     msg_info "Fetching ${APP} ${CHECK_UPDATE_RELEASE}"
     rm -rf /opt/rackula.new
 
@@ -165,12 +170,14 @@ function update_script() {
     fi
     rm -rf "$_DL_TMPDIR"
 
-    # Verify structure before touching the live install
-    if [[ ! -d /opt/rackula.new/config ]] || [[ ! -d /opt/rackula.new/api ]]; then
-      msg_error "Release did not populate config/ and api/, aborting before touching live install"
-      rm -rf /opt/rackula.new
-      exit 1
-    fi
+    # Verify structure before touching the live install (matches build-lxc.yml).
+    for _d in config api frontend; do
+      if [[ ! -d "/opt/rackula.new/${_d}" ]] || [[ -z "$(ls -A "/opt/rackula.new/${_d}" 2>/dev/null)" ]]; then
+        msg_error "Release did not populate ${_d}/, aborting before touching live install"
+        rm -rf /opt/rackula.new
+        exit 1
+      fi
+    done
 
     # Write version marker (strip leading 'v' for consistency with check_for_gh_release)
     echo "${CHECK_UPDATE_RELEASE#v}" > ~/.rackula

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -16,25 +16,8 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt install -y \
   nginx \
-  unzip \
   curl
 msg_ok "Installed Dependencies"
-
-msg_info "Installing Bun"
-export BUN_INSTALL=/opt/bun
-curl -fsSL https://bun.sh/install | $STD bash
-if [ ! -f /opt/bun/bin/bun ]; then
-  msg_error "Bun installation failed — binary not found at /opt/bun/bin/bun"
-  exit 1
-fi
-ln -sf /opt/bun/bin/bun /usr/local/bin/bun
-if [ -f /opt/bun/bin/bunx ]; then
-  ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
-else
-  # bunx is typically bun with different argv[0]; fall back to symlink via bun
-  ln -sf /usr/local/bin/bun /usr/local/bin/bunx
-fi
-msg_ok "Installed Bun"
 
 msg_info "Creating rackula user"
 if ! id -u rackula >/dev/null 2>&1; then

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -28,6 +28,34 @@ msg_ok "Created rackula user"
 msg_info "Installing Rackula"
 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
 
+# Integrity verification: re-download the tarball and verify its SHA256 against
+# the published checksum. fetch_and_deploy_gh_release extracted and removed the
+# tarball, so we download it again solely for verification. The tarball is small
+# (a few MB), acceptable for a one-time install.
+_INSTALLED_TAG="v$(cat ~/.rackula 2>/dev/null)"
+if [[ -n "$_INSTALLED_TAG" ]]; then
+  _VDIR=$(mktemp -d) || { msg_error "Cannot create temp dir for verification"; exit 1; }
+  _TARBALL="rackula-lxc-${_INSTALLED_TAG}.tar.gz"
+  _TARBALL_URL="https://github.com/RackulaLives/Rackula/releases/download/${_INSTALLED_TAG}/${_TARBALL}"
+  _CHECKSUM_URL="${_TARBALL_URL}.sha256"
+  if curl_download "$_VDIR/${_TARBALL}.sha256" "$_CHECKSUM_URL" 2>/dev/null && \
+     curl_download "$_VDIR/$_TARBALL" "$_TARBALL_URL" 2>/dev/null; then
+    _EXPECTED=$(awk '{print $1}' "$_VDIR/${_TARBALL}.sha256")
+    _ACTUAL=$(sha256sum "$_VDIR/$_TARBALL" | awk '{print $1}')
+    if [[ "$_EXPECTED" != "$_ACTUAL" ]]; then
+      msg_error "SHA256 verification failed for $_TARBALL"
+      msg_error "Expected: ${_EXPECTED}"
+      msg_error "Actual:   ${_ACTUAL}"
+      rm -rf /opt/rackula "$_VDIR"
+      exit 1
+    fi
+    msg_ok "SHA256 checksum verified"
+  else
+    msg_warn "Could not download checksum for verification (release may predate checksums)"
+  fi
+  rm -rf "$_VDIR"
+fi
+
 # Create persistent data directory (not in tarball)
 mkdir -p /opt/rackula/data
 mkdir -p /etc/nginx/snippets

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -32,24 +32,30 @@ fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest"
 # the published checksum. fetch_and_deploy_gh_release extracted and removed the
 # tarball, so we download it again solely for verification. The tarball is small
 # (a few MB), acceptable for a one-time install.
-_INSTALLED_TAG="v$(cat ~/.rackula 2>/dev/null)"
-if [[ -n "$_INSTALLED_TAG" ]]; then
+_INSTALLED_VER="$(cat ~/.rackula 2>/dev/null)"
+if [[ -n "$_INSTALLED_VER" ]]; then
+  _INSTALLED_TAG="v${_INSTALLED_VER}"
   _VDIR=$(mktemp -d) || { msg_error "Cannot create temp dir for verification"; exit 1; }
   _TARBALL="rackula-lxc-${_INSTALLED_TAG}.tar.gz"
   _TARBALL_URL="https://github.com/RackulaLives/Rackula/releases/download/${_INSTALLED_TAG}/${_TARBALL}"
   _CHECKSUM_URL="${_TARBALL_URL}.sha256"
-  if curl_download "$_VDIR/${_TARBALL}.sha256" "$_CHECKSUM_URL" 2>/dev/null && \
-     curl_download "$_VDIR/$_TARBALL" "$_TARBALL_URL" 2>/dev/null; then
-    _EXPECTED=$(awk '{print $1}' "$_VDIR/${_TARBALL}.sha256")
-    _ACTUAL=$(sha256sum "$_VDIR/$_TARBALL" | awk '{print $1}')
-    if [[ "$_EXPECTED" != "$_ACTUAL" ]]; then
-      msg_error "SHA256 verification failed for $_TARBALL"
-      msg_error "Expected: ${_EXPECTED}"
-      msg_error "Actual:   ${_ACTUAL}"
-      rm -rf /opt/rackula "$_VDIR"
+  if curl_download "$_VDIR/${_TARBALL}.sha256" "$_CHECKSUM_URL" 2>/dev/null; then
+    if curl_download "$_VDIR/$_TARBALL" "$_TARBALL_URL" 2>/dev/null; then
+      _EXPECTED=$(awk '{print $1}' "$_VDIR/${_TARBALL}.sha256")
+      _ACTUAL=$(sha256sum "$_VDIR/$_TARBALL" | awk '{print $1}')
+      if [[ "$_EXPECTED" != "$_ACTUAL" ]]; then
+        msg_error "SHA256 verification failed for $_TARBALL"
+        msg_error "Expected: ${_EXPECTED}"
+        msg_error "Actual:   ${_ACTUAL}"
+        rm -rf /opt/rackula "$_VDIR"
+        exit 1
+      fi
+      msg_ok "SHA256 checksum verified"
+    else
+      msg_error "Failed to re-download tarball for SHA256 verification"
+      rm -rf "$_VDIR"
       exit 1
     fi
-    msg_ok "SHA256 checksum verified"
   else
     msg_warn "Could not download checksum for verification (release may predate checksums)"
   fi

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -53,7 +53,7 @@ if [[ -n "$_INSTALLED_VER" ]]; then
       msg_ok "SHA256 checksum verified"
     else
       msg_error "Failed to re-download tarball for SHA256 verification"
-      rm -rf "$_VDIR"
+      rm -rf /opt/rackula "$_VDIR"
       exit 1
     fi
   else

--- a/deploy/lxc/community-scripts/json/rackula.json
+++ b/deploy/lxc/community-scripts/json/rackula.json
@@ -6,21 +6,22 @@
   "type": "ct",
   "updateable": true,
   "privileged": false,
+  "has_arm": false,
   "interface_port": 80,
   "documentation": "https://github.com/RackulaLives/Rackula",
   "website": "https://count.racku.la",
-  "config_path": "/opt/rackula/data/.env",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/rackula.webp",
   "description": "Rackula is a drag-and-drop rack layout designer for homelabbers. Visualize your server rack with an offline-ready, mobile-friendly interface. Includes persistence API for cross-browser syncing.",
   "install_methods": [
     {
       "type": "default",
       "script": "ct/rackula.sh",
+      "config_path": "/opt/rackula/data/.env",
       "resources": {
         "cpu": 1,
         "ram": 512,
         "hdd": 8,
-        "os": "debian",
+        "os": "Debian",
         "version": "13"
       }
     }


### PR DESCRIPTION
## **User description**
## Summary

- Add post-deployment SHA256 verification to the install script (re-downloads tarball and verifies against published checksum)
- Replace `fetch_and_deploy_gh_release` in the update script with manual download + SHA256 verify + staged extraction, ensuring integrity is verified before any live files are touched
- Add `var_arm64` to `ct/rackula.sh` for ProxmoxVED compatibility
- Update `rackula.json`: add `has_arm: false`, move `config_path` into `install_methods`, fix `os` casing to `Debian`
- Sync ProxmoxVED fork: flock-based locking, staged deployment, data-safe rollback, strict /etc backup error handling, SHA256 verification

## Acceptance Criteria (from #1891)

- [x] `build-lxc.yml` fires automatically after `release.yml` completes (via `workflow_run`) -- done in b2fcf9d9
- [x] Upload step uploads to existing published releases, never creates drafts -- done in b2fcf9d9
- [x] SHA256 checksum file generated and uploaded alongside tarball -- done in b2fcf9d9
- [x] Version format validation accepts CalVer and legacy SemVer -- done in b2fcf9d9
- [x] Tarball structure verification step -- done in b2fcf9d9
- [x] `workflow_dispatch` validates release exists and is published before uploading -- done in b2fcf9d9
- [x] **ProxmoxVED install/update scripts updated to verify SHA256 checksums after download** -- NEW in this PR
- [x] **Review fixes from ProxmoxVED fork synced back to Rackula source files** -- NEW in this PR

## Test Plan

- [ ] Verify install script SHA256 verification works with a published release that has a `.sha256` asset
- [ ] Verify install script gracefully degrades when `.sha256` is missing (warns, continues)
- [ ] Verify install script fails on SHA256 mismatch (removes /opt/rackula, exits 1)
- [ ] Verify update script downloads tarball and checksum, verifies, then extracts to /opt/rackula.new
- [ ] Verify update script fails on SHA256 mismatch (removes staging, exits 1)
- [ ] Verify update script fails on structure validation (missing config/ or api/)
- [ ] Verify flock-based locking prevents concurrent updates
- [ ] Verify ProxmoxVED fork ct/rackula.sh matches Rackula source improvements

Closes #1891


___

## **CodeAnt-AI Description**
**Harden LXC installs and updates with checksum verification**

### What Changed
- LXC installs and updates now verify the downloaded release against its published SHA256 checksum before using it
- Updates stage the release first, check its structure, and only then swap it into the live install
- The install script no longer pulls in Bun or unzip, reducing unnecessary setup during deployment
- The LXC build workflow now waits for the release workflow, rejects invalid version tags, checks tarball contents, and uploads the checksum file with the release
- Rackula package metadata now includes ARM support info and the install config path is stored with the install method

### Impact
`✅ Safer LXC installs`
`✅ Fewer broken updates from bad or incomplete releases`
`✅ Clearer release publishing failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

---

**CodeQL Fix:** Also resolves code-injection alert (#68) in `.github/workflows/build-lxc.yml` by passing externally-controlled GitHub Actions expressions through environment variables instead of interpolating them directly into `run:` shell blocks.