### PR TITLE
fix(lxc): api driver for lxc-smoke-test.sh (Proxmox API + ssh-into-CT)

### DIFF
--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -13,7 +13,8 @@
 #                   lifecycle via the Proxmox REST API and runs commands by SSH into
 #                   the CT. Reads its config from env (source proxmox-smoke.env first):
 #                   PROXMOX_VE_ENDPOINT/NODE/TOKEN_ID/TOKEN_SECRET/INSECURE,
-#                   RACKULA_CI_POOL/CT_STORAGE/CT_TEMPLATE/CT_ID_BASE/CT_SSH_KEY/CT_SSH_PUBKEY.
+#                   RACKULA_CI_POOL/CT_STORAGE/CT_SSH_KEY/CT_SSH_PUBKEY. The debian-13
+#                   template is auto-detected via the API (override with --template).
 #
 # Safety: the CT gets a sentinel hostname (rackula-smoke-*). Every destructive op
 # refuses any CT whose hostname lacks that prefix, so a real container is never touched.
@@ -120,13 +121,14 @@ else
   for c in curl jq ssh scp tar; do command -v "$c" >/dev/null || die "missing required command: $c (api driver)"; done
   _miss=()
   for v in PROXMOX_VE_ENDPOINT PROXMOX_VE_NODE PROXMOX_VE_TOKEN_ID PROXMOX_VE_TOKEN_SECRET \
-    RACKULA_CI_POOL RACKULA_CT_STORAGE RACKULA_CT_TEMPLATE RACKULA_CT_ID_BASE \
+    RACKULA_CI_POOL RACKULA_CT_STORAGE \
     RACKULA_CT_SSH_KEY RACKULA_CT_SSH_PUBKEY; do
     [[ -n "${!v:-}" ]] || _miss+=("$v")
   done
   [[ ${#_miss[@]} -eq 0 ]] || die "api driver missing env (source proxmox-smoke.env): ${_miss[*]}"
   STORAGE="${STORAGE:-$RACKULA_CT_STORAGE}"
-  TEMPLATE="${TEMPLATE:-$RACKULA_CT_TEMPLATE}"
+  # TEMPLATE: if not passed via --template, api_create auto-detects the newest debian-13
+  # vztmpl via the storage content API, so the gate is not tied to a pinned template version.
   if [[ $DRY_RUN -eq 0 ]]; then
     [[ -f "$RACKULA_CT_SSH_KEY" ]] || die "RACKULA_CT_SSH_KEY not found: $RACKULA_CT_SSH_KEY"
     [[ -f "$RACKULA_CT_SSH_PUBKEY" ]] || die "RACKULA_CT_SSH_PUBKEY not found: $RACKULA_CT_SSH_PUBKEY"
@@ -144,12 +146,15 @@ _urlenc() { jq -rn --arg s "$1" '$s|@uri'; }
 
 # _dry_stub METHOD PATH -> canned JSON so downstream jq parsing succeeds offline.
 _dry_stub() {
-  local path="$2"
+  local method="$1" path="$2"
   case "$path" in
-    /pools/*) echo '{"data":{"members":[]}}' ;;
+    /cluster/nextid) echo '{"data":"100"}' ;;
+    */content*) echo '{"data":[{"volid":"local:vztmpl/debian-13-standard_13.1-2_amd64.tar.zst"}]}' ;;
     */tasks/*/status) echo '{"data":{"status":"stopped","exitstatus":"OK"}}' ;;
     */interfaces) echo '{"data":[{"name":"eth0","inet":"10.0.0.123/24"}]}' ;;
     */config) echo "{\"data\":{\"hostname\":\"${SENTINEL_PREFIX}dry\"}}" ;;
+    */lxc) # GET = node CT list (empty), POST = create (returns a UPID)
+      if [[ "$method" == "GET" ]]; then echo '{"data":[]}'; else echo '{"data":"UPID:dry:0:0:0:dry::root@pam:"}'; fi ;;
     *) echo '{"data":"UPID:dry:00000000:00000000:00000000:dry::root@pam:"}' ;;
   esac
 }
@@ -272,19 +277,27 @@ api_ip() {
   printf '%s' "$ip"
 }
 
