### PR TITLE
chore(api): align api version with release flow (#1915)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -307,7 +307,11 @@ git commit -m "docs: update changelog, acknowledgements, and security policy for
 
 ```bash
 npm version "$NEW_VERSION" --no-git-tag-version
-git add package.json package-lock.json
+# api/ runs on Bun; use `npm pkg set` (not `npm version`) so no npm
+# lockfile is created. api/package.json's version is the local-dev
+# fallback for the /version endpoint; prod uses the APP_VERSION build arg.
+(cd api && npm pkg set version="$NEW_VERSION")
+git add package.json package-lock.json api/package.json
 git commit -m "chore(release): bump version to v$NEW_VERSION"
 ```
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -15,10 +15,10 @@ CHANGELOG.md is the single source of truth — GitHub releases derive from it.
 | Action | Scope                                         |
 | ------ | --------------------------------------------- |
 | Git    | add, commit, tag, push (to main)              |
-| npm    | version (no-git-tag-version)                  |
+| npm    | version (no-git-tag-version), pkg set         |
 | GitHub | None (GitHub Action handles release creation) |
 
-**Commands allowed:** `git log`, `git tag`, `gh pr list`, `gh issue list`, `npm version`, `scripts/next-version.sh`, `scripts/contributors.sh`
+**Commands allowed:** `git log`, `git tag`, `gh pr list`, `gh issue list`, `npm version`, `npm pkg set`, `scripts/next-version.sh`, `scripts/contributors.sh`
 
 ---
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rackula/api",
-  "version": "26.5.0",
+  "version": "26.6.1",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## **User description**
## Summary

`api/package.json` was frozen at **26.5.0** while the app shipped **26.6.1**, because `/release` only bumped the root `package.json`. The api version is `private` (never published) and serves only as the local-dev fallback for the `/version` endpoint (`api/src/app.ts:70`); prod injects `APP_VERSION` from the git tag at Docker build, so prod was always correct. The stale number was harmless but misleading in local dev.

## Changes

- Set `api/package.json` version to `26.6.1`.
- `/release` (`.claude/commands/release.md` step 4f) now also bumps `api/package.json` via `npm pkg set` and stages it in the release commit.

## Why `npm pkg set` not `npm version`

`npm version` recreates a `package-lock.json`. The api runs on Bun (`api/bun.lock`) and the zombie npm lockfile is being removed in #1914; `npm pkg set` edits only `package.json` and never touches a lockfile.

## Verification

- `node -p "require('./api/package.json').version"` -> `26.6.1`
- No `api/package-lock.json` resurrected by the version bump.

Closes #1915
Pairs with #1914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep the API version in sync with releases**

### What Changed
- The API now shows the current release version in local development instead of an older stale number
- The release process now updates `api/package.json` alongside the main app version so the `/version` fallback stays aligned
- The release step avoids creating an unnecessary npm lockfile for the Bun-based API

### Impact
`✅ Accurate local version info`
`✅ Fewer confusing release/version mismatches`
`✅ No extra npm lockfiles during releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
