### PR TITLE
docs: spike #1995 Unraid distribution research

### DIFF
--- a/docs/research/1995-codebase.md
+++ b/docs/research/1995-codebase.md
@@ -10,11 +10,11 @@
 **File:** `/Users/gvns/code/projects/Rackula/Rackula/deploy/Dockerfile`
 
 ### Image Details
-- **Base image (production):** `nginxinc/nginx-unprivileged:alpine` (line 22)
-- **Build image:** `node:22-alpine` (line 2)
-- **User:** `nginx` user (unprivileged, UID 101; see line 30)
-- **Port:** `8080` (line 50, line 70 EXPOSE; listen port is configurable via `RACKULA_LISTEN_PORT`)
-- **Healthcheck:** Lines 67-68
+- Base image (production): `nginxinc/nginx-unprivileged:alpine` (line 22)
+- Build image: `node:22-alpine` (line 2)
+- User: `nginx` user (unprivileged, UID 101; see line 30)
+- Port: `8080` (line 50, line 70 EXPOSE; listen port is configurable via `RACKULA_LISTEN_PORT`)
+- Healthcheck: Lines 67-68
   - Endpoint: `GET http://127.0.0.1:${RACKULA_LISTEN_PORT:-8080}/health`
   - Interval: 30s, timeout: 3s, start-period: 5s, retries: 3
   - Returns: Plain text "OK" (from nginx location block, not from app)
@@ -61,9 +61,9 @@ Wraps the official nginx entrypoint to:
 5. Log configuration details to stderr
 
 ### Security Posture
-- **Read-only root filesystem:** No (can write to `/var/cache/nginx`, `/var/run`, `/tmp`, `/etc/nginx/conf.d` via tmpfs)
-- **Capabilities:** Not dropped in Dockerfile (depends on docker compose security settings)
-- **Security headers:** Sourced from `/etc/nginx/snippets/security-headers.conf` (copied line 59)
+- Read-only root filesystem: No (can write to `/var/cache/nginx`, `/var/run`, `/tmp`, `/etc/nginx/conf.d` via tmpfs)
+- Capabilities: Not dropped in Dockerfile (depends on docker compose security settings)
+- Security headers: Sourced from `/etc/nginx/snippets/security-headers.conf` (copied line 59)
 
 ---
 
@@ -72,10 +72,10 @@ Wraps the official nginx entrypoint to:
 **File:** `/Users/gvns/code/projects/Rackula/Rackula/api/Dockerfile`
 
 ### Image Details
-- **Base image:** `oven/bun:1.3.10-alpine` (line 3)
-- **User:** `rackula` (non-root, UID 1001; created line 24-25)
-- **Port:** `3001` (line 55 EXPOSE)
-- **Healthcheck:** Lines 57-58
+- Base image: `oven/bun:1.3.10-alpine` (line 3)
+- User: `rackula` (non-root, UID 1001; created line 24-25)
+- Port: `3001` (line 55 EXPOSE)
+- Healthcheck: Lines 57-58
   - Endpoint: `GET http://127.0.0.1:3001/health`
   - Interval: 30s, timeout: 10s, start-period: 5s, retries: 3
   - Returns: JSON `{ ok: true, status: "ok", service: "rackula-persistence-api", version: 1 }`
@@ -197,22 +197,22 @@ When set, nginx injects `Authorization: Bearer <token>` header on PUT/DELETE req
 **File:** `/Users/gvns/code/projects/Rackula/Rackula/docker-compose.yml`
 
 Services:
-- **`rackula` (frontend):**
+- `rackula` (frontend):
   - Image: `ghcr.io/rackulalives/rackula:latest` (overridable via `RACKULA_IMAGE`)
   - Ports: `${RACKULA_PORT:-8080}:${RACKULA_LISTEN_PORT:-8080}` (host:container)
   - Container name: `${RACKULA_CONTAINER_NAME:-rackula}`
-  - **Always runs** (no profile)
+  - Always runs (no profile)
   - No volumes
   - Requires: None
   - Resources: 0.5 CPU / 128 MB limit, 0.1 CPU / 16 MB reserved
   - Security: `no-new-privileges`, all caps dropped, read-only root FS, tmpfs for nginx cache/run/tmp
   - Restart: `unless-stopped` with 10s grace period
 
-- **`rackula-api` (API sidecar, optional):**
+- `rackula-api` (API sidecar, optional):
   - Image: `ghcr.io/rackulalives/rackula-api:latest` (overridable via `RACKULA_API_IMAGE`)
   - Ports: Not exposed (internal only)
   - Container name: `${RACKULA_API_CONTAINER_NAME:-rackula-api}`
-  - **Profile: `persist`** - only runs with `docker compose --profile persist up`
+  - Profile: `persist` - only runs with `docker compose --profile persist up`
   - Volumes: `./data:/data` (note: host dir must be writable by UID 1001)
   - Resources: 0.25 CPU / 64 MB limit, 0.05 CPU / 16 MB reserved
   - Security: Same hardening as frontend
@@ -222,13 +222,13 @@ Services:
 **File:** `/Users/gvns/code/projects/Rackula/Rackula/deploy/docker-compose.persist.yml`
 
 Services:
-- **`rackula` (frontend):**
-  - Same as above, **but**:
+- `rackula` (frontend):
+  - Same as above, but:
   - Image: `ghcr.io/rackulalives/rackula:persist` (pre-configured for API)
   - Depends on: `rackula-api` (service_healthy condition, line 38-39)
   - Adds `RACKULA_TRUST_PROXY=${RACKULA_TRUST_PROXY:-0}` for reverse-proxy support
 
-- **`rackula-api` (API, always runs):**
+- `rackula-api` (API, always runs):
   - Volumes: `./data:/data`
   - Healthcheck: `wget -qO- http://127.0.0.1:3001/health` (line 124)
   - Same env vars as standard compose (see Environment Variables section below)
@@ -306,11 +306,11 @@ Services:
 **Primary config file:** `/Users/gvns/code/projects/Rackula/Rackula/api/src/security/config.ts` (lines 296-504)
 
 ### Mode: `none` (Default, No Authentication)
-- **Behavior:** All requests granted access immediately
-- **Session requirement:** None
-- **Routes:** Auth routes (`/auth/login`, `/auth/check`, `/auth/logout`) respond but grant 204/no-op
-- **nginx behavior (nginx.conf.template line 213-214):** Auth check returns 204 immediately, bypassing upstream call
-- **Use case:** Single-user homelab, isolated network, development
+- Behavior: All requests granted access immediately
+- Session requirement: None
+- Routes: Auth routes (`/auth/login`, `/auth/check`, `/auth/logout`) respond but grant 204/no-op
+- nginx behavior (nginx.conf.template line 213-214): Auth check returns 204 immediately, bypassing upstream call
+- Use case: Single-user homelab, isolated network, development
 
 ### Mode: `local` (Username/Password)
 **Files:**
@@ -324,7 +324,7 @@ Services:
    - Time cost: 3
    - Parallelism: 4
 3. Hash stored in-memory; plaintext password scrubbed from env (app.ts line 289)
-4. **No persistent user database** - credentials are ephemeral (hashed only during container lifetime)
+4. No persistent user database - credentials are ephemeral (hashed only during container lifetime)
 
 **Login flow:**
 1. User POST `/auth/login` with `{ username, password }`
@@ -332,8 +332,8 @@ Services:
 3. Timing-safe credential verification (lines 174-199)
 4. On success: Session token signed with `RACKULA_AUTH_SESSION_SECRET` and sent as httpOnly cookie
 5. On failure: Log event, return 401
-6. **nginx:** POST /auth/login passes through to API for validation (nginx.conf.template lines 118-120)
-7. **nginx:** GET /auth/login serves static `/login.html` for GET requests (line 119)
+6. nginx: POST /auth/login passes through to API for validation (nginx.conf.template lines 118-120)
+7. nginx: GET /auth/login serves static `/login.html` for GET requests (line 119)
 
 **Session token:**
 - Signed with HS256 (HMAC-SHA256) using `RACKULA_AUTH_SESSION_SECRET`
@@ -398,15 +398,15 @@ Services:
 ## Persistence / Volumes
 
 ### Frontend
-- **Volumes:** None (stateless; assets and config baked into image)
-- **Transient:** `/var/cache/nginx` (10 MB tmpfs, line 73 in docker-compose.yml)
-- **Session state:** Stored in session cookie (httpOnly, Secure, SameSite=Lax/Strict)
+- Volumes: None (stateless; assets and config baked into image)
+- Transient: `/var/cache/nginx` (10 MB tmpfs, line 73 in docker-compose.yml)
+- Session state: Stored in session cookie (httpOnly, Secure, SameSite=Lax/Strict)
 
 ### API
-- **Persistent volume:** `${DATA_DIR:-/data}` (mounted at `/data` inside container)
-- **Host mapping (docker-compose.persist.yml line 74):** `./data:/data`
-- **Ownership:** UID 1001:1001 (rackula:rackula)
-- **Permissions:** `750` (directory, line 83 in lxc/community-scripts/ct/rackula.sh)
+- Persistent volume: `${DATA_DIR:-/data}` (mounted at `/data` inside container)
+- Host mapping (docker-compose.persist.yml line 74): `./data:/data`
+- Ownership: UID 1001:1001 (rackula:rackula)
+- Permissions: `750` (directory, line 83 in lxc/community-scripts/ct/rackula.sh)
 
 **Storage structure (api/src/storage/filesystem.ts):**
 ```
@@ -428,12 +428,12 @@ Services:
 - Backup recommended before updates (see lxc/community-scripts/ct/rackula.sh lines 46-56)
 
 ### Session State (if auth enabled)
-- **Mechanism:** httpOnly cookie + server-side signature verification
-- **Persistence:** Signed JWT token; validation requires `RACKULA_AUTH_SESSION_SECRET`
-- **Local auth:** No user database; credentials ephemeral (hashed at startup only)
-- **OIDC:** Better Auth library handles provider session management (depends on configuration)
-- **TTL:** Max 12h absolute, 30m idle (configurable)
-- **Storage:** None (stateless; token is the source of truth)
+- Mechanism: httpOnly cookie + server-side signature verification
+- Persistence: Signed JWT token; validation requires `RACKULA_AUTH_SESSION_SECRET`
+- Local auth: No user database; credentials ephemeral (hashed at startup only)
+- OIDC: Better Auth library handles provider session management (depends on configuration)
+- TTL: Max 12h absolute, 30m idle (configurable)
+- Storage: None (stateless; token is the source of truth)
 
 **Invalidation (app.ts line 582, 587):**
 - Function `invalidateAuthSession(sessionId, expiration)` registered but implementation details not clear from snippet
@@ -493,16 +493,16 @@ Frontend calls `/api/layouts` → nginx forwards `http://rackula-api:3001/layout
 ### Static Asset Serving
 
 **Path:** `/assets/`
-- **Source:** Vite-built fingerprinted assets in `/usr/share/nginx/html/assets/`
-- **Cache:** 1 year (`Cache-Control: public, immutable`)
-- **Gzip:** Enabled (min 1KB, see lines 77-82)
+- Source: Vite-built fingerprinted assets in `/usr/share/nginx/html/assets/`
+- Cache: 1 year (`Cache-Control: public, immutable`)
+- Gzip: Enabled (min 1KB, see lines 77-82)
 
 ### SPA Fallback with Auth
 
 **Path:** `/` (line 274)
-- **Behavior:** All requests route to `index.html` (SPA)
-- **Auth gate:** `auth_request /_rackula_auth_check` (line 275)
-- **On 401:** Redirects to `/auth/login?next=<original-path>` (line 276)
+- Behavior: All requests route to `index.html` (SPA)
+- Auth gate: `auth_request /_rackula_auth_check` (line 275)
+- On 401: Redirects to `/auth/login?next=<original-path>` (line 276)
 
 ### Trust Proxy (Reverse Proxy Support)
 
@@ -592,49 +592,49 @@ Headers (typical web hardening):
 
 ## Open Questions / Gaps for Unraid Templating
 
-1. **Single-container vs. two-container deployment:**
+1. Single-container vs. two-container deployment:
    - Can Unraid template deploy frontend only (auth=none, no persistence)?
    - Or is API sidecar mandatory?
-   - **Answer from investigation:** Frontend is fully functional without API; auth mode defaults to `none`, persistence is optional. Single-container (frontend only) is viable, but persistence requires second container or volume mount.
+   - Answer from investigation: Frontend is fully functional without API; auth mode defaults to `none`, persistence is optional. Single-container (frontend only) is viable, but persistence requires second container or volume mount.
 
-2. **Volume mounting for persistence:**
+2. Volume mounting for persistence:
    - Unraid Docker template API: does it support volume bind mounts like docker-compose?
    - Community App or custom plugin required?
-   - **Answer:** Both Unraid Community Applications and Plugins support volumes. Template must declare `/data` as writable mount.
+   - Answer: Both Unraid Community Applications and Plugins support volumes. Template must declare `/data` as writable mount.
 
-3. **Environment variable UI in Unraid template:**
+3. Environment variable UI in Unraid template:
    - Which env vars should be exposed in the template UI vs. hardcoded?
    - Priority: `RACKULA_LISTEN_PORT`, `API_HOST`, `API_PORT`, `RACKULA_AUTH_MODE`, `RACKULA_API_WRITE_TOKEN`
    - Secondary (if auth enabled): `RACKULA_LOCAL_USERNAME`, `RACKULA_LOCAL_PASSWORD`, `RACKULA_AUTH_SESSION_SECRET`
 
-4. **Reverse proxy / SSL termination:**
+4. Reverse proxy / SSL termination:
    - Does Unraid have a built-in reverse proxy (similar to `docker-entrypoint-wrapper.sh` `RACKULA_TRUST_PROXY` support)?
    - Template must document how to enable `RACKULA_TRUST_PROXY=1` when Unraid reverse proxy is in use.
 
-5. **Auth mode selection in UI:**
+5. Auth mode selection in UI:
    - Should template offer radio buttons: "None (Anonymous)" | "Local (Username/Password)" | "OIDC (External IdP)"?
    - If local: expose `RACKULA_LOCAL_USERNAME`, `RACKULA_LOCAL_PASSWORD` fields
-   - If OIDC: needs additional OIDC provider configuration (provider ID, client ID, secret, discovery URL) - **not yet documented**
+   - If OIDC: needs additional OIDC provider configuration (provider ID, client ID, secret, discovery URL) - not yet documented
 
-6. **Data persistence strategy:**
+6. Data persistence strategy:
    - Should template suggest daily backups of `/data`?
    - LXC script already includes backup/restore logic (see rackula.sh); Docker template should mirror this.
 
-7. **Health check:**
+7. Health check:
    - Unraid template should define:
      - Port: 8080 (or `RACKULA_LISTEN_PORT` if configurable)
      - Endpoint: `GET /health`
      - Interval: 30s, timeout: 3s (from Dockerfile healthcheck)
 
-8. **Startup order (if two-container):**
+8. Startup order (if two-container):
    - Frontend should wait for API to be healthy (like docker-compose.persist.yml depends_on, line 37-39)
    - Or declare API as required dependency?
 
-9. **API write token generation:**
+9. API write token generation:
    - Should template auto-generate a strong write token?
    - LXC script notes it's auto-generated; template should mirror this (e.g., 32-byte random string in base64).
 
-10. **Container restart policy:**
+10. Container restart policy:
     - docker-compose uses `restart: unless-stopped` with 10s grace period
     - Unraid template should specify equivalent (always restart unless manually stopped)
 

--- a/docs/research/1995-codebase.md
+++ b/docs/research/1995-codebase.md
@@ -27,8 +27,8 @@
 
 ### Build Args (lines 6-11)
 - `VITE_ENV=production` (default; line 7)
-- `VITE_PERSIST_ENABLED=false` (default; line 11) — feature flag for server-side persistence
-- `APK_CACHEBUST=0` (default; line 27) — invalidated per-build for security patching
+- `VITE_PERSIST_ENABLED=false` (default; line 11) - feature flag for server-side persistence
+- `APK_CACHEBUST=0` (default; line 27) - invalidated per-build for security patching
 
 ### Runtime Environment Variables (lines 39-54)
 All env vars set inside the image as defaults; can be overridden at container run time.
@@ -109,7 +109,7 @@ When auth is enabled, the API **fails to start** if these are missing:
 | Variable | Purpose | Min Length | Default |
 |----------|---------|-----------|---------|
 | `RACKULA_AUTH_SESSION_SECRET` | Session token signing key | 32 chars | (required) |
-| `RACKULA_AUTH_MODE` | Mode: `none`, `oidc`, `local` | — | `none` (optional) |
+| `RACKULA_AUTH_MODE` | Mode: `none`, `oidc`, `local` | - | `none` (optional) |
 
 ### Auth Mode Specifics
 
@@ -145,10 +145,10 @@ Additional required env vars:
 | `RACKULA_AUTH_SESSION_MAX_AGE_SECONDS` | `43200` (12h) | `60` | `604800` (7 days) | Absolute session lifetime |
 | `RACKULA_AUTH_SESSION_IDLE_TIMEOUT_SECONDS` | `1800` (30m) | `60` | `authSessionMaxAgeSeconds` | Inactivity timeout |
 | `RACKULA_AUTH_SESSION_GENERATION` | `0` | 0 | (no max) | Increment to invalidate all active sessions globally |
-| `RACKULA_AUTH_SESSION_COOKIE_SAMESITE` | `Lax` | — | — | Cookie policy: `Lax`, `Strict`, `None` |
-| `RACKULA_AUTH_SESSION_COOKIE_SECURE` | `true` if prod, `false` if dev | — | — | HTTPS-only flag (forced `true` if SameSite=None) |
-| `RACKULA_AUTH_SESSION_COOKIE_NAME` | `rackula_auth_session` | — | — | Session cookie name (alphanumeric, `-`, `_` only) |
-| `RACKULA_AUTH_CSRF_PROTECTION` | `true` if auth enabled, `false` otherwise | — | — | CSRF token validation for authenticated writes |
+| `RACKULA_AUTH_SESSION_COOKIE_SAMESITE` | `Lax` | - | - | Cookie policy: `Lax`, `Strict`, `None` |
+| `RACKULA_AUTH_SESSION_COOKIE_SECURE` | `true` if prod, `false` if dev | - | - | HTTPS-only flag (forced `true` if SameSite=None) |
+| `RACKULA_AUTH_SESSION_COOKIE_NAME` | `rackula_auth_session` | - | - | Session cookie name (alphanumeric, `-`, `_` only) |
+| `RACKULA_AUTH_CSRF_PROTECTION` | `true` if auth enabled, `false` otherwise | - | - | CSRF token validation for authenticated writes |
 
 ### Write Route Authorization
 
