### PR TITLE
fix(lxc): install Bun under /opt so the hardened service can exec it (#1952)

### DIFF
--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -42,6 +42,10 @@ BUN_INSTALLER=$(mktemp)
 curl_with_retry "https://bun.sh/install" "$BUN_INSTALLER"
 $STD bash "$BUN_INSTALLER"
 rm -f "$BUN_INSTALLER"
+if [ ! -x /usr/local/bun/bin/bun ]; then
+  msg_error "Bun installation failed: /usr/local/bun/bin/bun not found or not executable"
+  exit 1
+fi
 ln -sf /usr/local/bun/bin/bun /usr/local/bin/bun
 ln -sf /usr/local/bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -27,7 +27,11 @@ fi
 msg_ok "Created rackula user"
 
 msg_info "Installing Bun"
-export BUN_INSTALL="/root/.bun"
+# Install under /opt (not /root): the rackula-api service runs as user rackula
+# with ProtectHome=true, which makes /root invisible, so a binary under
+# /root/.bun is unreachable (systemd 203/EXEC). /opt is accessible to the
+# service and readable under ProtectSystem=strict.
+export BUN_INSTALL="/opt/bun"
 # Fetch via curl_with_retry (bounded timeout, retries, DNS pre-check) so a slow
 # CDN or broken IPv6 fails fast instead of hanging. bun.sh/install needs unzip
 # (installed above) and auto-detects the CPU baseline variant. mktemp gives a
@@ -37,8 +41,8 @@ BUN_INSTALLER=$(mktemp)
 curl_with_retry "https://bun.sh/install" "$BUN_INSTALLER"
 $STD bash "$BUN_INSTALLER"
 rm -f "$BUN_INSTALLER"
-ln -sf /root/.bun/bin/bun /usr/local/bin/bun
-ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
+ln -sf /opt/bun/bin/bun /usr/local/bin/bun
+ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"
 
 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -27,11 +27,12 @@ fi
 msg_ok "Created rackula user"
 
 msg_info "Installing Bun"
-# Install under /opt (not /root): the rackula-api service runs as user rackula
-# with ProtectHome=true, which makes /root invisible, so a binary under
-# /root/.bun is unreachable (systemd 203/EXEC). /opt is accessible to the
-# service and readable under ProtectSystem=strict.
-export BUN_INSTALL="/opt/bun"
+# Install under /usr/local (not /root): the rackula-api service runs as user
+# rackula with ProtectHome=true, which makes /root invisible, so a binary under
+# /root/.bun is unreachable (systemd 203/EXEC). /usr/local/<runtime> + a symlink
+# into /usr/local/bin mirrors the framework's setup_go convention and is
+# readable by the sandboxed service under ProtectSystem=strict.
+export BUN_INSTALL="/usr/local/bun"
 # Fetch via curl_with_retry (bounded timeout, retries, DNS pre-check) so a slow
 # CDN or broken IPv6 fails fast instead of hanging. bun.sh/install needs unzip
 # (installed above) and auto-detects the CPU baseline variant. mktemp gives a
@@ -41,8 +42,8 @@ BUN_INSTALLER=$(mktemp)
 curl_with_retry "https://bun.sh/install" "$BUN_INSTALLER"
 $STD bash "$BUN_INSTALLER"
 rm -f "$BUN_INSTALLER"
-ln -sf /opt/bun/bin/bun /usr/local/bin/bun
-ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx
+ln -sf /usr/local/bun/bin/bun /usr/local/bin/bun
+ln -sf /usr/local/bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"
 
 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"


### PR DESCRIPTION
## **User description**
## Summary

After the Bun-install hang fix (#1933), the LXC install reached the verify step but `rackula-api` failed with `203/EXEC`:

```
rackula-api.service: Unable to locate executable '/usr/local/bin/bun': No such file or directory
rackula-api.service: Failed at step EXEC spawning /usr/local/bin/bun: No such file or directory
```

## Root cause

`rackula-api.service` runs as `User=rackula` with `ProtectHome=true`, which makes `/root` invisible to the service. Bun was installed to `/root/.bun` and `/usr/local/bin/bun` was a symlink into `/root/.bun/bin/bun` - so the sandboxed service could not resolve the target (even though `which bun` works for an interactive root shell). 

## Fix

Install Bun to `/opt/bun` (`BUN_INSTALL=/opt/bun`) and point the symlinks there. `/opt` is unaffected by `ProtectHome` and readable under `ProtectSystem=strict`. `ExecStart=/usr/local/bin/bun` is unchanged - the symlink now resolves to an accessible path.

## Verification

- `shellcheck` clean (only pre-existing SC1091 for the runtime-sourced framework).
- Live re-test on pve-prod: install completes, `rackula-api` active, `/health` responds. (Mirrored to the `ggfevans/ProxmoxVED` fork for the live test.)

Fixes #1952
Part of #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Install Bun in a location the hardened Rackula service can access**

### What Changed
- Bun is now installed under `/opt/bun` instead of `/root/.bun`
- The `bun` and `bunx` links now point to the new location, so the Rackula service can start without hitting `203/EXEC`
- This avoids install failures on systems where the service cannot see `/root`

### Impact
`✅ Fewer Rackula startup failures`
`✅ Successful LXC installs on hardened systems`
`✅ Clearer service startup behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
