### PR TITLE
docs: document community-scripts dev-override divergence

### DIFF
--- a/deploy/lxc/community-scripts/README.md
+++ b/deploy/lxc/community-scripts/README.md
@@ -40,8 +40,9 @@ fork branch.
 
 In short: canonical = upstream + dev override. When syncing, carry every other
 change over verbatim, then re-remove the override on the fork side. It lives in
-three places: the fail-loud guard and the deploy branch in `ct/rackula.sh`
-`update_script()`, and the deploy branch in `install/rackula-install.sh`.
+three places: the fail-loud guard in `update_script()` in `ct/rackula.sh`, the
+deploy branch in the same function, and the deploy branch in
+`install/rackula-install.sh`.
 
 ## URL note: ProxmoxVE vs ProxmoxVED
 

--- a/deploy/lxc/community-scripts/README.md
+++ b/deploy/lxc/community-scripts/README.md
@@ -27,7 +27,21 @@ cp "$SRC/install/rackula-install.sh" "$DST/install/rackula-install.sh"
 cp "$SRC/json/rackula.json"         "$DST/json/rackula.json"
 ```
 
-After syncing, the fork trio must be byte-identical to these files.
+After syncing, the fork trio must be byte-identical to these files, with one
+intentional exception described below.
+
+## Intentional divergence: no dev override upstream
+
+The canonical copies include the env-gated `RACKULA_PREBUILD_TARBALL` dev override
+(deploys a local tarball for smoke testing, used by the gated release pipeline).
+The upstream submission does not: community-scripts wants lean scripts with no
+dev-only paths, so the override blocks and their comments are stripped from the
+fork branch.
+
+In short: canonical = upstream + dev override. When syncing, carry every other
+change over verbatim, then re-remove the override on the fork side. It lives in
+three places: the fail-loud guard and the deploy branch in `ct/rackula.sh`
+`update_script()`, and the deploy branch in `install/rackula-install.sh`.
 
 ## URL note: ProxmoxVE vs ProxmoxVED
 


### PR DESCRIPTION
## **User description**
## Summary
- The upstream PR (community-scripts/ProxmoxVED#1897) now ships without the RACKULA_PREBUILD_TARBALL dev override, per reviewer style expectations.
- Documents the resulting intentional divergence in the canonical README: canonical = upstream + dev override, with sync instructions.

## Test Plan
- [x] Docs-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the intentional difference between the fork and upstream community scripts**

### What Changed
- Clarifies that the fork should stay byte-identical to upstream except for one deliberate difference
- Explains that the upstream submission omits the dev-only `RACKULA_PREBUILD_TARBALL` override, while the fork keeps stripping it
- Lists the three places where that override is removed during sync so maintainers can preserve the expected behavior

### Impact
`✅ Clearer sync instructions`
`✅ Fewer merge mistakes`
`✅ Easier upstream-to-fork updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