@@ -212,7 +212,7 @@ Services:
   - Image: `ghcr.io/rackulalives/rackula-api:latest` (overridable via `RACKULA_API_IMAGE`)
   - Ports: Not exposed (internal only)
   - Container name: `${RACKULA_API_CONTAINER_NAME:-rackula-api}`
-  - **Profile: `persist`** — only runs with `docker compose --profile persist up`
+  - **Profile: `persist`** - only runs with `docker compose --profile persist up`
   - Volumes: `./data:/data` (note: host dir must be writable by UID 1001)
   - Resources: 0.25 CPU / 64 MB limit, 0.05 CPU / 16 MB reserved
   - Security: Same hardening as frontend
@@ -274,7 +274,7 @@ Services:
 | `NODE_ENV` | `production` | Node environment | api/Dockerfile:53 | string | No |
 | `PORT` | `3001` | Fallback listen port | api/Dockerfile:53 | integer | No |
 | `RACKULA_API_PORT` | `3001` | API listen port (preferred) | api/index.ts:13 | integer | No |
-| `DATA_DIR` | `./data` | Persistent data directory | api/Dockerfile:53, filesystem.ts:28 | path | No |
+| `DATA_DIR` | `/data` | Persistent data directory (container default from api/Dockerfile:53; code fallback `./data` when unset, filesystem.ts:28) | api/Dockerfile:53, filesystem.ts:28 | path | No |
 | `RACKULA_AUTH_MODE` | `none` | Auth mode | api/src/security/config.ts:302 | enum(none/oidc/local) | No |
 | `RACKULA_AUTH_SESSION_SECRET` | (unset) | Session token signing key | api/src/security/config.ts:332 | string (32+ chars) | **Yes if auth enabled** |
 | `RACKULA_LOCAL_USERNAME` | (unset) | Local auth username | api/src/local-auth.ts:71 | string (1-255 chars) | **Yes if mode=local** |
@@ -324,7 +324,7 @@ Services:
    - Time cost: 3
    - Parallelism: 4
 3. Hash stored in-memory; plaintext password scrubbed from env (app.ts line 289)
-4. **No persistent user database** — credentials are ephemeral (hashed only during container lifetime)
+4. **No persistent user database** - credentials are ephemeral (hashed only during container lifetime)
 
 **Login flow:**
 1. User POST `/auth/login` with `{ username, password }`
@@ -614,7 +614,7 @@ Headers (typical web hardening):
 5. **Auth mode selection in UI:**
    - Should template offer radio buttons: "None (Anonymous)" | "Local (Username/Password)" | "OIDC (External IdP)"?
    - If local: expose `RACKULA_LOCAL_USERNAME`, `RACKULA_LOCAL_PASSWORD` fields
-   - If OIDC: needs additional OIDC provider configuration (provider ID, client ID, secret, discovery URL) — **not yet documented**
+   - If OIDC: needs additional OIDC provider configuration (provider ID, client ID, secret, discovery URL) - **not yet documented**
 
 6. **Data persistence strategy:**
    - Should template suggest daily backups of `/data`?

