### PR TITLE
feat(lxc): add artifact-only branch build mode to build-lxc.yml

### DIFF
--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -83,6 +83,11 @@ jobs:
           else
             SHORT_SHA="${SHA:0:7}"
             VERSION="${INPUT_VERSION:-vDEV-${SHORT_SHA}}"
+            if ! echo "$VERSION" | grep -qE '^[A-Za-z0-9._-]+$'; then
+              echo "ERROR: Branch-build version label '$VERSION' contains invalid characters."
+              echo "Use only letters, numbers, dot, underscore, or hyphen."
+              exit 1
+            fi
             CHECKOUT_REF="${INPUT_REF:-${GITHUB_REF_NAME}}"
             echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
             echo "retention=7" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -1,19 +1,28 @@
 name: Build LXC Tarball
 
-# Builds the self-contained LXC tarball (frontend + API + config) for a given
-# release tag and uploads it, with a SHA256 checksum, to the published release.
+# Builds the self-contained LXC tarball (frontend + API + config) and either
+# uploads it to a published release or stores it as a workflow artifact for
+# release-free branch testing.
 #
-# Called automatically by release.yml after the release is created
-# (workflow_call), and runnable manually to backfill or re-upload a tarball for
-# an existing release (workflow_dispatch). Both triggers are write-access-gated,
-# so checking out the requested tag is a trusted operation: there is no
-# privileged untrusted checkout, unlike the previous workflow_run design.
+# Two modes, controlled by the 'publish' input (workflow_dispatch only):
+#
+#   publish: true  (default) - release build
+#     Requires a valid vYY.M.MICRO version tag. Checks out the tag and uploads
+#     the tarball to the corresponding GitHub release. Called automatically by
+#     release.yml, and manually via workflow_dispatch to backfill a tarball.
+#
+#   publish: false - artifact-only branch build
+#     Checks out the given ref (defaults to the dispatched branch). Uses a
+#     synthetic version label (inputs.version or vDEV-<sha>). Skips the publish
+#     job entirely, so no release is created and deploy-prod is not triggered.
+#     Download the artifact with: gh run download <run-id>
 #
 # Split into two jobs by privilege:
-#   build   - contents: read. Checks out the tag and runs dependency code
+#   build   - contents: read. Checks out the ref and runs dependency code
 #             (npm ci, bun install) with no write-capable token.
 #   publish - contents: write. Downloads the build artifact and uploads it to
-#             the release. Runs no repo/dependency code.
+#             the release. Runs no repo/dependency code. Skipped when
+#             publish=false or when a branch build is in progress.
 on:
   workflow_call:
     inputs:
@@ -24,37 +33,66 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g. v26.6.0)"
-        required: true
+        description: "Version tag or label (e.g. v26.6.0). Leave blank for a branch build to use vDEV-<sha>."
+        required: false
         type: string
+      ref:
+        description: "Branch or commit to build from. Only used when publish is false."
+        required: false
+        type: string
+      publish:
+        description: "Upload tarball to the GitHub release. Set to false for artifact-only branch builds."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
 
-# Serialise per version so a manual dispatch and the release-triggered call
-# cannot race on the same release asset (gh release upload --clobber).
+# Serialise per version/ref so concurrent dispatches cannot race on the same asset.
 concurrency:
-  group: build-lxc-${{ inputs.version }}
+  group: build-lxc-${{ inputs.version || inputs.ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.config.outputs.version }}
     steps:
-      # Validate before checkout so only a strict version tag can be the ref.
-      - name: Validate version format
+      # Resolve effective version, checkout ref, and artifact retention.
+      # workflow_call always takes the release path (version required by caller).
+      # workflow_dispatch with publish=false takes the branch path.
+      - name: Resolve build config
+        id: config
         env:
-          VERSION: ${{ inputs.version }}
+          EVENT: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+          SHA: ${{ github.sha }}
         run: |
-          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
-            exit 1
+          if [ "$EVENT" = "workflow_call" ] || [ "$INPUT_PUBLISH" != "false" ]; then
+            VERSION="$INPUT_VERSION"
+            if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
+              exit 1
+            fi
+            echo "checkout_ref=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "retention=1" >> "$GITHUB_OUTPUT"
+          else
+            SHORT_SHA="${SHA:0:7}"
+            VERSION="${INPUT_VERSION:-vDEV-${SHORT_SHA}}"
+            CHECKOUT_REF="${INPUT_REF:-${GITHUB_REF_NAME}}"
+            echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+            echo "retention=7" >> "$GITHUB_OUTPUT"
           fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION"
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ steps.config.outputs.checkout_ref }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -95,7 +133,7 @@ jobs:
 
       - name: Assemble tarball
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.config.outputs.version }}
         run: |
           TARBALL_DIR="rackula-lxc-${VERSION}"
 
