### PR TITLE
fix(ci): pass tag and changelog notes via env to avoid run-shell injection (#1899)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,16 @@ jobs:
 
       - name: Extract version number
         id: version
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          VERSION="${{ github.ref_name }}"
-          VERSION_NUM="${VERSION#v}"  # Remove 'v' prefix (e.g., v26.6.0 → 26.6.0)
-          echo "version=$VERSION_NUM" >> $GITHUB_OUTPUT
+          VERSION_NUM="${REF_NAME#v}"  # Remove 'v' prefix (e.g., v26.6.0 -> 26.6.0)
+          echo "version=$VERSION_NUM" >> "$GITHUB_OUTPUT"
 
       - name: Validate changelog entry exists
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if ! grep -q "^## \[$VERSION\]" CHANGELOG.md; then
             echo "ERROR: No changelog entry found for version $VERSION"
             echo "Please update CHANGELOG.md before releasing."
@@ -60,9 +62,9 @@ jobs:
 
       - name: Extract changelog entry
         id: changelog
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Extract the section between this version header and the next version header
           # Uses awk to capture everything between ## [VERSION] and the next ## [
           NOTES=$(awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
@@ -75,15 +77,17 @@ jobs:
             echo "notes<<EOF"
             echo "$NOTES"
             echo "EOF"
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          NOTES: ${{ steps.changelog.outputs.notes }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
-            --notes "${{ steps.changelog.outputs.notes }}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "$NOTES"
 
   # Build the LXC tarball from the released tag and attach it to the release.
   # This runs in the trusted push/dispatch context of this workflow (not via a


### PR DESCRIPTION
## **User description**
## Summary

Eliminates a run-shell expression-injection sink in release.yml. github.ref_name and steps.changelog.outputs.notes were interpolated directly into the gh release create run: block, so a backtick or $(...) in CHANGELOG.md (or a crafted tag) could execute arbitrary commands on the runner with the contents:write + issues:write token. Same class as the CodeQL #68 finding fixed in build-lxc.yml.

- Route github.ref_name, steps.version.outputs.version, and steps.changelog.outputs.notes through env: and reference quoted shell variables.
- No GitHub Actions expression remains inside any run: block (verified).
- Quote "$GITHUB_OUTPUT" in the changelog step that was touched.

Found during review of #1898; behaviour is unchanged.

## Test Plan

- [ ] CodeQL reports no code-injection alert for release.yml
- [ ] actionlint passes (only the pre-existing line-39 SC2086 info on an untouched step remains)
- [ ] Next release still creates the GitHub Release with the correct tag, title, and changelog notes

Closes #1899


___

## **CodeAnt-AI Description**
**Make release creation safe when tag or changelog text contains shell characters**

### What Changed
- Release creation now treats the tag and changelog notes as plain text, so special characters in either no longer risk breaking the release step or running unwanted commands
- Changelog checks and version extraction now use the same safe input path, and release output is written with quoted file handling
- Release name, title, and notes still use the same values as before

### Impact
`✅ Safer release publishing`
`✅ Fewer failed releases from unusual changelog text`
`✅ Lower risk of command execution during CI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