--- a/docs/research/1995-codebase.md
+++ b/docs/research/1995-codebase.md
@@ -1,0 +1,678 @@
+# Spike #1995 - Codebase Findings (Rackula container/deploy surface)
+
+**Date:** 2026-06-08  
+**Purpose:** Ground-truth inventory of Rackula's Docker/container/deployment/auth surface for Unraid templating decision.
+
+---
+
+## Frontend image (deploy/Dockerfile)
+
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/deploy/Dockerfile`
+
+### Image Details
+- **Base image (production):** `nginxinc/nginx-unprivileged:alpine` (line 22)
+- **Build image:** `node:22-alpine` (line 2)
+- **User:** `nginx` user (unprivileged, UID 101; see line 30)
+- **Port:** `8080` (line 50, line 70 EXPOSE; listen port is configurable via `RACKULA_LISTEN_PORT`)
+- **Healthcheck:** Lines 67-68
+  - Endpoint: `GET http://127.0.0.1:${RACKULA_LISTEN_PORT:-8080}/health`
+  - Interval: 30s, timeout: 3s, start-period: 5s, retries: 3
+  - Returns: Plain text "OK" (from nginx location block, not from app)
+
+### OCI Labels (lines 32-36)
+- `org.opencontainers.image.source="https://github.com/RackulaLives/Rackula"`
+- `org.opencontainers.image.description="Rack Layout Designer for Homelabbers"`
+- `org.opencontainers.image.licenses="MIT"`
+- `org.opencontainers.image.title="Rackula"`
+
+### Build Args (lines 6-11)
+- `VITE_ENV=production` (default; line 7)
+- `VITE_PERSIST_ENABLED=false` (default; line 11) — feature flag for server-side persistence
+- `APK_CACHEBUST=0` (default; line 27) — invalidated per-build for security patching
+
+### Runtime Environment Variables (lines 39-54)
+All env vars set inside the image as defaults; can be overridden at container run time.
+
+| Variable | Default | Purpose | Allowed Values |
+|----------|---------|---------|-----------------|
+| `API_HOST` | `rackula-api` | API sidecar hostname/IP | hostname, FQDN, IP (no validation) |
+| `API_PORT` | `3001` | API sidecar port | 1-65535 (no validation in image) |
+| `RACKULA_AUTH_MODE` | `none` | Auth mode toggle | `none`, `oidc`, `local` (normalized by docker-entrypoint-wrapper.sh) |
+| `RACKULA_LISTEN_PORT` | `8080` | nginx listen port (inside container) | 1-65535 (no validation in image) |
+| `RACKULA_ENABLE_IPV6` | `auto` | IPv6 listener auto-detect | `auto`, `true`, `false` (normalized by docker-entrypoint-wrapper.sh) |
+| `NGINX_RESOLVER` | `127.0.0.11` | DNS resolver for nginx upstream | IP address (Docker's embedded DNS) |
+| `API_WRITE_TOKEN` | (unset) | Bearer token for API PUT/DELETE routes | Any string; optional |
+| `RACKULA_TRUST_PROXY` | `0` (unset) | Honor X-Forwarded-Proto from reverse proxy | `0`, `1`, `true`, `yes` (case-insensitive) |
+
+**nginx envsubst filter (line 53):** Only these vars are substituted into nginx template:
+```
+^(API_HOST|API_PORT|API_WRITE_TOKEN|RACKULA_AUTH_MODE|AUTH_MODE|RACKULA_LISTEN_PORT|RACKULA_IPV6_LISTEN|NGINX_RESOLVER|RACKULA_TRUST_PROXY)$
+```
+This prevents nginx built-in vars (`$host`, `$scheme`, etc.) from being overwritten.
+
+### Entrypoint
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/deploy/docker-entrypoint-wrapper.sh` (copied line 62)
+
+Wraps the official nginx entrypoint to:
+1. Normalize `RACKULA_AUTH_MODE` (accepts mixed case, defaults to `none`)
+2. Normalize `RACKULA_TRUST_PROXY` (accepts `1`, `true`, `yes` case-insensitive)
+3. Auto-detect or normalize IPv6 listener (reads `/proc/net/if_inet6`, generates `RACKULA_IPV6_LISTEN` var)
+4. Validate `NGINX_RESOLVER` for Kubernetes bare hostnames (warns if in K8s and `API_HOST` has no dots)
+5. Log configuration details to stderr
+
+### Security Posture
+- **Read-only root filesystem:** No (can write to `/var/cache/nginx`, `/var/run`, `/tmp`, `/etc/nginx/conf.d` via tmpfs)
+- **Capabilities:** Not dropped in Dockerfile (depends on docker compose security settings)
+- **Security headers:** Sourced from `/etc/nginx/snippets/security-headers.conf` (copied line 59)
+
+---
+
+## API image (api/Dockerfile)
+
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/api/Dockerfile`
+
+### Image Details
+- **Base image:** `oven/bun:1.3.10-alpine` (line 3)
+- **User:** `rackula` (non-root, UID 1001; created line 24-25)
+- **Port:** `3001` (line 55 EXPOSE)
+- **Healthcheck:** Lines 57-58
+  - Endpoint: `GET http://127.0.0.1:3001/health`
+  - Interval: 30s, timeout: 10s, start-period: 5s, retries: 3
+  - Returns: JSON `{ ok: true, status: "ok", service: "rackula-persistence-api", version: 1 }`
+
+### OCI Labels (lines 36-39)
+- `org.opencontainers.image.source="https://github.com/RackulaLives/Rackula"`
+- `org.opencontainers.image.description="Rackula API Sidecar for persistent storage"`
+- `org.opencontainers.image.licenses="MIT"`
+- `org.opencontainers.image.title="Rackula API"`
+
+### Build Args / Version Metadata (lines 43-51)
+- `APP_VERSION=""` (injected at build time from release tag; falls back to `api/package.json` version in dev)
+- `APP_COMMIT=""` (short git hash, optional)
+- `APP_BUILD_TIME=""` (ISO 8601 timestamp, optional)
+- Exposed at runtime via `GET /version` and `GET /api/version` (unauthenticated)
+
+### Runtime Environment Variables (line 53)
+| Variable | Default | Purpose | Required |
+|----------|---------|---------|----------|
+| `NODE_ENV` | `production` | Set to production mode | No (hardcoded in image) |
+| `PORT` | `3001` | Fallback port if `RACKULA_API_PORT` not set | No |
+| `RACKULA_API_PORT` | `3001` | API listen port (takes precedence) | No |
+| `DATA_DIR` | `/data` | Persistent data directory inside container | No |
+
+### Required Auth Env Vars (when `RACKULA_AUTH_MODE != none`)
+
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/api/src/security/config.ts` (lines 296-504)
+
+When auth is enabled, the API **fails to start** if these are missing:
+
+| Variable | Purpose | Min Length | Default |
+|----------|---------|-----------|---------|
+| `RACKULA_AUTH_SESSION_SECRET` | Session token signing key | 32 chars | (required) |
+| `RACKULA_AUTH_MODE` | Mode: `none`, `oidc`, `local` | — | `none` (optional) |
+
+### Auth Mode Specifics
+
+#### Mode: `none` (Default, No Auth)
+- Anonymous read/write access
+- No session secret required
+- Auth routes (`/auth/login`, `/auth/check`, etc.) still respond but grant access immediately
+
+#### Mode: `local` (Username/Password)
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/api/src/local-auth.ts`
+
+Additional required env vars:
+| Variable | Purpose | Min Length | Max Length | Notes |
+|----------|---------|-----------|-----------|-------|
+| `RACKULA_LOCAL_USERNAME` | Login username | 1 char | 255 chars | Trimmed; required if `RACKULA_AUTH_MODE=local` |
+| `RACKULA_LOCAL_PASSWORD` | Login password | 12 chars | 1024 chars | Plain text at startup; hashed with Argon2id (OWASP params: 64 MiB memory, 3 time cost, 4 parallelism); plaintext scrubbed from env after bootstrap (line 289 in app.ts) |
+
+**Password handling:**
+- Hashed via `@node-rs/argon2` package (Argon2id, lines 11-13 in local-auth.ts)
+- Login rate limiter: 5 attempts per 60s per IP (lines 19-22 in local-auth.ts)
+- Timing-safe comparison to prevent username enumeration (lines 174-199 in local-auth.ts)
+
+#### Mode: `oidc` (OpenID Connect)
+- Requires OIDC provider configuration via `better-auth` library (Hono app, line 348 in app.ts)
+- Setup not documented in env vars; likely configured via additional env vars not listed here or via config files
+
+### Session Configuration (when auth enabled)
+
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/api/src/security/config.ts` (lines 358-403)
+
+| Variable | Default | Min | Max | Purpose |
+|----------|---------|-----|-----|---------|
+| `RACKULA_AUTH_SESSION_MAX_AGE_SECONDS` | `43200` (12h) | `60` | `604800` (7 days) | Absolute session lifetime |
+| `RACKULA_AUTH_SESSION_IDLE_TIMEOUT_SECONDS` | `1800` (30m) | `60` | `authSessionMaxAgeSeconds` | Inactivity timeout |
+| `RACKULA_AUTH_SESSION_GENERATION` | `0` | 0 | (no max) | Increment to invalidate all active sessions globally |
+| `RACKULA_AUTH_SESSION_COOKIE_SAMESITE` | `Lax` | — | — | Cookie policy: `Lax`, `Strict`, `None` |
+| `RACKULA_AUTH_SESSION_COOKIE_SECURE` | `true` if prod, `false` if dev | — | — | HTTPS-only flag (forced `true` if SameSite=None) |
+| `RACKULA_AUTH_SESSION_COOKIE_NAME` | `rackula_auth_session` | — | — | Session cookie name (alphanumeric, `-`, `_` only) |
+| `RACKULA_AUTH_CSRF_PROTECTION` | `true` if auth enabled, `false` otherwise | — | — | CSRF token validation for authenticated writes |
+
+### Write Route Authorization
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `RACKULA_API_WRITE_TOKEN` | (unset) | Optional bearer token for PUT/DELETE routes (alternative to session auth) |
+
+When set, nginx injects `Authorization: Bearer <token>` header on PUT/DELETE requests (nginx.conf.template lines 14-28).
+
+### Storage / Data
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `DATA_DIR` | `/data` | Mounted volume path inside container; API creates if missing (filesystem.ts line 50) |
+
+**Storage structure:** Folder-per-layout, YAML-based:
+```
+{DATA_DIR}/
+  {LayoutName}-{UUID}/
+    {layout-name}.rackula.yaml    # Persisted layout data
+  {LayoutName}-{UUID}/assets/
+    {asset-id}.{ext}               # Images/attachments per layout
+```
+(api/src/storage/filesystem.ts, lines 4-5)
+
+### Optional Config
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CORS_ORIGIN` | `*` (dev), error (prod) | Allowed browser origins for API; comma-separated list or `*` |
+| `ALLOW_INSECURE_CORS` | `false` | Opt-in to wildcard CORS in production (security.config.ts lines 319-322) |
+| `MAX_ASSET_SIZE` | `5242880` (5 MB) | Max file upload size (bytes) |
+| `RACKULA_MAX_LAYOUTS` | `100` | Max layout count (0 = unlimited) |
+| `RACKULA_MAX_ASSETS_PER_LAYOUT` | `50` | Max assets per layout (0 = unlimited) |
+| `RACKULA_RATE_LIMIT_ENABLED` | `true` | Rate limiting toggle |
+| `RACKULA_RATE_LIMIT_WRITE_MAX` | `30` | Write requests per window |
+| `RACKULA_RATE_LIMIT_WRITE_WINDOW_MS` | `60000` (60s) | Write rate limit window |
+| `RACKULA_RATE_LIMIT_READ_MAX` | `120` | Read requests per window |
+| `RACKULA_RATE_LIMIT_READ_WINDOW_MS` | `60000` (60s) | Read rate limit window |
+
+---
+
+## Compose / Multi-container Wiring
+
+### Standard (No Persistence)
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/docker-compose.yml`
+
+Services:
+- **`rackula` (frontend):**
+  - Image: `ghcr.io/rackulalives/rackula:latest` (overridable via `RACKULA_IMAGE`)
+  - Ports: `${RACKULA_PORT:-8080}:${RACKULA_LISTEN_PORT:-8080}` (host:container)
+  - Container name: `${RACKULA_CONTAINER_NAME:-rackula}`
+  - **Always runs** (no profile)
+  - No volumes
+  - Requires: None
+  - Resources: 0.5 CPU / 128 MB limit, 0.1 CPU / 16 MB reserved
+  - Security: `no-new-privileges`, all caps dropped, read-only root FS, tmpfs for nginx cache/run/tmp
+  - Restart: `unless-stopped` with 10s grace period
+
+- **`rackula-api` (API sidecar, optional):**
+  - Image: `ghcr.io/rackulalives/rackula-api:latest` (overridable via `RACKULA_API_IMAGE`)
+  - Ports: Not exposed (internal only)
+  - Container name: `${RACKULA_API_CONTAINER_NAME:-rackula-api}`
+  - **Profile: `persist`** — only runs with `docker compose --profile persist up`
+  - Volumes: `./data:/data` (note: host dir must be writable by UID 1001)
+  - Resources: 0.25 CPU / 64 MB limit, 0.05 CPU / 16 MB reserved
+  - Security: Same hardening as frontend
+  - Restart: `unless-stopped` with 10s grace period
+
+### With Persistence
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/deploy/docker-compose.persist.yml`
+
+Services:
+- **`rackula` (frontend):**
+  - Same as above, **but**:
+  - Image: `ghcr.io/rackulalives/rackula:persist` (pre-configured for API)
+  - Depends on: `rackula-api` (service_healthy condition, line 38-39)
+  - Adds `RACKULA_TRUST_PROXY=${RACKULA_TRUST_PROXY:-0}` for reverse-proxy support
+
+- **`rackula-api` (API, always runs):**
+  - Volumes: `./data:/data`
+  - Healthcheck: `wget -qO- http://127.0.0.1:3001/health` (line 124)
+  - Same env vars as standard compose (see Environment Variables section below)
+
+### Frontend → API Wiring
+
+**nginx proxy (deploy/nginx.conf.template):**
+- Frontend serves static assets + SPA
+- All `/api/*` requests proxied to API upstream (lines 178-202)
+  - Upstream DNS: `${NGINX_RESOLVER}` (default `127.0.0.11`)
+  - Target: `http://${API_HOST}:${API_PORT}`
+  - Rewrite: `/api/layouts` → `/layouts` (prefix stripped at line 184)
+  - Write-token injection: If `API_WRITE_TOKEN` is set and method is PUT/DELETE, injects `Authorization: Bearer <token>` (lines 14-28)
+  - Timeouts: connect 5s, send 30s, read 30s
+
+**Auth routing (lines 209-241):**
+- Internal `/_rackula_auth_check` endpoint calls `/api/auth/check` for session validation
+- If auth mode is `none`, returns 204 immediately (line 214)
+- Otherwise proxies to API; failures return 401 (line 239)
+- App redirects 401 to `/auth/login?next=...` (line 251)
+
+---
+
+## Environment Variables (Complete Reference Table)
+
+**Frontend (nginx) env vars:**
+
+| Variable | Default | Purpose | File | Type |
+|----------|---------|---------|------|------|
+| `API_HOST` | `rackula-api` | API hostname/IP | deploy/Dockerfile:47 | string |
+| `API_PORT` | `3001` | API port | deploy/Dockerfile:48 | integer |
+| `RACKULA_AUTH_MODE` | `none` | Auth mode: none/oidc/local | deploy/Dockerfile:49 | enum |
+| `RACKULA_LISTEN_PORT` | `8080` | nginx listen port | deploy/Dockerfile:50 | integer |
+| `RACKULA_ENABLE_IPV6` | `auto` | IPv6: auto/true/false | deploy/Dockerfile:51 | enum |
+| `NGINX_RESOLVER` | `127.0.0.11` | DNS for nginx upstream | deploy/Dockerfile:52 | IP address |
+| `API_WRITE_TOKEN` | (unset) | Bearer token for write routes | compose line 48 | string (optional) |
+| `RACKULA_TRUST_PROXY` | `0` | Honor X-Forwarded-Proto | docker-compose.persist.yml:34 | 0/1 |
+
+**API env vars:**
+
+| Variable | Default | Purpose | File | Type | Required |
+|----------|---------|---------|------|------|----------|
+| `NODE_ENV` | `production` | Node environment | api/Dockerfile:53 | string | No |
+| `PORT` | `3001` | Fallback listen port | api/Dockerfile:53 | integer | No |
+| `RACKULA_API_PORT` | `3001` | API listen port (preferred) | api/index.ts:13 | integer | No |
+| `DATA_DIR` | `./data` | Persistent data directory | api/Dockerfile:53, filesystem.ts:28 | path | No |
+| `RACKULA_AUTH_MODE` | `none` | Auth mode | api/src/security/config.ts:302 | enum(none/oidc/local) | No |
+| `RACKULA_AUTH_SESSION_SECRET` | (unset) | Session token signing key | api/src/security/config.ts:332 | string (32+ chars) | **Yes if auth enabled** |
+| `RACKULA_LOCAL_USERNAME` | (unset) | Local auth username | api/src/local-auth.ts:71 | string (1-255 chars) | **Yes if mode=local** |
+| `RACKULA_LOCAL_PASSWORD` | (unset) | Local auth password | api/src/local-auth.ts:81 | string (12-1024 chars) | **Yes if mode=local** |
+| `RACKULA_AUTH_SESSION_MAX_AGE_SECONDS` | `43200` | Absolute session lifetime | api/src/security/config.ts:358 | integer (60-604800) | No |
+| `RACKULA_AUTH_SESSION_IDLE_TIMEOUT_SECONDS` | `1800` | Session inactivity timeout | api/src/security/config.ts:366 | integer (60-max_age) | No |
+| `RACKULA_AUTH_SESSION_GENERATION` | `0` | Session generation counter | api/src/security/config.ts:374 | integer (0+) | No |
+| `RACKULA_AUTH_SESSION_COOKIE_SAMESITE` | `Lax` | Cookie SameSite policy | api/src/security/config.ts:380 | enum(Lax/Strict/None) | No |
+| `RACKULA_AUTH_SESSION_COOKIE_SECURE` | true (prod)/false (dev) | HTTPS-only cookie | api/src/security/config.ts:384 | 0/1/true/false | No |
+| `RACKULA_AUTH_SESSION_COOKIE_NAME` | `rackula_auth_session` | Session cookie name | api/src/security/config.ts:328 | string (alphanumeric/-/_) | No |
+| `RACKULA_API_WRITE_TOKEN` | (unset) | Bearer token for PUT/DELETE | docker-compose.yml:48 | string (optional) | No |
+| `CORS_ORIGIN` | `*` (dev) / error (prod) | Allowed browser origins | docker-compose.yml:103 | string (comma-separated or `*`) | No (if prod: yes unless `ALLOW_INSECURE_CORS=true`) |
+| `ALLOW_INSECURE_CORS` | `false` | Opt-in to wildcard CORS in prod | docker-compose.yml:120 | 0/1/true/false | No |
+| `MAX_ASSET_SIZE` | `5242880` | Max upload size (bytes) | api/src/app.ts:838 | integer | No |
+| `RACKULA_MAX_LAYOUTS` | `100` | Max layout count (0=unlimited) | api/src/security/config.ts:463 | integer (0+) | No |
+| `RACKULA_MAX_ASSETS_PER_LAYOUT` | `50` | Max assets per layout (0=unlimited) | api/src/security/config.ts:470 | integer (0+) | No |
+| `RACKULA_RATE_LIMIT_ENABLED` | `true` | Rate limiting toggle | api/src/security/config.ts:421 | 0/1/true/false | No |
+| `RACKULA_RATE_LIMIT_WRITE_MAX` | `30` | Write requests per window | api/src/security/config.ts:427 | integer (1-10000) | No |
+| `RACKULA_RATE_LIMIT_WRITE_WINDOW_MS` | `60000` | Write rate window (ms) | api/src/security/config.ts:435 | integer (1000-3600000) | No |
+| `RACKULA_RATE_LIMIT_READ_MAX` | `120` | Read requests per window | api/src/security/config.ts:443 | integer (1-100000) | No |
+| `RACKULA_RATE_LIMIT_READ_WINDOW_MS` | `60000` | Read rate window (ms) | api/src/security/config.ts:451 | integer (1-3600000) | No |
+| `RACKULA_AUTH_LOG_HASH_KEY` | (derived from `RACKULA_AUTH_SESSION_SECRET`) | Auth log pseudonymization key | api/src/security/config.ts:334 | string (32+ chars, optional) | No |
+| `RACKULA_AUTH_LOGIN_PATH` | `/auth/login` | Auth login endpoint path | api/src/security/config.ts:331 | path | No |
+
+---
+
+## Auth Model (RACKULA_AUTH_MODE)
+
+**Primary config file:** `/Users/gvns/code/projects/Rackula/Rackula/api/src/security/config.ts` (lines 296-504)
+
+### Mode: `none` (Default, No Authentication)
+- **Behavior:** All requests granted access immediately
+- **Session requirement:** None
+- **Routes:** Auth routes (`/auth/login`, `/auth/check`, `/auth/logout`) respond but grant 204/no-op
+- **nginx behavior (nginx.conf.template line 213-214):** Auth check returns 204 immediately, bypassing upstream call
+- **Use case:** Single-user homelab, isolated network, development
+
+### Mode: `local` (Username/Password)
+**Files:**
+- `api/src/local-auth.ts` (implementation)
+- `api/src/app.ts` (line 285-298: bootstrap, line 634-797: login handler)
+
+**Startup:**
+1. API loads `RACKULA_LOCAL_USERNAME` and `RACKULA_LOCAL_PASSWORD` (required)
+2. Password hashed with Argon2id using OWASP parameters (local-auth.ts lines 11-13):
+   - Memory: 64 MiB
+   - Time cost: 3
+   - Parallelism: 4
+3. Hash stored in-memory; plaintext password scrubbed from env (app.ts line 289)
+4. **No persistent user database** — credentials are ephemeral (hashed only during container lifetime)
+
+**Login flow:**
+1. User POST `/auth/login` with `{ username, password }`
+2. Rate limiter checks IP: max 5 attempts per 60s (local-auth.ts lines 19-22)
+3. Timing-safe credential verification (lines 174-199)
+4. On success: Session token signed with `RACKULA_AUTH_SESSION_SECRET` and sent as httpOnly cookie
+5. On failure: Log event, return 401
+6. **nginx:** POST /auth/login passes through to API for validation (nginx.conf.template lines 118-120)
+7. **nginx:** GET /auth/login serves static `/login.html` for GET requests (line 119)
+
+**Session token:**
+- Signed with HS256 (HMAC-SHA256) using `RACKULA_AUTH_SESSION_SECRET`
+- Claims: `sub` (username), `role` (always "admin"), `iat`, `exp`, `idleExp`, `generation`, `sid`
+- Lifetime: `RACKULA_AUTH_SESSION_MAX_AGE_SECONDS` (default 12h)
+- Idle timeout: `RACKULA_AUTH_SESSION_IDLE_TIMEOUT_SECONDS` (default 30m)
+
+**Logout:**
+- POST `/auth/logout` invalidates session cookie (app.ts line 617)
+
+**Persistence:** None (credentials and sessions ephemeral; restart clears all state)
+
+### Mode: `oidc` (OpenID Connect)
+**Files:**
+- `api/src/auth/config.ts` (Better Auth configuration)
+- `api/src/app.ts` (lines 434-530: OAuth2 handler)
+
+**Configuration:** Not fully documented in env vars. Requires:
+- `RACKULA_AUTH_SESSION_SECRET` (required for token signing)
+- OIDC provider setup via `better-auth` library (Hono)
+- Providers likely configured via additional env vars or config files (not enumerated here)
+
+**Flow:**
+1. User navigates to `/auth/login`
+2. nginx proxies to API (line 124 in nginx.conf.template)
+3. API calls `signInWithOAuth2({ providerId: "oidc", callbackURL, ... })` (app.ts line 485)
+4. Better Auth returns authorization URL
+5. User redirected to IdP login
+6. IdP redirects back to `/auth/callback` with code
+7. API exchanges code for tokens, creates session, sets cookie (app.ts line 514-530)
+
+**Session:** Same as local auth (HS256 signed token)
+
+**Limitations:** MVP implementation; all authenticated users get "admin" role (see app.ts comment lines 216-217 re: RACKULA_OIDC_ROLE_CLAIM future feature)
+
+### Shared Auth Infrastructure
+
+**Session validation (nginx.conf.template lines 209-240):**
+- Internal `/_rackula_auth_check` endpoint
+- If auth mode is `none`: returns 204 (line 214)
+- If auth enabled: proxies to `/api/auth/check` to validate signed session cookie
+- API checks cookie signature and expiration (app.ts line 533-570)
+- Failure returns 401 → nginx redirects to login (line 251)
+
+**Write route protection (app.ts lines 815-823):**
+- When auth enabled, all PUT/DELETE routes require admin role
+- Routes affected: `/layouts/*`, `/assets/*`, `/api/layouts/*`, `/api/assets/*`
+
+**CSRF protection (when auth enabled):**
+- Enabled by default if auth is enabled (api/src/security/config.ts line 396-400)
+- Validates CSRF token for session-authenticated requests
+- Trusted origins: parsed from `CORS_ORIGIN` (lines 402-407)
+
+**Rate limiting:**
+- Global, per-IP read/write limits (api/src/security/rate-limit-middleware.ts)
+- Write: 30 requests per 60s (default)
+- Read: 120 requests per 60s (default)
+- Configurable but not per-user
+
+---
+
+## Persistence / Volumes
+
+### Frontend
+- **Volumes:** None (stateless; assets and config baked into image)
+- **Transient:** `/var/cache/nginx` (10 MB tmpfs, line 73 in docker-compose.yml)
+- **Session state:** Stored in session cookie (httpOnly, Secure, SameSite=Lax/Strict)
+
+### API
+- **Persistent volume:** `${DATA_DIR:-/data}` (mounted at `/data` inside container)
+- **Host mapping (docker-compose.persist.yml line 74):** `./data:/data`
+- **Ownership:** UID 1001:1001 (rackula:rackula)
+- **Permissions:** `750` (directory, line 83 in lxc/community-scripts/ct/rackula.sh)
+
+**Storage structure (api/src/storage/filesystem.ts):**
+```
+/data/
+  {LayoutName}-{UUID}/
+    {layout-name}.rackula.yaml    # YAML-serialized layout (js-yaml)
+  {LayoutName}-{UUID}/assets/
+    {asset-id}.{ext}              # Binary image/file attachments
+```
+
+**Data initialization:**
+- API creates `/data` if missing (filesystem.ts line 50)
+- Layout files created on first save
+- Asset directory created per-layout on first upload
+
+**Data consistency:**
+- YAML written atomically via `writeFile` (Node.js fs/promises, no locking)
+- No transactional semantics; concurrent updates to same file will race
+- Backup recommended before updates (see lxc/community-scripts/ct/rackula.sh lines 46-56)
+
+### Session State (if auth enabled)
+- **Mechanism:** httpOnly cookie + server-side signature verification
+- **Persistence:** Signed JWT token; validation requires `RACKULA_AUTH_SESSION_SECRET`
+- **Local auth:** No user database; credentials ephemeral (hashed at startup only)
+- **OIDC:** Better Auth library handles provider session management (depends on configuration)
+- **TTL:** Max 12h absolute, 30m idle (configurable)
+- **Storage:** None (stateless; token is the source of truth)
+
+**Invalidation (app.ts line 582, 587):**
+- Function `invalidateAuthSession(sessionId, expiration)` registered but implementation details not clear from snippet
+- Likely in-memory cache invalidation (clears token from memory, not disk)
+
+---
+
+## nginx / Reverse Proxy
+
+**Primary config:** `/Users/gvns/code/projects/Rackula/Rackula/deploy/nginx.conf.template` (envsubst-processed)
+
+### Key Locations
+
+| Path | Handler | Purpose |
+|------|---------|---------|
+| `/health` | Return 200 "OK" | Container health check (always passes, even if API down) |
+| `/login.html` | Serve file | Local auth login page (only if `RACKULA_AUTH_MODE=local`) |
+| `/_rackula_auth_check` | Internal proxy | Session validation (returns 204 or 401) |
+| `/auth/login` | Proxy to API | Auth bootstrap (GET serves login page in local mode, POST validates credentials) |
+| `/auth/callback` | Proxy to API | OIDC callback handler (returns 404 in local mode) |
+| `/auth/check` | Proxy to API | Session validation (used by internal check above) |
+| `/auth/logout` | Proxy to API | Session invalidation |
+| `/api/` | Proxy to API | Layout/asset read/write endpoints |
+| `/assets/` | Serve static files | Vite-built frontend assets (cached 1 year) |
+| `/` | SPA fallback | All unmatched paths → `index.html` (auth_request gated) |
+
+### API Proxy Behavior
+
+**Upstream:**
+- Hostname/IP: `${API_HOST}` (default `rackula-api`)
+- Port: `${API_PORT}` (default `3001`)
+- DNS resolver: `${NGINX_RESOLVER}` (default `127.0.0.11`, Docker embedded DNS)
+- Protocol: `http://` (internal, no TLS)
+
+**Path rewriting (line 184):**
+```nginx
+rewrite ^/api(/.*)$ $1 break;
+```
+Frontend calls `/api/layouts` → nginx forwards `http://rackula-api:3001/layouts`
+
+**Header forwarding (lines 188-193):**
+- `Host`: `$host` (original Host header)
+- `X-Real-IP`: `$remote_addr` (client IP)
+- `X-Forwarded-For`: `$proxy_add_x_forwarded_for` (proxy chain)
+- `X-Forwarded-Proto`: `$real_scheme` (honors `X-Forwarded-Proto` if `RACKULA_TRUST_PROXY=1`, else `$scheme`)
+- `Authorization`: Injected with bearer token if `API_WRITE_TOKEN` set for PUT/DELETE (lines 14-28)
+
+**Timeouts:**
+- Connect: 5s
+- Send: 30s
+- Read: 30s
+
+**Error handling:**
+- 502/503/504 from API → returns JSON error (line 206)
+- Auth service unavailable (502/503/504) → returns HTML error (line 163)
+
+### Static Asset Serving
+
+**Path:** `/assets/`
+- **Source:** Vite-built fingerprinted assets in `/usr/share/nginx/html/assets/`
+- **Cache:** 1 year (`Cache-Control: public, immutable`)
+- **Gzip:** Enabled (min 1KB, see lines 77-82)
+
+### SPA Fallback with Auth
+
+**Path:** `/` (line 274)
+- **Behavior:** All requests route to `index.html` (SPA)
+- **Auth gate:** `auth_request /_rackula_auth_check` (line 275)
+- **On 401:** Redirects to `/auth/login?next=<original-path>` (line 276)
+
+### Trust Proxy (Reverse Proxy Support)
+
+**Control:** `RACKULA_TRUST_PROXY` (docker-entrypoint-wrapper.sh lines 30-45)
+
+When `RACKULA_TRUST_PROXY=1`:
+- Honor `X-Forwarded-Proto` header from reverse proxy
+- Auth redirects use external scheme (https) instead of internal (http)
+- Prevents open-redirect attacks by validating scheme (only http/https accepted, line 59-63)
+
+**Use case:** Rackula behind TLS-terminating reverse proxy (e.g., Unraid with HTTPS)
+
+### Security Headers
+
+**File:** `/Users/gvns/code/projects/Rackula/Rackula/deploy/security-headers.conf`
+
+Included at server level (line 281) and `/assets/` location (line 91).
+
+Headers (typical web hardening):
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY` (or `SAMEORIGIN`)
+- `X-XSS-Protection: 1; mode=block`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- CSP, HSTS, etc. (exact headers not shown in summary, but file exists at line 57, 59)
+
+---
+
+## Existing Distribution References (LXC, Unraid Traces)
+
+### LXC Distribution (Proxmox Community Scripts)
+
+**Location:** `/Users/gvns/code/projects/Rackula/Rackula/deploy/lxc/community-scripts/`
+
+**JSON metadata (json/rackula.json):**
+- Name: Rackula
+- Slug: rackula
+- Category: 10 (homelab-related)
+- Type: `ct` (LXC container)
+- Updateable: true
+- Privileged: false (unprivileged container)
+- ARM64: yes
+- Interface port: 80 (reverse proxy maps to this)
+- Default OS: Debian 13
+- Min resources: 1 CPU, 512 MB RAM, 8 GB disk
+- No default credentials (auth mode=none by default)
+
+**Installation script (ct/rackula.sh):**
+- Fetches latest release tarball from GitHub (`RackulaLives/Rackula`)
+- Deploys to `/opt/rackula/`
+- Creates systemd services for nginx + rackula-api
+- Config files: `/opt/rackula/config/nginx.conf`, `rackula-api.service`, `nginx.service.d-override.conf`, `security-headers.conf`
+- Data directory: `/opt/rackula/data`
+- Auto-generates API write token during install (noted in rackula.json line 34)
+
+**Update function:**
+- Stops services
+- Backs up `/opt/rackula/data`
+- Deploys new tarball
+- Restores data
+- Reloads systemd
+- Starts services
+- Smoke test: `curl http://127.0.0.1/api/health` (must respond within 10s, line 98)
+
+**Research file (lxc-best-practices.md):**
+- Proxmox/LXC hardening guidance
+- systemd service sandbox recommendations
+- Capability and syscall filtering details
+- Caveat: Bun runtime uses JIT; `MemoryDenyWriteExecute` breaks it (line 81)
+
+### Unraid Traces
+
+**File count:** Minimal; mostly icon files (`node_modules/simple-icons/icons/unraid.svg`)
+
+**No existing Unraid template found** in codebase
+
+**No explicit references** to Unraid distribution in code (docs, scripts, config)
+
+**Implication:** Unraid distribution (Community App template or plugin) does not yet exist; spike #1995 is greenfield
+
+### Other Distribution References
+
+**Docker Hub:** Images published to `ghcr.io/rackulalives/rackula` and `ghcr.io/rackulalives/rackula-api`
+
+**Compose reference:** `docker-compose.yml` and `deploy/docker-compose.persist.yml` are reference implementations for self-hosting
+
+---
+
+## Open Questions / Gaps for Unraid Templating
+
+1. **Single-container vs. two-container deployment:**
+   - Can Unraid template deploy frontend only (auth=none, no persistence)?
+   - Or is API sidecar mandatory?
+   - **Answer from investigation:** Frontend is fully functional without API; auth mode defaults to `none`, persistence is optional. Single-container (frontend only) is viable, but persistence requires second container or volume mount.
+
+2. **Volume mounting for persistence:**
+   - Unraid Docker template API: does it support volume bind mounts like docker-compose?
+   - Community App or custom plugin required?
+   - **Answer:** Both Unraid Community Applications and Plugins support volumes. Template must declare `/data` as writable mount.
+
+3. **Environment variable UI in Unraid template:**
+   - Which env vars should be exposed in the template UI vs. hardcoded?
+   - Priority: `RACKULA_LISTEN_PORT`, `API_HOST`, `API_PORT`, `RACKULA_AUTH_MODE`, `RACKULA_API_WRITE_TOKEN`
+   - Secondary (if auth enabled): `RACKULA_LOCAL_USERNAME`, `RACKULA_LOCAL_PASSWORD`, `RACKULA_AUTH_SESSION_SECRET`
+
+4. **Reverse proxy / SSL termination:**
+   - Does Unraid have a built-in reverse proxy (similar to `docker-entrypoint-wrapper.sh` `RACKULA_TRUST_PROXY` support)?
+   - Template must document how to enable `RACKULA_TRUST_PROXY=1` when Unraid reverse proxy is in use.
+
+5. **Auth mode selection in UI:**
+   - Should template offer radio buttons: "None (Anonymous)" | "Local (Username/Password)" | "OIDC (External IdP)"?
+   - If local: expose `RACKULA_LOCAL_USERNAME`, `RACKULA_LOCAL_PASSWORD` fields
+   - If OIDC: needs additional OIDC provider configuration (provider ID, client ID, secret, discovery URL) — **not yet documented**
+
+6. **Data persistence strategy:**
+   - Should template suggest daily backups of `/data`?
+   - LXC script already includes backup/restore logic (see rackula.sh); Docker template should mirror this.
+
+7. **Health check:**
+   - Unraid template should define:
+     - Port: 8080 (or `RACKULA_LISTEN_PORT` if configurable)
+     - Endpoint: `GET /health`
+     - Interval: 30s, timeout: 3s (from Dockerfile healthcheck)
+
+8. **Startup order (if two-container):**
+   - Frontend should wait for API to be healthy (like docker-compose.persist.yml depends_on, line 37-39)
+   - Or declare API as required dependency?
+
+9. **API write token generation:**
+   - Should template auto-generate a strong write token?
+   - LXC script notes it's auto-generated; template should mirror this (e.g., 32-byte random string in base64).
+
+10. **Container restart policy:**
+    - docker-compose uses `restart: unless-stopped` with 10s grace period
+    - Unraid template should specify equivalent (always restart unless manually stopped)
+
+---
+
+## Summary: Deployment Arch for Unraid
+
+**Minimum viable setup (single container):**
+```yaml
+Frontend container:
+  - Image: ghcr.io/rackulalives/rackula:latest
+  - Port: 8080 → host port (configurable)
+  - Auth mode: none (default)
+  - Persistence: optional (no volume → stateless, all data lost on restart)
+```
+
+**Recommended setup (two containers with persistence):**
+```yaml
+Frontend container:
+  - Image: ghcr.io/rackulalives/rackula:persist
+  - Port: 8080 → host port
+  - API_HOST: rackula-api (internal docker network)
+  - API_PORT: 3001
+  - RACKULA_AUTH_MODE: none (or local/oidc if configured)
+  - RACKULA_TRUST_PROXY: 1 (if behind Unraid reverse proxy)
+  - Depends on: rackula-api healthcheck
+
+API container:
+  - Image: ghcr.io/rackulalives/rackula-api:latest
+  - Port: 3001 (not exposed; internal only)
+  - DATA_DIR: /data
+  - Volume: ./data → /data (persistent)
+  - RACKULA_AUTH_MODE: (inherit from frontend)
+  - RACKULA_AUTH_SESSION_SECRET: (if auth enabled, required)
+```
+
+**Config files needed:**
+1. Docker template (JSON) defining UI fields, image, ports, volumes, env vars, health check
+2. Optional: shell script to generate strong random tokens at deploy time
+3. Optional: documentation for reverse proxy setup if Unraid has built-in SSL/HTTPS gateway
+

--- a/docs/research/1995-external.md
+++ b/docs/research/1995-external.md
@@ -146,15 +146,15 @@ Every port, volume, and environment variable is one `<Config>` entry. General sh
 
 Type-specific meaning (src 7):
 
-- **`Type="Port"`** - `Target` is the *container* port (e.g. `8080`), `Mode` is the
+- `Type="Port"` - `Target` is the *container* port (e.g. `8080`), `Mode` is the
   protocol (`tcp`/`udp`), `Default` is the suggested *host* port. Pairs with `<WebUI>`.
-- **`Type="Path"`** - `Target` is the *container* mount path (e.g. `/data`), `Default` is
+- `Type="Path"` - `Target` is the *container* mount path (e.g. `/data`), `Default` is
   the suggested host path (e.g. `/mnt/user/appdata/rackula`), `Mode` is `rw`/`ro`. Guidance:
   "If it's a proper appdata location, set required to yes" (src 7).
-- **`Type="Variable"`** - `Target` is the *env var name* (e.g. `RACKULA_AUTH_MODE`); no
+- `Type="Variable"` - `Target` is the *env var name* (e.g. `RACKULA_AUTH_MODE`); no
   `Mode`; `Mask="true"` hides the value behind asterisks (use for secrets/session keys).
-- **`Type="Label"`** - display-only text, no user input.
-- **`Type="Device"`** - maps a host device into the container.
+- `Type="Label"` - display-only text, no user input.
+- `Type="Device"` - maps a host device into the container.
 
 Shared attributes (src 7): `Display` controls visibility tier - `always` (basic, editable),
 `always-hide` (basic, locked), `advanced` (advanced view, editable), `advanced-hide`. A
@@ -213,31 +213,31 @@ needs N containers is expressed as N independent templates the user installs in 
 
 ### How real multi-part apps handle it (prevailing patterns)
 
-- **Uptime Kuma** - genuinely single-container. One image, one template, a `/app/data`
+- Uptime Kuma - genuinely single-container. One image, one template, a `/app/data`
   volume; no second service needed (src 6). This is the easy baseline.
-- **Homepage (gethomepage)** - also single-container; one image plus a config volume (src 5).
-- **KitchenOwl (frontend + backend)** - the most instructive concrete example for Rackula.
+- Homepage (gethomepage) - also single-container; one image plus a config volume (src 5).
+- KitchenOwl (frontend + backend) - the most instructive concrete example for Rackula.
   Its evolution is documented: "The setup changed so that the frontend is now required... it's
   recommended to host the frontend too, with traffic routed through there to the backend"
   (src "KitchenOwl" search). Two distribution shapes coexist in CA:
-  1. **One combined template/image** - "there's a template that includes both front and
+  1. One combined template/image - "there's a template that includes both front and
      backend in one template that you can install from Community Applications" (src KitchenOwl).
-  2. **Two separate containers** - if run apart, the user installs both and wires them with
+  2. Two separate containers - if run apart, the user installs both and wires them with
      env vars: "FRONT_URL should point to the local IP & Port of the WebUI container, and
      BACK_URL should point to the Backend Container's IP & Port" (src KitchenOwl).
-- **Homelabarr** - ships a **backend template and a frontend template** explicitly "designed
+- Homelabarr - ships a backend template and a frontend template explicitly "designed
   to be used in conjunction with" each other (src "multi-container" search) - the pure
   two-template model.
 
 So across the ecosystem there are three idiomatic answers, in rough order of user-friendliness:
 
-1. **One combined image** (a single container running both processes, e.g. via s6/supervisor
+1. One combined image (a single container running both processes, e.g. via s6/supervisor
    or an nginx that also proxies an internal API). User installs one template - simplest UX,
    most maintenance burden on the maintainer's image.
-2. **Two templates, user adds the second** - the Homelabarr / KitchenOwl-split model. Each
+2. Two templates, user adds the second - the Homelabarr / KitchenOwl-split model. Each
    template is independent; the optional one is genuinely optional. The `<Requires>` element
    and the `<Overview>` text are used to tell the user "this needs the other container."
-3. **Frontend-only template + docs** - ship just the always-needed container and document the
+3. Frontend-only template + docs - ship just the always-needed container and document the
    optional second container for advanced users.
 
 ### Idiomatic answer for Rackula's *optional* API
@@ -317,25 +317,25 @@ Rackula meets none of those criteria - it is a web app that already ships as a c
 
 ### Concrete reasons Rackula should NOT ship as a plugin
 
-1. **No isolation / larger attack surface.** Containers "run safely in isolated
+1. No isolation / larger attack surface. Containers "run safely in isolated
    environments, while plugins have direct OS access"; plugins' "full filesystem access
    increases security risks" (src 13). Shipping a web app as a plugin would hand a web-facing
    app root-level host access for zero benefit, whereas the container model sandboxes it.
 
-2. **Higher moderation/trust bar, less benefit.** The official advice is "only install
+2. Higher moderation/trust bar, less benefit. The official advice is "only install
    plugins from trusted sources or well-known developers" (src 13) - i.e. plugins carry a
    heavier trust expectation than a routine CA Docker template, which only needs the
    moderation team's "basic vetting" (src 1). A new app clears the Docker-template bar far
    more easily.
 
-3. **Must survive every Unraid OS upgrade.** Plugins "can cause system instability,
+3. Must survive every Unraid OS upgrade. Plugins "can cause system instability,
    especially after OS updates," and when Unraid upgrades it "won't automatically remove
    incompatible plugins already installed" - users must manually check release notes for
    plugin breakage (src 13). A plugin is thus an open-ended maintenance commitment tied to
    the host OS lifecycle. A container is decoupled: image pinning and the normal Apps-tab
    update flow keep working across OS upgrades (src "plugin vs docker" search).
 
-4. **Wrong tool for the job / no packaging win.** Rackula is portable across any Docker host
+4. Wrong tool for the job / no packaging win. Rackula is portable across any Docker host
    (it already runs on the homelab, VPS, etc.). A `.plg` would re-implement install/upgrade
    logic that the container runtime + CA already provide for free, and would only run on
    Unraid - strictly more code to maintain for a strictly smaller audience.

--- a/docs/research/1995-external.md
+++ b/docs/research/1995-external.md
@@ -1,0 +1,376 @@
+# Spike #1995 - External Research (Unraid distribution)
+
+Research date: 2026-06-08. Scope: how to distribute Rackula (Docker frontend
+`ghcr.io/rackulalives/rackula` on :8080, optional Bun API on :3001 with `/data`
+volume, auth modes none/local/oidc) on Unraid. Working conclusion under test:
+ship as a **Community Applications (CA) Docker template**, not a native plugin.
+
+Note on sourcing: the rendered `docs.unraid.net` pages are JS-hydrated and return
+empty bodies to a plain fetch, so several official-docs claims below are quoted via
+the indexed search summary of the same canonical URL rather than a direct fetch.
+Those URLs are still cited (they are the authoritative source); the Selfhosters.net
+templating guide and the long-running forum schema thread are used where a direct,
+quotable body was retrievable.
+
+---
+
+## 1. Community Applications: how it works & publishing workflow
+
+### What CA is
+
+Community Applications (CA) is itself an Unraid plugin (the "app store") authored by
+Squidly271, distributed as `community.applications.plg` and actively maintained (latest
+build dated `2025.01.28`) (src 6, src 12). Once installed it adds an **Apps** tab to the
+Unraid WebGUI. From that tab a user browses a moderated catalogue, and installing an app
+is effectively **one-click**: CA hands the app's Docker template XML to Unraid's built-in
+`dockerMan` template manager, which pre-fills the Add Container form (image, ports, paths,
+env vars) so the user just reviews and clicks Apply (src 1, src 5). The public web mirror
+of the same catalogue is browseable at `ca.unraid.net` / `unraid.net/community/apps`
+(src 5, src 8).
+
+Key structural fact for Rackula: **CA installs exactly one container per template.** Each
+template = one `<Repository>` image. App settings are persisted as a per-container XML file
+under `/boot/config/plugins/dockerMan/templates-user` (src "multi-container" search, src 1).
+This single-container-per-template rule is the central constraint for section 3.
+
+### The publishing workflow (how a template gets listed)
+
+The official docs describe a three-step developer workflow (src 1):
+
+1. "prepare your application's template files and documentation"
+2. "create a support thread in the Unraid forums"
+3. "submit your application via the Community Applications submission form"
+
+Submissions are then "reviewed by the Community Applications moderation team, which performs
+basic vetting for security, functionality, and adherence to Unraid's design principles"
+(src 1). After listing, the developer is expected to: keep the app compatible with new
+Unraid releases, "respond to support requests in their forum threads," "clearly label beta
+or experimental versions," and "notify the moderation team if discontinuing support"
+(src 1). The moderation team "reserves the right to remove applications that become
+incompatible... or lack ongoing support," and for security-critical cases "may temporarily
+take over maintenance of abandoned projects" (src 1).
+
+### Where the template XML actually lives (the self-hosted-repo model - confirmed)
+
+This is the part newcomers misunderstand. CA does **not** store your XML for you. The
+prevailing/modern model is: **you host the template XML in your own GitHub repo** (e.g.
+`Owner/unraid-templates`) and that repo is registered with CA's catalogue. The historical
+"community" path was the `selfhosters/unRAID-CA-templates` request repo, where you open a
+**pull request** adding your XML and an approved template gets folded into Squidly271's
+`community.applications` feed (src 3). However, that request repo has explicitly announced
+"intent to slow down" accepting new requests and now "encourag[es] contributors to either
+create their own template repositories in Community Applications or transition to
+alternative community-backed repositories" (src 3). So the recommended path for a new app
+in 2025/2026 is the **maintainer's own template repo**, not the shared request repo.
+
+The `<TemplateURL>` element inside the XML is the canonical "raw GitHub URL to the XML
+template" itself, which is how CA fetches updates to the template after listing (src 2).
+
+### Prerequisites and quality bar
+
+The community request repo states the practical bar that the moderation ethos mirrors
+(src 3):
+
+> "The template must be made by a user with previous activity on GitHub. The application
+> must be of certain quality - not fully AI written - and be attributed to a GitHub account
+> with an active history."
+
+So the gating prerequisites are: an **established GitHub account with real history** (no
+throwaway accounts), a **genuine (non-AI-slop) app**, a working template, and a **forum
+support thread**. There is no documented hard requirement on repo star count or repo age,
+but "previous activity" / "active history" is the explicit account-quality screen (src 3).
+
+### Review timeline
+
+Neither the docs nor the request repo publish a fixed SLA. The realistic expectation is a
+**human, moderator-driven review measured in days to a couple of weeks**, gated on the
+moderation team's volunteer bandwidth, and slowed further by the request repo's stated
+slow-down (src 1, src 3). Plan for "submit, then wait for a human," not instant publish.
+
+**Rackula bottom line for section 1:** the right path is host our own
+`RackulaLives/unraid-templates` (or a `community-applications/` folder in the main repo),
+create an Unraid forum support thread, and submit through the CA form. Prerequisites are
+already met (real org, active history, real app). The friction is human review latency, not
+technical.
+
+---
+
+## 2. Docker template XML schema (with annotated example)
+
+Authoritative sources: the long-running forum schema thread (src 4), the Selfhosters.net
+templating guide which mirrors it (src 7), and the (now redirecting) Unraid wiki schema
+page (src 9). The schema below is drawn from the Selfhosters guide, which returned a full
+quotable body (src 7).
+
+### Container-level elements
+
+Root element is `<Container version="2">`. Notable children (src 7):
+
+| Element | Purpose |
+| --- | --- |
+| `<Name>` | Container name, preferably lowercase |
+| `<Repository>` | Docker image, e.g. `ghcr.io/rackulalives/rackula` |
+| `<Registry>` | Link to the image's registry/hub page |
+| `<Network>` | Usually `bridge` or `host` |
+| `<WebUI>` | Web UI URL pattern using macros: `http://[IP]:[PORT:8080]/` (auto-builds the "WebUI" button) |
+| `<Icon>` | Direct **HTTPS** URL to a square PNG ("It has to be loaded over https") |
+| `<Support>` | "A link to a support thread on the Unraid forums for the container" |
+| `<Project>` | GitHub repo / project homepage URL |
+| `<Overview>` | "Basic description of the project" shown in CA (Markdown) |
+| `<Category>` | Category tags, e.g. `Tools:Management Productivity:` |
+| `<TemplateURL>` | Raw GitHub URL of this XML file (used for template updates) |
+| `<ExtraParams>` | Extra raw `docker run` flags, e.g. `--restart unless-stopped` |
+| `<Requires>` | Free-text prerequisites warning shown to the user (used by multi-part apps) |
+| `<ExtraSearchTerms>` | Space-delimited extra search keywords |
+| `<Privileged>` | Boolean privileged mode (security-sensitive; keep false) |
+| `<ReadMe>` / `<Banner>` / `<Screenshot>` / `<Beta>` | README link, banner, gallery shots, beta flag |
+
+Icon requirements specifically: a **direct HTTPS link to a PNG**, square, served over https;
+the canonical hosting pattern is a raw GitHub URL like
+`https://raw.githubusercontent.com/<owner>/<repo>/<branch>/img/<app>.png` (src 7). Theme
+variants `Icon-black` / `Icon-white` / etc. are optional (src 7).
+
+### The `<Config>` element (ports, paths, env vars, labels)
+
+Every port, volume, and environment variable is one `<Config>` entry. General shape (src 7):
+
+```xml
+<Config Name="Label" Target="destination" Default="value"
+        Type="Port|Path|Variable|Label|Device"
+        Mode="rw|ro|tcp"
+        Description="Help text shown to the user"
+        Display="always|advanced|always-hide|advanced-hide"
+        Required="true|false"
+        Mask="true|false"/>
+```
+
+Type-specific meaning (src 7):
+
+- **`Type="Port"`** - `Target` is the *container* port (e.g. `8080`), `Mode` is the
+  protocol (`tcp`/`udp`), `Default` is the suggested *host* port. Pairs with `<WebUI>`.
+- **`Type="Path"`** - `Target` is the *container* mount path (e.g. `/data`), `Default` is
+  the suggested host path (e.g. `/mnt/user/appdata/rackula`), `Mode` is `rw`/`ro`. Guidance:
+  "If it's a proper appdata location, set required to yes" (src 7).
+- **`Type="Variable"`** - `Target` is the *env var name* (e.g. `RACKULA_AUTH_MODE`); no
+  `Mode`; `Mask="true"` hides the value behind asterisks (use for secrets/session keys).
+- **`Type="Label"`** - display-only text, no user input.
+- **`Type="Device"`** - maps a host device into the container.
+
+Shared attributes (src 7): `Display` controls visibility tier - `always` (basic, editable),
+`always-hide` (basic, locked), `advanced` (advanced view, editable), `advanced-hide`. A
+pipe-delimited `Default` renders a **dropdown**, which is ideal for Rackula's auth mode,
+e.g. `Default="none|local|oidc"` (src 7).
+
+### Annotated skeleton for Rackula (frontend container)
+
+```xml
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>rackula</Name>
+  <Repository>ghcr.io/rackulalives/rackula</Repository>
+  <Registry>https://github.com/RackulaLives/Rackula/pkgs/container/rackula</Registry>
+  <Network>bridge</Network>
+  <Privileged>false</Privileged>
+  <Support>https://forums.unraid.net/topic/XXXXXX-support-rackula/</Support>
+  <Project>https://github.com/RackulaLives/Rackula</Project>
+  <Overview>Rackula is a rack layout designer for homelabbers. This container
+    serves the frontend. Add the optional Rackula API container for persistence
+    and local/OIDC auth.</Overview>
+  <Category>Productivity: Tools:Utilities:</Category>
+  <WebUI>http://[IP]:[PORT:8080]/</WebUI>
+  <Icon>https://raw.githubusercontent.com/RackulaLives/Rackula/main/static/icon.png</Icon>
+  <TemplateURL>https://raw.githubusercontent.com/RackulaLives/unraid-templates/main/rackula.xml</TemplateURL>
+  <ExtraParams>--restart unless-stopped</ExtraParams>
+
+  <!-- HTTP port: container 8080 -> suggested host 8080 -->
+  <Config Name="WebUI Port" Target="8080" Default="8080" Mode="tcp"
+          Type="Port" Display="always" Required="true" Mask="false"
+          Description="Port for the Rackula web interface."/>
+
+  <!-- Example env var as a dropdown -->
+  <Config Name="Auth Mode" Target="RACKULA_AUTH_MODE" Default="none|local|oidc"
+          Type="Variable" Display="always" Required="false" Mask="false"
+          Description="Authentication mode. 'none' is fine for a trusted LAN."/>
+
+  <!-- Trust proxy flag (relevant behind SWAG/NPM, see section 4) -->
+  <Config Name="Trust Proxy" Target="RACKULA_TRUST_PROXY" Default="false|true"
+          Type="Variable" Display="advanced" Required="false" Mask="false"
+          Description="Set true only when Rackula sits behind a reverse proxy."/>
+</Container>
+```
+
+The optional API container would be a **second, separate template** of the same shape, with
+`<Repository>` pointing at the Bun API image, a `Type="Port"` for `3001`, and a `Type="Path"`
+mapping `/data` to `/mnt/user/appdata/rackula` (see section 3 for why two templates).
+
+---
+
+## 3. Multi-container apps on Unraid (frontend + optional API)
+
+This is the key architectural question, because CA is hard-wired to **one container per
+template** (section 1, src 1). There is no Compose/stack primitive in stock CA; an app that
+needs N containers is expressed as N independent templates the user installs in sequence.
+
+### How real multi-part apps handle it (prevailing patterns)
+
+- **Uptime Kuma** - genuinely single-container. One image, one template, a `/app/data`
+  volume; no second service needed (src 6). This is the easy baseline.
+- **Homepage (gethomepage)** - also single-container; one image plus a config volume (src 5).
+- **KitchenOwl (frontend + backend)** - the most instructive concrete example for Rackula.
+  Its evolution is documented: "The setup changed so that the frontend is now required... it's
+  recommended to host the frontend too, with traffic routed through there to the backend"
+  (src "KitchenOwl" search). Two distribution shapes coexist in CA:
+  1. **One combined template/image** - "there's a template that includes both front and
+     backend in one template that you can install from Community Applications" (src KitchenOwl).
+  2. **Two separate containers** - if run apart, the user installs both and wires them with
+     env vars: "FRONT_URL should point to the local IP & Port of the WebUI container, and
+     BACK_URL should point to the Backend Container's IP & Port" (src KitchenOwl).
+- **Homelabarr** - ships a **backend template and a frontend template** explicitly "designed
+  to be used in conjunction with" each other (src "multi-container" search) - the pure
+  two-template model.
+
+So across the ecosystem there are three idiomatic answers, in rough order of user-friendliness:
+
+1. **One combined image** (a single container running both processes, e.g. via s6/supervisor
+   or an nginx that also proxies an internal API). User installs one template - simplest UX,
+   most maintenance burden on the maintainer's image.
+2. **Two templates, user adds the second** - the Homelabarr / KitchenOwl-split model. Each
+   template is independent; the optional one is genuinely optional. The `<Requires>` element
+   and the `<Overview>` text are used to tell the user "this needs the other container."
+3. **Frontend-only template + docs** - ship just the always-needed container and document the
+   optional second container for advanced users.
+
+### Idiomatic answer for Rackula's *optional* API
+
+Rackula's API is **optional** (frontend works standalone with auth-mode `none`). That maps
+cleanly to model **2**: publish a primary **`rackula` (frontend)** template plus a separate
+**`rackula-api`** template. The frontend `<Overview>` advertises the API as optional; the API
+template carries the `/data` volume and the auth/session env vars. This keeps the common case
+one-click (frontend only) while letting persistence/OIDC users add the second container, and
+it avoids the maintenance cost of building/shipping a fat combined image just to satisfy CA's
+one-container rule. A combined single image would only be justified if we wanted the
+persistence path to be the default zero-config experience; given the API is explicitly
+optional, two templates is the better fit. (Synthesis from src 1 + KitchenOwl/Homelabarr.)
+
+---
+
+## 4. Reverse proxy / SSL patterns on Unraid
+
+Most Unraid users do not expose containers directly; they put a reverse proxy in front for
+HTTPS. The two dominant choices in the Unraid/homelab community are **SWAG**
+(LinuxServer.io's nginx + built-in Certbot + fail2ban) and **Nginx Proxy Manager (NPM)**,
+with **Traefik** as the more advanced, label-driven option (src "reverse proxy" search,
+src 11). SWAG "just works for most users" and ships "preset reverse proxy config files... for
+popular apps," whereas Traefik is more automated via Docker labels but more involved to set
+up; NPM is the GUI-first option favoured by users who want point-and-click (src reverse-proxy
+search). In practice **SWAG and NPM are the most common on Unraid**, both nginx-based.
+
+The standard Unraid pattern: put SWAG/NPM and the app on a **shared Docker "proxy" network**
+so the proxy can reach the app by container name, then the proxy terminates TLS and forwards
+to the app's internal port (src 10). For SWAG specifically, each app's proxy config
+`include /config/nginx/proxy.conf;`, which sets the forwarded headers (src "X-Forwarded"
+search):
+
+```nginx
+proxy_set_header X-Real-IP        $remote_addr;
+proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+```
+
+### Why this matters for Rackula's `RACKULA_TRUST_PROXY` and secure cookies
+
+The proxy terminates HTTPS and talks to Rackula over plain HTTP internally. The backend
+therefore cannot tell from the socket that the *client* used HTTPS; it must read
+`X-Forwarded-Proto` (src "X-Forwarded" search). That header "tells the backend application
+whether the original request came through HTTPS or HTTP" and "prevents issues where an
+application might reject or downgrade secure cookies when it incorrectly detects the
+connection protocol" (src "X-Forwarded" search). This is exactly the situation
+`RACKULA_TRUST_PROXY` exists for: when set, Rackula should honour `X-Forwarded-Proto` so its
+auth-session cookies get the `Secure` attribute and OIDC redirect URLs are built as `https://`.
+
+**Distribution implication:** the CA template should expose `RACKULA_TRUST_PROXY` as an
+**advanced** `Type="Variable"` defaulting to `false` (LAN-direct case), and the support
+thread / `<Overview>` should tell SWAG/NPM users to set it `true`. There is no Unraid-specific
+code change needed - just correct documentation and a discoverable env var in the template.
+
+---
+
+## 5. Plugin (.plg) model and why it's wrong for a Dockerized app
+
+### What a `.plg` is
+
+An Unraid plugin is an XML `.plg` descriptor that "integrate[s] directly with the operating
+system, enabling system-level enhancements... beyond what isolated containers can provide"
+(src 13). A `.plg` can install Slackware packages, drop files anywhere on the system, and
+**run arbitrary scripts at array start / boot**; plugins are granted "full filesystem access"
+and "deep integration with Unraid OS and the WebGUI" (src 13). That power is the point for
+things like driver/hardware plugins - and exactly the problem for an app that is already a
+self-contained Docker image.
+
+### The official guidance is explicit
+
+Unraid's own docs say to "reserve plugins for features that require direct integration with
+Unraid OS" and to use Docker containers "whenever you can"; plugins are for "system-level
+services or enhancements that need direct access to Unraid OS or the WebGUI" and "features
+that cannot be provided as Docker containers" (src 13, src "plugin vs docker" search).
+Rackula meets none of those criteria - it is a web app that already ships as a container.
+
+### Concrete reasons Rackula should NOT ship as a plugin
+
+1. **No isolation / larger attack surface.** Containers "run safely in isolated
+   environments, while plugins have direct OS access"; plugins' "full filesystem access
+   increases security risks" (src 13). Shipping a web app as a plugin would hand a web-facing
+   app root-level host access for zero benefit, whereas the container model sandboxes it.
+
+2. **Higher moderation/trust bar, less benefit.** The official advice is "only install
+   plugins from trusted sources or well-known developers" (src 13) - i.e. plugins carry a
+   heavier trust expectation than a routine CA Docker template, which only needs the
+   moderation team's "basic vetting" (src 1). A new app clears the Docker-template bar far
+   more easily.
+
+3. **Must survive every Unraid OS upgrade.** Plugins "can cause system instability,
+   especially after OS updates," and when Unraid upgrades it "won't automatically remove
+   incompatible plugins already installed" - users must manually check release notes for
+   plugin breakage (src 13). A plugin is thus an open-ended maintenance commitment tied to
+   the host OS lifecycle. A container is decoupled: image pinning and the normal Apps-tab
+   update flow keep working across OS upgrades (src "plugin vs docker" search).
+
+4. **Wrong tool for the job / no packaging win.** Rackula is portable across any Docker host
+   (it already runs on the homelab, VPS, etc.). A `.plg` would re-implement install/upgrade
+   logic that the container runtime + CA already provide for free, and would only run on
+   Unraid - strictly more code to maintain for a strictly smaller audience.
+
+**Verdict:** plugin distribution is rejected. The CA Docker template path gives one-click
+install, container isolation, OS-upgrade resilience, a lower review bar, and reuse of the
+existing image - with the only cost being human review latency at submission time.
+
+---
+
+## Sources (numbered URL list)
+
+1. Community Applications - Unraid Docs: https://docs.unraid.net/unraid-os/using-unraid-to/run-docker-containers/community-applications/
+2. (also) Community Applications manual page - Unraid Docs: https://docs.unraid.net/unraid-os/manual/applications/
+3. selfhosters/unRAID-CA-templates (community request repo + quality bar + slow-down notice): https://github.com/selfhosters/unRAID-CA-templates
+4. Docker Template XML Schema (forum thread, authoritative schema): https://forums.unraid.net/topic/38619-docker-template-xml-schema/
+5. Unraid Community Apps catalogue (public mirror): https://ca.unraid.net/apps  /  https://unraid.net/community/apps
+6. [Plug-In] Community Applications support thread (CA is itself a plugin, build dates): https://forums.unraid.net/topic/38582-plug-in-community-applications/
+7. Writing a template compatible for Unraid - Selfhosters.net (full XML schema + Config attrs + icon rules): https://selfhosters.net/docker/templating/templating/
+8. Unraid Community Apps catalog: https://ca.unraid.net/
+9. Unraid wiki DockerTemplateSchema (now 301-redirects to docs.unraid.net): https://wiki.unraid.net/DockerTemplateSchema
+10. Cloudflare Tunnel + SWAG nginx reverse proxy on Unraid (proxy-network pattern): https://christiantietze.de/posts/2025/05/cloudflare-tunnel-swag-nginx-reverse-proxy-unraid/
+11. linuxserver/docker-swag (SWAG: nginx + Certbot + fail2ban): https://github.com/linuxserver/docker-swag  /  reverse-proxy confs: https://github.com/linuxserver/reverse-proxy-confs
+12. community.applications.plg (Squidly271, the CA plugin descriptor): https://raw.githubusercontent.com/Squidly271/community.applications/master/plugins/community.applications.plg
+13. Plugins - Unraid Docs (what .plg is, security, OS-upgrade caveats, "reserve plugins for..."): https://docs.unraid.net/unraid-os/using-unraid-to/customize-your-experience/plugins/
+
+KitchenOwl multi-container template references (frontend/backend split + combined-image option):
+- https://github.com/UnknownHiker/unraid-template-kitchenowl/blob/main/README.md
+- https://codeberg.org/HanSolo97/unraid-templates/src/branch/main/README.md
+- https://codeberg.org/HanSolo97/unraid-templates/issues/4 (frontend became required)
+
+SWAG X-Forwarded-Proto / secure-cookie references:
+- https://docs.ibracorp.io/docs/reverse-proxies/swag/
+- https://github.com/linuxserver/reverse-proxy-confs/issues/310
+
+Plugins vs Docker (official guidance + community thread):
+- https://forums.unraid.net/topic/35906-docker-vs-plugins/
+- https://docs.unraid.net/unraid-os/manual/applications/

--- a/docs/research/1995-patterns.md
+++ b/docs/research/1995-patterns.md
@@ -1,0 +1,526 @@
+# Spike #1995 - Pattern Analysis & Synthesis (Rackula on Unraid)
+
+**Date:** 2026-06-08
+**Purpose:** Synthesis pass over `1995-codebase.md` and `1995-external.md`, applying a
+SECURE-CODING lens and a DEVIL'S-ADVOCATE lens, to feed implementation issue #1317.
+**Decided direction (not re-litigated here):** Community Applications (CA) Docker template;
+native Plugin (.plg) rejected.
+
+---
+
+## Key Insights
+
+Distilled from the two research files, the facts that actually drive the #1317 design:
+
+1. **CA installs exactly one container per template.** There is no Compose/stack primitive
+   in stock CA: an app needing N containers is N independent templates installed in sequence
+   (`1995-external.md` section 1, section 3). This single-container-per-template rule is the
+   pivot the whole distribution model turns on.
+
+2. **The API is genuinely optional.** The frontend nginx image (`nginxinc/nginx-unprivileged`,
+   port 8080, UID 101) is fully functional standalone with `RACKULA_AUTH_MODE=none` and no
+   volume. Persistence and auth require the Bun API sidecar (port 3001, UID 1001, `/data`
+   volume) (`1995-codebase.md` frontend/API sections, Open Question #1). This maps cleanly to
+   the ecosystem's two-template "optional second container" pattern (Homelabarr/KitchenOwl-split,
+   `1995-external.md` section 3).
+
+3. **Frontend-only with no volume is silently ephemeral, but for a different reason than
+   most apps.** Rackula's primary persistence is actually the browser (the SPA works without
+   any backend). The API adds *server-side* shared persistence. So "frontend only" is not
+   "data lost on restart" for the casual single-browser user; it is "no server-side storage,
+   no cross-device sync, no auth." This nuance matters for the devil's-advocate section: the
+   "my layouts don't save" failure mode is real but narrower than the codebase doc's blunt
+   "all data lost on restart" framing implies.
+
+4. **Auth is opt-in and fails closed when misconfigured.** Default is `none` (anonymous
+   read/write). When `RACKULA_AUTH_MODE != none`, the API *refuses to start* without
+   `RACKULA_AUTH_SESSION_SECRET` (32+ chars); `local` additionally requires username and a
+   12+ char password (Argon2id, OWASP params, plaintext scrubbed from env after bootstrap,
+   login rate-limited 5/60s, timing-safe compare). CSRF protection and Secure cookies turn on
+   automatically when auth is enabled (`1995-codebase.md` auth sections). The security model is
+   already solid; the Unraid risk is almost entirely in *how the template surfaces these knobs*,
+   not in the app code.
+
+5. **The reverse-proxy story is a documentation problem, not a code problem.**
+   `RACKULA_TRUST_PROXY` already exists to honour `X-Forwarded-Proto` behind SWAG/NPM (the two
+   dominant Unraid proxies, both nginx-based). No Unraid-specific code change is needed; the
+   template just needs to expose the flag as an advanced variable and the support thread must
+   explain when to flip it (`1995-external.md` section 4).
+
+6. **Plugin path is definitively wrong and the research closes it.** A `.plg` gets full host
+   filesystem access, must survive every Unraid OS upgrade, and carries a higher trust bar for
+   zero packaging benefit on an app that already ships as a container (`1995-external.md`
+   section 5). Not reopened here.
+
+7. **The real friction is human, not technical.** CA submission requires a self-hosted template
+   repo (`Owner/unraid-templates`), an Unraid *forum support thread*, and passes through a
+   volunteer moderation review (days to weeks) with an explicit account-quality screen:
+   "made by a user with previous activity on GitHub... attributed to a GitHub account with an
+   active history... not fully AI written" (`1995-external.md` section 1). Whether RackulaLives
+   has a usable Unraid *forum* account is an open prerequisite (see Recommendation summary).
+
+---
+
+## Recommended distribution model
+
+**CA Docker template, two-template approach.** Ship two independent CA templates plus a
+self-hosted template repo, an icon, and a forum support thread.
+
+### Template 1: `rackula` (frontend, always installed)
+
+- **Image:** `ghcr.io/rackulalives/rackula` (pin a tag, see secure-coding lens)
+- **Exposes:**
+  - Port `8080/tcp` (container) -> suggested host `8080`, drives the WebUI button
+  - `RACKULA_AUTH_MODE` dropdown (`none|local|oidc`), default `none`, basic visibility
+  - `API_HOST` / `API_PORT` (advanced) so a persistence user can point the frontend at the
+    API container by name/IP
+  - `RACKULA_TRUST_PROXY` (advanced, default `false`) for SWAG/NPM users
+  - `RACKULA_API_WRITE_TOKEN` (advanced, `Mask="true"`) when wiring writes to the API
+- **No volume.** Frontend is stateless.
+- **Overview text must state:** persistence/auth need the separate `rackula-api` container;
+  without it, layouts live only in the browser.
+
+### Template 2: `rackula-api` (optional, for persistence/auth/OIDC)
+
+- **Image:** `ghcr.io/rackulalives/rackula-api` (pinned tag)
+- **Exposes:**
+  - Port `3001/tcp` (advanced; only needed if frontend reaches it across networks; normally the
+    two share a Docker network and talk by container name)
+  - Path `/data` -> default host `/mnt/user/appdata/rackula`, `Mode="rw"`, `Required="true"`
+  - `RACKULA_AUTH_MODE` dropdown (`none|local|oidc`), default `none`
+  - `RACKULA_AUTH_SESSION_SECRET` (`Mask="true"`, no baked default; required when auth != none)
+  - `RACKULA_LOCAL_USERNAME` / `RACKULA_LOCAL_PASSWORD` (the password `Mask="true"`; shown when
+    mode=local)
+  - `RACKULA_API_WRITE_TOKEN` (`Mask="true"`, advanced)
+  - OIDC provider settings (advanced; flagged as under-documented, see open questions)
+- **`<Requires>`** text: "Pair with the Rackula frontend container."
+
+### Self-hosted template repo
+
+`RackulaLives/unraid-templates` holding `rackula.xml` and `rackula-api.xml`, each with a
+`<TemplateURL>` pointing at its own raw GitHub URL so CA can fetch template updates
+(`1995-external.md` section 1-2). This is the modern recommended path; the shared
+`selfhosters/unRAID-CA-templates` request repo has announced a slow-down and now steers new
+apps to their own repos.
+
+### Icon hosting
+
+Direct HTTPS link to a square PNG, e.g.
+`https://raw.githubusercontent.com/RackulaLives/Rackula/main/static/icon.png`
+(must be https, must be PNG, `1995-external.md` section 2). Confirm such a PNG exists at a
+stable path (the codebase doc references icon files but not a confirmed square PNG asset).
+
+### Support thread
+
+One Unraid forum thread covering both containers; its URL goes in each template's `<Support>`.
+
+### The common case stays trivial
+
+Install `rackula`, accept defaults (`auth_mode=none`, no volume), click Apply, open the WebUI.
+One container, zero secrets, one-click. The two-template complexity only appears for users who
+deliberately want server-side persistence or auth.
+
+### Annotated XML skeleton: `rackula` (frontend, full)
+
+```xml
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>rackula</Name>
+  <Repository>ghcr.io/rackulalives/rackula:26.6.0</Repository><!-- pin, not :latest -->
+  <Registry>https://github.com/RackulaLives/Rackula/pkgs/container/rackula</Registry>
+  <Network>bridge</Network>
+  <Privileged>false</Privileged>
+  <Support>https://forums.unraid.net/topic/XXXXXX-support-rackula/</Support>
+  <Project>https://github.com/RackulaLives/Rackula</Project>
+  <Overview>Rackula is a rack layout designer for homelabbers. This container serves the
+    web frontend and works on its own for a single browser. For server-side persistence,
+    cross-device storage, or login (local/OIDC), also install the optional "rackula-api"
+    container and point API Host at it. Default auth is "none" - safe on a trusted LAN,
+    do NOT expose this to the internet without enabling auth.</Overview>
+  <Category>Productivity: Tools:Utilities:</Category>
+  <WebUI>http://[IP]:[PORT:8080]/</WebUI>
+  <Icon>https://raw.githubusercontent.com/RackulaLives/Rackula/main/static/icon.png</Icon>
+  <TemplateURL>https://raw.githubusercontent.com/RackulaLives/unraid-templates/main/rackula.xml</TemplateURL>
+  <ExtraParams>--restart unless-stopped</ExtraParams>
+
+  <Config Name="WebUI Port" Target="8080" Default="8080" Mode="tcp"
+          Type="Port" Display="always" Required="true" Mask="false"
+          Description="Host port for the Rackula web interface."/>
+
+  <Config Name="Auth Mode" Target="RACKULA_AUTH_MODE" Default="none|local|oidc"
+          Type="Variable" Display="always" Required="false" Mask="false"
+          Description="none = anonymous (trusted LAN only). local = username/password.
+            oidc = external identity provider. Auth is enforced by the rackula-api
+            container; this setting must match it."/>
+
+  <Config Name="API Host" Target="API_HOST" Default="rackula-api"
+          Type="Variable" Display="advanced" Required="false" Mask="false"
+          Description="Container name or IP of the rackula-api container. Only needed if
+            you installed the API for persistence/auth."/>
+
+  <Config Name="API Port" Target="API_PORT" Default="3001"
+          Type="Variable" Display="advanced" Required="false" Mask="false"
+          Description="Port the rackula-api container listens on (default 3001)."/>
+
+  <Config Name="Trust Proxy" Target="RACKULA_TRUST_PROXY" Default="false|true"
+          Type="Variable" Display="advanced" Required="false" Mask="false"
+          Description="Set true ONLY when Rackula sits behind a reverse proxy (SWAG, NPM,
+            Traefik) that terminates HTTPS. Lets secure cookies and redirects use https."/>
+
+  <Config Name="API Write Token" Target="API_WRITE_TOKEN" Default=""
+          Type="Variable" Display="advanced" Required="false" Mask="true"
+          Description="Optional bearer token nginx injects on write requests to the API.
+            Must match RACKULA_API_WRITE_TOKEN on the rackula-api container."/>
+</Container>
+```
+
+### Annotated XML skeleton: `rackula-api` (optional)
+
+```xml
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>rackula-api</Name>
+  <Repository>ghcr.io/rackulalives/rackula-api:26.6.0</Repository><!-- pin, not :latest -->
+  <Registry>https://github.com/RackulaLives/Rackula/pkgs/container/rackula-api</Registry>
+  <Network>bridge</Network>
+  <Privileged>false</Privileged>
+  <Support>https://forums.unraid.net/topic/XXXXXX-support-rackula/</Support>
+  <Project>https://github.com/RackulaLives/Rackula</Project>
+  <Overview>Optional persistence and auth backend for Rackula. Stores layouts and assets in
+    /data and provides local/OIDC login. Install this alongside the "rackula" frontend and
+    point the frontend's API Host at this container. Not needed for single-browser use.</Overview>
+  <Requires>Install the "rackula" frontend container too and set its API Host to this
+    container's name.</Requires>
+  <Category>Productivity: Tools:Utilities:</Category>
+  <Icon>https://raw.githubusercontent.com/RackulaLives/Rackula/main/static/icon.png</Icon>
+  <TemplateURL>https://raw.githubusercontent.com/RackulaLives/unraid-templates/main/rackula-api.xml</TemplateURL>
+  <ExtraParams>--restart unless-stopped</ExtraParams>
+
+  <!-- Data volume: a proper appdata location, so Required=true (src 7 guidance) -->
+  <Config Name="Data" Target="/data" Default="/mnt/user/appdata/rackula" Mode="rw"
+          Type="Path" Display="always" Required="true" Mask="false"
+          Description="Where Rackula stores layouts and uploaded assets."/>
+
+  <!-- Port only needed for cross-network access; usually container-to-container by name -->
+  <Config Name="API Port" Target="3001" Default="3001" Mode="tcp"
+          Type="Port" Display="advanced" Required="false" Mask="false"
+          Description="Only publish this if the frontend reaches the API across networks.
+            On a shared Docker network you do NOT need to expose it to the host."/>
+
+  <Config Name="Auth Mode" Target="RACKULA_AUTH_MODE" Default="none|local|oidc"
+          Type="Variable" Display="always" Required="false" Mask="false"
+          Description="Must match the frontend's Auth Mode."/>
+
+  <Config Name="Session Secret" Target="RACKULA_AUTH_SESSION_SECRET" Default=""
+          Type="Variable" Display="always" Required="false" Mask="true"
+          Description="REQUIRED when Auth Mode is local or oidc. Generate 32+ random
+            characters, e.g. `openssl rand -base64 48`. Leave blank only for auth=none.
+            The API will refuse to start with auth enabled and no secret."/>
+
+  <Config Name="Local Username" Target="RACKULA_LOCAL_USERNAME" Default=""
+          Type="Variable" Display="advanced" Required="false" Mask="false"
+          Description="Login username. Required only when Auth Mode is local."/>
+
+  <Config Name="Local Password" Target="RACKULA_LOCAL_PASSWORD" Default=""
+          Type="Variable" Display="advanced" Required="false" Mask="true"
+          Description="Login password, 12+ chars. Required only when Auth Mode is local.
+            Hashed at startup; not stored in plaintext after boot."/>
+
+  <Config Name="API Write Token" Target="RACKULA_API_WRITE_TOKEN" Default=""
+          Type="Variable" Display="advanced" Required="false" Mask="true"
+          Description="Optional bearer token guarding PUT/DELETE when not using session auth.
+            Must match API Write Token on the frontend."/>
+</Container>
+```
+
+Note: with `auth=none`, the `rackula-api` install is also one-click after setting the data
+path: dropdowns default to `none`, secret stays blank, persistence "just works." The secret
+and credential fields only become load-bearing when the user chooses `local`/`oidc`.
+
+---
+
+## Approaches considered & trade-offs
+
+| Approach | Pros | Cons | When it'd be right |
+|---|---|---|---|
+| **(A) Frontend-only single template + docs** | Simplest possible CA listing; one template to maintain; one-click; zero secrets in the common path | Persistence/auth is "go read a compose file" - hostile to point-and-click Unraid users; no in-CA way to add the API | If the API were experimental/rare, or if browser-only storage were the only intended model |
+| **(B) Two templates [RECOMMENDED]** | Matches CA's one-container rule and the proven Homelabarr/KitchenOwl-split pattern; common case stays one-click; persistence is still installable from the Apps tab; reuses existing images unchanged | Two listings to maintain; risk of "installed frontend, no persistence" confusion (addressed in devil's-advocate); user must wire `API_HOST` | The actual Rackula shape: an always-needed frontend + a genuinely optional backend |
+| **(C) One combined fat image** | True one-click persistence with zero wiring; single template | Requires building/shipping a NEW image (s6/supervisor running nginx + Bun together) that does not exist today; doubles the build/security/patch surface; bakes the API in even for users who do not want it; contradicts the project's "simplicity first / only build what's asked" philosophy | Only if zero-config persistence were the default desired experience. It is not - the API is explicitly optional, so C is solving a problem we do not have |
+| **(D) Plugin (.plg)** | Deep OS integration; could auto-manage everything | Full host filesystem access for a web app (huge attack surface); must survive every Unraid OS upgrade; higher trust/moderation bar; Unraid-only; re-implements install/upgrade the container runtime already gives us | Never, for this app. Reserved for hardware/driver/OS-level features Rackula does not have |
+
+**Concrete rejection of (C):** there is no combined image in the repo. Choosing C means a net-new
+Dockerfile running two runtimes under a process supervisor, a third image to publish on every
+release, and a larger CVE/patch surface, all to avoid one extra "Apps" click. The codebase
+already cleanly separates the two concerns (separate Dockerfiles, separate users, separate
+healthchecks). Merging them is more code for less isolation.
+
+**Concrete rejection of (D):** `1995-external.md` section 5 is decisive. The official Unraid
+guidance is "use Docker whenever you can; reserve plugins for features that need direct OS/WebGUI
+integration." Rackula is already a self-contained container. A plugin would hand a web-facing app
+root-level host access for zero benefit and add an open-ended OS-upgrade maintenance liability.
+
+---
+
+## SECURE-CODING lens
+
+Specific to this app on Unraid. Each item gives a concrete template/AC requirement, not generic
+advice.
+
+### 1. Auth defaults: shipping `auth_mode=none` on a LAN appliance
+
+**Verdict: acceptable as a default, but ONLY with explicit guardrail text.** Unraid's threat model
+is a trusted LAN where the user opts into exposure. Rackula's `none` mode = anonymous read AND
+write to the API. On an isolated LAN with no port-forward, that matches the homelab norm (the LXC
+distribution already ships `none` by default, `1995-codebase.md`). The danger is the user who
+later port-forwards 8080 or puts it on a public reverse proxy without flipping auth on. That turns
+an unauthenticated *write* API (create/delete layouts, upload assets) onto the internet.
+
+**Template/AC must enforce:**
+- Frontend `<Overview>` and the support thread state plainly: "Default auth is none. Safe on a
+  trusted LAN. Do NOT expose Rackula to the internet without setting Auth Mode to local or oidc."
+- The `RACKULA_AUTH_MODE` Description repeats the "trusted LAN only" caveat (already in the
+  skeleton above).
+- Do not market a "publish to the internet" path anywhere without auth in the same breath.
+
+### 2. Secrets handling: `RACKULA_AUTH_SESSION_SECRET` and friends
+
+**Critical Unraid-specific fact:** Unraid persists template values as plaintext XML under
+`/boot/config/plugins/dockerMan/templates-user` (`1995-external.md` section 1) and shows variable
+values in the Edit Container UI. A secret typed into a normal Variable is visible on screen and on
+the flash drive.
+
+**Template/AC must enforce:**
+- `RACKULA_AUTH_SESSION_SECRET` -> `Mask="true"` (hides it behind asterisks in the UI). This does
+  not encrypt the on-disk XML, but it prevents shoulder-surf/screenshot leakage, which is the
+  realistic Unraid exposure.
+- `RACKULA_LOCAL_PASSWORD` -> `Mask="true"`.
+- `RACKULA_API_WRITE_TOKEN` (both containers) -> `Mask="true"`.
+- `RACKULA_LOCAL_USERNAME` is not a secret -> leave unmasked.
+- **No baked default for the session secret, the password, or the write token.** A shipped default
+  secret would let anyone forge a valid HS256 session cookie against every default install on
+  earth. The app already requires the operator to supply it (the API refuses to start with auth
+  enabled and no secret), so the template must NOT paper over that with a `Default=`. Leave
+  `Default=""` and document `openssl rand -base64 48`.
+- Document that values live in plaintext on `/boot/config`, so the secret should be treated as
+  flash-drive-readable and rotated via `RACKULA_AUTH_SESSION_GENERATION` if the flash is ever
+  compromised.
+
+### 3. Write protection: `RACKULA_API_WRITE_TOKEN` / admin-role PUT/DELETE
+
+The API guards writes two ways: when auth is enabled, all PUT/DELETE require the admin session
+role; independently, an optional `RACKULA_API_WRITE_TOKEN` lets nginx inject a bearer on writes
+(`1995-codebase.md` write-route sections). The footgun is a persistence user on `auth=none` who
+wants reads-anonymous-but-writes-protected and does not realise neither protection is on by
+default.
+
+**Template/AC must enforce:**
+- Expose `RACKULA_API_WRITE_TOKEN` (api) and `API_WRITE_TOKEN` (frontend) as advanced, masked,
+  with Description: "set the SAME value on both containers to require a token for create/delete."
+- Make explicit in docs: `auth=none` + no write token = fully open read/write. That is fine for a
+  single-user isolated LAN and is the intended trivial path, but it is the exact config that must
+  never be internet-exposed.
+- Do NOT auto-bake a write token default in the template (same reasoning as the secret: a shared
+  default token is no protection). If auto-generation is wanted, it belongs in install tooling that
+  produces a *unique random* value, not a static template `Default=`.
+
+### 4. Reverse proxy / cookies: Secure-cookie + `RACKULA_TRUST_PROXY`
+
+The proxy terminates TLS and talks HTTP to the container; the app reads `X-Forwarded-Proto` only
+when `RACKULA_TRUST_PROXY=1` (`1995-external.md` section 4). Cookie `Secure` is forced on in prod
+and whenever `SameSite=None`. The breakage modes:
+- **Auth enabled + plain HTTP + `TRUST_PROXY=0`:** Secure cookies are set, browser refuses to send
+  them back over HTTP, login appears to "not work" (infinite redirect to login). This is a support
+  magnet.
+- **`TRUST_PROXY=1` set when NOT behind a trusted proxy:** the app would trust a client-spoofable
+  `X-Forwarded-Proto`, a (minor) downgrade/redirect risk.
+
+**Template/AC must enforce:**
+- Default `RACKULA_TRUST_PROXY=false` (correct for LAN-direct). Keep it advanced so casual users
+  never touch it.
+- Support thread documents the two-line rule: "Behind SWAG/NPM/Traefik with HTTPS -> set Trust
+  Proxy true. Direct LAN access over http:// -> leave it false, and if you enable auth, reach
+  Rackula over the proxy's https URL, not the raw http IP." The "enabled auth over plain HTTP"
+  failure must be called out explicitly because it presents as a non-obvious login loop, not an
+  error.
+
+### 5. Volume / permissions: `/data` UID mismatch
+
+This is the most concrete Unraid footgun. The API runs as **UID 1001** (`rackula` user); Unraid's
+appdata is conventionally owned by **nobody:users = 99:100**. Bind-mounting
+`/mnt/user/appdata/rackula` into a container that writes as 1001 means the process may be unable to
+create/write `/data` (permission denied), or it creates files owned by 1001 that the Unraid user
+cannot manage from the file browser. The frontend (nginx UID 101) is stateless so it is unaffected;
+this is purely an API-container issue.
+
+**Template/AC must enforce:**
+- Document the UID explicitly in the API template Description and support thread: "the API writes as
+  UID 1001."
+- Recommend one of: (a) `chown -R 1001:1001 /mnt/user/appdata/rackula` once at setup, or (b) if the
+  image/entrypoint supports `PUID`/`PGID`-style remapping, expose those - **but the codebase shows
+  no PUID/PGID handling**, so (a) is the realistic instruction unless #1317 adds PUID support.
+- Flag as an open implementation question for #1317: do we add LinuxServer-style PUID/PGID to the
+  API image (Unraid users expect it), or document the one-time chown? The chown is zero-code and
+  ships now; PUID support is a nicer UX but is new code.
+
+### 6. Supply chain: tag pinning and provenance
+
+The compose files and external skeleton both reach for `:latest` / `:persist`. `:latest` on Unraid
+means an unattended "force update" can pull a different image than was reviewed, silently changing
+behaviour or pulling a regression.
+
+**Template/AC must enforce:**
+- Templates pin a concrete version tag (`ghcr.io/rackulalives/rackula:26.6.0`) rather than
+  `:latest`, and the release process bumps the template tag in `RackulaLives/unraid-templates` per
+  release. This makes the Apps-tab "update available" prompt meaningful and reviewable.
+- The images already emit OCI labels (`org.opencontainers.image.source`, `.licenses=MIT`,
+  `.title`, version/commit/build-time on the API). Keep these accurate so provenance is inspectable
+  from the pulled image. AC: verify the published GHCR image carries the source label pointing at
+  `RackulaLives/Rackula`.
+- Both images are non-root (101 / 1001) and `<Privileged>false</Privileged>` must be set in both
+  templates. Do not let a copy-paste flip privileged on.
+
+---
+
+## DEVIL'S-ADVOCATE lens
+
+Putting on the hat of a long-time Unraid app maintainer / CA moderator who has watched a thousand
+"frontend + backend" submissions confuse users and rot in the catalogue.
+
+### "Is two templates actually worse UX than one?"
+
+Honestly, for the persistence user, yes, a bit, and the failure mode is predictable: someone
+installs `rackula`, makes layouts, restarts or switches browsers, and files "my layouts don't
+save." Here is the saving grace the codebase gives us, and it must be used: **the frontend alone is
+not dead.** Layouts persist in the browser. So the bug report is really "no cross-device / no
+server storage," not "total data loss." Prevent the confusion with three cheap moves:
+
+1. **Naming makes dependency obvious:** `rackula` and `rackula-api`. A user seeing `rackula-api` in
+   the Apps tab infers it is the backend half.
+2. **Frontend Overview states the boundary in plain words:** "works on its own for a single
+   browser; install rackula-api for server-side persistence / login." (Drafted above.)
+3. **API `<Requires>` text** tells API installers they need the frontend too.
+
+But be honest in #1317: this WILL generate some support traffic no matter what. The mitigation is
+documentation discipline, not a technical guarantee.
+
+### "Is a separate unraid-templates repo + forum thread + CA submission worth it vs just shipping `docker-compose.persist.yml`?"
+
+This is the sharpest challenge. Rackula ALREADY ships `docker-compose.persist.yml`. A meaningful
+slice of Unraid users run `docker compose` via the Compose Manager plugin and would be perfectly
+served by "here's our compose file." The CA route buys you **discoverability in the Apps tab** and
+the one-click frontend, which is real value for the non-compose crowd, but it costs:
+- a new repo to keep in sync with every image tag bump,
+- a forum thread someone must actually watch and answer,
+- the ongoing "respond to support requests / keep compatible with new Unraid releases / notify if
+  discontinuing" obligations CA explicitly imposes (`1995-external.md` section 1).
+
+**Who maintains the forum thread?** This is unanswered and is a real commitment, not a checkbox.
+If the answer is "nobody reliably," CA listing is the wrong move and documenting compose is the
+honest one. #1317 should name an owner or scope CA as "frontend template + compose docs for
+persistence" (a hybrid: list the trivial frontend in CA, point persistence users at the existing
+compose file, skip the second template until demand proves out).
+
+### "Does the optional-API split map to how Unraid users actually think?"
+
+Mostly yes. Unraid users add containers one at a time from the Apps tab; a primary + optional
+companion is a familiar shape (plenty of *arr-adjacent stacks work this way). The friction is not
+the two-step install, it is the **wiring** (`API_HOST` must match the API container's name, both
+must be on a reachable network, auth mode must match on both). That is more fiddly than the typical
+self-contained Unraid app and is exactly where users get stuck. If #1317 keeps the API container's
+default name `rackula-api` and the frontend's `API_HOST` default `rackula-api`, the happy path works
+with zero edits *provided both land on the same bridge network* - verify that assumption holds on
+Unraid's default bridge, because container-name DNS resolution is not guaranteed on the stock
+`bridge` network (it works on user-defined networks). **This is a concrete thing #1317 must test,
+not assume.**
+
+### "CA review / account-history prerequisite: can RackulaLives clear vetting?"
+
+Partly known, partly not.
+- **GitHub history: likely fine.** RackulaLives is a real org with an active repo and real release
+  history; the "previous activity on GitHub / not fully AI written" screen is plausibly met
+  (`1995-external.md` section 1).
+- **Unraid FORUM account: UNKNOWN and a hard prerequisite.** CA requires a support *forum thread*,
+  which means an Unraid forum account in good standing. The research does not establish that
+  RackulaLives/the maintainer has one. **Flag as a prerequisite/blocker for #1317:** if there is no
+  established Unraid forum presence, that account (and the thread) must be created before submission,
+  and a brand-new forum account with no history may itself draw moderation scrutiny. Do not assume
+  this is free.
+
+### "Will the auth-mode dropdown (none/local/oidc) confuse users, especially OIDC on a LAN box?"
+
+Yes, `oidc` is a foot-gun on the dropdown for a LAN appliance. Most Unraid users want `none` or, at
+most, `local`. Exposing `oidc` as a peer option invites someone to pick it and then hit the
+under-documented OIDC provider config (`1995-codebase.md` notes OIDC env vars are not fully
+enumerated, and OIDC setup is "MVP"). Recommendation for #1317:
+- Keep the dropdown `none|local|oidc` (matches the app), but in the Description steer plainly:
+  "Most homelab users want none or local. oidc requires an external identity provider and extra
+  configuration."
+- Treat OIDC-on-Unraid as **explicitly out of scope for the first listing's documentation** until
+  the OIDC env surface is documented. Shipping a dropdown option the docs cannot fully support is a
+  support-debt generator.
+
+### "Anything that makes me say 'this is more work than #1317 assumes'?"
+
+Yes, three things:
+1. **The UID 1001 vs 99:100 permission mismatch** (secure-coding item 5) is the kind of detail that
+   turns "install and go" into a forum thread full of "permission denied" reports. Either add PUID
+   support (new code) or document the chown loudly. Not free.
+2. **Container-name networking on stock bridge** (above) may force a "create a user-defined Docker
+   network" instruction, which is an extra manual step most one-click apps do not need. Must be
+   verified on real Unraid.
+3. **The forum thread + ongoing support obligation** is a standing human cost, not a one-time
+   implementation task. CA can *delist* unmaintained apps. #1317 should not pretend the work ends at
+   "XML merged."
+
+---
+
+## Recommendation summary
+
+**Bottom line:** Ship the two-template CA model (frontend always, API optional). It is the correct,
+ecosystem-proven fit for Rackula's optional-backend shape, reuses the existing images unchanged, and
+keeps the common case one-click. The technical work is genuinely small; the real costs are (a) a few
+specific Unraid footguns the templates must defend against and (b) standing human/process
+commitments that are easy to under-scope. Do NOT combine into a fat image, do NOT ship a plugin.
+
+### IMPLEMENTATION (belongs in #1317)
+
+1. Author `rackula.xml` and `rackula-api.xml` per the skeletons above.
+2. Mask secrets: `RACKULA_AUTH_SESSION_SECRET`, `RACKULA_LOCAL_PASSWORD`, write tokens ->
+   `Mask="true"`; no baked defaults for any of them.
+3. Pin image tags (not `:latest`); wire template tag bumps into the release process.
+4. Set `<Privileged>false</Privileged>` on both; `/data` as `Required` rw path defaulting to
+   `/mnt/user/appdata/rackula`.
+5. Default `RACKULA_AUTH_MODE=none` and `RACKULA_TRUST_PROXY=false`; both surfaced with caveat
+   Descriptions.
+6. Write the guardrail Overview/Description text (auth=none is LAN-only; do not expose to internet
+   without auth; behind a proxy set Trust Proxy true; API writes as UID 1001).
+7. Decide and implement the `/data` permissions story: document the one-time chown (zero-code, ships
+   now) OR add PUID/PGID support to the API image (new code, nicer UX) - pick one in #1317.
+8. **Verify on real Unraid:** container-name resolution between `rackula` and `rackula-api` on the
+   default bridge; if it fails, add a "create a user-defined network" step to the docs.
+9. Confirm a square HTTPS PNG icon exists at a stable raw-GitHub path; add one if not.
+
+### PREREQUISITE / RESEARCH-RESOLVED
+
+- Distribution model decision (CA, two templates, no plugin): **resolved** by this spike.
+- CA workflow (self-host repo + forum thread + submission form, one-container-per-template rule,
+  masked-variable mechanics, icon/proxy/cookie behaviour): **resolved**.
+- GitHub account-quality screen: **likely met** (real org, real history) - confirm, don't assume.
+- **Unraid forum account in good standing + a support thread: UNRESOLVED prerequisite.** Must exist
+  before CA submission. Open question: who owns it.
+- **OIDC-on-Unraid documentation: out of scope** for the first listing until the OIDC env surface is
+  documented elsewhere; the dropdown keeps the option but docs steer to none/local.
+
+### NEW / SEPARATE WORKSTREAM (not #1317 implementation)
+
+- **Create and maintain `RackulaLives/unraid-templates`** repo (hosting + `<TemplateURL>` self-
+  reference + release-time tag sync). Small but ongoing.
+- **Create the Unraid forum support thread and assign an owner** to answer it. This is a standing
+  human commitment CA can enforce via delisting; it is not a code task and should be tracked
+  separately from #1317.
+- **CA submission + moderation cycle** (days to weeks, human-gated): track as its own task gated on
+  the repo, thread, and icon being ready.
+- **(Optional, demand-driven) hybrid fallback:** if no one can own the forum thread, scope down to
+  "list the frontend template in CA, document `docker-compose.persist.yml` for persistence" instead
+  of the second template. Worth holding as the escape hatch if the human-maintenance cost cannot be
+  met.