@@ -138,14 +176,17 @@ jobs:
         with:
           name: lxc-tarball
           path: |
-            rackula-lxc-${{ inputs.version }}.tar.gz
-            rackula-lxc-${{ inputs.version }}.tar.gz.sha256
+            rackula-lxc-${{ steps.config.outputs.version }}.tar.gz
+            rackula-lxc-${{ steps.config.outputs.version }}.tar.gz.sha256
           if-no-files-found: error
-          retention-days: 1
+          retention-days: ${{ steps.config.outputs.retention }}
 
   publish:
     needs: build
     runs-on: ubuntu-latest
+    # Skip when this is an artifact-only branch build (publish=false).
+    # workflow_call always publishes; workflow_dispatch defaults to publish=true.
+    if: github.event_name == 'workflow_call' || inputs.publish
     # contents: write is required only to upload the tarball and its checksum as
     # assets on the published release (gh release upload).
     permissions:
@@ -161,7 +202,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           TARBALL="rackula-lxc-${VERSION}.tar.gz"
 

--- a/docs/deployment/LXC-TESTING.md
+++ b/docs/deployment/LXC-TESTING.md
@@ -108,7 +108,7 @@ Both services should be active, and `/health` should return 200.
 The CI build always asserts both Linux binaries are present before assembling
 the tarball:
 
