### PR TITLE
ci(release): grant security-events: write to stage-docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # build-images.yml's scan-images job uploads Trivy SARIF; a reusable
+      # workflow's nested jobs cannot exceed the caller's grant, so the caller
+      # must grant security-events: write (else the run is a startup_failure).
+      security-events: write
     uses: ./.github/workflows/build-images.yml
     with:
       tag: ${{ needs.validate.outputs.tag }}


### PR DESCRIPTION
## **User description**
## Summary

The first real v26.6.3 release run failed at startup (`startup_failure`, no jobs ran) with:

> `release.yml`: the nested job `scan-images` is requesting `security-events: write`, but is only allowed `security-events: none`.

`build-images.yml`'s `scan-images` job (Trivy scan → SARIF upload to the Security tab) declares `security-events: write`. A reusable workflow's nested jobs cannot exceed the **caller** job's permission grant, and `stage-docker` only granted `contents: read` + `packages: write`. GitHub rejects the whole workflow at startup. actionlint doesn't validate this cross-workflow permission contract, so it passed local lint.

## Fix

Grant `security-events: write` on the `stage-docker` caller job. Verified the other two reusable calls are already covered: `stage-lxc` grants `contents: write` (⊇ build-lxc's `publish`), and `promote-prod` grants `contents: read` (⊇ deploy-prod).

Unblocks the v26.6.3 gated release (the first real end-to-end gate run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow release image scanning to run successfully**

### What Changed
- The release workflow now grants the security events permission needed to upload Trivy scan results for staged Docker images
- This prevents the release run from failing at startup before any jobs begin

### Impact
`✅ Fewer release startup failures`
`✅ Working image vulnerability scans during release`
`✅ Unblocked staged Docker releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
