### PR TITLE
feat(lxc): release-free dev build mode for LXC payload testing

### DIFF
--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -66,6 +66,15 @@ jobs:
           INPUT_REF: ${{ inputs.ref }}
           PUBLISH: ${{ inputs.publish }}
         run: |
+          # Guard against newline/CR injection via user-controlled inputs into $GITHUB_OUTPUT.
+          # Valid git refs and CalVer strings never contain these characters.
+          case "${INPUT_VERSION}${INPUT_REF}" in
+            *$'\n'*|*$'\r'*)
+              echo "ERROR: ref/version inputs must not contain newline or CR characters"
+              exit 1
+              ;;
+          esac
+
           if [ "$WF_EVENT" = "workflow_call" ] || [ "$PUBLISH" = "true" ]; then
             if [ -z "$INPUT_VERSION" ]; then
               echo "ERROR: version input is required when publish=true or for workflow_call"

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -67,6 +67,10 @@ jobs:
           PUBLISH: ${{ inputs.publish }}
         run: |
           if [ "$WF_EVENT" = "workflow_call" ] || [ "$PUBLISH" = "true" ]; then
+            if [ -z "$INPUT_VERSION" ]; then
+              echo "ERROR: version input is required when publish=true or for workflow_call"
+              exit 1
+            fi
             # Release builds (workflow_call or publish=true) must checkout the exact
             # version tag so release artifact provenance matches the tagged commit.
             echo "checkout_ref=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -53,6 +53,7 @@ concurrency:
 
 jobs:
   build:
+    name: Build LXC tarball
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.compute-version.outputs.version }}
@@ -192,6 +193,7 @@ jobs:
           retention-days: 7
 
   publish:
+    name: Publish to release
     needs: build
     # Run for workflow_call (release pipeline) or when explicitly requested via dispatch.
     # Skipped for dev builds (publish=false) so no release is touched.

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -63,12 +63,14 @@ jobs:
           WF_EVENT: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_REF: ${{ inputs.ref }}
+          PUBLISH: ${{ inputs.publish }}
         run: |
-          if [ "$WF_EVENT" = "workflow_call" ]; then
-            # workflow_call always checks out the version tag
+          if [ "$WF_EVENT" = "workflow_call" ] || [ "$PUBLISH" = "true" ]; then
+            # Release builds (workflow_call or publish=true) must checkout the exact
+            # version tag so release artifact provenance matches the tagged commit.
             echo "checkout_ref=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
           else
-            # workflow_dispatch checks out the provided ref (default: main)
+            # Dev builds (publish=false) checkout the provided ref (default: main).
             echo "checkout_ref=${INPUT_REF:-main}" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -1,19 +1,23 @@
 name: Build LXC Tarball
 
-# Builds the self-contained LXC tarball (frontend + API + config) for a given
-# release tag and uploads it, with a SHA256 checksum, to the published release.
+# Builds the self-contained LXC tarball (frontend + API + config).
 #
-# Called automatically by release.yml after the release is created
-# (workflow_call), and runnable manually to backfill or re-upload a tarball for
-# an existing release (workflow_dispatch). Both triggers are write-access-gated,
-# so checking out the requested tag is a trusted operation: there is no
-# privileged untrusted checkout, unlike the previous workflow_run design.
+# workflow_call: Called by release.yml after publishing a release. version is required and
+#   must match CalVer. Always uploads the tarball to the release.
+#
+# workflow_dispatch (publish=true, default): Manually re-upload a tarball for an existing
+#   release. version must match CalVer.
+#
+# workflow_dispatch (publish=false): Build a test artifact from any branch, tag, or SHA
+#   without creating or touching a release. version is optional; if omitted, a synthetic
+#   vDEV-<sha> label is used. The artifact stays as a downloadable run artifact only.
+#   Use this path for LXC payload testing during development (see docs/deployment/LXC-TESTING.md).
 #
 # Split into two jobs by privilege:
-#   build   - contents: read. Checks out the tag and runs dependency code
+#   build   - contents: read. Checks out the requested ref and runs dependency code
 #             (npm ci, bun install) with no write-capable token.
 #   publish - contents: write. Downloads the build artifact and uploads it to