-```
+```bash
 test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node
 test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
 ```

--- a/docs/deployment/LXC-TESTING.md
+++ b/docs/deployment/LXC-TESTING.md
@@ -1,0 +1,127 @@
+# LXC Testing Guide
+
+How to validate the Rackula LXC install at different layers without cutting a
+release or triggering a production deploy.
+
+---
+
+## Three test layers
+
+The LXC install stack has three independent concerns, each with different test
+requirements:
+
+### Layer 1 - Install script logic
+
+Tests: dependency installation (nginx, unzip, ca-certificates), Bun install,
+nginx and systemd wiring, `rackula-install.sh` flow.
+
+Requires a release? No. Serve the install script directly from your fork using
+`COMMUNITY_SCRIPTS_URL` and install against the existing `latest` release
+tarball. The script is exercised end-to-end; the payload content is not what
+is under test.
+
+### Layer 2 - Payload (this guide)
+
+Tests: frontend build output, API source + production deps, config files
+(nginx.conf, rackula-api.service, security-headers.conf, drop-in override).
+
+Requires a release? No. Use the artifact-only build mode described below to
+produce a real-fidelity tarball from any branch and extract it into a throwaway
+container.
+
+### Layer 3 - Fetch/verify/update machinery
+
+Tests: `fetch_and_deploy_gh_release`, sha256 verification, `--strip-components`,
+`check_for_gh_release`.
+
+Requires a release? Yes. This is stable framework code (proven by v26.6.2) that
+is rarely changed. Accept that it is exercised only at real release time.
+
+---
+
+## Release-free payload test (Layer 2)
+
+### 1. Trigger an artifact-only build
+
+Go to Actions > Build LXC Tarball > Run workflow, or use the CLI:
+
+```bash
+gh workflow run build-lxc.yml \
+  --field publish=false \
+  --field ref=main
+```
+
+Optional: pass `--field version=vDEV-mybranch` to give the tarball a meaningful
+label. Without it, the label defaults to `vDEV-<short-sha>`.
+
+This runs the full build job (frontend build, multi-arch argon2 bun install,
+tarball assembly, argon2 binary guards) and uploads the result as a GitHub
+Actions artifact. The publish job is skipped, so no release is created and
+`deploy-prod.yml` is not triggered.
+
+Artifact retention: 7 days.
+
+### 2. Download the artifact
+
+```bash
+# List recent runs
+gh run list --workflow=build-lxc.yml --limit=5
+
+# Download the artifact from the run
+gh run download <run-id> --name lxc-tarball --dir /tmp/rackula-lxc
+```
+
+### 3. Transfer to the container
+
+```bash
+# From the Proxmox host, copy the tarball into the CT
+pct push <CTID> /tmp/rackula-lxc/rackula-lxc-*.tar.gz /tmp/rackula-lxc.tar.gz
+```
+
+### 4. Extract and install into the CT
+
+Inside the CT, replace the fetch step from `rackula-install.sh` with a direct
+extract, then run the rest of the install manually:
+
+```bash
+# Extract the payload where the installer expects it
+mkdir -p /opt/rackula
+tar xzf /tmp/rackula-lxc.tar.gz --strip-components=1 -C /opt/rackula
+
+# Then run the install steps from rackula-install.sh
+# (from "Installing Rackula" onwards - skip the fetch_and_deploy_gh_release call)
+```
+
+### 5. Verify
+
+```bash
+systemctl status rackula-api nginx
+curl -sf http://127.0.0.1:3001/health
+```
+
+Both services should be active, and `/health` should return 200.
+
+---
+
+## argon2 multi-arch guards
+
+The CI build always asserts both Linux binaries are present before assembling
+the tarball:
+
+```
+test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node
+test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
+```
+
+If you build the tarball locally on macOS as a fallback, apply the same guards
+before distributing the tarball. A macOS-local build can silently omit a Linux
+argon2 binary; the CI guards catch this, but a local build does not run them
+automatically.
+
+```bash
+# After: bun install --frozen-lockfile --production --cpu='*' --os=linux
+test -f api/node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node \
+  || { echo "ERROR: x64 argon2 binary missing"; exit 1; }
+test -f api/node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node \
+  || { echo "ERROR: arm64 argon2 binary missing"; exit 1; }
+```


### PR DESCRIPTION
## **User description**
Closes #1949

## Summary

- Adds `publish` boolean input (default `true`) and `ref` input to `build-lxc.yml` `workflow_dispatch`
- When `publish: false`, the build job runs in full fidelity (npm ci, bun install --cpu='*' --os=linux, argon2 multi-arch guards, tarball assembly) but the publish job is skipped entirely - no release created, no prod deploy triggered
- Synthetic version label: `inputs.version` if provided, else `vDEV-<short-sha>`
- Artifact retained for 7 days (vs 1 day for release builds) to allow time for download
- Adds `docs/deployment/LXC-TESTING.md` documenting the three test layers and the release-free payload test procedure

## Changes

`build-lxc.yml`:
- New `workflow_dispatch` inputs: `version` (now optional), `ref`, `publish` (boolean, default true)
- Replaced the standalone `Validate version format` step with a `Resolve build config` step that outputs `version`, `checkout_ref`, and `retention` based on trigger type and inputs
- `workflow_call` always takes the release path (version required, format validated, publishes)
- `workflow_dispatch publish=true` (default) also takes the release path - no behaviour change
- `workflow_dispatch publish=false` checks out `inputs.ref` (or the dispatched branch), uses synthetic version, skips publish job
- `publish` job condition: `github.event_name == 'workflow_call' || inputs.publish`
- Build job outputs `version` for the publish job to consume via `needs.build.outputs.version`

`docs/deployment/LXC-TESTING.md`:
- Describes the three test layers (install script logic, payload, fetch/verify machinery) and which require a release
- Step-by-step release-free payload test: trigger artifact build, download with `gh run download`, transfer to CT, extract, verify services
- macOS local build argon2 guards section

## Test plan

- [ ] Dispatch workflow with `publish=false` and `ref=main`: confirm no release/tag created, artifact present, `deploy-prod` not triggered
- [ ] Dispatch workflow with `publish=true` and a valid version tag: confirm existing release-build behaviour unchanged
- [ ] `workflow_call` path (triggered by release.yml): confirm publish job runs as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL6QK7Lkkcc7WfGZa39kqz)_


___

## **CodeAnt-AI Description**
**Build LXC tarballs from branches without creating a release**

### What Changed
- You can now run the LXC build on a branch and download the tarball as a workflow artifact, without publishing a release or triggering production deploys
- Release builds still require a valid version tag and keep the existing publish flow
- Branch builds use a temporary version label when needed and keep artifacts available for 7 days
- Added a guide showing how to test the LXC payload locally without cutting a release

### Impact
`✅ Branch LXC testing without releases`
`✅ Fewer accidental production deploys`
`✅ Longer artifact access for review`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
