### PR TITLE
docs: spike #2019 storage model and data safety

### DIFF
--- a/docs/research/2019-codebase.md
+++ b/docs/research/2019-codebase.md
@@ -1,0 +1,180 @@
+# Spike #2019 codebase exploration
+
+Codebase ground truth for the storage model and data safety spike. All paths relative to repo root unless noted.
+
+## Files Examined
+
+- `docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md`: parent epic spec (storage sections)
+- `docs/superpowers/specs/2026-06-04-save-indicator-design.md`: save-indicator spec (#1901, approved, implemented)
+- `docs/superpowers/specs/2026-06-02-storage-abuse-guardrails-design.md`: server quota spec (#1780, implemented)
+- `docs/research/spike-1995-unraid-distribution.md`: Unraid two-template decision feeding #2008
+- `src/lib/utils/persistence-manager.svelte.ts`: autosave effects, circuit breaker, save/export entry points
+- `src/lib/utils/persistence-api.ts`: API client (health, layouts CRUD, assets)
+- `src/lib/utils/persistence-config.ts`: API_BASE_URL resolution
+- `src/lib/stores/persistence.svelte.ts`: runtime API availability detection
+- `src/lib/utils/session-storage.ts`: localStorage working copy + timestamp conflict helpers
+- `src/lib/utils/safe-storage.ts`: try/catch localStorage wrappers
+- `src/App.svelte` (onMount, lines 175-317): startup load priority and timestamp conflict resolution
+- `src/lib/components/PersistenceEffects.svelte`: visibilitychange/beforeunload flush, dirty-leave warning
+- `src/lib/utils/archive.ts`: file export (browser-fs-access fileSave, ZIP archive, YAML)
+- `src/lib/utils/load-pipeline.ts`: unified load from API or file
+- `src/lib/utils/file.ts`: file picker for import
+- `src/lib/utils/yaml.ts`: layout YAML serialization
+- `src/lib/utils/share.ts`: lz-string URL share encoding
+- `src/lib/stores/layout.svelte.ts`: isDirty / markClean / markDirty
+- `src/lib/stores/images.svelte.ts`: in-memory image store (not persisted to browser storage)
+- `src/lib/components/KeyboardHandler.svelte`: Ctrl+S/O/E wiring
+- `api/src/routes/layouts.ts`, `api/src/storage/filesystem.ts`, `api/src/storage/assets.ts`, `api/src/storage/quota.ts`: server storage
+- `api/src/app.ts`: middleware chain, /health, auth gating of /layouts and /assets
+- `deploy/nginx.conf.template`, `deploy/docker-entrypoint-wrapper.sh`: container runtime config and /api proxy
+- `vite.config.ts`: build-time env injection (`__BUILD_ENV__`, VITE_BASE_PATH)
+
+## Specs Summary
+
+### Canvas UX overhaul (parent epic spec)
+
+`docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md`
+
+Storage-relevant content (lines 135-193, 235-256, 265-286):
+
+- Explicit storage mode: `storage: browser` or `storage: server`, declared by configuration, not inferred at runtime (lines 139-144). Explicitly replaces "always probing /api and guessing intent from connection history", which made a backendless build indistinguishable from a down server.
+- Three-tier model (lines 146-150): file on disk (portable), browser (live working copy, autosaved), server (durable library, server build only). Browser build: durable home is the file. Server build: durable home is the server; file is a portable copy.
+- Concurrency target (lines 152-156): one user on multiple devices. Divergence resolves last-write-wins with an automatic pre-overwrite snapshot of the losing copy; no merge or prompt UX. Snapshot mechanics delegated to this spike.
+- Storage chip (lines 159-180): single compact chip, top-right, workspace-wide; green only when every open layout is in its durable home. Browser build states: green "In your browser, backed up" (recent file backup exists), amber "In your browser, backup needed". Labels differ as well as colours. The app can only know an export event happened, not that the file still exists; "recent" needs a definition (change-based vs time-based), delegated to this spike. Server build states: green "Saved to <instance>", neutral "Saving", red "<instance> unreachable". Chip click opens a popover with facts (where stored, last backup/sync) and actions (export all, import, browser-build restore from file).
+- Messaging (lines 183-193): browser build gets a one-time first-run notice (runs in your browser, nothing uploaded, clearing browser data erases layouts, export to keep a copy) and never the "server unavailable" toast. Server build keeps one instance-named toast on genuine backend drop, fired once, with a quiet recovery toast. The generic "Server unavailable, working offline" toast is removed.
+- Inactive tabs carry an unbacked-changes dot identifying which layout the amber chip state refers to (lines 66-69, 163-164).
+- Open questions assigned to this spike (lines 250-252): browser-mode data-loss recovery (nudge cadence, restore flow, recent-backup definition), pre-overwrite snapshot mechanics, the twin-tab case, and the mechanics of the explicit storage mode.
+- Decision log (lines 265-286) confirms: no persistent-file-handle mechanism for now; storage spike runs before the tabs spike.
+
+### Save-indicator spec (#1901, implemented)
+
+`docs/superpowers/specs/2026-06-04-save-indicator-design.md`
+
+Removed the toolbar `SaveStatus` component; all save feedback moved to toasts. Key decisions the new chip must reconcile with:
+
+- Auto-save is silent; only manual Ctrl+S shows a success toast (3000ms, role=status).
+- Save failures are persistent toasts (duration 0) with a Retry action and dedup via a tracked toast ID.
+- Offline produces "Server save unavailable, working offline. Use Ctrl+S to retry." (persistence-manager) and "Server unavailable, working offline" (App init).
+- Internal `_saveStatus` state kept (idle/saving/saved/error/offline/disabled) to gate health-check polling, but the exported SaveStatus API was deleted. The chip effectively reintroduces a visible save state surface, reversing the visual half of #1901 while the toast decisions about spam (silent autosave) still stand.
+
+### Storage-abuse-guardrails spec (#1780, implemented)
+
+`docs/superpowers/specs/2026-06-02-storage-abuse-guardrails-design.md`
+
+- Server-side quota enforcement: `RACKULA_MAX_LAYOUTS` (default 100) and `RACKULA_MAX_ASSETS_PER_LAYOUT` (default 50), `0` = unlimited. Implemented in `api/src/storage/quota.ts` and `api/src/security/storage-quota-middleware.ts`.
+- Layout quota counts directory entries on every create (no cache); update of an existing UUID skips the check (`findFolderByUuid`). Responses: 429 (layout quota) and 507 (asset quota) with `current`/`max` in the body.
+- No retention or cleanup policy: "the quota cap IS the guardrail". Pre-overwrite snapshots will add stored objects; whether snapshots count against `RACKULA_MAX_LAYOUTS` (and how snapshot retention interacts with "no cleanup policy") is a direct reconciliation point for this spike.
+- Frontend already special-cases quota errors: `persistence-manager.svelte.ts:131-151` detects 507, and 429-with-"quota" text, shows a "Storage full" toast, and explicitly does not flip to offline or trip the circuit breaker.
+
+## Current Persistence Architecture
+
+Working copy: a single layout in localStorage under key `Rackula:autosave` (`src/lib/utils/session-storage.ts:11`). Stored as JSON `{ layout, savedAt }` where `savedAt` is an ISO timestamp added for conflict resolution (`SessionData`, lines 17-20). There is exactly one autosave slot; the app is currently single-layout (no tabs, no multi-layout browser storage). No IndexedDB anywhere in src/.
+
+Autosave pipeline (`src/lib/utils/persistence-manager.svelte.ts:412-509`, registered by `src/lib/components/PersistenceEffects.svelte:24`):
+
+- Effect 1 (lines 419-447): debounced 1s localStorage save via `saveSession()` whenever the layout changes and `hasRack`. Clears the session when racks drop to zero (guarded against the initial-mount race).
+- Effect 2 (lines 450-484): debounced 2s server auto-save via `saveLayoutToServer()` when `isApiAvailable()`, gated by a circuit breaker (`MAX_SAVE_FAILURES = 3`, line 43). On success: `clearSession()` (localStorage copy is deleted once the server holds it; the server is treated as the durable home and localStorage purely as offline fallback).
+- Effect 3 (lines 487-508): 30s health-check polling while offline, only if `hasEverConnectedToApi()` and the breaker has not opened.
+- `flushSessionSave()` (lines 403-410) force-writes the pending debounce; called from `visibilitychange` (hidden) and `beforeunload` (`PersistenceEffects.svelte:29-34, 68-77`).
+
+Save status: internal only. `_saveStatus` (`persistence-manager.svelte.ts:39-40`) holds idle/saving/saved/error/offline/disabled but nothing renders it since #1901; feedback is toasts (`getToastStore()`). The chip will need this state exported again (or a new store) plus a "last export" record that does not exist today.
+
+Dirty tracking: `isDirty` boolean in `src/lib/stores/layout.svelte.ts:146` with `markDirty()`/`markClean()` (lines 1149-1155); set true by mutating actions. `markClean()` is called after server save, YAML file save, and any layout load. Note: dirty is a single boolean, not a change counter; a change-based "recent backup" definition for the chip would need a revision counter or content hash, neither of which exists. There is no record of export events at all (exports do not even call `markClean()` unless via `handleSaveAsArchive`).
+
+API availability detection (`src/lib/stores/persistence.svelte.ts`): runtime probe, not build flag. `initializePersistence()` (lines 67-99) fetches `/api/health` once on startup; `checkApiHealth()` (`persistence-api.ts:117-169`) requires a structured JSON payload (`service: "rackula-persistence-api"`) to guard against SPA-fallback false positives. `hasEverConnectedToApi()` persists `rackula.persistence.apiConnected = "true"` in localStorage (lines 17-31) and is what gates the "Server unavailable, working offline" toast, this is exactly the "guessing intent from connection history" the spec is replacing.
+
+Startup load priority (`src/App.svelte:175-317`):
+
+1. Share URL param (decode, load, return).
+2. No local session: reset and show StartScreen (the spec removes this).
+3. API available + local session: fetch layout list, sort by `updatedAt` desc, compare against `localSession.savedAt` via `isServerNewer()`; if server newer, load server copy and `clearSession()` (toast: `Loaded "<name>" from server`); if local newer, load local, `markDirty()`, toast "Loaded unsaved local changes (newer than server)" and let next autosave push it up. This is the existing timestamp conflict resolution the issue references. It is last-write-wins with no snapshot: whichever copy loses is silently discarded (the local copy via `clearSession()`, or the server copy on the next 2s autosave overwrite).
+4. Fallback: load local session, markDirty.
+
+`isServerNewer()` (`session-storage.ts:215-243`): prefers server on null/invalid local timestamps. Server `updatedAt` comes from file mtime (`api/src/storage/filesystem.ts:121,131,145,183`), not from a logical clock, so it is sensitive to clock skew between server filesystem time and the browser's `new Date().toISOString()`.
+
+Serialization: layouts serialize to YAML via `serializeLayoutToYaml()` (`src/lib/utils/yaml.ts:248`); localStorage uses plain JSON of the Layout object with version-based migrations on load (`session-storage.ts:62-102`). Images are in-memory only (`src/lib/stores/images.svelte.ts`, a `SvelteMap`); custom images survive only via server assets or ZIP export, not via the localStorage working copy. Any browser-mode durability story has to account for images being lost on reload unless bundled or re-imported.
+
+## API / Server Storage
+
+Bun + Hono app (`api/src/app.ts`). Routes:
+
+- `GET /layouts` list (name, version, updatedAt, rackCount, deviceCount, valid) via `listLayouts()` (`filesystem.ts:222`)
+- `GET /layouts/:uuid` returns raw YAML
+- `PUT /layouts/:uuid` create-or-update (`api/src/routes/layouts.ts:64-131`); validates UUID format and metadata.id-matches-URL; `saveLayout()` (`filesystem.ts:448-539`) writes `/data/{Name}-{UUID}/{name}.rackula.yaml`, handles folder rename on layout rename
+- `DELETE /layouts/:uuid` removes the folder recursively
+- `PUT/GET/DELETE /assets/:layoutId/:deviceSlug/:face` device images inside the layout folder (`api/src/storage/assets.ts`)
+- `GET /health` (and `/api/health`) structured payload; `GET /version`
+- Auth routes (`/auth/*`, `/api/auth/*`) for `none|local|oidc` modes
+
+All routes are mounted twice, bare and with `/api` prefix (`app.ts:885-886` `mountWithAlias`); nginx strips `/api` before proxying (`deploy/nginx.conf.template:178-196`).
+
+Storage backend is plain filesystem under DATA_DIR (no DB). Writes are `writeFile` (`filesystem.ts:536`), not atomic temp+rename for the YAML itself (assets use an atomic pattern per the guardrails spec). No versioning, no backups, no soft delete: a PUT replaces the YAML in place and DELETE is final. Pre-overwrite snapshots therefore have no existing mechanism to build on; candidate homes are a sibling file in the layout folder (counted or not by quota, decide explicitly) or a `/data/.snapshots/` area outside `checkLayoutQuota`'s directory scan (`quota.ts` counts UUID-suffixed dirs and legacy flat YAML in DATA_DIR root, per spec lines 69-75).
+
+Concurrency: no ETag, no If-Match, no optimistic locking. `PUT` is unconditional; the server never sees the client's notion of the base version. Last-write-wins already happens implicitly between two devices autosaving. The known quota race (two concurrent creates both pass) is documented as acceptable (guardrails spec, lines 162-164).
+
+Middleware chain (`app.ts:808-886`): writeAuth and requireAdmin on `/layouts/*` and `/assets/*`, body limits (1MB layout YAML, 5MB asset), then `storageQuotaMiddleware`. Auth modes: `none` (anonymous read/write), `local` (argon2 password), `oidc`; session tokens are HMAC-signed cookies. In `none` mode the frontend talks to the API with no credentials.
+
+Frontend client (`src/lib/utils/persistence-api.ts`): zod-validated list response, 10s request timeout, `PersistenceError` with statusCode. `saveLayoutToServer()` (lines 267-327) requires `layout.metadata.id` UUID; accesses it via a type assertion, i.e. metadata.id is not yet a first-class Layout field on the frontend type.
+
+## Export/Import Flows
+
+- Ctrl+S → `maybeSave()` (`persistence-manager.svelte.ts:236-243`, wired in `src/lib/components/KeyboardHandler.svelte:203-225`): if API available, manual server save; otherwise `handleSaveAsArchive()` which calls `downloadYamlFile()`.
+- `downloadYamlFile()` (`src/lib/utils/archive.ts:750-761`): bare YAML via `browser-fs-access` `fileSave()`, native Save As dialog on Chromium (File System Access API), anchor fallback on Firefox/Safari. `downloadArchive()` (lines 718-744) builds a `.Rackula.zip` folder archive (YAML + `assets/` images + metadata) via JSZip. Both throw `AbortError` on user cancel, which `handleSaveAsArchive()` swallows (lines 219-222), so "user cancelled the save dialog" is already distinguishable from "saved", useful for the chip's last-backup bookkeeping.
+- browser-fs-access is in `package.json:79` (`^0.38.0`), dynamically imported. Note the spec decision log: no persistent file handle for now, so `fileSave` is used one-shot; the handle it can return is not retained.
+- Ctrl+O → `handleLoad()` (`persistence-manager.svelte.ts:255-261`): LoadDialog (server list) when API available, else `loadFromFile()`. `loadFromFile()` (`src/lib/utils/load-pipeline.ts:104-123`) accepts `.yaml` and `.Rackula.zip` via a hidden input picker (`src/lib/utils/file.ts`), extracts with `extractFolderArchive()`, then `finalizeLayoutLoad()` resets images, loads, `markClean()`, `clearSession()`. This is the existing restore-from-file flow the chip popover would invoke.
+- Ctrl+E → export dialog (`handleExport`, SVG/PNG/JPEG/PDF/CSV image exports in `src/lib/utils/export.ts`); these are renders, not backups.
+- Share URLs (`src/lib/utils/share.ts`): lz-string `compressToEncodedURIComponent` of a MinimalLayout in the URL; decode-only legacy pako path. Loaded at startup priority 1.
+- There is no "export all": every save/export path operates on the single current layout. A multi-layout workspace needs a new export-all artifact (likely a multi-layout ZIP).
+
+## Runtime Config Mechanics
+
+- Build-time: `VITE_API_URL` baked into the bundle as `API_BASE_URL`, default `/api` (`src/lib/utils/persistence-config.ts:10`). `__BUILD_ENV__` from `VITE_ENV` (`vite.config.ts:167`) is only used for the window-title prefix. `VITE_BASE_PATH` for GitHub Pages base. There is no runtime config endpoint (no `/config.json`, no injected `window.__RACKULA_CONFIG__`).
+- Container runtime: `deploy/docker-entrypoint-wrapper.sh` normalizes `RACKULA_AUTH_MODE` (none|local|oidc), `RACKULA_TRUST_PROXY`, IPv6, `NGINX_RESOLVER`, `API_HOST`/`API_PORT`, then envsubsts `deploy/nginx.conf.template`. All of this configures nginx, none of it reaches the SPA. The frontend discovers the API solely by probing `/api/health` at runtime (`persistence.svelte.ts`, header comment: "This replaces the build-time VITE_PERSIST_ENABLED flag with runtime detection. The same Docker image can now work with or without the API sidecar").
+- The one-image constraint (#2008 / spike #1995): Unraid CA installs one container per template; the model is a `rackula` frontend template always installed plus an optional `rackula-api` template. The same `ghcr.io/rackulalives/rackula` image must therefore serve both storage modes, which rules out baking `storage: server` at build time. Natural implementation points for a runtime `storage` flag: (a) extend the entrypoint to envsubst a tiny config endpoint or inject a `<script>`/meta into index.html, (b) have nginx serve a `/config.json` rendered from env (`RACKULA_STORAGE_MODE=browser|server`), or (c) derive it in nginx from whether `API_HOST` is configured. GitHub Pages (d.racku.la) and the static Cloudflare prod (per memory: prod is static-only) have no entrypoint, so the browser build needs a sane no-config default (`storage: browser` when no config endpoint exists).
+- nginx already returns deliberate 502/503 from `/api/health` when the sidecar is down ("No fallback - let it fail to signal API unavailability", `nginx.conf.template:101-112`), which under explicit modes becomes a genuine "server down" signal rather than an ambiguity.
+
+## Multi-Tab Handling
+
+Effectively none. The only cross-tab-adjacent code is:
+
+- `visibilitychange`/`beforeunload` flush of the pending localStorage write (`PersistenceEffects.svelte:26-34, 68-77`).
+- `beforeunload` confirm dialog when `uiStore.warnOnUnsavedChanges && layoutStore.isDirty` (lines 72-76); the setting is user-toggleable and persisted (`ui.svelte.ts` WARN_UNSAVED_KEY). This is the existing "beforeunload decision" baseline.
+
+No `BroadcastChannel`, no `storage` event listener, no Web Locks, no tab ID. Two same-origin tabs both debounce-write the single `Rackula:autosave` key and (in server mode) both autosave to the same UUID every 2s; last writer wins at both tiers, silently. The twin-tab case the spike must design for is currently unmitigated and undetected.
+
+## Integration Points
+
+For the chip:
+
+- State source: resurrect/export save state from `persistence-manager.svelte.ts` (`_saveStatus`, `_consecutiveSaveFailures`) plus `persistence.svelte.ts` availability; add a "last backup" record (no such record exists; `handleSaveAsArchive`/`downloadYamlFile` success and `markClean()` are the hook points, `AbortError` already distinguishes cancellation).
+- Render slot: top-right toolbar region freed by SaveStatus removal (`src/lib/components/Toolbar.svelte`); #1901's reflow lesson says reserve fixed space rather than `{#if}` insert/remove.
+- A change-based "recent backup" definition needs a change counter or content hash in `layout.svelte.ts`; today there is only the `isDirty` boolean (line 146).
+- "Workspace-wide aggregation across open layouts" has no current substrate: one layout, one autosave key. The chip design must define its state model against the future tabs work (the storage spike deliberately runs first).
+
+For snapshots:
+
+- Server side: add to `saveLayout()` in `api/src/storage/filesystem.ts:448` (copy existing YAML aside before `writeFile` at line 536), or a dedicated route. Must decide interaction with `checkLayoutQuota`'s directory scan (`api/src/storage/quota.ts`) and the guardrails "no retention policy" stance; snapshots inside the layout folder dodge the layout count but could collide with `findYamlInFolder` (`filesystem.ts:515`) if stored as `.yaml` in the folder root, so use a subdirectory (e.g. `{folder}/snapshots/`) or non-YAML extension.
+- Trigger condition: the client currently has no way to know it is about to overwrite newer server data; PUT is unconditional. Options: client sends last-known `updatedAt` (If-Unmodified-Since-style) so the server can snapshot on mismatch, or server snapshots unconditionally pre-overwrite with retention N.
+- Find/restore UX: LoadDialog (`src/lib/components/LoadDialog.svelte`) lists layouts from `GET /layouts` and is the natural home for surfacing snapshots.
+
+For nudges and messaging:
+
+- Toast system supports persistent toasts, actions, dedup, ARIA role split (`src/lib/stores/toast.svelte.ts`, `Toast.svelte`); nudges with an "Export now" action are a direct fit.
+- The toasts to remove/replace per the spec: "Server unavailable, working offline" at `App.svelte:225-231` and `App.svelte:293-299` (gated on `hasEverConnectedToApi()`), and "Server save unavailable, working offline. Use Ctrl+S to retry." at `persistence-manager.svelte.ts:104-109`.
+- First-run notice: one-shot flag in localStorage via `safe-storage.ts` helpers, same pattern as `rackula.persistence.apiConnected`.
+
+For storage mode:
+
+- Replace the probe-and-guess in `persistence.svelte.ts` (`initializePersistence`, `hasEverConnectedToApi`) and the `isApiAvailable()` branching in `maybeSave`/`handleLoad` (`persistence-manager.svelte.ts:232-261`) with mode-driven behaviour; in server mode health state means up/down, never "switch to file saves".
+
+## Constraints
+
+- One frontend image must serve both modes (Unraid #2008, LXC, Pages, static CF prod), so storage mode must be runtime-deliverable with a default of `browser` when no config is present; build flags are out.
+- localStorage is the only browser persistence in use; the working copy is one slot, JSON, ~5MB quota ceiling shared with UI prefs, and `saveSession` already handles quota failure by returning false silently (`session-storage.ts:109-126`). Multi-layout tabs in browser mode will pressure this; images are not in it at all.
+- Server `updatedAt` is filesystem mtime; timestamp comparisons cross machine clocks (`isServerNewer`). Snapshot/LWW design should not assume well-ordered timestamps.
+- Quota guardrails (#1780): snapshots must not break `RACKULA_MAX_LAYOUTS` semantics or the create-vs-update skip in `storage-quota-middleware`; pick snapshot placement that the directory-count scan ignores deliberately, and document it.
+- Save-indicator decisions (#1901) to preserve: silent autosave, persistent error toasts with Retry and dedup, ARIA role split, no DOM insert/remove reflow in the toolbar.
+- Layout YAML PUT body limit is 1MB and asset limit 5MB (guardrails spec); export-all and snapshot payloads live within these.
+- `metadata.id` is accessed by type assertion on the frontend (`persistence-api.ts:277-285`); making storage identity first-class likely requires promoting it into the Layout type/schema.
+- No backend code paths are shared with the share-URL flow; share remains orthogonal (URL-encoded MinimalLayout).
+- API runs on Bun; argon2 and fs usage keep it container-bound (cannot become serverless), consistent with the one-container-everywhere direction in project memory.

--- a/docs/research/2019-external.md
+++ b/docs/research/2019-external.md
@@ -1,0 +1,130 @@
+# Spike #2019 external research
+
+Research date: 2026-06-10. Sources: WebSearch + WebFetch (both available).
+
+## Backup Nudge Patterns
+
+What comparable local-first tools actually do:
+
+- Excalidraw: no proactive backup nudge at all. It autosaves to localStorage/IndexedDB and shows a static "All your data is stored locally in your browser" notice. This has caused real pain: users hit the ~5 MB localStorage ceiling and silently lose work ([issue #8395](https://github.com/excalidraw/excalidraw/issues/8395)), and a long discussion thread exists of users frustrated there is no save reminder on exit ([discussion #6463](https://github.com/excalidraw/excalidraw/discussions/6463)). Issue [#10664](https://github.com/excalidraw/excalidraw/issues/10664) argued the message was misleading (browser storage is clearable by updates, cache clears, etc.) and was closed via PR #10721 rewording it to warn users to export to files regularly. Lesson: the absence of a nudge is itself a documented failure mode, and honest copy about storage fragility was the accepted fix.
+- draw.io: avoids the problem by forcing a storage decision up front. First-run dialog asks where to store the file (device, Google Drive, OneDrive, browser); choosing browser storage shows an explicit warning that it can be cleared. After that, a persistent "Unsaved changes. Click here to save" notification sits in the toolbar rather than popping up modals ([drawio blog: choose where to store your diagram files](https://www.drawio.com/blog/save-diagram-files)).
+- tldraw: autosaves to IndexedDB via `persistenceKey` and does not nudge. Its docs treat "unsaved changes" as an app-developer concern, with an official example that enables a Save button only while the document is dirty ([tldraw unsaved changes example](https://tldraw.dev/examples/unsaved-changes), [persistence docs](https://tldraw.dev/docs/persistence)).
+- Obsidian-style apps sidestep this entirely because the durable copy is a plain file on disk; there is nothing to nudge about. This is the contrast case: nudges only exist where the working copy is more durable-looking than it really is.
+
+Cadence and nudge fatigue:
+
+- There is no published standard for change-count vs time-based export nudges; products either nudge never (Excalidraw, tldraw) or show a persistent passive indicator (draw.io). The persistent-passive pattern is the one with real production precedent.
+- UX research on notification fatigue is consistent: high frequency is the top usability complaint, interruptive nudges train users to dismiss instantly, and habituation transfers to future (legitimate) alerts ([NN/g, Alert Fatigue in User Interfaces](https://www.nngroup.com/videos/alert-fatigue-user-interfaces/), [Smashing Magazine 2025 notification guidelines](https://www.smashingmagazine.com/2025/07/design-guidelines-better-notifications-ux/)). Recommended mitigations: snooze/mute controls, context-aware timing (do not interrupt mid-task), and escalating only on genuine risk signals ([signal detection theory in UX](https://www.ux-bulletin.com/signal-detection-theory-in-ux/)).
+- Practical synthesis for Rackula browser-mode: a passive, always-visible status chip (see next section) plus a soft nudge gated on meaningful deltas (N changes or M minutes of edits since last export, whichever first) is defensible; a wall-clock-only timer nags people who did nothing. Any nudge needs one-click dismiss and a snooze that persists, and should never be modal.
+
+## Status Indicator Patterns
+
+Two opposing philosophies in production:
+
+- Google Docs: positive confirmation at every step. Header chip cycles "Saving..." then "Saved to Drive" with a cloud check icon; clicking it opens version history. Gmail and Medium use the same subtle saving/saved header icon pattern ([RealWorldUX #59 Auto-save UX](https://realworldux.co/59-auto-save-ux/)).
+- Figma: silence-when-fine, alert-when-wrong. No message while autosaving; when offline or sync fails it shows a bottom-of-screen notification that the file has unsaved changes, stores edits locally, and syncs on reconnect ([Figma offline help](https://help.figma.com/hc/en-us/articles/360040328553-What-can-I-do-offline-in-Figma), [RealWorldUX analysis](https://realworldux.co/59-auto-save-ux/)).
+- For Rackula the honest framing differs per mode: in server-mode the Google Docs pattern fits ("Saved to server"); in browser-mode "saved" is misleading because localStorage is not durable. Excalidraw's PR #10721 is the precedent for honest copy: say "stored in this browser, export to keep" rather than "saved".
+
+Per-document dirty state and aggregation:
+
+- VS Code: dirty dot replaces the close button on each modified tab, mirrored in the Explorer. Crucially for the aggregation question, it also shows a numeric badge on the Explorer activity-bar icon counting unsaved files, and "1 unsaved" text in the Open Editors section header ([waveguide.io Unsaved File Affordance](https://www.waveguide.io/examples/entry/unsaved-file-affordance/), [vscode issue #2357](https://github.com/microsoft/vscode/issues/2357)). On window close with dirty files it shows a native confirm dialog. This badge-count-on-one-icon pattern is the cleanest precedent for "one chip summarising many documents".
+- draw.io's toolbar "Unsaved changes. Click here to save" is the single-document version: the indicator is also the action.
+- Synthesis: one chip with three honest states (safe on server / in this browser only / unexported changes) plus a count when multiple layouts are at risk matches both the VS Code aggregation precedent and the Figma alert-on-risk philosophy.
+
+## beforeunload Guidance
+
+Current state (2025/2026):
+
+- Custom message strings are dead everywhere: Chrome (since 51), Firefox (since 44), and Safari (since 9.1) ignore the returned string and show only a generic "Leave site? Changes you made may not be saved" dialog ([MDN beforeunload](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)).
+- Chrome and Firefox also require sticky user activation: if the user never interacted with the page, the prompt does not show at all ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)).
+- Chrome's explicit guidance: only add the `beforeunload` listener when unsaved changes exist, and remove it immediately once saved. Never attach it unconditionally on load ([Chrome Page Lifecycle API doc](https://developer.chrome.com/docs/web-platform/page-lifecycle-api)).
+- bfcache: in modern browsers `beforeunload` no longer makes a page ineligible for back/forward cache (it used to), but `unload` still does and is being fully deprecated by Chrome on a rollout ending around April 2026; never use `unload` ([web.dev bfcache](https://web.dev/articles/bfcache), [Chrome: deprecating unload](https://developer.chrome.com/docs/web-platform/deprecating-unload)).
+- Mobile is the killer: background tabs are killed without firing `beforeunload`. Chrome's guidance is that `visibilitychange` to hidden is "the last reliable time to save app and user data". The robust pattern is: save state on `visibilitychange`/`pagehide`, and treat `beforeunload` purely as a best-effort last-resort prompt for genuinely-dirty desktop sessions ([Page Lifecycle API](https://developer.chrome.com/docs/web-platform/page-lifecycle-api)).
+
+Implication for Rackula: since the working copy is continuously persisted to localStorage, there is rarely true "unsaved" state at unload time; `beforeunload` is only justified mid-write or if an in-flight server save could be lost. Attach conditionally, remove after flush, and flush on `visibilitychange` regardless.
+
+## Snapshot/Version Retention in Self-Hosted Tools
+
+Concrete retention and restore mechanics in comparable self-hosted apps:
+
+- Grafana dashboards: keeps the last 20 versions by default, configurable via `versions_to_keep` in grafana.ini (0 = unlimited). Restore is restore-as-new-version: restoring v3 creates a new highest-numbered version with v3's content, never an in-place revert, so history is never destroyed. Includes a two-version diff view with a raw JSON diff section and a restore button in the comparison view ([Grafana manage version history](https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/manage-version-history/)).
+- Home Assistant (2025.1 backup overhaul): automatic backups with retention configurable by count or by days; the onboarding wizard recommends keeping 3. Manual backups are exempt from automatic cleanup, which is a nice distinction: user-initiated snapshots are sacred, automatic ones are bounded ([HA 2025.1 release](https://www.home-assistant.io/blog/2025/01/03/3-2-1-backup/), [backup integration docs](https://www.home-assistant.io/integrations/backup/)).
+- Joplin: saves a revision of modified notes every 10 minutes; history kept 90 days by default, configurable; restore copies the old revision into a new note rather than overwriting ([Joplin note history](https://joplinapp.org/help/apps/note_history/)). Gotcha documented there: retention is effectively the minimum across synced devices.
+- Syncthing: five strategies, useful as a taxonomy ([Syncthing versioning docs](https://docs.syncthing.net/users/versioning.html)):
+  - Trash can: keep replaced/deleted files until older than N days (0 = forever).
+  - Simple: keep the last N versions (UI default 5), timestamped copies in `.stversions`.
+  - Staggered: thinning by age bands (versions kept at increasing intervals up to a max age), bounded disk use without losing all old history.
+  - External: delegate to a user command.
+  - Versions are named by appending a `~yyyymmdd-hhmmss` timestamp to the filename, which is the simplest credible naming scheme for file-on-disk snapshots.
+- Gitea (and Git-backed config tools generally): every change is a commit; retention unbounded but delta-compressed. Overkill for Rackula's settled LWW-plus-snapshot design but worth noting as the ceiling.
+
+Patterns to copy: bounded count in the 3 to 20 range is normal (HA 3, Syncthing 5, Grafana 20); timestamped filename suffixes for on-disk snapshots; restore-as-copy/new-version rather than destructive revert is the dominant UX; consider exempting explicit user snapshots from auto-pruning while bounding automatic pre-overwrite ones.
+
+## Multi-Tab Coordination Patterns
+
+Standard building blocks:
+
+- Web Locks API (`navigator.locks.request`): broadly supported since 2022 (Chrome 69+, Firefox 96+, Safari 15.4+). Holding an exclusive named lock for the lifetime of a tab is the canonical zero-dependency leader election; locks are released automatically on tab crash/close, which solves the stale-leader problem that plagued localStorage-heartbeat schemes ([MDN Web Locks](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API), [w3c explainer](https://github.com/w3c/web-locks/blob/main/EXPLAINER.md), [Green Vitriol: leader election the easy way](https://greenvitriol.com/posts/browser-leader)).
+- BroadcastChannel: same-origin pub/sub between tabs, used to announce "document changed, reload your copy" or leader handover. Typically paired with Web Locks ([Green Vitriol](https://greenvitriol.com/posts/browser-leader)).
+- `storage` event: fires in other tabs (not the writer) when localStorage changes; the legacy fallback and effectively a free change notification if the store is localStorage anyway.
+
+What production local-first apps do:
+
+- tldraw: `persistenceKey` persists to IndexedDB and automatically syncs the document across tabs of the same browser; multi-tab is handled inside the SDK, not left to the app ([tldraw persistence](https://tldraw.dev/docs/persistence)).
+- Pre-Web-Locks offline-first apps (documented in [pesterhazy's widely-cited gist](https://gist.github.com/pesterhazy/a840a21000b67cc5b7e601fdc91b9e18)) used asymmetric roles: one elected leader tab writes to IndexedDB, follower tabs run read-only/in-memory, with election via a Lamport mutual-exclusion algorithm over localStorage. RxDB ships this as a feature ([RxDB leader election](https://rxdb.info/leader-election.html)); standalone libs include [tab-election](https://github.com/dabblewriter/tab-election).
+- Replicache and Yjs (y-indexeddb) similarly elect one tab to own persistence/network and fan out via broadcast; Yjs forum guidance is y-indexeddb for local storage with cross-tab sync ([Yjs discussion](https://discuss.yjs.dev/t/best-practice-to-sync-across-tabs-windows/903)).
+
+Simplest credible option for Rackula (one localStorage key, whole-document LWW writes): full leader election is overkill. Wrap every read-modify-write of the key in `navigator.locks.request('rackula-layout', fn)` so two tabs cannot interleave, stamp the saved blob with a revision/timestamp and refuse (or snapshot-then-write) if the stored revision is newer than the one the tab loaded, and listen to the `storage` event (or BroadcastChannel) to refresh other tabs after a write. That is roughly 30 lines, uses no libraries, and degrades gracefully: without Web Locks the revision check alone still prevents silent clobbering.
+
+## Runtime Config for Static SPAs
+
+Standard patterns for one image, runtime config:
+
+- config.json fetched at boot: app does `fetch('/config.json')` before mount; the file is generated or template-substituted by the container entrypoint. Pros: plain JSON, no JS generation. Cons: an extra blocking request and a caching footgun (must serve with no-cache) ([dmetzler: configure a SPA at runtime](https://dmetzler.github.io/configure-spa-at-runtime/), [jonrshar.pe: runtime configuration for SPAs](https://blog.jonrshar.pe/2020/Sep/19/spa-config.html)).
+- env.js / `window.__CONFIG__`: entrypoint writes a tiny script (`window.__CONFIG__ = {...}`) that index.html loads before the bundle. Synchronous, no fetch race; the most common nginx-container idiom. The official nginx image runs any script in `/docker-entrypoint.d/` before serving, which is the idiomatic hook ([dev.to: runtime env vars with nginx and Docker](https://dev.to/imzihad21/runtime-environment-variables-for-react-apps-with-nginx-and-docker-3p62)).
+- envsubst over built bundles: build with `$PLACEHOLDER` values, entrypoint runs `envsubst` across the JS output (Red Hat's documented multi-stage pattern using jq + envsubst). Works but is the most fragile: framework-specific bundle paths, and envsubst nukes any stray `$` it does not recognise ([Red Hat Developer article](https://developers.redhat.com/blog/making-environment-variables-accessible-in-front-end-containers)).
+
+Unraid / Community Applications idiom:
+
+- CA templates expose container env vars as form fields in the Unraid WebGUI; per-container env vars are the configuration mechanism users expect, alongside PUID/PGID/TZ conventions ([Unraid docs: managing containers](https://docs.unraid.net/unraid-os/using-unraid-to/run-docker-containers/managing-and-customizing-containers/), [selfhosters.net template guide](https://selfhosters.net/docker/templating/templating/)). Spike #1995 already settled on a two-template model (rackula, optional rackula-api), so "API may or may not exist" is a first-class deployment state.
+
+Auto-detect API vs explicit config:
+
+- Auto-detect (probe a same-origin `/api/health` at boot) gives zero-config when the API is reverse-proxied behind the same host, which is the nicest default for the single-container and proxied cases. Its failure mode matters for this spike specifically: a temporarily-down API is indistinguishable from "no API configured", so the app could silently fall back to browser-mode and mislead the user about data safety.
+- Explicit config (env var like `RACKULA_API_URL` or `RACKULA_MODE` injected via `window.__CONFIG__`) is the Unraid-idiomatic choice and removes the ambiguity: if an API is configured but unreachable, the app can honestly show "server unreachable, changes held locally" (the Figma pattern) instead of quietly degrading.
+- Pragmatic hybrid seen in self-hosted apps: explicit config wins when set; if unset, a fast same-origin probe enables server-mode opportunistically. Given the data-safety framing of this spike, explicit-config-wins with honest unreachable-state UI is the safer recommendation.
+
+## External Resources
+
+- https://github.com/excalidraw/excalidraw/discussions/6463 (no auto-save-to-file frustration)
+- https://github.com/excalidraw/excalidraw/issues/8395 (localStorage limit data loss)
+- https://github.com/excalidraw/excalidraw/issues/10664 (misleading "stored locally" copy, fixed in PR #10721)
+- https://www.drawio.com/blog/save-diagram-files (draw.io storage-choice flow)
+- https://tldraw.dev/docs/persistence and https://tldraw.dev/examples/unsaved-changes
+- https://www.nngroup.com/videos/alert-fatigue-user-interfaces/
+- https://www.smashingmagazine.com/2025/07/design-guidelines-better-notifications-ux/
+- https://www.ux-bulletin.com/signal-detection-theory-in-ux/
+- https://realworldux.co/59-auto-save-ux/ (Google Docs vs Figma save-status philosophies)
+- https://help.figma.com/hc/en-us/articles/360040328553-What-can-I-do-offline-in-Figma
+- https://www.waveguide.io/examples/entry/unsaved-file-affordance/ (VS Code dirty dot + aggregate badge)
+- https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
+- https://developer.chrome.com/docs/web-platform/page-lifecycle-api
+- https://developer.chrome.com/docs/web-platform/deprecating-unload
+- https://web.dev/articles/bfcache
+- https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/manage-version-history/
+- https://www.home-assistant.io/blog/2025/01/03/3-2-1-backup/ and https://www.home-assistant.io/integrations/backup/
+- https://joplinapp.org/help/apps/note_history/
+- https://docs.syncthing.net/users/versioning.html
+- https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
+- https://github.com/w3c/web-locks/blob/main/EXPLAINER.md
+- https://greenvitriol.com/posts/browser-leader
+- https://gist.github.com/pesterhazy/a840a21000b67cc5b7e601fdc91b9e18
+- https://rxdb.info/leader-election.html
+- https://github.com/dabblewriter/tab-election
+- https://discuss.yjs.dev/t/best-practice-to-sync-across-tabs-windows/903
+- https://developers.redhat.com/blog/making-environment-variables-accessible-in-front-end-containers
+- https://dmetzler.github.io/configure-spa-at-runtime/
+- https://blog.jonrshar.pe/2020/Sep/19/spa-config.html
+- https://dev.to/imzihad21/runtime-environment-variables-for-react-apps-with-nginx-and-docker-3p62
+- https://docs.unraid.net/unraid-os/using-unraid-to/run-docker-containers/managing-and-customizing-containers/
+- https://selfhosters.net/docker/templating/templating/

--- a/docs/research/2019-patterns.md
+++ b/docs/research/2019-patterns.md
@@ -1,0 +1,392 @@
+# Spike #2019 pattern analysis
+
+Synthesis of `2019-codebase.md` and `2019-external.md` into concrete recommendations.
+Settled decisions (explicit mode, one honest chip, first-run notice, instance-named toast,
+one user on multiple devices, LWW plus pre-overwrite snapshot, manual export plus nudges,
+runtime config) are taken as given and not relitigated.
+
+## Key Insights
+
+1. The honest-copy lesson is the strongest external signal. Excalidraw shipped "stored
+   locally in your browser" for years, users lost work to cache clears and the 5 MB
+   ceiling, and the accepted fix (PR #10721) was rewording to "export to files regularly".
+   Rackula's chip copy should never say "saved" in browser mode; it should say where the
+   data is and what makes it safe.
+2. Production tools converge on passive persistent indicators, not interruptive nudges
+   (draw.io toolbar notice, VS Code dirty dot plus aggregate badge, Figma
+   alert-only-on-risk). NN/g alert-fatigue research says interruptive nudges train instant
+   dismissal. The chip should carry most of the load; toasts escalate rarely.
+3. The codebase has no substrate for "recent backup": only a dirty boolean, no change
+   counter, no record of export events, and exports do not reliably call `markClean()`.
+   Whatever definition we pick requires new state, so we should pick the state that is
+   cheapest and most honest: a counter reset on successful export.
+4. Server storage has no versioning at all: `PUT` is an unconditional in-place
+   `writeFile`, no ETag, no If-Match, and the startup LWW silently discards the loser.
+   Snapshots are greenfield; the only constraints are the quota directory scan
+   (`checkLayoutQuota` counts DATA_DIR root entries) and `findYamlInFolder` (must not see
+   snapshot YAML in the folder root).
+5. Timestamps cross machine clocks (server `updatedAt` is file mtime, local `savedAt` is
+   browser clock). Any conflict detection should compare server-issued values against
+   server-issued values (echo semantics), never browser clock against server clock.
+6. Retention norms in self-hosted tools are small bounded counts (Home Assistant
+   recommends 3, Syncthing defaults 5, Grafana 20), Syncthing-style timestamp-suffix
+   naming, and restore-as-new-version rather than destructive revert (Grafana, Joplin).
+7. For twin tabs, full leader election (RxDB-style) is overkill for one localStorage key
+   and whole-document LWW. The `storage` event is a free foreign-write notification;
+   Web Locks can serialize read-modify-write in a few lines if needed.
+8. For runtime config, the Unraid-idiomatic and least-fragile pattern is an env var
+   surfaced to the SPA as a synchronous `window.__RACKULA_CONFIG__` script injected by the
+   container entrypoint, with explicit-config-wins over any probe. Static hosts have no
+   entrypoint, so the absent-config default must be `browser`.
+
+## A. Browser-Mode Data Loss
+
+### Nudge cadence and tone
+
+Options considered:
+
+- No nudge, chip only (Excalidraw, tldraw). Documented failure mode: users never export
+  and lose work; Excalidraw's discussion #6463 is a thread of exactly this pain.
+- Time-based nudge (every M minutes/days). Nags users who changed nothing; wall-clock
+  cadence is the pattern alert-fatigue research warns against.
+- Change-based nudge (N changes since last export). Matches what the app can actually
+  know (export events and mutation counts), scales with real risk, silent when idle.
+- Persistent modal or blocking banner. Rejected outright: interruptive, trains dismissal.
+
+Recommendation: the amber chip is the always-on signal; add one non-modal toast nudge that
+fires when `changesSinceExport` crosses 30, with an "Export now" action and a dismiss.
+Dismissal snoozes the nudge until the counter crosses the next multiple of 30 (60, 90, ...),
+persisted in localStorage so reloads do not re-nag. The nudge also fires once on the first
+edit after the first-run notice session if the user has never exported (cold-start case
+where 30 changes may take weeks). Tone is factual, no urgency theatre:
+"This layout lives only in this browser. Export a file to keep a copy." Action: Export.
+
+Rationale: the persistent-passive pattern is the only one with production precedent
+(draw.io); the toast exists because a chip alone demonstrably fails (Excalidraw). N=30 is
+roughly a meaningful editing session (device placements, moves, renames each count one);
+small enough to fire before substantial loss, large enough that a quick tweak does not
+trigger it. Escalation by re-crossing multiples avoids both one-shot-and-forgotten and
+every-N-spam.
+
+### Restore-from-file flow
+
+Options considered:
+
+- Reuse Ctrl+O `loadFromFile()` as-is (picker, load, `markClean()`, `clearSession()`).
+  Works today but silently destroys the current working copy.
+- Full import wizard with diff/merge. Over-engineered; the app is whole-document LWW by
+  decision.
+- Reuse the pipeline, add a guard when the current working copy has unbacked changes.
+
+Recommendation: chip popover action "Restore from file" invokes the existing
+`loadFromFile()` pipeline (`.yaml` and `.rackula.zip`). If `changesSinceExport > 0`, show
+a small confirm first: "Replace the layout in this browser? It has changes that are not in
+any exported file." Buttons: "Export first" (runs export, then continues), "Replace",
+"Cancel". If the working copy is fully backed up, no confirm, just the picker. Wording in
+the popover: "Restore from file" with the subtext "Opens a .yaml or .rackula.zip export".
+
+Rationale: the pipeline already exists (`load-pipeline.ts`), restores images from ZIP, and
+resets state correctly; the only gap is overwrite protection, and a single conditional
+confirm is the simplest honest guard. "Export first" turns the dangerous moment into the
+backup moment, which is the only point a modal interruption is justified.
+
+### "Recent backup" definition for chip
+
+Options considered:
+
+- Time-based (exported within X hours/days). Dishonest both ways: a 10-minute-old export
+  can already be stale after heavy editing, and a week-old export of an untouched layout
+  is perfectly current. Also requires a wall clock judgement the app cannot defend.
+- Threshold-based green (green while `changesSinceExport <= N` for some N > 0). Lies for
+  up to N changes; "backed up" would be shown while unbacked changes exist, contradicting
+  the settled chip rule (green only when every open layout is in its durable home).
+- Exact: green if and only if zero changes since the last successful export.
+
+Recommendation: green means `changesSinceExport === 0`; any unexported change flips amber.
+N is therefore 1 for the chip (amber at the first unbacked change) and 30 for the nudge
+(see above): two thresholds, one honest state. Mechanics: add a `changesSinceExport`
+counter incremented inside `markDirty()` in `layout.svelte.ts` (the single choke point all
+mutating actions already call), persisted in the localStorage session blob alongside
+`savedAt` so it survives reload, and reset to 0 only when `fileSave()` resolves without
+`AbortError` in `downloadYamlFile()`/`downloadArchive()` (cancellation is already
+distinguishable). Loading a layout from file sets the counter to 0 (the file is the durable
+home and it matches by construction). Share-URL renders and image exports (Ctrl+E) do not
+reset it: they are not backups.
+
+Rationale: the spec's green rule is absolute, so any N > 0 for the chip is a contradiction;
+the fatigue concern that motivates a larger N is handled by the nudge threshold instead.
+The counter is the cheapest possible mechanism (one integer, one increment site, one reset
+site) and avoids content hashing entirely. The chip staying amber during active editing is
+correct: in browser mode the durable home really is out of date.
+
+### beforeunload decision
+
+Options considered:
+
+- Warn whenever `changesSinceExport > 0`. Fires on almost every close (users rarely export
+  before every close), pure habituation, and dishonest: closing the window loses nothing
+  because the working copy is in localStorage.
+- Never warn. Loses the one case where data genuinely evaporates: a pending debounced
+  write or an in-flight/failed server save at close time.
+- Warn only on genuine in-flight loss risk, attached conditionally.
+
+Recommendation: `beforeunload` warns only when there is real in-flight risk: a pending
+un-flushed localStorage debounce (rare, since `visibilitychange` flush runs first) or, in
+server mode, a dirty layout while the server is unreachable or a save is mid-flight.
+Unbacked-but-persisted changes never trigger it in browser mode. Follow Chrome guidance:
+attach the listener only while the risk condition holds, remove it as soon as the flush or
+save completes, and keep flushing on `visibilitychange` as the primary mechanism (mobile
+never fires `beforeunload`). Keep the existing user toggle (`warnOnUnsavedChanges`) with
+its current default, but redefine its condition to the risk condition above rather than
+the raw `isDirty` boolean; users who want a belt-and-braces close prompt can leave it on.
+
+Rationale: custom messages are dead in all browsers and sticky activation already gates
+the prompt, so the dialog buys very little; the localStorage working copy means close is
+not a loss event in browser mode. Tying the prompt to actual loss keeps the rare prompt
+meaningful. The clearing-browser-data loss vector cannot be intercepted by any event; the
+nudge and first-run notice are the mitigation for that, not `beforeunload`.
+
+## B. Server-Down Recovery
+
+### Snapshot mechanics
+
+Options considered:
+
+- Snapshot on every PUT. The 2s autosave would churn a snapshot every keystroke burst;
+  retention N would hold the last N autosaves of the same editing session, worthless for
+  recovering a divergent copy.
+- Client-side snapshots in localStorage. Competes with the 5 MB ceiling, invisible to
+  other devices, and does not survive the cache clear it is meant to guard against.
+- Server-side snapshot only when the overwrite is conflicting, detected via an echo
+  timestamp.
+
+Recommendation: snapshots live server-side inside the layout folder at
+`/data/{Name}-{UUID}/snapshots/{name}~YYYYMMDD-HHMMSS.yaml` (Syncthing naming). The client
+sends the `updatedAt` it last received from the server as an `If-Unmodified-Since`-style
+header on every PUT. In `saveLayout()`, if the stored file's `updatedAt` differs from the
+echoed value (or the header is absent but a file exists with no prior knowledge), copy the
+existing YAML into `snapshots/` before `writeFile`, then write: LWW is preserved, nothing
+is rejected, but the losing copy is captured. Keep the 5 most recent automatic snapshots
+per layout, pruning oldest on write. Snapshot YAML only, not assets (restored snapshots
+referencing since-deleted images degrade to placeholders, which is acceptable). Discovery
+and restore: `GET /layouts/:uuid/snapshots` lists them; LoadDialog grows a per-layout
+"Snapshots" expansion; restoring loads the snapshot into the editor as the working copy,
+and the next save writes it to the server through the same conflict-detecting path (which
+snapshots the current server copy in turn). Restore-as-new-write, never in-place revert,
+per the Grafana/Joplin pattern.
+
+Rationale: the echo comparison compares server time to server time, immune to the clock
+skew that makes mtime-vs-browser-clock comparisons unsafe. Mismatch-only snapshots mean
+every snapshot marks a genuine divergence point (the only thing worth recovering under
+LWW), so a small retention of 5 covers realistic multi-device drift. The `snapshots/`
+subdirectory is invisible to `checkLayoutQuota` (counts DATA_DIR root entries) and to
+`findYamlInFolder` (folder root scan) by construction; both exclusions must be stated in
+the guardrails spec (see Spec Reconciliation). Bound: at most 5 x 1 MB per layout, capped
+by `RACKULA_MAX_LAYOUTS`, so worst-case disk cost is known.
+
+### Relation to timestamp conflict resolution
+
+Options considered:
+
+- Leave the App.svelte startup `isServerNewer()` compare as-is and bolt snapshots on
+  server-side only. Covers the local-newer-wins direction (the autosave PUT triggers the
+  mismatch snapshot) but the server-newer-wins direction still silently discards the local
+  copy via `clearSession()`.
+- Keep the losing local copy in a second localStorage slot. Invisible, single-slot, and
+  lost with the same browser data it distrusts.
+- Route both directions through the server snapshot store.
+
+Recommendation: replace the mtime-vs-browser-clock `isServerNewer()` comparison with the
+echo model: the localStorage session stores the server `updatedAt` it was last synced to
+(instead of a browser-generated `savedAt` for comparison purposes). At startup, if the
+session's base `updatedAt` matches the server's current value, the local copy is simply
+ahead (offline edits): load local and let autosave push it; the PUT will see a matching
+echo and not snapshot (correct, nothing is lost). If they differ, the copies genuinely
+diverged: keep LWW by recency as today, but before discarding the local copy
+(server-newer-wins), POST it to `POST /layouts/:uuid/snapshots` so it lands in the same
+snapshot store; in the other direction the conflicting PUT snapshots the server copy
+automatically. Both losers end up findable in one place (LoadDialog snapshots). The
+"Loaded unsaved local changes" and "Loaded from server" toasts stay, with the losing-copy
+toast gaining "Previous copy saved as a snapshot".
+
+Additionally, stop calling `clearSession()` after successful server saves (Effect 2):
+keep the localStorage working copy in server mode, stamped with the server-echoed
+`updatedAt`. This is what makes server-down continuity seamless (edits keep landing in
+localStorage; reconnection pushes them through the snapshot-protected PUT) and it is what
+the parent spec's three-tier model already describes (browser tier is the live working
+copy in both modes).
+
+Rationale: the existing compare is the weakest link (clock skew plus silent discard); the
+echo model removes the skew and the snapshot store removes the silence, without adding
+merge UX. One snapshot home for both directions keeps find-and-restore to a single UI.
+
+### Twin-tab case
+
+Options considered:
+
+- Full leader election (Web Locks leader plus BroadcastChannel fan-out, RxDB-style). Solves
+  a collaboration problem the app does not have; the concurrency target is one user, and
+  the failure today is silent clobbering, not lack of live sync.
+- Do nothing (status quo). Two tabs ping-pong overwrite `Rackula:autosave` every second
+  and the same server UUID every 2s, silently; the chip would also lie in the stale tab.
+- Detect-and-pause: foreign-write detection via the `storage` event, pause the stale tab.
+
+Recommendation: detect-and-pause. Stamp each session write with a per-tab id (random,
+generated at startup). Each tab listens for the `storage` event on the autosave key; when
+a write from another tab id arrives, the receiving tab pauses its autosave effects (both
+localStorage and server) and shows one toast: "This layout is open in another tab, which
+now has the latest changes." with a "Reload this tab" action that re-reads the working
+copy and resumes. Wrap the session read-modify-write in
+`navigator.locks.request('rackula:autosave', fn)` where available so two near-simultaneous
+debounce flushes cannot interleave; without Web Locks the tab-id check alone still
+prevents silent ping-pong. No BroadcastChannel, no leader election, no live mirroring.
+
+Rationale: this is roughly 30 lines, zero dependencies, and converts the worst outcome
+(two tabs alternately destroying each other's work at both tiers, forever, invisibly) into
+an explicit single-toast state. It is also consistent with the settled multi-device answer:
+the second tab behaves like a second device that has voluntarily gone read-only. The
+server-side mismatch snapshot still backstops the case where both tabs raced a PUT before
+detection.
+
+## C. Mode Mechanics
+
+### Setting storage mode
+
+Options considered:
+
+- Auto-detect by probing `/api/health` (status quo plus `hasEverConnectedToApi`). This is
+  exactly the ambiguity the parent spec kills: a down server is indistinguishable from no
+  server, so the app silently degrades to browser-mode messaging while the user believes
+  the server holds their data.
+- `config.json` fetched at boot. Works, but adds a blocking fetch before mount and a
+  no-cache serving footgun; strictly more moving parts than a synchronous global.
+- envsubst over built bundles. Most fragile (bundle paths, stray `$`), rejected.
+- Entrypoint-injected `window.__RACKULA_CONFIG__` script, explicit env var, absent means
+  browser.
+
+Recommendation: a single env var `RACKULA_STORAGE_MODE=browser|server` read by the
+container entrypoint, which writes `/usr/share/nginx/html/config.js` containing
+`window.__RACKULA_CONFIG__ = { storage: "server" }` (idiomatic `/docker-entrypoint.d/`
+script) and injects/maintains a `<script src="config.js">` tag ahead of the bundle in
+index.html at container start. The app reads
+`window.__RACKULA_CONFIG__?.storage ?? "browser"`. Static hosts (GitHub Pages, Cloudflare
+prod) ship no config script and therefore default to browser mode with zero configuration.
+The image default is `browser`; the LXC build, docker-compose with the API sidecar, and the
+Unraid `rackula` template (when paired with `rackula-api`) set `server`. Explicit config
+always wins; no probe-based fallback between modes. Delete `hasEverConnectedToApi` and the
+probe-and-guess in `persistence.svelte.ts`; in server mode the health check means up/down,
+never "switch to file saves".
+
+Rationale: synchronous global, no fetch race, no cache headers to get wrong, and env vars
+are exactly what Unraid CA templates surface as form fields (spike #1995). The
+data-safety framing of this spike is the decider: only explicit mode lets the app honestly
+say "server unreachable, changes held in this browser" instead of quietly becoming a
+different product.
+
+### Server build first load
+
+Options considered:
+
+- Keep the current four-step priority with probe and StartScreen. Contradicts explicit
+  mode and the parent spec's StartScreen removal.
+- Mode-driven startup.
+
+Recommendation: in server mode, on first load: check `/api/health` once (the nginx
+deliberate 502/503 makes down unambiguous). If up: fetch the layout list; if the list is
+empty (true first run), create a new untitled layout and let autosave establish it on the
+server, no StartScreen; otherwise open the most recently updated layout, reconciled
+against any localStorage working copy via the echo comparison from section B. If down:
+load the localStorage working copy if present (else a new empty layout), show the red
+"<instance> unreachable" chip state and the single instance-named toast, keep autosaving
+locally, and poll health for the quiet recovery toast. Share-URL remains priority one in
+both modes. In browser mode, first load shows the one-time first-run notice and loads the
+working copy or a new layout; the API code paths are never consulted.
+
+Rationale: every branch is now a statement of fact rather than a guess; server-down on
+first load becomes a continuity story (local working copy plus honest red state) instead
+of a silent identity change.
+
+### Export-all and backup framing per mode
+
+Options considered:
+
+- One shared "Export" wording for both modes. Misses the point that the same artifact is
+  a backup in one mode and a convenience copy in the other.
+- Mode-specific framing over one shared mechanism.
+
+Recommendation: one artifact, two framings. Build export-all as a ZIP
+(`rackula-export-YYYYMMDD-HHMMSS.zip`) containing each layout's existing folder-archive
+form (YAML plus assets), reusing `downloadArchive()` mechanics; with a single layout open
+it degrades to today's single-layout archive. In browser mode the chip popover labels it
+"Back up all layouts" and a successful run resets `changesSinceExport` for every included
+layout (this is what turns the chip green). In server mode the popover labels it
+"Export a copy" with subtext "Your layouts are stored on <instance>; this makes a portable
+copy", and it never affects chip state (green comes from server sync, not exports). In
+server mode export-all pulls authoritative YAML from `GET /layouts` rather than browser
+state, so the copy matches the durable home.
+
+Rationale: the chip's green rule defines what counts as backup per mode, so the wording
+must follow it; identical mechanics with different labels is the minimum that stays honest.
+Automatic snapshots are deliberately excluded from export-all (they are recovery plumbing,
+not documents).
+
+## Spec Reconciliation
+
+Save-indicator spec (#1901, `2026-06-04-save-indicator-design.md`):
+
+- Contradiction: #1901 removed the visible SaveStatus surface; the chip reintroduces a
+  visible, persistent save-state surface and needs `_saveStatus` exported again.
+- Resolution: amend the #1901 decision record to state that the chip supersedes the
+  "toasts only, no persistent indicator" visual decision, while these #1901 decisions
+  stand unchanged: autosave success is silent (the chip changes state, it does not toast),
+  manual Ctrl+S keeps its success toast, save failures remain persistent toasts with Retry
+  and dedup, ARIA role split stays, and the toolbar reserves fixed space for the chip (the
+  #1901 reflow lesson). The chip replaces, rather than adds to, the two "working offline"
+  toasts being deleted (`App.svelte:225-231, 293-299`,
+  `persistence-manager.svelte.ts:104-109`).
+
+Storage-abuse-guardrails spec (#1780, `2026-06-02-storage-abuse-guardrails-design.md`):
+
+- Contradiction 1: "no retention or cleanup policy: the quota cap IS the guardrail" versus
+  snapshot pruning (keep 5, delete oldest).
+- Resolution: amend the guardrails spec to scope the no-retention stance to user layouts.
+  Automatic pre-overwrite snapshots are system artifacts with a fixed bound (5 per layout,
+  YAML only), which preserves the spirit of the stance: the bound is still a hard cap, not
+  a background cleanup job over user data. Worst-case disk impact is quantifiable
+  (5 x 1 MB x RACKULA_MAX_LAYOUTS).
+- Contradiction 2: quota counts directories under /data; snapshots add stored objects.
+- Resolution: snapshots live in `{layout-folder}/snapshots/`, which the DATA_DIR root scan
+  never sees, so `RACKULA_MAX_LAYOUTS` semantics are untouched; document this exclusion
+  explicitly in the guardrails spec so a future quota refactor does not accidentally start
+  counting them. The non-root placement also keeps `findYamlInFolder()` safe. The
+  create-vs-update skip in `storage-quota-middleware` is unaffected (snapshot writes happen
+  inside an update of an existing UUID).
+- New surface to note in the guardrails spec: `POST /layouts/:uuid/snapshots` (client
+  uploads a losing local copy) is a write endpoint and must sit behind the same writeAuth
+  and body-limit middleware as `PUT /layouts/:uuid`, and count against the per-layout
+  snapshot bound of 5.
+
+Parent epic spec (minor): it describes the browser tier as the live working copy in both
+modes, but Effect 2 currently deletes the localStorage copy after each successful server
+save. The recommendation in section B (keep the working copy, stamp it with the server
+echo) resolves the code toward the spec; flag it in the implementation plan as a
+behavioural change to `persistence-manager.svelte.ts`.
+
+## Trade-offs Summary
+
+| Decision           | Chosen                                                         | Accepted cost                                                                               |
+| ------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Nudge              | Chip-first, toast at 30-change multiples                       | Users who ignore both can still lose data; no nudge can stop a cache clear                  |
+| Chip green         | Strict zero changes since export                               | Chip is amber during normal editing; honesty over comfort                                   |
+| Backup state       | Single counter in `markDirty()`                                | Counts changes, not magnitude; an undo back to exported state still shows amber             |
+| beforeunload       | Only on in-flight loss risk                                    | No prompt for unbacked-but-persisted changes; nudges carry that load                        |
+| Snapshots          | Server-side, mismatch-only, keep 5, YAML only                  | No asset snapshots; offline-only browser mode gets no snapshot tier at all                  |
+| Conflict detection | Server-echo updatedAt header                                   | Adds one header and one comparison to PUT; no full ETag machinery                           |
+| Twin tabs          | Detect-and-pause via storage event plus Web Locks              | Stale tab goes passive until reload; no live cross-tab sync                                 |
+| Mode config        | RACKULA_STORAGE_MODE env to injected window.**RACKULA_CONFIG** | Mode is fixed at container start; changing it needs a restart (acceptable for self-hosting) |
+| Export-all         | One ZIP artifact, mode-specific framing                        | Server-mode export-all does N+1 API requests; fine at 100-layout cap                        |
+
+Every recommendation builds on an existing mechanism (markDirty, fileSave AbortError,
+load-pipeline, LoadDialog, toast store, entrypoint wrapper, layout folders) rather than
+introducing new infrastructure; the only new server surface is the snapshots
+subdirectory, its list/restore routes, and one request header.

--- a/docs/research/2019-patterns.md
+++ b/docs/research/2019-patterns.md
@@ -374,17 +374,17 @@ behavioural change to `persistence-manager.svelte.ts`.
 
 ## Trade-offs Summary
 
-| Decision           | Chosen                                                         | Accepted cost                                                                               |
-| ------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Nudge              | Chip-first, toast at 30-change multiples                       | Users who ignore both can still lose data; no nudge can stop a cache clear                  |
-| Chip green         | Strict zero changes since export                               | Chip is amber during normal editing; honesty over comfort                                   |
-| Backup state       | Single counter in `markDirty()`                                | Counts changes, not magnitude; an undo back to exported state still shows amber             |
-| beforeunload       | Only on in-flight loss risk                                    | No prompt for unbacked-but-persisted changes; nudges carry that load                        |
-| Snapshots          | Server-side, mismatch-only, keep 5, YAML only                  | No asset snapshots; offline-only browser mode gets no snapshot tier at all                  |
-| Conflict detection | Server-echo updatedAt header                                   | Adds one header and one comparison to PUT; no full ETag machinery                           |
-| Twin tabs          | Detect-and-pause via storage event plus Web Locks              | Stale tab goes passive until reload; no live cross-tab sync                                 |
-| Mode config        | RACKULA_STORAGE_MODE env to injected window.**RACKULA_CONFIG** | Mode is fixed at container start; changing it needs a restart (acceptable for self-hosting) |
-| Export-all         | One ZIP artifact, mode-specific framing                        | Server-mode export-all does N+1 API requests; fine at 100-layout cap                        |
+| Decision           | Chosen                                                             | Accepted cost                                                                               |
+| ------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| Nudge              | Chip-first, toast at 30-change multiples                           | Users who ignore both can still lose data; no nudge can stop a cache clear                  |
+| Chip green         | Strict zero changes since export                                   | Chip is amber during normal editing; honesty over comfort                                   |
+| Backup state       | Single counter in `markDirty()`                                    | Counts changes, not magnitude; an undo back to exported state still shows amber             |
+| beforeunload       | Only on in-flight loss risk                                        | No prompt for unbacked-but-persisted changes; nudges carry that load                        |
+| Snapshots          | Server-side, mismatch-only, keep 5, YAML only                      | No asset snapshots; offline-only browser mode gets no snapshot tier at all                  |
+| Conflict detection | Server-echo updatedAt header                                       | Adds one header and one comparison to PUT; no full ETag machinery                           |
+| Twin tabs          | Detect-and-pause via storage event plus Web Locks                  | Stale tab goes passive until reload; no live cross-tab sync                                 |
+| Mode config        | `RACKULA_STORAGE_MODE` env to injected `window.__RACKULA_CONFIG__` | Mode is fixed at container start; changing it needs a restart (acceptable for self-hosting) |
+| Export-all         | One ZIP artifact, mode-specific framing                            | Server-mode export-all does N+1 API requests; fine at 100-layout cap                        |
 
 Every recommendation builds on an existing mechanism (markDirty, fileSave AbortError,
 load-pipeline, LoadDialog, toast store, entrypoint wrapper, layout folders) rather than

--- a/docs/research/spike-2019-storage-model-data-safety.md
+++ b/docs/research/spike-2019-storage-model-data-safety.md
@@ -1,0 +1,426 @@
+# Spike #2019: Storage Model and Data Safety
+
+**Date:** 2026-06-10
+**Parent Epic:** #2017
+**Spec:** docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
+
+## Executive Summary
+
+This spike resolves the three storage questions the canvas UX overhaul spec delegated.
+
+Browser-mode data loss. The chip is the always-on signal and is strictly honest: green
+only when zero changes exist since the last successful file export, tracked by a new
+`changesSinceExport` counter. One non-modal toast nudge fires at 30-change multiples with
+an Export action and a persisted snooze. Restore-from-file reuses the existing load
+pipeline with a single confirm when unbacked changes would be replaced. `beforeunload`
+warns only on genuine in-flight loss risk, never on unbacked-but-persisted changes.
+
+Server-down recovery. Pre-overwrite snapshots live server-side in a `snapshots/`
+subdirectory of each layout folder, created only when a PUT's echoed `updatedAt` does not
+match the stored copy (a genuine divergence), keeping the 5 most recent. The startup
+timestamp comparison moves from mtime-versus-browser-clock to server-echo semantics, and
+the localStorage working copy is kept (not cleared) after server saves. Twin tabs are
+handled by detect-and-pause via the `storage` event plus a per-tab id, with Web Locks
+serialising writes where available.
+
+Mode mechanics. Storage mode is an explicit env var, `RACKULA_STORAGE_MODE=browser|server`,
+injected by the container entrypoint as a synchronous `window.__RACKULA_CONFIG__` script.
+Absent config means browser mode, which is what static hosts get for free. The
+probe-and-guess machinery (`hasEverConnectedToApi`) is deleted. Server-mode first load is
+mode-driven with no StartScreen, and export-all is one ZIP artifact with mode-specific
+framing: a backup in browser mode (resets the chip), a portable copy in server mode.
+
+## Recommendations
+
+### Nudge cadence and tone
+
+Decision. The amber chip carries the always-on signal. One non-modal toast nudge fires
+when `changesSinceExport` crosses 30, with an "Export now" action and a dismiss. Dismissal
+snoozes until the counter crosses the next multiple of 30 (60, 90, and so on), persisted
+in localStorage so reloads do not re-nag. The nudge also fires once on the first edit
+after the first-run notice if the user has never exported. Tone is factual: "This layout
+lives only in this browser. Export a file to keep a copy."
+
+Mechanics. Counter increments in `markDirty()`; nudge threshold checked there; snooze
+state in localStorage via the existing `safe-storage.ts` helpers; toast uses the existing
+action and dedup support in the toast store.
+
+Alternatives considered. No nudge at all (Excalidraw, tldraw): documented failure mode,
+users lose work. Time-based nudges: nag people who changed nothing. Modal or blocking
+banner: trains instant dismissal.
+
+Rationale. The persistent-passive pattern is the only one with production precedent
+(draw.io); the toast exists because a chip alone demonstrably fails (Excalidraw
+discussion #6463). N=30 approximates a meaningful editing session. Escalation by
+re-crossing multiples avoids both one-shot-and-forgotten and every-N spam.
+
+### Restore-from-file flow
+
+Decision. The chip popover gains a "Restore from file" action that invokes the existing
+`loadFromFile()` pipeline (`.yaml` and `.rackula.zip`). If `changesSinceExport > 0`, a
+small confirm appears first: "Replace the layout in this browser? It has changes that are
+not in any exported file." Buttons: "Export first" (runs export, then continues),
+"Replace", "Cancel". If the working copy is fully backed up, no confirm, just the picker.
+
+Alternatives considered. Reusing Ctrl+O as-is silently destroys the working copy. A full
+import wizard with diff or merge is over-engineered for a whole-document LWW app.
+
+Rationale. The pipeline already exists, restores images from ZIP, and resets state
+correctly; the only gap is overwrite protection. "Export first" turns the dangerous
+moment into the backup moment, the one point where a modal interruption is justified.
+
+### "Recent backup" chip definition
+
+Decision. Green means `changesSinceExport === 0`. Any unexported change flips the chip
+amber. The chip threshold is therefore 1 and the nudge threshold 30: two thresholds, one
+honest state.
+
+Mechanics. A `changesSinceExport` counter is incremented inside `markDirty()` in
+`layout.svelte.ts` (the single choke point all mutating actions call), persisted in the
+localStorage session blob alongside `savedAt`, and reset to 0 only when `fileSave()`
+resolves without `AbortError` in `downloadYamlFile()` or `downloadArchive()`. Loading a
+layout from file sets the counter to 0. Share-URL renders and image exports (Ctrl+E) do
+not reset it: they are not backups.
+
+Alternatives considered. Time-based (exported within X hours) is dishonest both ways: a
+10-minute-old export can be stale after heavy editing, and a week-old export of an
+untouched layout is current. Threshold-based green (green while changes <= N for N > 0)
+contradicts the spec's rule that green means every open layout is in its durable home.
+
+Rationale. The spec's green rule is absolute, so any N > 0 for the chip is a lie; the
+fatigue concern that motivates a larger N is handled by the nudge threshold instead. The
+counter is the cheapest possible mechanism: one integer, one increment site, one reset
+site, no content hashing.
+
+### beforeunload
+
+Decision. `beforeunload` warns only on genuine in-flight loss risk: a pending un-flushed
+localStorage debounce, or in server mode a dirty layout while the server is unreachable
+or a save is mid-flight. Unbacked-but-persisted changes never trigger it in browser mode.
+The listener is attached only while the risk condition holds and removed once the flush
+or save completes. `visibilitychange` flush remains the primary persistence mechanism.
+The existing `warnOnUnsavedChanges` toggle stays, redefined to gate the risk condition
+rather than the raw `isDirty` boolean.
+
+Alternatives considered. Warning whenever `changesSinceExport > 0` fires on almost every
+close and is dishonest (closing loses nothing; the working copy is in localStorage).
+Never warning loses the one case where data genuinely evaporates.
+
+Rationale. Custom messages are dead in all browsers, sticky activation already gates the
+prompt, and mobile never fires `beforeunload` (Chrome's guidance: `visibilitychange` to
+hidden is the last reliable save point). The clearing-browser-data loss vector cannot be
+intercepted by any event; the nudge and first-run notice mitigate that, not
+`beforeunload`.
+
+### Snapshot mechanics
+
+Decision. Snapshots are server-side, stored inside the layout folder at
+`/data/{Name}-{UUID}/snapshots/{name}~YYYYMMDD-HHMMSS.yaml` (Syncthing naming). The
+client sends the `updatedAt` it last received from the server as an
+If-Unmodified-Since-style header on every PUT. In `saveLayout()`, if the stored file's
+`updatedAt` differs from the echoed value, the existing YAML is copied into `snapshots/`
+before the write. LWW is preserved, nothing is rejected, but the losing copy is captured.
+Retention is the 5 most recent automatic snapshots per layout, pruned on write. Snapshots
+are YAML only, no assets. Discovery and restore: `GET /layouts/:uuid/snapshots` lists
+them, LoadDialog grows a per-layout snapshots expansion, and restoring loads the snapshot
+into the editor as the working copy. The next save writes it through the same
+conflict-detecting path, which snapshots the current server copy in turn:
+restore-as-new-write, never in-place revert.
+
+Alternatives considered. Snapshot on every PUT: the 2s autosave would churn snapshots
+every keystroke burst, and retention N would hold N autosaves of one session, worthless
+for recovering a divergent copy. Client-side snapshots in localStorage: competes with the
+5 MB ceiling, invisible to other devices, and does not survive the cache clear it guards
+against.
+
+Rationale. The echo comparison compares server time to server time, immune to the clock
+skew that makes mtime-versus-browser-clock unsafe. Mismatch-only snapshots mean every
+snapshot marks a genuine divergence point, so retention of 5 covers realistic
+multi-device drift (bounded counts of 3 to 20 are the self-hosted norm: Home Assistant 3,
+Syncthing 5, Grafana 20). The `snapshots/` subdirectory is invisible to
+`checkLayoutQuota` and `findYamlInFolder` by construction. Worst-case disk cost is known:
+5 x 1 MB per layout, capped by `RACKULA_MAX_LAYOUTS`.
+
+### Relation to timestamp conflict resolution
+
+Decision. Replace the `isServerNewer()` mtime-versus-browser-clock comparison with echo
+semantics: the localStorage session stores the server `updatedAt` it was last synced to.
+At startup, if the session's base `updatedAt` matches the server's current value, the
+local copy is simply ahead (offline edits): load local and let autosave push it; the PUT
+sees a matching echo and does not snapshot. If they differ, the copies genuinely
+diverged: keep LWW by recency, but before discarding a losing local copy, POST it to
+`POST /layouts/:uuid/snapshots` so both directions land in the same snapshot store. The
+losing-copy toast gains "Previous copy saved as a snapshot". Additionally, stop calling
+`clearSession()` after successful server saves: keep the localStorage working copy in
+server mode, stamped with the server-echoed `updatedAt`.
+
+Alternatives considered. Bolting snapshots onto the server side only leaves the
+server-newer-wins direction silently discarding the local copy. A second localStorage
+slot for the loser is invisible and lost with the same browser data it distrusts.
+
+Rationale. The existing compare is the weakest link (clock skew plus silent discard); the
+echo model removes the skew and the snapshot store removes the silence, without merge UX.
+Keeping the working copy is also what the parent spec's three-tier model already
+describes and is what makes server-down continuity seamless.
+
+### Twin-tab case
+
+Decision. Detect-and-pause. Each session write is stamped with a per-tab id (random,
+generated at startup). Each tab listens for the `storage` event on the autosave key; when
+a write from another tab id arrives, the receiving tab pauses its autosave effects (both
+localStorage and server) and shows one toast: "This layout is open in another tab, which
+now has the latest changes." with a "Reload this tab" action that re-reads the working
+copy and resumes. The session read-modify-write is wrapped in
+`navigator.locks.request('rackula:autosave', fn)` where available; without Web Locks the
+tab-id check alone still prevents silent ping-pong. No BroadcastChannel, no leader
+election, no live mirroring.
+
+Alternatives considered. Full leader election (RxDB-style Web Locks leader plus
+BroadcastChannel fan-out) solves a collaboration problem the app does not have. Doing
+nothing leaves two tabs alternately destroying each other's work at both tiers, forever,
+invisibly.
+
+Rationale. Roughly 30 lines, zero dependencies, converts the worst silent failure into an
+explicit single-toast state. The second tab behaves like a second device that has
+voluntarily gone read-only, consistent with the settled multi-device answer. The
+server-side mismatch snapshot still backstops a pre-detection PUT race.
+
+### Setting storage mode
+
+Decision. A single env var `RACKULA_STORAGE_MODE=browser|server` is read by the container
+entrypoint, which writes `/usr/share/nginx/html/config.js` containing
+`window.__RACKULA_CONFIG__ = { storage: "server" }` (idiomatic `/docker-entrypoint.d/`
+script) and ensures a `<script src="config.js">` tag loads ahead of the bundle. The app
+reads `window.__RACKULA_CONFIG__?.storage ?? "browser"`. Static hosts ship no config
+script and default to browser mode with zero configuration. Explicit config always wins;
+there is no probe-based fallback between modes. `hasEverConnectedToApi` and the
+probe-and-guess in `persistence.svelte.ts` are deleted; in server mode the health check
+means up or down, never "switch to file saves".
+
+Alternatives considered. Auto-detect by probing `/api/health` is exactly the ambiguity
+the spec kills: a down server is indistinguishable from no server. A fetched
+`config.json` adds a blocking request and a no-cache serving footgun. envsubst over built
+bundles is the most fragile option.
+
+Rationale. A synchronous global has no fetch race and no cache headers to get wrong, and
+env vars are exactly what Unraid CA templates surface as form fields (spike #1995). The
+data-safety framing is the decider: only explicit mode lets the app honestly say "server
+unreachable, changes held in this browser" instead of quietly becoming a different
+product.
+
+### Server build first load
+
+Decision. In server mode, first load checks `/api/health` once (nginx's deliberate
+502/503 makes down unambiguous). If up: fetch the layout list; if empty (true first run),
+create a new untitled layout and let autosave establish it, no StartScreen; otherwise
+open the most recently updated layout, reconciled against any localStorage working copy
+via the echo comparison. If down: load the localStorage working copy if present (else a
+new empty layout), show the red unreachable chip state and the single instance-named
+toast, keep autosaving locally, and poll health for the quiet recovery toast. Share-URL
+remains priority one in both modes. In browser mode, first load shows the one-time
+first-run notice and never consults the API code paths.
+
+Alternatives considered. Keeping the current four-step probe-driven priority contradicts
+explicit mode and the spec's StartScreen removal.
+
+Rationale. Every branch becomes a statement of fact rather than a guess; server-down on
+first load becomes a continuity story instead of a silent identity change.
+
+### Export-all framing per mode
+
+Decision. One artifact, two framings. Export-all builds a ZIP
+(`rackula-export-YYYYMMDD-HHMMSS.zip`) containing each layout's existing folder-archive
+form (YAML plus assets), reusing `downloadArchive()` mechanics; with a single layout open
+it degrades to today's single-layout archive. In browser mode the chip popover labels it
+"Back up all layouts" and a successful run resets `changesSinceExport` for every included
+layout. In server mode it is labelled "Export a copy" with subtext "Your layouts are
+stored on <instance>; this makes a portable copy", never affects chip state, and pulls
+authoritative YAML from `GET /layouts` rather than browser state. Automatic snapshots are
+excluded from export-all.
+
+Alternatives considered. One shared wording misses that the same artifact is a backup in
+one mode and a convenience copy in the other.
+
+Rationale. The chip's green rule defines what counts as backup per mode, so the wording
+must follow it; identical mechanics with different labels is the minimum that stays
+honest.
+
+## Technical Findings
+
+Condensed from docs/research/2019-codebase.md.
+
+Current persistence. One localStorage slot (`Rackula:autosave`) holding
+`{ layout, savedAt }` JSON; no IndexedDB. Autosave is a 1s debounced localStorage write
+plus a 2s debounced server save gated by a circuit breaker (3 failures), with 30s health
+polling while offline. After a successful server save the localStorage copy is deleted
+(`clearSession()`), which contradicts the spec's three-tier model and changes under this
+spike. Dirty tracking is a single `isDirty` boolean in `layout.svelte.ts`; there is no
+change counter and no record of export events, so the chip's backup state requires new
+state. Save status exists internally (`_saveStatus`) but renders nowhere since #1901.
+
+Startup and conflicts. Startup priority is share URL, then a probe-driven branch between
+server list and local session using `isServerNewer()`, which compares server file mtime
+against the browser clock and silently discards the loser. API availability is a runtime
+probe plus a `hasEverConnectedToApi` localStorage flag, the exact guess-from-history the
+spec removes.
+
+Server storage. Bun and Hono on a plain filesystem under DATA_DIR. `PUT /layouts/:uuid`
+is an unconditional in-place `writeFile`: no ETag, no If-Match, no versioning, no
+backups. Snapshots are greenfield. Quota guardrails (#1780) count DATA_DIR root entries
+(`RACKULA_MAX_LAYOUTS`, default 100) and skip the check on updates of an existing UUID.
+Layout YAML body limit is 1 MB.
+
+Multi-tab. Effectively nothing: no `storage` listener, no tab id, no locks. Two tabs
+silently ping-pong both the localStorage key and the server UUID.
+
+Runtime config. `VITE_API_URL` is baked at build time; the entrypoint configures nginx
+only and nothing reaches the SPA. There is no config endpoint. The one-image constraint
+(Unraid #2008, LXC, Pages, static Cloudflare prod) rules out build-time mode flags and
+requires a sane no-config default of browser.
+
+What must change. `persistence-manager.svelte.ts` (keep working copy, echo stamping,
+pause-on-foreign-write, beforeunload condition), `layout.svelte.ts` (counter in
+`markDirty()`), `session-storage.ts` (tab id, base `updatedAt`, counter in blob, delete
+`isServerNewer()`), `persistence.svelte.ts` (mode-driven, delete probe-and-guess),
+`App.svelte` (mode-driven startup), `archive.ts` (counter reset, export-all),
+`api/src/storage/filesystem.ts` and `api/src/routes/layouts.ts` (echo header, snapshot
+write, snapshot routes), `deploy/docker-entrypoint-wrapper.sh` and the nginx image setup
+(config.js injection), LoadDialog (snapshots), and the chip itself (new component plus
+re-exported save state).
+
+## External Research Highlights
+
+Condensed from docs/research/2019-external.md.
+
+- Honest copy is the strongest signal. Excalidraw shipped "stored locally in your
+  browser" for years, users lost work to cache clears and the 5 MB localStorage ceiling
+  (issues #8395, #10664), and the accepted fix (PR #10721) was rewording to "export to
+  files regularly". Browser-mode copy must never say "saved".
+- Production tools converge on passive persistent indicators, not interruptive nudges:
+  draw.io's toolbar "Unsaved changes" notice, VS Code's dirty dot plus aggregate badge,
+  Figma's alert-only-on-risk. NN/g alert-fatigue research: interruptive nudges train
+  instant dismissal.
+- beforeunload custom messages are ignored by all browsers; Chrome and Firefox require
+  sticky activation; mobile kills background tabs without firing it. Chrome guidance:
+  attach the listener only while unsaved changes exist, and treat `visibilitychange` to
+  hidden as the last reliable save point (developer.chrome.com Page Lifecycle API).
+- Snapshot retention norms are small bounded counts (Home Assistant recommends 3,
+  Syncthing defaults 5, Grafana 20), timestamp-suffix file naming (Syncthing
+  `~yyyymmdd-hhmmss`), and restore-as-new-version rather than destructive revert
+  (Grafana, Joplin).
+- For multi-tab, Web Locks (broad support since 2022) plus the `storage` event cover the
+  single-key LWW case in about 30 lines; full leader election (RxDB, Yjs, Replicache) is
+  for apps with live sync, which this is not.
+- For runtime SPA config, the entrypoint-written `window.__CONFIG__` script is the
+  idiomatic nginx-container pattern (synchronous, no fetch race); env vars are the
+  configuration surface Unraid CA templates expose as form fields.
+
+## Spec Reconciliation
+
+Save-indicator spec (#1901, docs/superpowers/specs/2026-06-04-save-indicator-design.md):
+
+- What it said: removed the visible SaveStatus surface; all save feedback is toasts;
+  autosave silent; failures are persistent toasts with Retry and dedup.
+- What changes: the storage chip reintroduces a visible persistent save-state surface,
+  reversing the visual half of #1901, and needs the internal `_saveStatus` exported
+  again.
+- Resolution: amend the #1901 decision record to state the chip supersedes the "toasts
+  only, no persistent indicator" decision. Standing unchanged: silent autosave (the chip
+  changes state, it does not toast), the manual Ctrl+S success toast, persistent failure
+  toasts with Retry and dedup, the ARIA role split, and reserving fixed toolbar space
+  (the #1901 reflow lesson). The chip replaces the two "working offline" toasts being
+  deleted (App.svelte:225-231, 293-299; persistence-manager.svelte.ts:104-109).
+
+Storage-abuse-guardrails spec (#1780,
+docs/superpowers/specs/2026-06-02-storage-abuse-guardrails-design.md):
+
+- What it said: server quotas (`RACKULA_MAX_LAYOUTS`, `RACKULA_MAX_ASSETS_PER_LAYOUT`)
+  with no retention or cleanup policy ("the quota cap IS the guardrail"); quota counts
+  DATA_DIR root entries; updates of an existing UUID skip the check.
+- What changes: snapshots add stored objects and a bounded prune (keep 5, delete oldest),
+  plus a new write endpoint (`POST /layouts/:uuid/snapshots`).
+- Resolution: amend the guardrails spec to scope the no-retention stance to user layouts.
+  Automatic pre-overwrite snapshots are system artifacts with a fixed bound (5 per
+  layout, YAML only), preserving the spirit: a hard cap, not a background cleanup job
+  over user data. Document explicitly that `{layout-folder}/snapshots/` is excluded from
+  the `RACKULA_MAX_LAYOUTS` directory scan and from `findYamlInFolder()`, so a future
+  quota refactor does not start counting them. The new snapshot POST endpoint sits behind
+  the same writeAuth and body-limit middleware as `PUT /layouts/:uuid` and counts against
+  the per-layout bound of 5. The create-versus-update quota skip is unaffected.
+
+Parent epic spec (minor): it describes the browser tier as the live working copy in both
+modes, but the code deletes the localStorage copy after each server save. This spike
+resolves the code toward the spec (keep the working copy, stamped with the server echo);
+flag it as a behavioural change to `persistence-manager.svelte.ts` in the implementation
+plan.
+
+## Implementation Phases
+
+Ordered for decomposition into GitHub issues. Sizes: small (under half a day), medium
+(about a day), large (multiple days). Phases 1 and 2 are independent of each other;
+everything else depends on at least one of them as noted.
+
+### Phase 1: change counter and chip state plumbing (frontend)
+
+1. Add `changesSinceExport` counter to `layout.svelte.ts` (increment in `markDirty()`),
+   persist it in the session blob in `session-storage.ts`, reset on successful
+   `fileSave()` (non-AbortError) in `archive.ts` and on file load. Small.
+2. Re-export save state from `persistence-manager.svelte.ts` (status, failures) plus the
+   new backup state as the chip's data source. Small.
+3. Build the storage chip component (states, labels, popover shell with facts and action
+   slots) in the reserved toolbar slot. Medium. Depends on 1 and 2.
+
+### Phase 2: runtime config injection and explicit mode (frontend, api/deploy)
+
+4. Entrypoint writes `config.js` from `RACKULA_STORAGE_MODE` and index.html loads it
+   ahead of the bundle; image default browser; LXC, compose, and Unraid server-mode
+   wiring. Medium. Deploy.
+5. Frontend reads `window.__RACKULA_CONFIG__?.storage ?? "browser"`; delete
+   `hasEverConnectedToApi` and probe-and-guess in `persistence.svelte.ts`; mode-driven
+   branching in `maybeSave` and `handleLoad`. Medium. Frontend.
+6. Mode-driven startup in `App.svelte`: browser-mode path with first-run notice,
+   server-mode path with health check, empty-list first run, server-down continuity;
+   remove the two "working offline" toasts; add the instance-named drop and recovery
+   toasts. Medium. Frontend. Depends on 5; full conflict handling lands in Phase 4.
+
+### Phase 3: nudges and restore flow (frontend)
+
+7. Backup nudge: threshold-30 toast with Export action, persisted snooze at multiples,
+   never-exported cold-start case. Small. Depends on Phase 1.
+8. Restore-from-file popover action: `loadFromFile()` behind the conditional confirm with
+   Export first, Replace, Cancel. Small. Depends on Phase 1 (counter) and 3 (popover).
+9. beforeunload rework: attach conditionally on in-flight risk only, redefine the
+   `warnOnUnsavedChanges` condition, keep `visibilitychange` flush. Small.
+
+### Phase 4: server snapshots and echo-based conflict detection (api, frontend)
+
+10. API: accept the echoed `updatedAt` header on PUT; on mismatch copy the existing YAML
+    to `{folder}/snapshots/{name}~YYYYMMDD-HHMMSS.yaml` before write; prune to 5. Medium.
+    API.
+11. API: `GET /layouts/:uuid/snapshots` (list) and `POST /layouts/:uuid/snapshots`
+    (client uploads a losing local copy), behind writeAuth and body limits. Medium. API.
+    Depends on 10.
+12. Frontend: store the server-echoed `updatedAt` in the session blob, send it on PUT,
+    stop calling `clearSession()` after server saves. Medium. Depends on 10.
+13. Frontend: replace `isServerNewer()` startup comparison with the echo model; POST the
+    losing local copy to the snapshot endpoint before discarding; update toasts. Medium.
+    Depends on 11 and 12.
+14. Frontend: LoadDialog snapshots expansion with restore-as-working-copy. Medium.
+    Depends on 11.
+15. Guardrails spec amendment (#1780 doc) and #1901 decision-record amendment per Spec
+    Reconciliation. Small. Docs.
+
+### Phase 5: twin-tab guard (frontend)
+
+16. Per-tab id stamped into session writes; `storage`-event foreign-write detection;
+    pause autosave effects; "open in another tab" toast with Reload action; Web Locks
+    wrap around the session read-modify-write. Medium. Independent of Phases 2 to 4;
+    touches the same autosave effects as 12, so sequence after Phase 4 to avoid churn.
+
+### Phase 6: export-all (frontend)
+
+17. Multi-layout ZIP via `downloadArchive()` mechanics; browser-mode "Back up all
+    layouts" with per-layout counter reset; server-mode "Export a copy" pulling YAML from
+    `GET /layouts`. Medium. Depends on Phase 1 (counter reset) and Phase 2 (mode
+    framing). Until the tabs work lands, "all layouts" degrades to the single open
+    layout in browser mode and the server list in server mode.

--- a/docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
@@ -265,7 +265,7 @@ Pre-overwrite snapshots are server-side, written only on a mismatched server-ech
 updatedAt, keep five per layout, and restore as a new write. Twin tabs are
 detect-and-pause via the storage event with a per-tab id, Web Locks serialising
 writes where available. Storage mode is set by RACKULA_STORAGE_MODE, injected by the
-container entrypoint as window.**RACKULA_CONFIG**, defaulting to browser when no
+container entrypoint as `window.__RACKULA_CONFIG__`, defaulting to browser when no
 config is present; explicit config always wins and the connection-history probe is
 deleted.
 
@@ -306,5 +306,5 @@ resolved the storage questions: chip green is strict zero-changes-since-export w
 a 30-change nudge cadence; snapshots are server-side and mismatch-only via a
 server-echoed updatedAt, keep five, restore as a new write; the browser working copy
 is kept after server saves; twin tabs detect-and-pause; storage mode comes from
-RACKULA_STORAGE_MODE via an entrypoint-injected window.**RACKULA_CONFIG**,
+RACKULA_STORAGE_MODE via an entrypoint-injected `window.__RACKULA_CONFIG__`,
 defaulting to browser (see docs/research/spike-2019-storage-model-data-safety.md).

--- a/docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
@@ -153,7 +153,13 @@ The design target for concurrency is one user on multiple devices, not multi-use
 editing. When the working copy and the server copy diverge (a reconnect after working
 offline, or another device wrote in between), the resolution is last-write-wins with
 an automatic pre-overwrite snapshot of the losing copy; there is no merge or prompt
-UX. The snapshot mechanics are designed in the storage spike.
+UX. Snapshot mechanics are resolved by spike #2019: snapshots live server-side in a
+snapshots subdirectory of the layout folder, written only when a save's echoed
+updatedAt mismatches the stored copy (a genuine divergence), keeping the five most
+recent, restorable from the load dialog as a new write rather than an in-place
+revert. The startup timestamp comparison moves to the same server-echo semantics,
+and the browser working copy is kept after server saves rather than cleared. See
+docs/research/spike-2019-storage-model-data-safety.md.
 
 ### The storage chip
 
@@ -167,9 +173,11 @@ Browser build: green "In your browser, backed up" when a recent file backup exis
 amber "In your browser, backup needed" when only a working copy exists. The labels
 differ as well as the colours, so colour is never the sole indicator of state. The
 app can only know that an
-export event happened, not that the file still exists on disk, so "recent" needs a
-definition (change-based versus time-based); that definition is delegated to the
-storage spike.
+export event happened, not that the file still exists on disk. "Recent" is defined
+change-based (spike #2019): green means zero changes since the last successful
+export, tracked by a changesSinceExport counter; any unexported change flips the
+chip amber. A non-modal nudge fires at 30-change multiples so the strict chip does
+not have to carry the reminder load alone.
 
 Server build: green "Saved to <instance>" when synced, neutral "Saving" while writing,
 red "<instance> unreachable" when disconnected and working from the browser.
@@ -189,8 +197,8 @@ instance-named, reassuring toast when the backend genuinely drops ("Lost connect
 once, with a quiet recovery toast on resync. The generic "Server unavailable, working
 offline" toast is removed.
 
-Open data-safety and race-condition questions are tracked as a design spike (see Open
-Questions: storage).
+The data-safety and race-condition questions are resolved by spike #2019 (see Open
+questions: storage).
 
 ## Creation and placement
 
@@ -234,9 +242,10 @@ Collapsing and expanding the side panel manages focus rather than dropping it. S
 
 ## Open questions (design spikes)
 
-Two areas are deliberately left open and tracked as design spikes under the UX
-Overhaul epic, with the storage spike running first because tabs depend on its
-semantics; a third spike, the command palette, is decided and non-blocking:
+Two areas were tracked as design spikes under the UX Overhaul epic, with the storage
+spike running first because tabs depend on its semantics. The storage spike (#2019)
+is now resolved; the tabs spike remains open. A third spike, the command palette, is
+decided and non-blocking:
 
 Tabs interaction model: overflow strategy, the precise close-versus-delete affordance,
 the fate of browser-mode working copies of closed tabs, and the
@@ -246,10 +255,19 @@ renaming a layout open in a tab, duplicate layout names across tabs, and a keybo
 map that reconciles the existing app shortcuts (Ctrl+S, Ctrl+O, Ctrl+E, Ctrl+H,
 Ctrl+D, I, F, Delete, arrows).
 
-Storage model and data safety: the browser-mode data-loss recovery experience (manual
-export plus nudges; the nudge cadence, restore flow, and recent-backup definition are
-the open parts), the pre-overwrite snapshot mechanics behind last-write-wins, the
-twin-tab case, and the mechanics of the explicit storage mode.
+Storage model and data safety: resolved by spike #2019, full findings in
+docs/research/spike-2019-storage-model-data-safety.md. The decisions: the chip is
+green only at zero changes since the last successful export (a changesSinceExport
+counter), with a non-modal nudge at 30-change multiples and a persisted snooze;
+restore-from-file reuses the existing load pipeline behind a confirm when unbacked
+changes would be replaced; beforeunload warns only on genuine in-flight loss risk.
+Pre-overwrite snapshots are server-side, written only on a mismatched server-echoed
+updatedAt, keep five per layout, and restore as a new write. Twin tabs are
+detect-and-pause via the storage event with a per-tab id, Web Locks serialising
+writes where available. Storage mode is set by RACKULA_STORAGE_MODE, injected by the
+container entrypoint as window.**RACKULA_CONFIG**, defaulting to browser when no
+config is present; explicit config always wins and the connection-history probe is
+deleted.
 
 Command palette: deferred. The build-later call is made; the shell implementation
 structures menu and verb actions as a command registry so a Ctrl+K palette can layer
@@ -283,4 +301,10 @@ plus nudges; no persistent-file-handle mechanism for now. The command palette is
 build-later; shell actions are structured as a command registry so it can layer on.
 Theme lives behind the Settings gear as an app preference; the View tab holds
 layout-scoped toggles only. Delivery is incremental in coherent slices on main, no
-long-lived branch; the storage spike runs before the tabs spike.
+long-lived branch; the storage spike runs before the tabs spike. Spike #2019
+resolved the storage questions: chip green is strict zero-changes-since-export with
+a 30-change nudge cadence; snapshots are server-side and mismatch-only via a
+server-echoed updatedAt, keep five, restore as a new write; the browser working copy
+is kept after server saves; twin tabs detect-and-pause; storage mode comes from
+RACKULA_STORAGE_MODE via an entrypoint-injected window.**RACKULA_CONFIG**,
+defaulting to browser (see docs/research/spike-2019-storage-model-data-safety.md).


### PR DESCRIPTION
## **User description**
## Summary

Research deliverables for spike #2019 (epic #2017, M14 Canvas UX Overhaul).

- Main findings: docs/research/spike-2019-storage-model-data-safety.md
- Working files: 2019-codebase.md, 2019-external.md, 2019-patterns.md
- Decisions recorded back into docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md

## Headline decisions

- Chip green state is change-based: green only at changesSinceExport === 0, via a new counter in markDirty(); export nudge fires as a non-modal toast at multiples of 30 changes
- beforeunload attaches only on genuine in-flight risk (pending debounce flush, or dirty while server unreachable), never for unbacked-but-persisted changes
- Server snapshots: written on conflicting PUTs detected via a server-echoed updatedAt (replaces mtime-vs-browser-clock isServerNewer()), stored at {folder}/snapshots/, keep 5, restore-as-new-write; placement dodges the quota scan
- Twin tabs: detect-and-pause via tab-id-stamped storage events plus Web Locks, no leader election
- Storage mode: RACKULA_STORAGE_MODE env injected as window.__RACKULA_CONFIG__ at container entrypoint; absent config defaults to browser (static hosting safe)
- Export-all: one ZIP, framed "Back up all layouts" (browser) vs "Export a copy" (server)
- Spec reconciliation: #1901 save-indicator removal superseded by the chip (toast decisions stand); #1780 no-retention stance scoped to user layouts

## Implementation issues

Created #2034-#2045 in M14, linked in epic #2017.

Closes #2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the storage model and data-safety decisions for the canvas UX overhaul**

### What Changed
- Added the research findings that settle browser-mode backup nudges, restore-from-file behavior, `beforeunload` handling, snapshot retention, twin-tab handling, and runtime storage mode selection
- Added a patterns summary that turns the research into concrete recommendations and implementation phases
- Added a codebase review that records the current persistence flow, startup conflict handling, API storage behavior, export/import paths, and gaps these decisions will change
- Updated the main canvas UX overhaul spec to reference the resolved storage decisions, remove the open storage questions, and define the chip, snapshots, and storage mode behavior

### Impact
`✅ Clearer storage and backup behavior`
`✅ Fewer unanswered design questions`
`✅ Faster implementation planning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