-#             the release. Runs no repo/dependency code.
+#             the release. Skipped when publish=false.
 on:
   workflow_call:
     inputs:
@@ -23,39 +27,81 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version tag (e.g. v26.6.0)"
-        required: true
+      ref:
+        description: "Branch, tag, or SHA to build from (default: main)"
+        required: false
+        default: "main"
         type: string
+      version:
+        description: "Version label (e.g. v26.6.0). Leave empty for a dev build (uses vDEV-<sha>)."
+        required: false
+        type: string
+      publish:
+        description: "Upload tarball to the GitHub Release (requires a valid CalVer tag and an existing published release)"
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
 
-# Serialise per version so a manual dispatch and the release-triggered call
-# cannot race on the same release asset (gh release upload --clobber).
+# Serialise per ref so concurrent dispatches on the same branch or version cannot
+# race on the same release asset (gh release upload --clobber).
 concurrency:
-  group: build-lxc-${{ inputs.version }}
+  group: build-lxc-${{ inputs.version || inputs.ref || 'main' }}
   cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute-version.outputs.version }}
     steps:
-      # Validate before checkout so only a strict version tag can be the ref.
-      - name: Validate version format
+      - name: Resolve checkout ref
+        id: resolve-ref
         env:
-          VERSION: ${{ inputs.version }}
+          WF_EVENT: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
-            exit 1
+          if [ "$WF_EVENT" = "workflow_call" ]; then
+            # workflow_call always checks out the version tag
+            echo "checkout_ref=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            # workflow_dispatch checks out the provided ref (default: main)
+            echo "checkout_ref=${INPUT_REF:-main}" >> "$GITHUB_OUTPUT"
           fi
-          echo "Version: $VERSION"
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ steps.resolve-ref.outputs.checkout_ref }}
           persist-credentials: false
+
+      - name: Compute version
+        id: compute-version
+        env:
+          WF_EVENT: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          PUBLISH: ${{ inputs.publish }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            SHA=$(git rev-parse --short HEAD)
+            VERSION="vDEV-${SHA}"
+          fi
+
+          # Enforce strict CalVer for release uploads and workflow_call (release pipeline).
+          # Dev builds (publish=false) accept any label, including the synthetic vDEV-<sha>.
+          if [ "$WF_EVENT" = "workflow_call" ] || [ "$PUBLISH" = "true" ]; then
+            if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
+              exit 1
+            fi
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION}"
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -95,7 +141,7 @@ jobs:
 
       - name: Assemble tarball
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.compute-version.outputs.version }}
         run: |
           TARBALL_DIR="rackula-lxc-${VERSION}"
 
@@ -138,13 +184,16 @@ jobs:
         with:
           name: lxc-tarball
           path: |
-            rackula-lxc-${{ inputs.version }}.tar.gz
-            rackula-lxc-${{ inputs.version }}.tar.gz.sha256
+            rackula-lxc-${{ steps.compute-version.outputs.version }}.tar.gz
+            rackula-lxc-${{ steps.compute-version.outputs.version }}.tar.gz.sha256
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 7
 
   publish:
     needs: build
+    # Run for workflow_call (release pipeline) or when explicitly requested via dispatch.
+    # Skipped for dev builds (publish=false) so no release is touched.
+    if: github.event_name == 'workflow_call' || inputs.publish == true
     runs-on: ubuntu-latest
     # contents: write is required only to upload the tarball and its checksum as
     # assets on the published release (gh release upload).
@@ -161,7 +210,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           TARBALL="rackula-lxc-${VERSION}.tar.gz"
 

