### PR TITLE
fix: make export clipPath IDs unique across racks, faces, and devices

### DIFF
--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -912,7 +912,7 @@ export function generateExportSVG(
         rackGroup.appendChild(imageEl);
 
         // Clip the image to rounded corners
-        const clipId = `clip-${device.slug}-${placedDevice.position}`;
+        const clipId = `clip-${rack.id}-${placedDevice.id}-${face}`;
         const clipPath = document.createElementNS(
           "http://www.w3.org/2000/svg",
           "clipPath",


### PR DESCRIPTION
## **User description**
## Summary

- `clipId` in `renderRackView()` was built as `` `clip-${device.slug}-${placedDevice.position}` ``, omitting rack ID and face
- In a multi-rack dual-view export, two racks can hold the same device type at the same U position, producing duplicate `clipPath` IDs in the same SVG `<defs>` block
- SVG requires document-unique IDs; on collision the renderer uses whichever `clipPath` appears first, silently misclipping device images in the second rack

## Why

Use `` `clip-${rack.id}-${placedDevice.id}-${face}` `` instead. `placedDevice.id` is already unique per placed device, so collisions are impossible even in multi-rack dual-view exports.

Surfaced in the code review for #1902, which made placement images actually render in exports (previously silently dropped), making the collision scenario reachable in practice.

## Test Plan

- [x] Lint passes (`npm run lint`)
- [x] Unit tests pass (`npm run test:run` - 2059 tests across 105 files)
- [x] Build passes (`npm run build`)
- Manually verify: export a multi-rack layout in dual-view image mode with the same device type at the same U position in two racks - device images should clip correctly in both racks

Closes #1904

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjoHiYqpxBvjWgL6DX7q2h)_


___

## **CodeAnt-AI Description**
Fix export clipping so device images stay correctly rounded in multi-rack exports

### What Changed
- Exported device images now use unique clip shapes for each rack, device, and face
- This prevents one device’s clipping shape from being reused by another rack in the same export
- Multi-rack dual-view exports now keep device images clipped correctly instead of silently misrendering them

### Impact
`✅ Correct device images in multi-rack exports`
`✅ Fewer export rendering mistakes`
`✅ Reliable dual-view SVG output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
