### PR TITLE
fix: render device placement images in exports (#1902)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-export-placement-images.md
+++ b/docs/superpowers/plans/2026-06-05-export-placement-images.md
@@ -1,0 +1,210 @@
+# Export Placement Images Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render device placement images (custom front/rear photos) in image-based exports, matching the editor.
+
+**Architecture:** The export SVG generator (`export.ts` `renderRackView()`) currently looks up device images only by device-type slug. Add a placement-first, per-face lookup that mirrors `RackDevice.svelte`, so a `placement-{id}` image wins for the exported face and falls back to the device-type image when that face is absent. Single render path, so SVG/PNG/JPEG/PDF are all fixed at once.
+
+**Tech Stack:** TypeScript, Vitest, the existing `generateExportSVG` SVG-construction code and `src/tests/factories.ts`.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-export-placement-images-design.md`
+
+---
+
+### Task 1: Render placement images in exports with per-face fallback
+
+**Files:**
+- Modify: `src/lib/utils/export.ts` (inside `renderRackView()`, the image lookup near line 886-891)
+- Test: `src/tests/export-placement-images.test.ts` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/tests/export-placement-images.test.ts` with this exact content:
+
+```typescript
+/**
+ * Export placement images (#1902)
+ *
+ * Placement images (custom front/rear photos keyed by `placement-{id}`) render
+ * in the editor (RackDevice.svelte) but were dropped from exports because the
+ * export renderer only looked images up by device-type slug. These tests pin the
+ * placement-first, per-face lookup that mirrors the editor.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateExportSVG } from "$lib/utils/export";
+import type { ExportOptions } from "$lib/types";
+import type { ImageStoreMap } from "$lib/types/images";
+import {
+  createTestRack,
+  createTestDeviceType,
+  createTestDevice,
+} from "./factories";
+
+const baseOptions: ExportOptions = {
+  format: "png",
+  scope: "all",
+  includeNames: true,
+  includeLegend: false,
+  background: "solid",
+  displayMode: "image",
+};
+
+function imageHrefs(svg: SVGElement): string[] {
+  return Array.from(svg.getElementsByTagName("image"))
+    .map((el) => el.getAttribute("href") ?? "")
+    .filter((href) => href.startsWith("data:"));
+}
+
+describe("export placement images (#1902)", () => {
+  it("renders a placement image in the export, not just the device-type image", () => {
+    const deviceType = createTestDeviceType({
+      slug: "test-device",
+      u_height: 2,
+      is_full_depth: true,
+    });
+    const placed = createTestDevice({
+      id: "dev-1",
+      device_type: "test-device",
+      position: 10,
+      face: "both",
+    });
+    const rack = createTestRack({ devices: [placed] });
+
+    const images: ImageStoreMap = new Map();
+    images.set("placement-dev-1", {
+      front: {
+        dataUrl: "data:image/png;base64,PLACEMENTFRONT",
+        filename: "placement-front.png",
+      },
+    });
+    images.set("test-device", {
+      front: {
+        dataUrl: "data:image/png;base64,SLUGFRONT",
+        filename: "slug-front.png",
+      },
+      rear: {
+        dataUrl: "data:image/png;base64,SLUGREAR",
+        filename: "slug-rear.png",
+      },
+    });
+
+    const svg = generateExportSVG([rack], [deviceType], {
+      ...baseOptions,
+      exportView: "front",
+    });
+
+    expect(imageHrefs(svg)).toContain("data:image/png;base64,PLACEMENTFRONT");
+  });
+
+  it("falls back per face: front-only placement still shows the device-type rear image in a rear export", () => {
+    const deviceType = createTestDeviceType({
+      slug: "test-device",
+      u_height: 2,
+      is_full_depth: true,
+    });
+    const placed = createTestDevice({
+      id: "dev-1",
+      device_type: "test-device",
+      position: 10,
+      face: "both",
+    });
+    const rack = createTestRack({ devices: [placed] });
+
+    const images: ImageStoreMap = new Map();
+    images.set("placement-dev-1", {
+      front: {
+        dataUrl: "data:image/png;base64,PLACEMENTFRONT",
+        filename: "placement-front.png",
+      },
+    });
+    images.set("test-device", {
+      rear: {
+        dataUrl: "data:image/png;base64,SLUGREAR",
+        filename: "slug-rear.png",
+      },
+    });
+
+    const svg = generateExportSVG([rack], [deviceType], {
+      ...baseOptions,
+      exportView: "rear",
+    });
+
+    const hrefs = imageHrefs(svg);
+    expect(hrefs).toContain("data:image/png;base64,SLUGREAR");
+    expect(hrefs).not.toContain("data:image/png;base64,PLACEMENTFRONT");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/tests/export-placement-images.test.ts`
+Expected: FAIL. The first test fails because the export uses `images.get(device.slug)` and returns `SLUGFRONT` (or nothing), never `PLACEMENTFRONT`.
+
+- [ ] **Step 3: Apply the fix**
+
+In `src/lib/utils/export.ts`, inside `renderRackView()`, find this block (around line 886-891):
+
+```typescript
+      // Check if we should show an image
+      const face = faceFilter === "rear" ? "rear" : "front";
+      const deviceImages = images?.get(device.slug);
+      const deviceImage = deviceImages?.[face];
+      // Support both URL-based (bundled) and dataUrl-based (user upload) images
+      const imageUrl = deviceImage?.url ?? deviceImage?.dataUrl;
+```
+
+Replace it with:
+
+```typescript
+      // Check if we should show an image
+      const face = faceFilter === "rear" ? "rear" : "front";
+      // Placement-first, per-face lookup mirrors RackDevice.svelte: a placement
+      // image wins for this face, otherwise fall back to the device-type image.
+      // Per-face (not per-device) so a front-only placement still inherits the
+      // device-type rear image.
+      const placementImages = images?.get(`placement-${placedDevice.id}`);
+      const slugImages = images?.get(device.slug);
+      const deviceImage = placementImages?.[face] ?? slugImages?.[face];
+      // Support both URL-based (bundled) and dataUrl-based (user upload) images
+      const imageUrl = deviceImage?.url ?? deviceImage?.dataUrl;
+```
+
+Note: `placedDevice` is the `renderRackView()` loop variable and `device` is its
+resolved `DeviceType`; both are already in scope at this point. No signature changes.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/tests/export-placement-images.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run lint and the full unit suite to confirm no regressions**
+
+Run: `npm run lint && npm run test:run`
+Expected: lint clean; all tests pass (including the existing export tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/utils/export.ts src/tests/export-placement-images.test.ts
+git commit -m "fix: render device placement images in exports (#1902)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Mirror the editor's per-face fallback at the single export render point" -> Task 1 Step 3.
+- "Per-face, not per-device" with the front-only edge case -> Task 1 Step 1 second test + Step 3 comment.
+- "Fixes SVG/PNG/JPEG/PDF together" -> single change in the shared `renderRackView()`; no per-format work needed.
+- "No toggle, no data-model change, no new deps" -> only `export.ts` lookup and a new test file are touched.
+- Tests: placement `dataUrl` present in serialized export; per-face fallback -> both tests in Step 1, asserting on `<image>` hrefs via `getElementsByTagName` (no `querySelector`, no `toHaveClass`).
+
+**Placeholder scan:** None. All steps contain runnable code and exact commands.
+
+**Type consistency:** `ImageStoreMap`, `DeviceImageData` (`front`/`rear`), `ImageData` (`dataUrl`/`url`/`filename`), `ExportOptions`, and the factory signatures (`createTestRack`, `createTestDeviceType`, `createTestDevice`) match their definitions. `placedDevice.id` and `device.slug` match the loop variables in `renderRackView()`.

--- a/docs/superpowers/specs/2026-06-05-export-placement-images-design.md
+++ b/docs/superpowers/specs/2026-06-05-export-placement-images-design.md
@@ -1,0 +1,78 @@
+# Export placement images design
+
+Issue: #1902 (bug: Export does not include device placement images)
+
+## Problem
+
+Device placement images (custom front/rear photos attached to a specific device
+placement) render in the editor but are missing from every image-based export
+(SVG, PNG, JPEG, PDF). CSV is data-only and unaffected.
+
+## Verdict: bug, not a design choice
+
+The data model supports placement images and the editor renders them; only the
+export path omits them.
+
+- Storage: images live in a `Map<string, DeviceImageData>` keyed either by device
+  type slug (for example `dell-r620`) or by placement key `placement-{placedDevice.id}`.
+- Editor: `RackDevice.svelte:156-171` does a placement-first, per-face lookup. It
+  tries `getImageUrl("placement-{id}", face)` and falls back to
+  `getImageUrl(device.slug, face)`.
+- Export: `export.ts` `renderRackView()` (around line 888) looks up images only by
+  type slug: `images?.get(device.slug)`. It never tries the `placement-{id}` key,
+  so placement photos are silently dropped.
+
+The full image map is already passed into `generateExportSVG()` from
+`persistence-manager.svelte.ts`, so the data is present at export time. Nothing in
+the pipeline intentionally excludes placement images; the lookup is simply incomplete.
+
+## Fix
+
+Mirror the editor's per-face fallback at the single export render point in
+`export.ts` `renderRackView()`:
+
+```js
+const placementImages = images?.get(`placement-${placedDevice.id}`);
+const slugImages = images?.get(device.slug);
+const deviceImage = placementImages?.[face] ?? slugImages?.[face];
+const imageUrl = deviceImage?.url ?? deviceImage?.dataUrl;
+```
+
+The fallback is per face (`?.[face] ?? ?.[face]`), not per device. A placement with
+only a front image must still inherit the rear image from its device type, exactly
+as the editor behaves. A per-device fallback (`placementImages ?? slugImages`) would
+regress this: a truthy placement object with only a front image would shadow the
+slug's rear image.
+
+`placedDevice` is the `renderRackView()` loop variable and carries `.id`, so the
+placement key is available without signature changes.
+
+### Why no extra work is needed
+
+- Serialization: `ImageData` always carries `url` (bundled asset) or `dataUrl`
+  (base64 user upload). Export already resolves `url ?? dataUrl`. Placement images
+  are user uploads with `dataUrl`, which survives serialization into standalone SVG,
+  PNG, and PDF. No blob or object-URL conversion is required.
+- Formats: SVG, PNG, JPEG, and PDF all derive from `generateExportSVG()`, so the
+  single lookup change fixes all of them. CSV carries no images.
+- No toggle: image visibility is already controlled by `displayMode`
+  (`label`, `image`, `image-label`) in both editor and export. A separate export
+  toggle would duplicate that control.
+
+## Testing
+
+TDD, written first against the export SVG generation:
+
+1. A device with a placement image, exported in an image display mode, produces a
+   serialized SVG that contains an `<image>` referencing the placement `dataUrl`.
+2. Per-face fallback: a placement with only a front image, exported for the rear
+   face, still emits the device type's rear image.
+
+Assertions run against the serialized SVG string (substring or `<image>` count), not
+DOM queries, to respect the ESLint test rules (no `querySelector`, no `toHaveClass`).
+
+## Out of scope
+
+- No export image on/off toggle (`displayMode` already covers this).
+- No data-model or image-store changes.
+- No changes to CSV export.

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -885,8 +885,12 @@ export function generateExportSVG(
 
       // Check if we should show an image
       const face = faceFilter === "rear" ? "rear" : "front";
-      const deviceImages = images?.get(device.slug);
-      const deviceImage = deviceImages?.[face];
+      // Placement image wins per face, else fall back to the device-type image
+      // (mirrors RackDevice.svelte). Per-face so a front-only placement still
+      // inherits the device-type rear image.
+      const placementImages = images?.get(`placement-${placedDevice.id}`);
+      const slugImages = images?.get(device.slug);
+      const deviceImage = placementImages?.[face] ?? slugImages?.[face];
       // Support both URL-based (bundled) and dataUrl-based (user upload) images
       const imageUrl = deviceImage?.url ?? deviceImage?.dataUrl;
       const isImageMode =

--- a/src/tests/export-placement-images.test.ts
+++ b/src/tests/export-placement-images.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Export placement images (#1902)
+ *
+ * Placement images (custom front/rear photos keyed by `placement-{id}`) render
+ * in the editor (RackDevice.svelte) but were dropped from exports because the
+ * export renderer only looked images up by device-type slug. These tests pin the
+ * placement-first, per-face lookup that mirrors the editor.
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateExportSVG } from "$lib/utils/export";
+import type { ExportOptions } from "$lib/types";
+import type { ImageStoreMap } from "$lib/types/images";
+import {
+  createTestRack,
+  createTestDeviceType,
+  createTestDevice,
+} from "./factories";
+
+const baseOptions: ExportOptions = {
+  format: "png",
+  scope: "all",
+  includeNames: true,
+  includeLegend: false,
+  background: "solid",
+  displayMode: "image",
+};
+
+// Collects rendered image hrefs, keeping only data URLs. The test fixtures use
+// data: URLs exclusively, so this isolates the placement/slug images under test
+// from any bundled (static-path) images.
+function imageHrefs(svg: SVGElement): string[] {
+  return Array.from(svg.getElementsByTagName("image"))
+    .map((el) => el.getAttribute("href") ?? "")
+    .filter((href) => href.startsWith("data:"));
+}
+
+describe("export placement images (#1902)", () => {
+  it("renders a placement image in the export, not just the device-type image", () => {
+    const deviceType = createTestDeviceType({
+      slug: "test-device",
+      u_height: 2,
+      is_full_depth: true,
+    });
+    const placed = createTestDevice({
+      id: "dev-1",
+      device_type: "test-device",
+      position: 10,
+      face: "both",
+    });
+    const rack = createTestRack({ devices: [placed] });
+
+    const images: ImageStoreMap = new Map();
+    images.set("placement-dev-1", {
+      front: {
+        dataUrl: "data:image/png;base64,PLACEMENTFRONT",
+        filename: "placement-front.png",
+      },
+    });
+    images.set("test-device", {
+      front: {
+        dataUrl: "data:image/png;base64,SLUGFRONT",
+        filename: "slug-front.png",
+      },
+      rear: {
+        dataUrl: "data:image/png;base64,SLUGREAR",
+        filename: "slug-rear.png",
+      },
+    });
+
+    const svg = generateExportSVG([rack], [deviceType], {
+      ...baseOptions,
+      exportView: "front",
+    }, images);
+
+    expect(imageHrefs(svg)).toContain("data:image/png;base64,PLACEMENTFRONT");
+  });
+
+  it("falls back per face: front-only placement still shows the device-type rear image in a rear export", () => {
+    const deviceType = createTestDeviceType({
+      slug: "test-device",
+      u_height: 2,
+      is_full_depth: true,
+    });
+    const placed = createTestDevice({
+      id: "dev-1",
+      device_type: "test-device",
+      position: 10,
+      face: "both",
+    });
+    const rack = createTestRack({ devices: [placed] });
+
+    const images: ImageStoreMap = new Map();
+    images.set("placement-dev-1", {
+      front: {
+        dataUrl: "data:image/png;base64,PLACEMENTFRONT",
+        filename: "placement-front.png",
+      },
+    });
+    images.set("test-device", {
+      rear: {
+        dataUrl: "data:image/png;base64,SLUGREAR",
+        filename: "slug-rear.png",
+      },
+    });
+
+    const svg = generateExportSVG([rack], [deviceType], {
+      ...baseOptions,
+      exportView: "rear",
+    }, images);
+
+    const hrefs = imageHrefs(svg);
+    expect(hrefs).toContain("data:image/png;base64,SLUGREAR");
+    expect(hrefs).not.toContain("data:image/png;base64,PLACEMENTFRONT");
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Placement images (custom front/rear photos keyed by `placement-{id}`) rendered in the editor but were dropped from every image-based export (SVG/PNG/JPEG/PDF).
- Root cause: `export.ts` `renderRackView()` looked images up only by device-type slug, never the placement key. The editor (`RackDevice.svelte`) does a placement-first, per-face lookup.
- Fix: mirror that lookup at the single export render point. Per face, not per device, so a front-only placement still inherits the device-type rear image.
- No toggle (the existing displayMode already gates image visibility), no data-model change, no new deps. CSV is data-only and unaffected.

Confirmed a bug, not a design choice (see #1902). A pre-existing clipPath ID collision surfaced during review and is tracked separately in #1904.

Spec: `docs/superpowers/specs/2026-06-05-export-placement-images-design.md`
Plan: `docs/superpowers/plans/2026-06-05-export-placement-images.md`

## Test Plan

- [x] New `src/tests/export-placement-images.test.ts`: placement dataUrl appears in exported `<image>` hrefs; per-face fallback (front-only placement, rear export, shows device-type rear, not placement front)
- [x] `npm run lint` clean
- [x] `npm run test:run` (2059 tests, 105 files) pass

Closes #1902


___

## **CodeAnt-AI Description**
**Render placement images in image exports**

### What Changed
- Exported SVG, PNG, JPEG, and PDF files now include device placement photos, not just the device-type image.
- When a placement has only one face image, exports now fall back to the device-type image for the missing face instead of dropping the image.
- Added tests to confirm placement images appear in exports and that rear-face exports still use the device-type rear image when no rear placement image exists.
- Added design and implementation notes for the export image behavior.

### Impact
`✅ Placement photos now appear in exported rack views`
`✅ Fewer missing images in PDF, PNG, JPEG, and SVG exports`
`✅ Correct front/rear image fallback in exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
