### PR TITLE
ci(gate-lxc): download staged tarball via curl, not the gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,20 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          gh release download "$TAG" --pattern 'rackula-lxc-*.tar.gz' --dir .
+          # Resolve the rackula-lxc tarball asset on the (pre)release for $TAG, then
+          # download it by asset API URL. Uses curl + jq only: the self-hosted runner
+          # has no gh CLI (and does not need one).
+          asset_url="$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GH_REPO}/releases/tags/${TAG}" \
+            | jq -r 'first(.assets[] | select(.name | test("^rackula-lxc-.*\\.tar\\.gz$")) | .url) // empty')"
+          [ -n "$asset_url" ] || { echo "::error::no rackula-lxc-*.tar.gz asset on release ${TAG}"; exit 1; }
+          curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/octet-stream" \
+            -o "rackula-lxc-${TAG}.tar.gz" "$asset_url"
+          [ -s "rackula-lxc-${TAG}.tar.gz" ] || { echo "::error::downloaded tarball is empty"; exit 1; }
 
       - name: LXC smoke gate (deploy-only bootstrap for v26.6.3)
         run: |


### PR DESCRIPTION
## **User description**
## Summary

The `gate-lxc` job runs on the self-hosted ci-runner, which has `curl` + `jq` but no `gh` CLI. The current step uses `gh release download`, so a real gated release would fail there. This swaps it for a `curl` + `jq` equivalent: resolve the `rackula-lxc-*.tar.gz` asset on the (pre)release via the GitHub releases API, then download it by asset URL (`Accept: application/octet-stream`).

This was never caught because `gate-lxc` has never run a real job — prior LXC validation was manual (a `curl`-archive checkout + direct script run), which bypassed the workflow entirely.

## Why curl, not install gh

We deliberately keep the runner's toolchain minimal. `git` is still needed for `actions/checkout` and is being added to the runner via the IaC role (homelab-infra) separately; `gh` is avoidable here, so we avoid it. The other `gh` calls in this workflow (`stage-release`, `promote-github`) run on `ubuntu-latest`, which has `gh` preinstalled, and are unchanged.

## Notes

- The jq filter is anchored (`^rackula-lxc-.*\.tar\.gz$`) so it selects the tarball, not the `.sha256` sidecar.
- Errors out if no matching asset is found or the download is empty.
- The runner's curl (8.14.1) strips the `Authorization` header on the cross-host redirect to the asset CDN, so the pre-signed download succeeds.

Part of making the LXC release gate actually runnable for the v26.6.3 cut (validated separately: a fresh main tarball deploys clean on a real unprivileged CT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make the LXC release gate work on the self-hosted runner

### What Changed
- The staged LXC tarball is now downloaded with tools available on the self-hosted runner, so the release gate can run without the GitHub CLI
- The workflow now looks up the tarball from the release by name, downloads the exact asset, and fails clearly if the asset is missing or the download is empty

### Impact
`✅ Fewer release-gate failures on self-hosted runners`
`✅ Reliable LXC release checks`
`✅ Clearer missing-asset errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