+# Newest debian-13 vztmpl on the `local` storage, via the content API (no host CLI).
+api_detect_template() {
+  _pve GET "/nodes/${PROXMOX_VE_NODE}/storage/local/content?content=vztmpl" 2>/dev/null |
+    jq -r '.data[]?.volid // empty' 2>/dev/null | grep 'debian-13' | sort -V | tail -1
+}
+
 api_create() {
-  local host used newid pubkey upid
+  local host newid pubkey upid template
   host="$(_sentinel_host)"
-  # No /cluster/nextid (token has no rights on /): pick a free id >= base from the pool.
-  used="$(_pve GET "/pools/${RACKULA_CI_POOL}" | jq -r '.data.members[]?.vmid // empty')"
-  newid="$RACKULA_CT_ID_BASE"
-  while printf '%s\n' "$used" | grep -qx "$newid"; do newid=$((newid + 1)); done
+  # Cluster-global next free id. Accounts for BOTH VMs and CTs (the node CT list alone
+  # misses VMs, e.g. the debian-13-cloud template at 9000). The CT is kept safe by its
+  # sentinel hostname + ci-smoke pool membership + ephemeral teardown, not by its id range.
+  newid="$(_pve GET /cluster/nextid | jq -r '.data')"
+  template="${TEMPLATE:-$(api_detect_template)}"
+  [[ -n "$template" ]] || die "no debian-13 vztmpl found via API on storage 'local'; pass --template"
   pubkey="$(cat "$RACKULA_CT_SSH_PUBKEY" 2>/dev/null || true)"
-  info "creating CT $newid ($host) via API on $PROXMOX_VE_NODE (pool $RACKULA_CI_POOL)"
+  info "creating CT $newid ($host) via API on $PROXMOX_VE_NODE (pool $RACKULA_CI_POOL, template $template)"
   upid="$(_pve POST "/nodes/${PROXMOX_VE_NODE}/lxc" \
     --data-urlencode "vmid=${newid}" \
     --data-urlencode "hostname=${host}" \
-    --data-urlencode "ostemplate=${TEMPLATE}" \
+    --data-urlencode "ostemplate=${template}" \
     --data-urlencode "storage=${STORAGE}" \
     --data-urlencode "rootfs=${STORAGE}:8" \
     --data-urlencode "unprivileged=1" \

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -347,8 +347,10 @@ api_destroy() {
   local id="$1" upid
   upid="$(_pve POST "/nodes/${PROXMOX_VE_NODE}/lxc/${id}/status/stop" 2>/dev/null | jq -r '.data // empty' 2>/dev/null || true)"
   [[ -n "$upid" ]] && _api_wait_task "$upid" >/dev/null 2>&1 || true
-  upid="$(_pve DELETE "/nodes/${PROXMOX_VE_NODE}/lxc/${id}?force=1&purge=1" | jq -r '.data')"
-  _api_wait_task "$upid" || true
+  # No bare assignment here: under set -e+pipefail a failed DELETE (e.g. transient API
+  # outage during teardown) would otherwise abort the cleanup trap before TMPD is removed.
+  upid="$(_pve DELETE "/nodes/${PROXMOX_VE_NODE}/lxc/${id}?force=1&purge=1" 2>/dev/null | jq -r '.data // empty' 2>/dev/null || true)"
+  [[ -n "$upid" ]] && _api_wait_task "$upid" >/dev/null 2>&1 || true
 }
 
 # --- driver dispatch --------------------------------------------------------
@@ -364,13 +366,23 @@ ct_ip() { case "$DRIVER" in pct) pct_ip "$1" ;; api) api_ip "$1" ;; esac; }
 # --- teardown ---------------------------------------------------------------
 # shellcheck disable=SC2329  # invoked via trap
 cleanup() {
-  local rc=$?
+  local rc=$? host
   if [[ -n "$CREATED_CTID" ]]; then
+    host="$(ct_hostname "$CREATED_CTID")"
     if [[ $KEEP -eq 1 ]]; then
-      warn "--keep set: leaving CT $CREATED_CTID ($(ct_hostname "$CREATED_CTID")) running"
-    elif [[ "$(ct_hostname "$CREATED_CTID")" == "${SENTINEL_PREFIX}"* ]]; then
+      warn "--keep set: leaving CT $CREATED_CTID ($host) running"
+    elif [[ "$host" == "${SENTINEL_PREFIX}"* ]]; then
       info "tearing down CT $CREATED_CTID"
       ct_destroy "$CREATED_CTID"
+    elif [[ -z "$host" ]]; then
+      # Hostname unreadable (e.g. transient API outage). CREATED_CTID was validated as a
+      # sentinel CT at create time, so it is ours to remove; tear down but warn loudly so a
+      # genuine leak is visible rather than silently skipped. ct_destroy is a safe no-op if
+      # the CT is already gone.
+      warn "could not read hostname for CT $CREATED_CTID (API unreachable?); tearing down the CT we created"
+      ct_destroy "$CREATED_CTID"
+    else
+      warn "refusing to tear down CT $CREATED_CTID: hostname '$host' lacks '${SENTINEL_PREFIX}' prefix; remove it manually if it is ours"
     fi
   fi
   [[ -n "$TMPD" ]] && rm -rf "$TMPD"

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -2,19 +2,27 @@
 #
 # lxc-smoke-test.sh - dev smoke test for the Rackula Proxmox LXC deploy + upgrade.
 #
-# Runs ON a Proxmox host (root). Builds nothing: it takes a prebuilt dev tarball
-# (a build-lxc-dev.yml artifact, rackula-lxc-*.tar.gz), spins up a throwaway CT,
-# runs the REAL canonical rackula-install.sh / update_script against that payload
-# via the RACKULA_PREBUILD_TARBALL override, and verifies the result.
+# Builds nothing: it takes a prebuilt dev tarball (a build-lxc-dev.yml artifact,
+# rackula-lxc-*.tar.gz), spins up a throwaway CT, runs the REAL canonical
+# rackula-install.sh / update_script against that payload via the
+# RACKULA_PREBUILD_TARBALL override, and verifies the result.
 #
-# Safety: the CT is auto-allocated (pvesh nextid) with a sentinel hostname
-# (rackula-smoke-*). Every destructive pct call refuses any CT whose hostname
-# lacks that prefix, so a real container can never be touched.
+# Two drivers:
+#   pct (default) - run ON a Proxmox host as root; uses the pct/pvesh/pveam CLI.
+#   api           - run from anywhere (e.g. a CI runner VM with no pct); drives CT
+#                   lifecycle via the Proxmox REST API and runs commands by SSH into
+#                   the CT. Reads its config from env (source proxmox-smoke.env first):
+#                   PROXMOX_VE_ENDPOINT/NODE/TOKEN_ID/TOKEN_SECRET/INSECURE,
+#                   RACKULA_CI_POOL/CT_STORAGE/CT_TEMPLATE/CT_ID_BASE/CT_SSH_KEY/CT_SSH_PUBKEY.
+#
+# Safety: the CT gets a sentinel hostname (rackula-smoke-*). Every destructive op
+# refuses any CT whose hostname lacks that prefix, so a real container is never touched.
 #
 # Usage:
 #   scripts/lxc-smoke-test.sh --tarball <file> [--mode deploy|upgrade|both]
-#                             [--baseline release|<tarball>] [--storage <s>]
-#                             [--bridge <b>] [--template <vztmpl>] [--keep]
+#                             [--baseline release|<tarball>] [--driver pct|api]
+#                             [--storage <s>] [--bridge <b>] [--template <vztmpl>]
+#                             [--keep] [--dry-run]
 #
 set -euo pipefail
 
@@ -22,6 +30,8 @@ set -euo pipefail
 MODE="both"
 TARBALL=""
 BASELINE="release"
+DRIVER="pct"
+DRY_RUN=0
 STORAGE=""
 BRIDGE="vmbr0"
 TEMPLATE=""
@@ -36,6 +46,8 @@ CANON="$REPO_ROOT/deploy/lxc/community-scripts"
 CREATED_CTID=""
 CHECK_FAILS=0
 TMPD=""
+CT_IP_CACHE=""
+SSH_OPTS=()
 
 # --- logging ----------------------------------------------------------------
 info() { echo -e "\033[34m[*]\033[0m $*" >&2; }
@@ -49,7 +61,7 @@ die() {
 }
 
 usage() {
-  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -59,85 +71,159 @@ while [[ $# -gt 0 ]]; do
     --tarball) TARBALL="${2:?--tarball needs a path}"; shift 2 ;;
     --mode) MODE="${2:?}"; shift 2 ;;
     --baseline) BASELINE="${2:?}"; shift 2 ;;
+    --driver) DRIVER="${2:?--driver needs pct|api}"; shift 2 ;;
     --storage) STORAGE="${2:?}"; shift 2 ;;
     --bridge) BRIDGE="${2:?}"; shift 2 ;;
     --template) TEMPLATE="${2:?}"; shift 2 ;;
     --keep) KEEP=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
     -h | --help) usage 0 ;;
     *) die "unknown argument: $1 (see --help)" ;;
   esac
 done
 
 case "$MODE" in deploy | upgrade | both) ;; *) die "--mode must be deploy|upgrade|both" ;; esac
