### PR TITLE
fix(a11y): resolve autofocus warning on layout name input (#1896)

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -99,6 +99,17 @@
   // Inline layout name editing state
   let isEditingName = $state(false);
   let editNameValue = $state("");
+  let nameInputElement = $state<HTMLInputElement | null>(null);
+
+  // Focus the rename input when it appears (replaces autofocus attribute)
+  $effect(() => {
+    if (!isEditingName) return;
+    const frame = requestAnimationFrame(() => {
+      nameInputElement?.focus();
+      nameInputElement?.select();
+    });
+    return () => cancelAnimationFrame(frame);
+  });
 
   // View mode labels for tooltip
   const displayModeLabels: Record<DisplayMode, string> = {
@@ -269,6 +280,7 @@
     <div class="toolbar-section toolbar-name" data-testid="layout-name">
       {#if isEditingName}
         <input
+          bind:this={nameInputElement}
           class="toolbar-name-input"
           type="text"
           bind:value={editNameValue}
@@ -276,7 +288,6 @@
           onblur={() => isEditingName && commitName()}
           aria-label="Layout name"
           data-testid="layout-name-input"
-          autofocus
         />
       {:else}
         <button


### PR DESCRIPTION
## **User description**
## Summary

Replaces the `autofocus` attribute on the inline layout-name rename input in `Toolbar.svelte`, which triggered Svelte's `a11y_autofocus` warning during the e2e smoke build.

The new approach matches the codebase's existing focus pattern (see `CleanupPromptDialog.svelte`, `BottomSheet.svelte`): `bind:this` plus an `$effect` that focuses the input via `requestAnimationFrame` when editing begins. It also `select()`s the text so the user can type over the existing name immediately.

## Scope

This addresses the **autofocus** acceptance criterion only. The chunk-size warning from the same issue is deferred (per "for now"), so this is `Part of #1896`, not a full close.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run build` succeeds with no `a11y_autofocus` / "Avoid using autofocus" warning (chunk-size warning still present, out of scope)
- [x] CodeRabbit local review: 0 findings
- [ ] Manually: click the layout name, confirm the input focuses and selects its text; Enter commits, Escape cancels

Part of #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix layout name editing focus without triggering accessibility warnings**

### What Changed
- The layout name field now focuses automatically when renaming starts without using the browser autofocus behavior that caused the warning.
- The text in the layout name field is selected on open, so users can immediately type a replacement name.
- The rename field still opens and closes as before, but now follows the app’s existing focus pattern.

### Impact
`✅ Fewer accessibility build warnings`
`✅ Faster layout renaming`
`✅ Easier rename-and-replace typing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
