### PR TITLE
fix(lxc): install unzip and fetch Bun installer resiliently (#1933)

### DIFF
--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -30,10 +30,13 @@ msg_info "Installing Bun"
 export BUN_INSTALL="/root/.bun"
 # Fetch via curl_with_retry (bounded timeout, retries, DNS pre-check) so a slow
 # CDN or broken IPv6 fails fast instead of hanging. bun.sh/install needs unzip
-# (installed above) and auto-detects the CPU baseline variant.
-curl_with_retry "https://bun.sh/install" "/tmp/bun-install.sh"
-$STD bash /tmp/bun-install.sh
-rm -f /tmp/bun-install.sh
+# (installed above) and auto-detects the CPU baseline variant. mktemp gives a
+# 0600 unguessable path so a local user cannot pre-create a symlink for this
+# root process to follow.
+BUN_INSTALLER=$(mktemp)
+curl_with_retry "https://bun.sh/install" "$BUN_INSTALLER"
+$STD bash "$BUN_INSTALLER"
+rm -f "$BUN_INSTALLER"
 ln -sf /root/.bun/bin/bun /usr/local/bin/bun
 ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -14,7 +14,10 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y nginx
+$STD apt install -y \
+  nginx \
+  unzip \
+  ca-certificates
 msg_ok "Installed Dependencies"
 
 msg_info "Creating rackula user"
@@ -25,7 +28,12 @@ msg_ok "Created rackula user"
 
 msg_info "Installing Bun"
 export BUN_INSTALL="/root/.bun"
-curl -fsSL https://bun.sh/install | $STD bash
+# Fetch via curl_with_retry (bounded timeout, retries, DNS pre-check) so a slow
+# CDN or broken IPv6 fails fast instead of hanging. bun.sh/install needs unzip
+# (installed above) and auto-detects the CPU baseline variant.
+curl_with_retry "https://bun.sh/install" "/tmp/bun-install.sh"
+$STD bash /tmp/bun-install.sh
+rm -f /tmp/bun-install.sh
 ln -sf /root/.bun/bin/bun /usr/local/bin/bun
 ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"


### PR DESCRIPTION
## **User description**
## Summary

The Rackula LXC install hung indefinitely at "Installing Bun" (reproduced on a Proxmox host, Debian 13 unprivileged CT). Two causes in `deploy/lxc/community-scripts/install/rackula-install.sh`:

- `bun.sh/install` shells out to `unzip` to extract the binary, but the dependencies block installed only `nginx` - `unzip` is absent on a minimal Debian 13 template.
- The bare `curl -fsSL https://bun.sh/install | $STD bash` had no timeout/retry, so a host with broken IPv6 (the test host reported `IPv6 Internet Not Connected`) or a slow CDN hung silently forever instead of failing fast.

Confirmed by manually installing Bun on the host with `unzip` present - it completed immediately.

## Changes

- Add `unzip` and `ca-certificates` to the `$STD apt install -y` dependencies block (canonical community-scripts pattern; `apt`, multi-line).
- Fetch the Bun installer via the framework helper `curl_with_retry` (`misc/tools.func`: bounded `--connect-timeout`/`--max-time`, exponential-backoff retries, DNS pre-check), then run it and clean up. Keep `bun.sh/install` - it auto-detects the CPU baseline variant (older CPUs without AVX2 need `bun-linux-x64-baseline`), which a hand-rolled download would get wrong.

`curl_with_retry` is in scope: `update_os` (which sources `tools.func`) runs before the Bun step, and the script already calls another `tools.func` function (`fetch_and_deploy_gh_release`).

## Scope notes

- This wraps the outer installer fetch; Bun's own internal binary download is still its own curl (it completed fine in testing).
- `blinko-install.sh` / `localagi-install.sh` in ProxmoxVED carry the same fragile Bun block; a shared `setup_bun` helper in `tools.func` would fix all three (future, out of scope).
- The same change is being mirrored into the `ggfevans/ProxmoxVED` fork (`feat/add-rackula`) for live re-test and upstream re-submission.

## Verification

- `shellcheck` clean (only pre-existing SC1091 for the runtime-sourced framework).
- Live re-test on the Proxmox host: install completes past "Installing Bun"; `rackula-api` + nginx active; `/health` and `/version.json` (26.6.2) respond.

Fixes #1933

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix LXC installs that got stuck while installing Bun

### What Changed
- Added the missing install tools needed for Bun on minimal Debian templates
- Changed Bun setup to download with retries and time limits so broken network paths fail fast instead of hanging
- Kept Bun’s normal installer flow, then cleaned up the temporary download file after use

### Impact
`✅ Fewer stuck LXC installs`
`✅ Faster failure on broken network connections`
`✅ Reliable Bun installation on minimal Debian templates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
