### PR TITLE
docs(security): document hardening baseline for epic #1274

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -85,6 +85,30 @@ NODE_ENV=development
 # RACKULA_MAX_ASSETS_PER_LAYOUT=50
 
 # ========================================
+# Rate Limiting (in-app, per IP)
+# ========================================
+
+# Enabled by default; set to false to disable the in-app rate limiter.
+# RACKULA_RATE_LIMIT_ENABLED=true
+
+# Write requests (PUT, DELETE): max per IP per window, and window in ms.
+# RACKULA_RATE_LIMIT_WRITE_MAX=30
+# RACKULA_RATE_LIMIT_WRITE_WINDOW_MS=60000
+
+# Read requests (GET, HEAD): max per IP per window, and window in ms.
+# RACKULA_RATE_LIMIT_READ_MAX=120
+# RACKULA_RATE_LIMIT_READ_WINDOW_MS=60000
+
+# ========================================
+# Mutating-Request Origin Policy
+# ========================================
+#
+# No dedicated variable. The origin policy is enforced automatically on mutating
+# requests when auth is enabled and CSRF protection is active; trusted origins are
+# taken from CORS_ORIGIN (wildcard is rejected in that mode). A valid
+# RACKULA_API_WRITE_TOKEN bypasses the origin check for non-browser clients.
+
+# ========================================
 # Docker Secrets (Production Alternative)
 # ========================================
 #

--- a/docs/deployment/SELF-HOSTING.md
+++ b/docs/deployment/SELF-HOSTING.md
@@ -627,6 +627,11 @@ All variables have sensible defaults. Only configure if you need to change somet
 | `RACKULA_OIDC_REDIRECT_URI`          | _derived from BASE_URL_ | Explicit OIDC callback URL; must match the IdP's registered redirect URI exactly                   |
 | `RACKULA_MAX_LAYOUTS`                | `100`                   | Maximum number of stored layouts. Set to `0` for unlimited                                         |
 | `RACKULA_MAX_ASSETS_PER_LAYOUT`      | `50`                    | Maximum number of assets per layout. Set to `0` for unlimited                                      |
+| `RACKULA_RATE_LIMIT_ENABLED`         | `true`                  | Set to `false` to disable the in-app IP rate limiter                                               |
+| `RACKULA_RATE_LIMIT_WRITE_MAX`       | `30`                    | Max write requests (PUT, DELETE) per IP per window                                                 |
+| `RACKULA_RATE_LIMIT_WRITE_WINDOW_MS` | `60000`                 | Write rate-limit window in milliseconds                                                            |
+| `RACKULA_RATE_LIMIT_READ_MAX`        | `120`                   | Max read requests (GET, HEAD) per IP per window                                                    |
+| `RACKULA_RATE_LIMIT_READ_WINDOW_MS`  | `60000`                 | Read rate-limit window in milliseconds                                                             |
 | `LOG_LEVEL`                          | `info`                  | API log verbosity: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, or `silent`                 |
 
 **Port mapping explained:**
@@ -826,6 +831,51 @@ The provided docker-compose.persist.yml includes:
 - production-safe CORS defaults (`CORS_ORIGIN`, `ALLOW_INSECURE_CORS=false`)
 - optional write-route bearer auth (`RACKULA_API_WRITE_TOKEN`)
 