--- a/docs/deployment/LXC-TESTING.md
+++ b/docs/deployment/LXC-TESTING.md
@@ -1,0 +1,156 @@
+# LXC Testing Guide
+
+Testing the Proxmox LXC install without cutting a release.
+
+---
+
+## Three Test Layers
+
+There are three distinct concerns in the LXC install pipeline. Each has a different testing strategy:
+
+| Layer | What it covers | Needs a release? |
+|---|---|---|
+| Install script logic | Dependencies, Bun install, nginx/systemd wiring in `rackula-install.sh` | No |
+| Payload | Frontend build, API source, native deps, config files in the tarball | No |
+| Fetch/verify/update machinery | `fetch_and_deploy_gh_release`, update flow | Yes |
+
+The fetch/verify/update machinery is stable framework code proven by the initial release and rarely changed. The install script and payload change frequently during active development. Test those without releasing.
+
+---
+
+## Layer 1: Testing install script logic
+
+The install script (`install/rackula-install.sh`) can be tested against a new version of the script without changing the payload. Point a throwaway CT at a fork branch to serve the modified script, and let it install the existing `latest` release tarball.
+
+```bash
+# On your Proxmox host, run the install with a custom script URL pointing at your fork.
+# The CT fetches rackula-install.sh from the URL you provide, then pulls the latest
+# release tarball from GitHub.
+COMMUNITY_SCRIPTS_URL=https://raw.githubusercontent.com/<your-fork>/ProxmoxVED/<branch> \
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/<your-fork>/ProxmoxVED/<branch>/ct/rackula.sh)"
+```
+
+This is sufficient for changes to script structure, dependency installs, and nginx/systemd wiring.
+
+---
+
+## Layer 2: Testing the payload (release-free)
+
+Use the `build-lxc.yml` workflow in artifact-only mode to build a tarball from any branch or SHA without publishing a release.
+
+### Trigger a dev build
+
+In the GitHub Actions UI, run "Build LXC Tarball" (`build-lxc.yml`) with:
+
+- **ref**: the branch or SHA to build (e.g. `main` or a feature branch)
+- **version**: leave empty (auto-computes `vDEV-<sha>`)
+- **publish**: unchecked (false)
+
+Or with the `gh` CLI:
+
+```bash
+gh workflow run build-lxc.yml \
+  --field ref=main \
+  --field publish=false
+```
+
+### Download the artifact
+
+```bash
+# Find the run ID
+gh run list --workflow=build-lxc.yml --limit=5
+
+# Download the artifact from that run
+gh run download <run-id> --name lxc-tarball --dir /tmp/rackula-lxc-test
+ls /tmp/rackula-lxc-test/
+# rackula-lxc-vDEV-abc1234.tar.gz
+# rackula-lxc-vDEV-abc1234.tar.gz.sha256
+```
+
+### Deploy to a throwaway CT
+
+Copy the tarball to your Proxmox host and extract it manually:
+
+```bash
+# On Proxmox host: create a throwaway CT (Debian 13, unprivileged, 512MB RAM)
+# Then copy and extract the tarball:
+scp /tmp/rackula-lxc-test/rackula-lxc-vDEV-*.tar.gz root@<pve-host>:/tmp/
+
+# Inside the CT:
+mkdir -p /opt/rackula
+tar xzf /tmp/rackula-lxc-vDEV-*.tar.gz -C /opt/rackula --strip-components=1
+
+# Then run the install steps manually (or run rackula-install.sh with a patched
+# fetch step that points at /opt/rackula instead of fetching from GitHub).
+```
+
+### Verify the payload
+
+After deploying:
+
+```bash
+# API responds
+curl -sf http://127.0.0.1:3001/health
+
+# Frontend serves
+curl -sf http://127.0.0.1/
+
+# argon2 native module loads (Bun starts without crashing)
+bun /opt/rackula/api/src/index.ts &
+curl -sf http://127.0.0.1:3001/health
+```
+
+---
+
+## Layer 3: Testing fetch/verify/update machinery
+
+This layer requires a real GitHub Release with a tarball asset. Use the standard release process:
+
+```bash
+/release    # creates tag, changelog entry, and triggers build-lxc.yml
+```
+
+Only do this when the machinery itself changes (e.g. `fetch_and_deploy_gh_release` logic, checksum verification, or the update flow in `ct/rackula.sh`).
+
+---
+
+## Local macOS build fallback
+
+If you need to assemble the tarball locally (e.g. for offline CT testing):
+
+```bash
+# Prerequisites: Node 22, Bun 1.x
+
+# 1. Build the frontend
+VITE_ENV=production VITE_PERSIST_ENABLED=true VITE_UMAMI_ENABLED=false npm ci && npm run build
+
+# 2. Install API production dependencies with cross-platform native binaries
+cd api
+bun install --frozen-lockfile --production --cpu='*' --os=linux
+
+# 3. Verify argon2 native binaries are present for both architectures
+test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node \
+  || { echo "ERROR: x64 argon2 binary missing"; exit 1; }
+test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node \
+  || { echo "ERROR: arm64 argon2 binary missing"; exit 1; }
+
+# 4. Assemble the tarball
+cd ..
+VERSION="vDEV-local"
+TARBALL_DIR="rackula-lxc-${VERSION}"
+
+mkdir -p "${TARBALL_DIR}/frontend" "${TARBALL_DIR}/api" "${TARBALL_DIR}/config"
+
+cp -r dist/* "${TARBALL_DIR}/frontend/"
+cp -r api/src api/node_modules api/package.json api/tsconfig.json "${TARBALL_DIR}/api/"
+cp deploy/lxc/nginx.conf deploy/lxc/rackula-api.service \
+   deploy/lxc/security-headers.conf deploy/lxc/nginx.service.d-override.conf \
+   "${TARBALL_DIR}/config/"
+
+tar czf "rackula-lxc-${VERSION}.tar.gz" "${TARBALL_DIR}"
+sha256sum "rackula-lxc-${VERSION}.tar.gz" > "rackula-lxc-${VERSION}.tar.gz.sha256"
+rm -rf "${TARBALL_DIR}"
+echo "Built: rackula-lxc-${VERSION}.tar.gz"
+```
+
+The `test -f` guards for both `argon2-linux-x64-gnu` and `argon2-linux-arm64-gnu` are mandatory. Without the `--cpu='*' --os=linux` flags, Bun installs only the host platform binary, which causes the API to fail at startup on arm64 LXC containers.


