### PR TITLE
chore(lxc): reusable dev smoke-test script (deploy + upgrade) (#1967)

### DIFF
--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -32,6 +32,12 @@ function update_script() {
 
   # RACKULA_PREBUILD_TARBALL (dev/test only): when set to a local tarball, force the update
   # body to run and deploy that payload instead of a published release. Inert when unset.
+  # Fail before stopping services if it is set but missing (a typo must not trigger an update).
+  if [[ -n "${RACKULA_PREBUILD_TARBALL:-}" && ! -f "${RACKULA_PREBUILD_TARBALL}" ]]; then
+    msg_error "RACKULA_PREBUILD_TARBALL set but file not found: ${RACKULA_PREBUILD_TARBALL}"
+    exit 1
+  fi
+
   if [[ -n "${RACKULA_PREBUILD_TARBALL:-}" ]] || check_for_gh_release "rackula" "RackulaLives/Rackula"; then
     msg_info "Stopping Services"
     systemctl stop rackula-api nginx

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -30,7 +30,9 @@ function update_script() {
     exit 1
   fi
 
-  if check_for_gh_release "rackula" "RackulaLives/Rackula"; then
+  # RACKULA_PREBUILD_TARBALL (dev/test only): when set to a local tarball, force the update
+  # body to run and deploy that payload instead of a published release. Inert when unset.
+  if [[ -n "${RACKULA_PREBUILD_TARBALL:-}" ]] || check_for_gh_release "rackula" "RackulaLives/Rackula"; then
     msg_info "Stopping Services"
     systemctl stop rackula-api nginx
     msg_ok "Stopped Services"
@@ -47,7 +49,15 @@ function update_script() {
     }
     msg_ok "Backed up Data"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
+    if [[ -n "${RACKULA_PREBUILD_TARBALL:-}" && -f "${RACKULA_PREBUILD_TARBALL}" ]]; then
+      msg_info "Deploying dev prebuild (RACKULA_PREBUILD_TARBALL)"
+      rm -rf /opt/rackula/*
+      mkdir -p /opt/rackula
+      tar --no-same-owner -xzf "$RACKULA_PREBUILD_TARBALL" -C /opt/rackula --strip-components=1
+      msg_ok "Deployed dev prebuild"
+    else
+      CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
+    fi
 
     msg_info "Restoring Data"
     rm -rf /opt/rackula/data

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -50,7 +50,11 @@ msg_ok "Installed Bun"
 
 # RACKULA_PREBUILD_TARBALL (dev/test only): when set to a local tarball, deploy that payload
 # instead of fetching a published release. Inert when unset. See docs/deployment/LXC-TESTING.md.
-if [[ -n "${RACKULA_PREBUILD_TARBALL:-}" && -f "${RACKULA_PREBUILD_TARBALL}" ]]; then
+if [[ -n "${RACKULA_PREBUILD_TARBALL:-}" ]]; then
+  [[ -f "${RACKULA_PREBUILD_TARBALL}" ]] || {
+    msg_error "RACKULA_PREBUILD_TARBALL set but file not found: ${RACKULA_PREBUILD_TARBALL}"
+    exit 1
+  }
   msg_info "Deploying dev prebuild (RACKULA_PREBUILD_TARBALL)"
   mkdir -p /opt/rackula
   tar --no-same-owner -xzf "$RACKULA_PREBUILD_TARBALL" -C /opt/rackula --strip-components=1

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -48,7 +48,16 @@ ln -sf /usr/local/bun/bin/bun /usr/local/bin/bunx
 }
 msg_ok "Installed Bun"
 
-fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
+# RACKULA_PREBUILD_TARBALL (dev/test only): when set to a local tarball, deploy that payload
+# instead of fetching a published release. Inert when unset. See docs/deployment/LXC-TESTING.md.
+if [[ -n "${RACKULA_PREBUILD_TARBALL:-}" && -f "${RACKULA_PREBUILD_TARBALL}" ]]; then
+  msg_info "Deploying dev prebuild (RACKULA_PREBUILD_TARBALL)"
+  mkdir -p /opt/rackula
+  tar --no-same-owner -xzf "$RACKULA_PREBUILD_TARBALL" -C /opt/rackula --strip-components=1
+  msg_ok "Deployed dev prebuild"
+else
+  fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
+fi
 
 msg_info "Installing Rackula"
 mkdir -p /opt/rackula/data

--- a/docs/deployment/LXC-TESTING.md
+++ b/docs/deployment/LXC-TESTING.md
@@ -65,19 +65,27 @@ ls /tmp/rackula-lxc-test/
 
 ### Smoke test on a Proxmox host
 
-Copy the tarball to your Proxmox host and run `scripts/lxc-smoke-test.sh`. It auto-allocates a
-throwaway CT (hostname `rackula-smoke-*`), runs the real `rackula-install.sh` against the
-payload, exercises the upgrade path, runs health/frontend/service checks, and tears the CT down
-(unless `--keep`). It refuses to touch any CT whose hostname lacks the `rackula-smoke-` prefix,
-so a real container is never at risk.
+Run `scripts/lxc-smoke-test.sh` on your Proxmox host. It auto-allocates a throwaway CT
+(hostname `rackula-smoke-*`), runs the real `rackula-install.sh` against the payload, exercises
+the upgrade path, runs health/frontend/service checks, and tears the CT down (unless `--keep`).
+It refuses to touch any CT whose hostname lacks the `rackula-smoke-` prefix, so a real container
+is never at risk.
+
+The script runs the canonical install/update scripts, so it needs the repo layout
+(`deploy/lxc/community-scripts/`), not just `lxc-smoke-test.sh` on its own. Clone the repo on
+the host, or `rsync` the repo (or at least `scripts/` + `deploy/lxc/community-scripts/`) across:
 
 ```bash
-scp /tmp/rackula-lxc-test/rackula-lxc-*.tar.gz root@<pve-host>:/tmp/
-scp scripts/lxc-smoke-test.sh root@<pve-host>:/tmp/        # or clone the repo on the host
+# Option A: clone on the host
+git clone https://github.com/RackulaLives/Rackula && cd Rackula
 
-# On the Proxmox host (root):
-./lxc-smoke-test.sh --tarball /tmp/rackula-lxc-vDEV-*.tar.gz          # deploy + upgrade (default)
-./lxc-smoke-test.sh --tarball /tmp/rackula-lxc-vDEV-*.tar.gz --mode deploy --keep
+# Option B: rsync from your workstation (preserves the layout the script expects)
+rsync -a --relative scripts/lxc-smoke-test.sh deploy/lxc/community-scripts root@<pve-host>:rackula/
+scp /tmp/rackula-lxc-test/rackula-lxc-*.tar.gz root@<pve-host>:/tmp/
+
+# On the Proxmox host (root), from the repo root:
+./scripts/lxc-smoke-test.sh --tarball /tmp/rackula-lxc-vDEV-*.tar.gz             # deploy + upgrade (default)
+./scripts/lxc-smoke-test.sh --tarball /tmp/rackula-lxc-vDEV-*.tar.gz --mode deploy --keep
 ```
 
 Flags: `--mode deploy|upgrade|both`, `--baseline release|<tarball>` (upgrade-from payload,

--- a/docs/deployment/LXC-TESTING.md
+++ b/docs/deployment/LXC-TESTING.md
@@ -63,38 +63,38 @@ ls /tmp/rackula-lxc-test/
 # rackula-lxc-vDEV-abc1234.tar.gz.sha256
 ```
 
-### Deploy to a throwaway CT
+### Smoke test on a Proxmox host
 
-Copy the tarball to your Proxmox host and extract it manually:
-
-```bash
-# On Proxmox host: create a throwaway CT (Debian 13, unprivileged, 512MB RAM)
-# Then copy and extract the tarball:
-scp /tmp/rackula-lxc-test/rackula-lxc-vDEV-*.tar.gz root@<pve-host>:/tmp/
-
-# Inside the CT:
-mkdir -p /opt/rackula
-tar xzf /tmp/rackula-lxc-vDEV-*.tar.gz -C /opt/rackula --strip-components=1
-
-# Then run the install steps manually (or run rackula-install.sh with a patched
-# fetch step that points at /opt/rackula instead of fetching from GitHub).
-```
-
-### Verify the payload
-
-After deploying:
+Copy the tarball to your Proxmox host and run `scripts/lxc-smoke-test.sh`. It auto-allocates a
+throwaway CT (hostname `rackula-smoke-*`), runs the real `rackula-install.sh` against the
+payload, exercises the upgrade path, runs health/frontend/service checks, and tears the CT down
+(unless `--keep`). It refuses to touch any CT whose hostname lacks the `rackula-smoke-` prefix,
+so a real container is never at risk.
 
 ```bash
-# API responds
-curl -sf http://127.0.0.1:3001/health
+scp /tmp/rackula-lxc-test/rackula-lxc-*.tar.gz root@<pve-host>:/tmp/
+scp scripts/lxc-smoke-test.sh root@<pve-host>:/tmp/        # or clone the repo on the host
 
-# Frontend serves
-curl -sf http://127.0.0.1/
-
-# argon2 native module loads (Bun starts without crashing)
-bun /opt/rackula/api/src/index.ts &
-curl -sf http://127.0.0.1:3001/health
+# On the Proxmox host (root):
+./lxc-smoke-test.sh --tarball /tmp/rackula-lxc-vDEV-*.tar.gz          # deploy + upgrade (default)
+./lxc-smoke-test.sh --tarball /tmp/rackula-lxc-vDEV-*.tar.gz --mode deploy --keep
 ```
+
+Flags: `--mode deploy|upgrade|both`, `--baseline release|<tarball>` (upgrade-from payload,
+default the real latest release), `--storage`/`--bridge`/`--template` (auto-detected),
+`--keep` (skip teardown). Exit code is non-zero if any check fails.
+
+The upgrade test installs the baseline, seeds a marker in `/opt/rackula/data`, runs the real
+`update_script`, and verifies the marker survived.
+
+### How the override works
+
+`scripts/lxc-smoke-test.sh` deploys a local tarball by setting `RACKULA_PREBUILD_TARBALL` for
+the real install and update scripts. Both `install/rackula-install.sh` and the ct
+`update_script` honor it: when set to an existing tarball they extract that payload instead of
+calling `fetch_and_deploy_gh_release ... latest`, and `update_script` skips its
+`check_for_gh_release` version gate so the upgrade body runs. The override is inert when the
+variable is unset, so a normal release install is unaffected.
 
 ---
 

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -77,6 +77,11 @@ TARBALL="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
 # --- preflight --------------------------------------------------------------
 [[ "$(id -u)" -eq 0 ]] || die "must run as root on a Proxmox host"
 for c in pct pvesh curl tar; do command -v "$c" >/dev/null || die "missing required command: $c"; done
+# The script runs the canonical install/update scripts, so it needs the full repo layout
+# (deploy/lxc/community-scripts/), not just lxc-smoke-test.sh on its own.
+for f in "$CANON/install/rackula-install.sh" "$CANON/ct/rackula.sh"; do
+  [[ -f "$f" ]] || die "missing $f - run from a Rackula checkout (ship deploy/lxc/community-scripts/ alongside this script)"
+done
 
 if [[ -z "$STORAGE" ]]; then
   # first ACTIVE storage that can hold a container rootfs (Status column == active)
@@ -229,7 +234,8 @@ _check() {
   fi
 }
 
-ct_ip() { pct exec "$1" -- bash -c "hostname -I 2>/dev/null | awk '{print \$1; exit}'" 2>/dev/null; }
+# First IPv4 of the CT (hostname -I can list IPv6/link-local first; a bare IPv6 in http:// is invalid).
+ct_ip() { pct exec "$1" -- bash -c "hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^[0-9]+(\.[0-9]+){3}\$' | head -1" 2>/dev/null; }
 
 smoke_checks() {
   local id="$1"

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+# lxc-smoke-test.sh - dev smoke test for the Rackula Proxmox LXC deploy + upgrade.
+#
+# Runs ON a Proxmox host (root). Builds nothing: it takes a prebuilt dev tarball
+# (a build-lxc-dev.yml artifact, rackula-lxc-*.tar.gz), spins up a throwaway CT,
+# runs the REAL canonical rackula-install.sh / update_script against that payload
+# via the RACKULA_PREBUILD_TARBALL override, and verifies the result.
+#
+# Safety: the CT is auto-allocated (pvesh nextid) with a sentinel hostname
+# (rackula-smoke-*). Every destructive pct call refuses any CT whose hostname
+# lacks that prefix, so a real container can never be touched.
+#
+# Usage:
+#   scripts/lxc-smoke-test.sh --tarball <file> [--mode deploy|upgrade|both]
+#                             [--baseline release|<tarball>] [--storage <s>]
+#                             [--bridge <b>] [--template <vztmpl>] [--keep]
+#
+set -euo pipefail
+
+# --- defaults ---------------------------------------------------------------
+MODE="both"
+TARBALL=""
+BASELINE="release"
+STORAGE=""
+BRIDGE="vmbr0"
+TEMPLATE=""
+KEEP=0
+SENTINEL_PREFIX="rackula-smoke-"
+COMMUNITY_SCRIPTS_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CANON="$REPO_ROOT/deploy/lxc/community-scripts"
+
+CREATED_CTID=""
+CHECK_FAILS=0
+TMPD=""
+
+# --- logging ----------------------------------------------------------------
+info() { echo -e "\033[34m[*]\033[0m $*" >&2; }
+ok() { echo -e "\033[32m[+]\033[0m $*" >&2; }
+# shellcheck disable=SC2329  # invoked from cleanup (trap)
+warn() { echo -e "\033[33m[!]\033[0m $*" >&2; }
+err() { echo -e "\033[31m[x]\033[0m $*" >&2; }
+die() {
+  err "$*"
+  exit 1
+}
+
+usage() {
+  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+# --- arg parsing ------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tarball) TARBALL="${2:?--tarball needs a path}"; shift 2 ;;
+    --mode) MODE="${2:?}"; shift 2 ;;
+    --baseline) BASELINE="${2:?}"; shift 2 ;;
+    --storage) STORAGE="${2:?}"; shift 2 ;;
+    --bridge) BRIDGE="${2:?}"; shift 2 ;;
+    --template) TEMPLATE="${2:?}"; shift 2 ;;
+    --keep) KEEP=1; shift ;;
+    -h | --help) usage 0 ;;
+    *) die "unknown argument: $1 (see --help)" ;;
+  esac
+done
+
+case "$MODE" in deploy | upgrade | both) ;; *) die "--mode must be deploy|upgrade|both" ;; esac
+[[ -n "$TARBALL" ]] || die "--tarball is required (a build-lxc-dev rackula-lxc-*.tar.gz)"
+[[ -f "$TARBALL" ]] || die "tarball not found: $TARBALL"
+TARBALL="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
+[[ "$BASELINE" == "release" || -f "$BASELINE" ]] || die "--baseline must be 'release' or an existing tarball"
+
+# --- preflight --------------------------------------------------------------
+[[ "$(id -u)" -eq 0 ]] || die "must run as root on a Proxmox host"
+for c in pct pvesh curl tar; do command -v "$c" >/dev/null || die "missing required command: $c"; done
+
+if [[ -z "$STORAGE" ]]; then
+  # first ACTIVE storage that can hold a container rootfs (Status column == active)
+  STORAGE="$(pvesm status -content rootdir 2>/dev/null | awk 'NR>1 && $3=="active"{print $1; exit}')"
+  [[ -n "$STORAGE" ]] || die "could not auto-detect an active rootdir storage; pass --storage"
+  info "auto-detected storage: $STORAGE"
+fi
+if [[ -z "$TEMPLATE" ]]; then
+  # newest debian-13 template across all active template (vztmpl) storages
+  for _st in $(pvesm status -content vztmpl 2>/dev/null | awk 'NR>1 && $3=="active"{print $1}'); do
+    TEMPLATE="$(pveam list "$_st" 2>/dev/null | awk '/debian-13/{print $1}' | sort -V | tail -1)"
+    [[ -n "$TEMPLATE" ]] && break
+  done
+  [[ -n "$TEMPLATE" ]] || die "could not auto-detect a debian-13 template; pass --template (e.g. local:vztmpl/debian-13-standard_*.tar.zst)"
+  info "auto-detected template: $TEMPLATE"
+fi
+
+TMPD="$(mktemp -d)"
+
+# --- sentinel-guarded CT helpers -------------------------------------------
+_ct_hostname() { pct config "$1" 2>/dev/null | awk -F': ' '/^hostname:/{print $2}'; }
+
+_assert_sentinel() {
+  local id="$1" host
+  host="$(_ct_hostname "$id")"
+  [[ "$host" == "${SENTINEL_PREFIX}"* ]] ||
+    die "refusing to touch CT $id: hostname '$host' lacks '${SENTINEL_PREFIX}' prefix"
+}
+
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+  local rc=$?
+  if [[ -n "$CREATED_CTID" ]]; then
+    if [[ $KEEP -eq 1 ]]; then
+      warn "--keep set: leaving CT $CREATED_CTID ($(_ct_hostname "$CREATED_CTID")) running"
+    elif [[ "$(_ct_hostname "$CREATED_CTID")" == "${SENTINEL_PREFIX}"* ]]; then
+      info "tearing down CT $CREATED_CTID"
+      pct stop "$CREATED_CTID" >/dev/null 2>&1 || true
+      pct destroy "$CREATED_CTID" >/dev/null 2>&1 || true
+    fi
+  fi
+  [[ -n "$TMPD" ]] && rm -rf "$TMPD"
+  return "$rc"
+}
+trap cleanup EXIT
+
+# Creates the throwaway CT and sets the global CREATED_CTID (no stdout capture, no
+# subshell - so the EXIT trap can always tear it down).
+create_ct() {
+  local newid host suffix
+  # DNS-label-safe hostname suffix from the tarball name
+  suffix="$(basename "$TARBALL" .tar.gz | tr -c 'A-Za-z0-9' '-' | tr -s '-' | sed 's/^-//; s/-$//')"
+  [[ -n "$suffix" ]] || suffix="ct"
+  host="${SENTINEL_PREFIX}${suffix}"
+  host="${host:0:63}"
+  host="${host%-}"
+  newid="$(pvesh get /cluster/nextid)"
+  info "creating CT $newid ($host) from $TEMPLATE on $STORAGE"
+  pct create "$newid" "$TEMPLATE" \
+    --hostname "$host" --unprivileged 1 --features nesting=1 \
+    --cores 1 --memory 512 --rootfs "${STORAGE}:8" \
+    --net0 "name=eth0,bridge=${BRIDGE},ip=dhcp" \
+    --ostype debian >/dev/null
+  # set only after pct create succeeds, so cleanup never targets a non-existent CT
+  CREATED_CTID="$newid"
+  _assert_sentinel "$CREATED_CTID"
+  pct start "$CREATED_CTID" >/dev/null
+  local i
+  for i in $(seq 1 30); do
+    pct exec "$CREATED_CTID" -- bash -c 'getent hosts github.com >/dev/null 2>&1' && break
+    sleep 2
+    [[ "$i" -eq 30 ]] && die "CT $CREATED_CTID has no network after 60s"
+  done
+  ok "CT $CREATED_CTID up with network"
+}
+
+# Stage the framework helpers + canonical scripts into the CT once.
+stage_ct() {
+  local id="$1"
+  _assert_sentinel "$id"
+  curl -fsSL "$COMMUNITY_SCRIPTS_URL/misc/install.func" -o "$TMPD/install.func" ||
+    die "failed to fetch install.func"
+  pct exec "$id" -- bash -c 'apt-get update -qq && apt-get install -y -qq curl ca-certificates tar >/dev/null' ||
+    die "failed to install base tools in CT $id"
+  pct push "$id" "$TMPD/install.func" /root/install.func
+  pct push "$id" "$CANON/install/rackula-install.sh" /root/rackula-install.sh
+  # Extract just the update_script function body (closing brace is at column 0).
+  sed -n '/^function update_script()/,/^}/p' "$CANON/ct/rackula.sh" >"$TMPD/update_script.sh"
+  pct push "$id" "$TMPD/update_script.sh" /root/update_script.sh
+}
+
+# Run the real rackula-install.sh inside the CT. $2 = payload tarball path on host,
+# or empty for a real release fetch (baseline=release).
+run_install() {
+  local id="$1" payload="${2:-}"
+  _assert_sentinel "$id"
+  local pre=""
+  if [[ -n "$payload" ]]; then
+    pct push "$id" "$payload" /root/payload.tar.gz
+    pre='export RACKULA_PREBUILD_TARBALL=/root/payload.tar.gz;'
+    info "installing dev payload ($(basename "$payload")) via real rackula-install.sh"
+  else
+    info "installing baseline (real latest-release fetch) via rackula-install.sh"
+  fi
+  pct exec "$id" -- bash -c "
+    set -euo pipefail
+    export FUNCTIONS_FILE_PATH=\"\$(cat /root/install.func)\"
+    export tz=\"\${tz:-Etc/UTC}\"
+    $pre
+    bash /root/rackula-install.sh
+  "
+}
+
+# Run the real update_script body inside the CT against the dev tarball.
+run_update() {
+  local id="$1" payload="$2"
+  _assert_sentinel "$id"
+  pct push "$id" "$payload" /root/payload.tar.gz
+  info "upgrading to dev payload ($(basename "$payload")) via real update_script"
+  # shellcheck disable=SC2016  # body runs inside the CT; $vars must not expand on the host
+  pct exec "$id" -- bash -c '
+    # No errexit: the framework runs update_script without it; update_script signals
+    # real failure via its own exit 1, and the marker + smoke checks are the verdict.
+    set -o pipefail
+    export FUNCTIONS_FILE_PATH="$(cat /root/install.func)"
+    source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+    color 2>/dev/null || true
+    # host-only framework guards are no-ops inside the CT
+    header_info() { :; }
+    check_container_storage() { :; }
+    check_container_resources() { :; }
+    APP="Rackula"
+    export RACKULA_PREBUILD_TARBALL=/root/payload.tar.gz
+    source /root/update_script.sh
+    update_script
+  '
+}
+
+# --- smoke checks -----------------------------------------------------------
+_check() {
+  local id="$1" name="$2" cmd="$3"
+  if pct exec "$id" -- bash -c "$cmd" >/dev/null 2>&1; then
+    ok "  check: $name"
+  else
+    err "  check FAILED: $name"
+    CHECK_FAILS=$((CHECK_FAILS + 1))
+  fi
+}
+
+smoke_checks() {
+  local id="$1"
+  info "smoke checks on CT $id"
+  _check "$id" "API /api/health responds" "curl -sf --max-time 5 http://127.0.0.1/api/health"
+  _check "$id" "frontend served" "curl -sf --max-time 5 -o /dev/null http://127.0.0.1/"
+  _check "$id" "rackula-api active" "systemctl is-active --quiet rackula-api"
+  _check "$id" "nginx active" "systemctl is-active --quiet nginx"
+  _check "$id" "no API crash in journal" \
+    "! journalctl -u rackula-api --no-pager 2>/dev/null | grep -qiE 'panic|segfault|MODULE_NOT_FOUND|cannot find module'"
+}
+
+# --- run --------------------------------------------------------------------
+info "Rackula LXC smoke test - tarball $(basename "$TARBALL"), mode $MODE"
+create_ct
+CTID="$CREATED_CTID"
+stage_ct "$CTID"
+
+case "$MODE" in
+  deploy)
+    run_install "$CTID" "$TARBALL"
+    smoke_checks "$CTID"
+    ;;
+  upgrade | both)
+    # baseline install (release by default, so the real fetch_and_deploy runs once)
+    if [[ "$BASELINE" == "release" ]]; then
+      run_install "$CTID" ""
+    else
+      run_install "$CTID" "$BASELINE"
+    fi
+    smoke_checks "$CTID"
+    # seed a data marker, then upgrade to the dev payload
+    MARKER="smoke-$(date +%s)-$$"
+    pct exec "$CTID" -- bash -c "mkdir -p /opt/rackula/data && printf '%s' '$MARKER' > /opt/rackula/data/.smoke-marker"
+    info "seeded data marker: $MARKER"
+    run_update "$CTID" "$TARBALL"
+    smoke_checks "$CTID"
+    GOT="$(pct exec "$CTID" -- bash -c 'cat /opt/rackula/data/.smoke-marker 2>/dev/null' || true)"
+    if [[ "$GOT" == "$MARKER" ]]; then
+      ok "  check: data survived upgrade"
+    else
+      err "  check FAILED: data marker lost (got '${GOT}', want '${MARKER}')"
+      CHECK_FAILS=$((CHECK_FAILS + 1))
+    fi
+    ;;
+esac
+
+echo
+if [[ "$CHECK_FAILS" -eq 0 ]]; then
+  ok "SMOKE TEST PASSED (mode: $MODE)"
+  exit 0
+else
+  err "SMOKE TEST FAILED: $CHECK_FAILS check(s) failed (mode: $MODE)"
+  exit 1
+fi

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -226,6 +226,8 @@ _check() {
   fi
 }
 
+ct_ip() { pct exec "$1" -- bash -c "hostname -I 2>/dev/null | awk '{print \$1; exit}'" 2>/dev/null; }
+
 smoke_checks() {
   local id="$1"
   info "smoke checks on CT $id"
@@ -273,6 +275,11 @@ case "$MODE" in
 esac
 
 echo
+IP="$(ct_ip "$CTID")"
+if [[ -n "$IP" ]]; then
+  info "web UI: http://${IP}/   (CT $CTID, ${SENTINEL_PREFIX}*)"
+  [[ $KEEP -eq 1 ]] && info "CT kept (--keep): browse http://${IP}/ or 'pct enter $CTID'; remove with 'pct stop $CTID && pct destroy $CTID'"
+fi
 if [[ "$CHECK_FAILS" -eq 0 ]]; then
   ok "SMOKE TEST PASSED (mode: $MODE)"
   exit 0

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -181,10 +181,13 @@ run_install() {
   else
     info "installing baseline (real latest-release fetch) via rackula-install.sh"
   fi
+  # No errexit/nounset: the framework runs install.sh without them and install.sh
+  # self-manages via catch_errors. app/APPLICATION are framework vars its motd/cleanup
+  # tail references; provide them so the tail does not trip on an unset value.
   pct exec "$id" -- bash -c "
-    set -euo pipefail
+    set -o pipefail
     export FUNCTIONS_FILE_PATH=\"\$(cat /root/install.func)\"
-    export tz=\"\${tz:-Etc/UTC}\"
+    export app=rackula APPLICATION=Rackula tz=\"\${tz:-Etc/UTC}\"
     $pre
     bash /root/rackula-install.sh
   "


### PR DESCRIPTION
## **User description**
Closes #1967. Sub-issue of epic #1211.

## Summary

Adds `scripts/lxc-smoke-test.sh`, a headless host-side script (run on a Proxmox host as root)
that validates a dev LXC payload on real hardware before cutting a release: it deploys a
`build-lxc-dev` tarball to a throwaway CT via the real install script and exercises the upgrade
path.

## What's here

- **Inert override in canonical scripts.** `install/rackula-install.sh` and the ct
  `update_script` honor `RACKULA_PREBUILD_TARBALL`: when set to an existing tarball they extract
  that payload instead of `fetch_and_deploy_gh_release ... latest`, and `update_script` bypasses
  its `check_for_gh_release` version gate so the upgrade body runs. Inert when unset (a normal
  release install is unaffected). The `ggfevans/ProxmoxVED` `feat/add-rackula` trio is re-synced
  byte-identical (committed locally, not pushed).
- **`scripts/lxc-smoke-test.sh`.** Auto-allocates the CTID (`pvesh nextid`) with a
  `rackula-smoke-<sha>` hostname and a sentinel guard that refuses any `pct` op on a CT lacking
  that prefix. Deploy runs the real `rackula-install.sh`; upgrade installs a baseline (real
  latest-release fetch by default), seeds a marker in `/opt/rackula/data`, runs the real
  `update_script`, and verifies the marker survived. Flags: `--tarball` (required),
  `--mode deploy|upgrade|both`, `--baseline release|<tarball>`, `--storage`/`--bridge`/`--template`
  (auto-detected), `--keep`. Non-zero exit on any failed check.
- **Docs.** `docs/deployment/LXC-TESTING.md` Layer 2 now documents the one-command flow and the
  override.

## Review notes

A local high-effort `/code-review` caught and fixed two show-stoppers before push: `create_ct`
previously returned the CTID via stdout (capturing `info`/`ok` log lines) and set `CREATED_CTID`
inside a command-substitution subshell (so the EXIT-trap teardown never fired). It now sets a
global directly with logs on stderr. Also hardened hostname sanitization (valid DNS label) and
storage/template auto-detection (active-storage filter).

## Test Plan

- [ ] `lxc-smoke-test.sh --tarball <file> --mode deploy --keep` on pve-prod: CT up,
      `/api/health` 200, frontend served, `rackula-api` active
- [ ] `--mode upgrade`: data marker present post-upgrade, services healthy, exit 0
- [ ] Sentinel guard refuses a non-`rackula-smoke-` CT
- [ ] `shellcheck` clean (canonical scripts show only the expected SC1090)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add a Proxmox host smoke test for Rackula LXC installs and upgrades**

### What Changed
- Added a host-side smoke test that creates a throwaway container, installs Rackula from a prebuilt tarball, runs the upgrade path, and checks that the app still works afterward
- The install and upgrade flows can now use a local dev tarball instead of a published release when the smoke test sets the override, while normal release installs stay unchanged
- The upgrade check now verifies that existing data survives the update
- Updated the LXC testing guide with the new one-command smoke test flow and override behavior

### Impact
`✅ Safer pre-release LXC testing`
`✅ Fewer broken upgrade releases`
`✅ Lower risk of data loss during updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