+The API ships a hardening baseline for self-hosted deployments built from three
+abuse-resistance controls: write-route rate limiting, a mutating-request origin policy,
+and storage quotas. Each has safe defaults and operator overrides, described below.
+
+### Rate Limiting
+
+The API applies an in-process, per-IP rate limit to absorb bursts and abuse, independent
+of any reverse-proxy limit. Write requests (PUT, DELETE) and read requests (GET, HEAD)
+have separate budgets. It is enabled by default.
+
+| Setting                              | Default | Description                                  |
+| ------------------------------------ | ------- | -------------------------------------------- |
+| `RACKULA_RATE_LIMIT_ENABLED`         | `true`  | Set to `false` to disable in-app rate limits |
+| `RACKULA_RATE_LIMIT_WRITE_MAX`       | `30`    | Max write requests per IP per window         |
+| `RACKULA_RATE_LIMIT_WRITE_WINDOW_MS` | `60000` | Write window length in milliseconds          |
+| `RACKULA_RATE_LIMIT_READ_MAX`        | `120`   | Max read requests per IP per window          |
+| `RACKULA_RATE_LIMIT_READ_WINDOW_MS`  | `60000` | Read window length in milliseconds           |
+
+When a limit is exceeded the API returns HTTP 429 with a `Retry-After` header and a JSON
+body `{ "error": "Too Many Requests" }`. Rate limiting is skipped when the client IP
+cannot be determined. This is separate from, and complementary to, any NGINX `limit_req`
+applied at the proxy.
+
+### Mutating-Request Origin Policy
+
+For state-changing requests (POST, PUT, PATCH, DELETE), the API requires a trusted
+`Origin` (or `Referer`) header. This closes the cross-origin write gap that bearer-token
+checks alone do not cover, for example a malicious page in a victim's browser issuing
+writes to a reachable API.
+
+The origin policy is enforced automatically when authentication is enabled and CSRF
+protection is active. Both require an explicit `CORS_ORIGIN` (wildcard origins are
+rejected in this mode), and the trusted origins are taken from `CORS_ORIGIN`. There is no
+separate toggle.
+
+When enforced:
+
+- Requests from a trusted origin pass.
+- A valid write bearer token (`RACKULA_API_WRITE_TOKEN`) bypasses the origin check, for
+  non-browser clients that cannot send an `Origin`.
+- Mutating requests with no `Origin` or `Referer` and no valid token are rejected with
+  HTTP 403.
+- When auth is disabled or `CORS_ORIGIN` is a wildcard, the policy is skipped, because
+  write-token auth alone protects write routes.
+
 ### Storage Quotas
 
 Rackula enforces storage quotas to prevent unauthenticated or misconfigured clients from filling the disk with unlimited layout creates or asset uploads.
@@ -851,13 +901,13 @@ Layout quota only applies to new layouts. Updating an existing layout always suc
 The API logs through a single pino logger. Verbosity is controlled by the `LOG_LEVEL`
 environment variable (default `info`), so debug tracing is off by default in production.
 
-| `LOG_LEVEL`        | Output                                                |
-| ------------------ | ----------------------------------------------------- |
-| `debug` or `trace` | Verbose tracing plus all info, warnings, and errors   |
-| `info` (default)   | Startup and operational info, warnings, and errors    |
-| `warn`             | Warnings and errors only                              |
-| `error` or `fatal` | Errors only                                           |
-| `silent`           | No output                                             |
+| `LOG_LEVEL`        | Output                                              |
+| ------------------ | --------------------------------------------------- |
+| `debug` or `trace` | Verbose tracing plus all info, warnings, and errors |
+| `info` (default)   | Startup and operational info, warnings, and errors  |
+| `warn`             | Warnings and errors only                            |
+| `error` or `fatal` | Errors only                                         |
+| `silent`           | No output                                           |
 
 In production (`NODE_ENV=production`) logs are emitted as structured JSON, one object per
 line, suitable for log shippers. In non-production interactive terminals (TTY) logs are

--- a/docs/research/Rackula-threat-model.md
+++ b/docs/research/Rackula-threat-model.md
@@ -1,7 +1,34 @@
 ## Executive summary
+
 Rackula’s highest practical risks are unauthorized data mutation and service disruption in persistence-enabled deployments, especially where the dev environment is internet-exposed and API auth is intentionally absent. The API has strong input/path validation and size limits, but it currently relies on network placement and reverse-proxy controls for security boundaries; without those controls, integrity and availability risks dominate over confidentiality (which is low-sensitivity by context).
 