--- a/docs/research/1995-patterns.md
+++ b/docs/research/1995-patterns.md
@@ -75,7 +75,7 @@ self-hosted template repo, an icon, and a forum support thread.
   - `API_HOST` / `API_PORT` (advanced) so a persistence user can point the frontend at the
     API container by name/IP
   - `RACKULA_TRUST_PROXY` (advanced, default `false`) for SWAG/NPM users
-  - `RACKULA_API_WRITE_TOKEN` (advanced, `Mask="true"`) when wiring writes to the API
+  - `API_WRITE_TOKEN` (advanced, `Mask="true"`) when wiring writes to the API (the frontend's env var is `API_WRITE_TOKEN`; it must match `RACKULA_API_WRITE_TOKEN` on the API container)
 - **No volume.** Frontend is stateless.
 - **Overview text must state:** persistence/auth need the separate `rackula-api` container;
   without it, layouts live only in the browser.

--- a/docs/research/1995-patterns.md
+++ b/docs/research/1995-patterns.md
@@ -12,27 +12,27 @@ native Plugin (.plg) rejected.
 
 Distilled from the two research files, the facts that actually drive the #1317 design:
 
-1. **CA installs exactly one container per template.** There is no Compose/stack primitive
+1. CA installs exactly one container per template. There is no Compose/stack primitive
    in stock CA: an app needing N containers is N independent templates installed in sequence
    (`1995-external.md` section 1, section 3). This single-container-per-template rule is the
    pivot the whole distribution model turns on.
 
-2. **The API is genuinely optional.** The frontend nginx image (`nginxinc/nginx-unprivileged`,
+2. The API is genuinely optional. The frontend nginx image (`nginxinc/nginx-unprivileged`,
    port 8080, UID 101) is fully functional standalone with `RACKULA_AUTH_MODE=none` and no
    volume. Persistence and auth require the Bun API sidecar (port 3001, UID 1001, `/data`
    volume) (`1995-codebase.md` frontend/API sections, Open Question #1). This maps cleanly to
    the ecosystem's two-template "optional second container" pattern (Homelabarr/KitchenOwl-split,
    `1995-external.md` section 3).
 
-3. **Frontend-only with no volume is silently ephemeral, but for a different reason than
-   most apps.** Rackula's primary persistence is actually the browser (the SPA works without
+3. Frontend-only with no volume is silently ephemeral, but for a different reason than
+   most apps. Rackula's primary persistence is actually the browser (the SPA works without
    any backend). The API adds *server-side* shared persistence. So "frontend only" is not
    "data lost on restart" for the casual single-browser user; it is "no server-side storage,
    no cross-device sync, no auth." This nuance matters for the devil's-advocate section: the
    "my layouts don't save" failure mode is real but narrower than the codebase doc's blunt
    "all data lost on restart" framing implies.
 
-4. **Auth is opt-in and fails closed when misconfigured.** Default is `none` (anonymous
+4. Auth is opt-in and fails closed when misconfigured. Default is `none` (anonymous
    read/write). When `RACKULA_AUTH_MODE != none`, the API *refuses to start* without
    `RACKULA_AUTH_SESSION_SECRET` (32+ chars); `local` additionally requires username and a
    12+ char password (Argon2id, OWASP params, plaintext scrubbed from env after bootstrap,
@@ -41,18 +41,18 @@ Distilled from the two research files, the facts that actually drive the #1317 d
    already solid; the Unraid risk is almost entirely in *how the template surfaces these knobs*,
    not in the app code.
 
-5. **The reverse-proxy story is a documentation problem, not a code problem.**
+5. The reverse-proxy story is a documentation problem, not a code problem.
    `RACKULA_TRUST_PROXY` already exists to honour `X-Forwarded-Proto` behind SWAG/NPM (the two
    dominant Unraid proxies, both nginx-based). No Unraid-specific code change is needed; the
    template just needs to expose the flag as an advanced variable and the support thread must
    explain when to flip it (`1995-external.md` section 4).
 
-6. **Plugin path is definitively wrong and the research closes it.** A `.plg` gets full host
+6. Plugin path is definitively wrong and the research closes it. A `.plg` gets full host
    filesystem access, must survive every Unraid OS upgrade, and carries a higher trust bar for
    zero packaging benefit on an app that already ships as a container (`1995-external.md`
    section 5). Not reopened here.
 
-7. **The real friction is human, not technical.** CA submission requires a self-hosted template
+7. The real friction is human, not technical. CA submission requires a self-hosted template
    repo (`Owner/unraid-templates`), an Unraid *forum support thread*, and passes through a
    volunteer moderation review (days to weeks) with an explicit account-quality screen:
    "made by a user with previous activity on GitHub... attributed to a GitHub account with an
@@ -68,22 +68,22 @@ self-hosted template repo, an icon, and a forum support thread.
 
 ### Template 1: `rackula` (frontend, always installed)
 
-- **Image:** `ghcr.io/rackulalives/rackula` (pin a tag, see secure-coding lens)
-- **Exposes:**
+- Image: `ghcr.io/rackulalives/rackula` (pin a tag, see secure-coding lens)
+- Exposes:
   - Port `8080/tcp` (container) -> suggested host `8080`, drives the WebUI button
   - `RACKULA_AUTH_MODE` dropdown (`none|local|oidc`), default `none`, basic visibility
   - `API_HOST` / `API_PORT` (advanced) so a persistence user can point the frontend at the
     API container by name/IP
   - `RACKULA_TRUST_PROXY` (advanced, default `false`) for SWAG/NPM users
   - `API_WRITE_TOKEN` (advanced, `Mask="true"`) when wiring writes to the API (the frontend's env var is `API_WRITE_TOKEN`; it must match `RACKULA_API_WRITE_TOKEN` on the API container)
-- **No volume.** Frontend is stateless.
-- **Overview text must state:** persistence/auth need the separate `rackula-api` container;
+- No volume. Frontend is stateless.
+- Overview text must state: persistence/auth need the separate `rackula-api` container;
   without it, layouts live only in the browser.
 
 ### Template 2: `rackula-api` (optional, for persistence/auth/OIDC)
 
-- **Image:** `ghcr.io/rackulalives/rackula-api` (pinned tag)
-- **Exposes:**
+- Image: `ghcr.io/rackulalives/rackula-api` (pinned tag)
+- Exposes:
   - Port `3001/tcp` (advanced; only needed if frontend reaches it across networks; normally the
     two share a Docker network and talk by container name)
   - Path `/data` -> default host `/mnt/user/appdata/rackula`, `Mode="rw"`, `Required="true"`
@@ -93,7 +93,7 @@ self-hosted template repo, an icon, and a forum support thread.
     mode=local)
   - `RACKULA_API_WRITE_TOKEN` (`Mask="true"`, advanced)
   - OIDC provider settings (advanced; flagged as under-documented, see open questions)
-- **`<Requires>`** text: "Pair with the Rackula frontend container."
+- `<Requires>` text: "Pair with the Rackula frontend container."
 
 ### Self-hosted template repo
 
@@ -296,7 +296,7 @@ the flash drive.
 - `RACKULA_LOCAL_PASSWORD` -> `Mask="true"`.
 - `RACKULA_API_WRITE_TOKEN` (both containers) -> `Mask="true"`.
 - `RACKULA_LOCAL_USERNAME` is not a secret -> leave unmasked.
-- **No baked default for the session secret, the password, or the write token.** A shipped default
+- No baked default for the session secret, the password, or the write token. A shipped default
   secret would let anyone forge a valid HS256 session cookie against every default install on
   earth. The app already requires the operator to supply it (the API refuses to start with auth
   enabled and no secret), so the template must NOT paper over that with a `Default=`. Leave
@@ -328,10 +328,10 @@ default.
 The proxy terminates TLS and talks HTTP to the container; the app reads `X-Forwarded-Proto` only
 when `RACKULA_TRUST_PROXY=1` (`1995-external.md` section 4). Cookie `Secure` is forced on in prod
 and whenever `SameSite=None`. The breakage modes:
-- **Auth enabled + plain HTTP + `TRUST_PROXY=0`:** Secure cookies are set, browser refuses to send
+- Auth enabled + plain HTTP + `TRUST_PROXY=0`: Secure cookies are set, browser refuses to send
   them back over HTTP, login appears to "not work" (infinite redirect to login). This is a support
   magnet.
-- **`TRUST_PROXY=1` set when NOT behind a trusted proxy:** the app would trust a client-spoofable
+- `TRUST_PROXY=1` set when NOT behind a trusted proxy: the app would trust a client-spoofable
   `X-Forwarded-Proto`, a (minor) downgrade/redirect risk.
 
 **Template/AC must enforce:**
@@ -356,8 +356,8 @@ this is purely an API-container issue.
 - Document the UID explicitly in the API template Description and support thread: "the API writes as
   UID 1001."
 - Recommend one of: (a) `chown -R 1001:1001 /mnt/user/appdata/rackula` once at setup, or (b) if the
-  image/entrypoint supports `PUID`/`PGID`-style remapping, expose those - **but the codebase shows
-  no PUID/PGID handling**, so (a) is the realistic instruction unless #1317 adds PUID support.
+  image/entrypoint supports `PUID`/`PGID`-style remapping, expose those - but the codebase shows
+  no PUID/PGID handling, so (a) is the realistic instruction unless #1317 adds PUID support.
 - Flag as an open implementation question for #1317: do we add LinuxServer-style PUID/PGID to the
   API image (Unraid users expect it), or document the one-time chown? The chown is zero-code and
   ships now; PUID support is a nicer UX but is new code.
@@ -394,11 +394,11 @@ save." Here is the saving grace the codebase gives us, and it must be used: **th
 not dead.** Layouts persist in the browser. So the bug report is really "no cross-device / no
 server storage," not "total data loss." Prevent the confusion with three cheap moves:
 
-1. **Naming makes dependency obvious:** `rackula` and `rackula-api`. A user seeing `rackula-api` in
+1. Naming makes dependency obvious: `rackula` and `rackula-api`. A user seeing `rackula-api` in
    the Apps tab infers it is the backend half.
-2. **Frontend Overview states the boundary in plain words:** "works on its own for a single
+2. Frontend Overview states the boundary in plain words: "works on its own for a single
    browser; install rackula-api for server-side persistence / login." (Drafted above.)
-3. **API `<Requires>` text** tells API installers they need the frontend too.
+3. API `<Requires>` text tells API installers they need the frontend too.
 
 But be honest in #1317: this WILL generate some support traffic no matter what. The mitigation is
 documentation discipline, not a technical guarantee.
@@ -436,12 +436,12 @@ not assume.**
 ### "CA review / account-history prerequisite: can RackulaLives clear vetting?"
 
 Partly known, partly not.
-- **GitHub history: likely fine.** RackulaLives is a real org with an active repo and real release
+- GitHub history: likely fine. RackulaLives is a real org with an active repo and real release
   history; the "previous activity on GitHub / not fully AI written" screen is plausibly met
   (`1995-external.md` section 1).
-- **Unraid FORUM account: UNKNOWN and a hard prerequisite.** CA requires a support *forum thread*,
+- Unraid FORUM account: UNKNOWN and a hard prerequisite. CA requires a support *forum thread*,
   which means an Unraid forum account in good standing. The research does not establish that
-  RackulaLives/the maintainer has one. **Flag as a prerequisite/blocker for #1317:** if there is no
+  RackulaLives/the maintainer has one. Flag as a prerequisite/blocker for #1317: if there is no
   established Unraid forum presence, that account (and the thread) must be created before submission,
   and a brand-new forum account with no history may itself draw moderation scrutiny. Do not assume
   this is free.
@@ -455,20 +455,20 @@ enumerated, and OIDC setup is "MVP"). Recommendation for #1317:
 - Keep the dropdown `none|local|oidc` (matches the app), but in the Description steer plainly:
   "Most homelab users want none or local. oidc requires an external identity provider and extra
   configuration."
-- Treat OIDC-on-Unraid as **explicitly out of scope for the first listing's documentation** until
+- Treat OIDC-on-Unraid as explicitly out of scope for the first listing's documentation until
   the OIDC env surface is documented. Shipping a dropdown option the docs cannot fully support is a
   support-debt generator.
 
 ### "Anything that makes me say 'this is more work than #1317 assumes'?"
 
 Yes, three things:
-1. **The UID 1001 vs 99:100 permission mismatch** (secure-coding item 5) is the kind of detail that
+1. The UID 1001 vs 99:100 permission mismatch (secure-coding item 5) is the kind of detail that
    turns "install and go" into a forum thread full of "permission denied" reports. Either add PUID
    support (new code) or document the chown loudly. Not free.
-2. **Container-name networking on stock bridge** (above) may force a "create a user-defined Docker
+2. Container-name networking on stock bridge (above) may force a "create a user-defined Docker
    network" instruction, which is an extra manual step most one-click apps do not need. Must be
    verified on real Unraid.
-3. **The forum thread + ongoing support obligation** is a standing human cost, not a one-time
+3. The forum thread + ongoing support obligation is a standing human cost, not a one-time
    implementation task. CA can *delist* unmaintained apps. #1317 should not pretend the work ends at
    "XML merged."
 
@@ -496,31 +496,31 @@ commitments that are easy to under-scope. Do NOT combine into a fat image, do NO
    without auth; behind a proxy set Trust Proxy true; API writes as UID 1001).
 7. Decide and implement the `/data` permissions story: document the one-time chown (zero-code, ships
    now) OR add PUID/PGID support to the API image (new code, nicer UX) - pick one in #1317.
-8. **Verify on real Unraid:** container-name resolution between `rackula` and `rackula-api` on the
+8. Verify on real Unraid: container-name resolution between `rackula` and `rackula-api` on the
    default bridge; if it fails, add a "create a user-defined network" step to the docs.
 9. Confirm a square HTTPS PNG icon exists at a stable raw-GitHub path; add one if not.
 
 ### PREREQUISITE / RESEARCH-RESOLVED
 
-- Distribution model decision (CA, two templates, no plugin): **resolved** by this spike.
+- Distribution model decision (CA, two templates, no plugin): resolved by this spike.
 - CA workflow (self-host repo + forum thread + submission form, one-container-per-template rule,
-  masked-variable mechanics, icon/proxy/cookie behaviour): **resolved**.
-- GitHub account-quality screen: **likely met** (real org, real history) - confirm, don't assume.
-- **Unraid forum account in good standing + a support thread: UNRESOLVED prerequisite.** Must exist
+  masked-variable mechanics, icon/proxy/cookie behaviour): resolved.
+- GitHub account-quality screen: likely met (real org, real history) - confirm, don't assume.
+- Unraid forum account in good standing + a support thread: UNRESOLVED prerequisite. Must exist
   before CA submission. Open question: who owns it.
