### PR TITLE
feat(lxc): advertise arm64 support for the LXC install (#1850)

### DIFF
--- a/.github/workflows/arm64-lxc-verify.yml
+++ b/.github/workflows/arm64-lxc-verify.yml
@@ -1,0 +1,48 @@
+name: arm64 LXC verify
+
+# Proves the LXC release tarball's native deps load on arm64. The tarball bundles
+# @node-rs/argon2 binaries for every linux CPU (build-lxc.yml installs with
+# --cpu='*' --os=linux); this job rebuilds that production node_modules and loads
+# argon2 on a native arm64 runner, so an arm64-incompatible change fails CI here
+# instead of the community-scripts install on a real arm64 host.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "api/**"
+      - ".github/workflows/build-lxc.yml"
+      - ".github/workflows/arm64-lxc-verify.yml"
+      - "deploy/lxc/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  arm64-argon2:
+    name: arm64 native deps load
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1"
+
+      - name: Install API production deps (build-lxc parity)
+        working-directory: api
+        run: bun install --frozen-lockfile --production --cpu='*' --os=linux
+
+      - name: Assert both argon2 binaries are bundled
+        working-directory: api
+        run: |
+          test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node
+          test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
+
+      - name: Load argon2 on arm64 and verify a hash round-trip
+        working-directory: api
+        run: |
+          bun -e "const { hash, verify, Algorithm } = await import('@node-rs/argon2'); const h = await hash('arm64 ci check', { algorithm: Algorithm.Argon2id }); if (!(await verify(h, 'arm64 ci check')) || (await verify(h, 'wrong'))) { throw new Error('argon2 verify failed on arm64'); } console.log('argon2 OK on', process.arch, process.platform);"

--- a/.github/workflows/arm64-lxc-verify.yml
+++ b/.github/workflows/arm64-lxc-verify.yml
@@ -15,6 +15,10 @@ on:
       - "deploy/lxc/**"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -45,4 +49,14 @@ jobs:
       - name: Load argon2 on arm64 and verify a hash round-trip
         working-directory: api
         run: |
-          bun -e "const { hash, verify, Algorithm } = await import('@node-rs/argon2'); const h = await hash('arm64 ci check', { algorithm: Algorithm.Argon2id }); if (!(await verify(h, 'arm64 ci check')) || (await verify(h, 'wrong'))) { throw new Error('argon2 verify failed on arm64'); } console.log('argon2 OK on', process.arch, process.platform);"
+          cat > argon2-check.mjs <<'EOF'
+          import { hash, verify, Algorithm } from "@node-rs/argon2";
+
+          const h = await hash("arm64 ci check", { algorithm: Algorithm.Argon2id });
+          if (!(await verify(h, "arm64 ci check")) || (await verify(h, "wrong"))) {
+            throw new Error("argon2 verify failed on arm64");
+          }
+          console.log("argon2 OK on", process.arch, process.platform);
+          EOF
+          bun argon2-check.mjs
+          rm -f argon2-check.mjs

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/deploy/lxc/community-scripts/json/rackula.json
+++ b/deploy/lxc/community-scripts/json/rackula.json
@@ -6,7 +6,7 @@
   "type": "ct",
   "updateable": true,
   "privileged": false,
-  "has_arm": false,
+  "has_arm": true,
   "interface_port": 80,
   "documentation": "https://github.com/RackulaLives/Rackula",
   "website": "https://count.racku.la",


### PR DESCRIPTION
## **User description**
## Summary

- Flip the community-scripts metadata so arm64 Proxmox hosts are no longer gated off:
  - `ct/rackula.sh`: `var_arm64` no -> yes
  - `json/rackula.json`: `has_arm` false -> true
- The release tarball already bundles both architectures: `build-lxc.yml` installs with `bun install --cpu='*' --os=linux` and fails the build if either `@node-rs/argon2` x64 or arm64 `.node` is missing. Audit confirms argon2 is the only native dependency in `api/package.json`.
- Add `arm64-lxc-verify.yml`: a CI job on a native `ubuntu-24.04-arm` runner that rebuilds the production `node_modules` with the same `--cpu='*' --os=linux` flags, asserts both binaries ship, and loads/round-trips argon2 on arm64. Catches an arm64-incompatible change in CI instead of at install time.

## Verification

- Local (native linux/arm64 via Docker on Apple Silicon, not emulation):
  - Built the API production deps in a linux/amd64 container with build-lxc's `--cpu='*' --os=linux` (reproducing the x86 release build); both x64-gnu and arm64-gnu argon2 binaries present.
  - Ran that x86-built `node_modules` under linux/arm64: argon2 loaded, Argon2id hash round-trip verified (correct password true, wrong password false), `arch=arm64 platform=linux`.
- CI: `arm64-lxc-verify.yml` runs the same proof on a native arm64 runner.

This verifies the one real architecture risk (the native argon2 binary loading on arm64). The `ct/rackula.sh` install script itself is arch-agnostic shell. A full `ct/rackula.sh` install on a physical arm64 Proxmox host was not run (no hardware available); the binary-load proof above plus the arch-agnostic script cover the failure modes.

After merge: update the downstream community-scripts held PR (`feat/add-rackula`) and ProxmoxVED#1883 to advertise arm support.

## Test Plan

- [x] `jq empty` valid JSON, `bash -n` and `shellcheck -S error` clean on `ct/rackula.sh`
- [x] Local linux/arm64 argon2 load + hash round-trip (Docker on Apple Silicon)
- [x] CI arm64 job added (`arm64-lxc-verify.yml`)

Refs #1850


___

## **CodeAnt-AI Description**
**Advertise arm64 support for the LXC install and verify arm64 native dependencies in CI**

### What Changed
- The Rackula LXC installer now shows arm64 as supported, so arm64 Proxmox hosts are no longer blocked from the install flow.
- The community-scripts metadata now marks Rackula as arm64-compatible.
- A new CI check runs on a native arm64 runner, rebuilds the production API dependencies, confirms both Linux x64 and arm64 argon2 binaries are present, and verifies argon2 works on arm64.
- The arm64 verification job cancels older runs on new pushes to avoid wasting runner time.

### Impact
`✅ Arm64 LXC installs are no longer hidden`
`✅ Fewer arm64 install-time failures`
`✅ Earlier detection of arm64 dependency issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