### PR DESCRIPTION
## **User description**
## Summary

Closes #1949.

Adds a `publish=false` mode to `build-lxc.yml` so the LXC tarball can be built from any branch or SHA without touching a GitHub release or triggering a production deploy.

- New `workflow_dispatch` inputs: `ref` (branch/tag/SHA, default `main`), `version` (optional), `publish` (boolean, default `true`)
- When `publish=false`: build job runs, computes a synthetic `vDEV-<sha>` version if none provided, skips the publish job entirely
- When `publish=true` or triggered via `workflow_call` (release pipeline): strict CalVer validation enforced, tarball uploaded to release as before
- Artifact retention increased from 1 to 7 days so dev builds are downloadable for CT testing
- New `docs/deployment/LXC-TESTING.md` documenting the three test layers and the release-free payload procedure with local macOS build fallback including argon2 `test -f` guards

## Test plan

- [ ] Trigger `build-lxc.yml` via workflow_dispatch with `ref=main`, `publish=false` - confirm build job succeeds, publish job is skipped, artifact appears in run summary
- [ ] Download artifact with `gh run download <run-id> --name lxc-tarball` and verify tarball structure
- [ ] Trigger with `publish=false` and no version - confirm artifact filename uses `vDEV-<sha>`
- [ ] Confirm existing `workflow_call` path (from release.yml) is unchanged: strict CalVer enforced, publish job runs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wyiie5nA8iNhRfLaf5rT18)_


___

## **CodeAnt-AI Description**
**Build LXC tarballs from any branch without creating a release**

### What Changed
- The LXC build can now be run against any branch, tag, or commit for testing without publishing a GitHub release
- When no version is provided for a test build, the tarball gets a temporary `vDEV-<sha>` label
- Release uploads still require a valid CalVer version, and the publish step is skipped entirely for dev builds
- Downloadable build artifacts are kept for 7 days instead of 1, giving more time to fetch and test them
- Added a guide that explains how to test the LXC install script, the tarball payload, and the release update flow

### Impact
`✅ Release-free LXC testing`
`✅ Longer artifact download window`
`✅ Fewer unnecessary release publishes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