-- **OIDC-on-Unraid documentation: out of scope** for the first listing until the OIDC env surface is
+- OIDC-on-Unraid documentation: out of scope for the first listing until the OIDC env surface is
   documented elsewhere; the dropdown keeps the option but docs steer to none/local.
 
 ### NEW / SEPARATE WORKSTREAM (not #1317 implementation)
 
-- **Create and maintain `RackulaLives/unraid-templates`** repo (hosting + `<TemplateURL>` self-
+- Create and maintain `RackulaLives/unraid-templates` repo (hosting + `<TemplateURL>` self-
   reference + release-time tag sync). Small but ongoing.
-- **Create the Unraid forum support thread and assign an owner** to answer it. This is a standing
+- Create the Unraid forum support thread and assign an owner to answer it. This is a standing
   human commitment CA can enforce via delisting; it is not a code task and should be tracked
   separately from #1317.
-- **CA submission + moderation cycle** (days to weeks, human-gated): track as its own task gated on
+- CA submission + moderation cycle (days to weeks, human-gated): track as its own task gated on
   the repo, thread, and icon being ready.
-- **(Optional, demand-driven) hybrid fallback:** if no one can own the forum thread, scope down to
+- (Optional, demand-driven) hybrid fallback: if no one can own the forum thread, scope down to
   "list the frontend template in CA, document `docker-compose.persist.yml` for persistence" instead
   of the second template. Worth holding as the escape hatch if the human-maintenance cost cannot be
   met.

--- a/docs/research/spike-1995-unraid-distribution.md
+++ b/docs/research/spike-1995-unraid-distribution.md
@@ -1,0 +1,155 @@
+# Spike #1995: Unraid distribution architecture (Community App vs Plugin)
+
+**Date:** 2026-06-08
+**Milestone:** M02 -- LXC Release & Stability
+**Feeds:** #1317 (Submit Rackula as Unraid Community App)
+**Status:** Complete
+
+Research files:
+
+- `docs/research/1995-codebase.md` - Rackula container/deploy/auth ground truth
+- `docs/research/1995-external.md` - Unraid CA workflow, XML schema, multi-container patterns
+- `docs/research/1995-patterns.md` - synthesis with secure-coding and devils-advocate lenses, full XML skeletons
+
+---
+
+## Executive summary
+
+Distribute Rackula on Unraid as **Community Applications (CA) Docker templates**, using a
+**two-template** model: a `rackula` frontend template (always installed) plus an optional
+`rackula-api` template for server-side persistence and auth. A native Unraid Plugin (`.plg`) is
+rejected: it grants a web-facing app full host access, must survive every Unraid OS upgrade, and
+carries a higher moderation bar for zero packaging benefit on an app that already ships as a
+container.
+
+The technical work is small (author two XML templates that wrap the existing images, unchanged).
+The real costs are a handful of Unraid-specific footguns the templates must defend against, plus
+standing human/process commitments (a forum support thread, a template repo) that #1317 currently
+under-scopes.
+
+**One hard prerequisite surfaced:** CA submission requires an Unraid forum support thread, which
+needs a forum account in good standing. The research did not establish that RackulaLives has one.
+This must be resolved before submission and is tracked as a separate workstream below.
+
+---
+
+## Why CA Docker template, not Plugin
+
+| Model | Fit for Rackula |
+| ----- | --------------- |
+| CA Docker template | Correct. Rackula already ships container images with healthchecks and OCI labels. CA wraps them in a one-click install with no app changes. |
+| Plugin (`.plg`) | Wrong. Full host filesystem access for a web app, must track Unraid OS releases, higher trust bar, Unraid-only, re-implements install/upgrade the container runtime already provides. Official Unraid guidance: use containers whenever you can; reserve plugins for OS-level integration Rackula does not need. |
+
+CA installs exactly one container per template (no Compose/stack primitive). That single rule is
+the pivot for everything below.
+
+## Why two templates, not one
+
+Rackula's API is genuinely optional. The frontend image runs standalone with `RACKULA_AUTH_MODE=none`
+and no volume; the SPA persists layouts in the browser. The Bun API adds server-side storage,
+cross-device sync, and login. Because CA is one-container-per-template, an optional second container
+maps to a second optional template. This matches the proven ecosystem pattern for frontend-plus-backend
+apps (Homelabarr, KitchenOwl-split).
+
+Alternatives considered and rejected:
+
+- One combined fat image: requires a net-new image running nginx and Bun under a process supervisor.
+  Doubles build/patch/CVE surface and bakes in the API for users who do not want it. Contradicts the
+  project's simplicity-first philosophy. No such image exists today.
+- Frontend-only template plus compose docs: viable hybrid fallback (see workstreams), but leaves
+  point-and-click Unraid users with no in-Apps way to add persistence.
+
+The common case stays trivial: install `rackula`, accept defaults, open the WebUI. One container,
+zero secrets, one click. The second template only appears for users who deliberately want
+persistence or auth.
+
+Full annotated XML skeletons for both templates are in `1995-patterns.md`.
+
+---
+
+## Security findings (must shape the templates)
+
+These come from the secure-coding lens and are the difference between a safe listing and a footgun.
+
+1. Default `RACKULA_AUTH_MODE=none` is acceptable for Unraid's trusted-LAN model, but the frontend
+   Overview and support thread must state plainly: safe on a trusted LAN, do not expose to the
+   internet without enabling auth. `none` means anonymous read AND write to the API.
+2. Mask all secrets. Unraid stores template values as plaintext XML on the flash drive and shows
+   them in the Edit Container UI. `RACKULA_AUTH_SESSION_SECRET`, `RACKULA_LOCAL_PASSWORD`, and the
+   write tokens get `Mask="true"`.
+3. No baked default for the session secret, password, or write token. A shipped default secret would
+   let anyone forge a valid HS256 session cookie against every default install. Leave `Default=""`
+   and document `openssl rand -base64 48`. The API already refuses to start with auth enabled and no
+   secret; the template must not paper over that.
+4. Reverse proxy: default `RACKULA_TRUST_PROXY=false`. Document the failure mode where auth-enabled
+   over plain HTTP with trust-proxy off produces a silent login loop (Secure cookies the browser
+   will not return). Behind SWAG/NPM/Traefik with HTTPS, set it true.
+5. `/data` permission mismatch: the API runs as UID 1001; Unraid appdata is conventionally
+   nobody:users (99:100). #1317 must pick one fix: document a one-time `chown` (zero-code, ships now)
+   or add PUID/PGID support to the API image (new code, nicer UX). The frontend is stateless and
+   unaffected.
+6. Pin image tags (not `:latest`) in the templates so the Apps-tab update prompt is meaningful, and
+   set `<Privileged>false</Privileged>` on both.
+
+## Devils-advocate findings (real-world friction)
+
+- The two-template split will generate some "my layouts don't save" support traffic. Mitigate with
+  naming (`rackula` / `rackula-api`), explicit Overview text, and `<Requires>` text. It is a
+  documentation discipline, not a technical guarantee. Note the failure is narrower than total data
+  loss: the frontend still persists in the browser; what is missing is server-side and cross-device
+  storage.
+- Container-name DNS between `rackula` and `rackula-api` is not guaranteed on Unraid's stock `bridge`
+  network (works on user-defined networks). #1317 must verify this on real Unraid; if it fails, the
+  docs need a "create a user-defined Docker network" step. Do not assume the happy path.
+- OIDC on a LAN box is a dropdown footgun and its env surface is under-documented. Keep the
+  `none|local|oidc` dropdown but steer users to none/local in the Description; treat OIDC-on-Unraid
+  docs as out of scope for the first listing.
+- Maintenance is a standing human cost: a forum thread someone must answer, a template repo to keep
+  in tag-sync, and CA's delisting policy for unmaintained apps. Name an owner or scope down.
+
+---
+
+## What this means for #1317
+
+### Implementation (belongs in #1317)
+
+1. Author `rackula.xml` and `rackula-api.xml` per the skeletons in `1995-patterns.md`.
+2. Mask all secrets; no baked defaults for secret/password/write-token.
+3. Pin image tags; wire template tag bumps into the release process.
+4. `<Privileged>false</Privileged>` on both; `/data` as a required rw path defaulting to
+   `/mnt/user/appdata/rackula`.
+5. Defaults `RACKULA_AUTH_MODE=none` and `RACKULA_TRUST_PROXY=false`, each with caveat Descriptions.
+6. Guardrail Overview/Description text (LAN-only default, no internet without auth, proxy guidance,
+   API writes as UID 1001).
+7. Decide and implement the `/data` permissions story: documented one-time chown or PUID/PGID support.
+8. Verify on real Unraid: container-name resolution on the default bridge; add a user-defined-network
+   step to docs if it fails.
+9. Confirm a square HTTPS PNG icon exists at a stable raw-GitHub path; add one if not.
+
+### Resolved by this spike
+
+- Distribution model: CA, two templates, no plugin.
+- CA workflow: self-hosted template repo, forum thread, submission form, one-container-per-template
+  rule, masked-variable mechanics, icon/proxy/cookie behaviour.
+- GitHub account-quality screen: likely met (real org, real history); confirm, do not assume.
+
+### Separate workstreams (not #1317 implementation)
+
+- Create and maintain `RackulaLives/unraid-templates` (hosts the XML, self-referenced via
+  `<TemplateURL>`, tag-synced each release).
+- Create the Unraid forum support thread and assign an owner. Standing commitment; CA can delist
+  unmaintained apps. This is the gating prerequisite, not a code task.
+- CA submission and moderation cycle (days to weeks, human-gated). Gate on repo, thread, and icon
+  being ready.
+- Optional hybrid fallback: if no one can own the forum thread, list only the frontend template in CA
+  and document `docker-compose.persist.yml` for persistence. Hold as the escape hatch.
+
+---
+
+## Sourcing caveat
+
+The rendered `docs.unraid.net` pages are JavaScript-hydrated and returned empty to direct fetch, so
+some official-docs claims in `1995-external.md` are cited via the indexed search summary of the same
+canonical URLs rather than a direct page body. The CA forum schema thread and the Selfhosters
+templating guide provided directly-quotable detail for the XML schema. The forum-account prerequisite
+and stock-bridge DNS behaviour should be confirmed during #1317 implementation, not taken as settled.


### PR DESCRIPTION
## **User description**
## Summary

Research spike #1995: how to distribute Rackula on Unraid.

Conclusion: ship as Unraid Community Applications Docker templates using a two-template model (`rackula` frontend always, `rackula-api` optional for persistence/auth). Native Plugin (`.plg`) rejected. Findings folded into #1317's acceptance criteria.

## Deliverables

- `docs/research/spike-1995-unraid-distribution.md` - main findings
- `docs/research/1995-codebase.md` - container/deploy/auth ground truth
- `docs/research/1995-external.md` - CA workflow, XML schema, multi-container patterns
- `docs/research/1995-patterns.md` - synthesis + secure-coding and devils-advocate lenses, full XML skeletons

## Key outcomes

- CA is one-container-per-template; the API is genuinely optional, so two templates fit
- Security: mask all secrets, no baked default for the session secret, default auth=none is LAN-only
- Two real footguns for #1317: `/data` UID 1001 vs Unraid 99:100 permissions, and container-name DNS on the stock bridge network
- One prerequisite/blocker: Unraid forum account + support thread (needed for CA submission), folded into #1317

## Test Plan

- [ ] Docs-only change; no code or tests affected

Closes #1995


___

## **CodeAnt-AI Description**
**Document the Unraid distribution plan for Rackula**

### What Changed
- Added a research summary that recommends publishing Rackula on Unraid through Community Applications with two templates: `rackula` for the frontend and optional `rackula-api` for persistence and login
- Documented why a native Unraid plugin was rejected, along with the main setup rules and risks for the templates, including secret handling, proxy setup, and `/data` permissions
- Added deeper research notes covering Unraid template behavior, multi-container app patterns, reverse proxy handling, and Rackula’s container and auth requirements

### Impact
`✅ Clearer Unraid installation guidance`
`✅ Fewer setup mistakes for persistence and login`
`✅ Safer secret handling in Unraid templates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