+## Hardening baseline status (2026-06-04)
+
+This model was written against the pre-hardening API. The self-hosted hardening baseline
+(epic #1274) is now implemented, so the per-boundary "Rate limiting: none" notes and the
+unmitigated origin and storage gaps in the threat table below describe the prior state.
+Current mitigations, on by default:
+
+- Write-route and read-route rate limiting (#1778): in-app per-IP limits (writes 30 per
+  60s, reads 120 per 60s by default), returning HTTP 429 with `Retry-After`. Mitigates the
+  availability/abuse paths flagged as "Rate limiting: none" across TB-1 through TB-5 and
+  abuse path 3.
+- Mutating-request origin policy (#1779): trusted `Origin`/`Referer` required on
+  state-changing requests, rejected with HTTP 403. Mitigates the cross-origin drive-by
+  write path (TM-002). Active only when auth and CSRF protection are enabled; a valid
+  write token bypasses it for non-browser clients.
+- Storage quotas (#1780): default caps of 100 layouts and 50 assets per layout, returning
+  HTTP 429/507. Mitigates the storage-exhaustion path (TB-4, TM-003).
+
+Residual risk after hardening: rate limiting is skipped when the client IP cannot be
+determined (untrusted proxy headers), and limits are per-IP (shared-NAT clients share a
+budget); the origin policy is not enforced in auth-less or wildcard-CORS deployments,
+which still rely on network placement plus the optional write token; quota checks are not
+atomic with writes (a small concurrent-overshoot window, accepted for low-concurrency
+homelab use). See `docs/deployment/SELF-HOSTING.md` for operator configuration.
+
 ## Scope and assumptions
+
 - In scope paths:
   `src/` (SPA runtime), `api/src/` (persistence API), `deploy/` + `docker-compose.yml` + `deploy/docker-compose.persist.yml` (runtime deployment), `.github/workflows/` (build/release supply chain).
 - Out of scope:
@@ -16,7 +43,9 @@ Rackula’s highest practical risks are unauthorized data mutation and service d
   All discovered entry points are covered, each trust boundary is represented in at least one threat, runtime and CI/dev are separated, user clarifications are integrated, and assumptions/open questions are explicit.
 
 ## System model
+
 ### Primary components
+
 - Browser SPA (Svelte/TypeScript) handling layout editing, share-link decode, archive import/export, and autosave.
   Evidence: `src/App.svelte` (`onMount`, `handleLoad`, autosave effects), `src/lib/utils/share.ts`, `src/lib/utils/archive.ts`.
 - Nginx frontend container serving static assets and proxying `/api/*` to sidecar API.
@@ -29,6 +58,7 @@ Rackula’s highest practical risks are unauthorized data mutation and service d
   Evidence: `.github/workflows/deploy-dev.yml`, `.github/workflows/deploy-prod.yml`, `.github/workflows/release.yml`.
 
 ### Data flows and trust boundaries
+
 - TB-1: User Browser -> SPA (`GET /`, JS bundles, URL query string `?l=...`).
   Data: share payload, user edits, local autosave state.
   Channel: HTTPS/HTTP.
@@ -72,6 +102,7 @@ Rackula’s highest practical risks are unauthorized data mutation and service d
   Evidence: `.github/workflows/deploy-prod.yml`, `.github/workflows/deploy-dev.yml`, `.github/workflows/codeql.yml`, `.github/workflows/release.yml`.
 
 #### Diagram
+
 ```mermaid
 flowchart LR
   subgraph client_zone["Client Zone"]
@@ -106,17 +137,20 @@ flowchart LR
 ```
 
 ## Assets and security objectives
-| Asset | Why it matters | Security objective (C/I/A) |
-|---|---|---|
-| Layout YAML and metadata (`name`, device placement, notes/custom fields) | Integrity loss breaks planning docs; exposure can reveal internal infrastructure naming/details | I > A > C |
-| Uploaded device images | Tampering can mislead operators; large volume can consume storage | I, A |
-| Persistence API availability | Save/load outages directly break core self-hosted persistence workflow | A, I |
-| Data volume capacity (`/data`) | Exhaustion causes write failures and possible broader host instability | A |
-| Container images and deployment workflow | Compromise can ship malicious runtime behavior to dev/prod | I, A |
-| Local browser autosave/share payload state | Corruption can cause user data loss or client-side denial of use | I, A |
+
+| Asset                                                                    | Why it matters                                                                                  | Security objective (C/I/A) |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | -------------------------- |
+| Layout YAML and metadata (`name`, device placement, notes/custom fields) | Integrity loss breaks planning docs; exposure can reveal internal infrastructure naming/details | I > A > C                  |
+| Uploaded device images                                                   | Tampering can mislead operators; large volume can consume storage                               | I, A                       |
+| Persistence API availability                                             | Save/load outages directly break core self-hosted persistence workflow                          | A, I                       |
+| Data volume capacity (`/data`)                                           | Exhaustion causes write failures and possible broader host instability                          | A                          |
+| Container images and deployment workflow                                 | Compromise can ship malicious runtime behavior to dev/prod                                      | I, A                       |
+| Local browser autosave/share payload state                               | Corruption can cause user data loss or client-side denial of use                                | I, A                       |
 
 ## Attacker model
+
 ### Capabilities
+
 - Remote internet attacker can reach internet-exposed dev endpoints and call unauthenticated API routes directly.
 - Internal network attacker (or compromised host) can reach self-hosted services and mutate shared layouts.
 - Malicious web page can trigger cross-origin API requests from a victim browser when API is reachable and CORS is permissive.
@@ -124,26 +158,29 @@ flowchart LR
 - Supply-chain attacker with CI/workflow/release foothold can influence shipped images.
 
 ### Non-capabilities
+
 - No assumption of attacker access to host root/shell by default.
 - No assumption of high-value regulated data in layouts (user confirmed low sensitivity), reducing confidentiality impact tiers.
 - No direct server-side code execution through YAML object tags in current parser mode (`JSON_SCHEMA` used server-side).
 - No assumption that browser storage attacks cross user/browser boundaries; localStorage/sessionStorage scope remains same-origin.
 
 ## Entry points and attack surfaces
-| Surface | How reached | Trust boundary | Notes | Evidence (repo path / symbol) |
-|---|---|---|---|---|
-| `GET /api/layouts` and `GET /api/layouts/:uuid` | Browser or direct HTTP client | TB-3 | Enumerates and reads saved layouts without app auth | `api/src/routes/layouts.ts` (`layouts.get`) |
-| `PUT /api/layouts/:uuid` | Browser autosave/manual client | TB-3 | Writes YAML; UUID and schema checks exist but no auth/rate limit | `api/src/routes/layouts.ts` (`layouts.put`), `api/src/index.ts` |
-| `DELETE /api/layouts/:uuid` | Browser/manual client | TB-3 | Deletes layout folders; no ownership model | `api/src/routes/layouts.ts` (`layouts.delete`) |
-| `PUT /api/assets/:layoutId/:deviceSlug/:face` | Browser/manual client | TB-3 | 5MB limit and content-type checks; unauthenticated write | `api/src/routes/assets.ts` (`assets.put`) |
-| API CORS policy | Any origin by default | TB-5 | `*` default enables cross-origin browser invocation when reachable | `api/src/index.ts` (`cors` config) |
-| Share parameter `?l=` decode path | Visiting crafted URL | TB-1 | Inflates/decompresses user-controlled payload in browser | `src/App.svelte` (`decodeLayout` on mount), `src/lib/utils/share.ts` |
-| Archive import (`.zip`) | Local file load | TB-2 | Parses zip and nested files; no explicit uncompressed byte/entry cap | `src/lib/utils/file.ts`, `src/lib/utils/archive.ts` |
-| NetBox YAML import dialog | Local YAML file or text | TB-2 | YAML parse + field checks; could be large/complex input | `src/lib/components/ImportFromNetBoxDialog.svelte`, `src/lib/utils/netbox-import.ts` |
-| Device library JSON import | Local JSON file | TB-2 | File text parsed and validated, duplicate slug handling | `src/App.svelte` (`handleDeviceImportFileChange`), `src/lib/utils/import.ts` |
-| Dynamic analytics script load | Build/runtime config | TB-6 | Script src from build vars; CSP constrains allowed source in nginx deployments | `src/lib/utils/analytics.ts`, `vite.config.ts`, `deploy/security-headers.conf` |
+
+| Surface                                         | How reached                    | Trust boundary | Notes                                                                          | Evidence (repo path / symbol)                                                        |
+| ----------------------------------------------- | ------------------------------ | -------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `GET /api/layouts` and `GET /api/layouts/:uuid` | Browser or direct HTTP client  | TB-3           | Enumerates and reads saved layouts without app auth                            | `api/src/routes/layouts.ts` (`layouts.get`)                                          |
+| `PUT /api/layouts/:uuid`                        | Browser autosave/manual client | TB-3           | Writes YAML; UUID and schema checks exist but no auth/rate limit               | `api/src/routes/layouts.ts` (`layouts.put`), `api/src/index.ts`                      |
+| `DELETE /api/layouts/:uuid`                     | Browser/manual client          | TB-3           | Deletes layout folders; no ownership model                                     | `api/src/routes/layouts.ts` (`layouts.delete`)                                       |
+| `PUT /api/assets/:layoutId/:deviceSlug/:face`   | Browser/manual client          | TB-3           | 5MB limit and content-type checks; unauthenticated write                       | `api/src/routes/assets.ts` (`assets.put`)                                            |
+| API CORS policy                                 | Any origin by default          | TB-5           | `*` default enables cross-origin browser invocation when reachable             | `api/src/index.ts` (`cors` config)                                                   |
+| Share parameter `?l=` decode path               | Visiting crafted URL           | TB-1           | Inflates/decompresses user-controlled payload in browser                       | `src/App.svelte` (`decodeLayout` on mount), `src/lib/utils/share.ts`                 |
+| Archive import (`.zip`)                         | Local file load                | TB-2           | Parses zip and nested files; no explicit uncompressed byte/entry cap           | `src/lib/utils/file.ts`, `src/lib/utils/archive.ts`                                  |
+| NetBox YAML import dialog                       | Local YAML file or text        | TB-2           | YAML parse + field checks; could be large/complex input                        | `src/lib/components/ImportFromNetBoxDialog.svelte`, `src/lib/utils/netbox-import.ts` |
+| Device library JSON import                      | Local JSON file                | TB-2           | File text parsed and validated, duplicate slug handling                        | `src/App.svelte` (`handleDeviceImportFileChange`), `src/lib/utils/import.ts`         |
+| Dynamic analytics script load                   | Build/runtime config           | TB-6           | Script src from build vars; CSP constrains allowed source in nginx deployments | `src/lib/utils/analytics.ts`, `vite.config.ts`, `deploy/security-headers.conf`       |
 
 ## Top abuse paths
+
 1. Goal: Unauthorized modification/deletion of persisted layouts.
    Steps: Discover exposed `/api` endpoint -> call `PUT/DELETE /api/layouts/:uuid` without credentials -> overwrite or remove data -> users load tampered/missing layouts.
    Impact: Integrity and availability loss for shared instance.
@@ -164,16 +201,18 @@ flowchart LR
    Impact: High integrity impact on runtime if supply chain is compromised.
 
 ## Threat model table
-| Threat ID | Threat source | Prerequisites | Threat action | Impact | Impacted assets | Existing controls (evidence) | Gaps | Recommended mitigations | Detection ideas | Likelihood | Impact severity | Priority |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| TM-001 | External or internal unauthenticated client | API reachable from attacker network path; no reverse-proxy auth configured | Call layout/asset CRUD endpoints to alter or delete persisted state | Shared layout tampering or loss | Layout YAML, images, API availability | UUID/path validation and schema checks (`api/src/routes/layouts.ts`, `api/src/schemas/layout.ts`); hardened containers (`docker-compose.yml`) | No app-level authZ/authN or ownership model | Add reverse-proxy auth for `/api/*` (Basic/OIDC/VPN allowlist), optionally add API token check for writes, split read/write permissions | Structured access logs by route+IP+UUID, alert on delete bursts and write spikes | High (dev internet exposed) | Medium | high |
-| TM-002 | Malicious website abusing victim browser | Victim browser can reach Rackula API; default CORS wildcard or broad origin | Cross-origin scripted requests mutate/delete layouts | Integrity compromise via drive-by interaction | Layout YAML, images | CORS can be restricted via env (`api/src/index.ts`); input validation still applies | Default `origin: "*"` in production if unset; no CSRF-style origin enforcement | Set explicit `CORS_ORIGIN` for each environment, reject unexpected/missing `Origin` on state-changing requests, add proxy ACL for `/api/*` | Log Origin header and preflight failures; alert on cross-origin write patterns | Medium | Medium | medium |
-| TM-003 | Remote API abuse (scripted) | API reachable and attacker can send repeated valid requests | Flood layout/image writes within allowed per-request size to fill disk and increase I/O | Persistence degradation or outage | Data volume, API availability | Body limits (`bodyLimit`, `MAX_SIZE`) and file type checks (`api/src/index.ts`, `api/src/routes/assets.ts`) | No rate limiting, no quota, no write throttling or retention policy | Add nginx `limit_req`/IP throttles for `/api/*`, enforce per-layout and global storage quotas, reject too-frequent writes, add cleanup policy | Monitor disk usage, write throughput, 4xx/5xx ratios, API latency; page when thresholds exceeded | High (if exposed), Medium (internal) | Medium | high |
-| TM-004 | Social-engineering attacker with crafted file/link | User loads attacker-provided share URL or archive | Trigger heavy decompression/parsing (`pako`, `JSZip`) and large object creation in browser | Client freeze/crash and interrupted work | Browser availability, local unsaved state | Schema validation after parse (`src/lib/schemas/share.ts`, `src/lib/utils/yaml.ts`), import type filtering (`src/lib/utils/file.ts`) | No explicit max share length before inflate; no zip entry/uncompressed size/depth caps; parsing on main thread | Enforce strict encoded-length and decompressed-size limits, cap zip entries and total extracted bytes, parse in Web Worker with timeout/cancel path | Track import/decode failures and parse duration metrics; add UI warnings for oversized payloads | Medium | Medium | medium |
-| TM-005 | Opportunistic recon attacker | Internet-exposed dev API and no auth | Enumerate `GET /api/layouts`, fetch YAML for IDs, collect names/notes/topology hints | Metadata disclosure enabling follow-on targeting | Layout metadata confidentiality | Path and UUID validation (`api/src/routes/layouts.ts`) | Read endpoints exposed without auth; design intentionally shared/single-user | Gate read endpoints behind proxy auth even in dev, or isolate dev instance/network; optionally disable persistence on public demos | Alert on high-rate list/get sweeps from single IP/ASN | Medium | Low to Medium | medium |
-| TM-006 | Build/release supply-chain attacker | Control of workflow inputs, tags, or runner/repo context | Publish/pull compromised images via normal deploy path | Runtime compromise in self-hosted environments | Container image integrity, runtime trust | Pinned GitHub action SHAs and CodeQL workflow (`.github/workflows/deploy-prod.yml`, `.github/workflows/codeql.yml`) | No image signature verification at deploy; self-hosted runner trust boundary not explicitly hardened in repo | Sign images (cosign), verify digests at deploy, enforce protected tags/branches and required reviews, harden self-hosted runner network and credentials | Alert on unexpected tag releases/workflow dispatch; verify digest drift before rollout | Low to Medium | High | medium |
+
+| Threat ID | Threat source                                      | Prerequisites                                                               | Threat action                                                                              | Impact                                           | Impacted assets                           | Existing controls (evidence)                                                                                                                  | Gaps                                                                                                           | Recommended mitigations                                                                                                                                 | Detection ideas                                                                                  | Likelihood                           | Impact severity | Priority |
+| --------- | -------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------ | --------------- | -------- |
+| TM-001    | External or internal unauthenticated client        | API reachable from attacker network path; no reverse-proxy auth configured  | Call layout/asset CRUD endpoints to alter or delete persisted state                        | Shared layout tampering or loss                  | Layout YAML, images, API availability     | UUID/path validation and schema checks (`api/src/routes/layouts.ts`, `api/src/schemas/layout.ts`); hardened containers (`docker-compose.yml`) | No app-level authZ/authN or ownership model                                                                    | Add reverse-proxy auth for `/api/*` (Basic/OIDC/VPN allowlist), optionally add API token check for writes, split read/write permissions                 | Structured access logs by route+IP+UUID, alert on delete bursts and write spikes                 | High (dev internet exposed)          | Medium          | high     |
+| TM-002    | Malicious website abusing victim browser           | Victim browser can reach Rackula API; default CORS wildcard or broad origin | Cross-origin scripted requests mutate/delete layouts                                       | Integrity compromise via drive-by interaction    | Layout YAML, images                       | CORS can be restricted via env (`api/src/index.ts`); input validation still applies                                                           | Default `origin: "*"` in production if unset; no CSRF-style origin enforcement                                 | Set explicit `CORS_ORIGIN` for each environment, reject unexpected/missing `Origin` on state-changing requests, add proxy ACL for `/api/*`              | Log Origin header and preflight failures; alert on cross-origin write patterns                   | Medium                               | Medium          | medium   |
+| TM-003    | Remote API abuse (scripted)                        | API reachable and attacker can send repeated valid requests                 | Flood layout/image writes within allowed per-request size to fill disk and increase I/O    | Persistence degradation or outage                | Data volume, API availability             | Body limits (`bodyLimit`, `MAX_SIZE`) and file type checks (`api/src/index.ts`, `api/src/routes/assets.ts`)                                   | No rate limiting, no quota, no write throttling or retention policy                                            | Add nginx `limit_req`/IP throttles for `/api/*`, enforce per-layout and global storage quotas, reject too-frequent writes, add cleanup policy           | Monitor disk usage, write throughput, 4xx/5xx ratios, API latency; page when thresholds exceeded | High (if exposed), Medium (internal) | Medium          | high     |
+| TM-004    | Social-engineering attacker with crafted file/link | User loads attacker-provided share URL or archive                           | Trigger heavy decompression/parsing (`pako`, `JSZip`) and large object creation in browser | Client freeze/crash and interrupted work         | Browser availability, local unsaved state | Schema validation after parse (`src/lib/schemas/share.ts`, `src/lib/utils/yaml.ts`), import type filtering (`src/lib/utils/file.ts`)          | No explicit max share length before inflate; no zip entry/uncompressed size/depth caps; parsing on main thread | Enforce strict encoded-length and decompressed-size limits, cap zip entries and total extracted bytes, parse in Web Worker with timeout/cancel path     | Track import/decode failures and parse duration metrics; add UI warnings for oversized payloads  | Medium                               | Medium          | medium   |
+| TM-005    | Opportunistic recon attacker                       | Internet-exposed dev API and no auth                                        | Enumerate `GET /api/layouts`, fetch YAML for IDs, collect names/notes/topology hints       | Metadata disclosure enabling follow-on targeting | Layout metadata confidentiality           | Path and UUID validation (`api/src/routes/layouts.ts`)                                                                                        | Read endpoints exposed without auth; design intentionally shared/single-user                                   | Gate read endpoints behind proxy auth even in dev, or isolate dev instance/network; optionally disable persistence on public demos                      | Alert on high-rate list/get sweeps from single IP/ASN                                            | Medium                               | Low to Medium   | medium   |
+| TM-006    | Build/release supply-chain attacker                | Control of workflow inputs, tags, or runner/repo context                    | Publish/pull compromised images via normal deploy path                                     | Runtime compromise in self-hosted environments   | Container image integrity, runtime trust  | Pinned GitHub action SHAs and CodeQL workflow (`.github/workflows/deploy-prod.yml`, `.github/workflows/codeql.yml`)                           | No image signature verification at deploy; self-hosted runner trust boundary not explicitly hardened in repo   | Sign images (cosign), verify digests at deploy, enforce protected tags/branches and required reviews, harden self-hosted runner network and credentials | Alert on unexpected tag releases/workflow dispatch; verify digest drift before rollout           | Low to Medium                        | High            | medium   |
 
 ## Criticality calibration
+
 - `critical` for this repo/context:
   Pre-auth remote code execution in API runtime, or supply-chain compromise that ships attacker code broadly without detection.
   Cross-environment compromise (dev to prod) through shared secrets/runner trust.
@@ -191,21 +230,22 @@ flowchart LR
   Analytics-related visibility issues without direct security impact.
 
 ## Focus paths for security review
-| Path | Why it matters | Related Threat IDs |
-|---|---|---|
-| `api/src/index.ts` | Central security posture: CORS defaults, body limits, route exposure | TM-001, TM-002, TM-003, TM-005 |
-| `api/src/routes/layouts.ts` | Unauthenticated list/get/put/delete flows and YAML handling | TM-001, TM-005 |
-| `api/src/routes/assets.ts` | Upload/delete surface and size/type enforcement | TM-001, TM-003 |
-| `api/src/storage/filesystem.ts` | Filesystem writes, migrations, path/UUID safety controls | TM-001, TM-003 |
-| `api/src/storage/assets.ts` | Asset write patterns and path-building controls | TM-001, TM-003 |
-| `api/src/schemas/layout.ts` | Core schema and path sanitization assumptions | TM-001, TM-005 |
-| `deploy/nginx.conf.template` | API exposure, proxy behavior, and where rate limiting can be added | TM-001, TM-002, TM-003 |
-| `deploy/security-headers.conf` | Browser-side hardening and CSP policy boundaries | TM-004, TM-006 |
-| `deploy/docker-compose.persist.yml` | Runtime isolation/hardening and network exposure defaults | TM-001, TM-003 |
-| `docker-compose.yml` | Common self-host deployment pattern and optional persistence profile | TM-001, TM-003 |
-| `src/App.svelte` | Share-link load path, import handlers, autosave/server sync logic | TM-004 |
-| `src/lib/utils/share.ts` | `pako` inflate/decode path for attacker-controlled URL data | TM-004 |
-| `src/lib/utils/archive.ts` | ZIP parsing and extraction behavior for untrusted files | TM-004 |
-| `src/lib/utils/file.ts` | Import file type gating and user file entry path | TM-004 |
-| `.github/workflows/deploy-prod.yml` | Production image build/push/deploy trust chain | TM-006 |
-| `.github/workflows/deploy-dev.yml` | Dev deployment exposure and pipeline hardening surface | TM-006 |
+
+| Path                                | Why it matters                                                       | Related Threat IDs             |
+| ----------------------------------- | -------------------------------------------------------------------- | ------------------------------ |
+| `api/src/index.ts`                  | Central security posture: CORS defaults, body limits, route exposure | TM-001, TM-002, TM-003, TM-005 |
+| `api/src/routes/layouts.ts`         | Unauthenticated list/get/put/delete flows and YAML handling          | TM-001, TM-005                 |
+| `api/src/routes/assets.ts`          | Upload/delete surface and size/type enforcement                      | TM-001, TM-003                 |
+| `api/src/storage/filesystem.ts`     | Filesystem writes, migrations, path/UUID safety controls             | TM-001, TM-003                 |
+| `api/src/storage/assets.ts`         | Asset write patterns and path-building controls                      | TM-001, TM-003                 |
+| `api/src/schemas/layout.ts`         | Core schema and path sanitization assumptions                        | TM-001, TM-005                 |
+| `deploy/nginx.conf.template`        | API exposure, proxy behavior, and where rate limiting can be added   | TM-001, TM-002, TM-003         |
+| `deploy/security-headers.conf`      | Browser-side hardening and CSP policy boundaries                     | TM-004, TM-006                 |
+| `deploy/docker-compose.persist.yml` | Runtime isolation/hardening and network exposure defaults            | TM-001, TM-003                 |
+| `docker-compose.yml`                | Common self-host deployment pattern and optional persistence profile | TM-001, TM-003                 |
+| `src/App.svelte`                    | Share-link load path, import handlers, autosave/server sync logic    | TM-004                         |
+| `src/lib/utils/share.ts`            | `pako` inflate/decode path for attacker-controlled URL data          | TM-004                         |
+| `src/lib/utils/archive.ts`          | ZIP parsing and extraction behavior for untrusted files              | TM-004                         |
+| `src/lib/utils/file.ts`             | Import file type gating and user file entry path                     | TM-004                         |
+| `.github/workflows/deploy-prod.yml` | Production image build/push/deploy trust chain                       | TM-006                         |
+| `.github/workflows/deploy-dev.yml`  | Dev deployment exposure and pipeline hardening surface               | TM-006                         |


### PR DESCRIPTION
## **User description**
## Summary

Epic #1274 (self-hosted API hardening baseline) had all three implementation children merged but only one documented. This closes the epic's documentation acceptance criteria (AC1 baseline + threat assumptions, AC5 operator docs for all three controls).

Closes #1274. Children: #1778 (rate limiting), #1779 (origin policy), #1780 (storage quotas) - all already merged.

## What was missing

- App-level rate limiting (#1778): the `RACKULA_RATE_LIMIT_*` env vars appeared **0 times** in `SELF-HOSTING.md` and `.env.example` (only NGINX proxy-level limiting was documented).
- Mutating-origin policy (#1779): undocumented operationally.
- The threat model (`docs/research/Rackula-threat-model.md`) predated implementation and still said "Rate limiting: none" / "no CSRF-style origin enforcement".

## Changes

- `SELF-HOSTING.md`: new Rate Limiting and Mutating-Request Origin Policy sections; `RACKULA_RATE_LIMIT_*` rows in the env reference table; the three controls framed as the hardening baseline.
- `api/.env.example`: rate-limit vars + a note on how the origin policy is derived (auth + CSRF, trusted origins from `CORS_ORIGIN`, write-token bypass).
- `threat-model.md`: dated hardening-baseline status note mapping each implemented control to the threats it mitigates, with residual risk. Pre-hardening notes in the body are left as the historical prior-state analysis.

## Accuracy

All documented values verified against `api/src/security/config.ts` and the middlewares: rate limits write 30/60s and read 120/60s (enabled by default), 429 + `Retry-After`; origin policy enforced when auth+CSRF are active, 403, trusted origins from `CORS_ORIGIN`, write-token bypass; quotas 100 layouts / 50 assets, 429/507.

## Test Plan
- [x] Values cross-checked against `config.ts` defaults and middleware behaviour
- [x] Prettier-formatted; no em dashes/emoji per house style
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Document the self-hosted security baseline for rate limits, origin checks, and storage quotas

### What Changed
- Adds a hardening status note to the threat model showing the current default protections and the risks that still remain
- Documents new rate limiting and mutating-request origin rules for self-hosted setups, including the expected responses when requests are blocked
- Adds the rate limit settings to the environment examples and self-hosting guide so operators can configure them from one place

### Impact
`✅ Clearer self-hosting security setup`
`✅ Fewer misconfigured deployments`
`✅ Faster operator review of security defaults`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