+case "$DRIVER" in pct | api) ;; *) die "--driver must be pct|api" ;; esac
+[[ $DRY_RUN -eq 1 && "$DRIVER" != "api" ]] && die "--dry-run is only supported with --driver api"
 [[ -n "$TARBALL" ]] || die "--tarball is required (a build-lxc-dev rackula-lxc-*.tar.gz)"
 [[ -f "$TARBALL" ]] || die "tarball not found: $TARBALL"
 TARBALL="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"
 [[ "$BASELINE" == "release" || -f "$BASELINE" ]] || die "--baseline must be 'release' or an existing tarball"
 
 # --- preflight --------------------------------------------------------------
-[[ "$(id -u)" -eq 0 ]] || die "must run as root on a Proxmox host"
-for c in pct pvesh curl tar; do command -v "$c" >/dev/null || die "missing required command: $c"; done
 # The script runs the canonical install/update scripts, so it needs the full repo layout
-# (deploy/lxc/community-scripts/), not just lxc-smoke-test.sh on its own.
+# (deploy/lxc/community-scripts/), not just lxc-smoke-test.sh on its own. Both drivers.
 for f in "$CANON/install/rackula-install.sh" "$CANON/ct/rackula.sh"; do
   [[ -f "$f" ]] || die "missing $f - run from a Rackula checkout (ship deploy/lxc/community-scripts/ alongside this script)"
 done
 
-if [[ -z "$STORAGE" ]]; then
-  # first ACTIVE storage that can hold a container rootfs (Status column == active)
-  STORAGE="$(pvesm status -content rootdir 2>/dev/null | awk 'NR>1 && $3=="active"{print $1; exit}')"
-  [[ -n "$STORAGE" ]] || die "could not auto-detect an active rootdir storage; pass --storage"
-  info "auto-detected storage: $STORAGE"
-fi
-if [[ -z "$TEMPLATE" ]]; then
-  # newest debian-13 template across all active template (vztmpl) storages
-  for _st in $(pvesm status -content vztmpl 2>/dev/null | awk 'NR>1 && $3=="active"{print $1}'); do
-    TEMPLATE="$(pveam list "$_st" 2>/dev/null | awk '/debian-13/{print $1}' | sort -V | tail -1)"
-    [[ -n "$TEMPLATE" ]] && break
+if [[ "$DRIVER" == "pct" ]]; then
+  [[ "$(id -u)" -eq 0 ]] || die "pct driver must run as root on a Proxmox host"
+  for c in pct pvesh curl tar; do command -v "$c" >/dev/null || die "missing required command: $c"; done
+  if [[ -z "$STORAGE" ]]; then
+    # first ACTIVE storage that can hold a container rootfs (Status column == active)
+    STORAGE="$(pvesm status -content rootdir 2>/dev/null | awk 'NR>1 && $3=="active"{print $1; exit}')"
+    [[ -n "$STORAGE" ]] || die "could not auto-detect an active rootdir storage; pass --storage"
+    info "auto-detected storage: $STORAGE"
+  fi
+  if [[ -z "$TEMPLATE" ]]; then
+    # newest debian-13 template across all active template (vztmpl) storages
+    for _st in $(pvesm status -content vztmpl 2>/dev/null | awk 'NR>1 && $3=="active"{print $1}'); do
+      TEMPLATE="$(pveam list "$_st" 2>/dev/null | awk '/debian-13/{print $1}' | sort -V | tail -1)"
+      [[ -n "$TEMPLATE" ]] && break
+    done
+    [[ -n "$TEMPLATE" ]] || die "could not auto-detect a debian-13 template; pass --template (e.g. local:vztmpl/debian-13-standard_*.tar.zst)"
+    info "auto-detected template: $TEMPLATE"
+  fi
+else
+  # api driver: no root, no pct. Needs curl/jq for the REST API and ssh/scp into the CT.
+  for c in curl jq ssh scp tar; do command -v "$c" >/dev/null || die "missing required command: $c (api driver)"; done
+  _miss=()
+  for v in PROXMOX_VE_ENDPOINT PROXMOX_VE_NODE PROXMOX_VE_TOKEN_ID PROXMOX_VE_TOKEN_SECRET \
+    RACKULA_CI_POOL RACKULA_CT_STORAGE RACKULA_CT_TEMPLATE RACKULA_CT_ID_BASE \
+    RACKULA_CT_SSH_KEY RACKULA_CT_SSH_PUBKEY; do
+    [[ -n "${!v:-}" ]] || _miss+=("$v")
   done
