### PR TITLE
fix(lxc): align community-scripts with ProxmoxVED + harden build-lxc checkout (#1953)

### DIFF
--- a/.github/workflows/build-lxc-dev.yml
+++ b/.github/workflows/build-lxc-dev.yml
@@ -1,0 +1,160 @@
+name: Build LXC Tarball (dev)
+
+# Builds a self-contained LXC tarball (frontend + API + config) from any branch, tag,
+# or SHA for development payload testing, WITHOUT touching a release.
+#
+# This is the dev counterpart to build-lxc.yml. It is intentionally separate and
+# unprivileged: the whole workflow is contents: read with no publish job, so checking
+# out an arbitrary requested ref and running its dependency code (npm ci, bun install)
+# never happens in a context that can write to the repo or reach release secrets.
+# workflow_dispatch also requires write access to trigger.
+#
+# The tarball is uploaded as a downloadable run artifact only, labelled vDEV-<sha> when
+# no explicit label is given. See docs/deployment/LXC-TESTING.md.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build from (default: main)"
+        required: false
+        default: "main"
+        type: string
+      version:
+        description: "Artifact label (default: vDEV-<sha>). Allowed chars: A-Z a-z 0-9 . _ -"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+# Serialise per ref so concurrent dispatches on the same branch do not clobber each other.
+concurrency:
+  group: build-lxc-dev-${{ inputs.ref || 'main' }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build LXC tarball (dev)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          # Reject newline/CR so user input cannot inject extra lines into $GITHUB_OUTPUT.
+          case "${INPUT_VERSION}${INPUT_REF}" in
+            *$'\n'*|*$'\r'*)
+              echo "ERROR: ref/version inputs must not contain newline or CR characters"
+              exit 1
+              ;;
+          esac
+          # Keep the label filename-safe (it becomes part of the tarball name).
+          if [ -n "$INPUT_VERSION" ] && ! echo "$INPUT_VERSION" | grep -qE '^[A-Za-z0-9._-]+$'; then
+            echo "ERROR: version label may only contain A-Z a-z 0-9 . _ -"
+            exit 1
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Compute version
+        id: compute-version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="vDEV-$(git rev-parse --short HEAD)"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1"
+
+      - name: Build frontend
+        env:
+          VITE_ENV: production
+          VITE_PERSIST_ENABLED: "true"
+          VITE_UMAMI_ENABLED: "false"
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install API production dependencies
+        run: |
+          cd api
+          # The tarball is built on x86 but installs on any LXC arch (incl. arm64).
+          # @node-rs/argon2 (the only native dep) ships per-platform binaries as
+          # os/cpu-gated optional deps, so a normal host install pulls x64 only.
+          # --cpu='*' --os=linux materialises every linux variant (x64 + arm64, gnu and
+          # musl) in one production install, so the bundled node_modules runs on both
+          # architectures. --production keeps devDependencies out of the tarball. The
+          # runtime loader selects the binary by file presence, not the os/cpu manifest.
+          bun install --frozen-lockfile --production --cpu='*' --os=linux
+
+          # Fail the build if either native binary is missing.
+          test -f node_modules/@node-rs/argon2-linux-x64-gnu/argon2.linux-x64-gnu.node
+          test -f node_modules/@node-rs/argon2-linux-arm64-gnu/argon2.linux-arm64-gnu.node
+
+      - name: Assemble tarball
+        env:
+          VERSION: ${{ steps.compute-version.outputs.version }}
+        run: |
+          TARBALL_DIR="rackula-lxc-${VERSION}"
+
+          mkdir -p "${TARBALL_DIR}/frontend"
+          mkdir -p "${TARBALL_DIR}/api"
+          mkdir -p "${TARBALL_DIR}/config"
+
+          # Frontend build output
+          cp -r dist/* "${TARBALL_DIR}/frontend/"
+
+          # API source + production deps (Bun runs TS natively)
+          cp -r api/src "${TARBALL_DIR}/api/src"
+          cp -r api/node_modules "${TARBALL_DIR}/api/node_modules"
+          cp api/package.json "${TARBALL_DIR}/api/package.json"
+          cp api/tsconfig.json "${TARBALL_DIR}/api/tsconfig.json"
+
+          # LXC-specific config files
+          cp deploy/lxc/nginx.conf "${TARBALL_DIR}/config/"
+          cp deploy/lxc/rackula-api.service "${TARBALL_DIR}/config/"
+          cp deploy/lxc/security-headers.conf "${TARBALL_DIR}/config/"
+          cp deploy/lxc/nginx.service.d-override.conf "${TARBALL_DIR}/config/"
+
+          # Verify expected directories exist in the tarball
+          for dir in frontend api config; do
+            if [ ! -d "${TARBALL_DIR}/${dir}" ] || [ -z "$(ls -A "${TARBALL_DIR}/${dir}")" ]; then
+              echo "ERROR: Tarball directory '${dir}' is missing or empty"
+              exit 1
+            fi
+          done
+
+          tar czf "rackula-lxc-${VERSION}.tar.gz" "${TARBALL_DIR}"
+
+          # Generate SHA256 checksum for integrity verification
+          sha256sum "rackula-lxc-${VERSION}.tar.gz" > "rackula-lxc-${VERSION}.tar.gz.sha256"
+
+          rm -rf "${TARBALL_DIR}"
+
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lxc-tarball-${{ steps.compute-version.outputs.version }}
+          path: |
+            rackula-lxc-${{ steps.compute-version.outputs.version }}.tar.gz
+            rackula-lxc-${{ steps.compute-version.outputs.version }}.tar.gz.sha256
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/build-lxc-dev.yml
+++ b/.github/workflows/build-lxc-dev.yml
@@ -1,24 +1,19 @@
 name: Build LXC Tarball (dev)
 
-# Builds a self-contained LXC tarball (frontend + API + config) from any branch, tag,
-# or SHA for development payload testing, WITHOUT touching a release.
+# Builds a self-contained LXC tarball (frontend + API + config) from the branch or tag the
+# run is dispatched on, for development payload testing, WITHOUT touching a release.
 #
 # This is the dev counterpart to build-lxc.yml. It is intentionally separate and
-# unprivileged: the whole workflow is contents: read with no publish job, so checking
-# out an arbitrary requested ref and running its dependency code (npm ci, bun install)
-# never happens in a context that can write to the repo or reach release secrets.
-# workflow_dispatch also requires write access to trigger.
+# unprivileged: the whole workflow is contents: read with no publish job. It checks out the
+# dispatched ref (github.ref) rather than a ref passed as an input, so there is no
+# untrusted-checkout surface. Pick the branch/tag in the Actions "Run workflow" dropdown, or
+# with the gh CLI:  gh workflow run build-lxc-dev.yml --ref <branch-or-tag>
 #
-# The tarball is uploaded as a downloadable run artifact only, labelled vDEV-<sha> when
-# no explicit label is given. See docs/deployment/LXC-TESTING.md.
+# The tarball is uploaded as a downloadable run artifact only, labelled vDEV-<sha> when no
+# explicit label is given. See docs/deployment/LXC-TESTING.md.
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Branch, tag, or SHA to build from (default: main)"
-        required: false
-        default: "main"
-        type: string
       version:
         description: "Artifact label (default: vDEV-<sha>). Allowed chars: A-Z a-z 0-9 . _ -"
         required: false
@@ -27,9 +22,9 @@ on:
 permissions:
   contents: read
 
-# Serialise per ref so concurrent dispatches on the same branch do not clobber each other.
+# Serialise per dispatched ref so concurrent dispatches on the same branch do not clobber.
 concurrency:
-  group: build-lxc-dev-${{ inputs.ref || 'main' }}
+  group: build-lxc-dev-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -37,27 +32,26 @@ jobs:
     name: Build LXC tarball (dev)
     runs-on: ubuntu-latest
     steps:
-      - name: Validate inputs
+      - name: Validate label
         env:
           INPUT_VERSION: ${{ inputs.version }}
-          INPUT_REF: ${{ inputs.ref }}
         run: |
-          # Reject newline/CR so user input cannot inject extra lines into $GITHUB_OUTPUT.
-          case "${INPUT_VERSION}${INPUT_REF}" in
+          # Reject newline/CR so the label cannot inject extra lines into $GITHUB_OUTPUT,
+          # and keep it filename-safe (it becomes part of the tarball name).
+          case "$INPUT_VERSION" in
             *$'\n'*|*$'\r'*)
-              echo "ERROR: ref/version inputs must not contain newline or CR characters"
+              echo "ERROR: version label must not contain newline or CR characters"
               exit 1
               ;;
           esac
-          # Keep the label filename-safe (it becomes part of the tarball name).
           if [ -n "$INPUT_VERSION" ] && ! echo "$INPUT_VERSION" | grep -qE '^[A-Za-z0-9._-]+$'; then
             echo "ERROR: version label may only contain A-Z a-z 0-9 . _ -"
             exit 1
           fi
 
+      # No ref input: checks out the ref the run was dispatched on (github.ref).
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Compute version

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -50,6 +50,15 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
+          # Reject newline/CR first: grep matches line-by-line, so a multiline value
+          # whose first line is valid CalVer would otherwise pass and then flow into the
+          # checkout ref, tarball filenames, and gh release calls.
+          case "$VERSION" in
+            *$'\n'*|*$'\r'*)
+              echo "ERROR: Version must not contain newline or CR characters"
+              exit 1
+              ;;
+          esac
           if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
             exit 1

--- a/.github/workflows/build-lxc.yml
+++ b/.github/workflows/build-lxc.yml
@@ -1,23 +1,22 @@
 name: Build LXC Tarball
 
-# Builds the self-contained LXC tarball (frontend + API + config).
+# Builds the self-contained LXC tarball (frontend + API + config) for a published
+# release and uploads it, with a SHA256 checksum, to that release.
 #
-# workflow_call: Called by release.yml after publishing a release. version is required and
-#   must match CalVer. Always uploads the tarball to the release.
+# workflow_call: Called by release.yml after a release is created. version is required
+#   and must match CalVer.
+# workflow_dispatch: Manually re-upload the tarball for an existing release. version is
+#   required and must match CalVer.
 #
-# workflow_dispatch (publish=true, default): Manually re-upload a tarball for an existing
-#   release. version must match CalVer.
-#
-# workflow_dispatch (publish=false): Build a test artifact from any branch, tag, or SHA
-#   without creating or touching a release. version is optional; if omitted, a synthetic
-#   vDEV-<sha> label is used. The artifact stays as a downloadable run artifact only.
-#   Use this path for LXC payload testing during development (see docs/deployment/LXC-TESTING.md).
+# Both triggers are write-access-gated and only ever check out the validated CalVer tag,
+# so there is no untrusted checkout here. For building a test artifact from an arbitrary
+# branch/tag/SHA during development, use build-lxc-dev.yml (see docs/deployment/LXC-TESTING.md).
 #
 # Split into two jobs by privilege:
-#   build   - contents: read. Checks out the requested ref and runs dependency code
+#   build   - contents: read. Checks out the version tag and runs dependency code
 #             (npm ci, bun install) with no write-capable token.
-#   publish - contents: write. Downloads the build artifact and uploads it to
-#             the release. Skipped when publish=false.
+#   publish - contents: write. Downloads the build artifact and uploads it to the
+#             release. Runs no repo/dependency code.
 on:
   workflow_call:
     inputs:
@@ -27,97 +26,40 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Branch, tag, or SHA to build from (default: main)"
-        required: false
-        default: "main"
-        type: string
       version:
-        description: "Version label (e.g. v26.6.0). Leave empty for a dev build (uses vDEV-<sha>)."
-        required: false
+        description: "Version tag (e.g. v26.6.0)"
+        required: true
         type: string
-      publish:
-        description: "Upload tarball to the GitHub Release (requires a valid CalVer tag and an existing published release)"
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
 
-# Serialise per ref so concurrent dispatches on the same branch or version cannot
-# race on the same release asset (gh release upload --clobber).
+# Serialise per version so a manual dispatch and the release-triggered call cannot race
+# on the same release asset (gh release upload --clobber).
 concurrency:
-  group: build-lxc-${{ inputs.version || inputs.ref || 'main' }}
+  group: build-lxc-${{ inputs.version }}
   cancel-in-progress: false
 
 jobs:
   build:
     name: Build LXC tarball
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.compute-version.outputs.version }}
     steps:
-      - name: Resolve checkout ref
-        id: resolve-ref
+      # Validate before checkout so only a strict CalVer tag can be the checkout ref.
+      - name: Validate version format
         env:
-          WF_EVENT: ${{ github.event_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-          INPUT_REF: ${{ inputs.ref }}
-          PUBLISH: ${{ inputs.publish }}
+          VERSION: ${{ inputs.version }}
         run: |
-          # Guard against newline/CR injection via user-controlled inputs into $GITHUB_OUTPUT.
-          # Valid git refs and CalVer strings never contain these characters.
-          case "${INPUT_VERSION}${INPUT_REF}" in
-            *$'\n'*|*$'\r'*)
-              echo "ERROR: ref/version inputs must not contain newline or CR characters"
-              exit 1
-              ;;
-          esac
-
-          if [ "$WF_EVENT" = "workflow_call" ] || [ "$PUBLISH" = "true" ]; then
-            if [ -z "$INPUT_VERSION" ]; then
-              echo "ERROR: version input is required when publish=true or for workflow_call"
-              exit 1
-            fi
-            # Release builds (workflow_call or publish=true) must checkout the exact
-            # version tag so release artifact provenance matches the tagged commit.
-            echo "checkout_ref=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
-          else
-            # Dev builds (publish=false) checkout the provided ref (default: main).
-            echo "checkout_ref=${INPUT_REF:-main}" >> "$GITHUB_OUTPUT"
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
+            exit 1
           fi
+          echo "Version: $VERSION"
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ steps.resolve-ref.outputs.checkout_ref }}
+          ref: ${{ inputs.version }}
           persist-credentials: false
-
-      - name: Compute version
-        id: compute-version
-        env:
-          WF_EVENT: ${{ github.event_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-          PUBLISH: ${{ inputs.publish }}
-        run: |
-          if [ -n "$INPUT_VERSION" ]; then
-            VERSION="$INPUT_VERSION"
-          else
-            SHA=$(git rev-parse --short HEAD)
-            VERSION="vDEV-${SHA}"
-          fi
-
-          # Enforce strict CalVer for release uploads and workflow_call (release pipeline).
-          # Dev builds (publish=false) accept any label, including the synthetic vDEV-<sha>.
-          if [ "$WF_EVENT" = "workflow_call" ] || [ "$PUBLISH" = "true" ]; then
-            if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "ERROR: Version '$VERSION' does not match expected format vYY.M.MICRO (e.g. v26.6.0)"
-              exit 1
-            fi
-          fi
-
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Version: ${VERSION}"
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -157,7 +99,7 @@ jobs:
 
       - name: Assemble tarball
         env:
-          VERSION: ${{ steps.compute-version.outputs.version }}
+          VERSION: ${{ inputs.version }}
         run: |
           TARBALL_DIR="rackula-lxc-${VERSION}"
 
@@ -200,17 +142,14 @@ jobs:
         with:
           name: lxc-tarball
           path: |
-            rackula-lxc-${{ steps.compute-version.outputs.version }}.tar.gz
-            rackula-lxc-${{ steps.compute-version.outputs.version }}.tar.gz.sha256
+            rackula-lxc-${{ inputs.version }}.tar.gz
+            rackula-lxc-${{ inputs.version }}.tar.gz.sha256
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1
 
   publish:
     name: Publish to release
     needs: build
-    # Run for workflow_call (release pipeline) or when explicitly requested via dispatch.
-    # Skipped for dev builds (publish=false) so no release is touched.
-    if: github.event_name == 'workflow_call' || inputs.publish == true
     runs-on: ubuntu-latest
     # contents: write is required only to upload the tarball and its checksum as
     # assets on the published release (gh release upload).
@@ -227,7 +166,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          VERSION: ${{ needs.build.outputs.version }}
+          VERSION: ${{ inputs.version }}
         run: |
           TARBALL="rackula-lxc-${VERSION}.tar.gz"
 

--- a/deploy/lxc/community-scripts/README.md
+++ b/deploy/lxc/community-scripts/README.md
@@ -1,0 +1,36 @@
+# Rackula community-scripts (canonical)
+
+These three files are the canonical source of truth for the Rackula PVE Community
+Scripts entry:
+
+- `ct/rackula.sh`
+- `install/rackula-install.sh`
+- `json/rackula.json`
+
+## Sync direction: canonical to fork, one way only
+
+The upstream submission goes through the `ggfevans/ProxmoxVED` fork on branch
+`feat/add-rackula` (which targets `community-scripts/ProxmoxVED`). That fork is a
+downstream mirror, not a second source of truth.
+
+Always edit these files here first, then copy them to the fork. Never edit the fork
+first. Editing fork-first is what caused past drift, where install and runtime fixes
+landed in the fork or on feature branches but never reached these canonical copies.
+
+To re-sync after changing anything here:
+
+```bash
+SRC=deploy/lxc/community-scripts
+DST=/path/to/ggfevans/ProxmoxVED
+cp "$SRC/ct/rackula.sh"             "$DST/ct/rackula.sh"
+cp "$SRC/install/rackula-install.sh" "$DST/install/rackula-install.sh"
+cp "$SRC/json/rackula.json"         "$DST/json/rackula.json"
+```
+
+After syncing, the fork trio must be byte-identical to these files.
+
+## URL note: ProxmoxVE vs ProxmoxVED
+
+The `build.func` source line and the License URL point at `ProxmoxVED` (the dev/testing
+repo), matching the re-submission target. When a script is promoted from ProxmoxVED to
+the production `ProxmoxVE` repo, those two URLs flip to `ProxmoxVE`.

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: gVNS (ggfevans)
-# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
 # Source: https://github.com/RackulaLives/Rackula
 
 APP="Rackula"

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: gVNS (ggfevans)
-# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
 # Source: https://github.com/RackulaLives/Rackula
 
 source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"

--- a/docs/deployment/LXC-TESTING.md
+++ b/docs/deployment/LXC-TESTING.md
@@ -40,16 +40,14 @@ Use the `build-lxc-dev.yml` workflow to build a tarball from any branch or SHA a
 
 ### Trigger a dev build
 
-In the GitHub Actions UI, run "Build LXC Tarball (dev)" (`build-lxc-dev.yml`) with:
+In the GitHub Actions UI, open "Build LXC Tarball (dev)" (`build-lxc-dev.yml`), pick the
+branch or tag to build from the "Use workflow from" dropdown, and optionally set a custom
+**version** label (defaults to `vDEV-<sha>`).
 
-- **ref**: the branch or SHA to build (e.g. `main` or a feature branch)
-- **version**: leave empty (auto-computes `vDEV-<sha>`), or set a custom label
-
-Or with the `gh` CLI:
+Or with the `gh` CLI (`--ref` selects the branch or tag to build from):
 
 ```bash
-gh workflow run build-lxc-dev.yml \
-  --field ref=main
+gh workflow run build-lxc-dev.yml --ref my-feature-branch
 ```
 
 ### Download the artifact

--- a/docs/deployment/LXC-TESTING.md
+++ b/docs/deployment/LXC-TESTING.md
@@ -36,32 +36,30 @@ This is sufficient for changes to script structure, dependency installs, and ngi
 
 ## Layer 2: Testing the payload (release-free)
 
-Use the `build-lxc.yml` workflow in artifact-only mode to build a tarball from any branch or SHA without publishing a release.
+Use the `build-lxc-dev.yml` workflow to build a tarball from any branch or SHA as a downloadable run artifact, without creating or touching a release. It is a separate, read-only workflow (no release-write permissions), unlike the release `build-lxc.yml`.
 
 ### Trigger a dev build
 
-In the GitHub Actions UI, run "Build LXC Tarball" (`build-lxc.yml`) with:
+In the GitHub Actions UI, run "Build LXC Tarball (dev)" (`build-lxc-dev.yml`) with:
 
 - **ref**: the branch or SHA to build (e.g. `main` or a feature branch)
-- **version**: leave empty (auto-computes `vDEV-<sha>`)
-- **publish**: unchecked (false)
+- **version**: leave empty (auto-computes `vDEV-<sha>`), or set a custom label
 
 Or with the `gh` CLI:
 
 ```bash
-gh workflow run build-lxc.yml \
-  --field ref=main \
-  --field publish=false
+gh workflow run build-lxc-dev.yml \
+  --field ref=main
 ```
 
 ### Download the artifact
 
 ```bash
 # Find the run ID
-gh run list --workflow=build-lxc.yml --limit=5
+gh run list --workflow=build-lxc-dev.yml --limit=5
 
-# Download the artifact from that run
-gh run download <run-id> --name lxc-tarball --dir /tmp/rackula-lxc-test
+# Download the artifact from that run (named lxc-tarball-<version>)
+gh run download <run-id> --dir /tmp/rackula-lxc-test
 ls /tmp/rackula-lxc-test/
 # rackula-lxc-vDEV-abc1234.tar.gz
 # rackula-lxc-vDEV-abc1234.tar.gz.sha256


### PR DESCRIPTION
## **User description**
Closes #1953 & #1950. Resolves CodeQL alert #76 (`actions/untrusted-checkout/medium`).

## Part A: community-scripts alignment (#1953)

Audited the canonical trio (`deploy/lxc/community-scripts/{ct,install,json}`) against the
[detailed container guide](https://github.com/community-scripts/ProxmoxVED/blob/main/docs/ct/DETAILED_GUIDE.md)
and the `edit-mind`/`affine` reference scripts. The structure, `var_*` conventions,
function-call order, `update_script` storage/resource checks, final echo block, and the
`motd_ssh`/`customize`/`cleanup_lxc` install tail all already conform (most of that landed
via #1961). The only deviation was the upstream repo reference:

- `ct/rackula.sh` + `install/rackula-install.sh`: switch the `build.func` source and License
  URLs from `ProxmoxVE` to `ProxmoxVED`, matching the re-submission target. They flip back to
  `ProxmoxVE` only on promotion to the production repo.
- `json/rackula.json` needs no change (already conformant).

Added `deploy/lxc/community-scripts/README.md` documenting the **canonical -> fork** one-way
sync direction. The earlier drift (fixes landing in the fork or on feature branches but never
reaching the canonical copies) came from editing fork-first; this writes the rule down. The
`ggfevans/ProxmoxVED` fork (`feat/add-rackula`) is now byte-identical to the canonical trio.

The earlier upstream PR (community-scripts/ProxmoxVED#1893) was bot-closed for a missing PR
template, not a code defect. Eligibility is met (1358 stars, >6 months, tarballs publish), so
re-submission is unblocked as a follow-up.

## Part B: CodeQL #76 (untrusted-checkout in build-lxc.yml)

#1959 added a release-free dev-build mode to `build-lxc.yml` that resolves an arbitrary
`inputs.ref` (`checkout_ref=${INPUT_REF:-main}`) and checks it out, then runs `npm ci` /
`bun install`. Because that file also contains a `contents: write` publish job, CodeQL flagged
it as an untrusted checkout in a privileged context.

Fix (restructure):

- New `.github/workflows/build-lxc-dev.yml`: the dev path moves here. `workflow_dispatch` only,
  top-level `permissions: contents: read`, single build job, **no publish job and no
  `contents: write` anywhere**. It uploads a `vDEV-<sha>` run artifact. Keeps the newline/CR
  input guard, adds a filename-safe label check, and `persist-credentials: false`.
- `build-lxc.yml` slims to release-only: `workflow_call` + `workflow_dispatch`, both with a
  required CalVer `version`. The only checkout is the validated tag (`ref: inputs.version`),
  removing the arbitrary input-controlled ref. This returns to the pre-#1959 shape that CodeQL
  did not flag. The read-only `build` / write-only `publish` split is preserved.
- `release.yml`'s `workflow_call` (passes only `version`) is unaffected.
- `LXC-TESTING.md` dev-build instructions now point at `build-lxc-dev.yml`.

## Verification

- `shellcheck` clean apart from `SC1090` (unreadable curl-sourced `build.func`), which every
  community-scripts ct script trips and which upstream handles at its own CI level; not added
  as a directive to stay convention-aligned.
- `jq empty` passes on the JSON.
- `actionlint` clean on both workflows.
- Canonical trio byte-identical to the fork.
- After merge, the CodeQL scan should auto-close #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Separate LXC testing from release builds and align Rackula script references**

### What Changed
- Rackula’s community script files now point to the ProxmoxVED source and license URLs used for submission
- Added a clear note that the canonical Rackula files must be edited first, then copied to the fork, to prevent drift
- Added a separate dev-only LXC build workflow for test artifacts from any branch or SHA, without release access
- Release LXC builds now only accept a version tag, and the release workflow no longer supports arbitrary dev checkouts
- Updated the testing guide to use the new dev workflow and download its artifact by run output

### Impact
`✅ Safer LXC test builds`
`✅ Fewer release workflow checkout risks`
`✅ Clearer Rackula script submission path`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
