### PR TITLE
fix(ci): repair deploy-dev path filter so pushes to main deploy again (#1924)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -3,11 +3,21 @@ name: Deploy Dev
 on:
   push:
     branches: [main]
+    # Globs must be `dir/**` to match files inside a directory; a bare `dir/`
+    # matches nothing, which silently disabled push deploys (#1924). Cover every
+    # input that affects the built images and the deploy step.
     paths:
-      - api/
-      - src/
-      - deploy/
-      - assets/
+      - api/**
+      - src/**
+      - deploy/**
+      - assets/**
+      - package.json
+      - package-lock.json
+      - docker-compose.yml
+      - vite.config.*
+      - svelte.config.*
+      - tsconfig*.json
+      - index.html
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,6 +11,8 @@ on:
       - src/**
       - deploy/**
       - assets/**
+      - static/**
+      - login.html
       - package.json
       - package-lock.json
       - docker-compose.yml


### PR DESCRIPTION
## **User description**
## Summary

Dev (d.racku.la) stopped auto-deploying on push to `main`. Root cause: the `paths:` filter added in #1772 used bare directory names (`api/`, `src/`, `deploy/`, `assets/`). GitHub Actions only matches files inside a directory with a `dir/**` glob, so the bare patterns matched nothing and every push was filtered out, silently disabling dev auto-deploy since 2026-05-29.

## Fix

- Convert the four patterns to `dir/**` globs.
- Add the remaining inputs that affect the built images and the deploy step but were missing: `package.json`, `package-lock.json`, `docker-compose.yml` (the deploy job copies it to the host), and frontend build config (`vite.config.*`, `svelte.config.*`, `tsconfig*.json`, `index.html`).

## Evidence (root cause)

- Last push-triggered Deploy Dev run was 2026-05-29 (`695ce80`), immediately before #1772 merged; no push runs since, only a manual `workflow_dispatch` on 06-05.
- Pushes touching the exact filtered dirs still did not trigger: `cf3b2f93` (`src/`), `cb335406` (`api/package.json`).
- Workflow is `active`; the self-hosted runner is online (manual dispatch deploys fine).

## Verification

YAML parses; trigger paths confirmed. Full end-to-end verification requires a real push to `main` touching a filtered path after merge (path filters evaluate the pushed commit, and the merge commit only touches `.github/`). The next normal code push will exercise it; `workflow_dispatch` independently confirms the deploy job path.

Fixes #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Restore automatic dev deploys on pushes to `main` and include all files that can change the deployed app

### What Changed
- Pushes to `main` now trigger the dev deploy again when changes land in the app, deploy, or asset directories
- Changes to package files, Docker compose settings, and frontend build config files also now trigger a deploy
- The path rules now match files inside directories instead of missing them entirely

### Impact
`✅ Restored main-branch dev deployments`
`✅ Fewer missed deploys after app or config changes`
`✅ Consistent updates when deployment inputs change`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