-  [[ -n "$TEMPLATE" ]] || die "could not auto-detect a debian-13 template; pass --template (e.g. local:vztmpl/debian-13-standard_*.tar.zst)"
-  info "auto-detected template: $TEMPLATE"
+  [[ ${#_miss[@]} -eq 0 ]] || die "api driver missing env (source proxmox-smoke.env): ${_miss[*]}"
+  STORAGE="${STORAGE:-$RACKULA_CT_STORAGE}"
+  TEMPLATE="${TEMPLATE:-$RACKULA_CT_TEMPLATE}"
+  if [[ $DRY_RUN -eq 0 ]]; then
+    [[ -f "$RACKULA_CT_SSH_KEY" ]] || die "RACKULA_CT_SSH_KEY not found: $RACKULA_CT_SSH_KEY"
+    [[ -f "$RACKULA_CT_SSH_PUBKEY" ]] || die "RACKULA_CT_SSH_PUBKEY not found: $RACKULA_CT_SSH_PUBKEY"
+  fi
+  # Throwaway CTs reuse CTIDs/IPs, so host keys legitimately churn every run. No host-key
+  # check here is intentional and scoped to runner->ephemeral-CT only (see #1982 plan).
+  SSH_OPTS=(-T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+    -o LogLevel=ERROR -o ConnectTimeout=10 -o BatchMode=yes -i "$RACKULA_CT_SSH_KEY")
 fi
 
 TMPD="$(mktemp -d)"
 
-# --- sentinel-guarded CT helpers -------------------------------------------
-_ct_hostname() { pct config "$1" 2>/dev/null | awk -F': ' '/^hostname:/{print $2}'; }
+# --- Proxmox REST helpers (api driver) -------------------------------------
+_urlenc() { jq -rn --arg s "$1" '$s|@uri'; }
 
-_assert_sentinel() {
-  local id="$1" host
-  host="$(_ct_hostname "$id")"
-  [[ "$host" == "${SENTINEL_PREFIX}"* ]] ||
-    die "refusing to touch CT $id: hostname '$host' lacks '${SENTINEL_PREFIX}' prefix"
+# _dry_stub METHOD PATH -> canned JSON so downstream jq parsing succeeds offline.
+_dry_stub() {
+  local path="$2"
+  case "$path" in
+    /pools/*) echo '{"data":{"members":[]}}' ;;
+    */tasks/*/status) echo '{"data":{"status":"stopped","exitstatus":"OK"}}' ;;
+    */interfaces) echo '{"data":[{"name":"eth0","inet":"10.0.0.123/24"}]}' ;;
+    */config) echo "{\"data\":{\"hostname\":\"${SENTINEL_PREFIX}dry\"}}" ;;
+    *) echo '{"data":"UPID:dry:00000000:00000000:00000000:dry::root@pam:"}' ;;
+  esac
 }
 
-# shellcheck disable=SC2329  # invoked via trap
-cleanup() {
-  local rc=$?
-  if [[ -n "$CREATED_CTID" ]]; then
-    if [[ $KEEP -eq 1 ]]; then
-      warn "--keep set: leaving CT $CREATED_CTID ($(_ct_hostname "$CREATED_CTID")) running"
-    elif [[ "$(_ct_hostname "$CREATED_CTID")" == "${SENTINEL_PREFIX}"* ]]; then
-      info "tearing down CT $CREATED_CTID"
-      pct stop "$CREATED_CTID" >/dev/null 2>&1 || true
-      pct destroy "$CREATED_CTID" >/dev/null 2>&1 || true
-    fi
+# _pve METHOD PATH [curl-args...] -> response body on stdout.
+_pve() {
+  local method="$1" path="$2"; shift 2
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY-RUN curl -X $method ${PROXMOX_VE_ENDPOINT}/api2/json${path} $*" >&2
+    _dry_stub "$method" "$path"
+    return 0
   fi
-  [[ -n "$TMPD" ]] && rm -rf "$TMPD"
-  return "$rc"
+  local opts=(-fsS -H "Authorization: PVEAPIToken=${PROXMOX_VE_TOKEN_ID}=${PROXMOX_VE_TOKEN_SECRET}" -X "$method")
+  [[ "${PROXMOX_VE_INSECURE:-}" == "true" ]] && opts+=(-k)
+  curl "${opts[@]}" "$@" "${PROXMOX_VE_ENDPOINT}/api2/json${path}"
 }
-trap cleanup EXIT
 
-# Creates the throwaway CT and sets the global CREATED_CTID (no stdout capture, no
-# subshell - so the EXIT trap can always tear it down).
-create_ct() {
-  local newid host suffix
-  # DNS-label-safe hostname suffix from the tarball name
+# Poll an async PVE task (UPID) to completion. Returns nonzero on failure/timeout.
+_api_wait_task() {
+  local upid="$1" enc resp st ex
+  enc="$(_urlenc "$upid")"
+  for _ in $(seq 1 60); do
+    resp="$(_pve GET "/nodes/${PROXMOX_VE_NODE}/tasks/${enc}/status" 2>/dev/null || true)"
+    st="$(printf '%s' "$resp" | jq -r '.data.status // empty' 2>/dev/null || true)"
+    if [[ "$st" == "stopped" ]]; then
+      ex="$(printf '%s' "$resp" | jq -r '.data.exitstatus // empty' 2>/dev/null || true)"
+      [[ "$ex" == "OK" ]] && return 0
+      warn "PVE task finished non-OK ($ex): $upid"
+      return 1
+    fi
+    sleep 2
+  done
+  warn "PVE task did not finish in 120s: $upid"
+  return 1
+}
+
+# --- SSH/scp helpers (api driver; dry-run prints instead of contacting) -----
+_shq() { local s=${1//\'/\'\\\'\'}; printf "'%s'" "$s"; }
+
+_ssh() {
+  if [[ $DRY_RUN -eq 1 ]]; then echo "DRY-RUN ssh ${SSH_OPTS[*]} $*" >&2; return 0; fi
+  # shellcheck disable=SC2029  # the remote command is built client-side on purpose (see _shq)
+  ssh "${SSH_OPTS[@]}" "$@"
+}
+_scp() {
+  if [[ $DRY_RUN -eq 1 ]]; then echo "DRY-RUN scp ${SSH_OPTS[*]} $*" >&2; return 0; fi
+  scp "${SSH_OPTS[@]}" "$@"
+}
+
+# --- shared CT helpers ------------------------------------------------------
+# Sentinel hostname derived from the tarball name (DNS-label-safe, <=63 chars).
+_sentinel_host() {
+  local suffix host
   suffix="$(basename "$TARBALL" .tar.gz | tr -c 'A-Za-z0-9' '-' | tr -s '-' | sed 's/^-//; s/-$//')"
   [[ -n "$suffix" ]] || suffix="ct"
   host="${SENTINEL_PREFIX}${suffix}"
   host="${host:0:63}"
   host="${host%-}"
+  printf '%s' "$host"
+}
+
+_assert_sentinel() {
+  local id="$1" host
+  host="$(ct_hostname "$id")"
+  [[ "$host" == "${SENTINEL_PREFIX}"* ]] ||
+    die "refusing to touch CT $id: hostname '$host' lacks '${SENTINEL_PREFIX}' prefix"
+}
+
+# --- driver: pct ------------------------------------------------------------
+pct_hostname() { pct config "$1" 2>/dev/null | awk -F': ' '/^hostname:/{print $2}'; }
+
+pct_create() {
+  local host newid
+  host="$(_sentinel_host)"
   newid="$(pvesh get /cluster/nextid)"
   info "creating CT $newid ($host) from $TEMPLATE on $STORAGE"
   pct create "$newid" "$TEMPLATE" \
@@ -145,42 +231,168 @@ create_ct() {
     --cores 1 --memory 512 --rootfs "${STORAGE}:8" \
     --net0 "name=eth0,bridge=${BRIDGE},ip=dhcp" \
     --ostype debian >/dev/null
-  # set only after pct create succeeds, so cleanup never targets a non-existent CT
+  # set only after create succeeds, so cleanup never targets a non-existent CT
   CREATED_CTID="$newid"
   _assert_sentinel "$CREATED_CTID"
   pct start "$CREATED_CTID" >/dev/null
-  local i
-  for i in $(seq 1 30); do
-    pct exec "$CREATED_CTID" -- bash -c 'getent hosts github.com >/dev/null 2>&1' && break
-    sleep 2
-    [[ "$i" -eq 30 ]] && die "CT $CREATED_CTID has no network after 60s"
-  done
-  ok "CT $CREATED_CTID up with network"
 }
 
+pct_wait_net() {
+  for _ in $(seq 1 30); do
+    pct exec "$CREATED_CTID" -- bash -c 'getent hosts github.com >/dev/null 2>&1' &&
+      { ok "CT $CREATED_CTID up with network"; return 0; }
+    sleep 2
+  done
+  die "CT $CREATED_CTID has no network after 60s"
+}
+
+pct_exec() { pct exec "$1" -- bash -c "$2"; }
+pct_push() { pct push "$1" "$2" "$3"; }
+# shellcheck disable=SC2329  # invoked indirectly via ct_destroy from the cleanup trap
+pct_destroy() {
+  pct stop "$1" >/dev/null 2>&1 || true
+  pct destroy "$1" >/dev/null 2>&1 || true
+}
+# First IPv4 of the CT (hostname -I can list IPv6/link-local first; a bare IPv6 in http:// is invalid).
+pct_ip() { pct exec "$1" -- bash -c "hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^[0-9]+(\.[0-9]+){3}\$' | head -1" 2>/dev/null; }
+
+# --- driver: api ------------------------------------------------------------
+api_hostname() {
+  _pve GET "/nodes/${PROXMOX_VE_NODE}/lxc/${1}/config" 2>/dev/null | jq -r '.data.hostname // empty' 2>/dev/null || true
+}
+
+api_ip() {
+  if [[ -n "$CT_IP_CACHE" ]]; then printf '%s' "$CT_IP_CACHE"; return 0; fi
+  local ip
+  ip="$(_pve GET "/nodes/${PROXMOX_VE_NODE}/lxc/${1}/interfaces" 2>/dev/null |
+    jq -r '.data[]? | select(.name=="eth0") | .inet // empty' 2>/dev/null |
+    sed 's#/.*##' | grep -E '^[0-9]+(\.[0-9]+){3}$' | head -1 || true)"
+  [[ -n "$ip" ]] || return 1
+  CT_IP_CACHE="$ip"
+  printf '%s' "$ip"
+}
+
+api_create() {
+  local host used newid pubkey upid
+  host="$(_sentinel_host)"
+  # No /cluster/nextid (token has no rights on /): pick a free id >= base from the pool.
+  used="$(_pve GET "/pools/${RACKULA_CI_POOL}" | jq -r '.data.members[]?.vmid // empty')"
+  newid="$RACKULA_CT_ID_BASE"
+  while printf '%s\n' "$used" | grep -qx "$newid"; do newid=$((newid + 1)); done
+  pubkey="$(cat "$RACKULA_CT_SSH_PUBKEY" 2>/dev/null || true)"
+  info "creating CT $newid ($host) via API on $PROXMOX_VE_NODE (pool $RACKULA_CI_POOL)"
+  upid="$(_pve POST "/nodes/${PROXMOX_VE_NODE}/lxc" \
+    --data-urlencode "vmid=${newid}" \
+    --data-urlencode "hostname=${host}" \
+    --data-urlencode "ostemplate=${TEMPLATE}" \
+    --data-urlencode "storage=${STORAGE}" \
+    --data-urlencode "rootfs=${STORAGE}:8" \
+    --data-urlencode "unprivileged=1" \
+    --data-urlencode "features=nesting=1" \
+    --data-urlencode "cores=1" \
+    --data-urlencode "memory=512" \
+    --data-urlencode "net0=name=eth0,bridge=${BRIDGE},ip=dhcp" \
+    --data-urlencode "ostype=debian" \
+    --data-urlencode "pool=${RACKULA_CI_POOL}" \
+    --data-urlencode "ssh-public-keys=${pubkey}" | jq -r '.data')"
+  if ! _api_wait_task "$upid"; then
+    # The create task may have materialised the CT before failing; purge it if it's ours.
+    [[ "$(api_hostname "$newid")" == "${SENTINEL_PREFIX}"* ]] && api_destroy "$newid" || true
+    die "CT create failed for $newid"
+  fi
+  CREATED_CTID="$newid"
+  _assert_sentinel "$CREATED_CTID"
+  upid="$(_pve POST "/nodes/${PROXMOX_VE_NODE}/lxc/${newid}/status/start" | jq -r '.data')"
+  _api_wait_task "$upid" || die "CT start failed for $newid"
+}
+
+api_wait_net() {
+  local ip
+  for _ in $(seq 1 30); do
+    if ip="$(api_ip "$CREATED_CTID")" && [[ -n "$ip" ]]; then
+      if _ssh "root@${ip}" 'getent hosts github.com >/dev/null 2>&1'; then
+        ok "CT $CREATED_CTID up at $ip with network + sshd"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+  die "CT $CREATED_CTID: no IP / sshd / network after 60s"
+}
+
+api_exec() {
+  local id="$1" cmd="$2" ip
+  ip="$(api_ip "$id")" || die "no IP for CT $id"
+  _ssh "root@${ip}" "bash -c $(_shq "$cmd")"
+}
+api_push() {
+  local id="$1" src="$2" dst="$3" ip
+  ip="$(api_ip "$id")" || die "no IP for CT $id"
+  _scp "$src" "root@${ip}:${dst}"
+}
+api_destroy() {
+  local id="$1" upid
+  upid="$(_pve POST "/nodes/${PROXMOX_VE_NODE}/lxc/${id}/status/stop" 2>/dev/null | jq -r '.data // empty' 2>/dev/null || true)"
+  [[ -n "$upid" ]] && _api_wait_task "$upid" >/dev/null 2>&1 || true
+  upid="$(_pve DELETE "/nodes/${PROXMOX_VE_NODE}/lxc/${id}?force=1&purge=1" | jq -r '.data')"
+  _api_wait_task "$upid" || true
+}
+
+# --- driver dispatch --------------------------------------------------------
+ct_hostname() { case "$DRIVER" in pct) pct_hostname "$1" ;; api) api_hostname "$1" ;; esac; }
+ct_create() { case "$DRIVER" in pct) pct_create ;; api) api_create ;; esac; }
+ct_wait_net() { case "$DRIVER" in pct) pct_wait_net ;; api) api_wait_net ;; esac; }
+ct_exec() { case "$DRIVER" in pct) pct_exec "$1" "$2" ;; api) api_exec "$1" "$2" ;; esac; }
+ct_push() { case "$DRIVER" in pct) pct_push "$1" "$2" "$3" ;; api) api_push "$1" "$2" "$3" ;; esac; }
+# shellcheck disable=SC2329  # invoked indirectly from the cleanup trap
+ct_destroy() { case "$DRIVER" in pct) pct_destroy "$1" ;; api) api_destroy "$1" ;; esac; }
+ct_ip() { case "$DRIVER" in pct) pct_ip "$1" ;; api) api_ip "$1" ;; esac; }
+
+# --- teardown ---------------------------------------------------------------
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+  local rc=$?
+  if [[ -n "$CREATED_CTID" ]]; then
+    if [[ $KEEP -eq 1 ]]; then
+      warn "--keep set: leaving CT $CREATED_CTID ($(ct_hostname "$CREATED_CTID")) running"
+    elif [[ "$(ct_hostname "$CREATED_CTID")" == "${SENTINEL_PREFIX}"* ]]; then
+      info "tearing down CT $CREATED_CTID"
+      ct_destroy "$CREATED_CTID"
+    fi
+  fi
+  [[ -n "$TMPD" ]] && rm -rf "$TMPD"
+  return "$rc"
+}
+trap cleanup EXIT
+
+# --- stage + install/update -------------------------------------------------
 # Stage the framework helpers + canonical scripts into the CT once.
 stage_ct() {
   local id="$1"
   _assert_sentinel "$id"
-  curl -fsSL "$COMMUNITY_SCRIPTS_URL/misc/install.func" -o "$TMPD/install.func" ||
-    die "failed to fetch install.func"
-  pct exec "$id" -- bash -c 'apt-get update -qq && apt-get install -y -qq curl ca-certificates tar >/dev/null' ||
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "DRY-RUN curl $COMMUNITY_SCRIPTS_URL/misc/install.func -> $TMPD/install.func" >&2
+    : >"$TMPD/install.func"
+  else
+    curl -fsSL "$COMMUNITY_SCRIPTS_URL/misc/install.func" -o "$TMPD/install.func" ||
+      die "failed to fetch install.func"
+  fi
+  ct_exec "$id" 'apt-get update -qq && apt-get install -y -qq curl ca-certificates tar >/dev/null' ||
     die "failed to install base tools in CT $id"
-  pct push "$id" "$TMPD/install.func" /root/install.func
-  pct push "$id" "$CANON/install/rackula-install.sh" /root/rackula-install.sh
+  ct_push "$id" "$TMPD/install.func" /root/install.func
+  ct_push "$id" "$CANON/install/rackula-install.sh" /root/rackula-install.sh
   # Extract just the update_script function body (closing brace is at column 0).
   sed -n '/^function update_script()/,/^}/p' "$CANON/ct/rackula.sh" >"$TMPD/update_script.sh"
-  pct push "$id" "$TMPD/update_script.sh" /root/update_script.sh
+  ct_push "$id" "$TMPD/update_script.sh" /root/update_script.sh
 }
 
 # Run the real rackula-install.sh inside the CT. $2 = payload tarball path on host,
 # or empty for a real release fetch (baseline=release).
 run_install() {
-  local id="$1" payload="${2:-}"
+  local id="$1" payload="${2:-}" pre="" body
   _assert_sentinel "$id"
-  local pre=""
   if [[ -n "$payload" ]]; then
-    pct push "$id" "$payload" /root/payload.tar.gz
+    ct_push "$id" "$payload" /root/payload.tar.gz
     pre='export RACKULA_PREBUILD_TARBALL=/root/payload.tar.gz;'
     info "installing dev payload ($(basename "$payload")) via real rackula-install.sh"
   else
@@ -189,23 +401,24 @@ run_install() {
   # No errexit/nounset: the framework runs install.sh without them and install.sh
   # self-manages via catch_errors. app/APPLICATION are framework vars its motd/cleanup
   # tail references; provide them so the tail does not trip on an unset value.
-  pct exec "$id" -- bash -c "
+  body="
     set -o pipefail
     export FUNCTIONS_FILE_PATH=\"\$(cat /root/install.func)\"
     export app=rackula APPLICATION=Rackula tz=\"\${tz:-Etc/UTC}\"
-    $pre
+    ${pre}
     bash /root/rackula-install.sh
   "
+  ct_exec "$id" "$body"
 }
 
 # Run the real update_script body inside the CT against the dev tarball.
 run_update() {
-  local id="$1" payload="$2"
+  local id="$1" payload="$2" body
   _assert_sentinel "$id"
-  pct push "$id" "$payload" /root/payload.tar.gz
+  ct_push "$id" "$payload" /root/payload.tar.gz
   info "upgrading to dev payload ($(basename "$payload")) via real update_script"
   # shellcheck disable=SC2016  # body runs inside the CT; $vars must not expand on the host
-  pct exec "$id" -- bash -c '
+  body='
     # No errexit: the framework runs update_script without it; update_script signals
     # real failure via its own exit 1, and the marker + smoke checks are the verdict.
     set -o pipefail
@@ -221,21 +434,19 @@ run_update() {
     source /root/update_script.sh
     update_script
   '
+  ct_exec "$id" "$body"
 }
 
 # --- smoke checks -----------------------------------------------------------
 _check() {
   local id="$1" name="$2" cmd="$3"
-  if pct exec "$id" -- bash -c "$cmd" >/dev/null 2>&1; then
+  if ct_exec "$id" "$cmd" >/dev/null 2>&1; then
     ok "  check: $name"
   else
     err "  check FAILED: $name"
     CHECK_FAILS=$((CHECK_FAILS + 1))
   fi
 }
-
-# First IPv4 of the CT (hostname -I can list IPv6/link-local first; a bare IPv6 in http:// is invalid).
-ct_ip() { pct exec "$1" -- bash -c "hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^[0-9]+(\.[0-9]+){3}\$' | head -1" 2>/dev/null; }
 
 smoke_checks() {
   local id="$1"
@@ -249,8 +460,9 @@ smoke_checks() {
 }
 
 # --- run --------------------------------------------------------------------
-info "Rackula LXC smoke test - tarball $(basename "$TARBALL"), mode $MODE"
-create_ct
+info "Rackula LXC smoke test - tarball $(basename "$TARBALL"), mode $MODE, driver $DRIVER$([[ $DRY_RUN -eq 1 ]] && echo ' (dry-run)')"
+ct_create
+ct_wait_net
 CTID="$CREATED_CTID"
 stage_ct "$CTID"
 
@@ -269,12 +481,14 @@ case "$MODE" in
     smoke_checks "$CTID"
     # seed a data marker, then upgrade to the dev payload
     MARKER="smoke-$(date +%s)-$$"
-    pct exec "$CTID" -- bash -c "mkdir -p /opt/rackula/data && printf '%s' '$MARKER' > /opt/rackula/data/.smoke-marker"
+    ct_exec "$CTID" "mkdir -p /opt/rackula/data && printf '%s' '$MARKER' > /opt/rackula/data/.smoke-marker"
     info "seeded data marker: $MARKER"
     run_update "$CTID" "$TARBALL"
     smoke_checks "$CTID"
-    GOT="$(pct exec "$CTID" -- bash -c 'cat /opt/rackula/data/.smoke-marker 2>/dev/null' || true)"
-    if [[ "$GOT" == "$MARKER" ]]; then
+    GOT="$(ct_exec "$CTID" 'cat /opt/rackula/data/.smoke-marker 2>/dev/null' || true)"
+    if [[ $DRY_RUN -eq 1 ]]; then
+      : # dry-run: ssh stdout is not captured, so the marker verdict is not meaningful
+    elif [[ "$GOT" == "$MARKER" ]]; then
       ok "  check: data survived upgrade"
     else
       err "  check FAILED: data marker lost (got '${GOT}', want '${MARKER}')"
@@ -284,10 +498,14 @@ case "$MODE" in
 esac
 
 echo
-IP="$(ct_ip "$CTID")"
+IP="$(ct_ip "$CTID" || true)"
 if [[ -n "$IP" ]]; then
   info "web UI: http://${IP}/   (CT $CTID, ${SENTINEL_PREFIX}*)"
-  [[ $KEEP -eq 1 ]] && info "CT kept (--keep): browse http://${IP}/ or 'pct enter $CTID'; remove with 'pct stop $CTID && pct destroy $CTID'"
+  [[ $KEEP -eq 1 ]] && info "CT kept (--keep): browse http://${IP}/ or reach it via SSH; remove the CT manually when done"
+fi
+if [[ $DRY_RUN -eq 1 ]]; then
+  ok "DRY-RUN complete (api call flow walked; health checks not evaluated)"
+  exit 0
 fi
 if [[ "$CHECK_FAILS" -eq 0 ]]; then
   ok "SMOKE TEST PASSED (mode: $MODE)"

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -12,8 +12,8 @@
 #   api           - run from anywhere (e.g. a CI runner VM with no pct); drives CT
 #                   lifecycle via the Proxmox REST API and runs commands by SSH into
 #                   the CT. Reads its config from env (source proxmox-smoke.env first):
-#                   PROXMOX_VE_ENDPOINT/NODE/TOKEN_ID/TOKEN_SECRET/INSECURE,
-#                   RACKULA_CI_POOL/CT_STORAGE/CT_SSH_KEY/CT_SSH_PUBKEY. The debian-13
+#                   PROXMOX_VE_{ENDPOINT,NODE,TOKEN_ID,TOKEN_SECRET,INSECURE} and
+#                   RACKULA_{CI_POOL,CT_STORAGE,CT_SSH_KEY,CT_SSH_PUBKEY}. The debian-13
 #                   template is auto-detected via the API (override with --template).
 #
 # Safety: the CT gets a sentinel hostname (rackula-smoke-*). Every destructive op
@@ -465,6 +465,12 @@ run_update() {
 # --- smoke checks -----------------------------------------------------------
 _check() {
   local id="$1" name="$2" cmd="$3"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    # In dry-run the remote command is not executed, so a pass/fail verdict would
+    # be meaningless. Report it as skipped rather than printing a misleading "ok".
+    info "  check (dry-run, not evaluated): $name"
+    return 0
+  fi
   if ct_exec "$id" "$cmd" >/dev/null 2>&1; then
     ok "  check: $name"
   else


### PR DESCRIPTION
## **User description**
## Summary

Adds an `api` driver to `scripts/lxc-smoke-test.sh` so the LXC smoke test can run from a CI runner VM that has no `pct` CLI. The driver drives CT lifecycle via the Proxmox REST API and runs commands by SSHing into the ephemeral CT. The existing `pct` driver (run on a Proxmox host) is preserved behind `--driver pct` (default), and a `--dry-run` mode walks the full API/SSH call flow offline.

This splits out of #1977 (the gated release pipeline) so it can land and merge independently; #1977's `gate-lxc` job calls this driver.

## What changed

- `--driver pct|api` (default `pct`) and `--dry-run` (api only).
- `api` driver: CT create/start/destroy + task polling via the Proxmox API, `--data-urlencode` for all params, cluster-global `/cluster/nextid`, debian-13 vztmpl auto-detect via the storage content API, ssh/scp into the CT for exec/push.
- Config sourced from env (`proxmox-smoke.env`): `PROXMOX_VE_*`, `RACKULA_CI_POOL`, `RACKULA_CT_STORAGE`, `RACKULA_CT_SSH_KEY/PUBKEY`.
- Sentinel-hostname safety guard preserved across both drivers.

## Validation

Validated live on the ci-runner VM against `v26.6.2`: it created a CT in the `ci-smoke` pool via the API, SSHed in, ran the real `rackula-install.sh`, and correctly failed on the #1969 unprivileged-LXC nginx bug, then tore the CT down. `shellcheck` clean; `--dry-run --mode both` walks the full flow and exits 0.

## Review fixes (this branch)

A local code-review pass found and fixed two teardown-robustness bugs under a transient API failure:
- `api_destroy`'s DELETE used a bare assignment, so a failed call would abort the cleanup trap (under `set -e`+`pipefail`) before `TMPD` removal and mask the test exit code. Now guarded like its sibling stop call.
- The cleanup sentinel re-check fetched the hostname via a live REST call and fell open (empty hostname -> CT silently skipped), leaking the ephemeral CT on every API blip. Now fetches once and branches three ways: matches sentinel -> destroy; empty/unreadable -> destroy the CT we created + warn; non-empty mismatch -> refuse (preserves the real-CT safety boundary).

Closes #1982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Run the LXC smoke test from a CI runner and keep teardown safe**

### What Changed
- The LXC smoke test can now run either on a Proxmox host or from a CI runner VM without the `pct` tool, using the Proxmox API and SSH for container setup and commands
- Added a dry-run mode for the API path so the full create/start/exec/destroy flow can be checked without touching a live container
- Teardown now warns and still removes the test container if the hostname cannot be read, instead of silently leaving it behind after a temporary API issue
- Milestone names and planning docs were updated to use zero-padded numbering, so GitHub milestone order now matches the intended sequence

### Impact
`✅ LXC smoke tests can run in CI runners without Proxmox host access`
`✅ Fewer leaked test containers after temporary API failures`
`✅ Correct milestone ordering in GitHub Projects`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>