### PR TITLE
feat: runtime storage mode config injection (#2036)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ RACKULA_LISTEN_PORT=8080
 # API sidecar listen port
 RACKULA_API_PORT=3001
 # Frontend storage mode: browser (layouts stay in the browser) | server
-# (layouts saved via the API). The persist stack defaults to server.
+# (layouts saved via the API). The persist stack defaults to server; set
+# RACKULA_STORAGE_MODE=server when running docker-compose.yml with --profile persist.
 # RACKULA_STORAGE_MODE=server
 # Optional image overrides (useful for branch/dev tags)
 # Production recommendation: pin specific release tags (not :latest),

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ RACKULA_ENABLE_IPV6=auto
 RACKULA_LISTEN_PORT=8080
 # API sidecar listen port
 RACKULA_API_PORT=3001
+# Frontend storage mode: browser (layouts stay in the browser) | server
+# (layouts saved via the API). The persist stack defaults to server.
+# RACKULA_STORAGE_MODE=server
 # Optional image overrides (useful for branch/dev tags)
 # Production recommendation: pin specific release tags (not :latest),
 # then update them deliberately during releases for reproducible deploys.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -41,6 +41,7 @@ LABEL org.opencontainers.image.title="Rackula"
 # API_PORT: Port the API listens on (default: 3001)
 # API_WRITE_TOKEN: Optional bearer token injected for PUT/DELETE API requests (runtime env)
 # RACKULA_AUTH_MODE: Auth mode toggle for app/API anonymous access gate (none|oidc|local)
+# RACKULA_STORAGE_MODE: Frontend storage mode written to config.js at startup (browser|server; default: browser)
 # RACKULA_LISTEN_PORT: Port nginx listens on inside the container (default: 8080)
 # RACKULA_ENABLE_IPV6: IPv6 listen auto-detection (auto|true|false; default: auto)
 # NGINX_RESOLVER: DNS resolver for nginx upstream resolution (default: 127.0.0.11 for Docker; override for Kubernetes)
@@ -48,6 +49,7 @@ LABEL org.opencontainers.image.title="Rackula"
 ENV API_HOST=rackula-api
 ENV API_PORT=3001
 ENV RACKULA_AUTH_MODE=none
+ENV RACKULA_STORAGE_MODE=browser
 ENV RACKULA_LISTEN_PORT=8080
 ENV RACKULA_ENABLE_IPV6=auto
 ENV NGINX_RESOLVER=127.0.0.11

--- a/deploy/docker-compose.persist.yml
+++ b/deploy/docker-compose.persist.yml
@@ -21,6 +21,9 @@ services:
       - API_WRITE_TOKEN=${RACKULA_API_WRITE_TOKEN:-}
       # Auth mode for nginx routing behavior
       - RACKULA_AUTH_MODE=${RACKULA_AUTH_MODE:-none}
+      # Storage mode for the frontend (browser|server). This stack provisions
+      # the API, so layouts save server-side by default.
+      - RACKULA_STORAGE_MODE=${RACKULA_STORAGE_MODE:-server}
       # IPv6 listen: auto-detect (default), force on, or force off
       - RACKULA_ENABLE_IPV6=${RACKULA_ENABLE_IPV6:-auto}
       # DNS resolver for nginx upstream resolution (override for Kubernetes)

--- a/deploy/docker-entrypoint-wrapper.sh
+++ b/deploy/docker-entrypoint-wrapper.sh
@@ -75,6 +75,30 @@ else
 fi
 export RACKULA_IPV6_LISTEN
 
+# Storage mode -- generate runtime config.js consumed by index.html.
+# Validated against an allowlist before being written into JavaScript; the
+# printf below only ever receives the literal strings "browser" or "server".
+# Written to tmpfs (not the read-only html root) and served via an exact
+# nginx location alias.
+raw_storage_mode="${RACKULA_STORAGE_MODE:-browser}"
+storage_mode="$(printf '%s' "$raw_storage_mode" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+
+case "$storage_mode" in
+  "" | "browser")
+    storage_mode="browser"
+    ;;
+  "server")
+    storage_mode="server"
+    ;;
+  *)
+    echo "WARN: Invalid RACKULA_STORAGE_MODE '$raw_storage_mode'; defaulting to browser" >&2
+    storage_mode="browser"
+    ;;
+esac
+
+mkdir -p /tmp/rackula-config
+printf 'window.__RACKULA_CONFIG__ = { storage: "%s" };\n' "$storage_mode" >/tmp/rackula-config/config.js
+
 # Default resolver for nginx upstream DNS resolution.
 # Docker uses 127.0.0.11 (embedded DNS). Override via NGINX_RESOLVER for other
 # environments (e.g., Kubernetes cluster DNS IP).
@@ -82,7 +106,7 @@ export RACKULA_IPV6_LISTEN
 export NGINX_RESOLVER
 
 # Log configuration for debugging connectivity issues.
-echo "Rackula: DNS resolver=${NGINX_RESOLVER} API upstream=${API_HOST}:${API_PORT} trust_proxy=${RACKULA_TRUST_PROXY}" >&2
+echo "Rackula: DNS resolver=${NGINX_RESOLVER} API upstream=${API_HOST}:${API_PORT} trust_proxy=${RACKULA_TRUST_PROXY} storage_mode=${storage_mode}" >&2
 
 # Warn Kubernetes users if API_HOST is a bare hostname (no dots).
 # nginx resolver doesn't apply search domains, so bare names won't resolve

--- a/deploy/docker-entrypoint-wrapper.sh
+++ b/deploy/docker-entrypoint-wrapper.sh
@@ -79,7 +79,10 @@ export RACKULA_IPV6_LISTEN
 # Validated against an allowlist before being written into JavaScript; the
 # printf below only ever receives the literal strings "browser" or "server".
 # Written to tmpfs (not the read-only html root) and served via an exact
-# nginx location alias.
+# nginx location alias, which overrides the browser-mode default the build
+# ships in the html root.
+# CROSS-REF: keep in sync with static/config.js and the LXC writers in
+# deploy/lxc/community-scripts/{install/rackula-install.sh,ct/rackula.sh}.
 raw_storage_mode="${RACKULA_STORAGE_MODE:-browser}"
 storage_mode="$(printf '%s' "$raw_storage_mode" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
 

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -76,6 +76,9 @@ function update_script() {
     cp /opt/rackula/config/rackula-api.service /etc/systemd/system/rackula-api.service
     mkdir -p /etc/systemd/system/nginx.service.d
     cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.service.d/override.conf
+    # Rewrite runtime storage mode config: the tarball ships a browser-mode default.
+    # CROSS-REF: keep in sync with install/rackula-install.sh and static/config.js.
+    printf 'window.__RACKULA_CONFIG__ = { storage: "server" };\n' >/opt/rackula/frontend/config.js
     chown -R root:root /opt/rackula/frontend
     find /opt/rackula/frontend -type d -exec chmod 755 {} \;
     find /opt/rackula/frontend -type f -exec chmod 644 {} \;

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -76,6 +76,7 @@ cp "$SECURITY_HEADERS_SRC" /etc/nginx/snippets/security-headers.conf
 
 # Runtime storage mode config consumed by index.html. The LXC always
 # provisions the API alongside the frontend, so server mode is fixed.
+# CROSS-REF: keep in sync with ct/rackula.sh update_script and static/config.js.
 printf 'window.__RACKULA_CONFIG__ = { storage: "server" };\n' >/opt/rackula/frontend/config.js
 
 chown -R root:root /opt/rackula/frontend

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -74,6 +74,10 @@ if [ ! -f "$SECURITY_HEADERS_SRC" ]; then
 fi
 cp "$SECURITY_HEADERS_SRC" /etc/nginx/snippets/security-headers.conf
 
+# Runtime storage mode config consumed by index.html. The LXC always
+# provisions the API alongside the frontend, so server mode is fixed.
+printf 'window.__RACKULA_CONFIG__ = { storage: "server" };\n' >/opt/rackula/frontend/config.js
+
 chown -R root:root /opt/rackula/frontend
 find /opt/rackula/frontend -type d -exec chmod 755 {} \;
 find /opt/rackula/frontend -type f -exec chmod 644 {} \;

--- a/deploy/lxc/nginx.conf
+++ b/deploy/lxc/nginx.conf
@@ -55,6 +55,17 @@ server {
         include /etc/nginx/snippets/security-headers.conf;
     }
 
+    # Runtime storage mode config, written by the install script into the
+    # frontend root. no-cache: a stale mode after a reinstall would silently
+    # flip storage behavior.
+    location = /config.js {
+        add_header Cache-Control "no-cache" always;
+
+        # nginx drops ALL server-level add_header directives when a location block
+        # defines its own; include shared security headers to avoid drift.
+        include /etc/nginx/snippets/security-headers.conf;
+    }
+
     # API health check — used by frontend to detect persistence API availability
     location = /api/health {
         proxy_pass http://127.0.0.1:3001/health;

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -92,9 +92,17 @@ server {
     }
 
     # Runtime storage mode config, written to tmpfs by the entrypoint wrapper
-    # (the html root is read-only). no-cache: a stale mode after a redeploy or
-    # env change would silently flip storage behavior.
+    # (the html root is read-only; this exact-match alias overrides the
+    # browser-mode default the build ships at /usr/share/nginx/html/config.js).
+    # no-cache: a stale mode after a redeploy or env change would silently
+    # flip storage behavior.
+    # Auth-gated like the SPA shell (location /): only index.html loads this
+    # file post-auth; the pre-auth login page (login.html) does not load it,
+    # so gating cannot break the login flow. The internal probe returns 204
+    # when auth mode is none.
     location = /config.js {
+        auth_request /_rackula_auth_check;
+        error_page 401 = @auth_login_redirect;
         alias /tmp/rackula-config/config.js;
         add_header Cache-Control "no-cache" always;
 

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -91,6 +91,18 @@ server {
         include /etc/nginx/snippets/security-headers.conf;
     }
 
+    # Runtime storage mode config, written to tmpfs by the entrypoint wrapper
+    # (the html root is read-only). no-cache: a stale mode after a redeploy or
+    # env change would silently flip storage behavior.
+    location = /config.js {
+        alias /tmp/rackula-config/config.js;
+        add_header Cache-Control "no-cache" always;
+
+        # nginx drops ALL server-level add_header directives when a location block
+        # defines its own; include shared security headers to avoid drift.
+        include /etc/nginx/snippets/security-headers.conf;
+    }
+
     # API proxy (when sidecar is running)
     # Use variable to defer DNS resolution to request time (allows nginx to start without API)
     # Using $uri$is_args$args for normalized path+query (safer than $request_uri)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,8 @@ services:
       - API_WRITE_TOKEN=${RACKULA_API_WRITE_TOKEN:-}
       # Auth mode for nginx routing behavior
       - RACKULA_AUTH_MODE=${RACKULA_AUTH_MODE:-none}
-      # Storage mode for the frontend (browser|server). Default browser since
-      # the API only runs with --profile persist; set server when using it.
+      # Storage mode for the frontend (browser|server). Defaults to browser;
+      # set RACKULA_STORAGE_MODE=server when running with --profile persist.
       - RACKULA_STORAGE_MODE=${RACKULA_STORAGE_MODE:-browser}
       # IPv6 listen: auto-detect (default), force on, or force off
       - RACKULA_ENABLE_IPV6=${RACKULA_ENABLE_IPV6:-auto}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@
 #   CORS_ORIGIN: Allowed browser origin(s) for API CORS (default: http://localhost:8080)
 #   RACKULA_API_WRITE_TOKEN: Optional token protecting API PUT/DELETE routes
 #   RACKULA_AUTH_MODE: Auth mode toggle (none|oidc|local, default: none)
+#   RACKULA_STORAGE_MODE: Frontend storage mode (browser|server, default: browser)
 #   RACKULA_AUTH_SESSION_SECRET: Required when auth mode != none (min 32 chars)
 #   RACKULA_AUTH_SESSION_MAX_AGE_SECONDS: Absolute auth session lifetime (default: 43200)
 #   RACKULA_AUTH_SESSION_IDLE_TIMEOUT_SECONDS: Idle session timeout (default: 1800)
@@ -48,6 +49,9 @@ services:
       - API_WRITE_TOKEN=${RACKULA_API_WRITE_TOKEN:-}
       # Auth mode for nginx routing behavior
       - RACKULA_AUTH_MODE=${RACKULA_AUTH_MODE:-none}
+      # Storage mode for the frontend (browser|server). Default browser since
+      # the API only runs with --profile persist; set server when using it.
+      - RACKULA_STORAGE_MODE=${RACKULA_STORAGE_MODE:-browser}
       # IPv6 listen: auto-detect (default), force on, or force off
       - RACKULA_ENABLE_IPV6=${RACKULA_ENABLE_IPV6:-auto}
       # DNS resolver for nginx upstream resolution (override for Kubernetes)

--- a/docs/deployment/SELF-HOSTING.md
+++ b/docs/deployment/SELF-HOSTING.md
@@ -602,38 +602,38 @@ All variables have sensible defaults. Only configure if you need to change somet
 
 ### Runtime Variables
 
-| Variable                             | Default                 | Description                                                                                        |
-| ------------------------------------ | ----------------------- | -------------------------------------------------------------------------------------------------- |
-| `RACKULA_PORT`                       | `8080`                  | Host port for the web UI                                                                           |
-| `RACKULA_LISTEN_PORT`                | `8080`                  | Port nginx listens on inside the container                                                         |
-| `RACKULA_API_PORT`                   | `3001`                  | Port the API listens on                                                                            |
-| `API_HOST`                           | `rackula-api`           | Hostname of API container (for nginx proxy)                                                        |
-| `API_PORT`                           | `3001`                  | Port of API container (for nginx proxy)                                                            |
-| `RACKULA_STORAGE_MODE`               | `server`                | Frontend storage mode: `browser` or `server` (image default is `browser`)                          |
-| `CORS_ORIGIN`                        | `http://localhost:8080` | Allowed browser origin(s) for API access (production-safe default)                                 |
-| `RACKULA_API_WRITE_TOKEN`            | _unset_                 | Optional bearer token required for API `PUT`/`DELETE`                                              |
-| `ALLOW_INSECURE_CORS`                | `false`                 | Explicitly allow wildcard CORS in production (not recommended)                                     |
-| `NGINX_RESOLVER`                     | `127.0.0.11`            | DNS resolver for nginx upstream resolution (override for Kubernetes)                               |
-| `DATA_DIR`                           | `/data`                 | Path to data directory inside API container                                                        |
-| `RACKULA_AUTH_MODE`                  | `none`                  | Auth gate mode: `none`, `local`, or `oidc`                                                         |
-| `RACKULA_AUTH_SESSION_SECRET`        | _unset_                 | Required when auth mode is enabled (min 32 chars, use `openssl rand -hex 32`)                      |
-| `RACKULA_AUTH_SESSION_COOKIE_SECURE` | `true`                  | Set `false` for local HTTP testing only                                                            |
-| `RACKULA_LOCAL_USERNAME`             | _unset_                 | Username for local auth mode (min 3 chars)                                                         |
-| `RACKULA_LOCAL_PASSWORD`             | _unset_                 | Password for local auth mode (min 12 chars)                                                        |
-| `RACKULA_OIDC_ISSUER`                | _unset_                 | OIDC issuer URL (required for `oidc` mode)                                                         |
-| `RACKULA_OIDC_CLIENT_ID`             | _unset_                 | OIDC client ID (required for `oidc` mode)                                                          |
-| `RACKULA_OIDC_CLIENT_SECRET`         | _unset_                 | OIDC client secret (required for `oidc` mode)                                                      |
-| `RACKULA_TRUST_PROXY`                | `0`                     | Set to `1` behind a TLS-terminating reverse proxy; enables HTTPS redirects via `X-Forwarded-Proto` |
-| `RACKULA_BASE_URL`                   | `http://localhost:3000` | External URL for OIDC callback construction; set to your HTTPS URL behind a proxy                  |
-| `RACKULA_OIDC_REDIRECT_URI`          | _derived from BASE_URL_ | Explicit OIDC callback URL; must match the IdP's registered redirect URI exactly                   |
-| `RACKULA_MAX_LAYOUTS`                | `100`                   | Maximum number of stored layouts. Set to `0` for unlimited                                         |
-| `RACKULA_MAX_ASSETS_PER_LAYOUT`      | `50`                    | Maximum number of assets per layout. Set to `0` for unlimited                                      |
-| `RACKULA_RATE_LIMIT_ENABLED`         | `true`                  | Set to `false` to disable the in-app IP rate limiter                                               |
-| `RACKULA_RATE_LIMIT_WRITE_MAX`       | `30`                    | Max write requests (PUT, DELETE) per IP per window                                                 |
-| `RACKULA_RATE_LIMIT_WRITE_WINDOW_MS` | `60000`                 | Write rate-limit window in milliseconds                                                            |
-| `RACKULA_RATE_LIMIT_READ_MAX`        | `120`                   | Max read requests (GET, HEAD) per IP per window                                                    |
-| `RACKULA_RATE_LIMIT_READ_WINDOW_MS`  | `60000`                 | Read rate-limit window in milliseconds                                                             |
-| `LOG_LEVEL`                          | `info`                  | API log verbosity: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, or `silent`                 |
+| Variable                             | Default                 | Description                                                                                         |
+| ------------------------------------ | ----------------------- | --------------------------------------------------------------------------------------------------- |
+| `RACKULA_PORT`                       | `8080`                  | Host port for the web UI                                                                            |
+| `RACKULA_LISTEN_PORT`                | `8080`                  | Port nginx listens on inside the container                                                          |
+| `RACKULA_API_PORT`                   | `3001`                  | Port the API listens on                                                                             |
+| `API_HOST`                           | `rackula-api`           | Hostname of API container (for nginx proxy)                                                         |
+| `API_PORT`                           | `3001`                  | Port of API container (for nginx proxy)                                                             |
+| `RACKULA_STORAGE_MODE`               | `browser`               | Frontend storage mode: `browser` or `server` (`docker-compose.persist.yml` defaults it to `server`) |
+| `CORS_ORIGIN`                        | `http://localhost:8080` | Allowed browser origin(s) for API access (production-safe default)                                  |
+| `RACKULA_API_WRITE_TOKEN`            | _unset_                 | Optional bearer token required for API `PUT`/`DELETE`                                               |
+| `ALLOW_INSECURE_CORS`                | `false`                 | Explicitly allow wildcard CORS in production (not recommended)                                      |
+| `NGINX_RESOLVER`                     | `127.0.0.11`            | DNS resolver for nginx upstream resolution (override for Kubernetes)                                |
+| `DATA_DIR`                           | `/data`                 | Path to data directory inside API container                                                         |
+| `RACKULA_AUTH_MODE`                  | `none`                  | Auth gate mode: `none`, `local`, or `oidc`                                                          |
+| `RACKULA_AUTH_SESSION_SECRET`        | _unset_                 | Required when auth mode is enabled (min 32 chars, use `openssl rand -hex 32`)                       |
+| `RACKULA_AUTH_SESSION_COOKIE_SECURE` | `true`                  | Set `false` for local HTTP testing only                                                             |
+| `RACKULA_LOCAL_USERNAME`             | _unset_                 | Username for local auth mode (min 3 chars)                                                          |
+| `RACKULA_LOCAL_PASSWORD`             | _unset_                 | Password for local auth mode (min 12 chars)                                                         |
+| `RACKULA_OIDC_ISSUER`                | _unset_                 | OIDC issuer URL (required for `oidc` mode)                                                          |
+| `RACKULA_OIDC_CLIENT_ID`             | _unset_                 | OIDC client ID (required for `oidc` mode)                                                           |
+| `RACKULA_OIDC_CLIENT_SECRET`         | _unset_                 | OIDC client secret (required for `oidc` mode)                                                       |
+| `RACKULA_TRUST_PROXY`                | `0`                     | Set to `1` behind a TLS-terminating reverse proxy; enables HTTPS redirects via `X-Forwarded-Proto`  |
+| `RACKULA_BASE_URL`                   | `http://localhost:3000` | External URL for OIDC callback construction; set to your HTTPS URL behind a proxy                   |
+| `RACKULA_OIDC_REDIRECT_URI`          | _derived from BASE_URL_ | Explicit OIDC callback URL; must match the IdP's registered redirect URI exactly                    |
+| `RACKULA_MAX_LAYOUTS`                | `100`                   | Maximum number of stored layouts. Set to `0` for unlimited                                          |
+| `RACKULA_MAX_ASSETS_PER_LAYOUT`      | `50`                    | Maximum number of assets per layout. Set to `0` for unlimited                                       |
+| `RACKULA_RATE_LIMIT_ENABLED`         | `true`                  | Set to `false` to disable the in-app IP rate limiter                                                |
+| `RACKULA_RATE_LIMIT_WRITE_MAX`       | `30`                    | Max write requests (PUT, DELETE) per IP per window                                                  |
+| `RACKULA_RATE_LIMIT_WRITE_WINDOW_MS` | `60000`                 | Write rate-limit window in milliseconds                                                             |
+| `RACKULA_RATE_LIMIT_READ_MAX`        | `120`                   | Max read requests (GET, HEAD) per IP per window                                                     |
+| `RACKULA_RATE_LIMIT_READ_WINDOW_MS`  | `60000`                 | Read rate-limit window in milliseconds                                                              |
+| `LOG_LEVEL`                          | `info`                  | API log verbosity: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, or `silent`                  |
 
 **Port mapping explained:**
 

--- a/docs/deployment/SELF-HOSTING.md
+++ b/docs/deployment/SELF-HOSTING.md
@@ -609,6 +609,7 @@ All variables have sensible defaults. Only configure if you need to change somet
 | `RACKULA_API_PORT`                   | `3001`                  | Port the API listens on                                                                            |
 | `API_HOST`                           | `rackula-api`           | Hostname of API container (for nginx proxy)                                                        |
 | `API_PORT`                           | `3001`                  | Port of API container (for nginx proxy)                                                            |
+| `RACKULA_STORAGE_MODE`               | `server`                | Frontend storage mode: `browser` or `server` (image default is `browser`)                          |
 | `CORS_ORIGIN`                        | `http://localhost:8080` | Allowed browser origin(s) for API access (production-safe default)                                 |
 | `RACKULA_API_WRITE_TOKEN`            | _unset_                 | Optional bearer token required for API `PUT`/`DELETE`                                              |
 | `ALLOW_INSECURE_CORS`                | `false`                 | Explicitly allow wildcard CORS in production (not recommended)                                     |

--- a/docs/research/1995-patterns.md
+++ b/docs/research/1995-patterns.md
@@ -439,12 +439,12 @@ compose file, skip the second template until demand proves out).
 ### "Does the optional-API split map to how Unraid users actually think?"
 
 Mostly yes. Unraid users add containers one at a time from the Apps tab; a primary + optional
-companion is a familiar shape (plenty of *arr-adjacent stacks work this way). The friction is not
+companion is a familiar shape (plenty of \*arr-adjacent stacks work this way). The friction is not
 the two-step install, it is the **wiring** (`API_HOST` must match the API container's name, both
 must be on a reachable network, auth mode must match on both). That is more fiddly than the typical
 self-contained Unraid app and is exactly where users get stuck. If #1317 keeps the API container's
 default name `rackula-api` and the frontend's `API_HOST` default `rackula-api`, the happy path works
-with zero edits *provided both land on the same bridge network\* - verify that assumption holds on
+with zero edits _provided both land on the same bridge network_ - verify that assumption holds on
 Unraid's default bridge, because container-name DNS resolution is not guaranteed on the stock
 `bridge` network (it works on user-defined networks). **This is a concrete thing #1317 must test,
 not assume.**

--- a/docs/research/1995-patterns.md
+++ b/docs/research/1995-patterns.md
@@ -26,19 +26,19 @@ Distilled from the two research files, the facts that actually drive the #1317 d
 
 3. Frontend-only with no volume is silently ephemeral, but for a different reason than
    most apps. Rackula's primary persistence is actually the browser (the SPA works without
-   any backend). The API adds *server-side* shared persistence. So "frontend only" is not
+   any backend). The API adds _server-side_ shared persistence. So "frontend only" is not
    "data lost on restart" for the casual single-browser user; it is "no server-side storage,
    no cross-device sync, no auth." This nuance matters for the devil's-advocate section: the
    "my layouts don't save" failure mode is real but narrower than the codebase doc's blunt
    "all data lost on restart" framing implies.
 
 4. Auth is opt-in and fails closed when misconfigured. Default is `none` (anonymous
-   read/write). When `RACKULA_AUTH_MODE != none`, the API *refuses to start* without
+   read/write). When `RACKULA_AUTH_MODE != none`, the API _refuses to start_ without
    `RACKULA_AUTH_SESSION_SECRET` (32+ chars); `local` additionally requires username and a
    12+ char password (Argon2id, OWASP params, plaintext scrubbed from env after bootstrap,
    login rate-limited 5/60s, timing-safe compare). CSRF protection and Secure cookies turn on
    automatically when auth is enabled (`1995-codebase.md` auth sections). The security model is
-   already solid; the Unraid risk is almost entirely in *how the template surfaces these knobs*,
+   already solid; the Unraid risk is almost entirely in _how the template surfaces these knobs_,
    not in the app code.
 
 5. The reverse-proxy story is a documentation problem, not a code problem.
@@ -53,11 +53,11 @@ Distilled from the two research files, the facts that actually drive the #1317 d
    section 5). Not reopened here.
 
 7. The real friction is human, not technical. CA submission requires a self-hosted template
-   repo (`Owner/unraid-templates`), an Unraid *forum support thread*, and passes through a
+   repo (`Owner/unraid-templates`), an Unraid _forum support thread_, and passes through a
    volunteer moderation review (days to weeks) with an explicit account-quality screen:
    "made by a user with previous activity on GitHub... attributed to a GitHub account with an
    active history... not fully AI written" (`1995-external.md` section 1). Whether RackulaLives
-   has a usable Unraid *forum* account is an open prerequisite (see Recommendation summary).
+   has a usable Unraid _forum_ account is an open prerequisite (see Recommendation summary).
 
 ---
 
@@ -72,6 +72,8 @@ self-hosted template repo, an icon, and a forum support thread.
 - Exposes:
   - Port `8080/tcp` (container) -> suggested host `8080`, drives the WebUI button
   - `RACKULA_AUTH_MODE` dropdown (`none|local|oidc`), default `none`, basic visibility
+  - `RACKULA_STORAGE_MODE` dropdown (`browser|server`), default `browser`; set `server`
+    when the `rackula-api` container is installed (#2036)
   - `API_HOST` / `API_PORT` (advanced) so a persistence user can point the frontend at the
     API container by name/IP
   - `RACKULA_TRUST_PROXY` (advanced, default `false`) for SWAG/NPM users
@@ -153,6 +155,12 @@ deliberately want server-side persistence or auth.
             oidc = external identity provider. Auth is enforced by the rackula-api
             container; this setting must match it."/>
 
+  <Config Name="Storage Mode" Target="RACKULA_STORAGE_MODE" Default="browser|server"
+          Type="Variable" Display="always" Required="false" Mask="false"
+          Description="browser = layouts stay in this browser only. server = layouts are
+            saved by the rackula-api container. Set to server when you install
+            rackula-api, and point API Host at it."/>
+
   <Config Name="API Host" Target="API_HOST" Default="rackula-api"
           Type="Variable" Display="advanced" Required="false" Mask="false"
           Description="Container name or IP of the rackula-api container. Only needed if
@@ -189,8 +197,8 @@ deliberately want server-side persistence or auth.
   <Overview>Optional persistence and auth backend for Rackula. Stores layouts and assets in
     /data and provides local/OIDC login. Install this alongside the "rackula" frontend and
     point the frontend's API Host at this container. Not needed for single-browser use.</Overview>
-  <Requires>Install the "rackula" frontend container too and set its API Host to this
-    container's name.</Requires>
+  <Requires>Install the "rackula" frontend container too, set its API Host to this
+    container's name, and set its Storage Mode to server.</Requires>
   <Category>Productivity: Tools:Utilities:</Category>
   <Icon>https://raw.githubusercontent.com/RackulaLives/Rackula/main/static/icon.png</Icon>
   <TemplateURL>https://raw.githubusercontent.com/RackulaLives/unraid-templates/main/rackula-api.xml</TemplateURL>
@@ -241,12 +249,12 @@ and credential fields only become load-bearing when the user chooses `local`/`oi
 
 ## Approaches considered & trade-offs
 
-| Approach | Pros | Cons | When it'd be right |
-|---|---|---|---|
-| **(A) Frontend-only single template + docs** | Simplest possible CA listing; one template to maintain; one-click; zero secrets in the common path | Persistence/auth is "go read a compose file" - hostile to point-and-click Unraid users; no in-CA way to add the API | If the API were experimental/rare, or if browser-only storage were the only intended model |
-| **(B) Two templates [RECOMMENDED]** | Matches CA's one-container rule and the proven Homelabarr/KitchenOwl-split pattern; common case stays one-click; persistence is still installable from the Apps tab; reuses existing images unchanged | Two listings to maintain; risk of "installed frontend, no persistence" confusion (addressed in devil's-advocate); user must wire `API_HOST` | The actual Rackula shape: an always-needed frontend + a genuinely optional backend |
-| **(C) One combined fat image** | True one-click persistence with zero wiring; single template | Requires building/shipping a NEW image (s6/supervisor running nginx + Bun together) that does not exist today; doubles the build/security/patch surface; bakes the API in even for users who do not want it; contradicts the project's "simplicity first / only build what's asked" philosophy | Only if zero-config persistence were the default desired experience. It is not - the API is explicitly optional, so C is solving a problem we do not have |
-| **(D) Plugin (.plg)** | Deep OS integration; could auto-manage everything | Full host filesystem access for a web app (huge attack surface); must survive every Unraid OS upgrade; higher trust/moderation bar; Unraid-only; re-implements install/upgrade the container runtime already gives us | Never, for this app. Reserved for hardware/driver/OS-level features Rackula does not have |
+| Approach                                     | Pros                                                                                                                                                                                                  | Cons                                                                                                                                                                                                                                                                                           | When it'd be right                                                                                                                                        |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **(A) Frontend-only single template + docs** | Simplest possible CA listing; one template to maintain; one-click; zero secrets in the common path                                                                                                    | Persistence/auth is "go read a compose file" - hostile to point-and-click Unraid users; no in-CA way to add the API                                                                                                                                                                            | If the API were experimental/rare, or if browser-only storage were the only intended model                                                                |
+| **(B) Two templates [RECOMMENDED]**          | Matches CA's one-container rule and the proven Homelabarr/KitchenOwl-split pattern; common case stays one-click; persistence is still installable from the Apps tab; reuses existing images unchanged | Two listings to maintain; risk of "installed frontend, no persistence" confusion (addressed in devil's-advocate); user must wire `API_HOST`                                                                                                                                                    | The actual Rackula shape: an always-needed frontend + a genuinely optional backend                                                                        |
+| **(C) One combined fat image**               | True one-click persistence with zero wiring; single template                                                                                                                                          | Requires building/shipping a NEW image (s6/supervisor running nginx + Bun together) that does not exist today; doubles the build/security/patch surface; bakes the API in even for users who do not want it; contradicts the project's "simplicity first / only build what's asked" philosophy | Only if zero-config persistence were the default desired experience. It is not - the API is explicitly optional, so C is solving a problem we do not have |
+| **(D) Plugin (.plg)**                        | Deep OS integration; could auto-manage everything                                                                                                                                                     | Full host filesystem access for a web app (huge attack surface); must survive every Unraid OS upgrade; higher trust/moderation bar; Unraid-only; re-implements install/upgrade the container runtime already gives us                                                                          | Never, for this app. Reserved for hardware/driver/OS-level features Rackula does not have                                                                 |
 
 **Concrete rejection of (C):** there is no combined image in the repo. Choosing C means a net-new
 Dockerfile running two runtimes under a process supervisor, a third image to publish on every
@@ -273,9 +281,10 @@ is a trusted LAN where the user opts into exposure. Rackula's `none` mode = anon
 write to the API. On an isolated LAN with no port-forward, that matches the homelab norm (the LXC
 distribution already ships `none` by default, `1995-codebase.md`). The danger is the user who
 later port-forwards 8080 or puts it on a public reverse proxy without flipping auth on. That turns
-an unauthenticated *write* API (create/delete layouts, upload assets) onto the internet.
+an unauthenticated _write_ API (create/delete layouts, upload assets) onto the internet.
 
 **Template/AC must enforce:**
+
 - Frontend `<Overview>` and the support thread state plainly: "Default auth is none. Safe on a
   trusted LAN. Do NOT expose Rackula to the internet without setting Auth Mode to local or oidc."
 - The `RACKULA_AUTH_MODE` Description repeats the "trusted LAN only" caveat (already in the
@@ -290,6 +299,7 @@ values in the Edit Container UI. A secret typed into a normal Variable is visibl
 the flash drive.
 
 **Template/AC must enforce:**
+
 - `RACKULA_AUTH_SESSION_SECRET` -> `Mask="true"` (hides it behind asterisks in the UI). This does
   not encrypt the on-disk XML, but it prevents shoulder-surf/screenshot leakage, which is the
   realistic Unraid exposure.
@@ -314,6 +324,7 @@ wants reads-anonymous-but-writes-protected and does not realise neither protecti
 default.
 
 **Template/AC must enforce:**
+
 - Expose `RACKULA_API_WRITE_TOKEN` (api) and `API_WRITE_TOKEN` (frontend) as advanced, masked,
   with Description: "set the SAME value on both containers to require a token for create/delete."
 - Make explicit in docs: `auth=none` + no write token = fully open read/write. That is fine for a
@@ -321,13 +332,14 @@ default.
   never be internet-exposed.
 - Do NOT auto-bake a write token default in the template (same reasoning as the secret: a shared
   default token is no protection). If auto-generation is wanted, it belongs in install tooling that
-  produces a *unique random* value, not a static template `Default=`.
+  produces a _unique random_ value, not a static template `Default=`.
 
 ### 4. Reverse proxy / cookies: Secure-cookie + `RACKULA_TRUST_PROXY`
 
 The proxy terminates TLS and talks HTTP to the container; the app reads `X-Forwarded-Proto` only
 when `RACKULA_TRUST_PROXY=1` (`1995-external.md` section 4). Cookie `Secure` is forced on in prod
 and whenever `SameSite=None`. The breakage modes:
+
 - Auth enabled + plain HTTP + `TRUST_PROXY=0`: Secure cookies are set, browser refuses to send
   them back over HTTP, login appears to "not work" (infinite redirect to login). This is a support
   magnet.
@@ -335,6 +347,7 @@ and whenever `SameSite=None`. The breakage modes:
   `X-Forwarded-Proto`, a (minor) downgrade/redirect risk.
 
 **Template/AC must enforce:**
+
 - Default `RACKULA_TRUST_PROXY=false` (correct for LAN-direct). Keep it advanced so casual users
   never touch it.
 - Support thread documents the two-line rule: "Behind SWAG/NPM/Traefik with HTTPS -> set Trust
@@ -353,6 +366,7 @@ cannot manage from the file browser. The frontend (nginx UID 101) is stateless s
 this is purely an API-container issue.
 
 **Template/AC must enforce:**
+
 - Document the UID explicitly in the API template Description and support thread: "the API writes as
   UID 1001."
 - Recommend one of: (a) `chown -R 1001:1001 /mnt/user/appdata/rackula` once at setup, or (b) if the
@@ -369,6 +383,7 @@ means an unattended "force update" can pull a different image than was reviewed,
 behaviour or pulling a regression.
 
 **Template/AC must enforce:**
+
 - Templates pin a concrete version tag (`ghcr.io/rackulalives/rackula:26.6.0`) rather than
   `:latest`, and the release process bumps the template tag in `RackulaLives/unraid-templates` per
   release. This makes the Apps-tab "update available" prompt meaningful and reviewable.
@@ -409,6 +424,7 @@ This is the sharpest challenge. Rackula ALREADY ships `docker-compose.persist.ym
 slice of Unraid users run `docker compose` via the Compose Manager plugin and would be perfectly
 served by "here's our compose file." The CA route buys you **discoverability in the Apps tab** and
 the one-click frontend, which is real value for the non-compose crowd, but it costs:
+
 - a new repo to keep in sync with every image tag bump,
 - a forum thread someone must actually watch and answer,
 - the ongoing "respond to support requests / keep compatible with new Unraid releases / notify if
@@ -428,7 +444,7 @@ the two-step install, it is the **wiring** (`API_HOST` must match the API contai
 must be on a reachable network, auth mode must match on both). That is more fiddly than the typical
 self-contained Unraid app and is exactly where users get stuck. If #1317 keeps the API container's
 default name `rackula-api` and the frontend's `API_HOST` default `rackula-api`, the happy path works
-with zero edits *provided both land on the same bridge network* - verify that assumption holds on
+with zero edits *provided both land on the same bridge network\* - verify that assumption holds on
 Unraid's default bridge, because container-name DNS resolution is not guaranteed on the stock
 `bridge` network (it works on user-defined networks). **This is a concrete thing #1317 must test,
 not assume.**
@@ -436,10 +452,11 @@ not assume.**
 ### "CA review / account-history prerequisite: can RackulaLives clear vetting?"
 
 Partly known, partly not.
+
 - GitHub history: likely fine. RackulaLives is a real org with an active repo and real release
   history; the "previous activity on GitHub / not fully AI written" screen is plausibly met
   (`1995-external.md` section 1).
-- Unraid FORUM account: UNKNOWN and a hard prerequisite. CA requires a support *forum thread*,
+- Unraid FORUM account: UNKNOWN and a hard prerequisite. CA requires a support _forum thread_,
   which means an Unraid forum account in good standing. The research does not establish that
   RackulaLives/the maintainer has one. Flag as a prerequisite/blocker for #1317: if there is no
   established Unraid forum presence, that account (and the thread) must be created before submission,
@@ -452,6 +469,7 @@ Yes, `oidc` is a foot-gun on the dropdown for a LAN appliance. Most Unraid users
 most, `local`. Exposing `oidc` as a peer option invites someone to pick it and then hit the
 under-documented OIDC provider config (`1995-codebase.md` notes OIDC env vars are not fully
 enumerated, and OIDC setup is "MVP"). Recommendation for #1317:
+
 - Keep the dropdown `none|local|oidc` (matches the app), but in the Description steer plainly:
   "Most homelab users want none or local. oidc requires an external identity provider and extra
   configuration."
@@ -462,6 +480,7 @@ enumerated, and OIDC setup is "MVP"). Recommendation for #1317:
 ### "Anything that makes me say 'this is more work than #1317 assumes'?"
 
 Yes, three things:
+
 1. The UID 1001 vs 99:100 permission mismatch (secure-coding item 5) is the kind of detail that
    turns "install and go" into a forum thread full of "permission denied" reports. Either add PUID
    support (new code) or document the chown loudly. Not free.
@@ -469,7 +488,7 @@ Yes, three things:
    network" instruction, which is an extra manual step most one-click apps do not need. Must be
    verified on real Unraid.
 3. The forum thread + ongoing support obligation is a standing human cost, not a one-time
-   implementation task. CA can *delist* unmaintained apps. #1317 should not pretend the work ends at
+   implementation task. CA can _delist_ unmaintained apps. #1317 should not pretend the work ends at
    "XML merged."
 
 ---

--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
   </head>
   <body>
     <div id="app"></div>
+    <!-- Runtime deployment config (window.__RACKULA_CONFIG__). Written by the
+         container entrypoint; static hosts serve no config.js and the 404 is
+         harmless: the app defaults to browser mode. -->
+    <script src="/config.js" vite-ignore></script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -33,9 +33,11 @@
   </head>
   <body>
     <div id="app"></div>
-    <!-- Runtime deployment config (window.__RACKULA_CONFIG__). Written by the
-         container entrypoint; static hosts serve no config.js and the 404 is
-         harmless: the app defaults to browser mode. -->
+    <!-- Runtime deployment config (window.__RACKULA_CONFIG__). static/config.js
+         ships a browser-mode default in every build; container deployments
+         (Docker entrypoint, LXC install/update scripts) overwrite it at runtime.
+         CROSS-REF: static/config.js, deploy/docker-entrypoint-wrapper.sh,
+         deploy/lxc/community-scripts/{install/rackula-install.sh,ct/rackula.sh} -->
     <script src="/config.js" vite-ignore></script>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/scripts/check-compose-persist-parity.sh
+++ b/scripts/check-compose-persist-parity.sh
@@ -25,4 +25,20 @@ for compose_file in "$ROOT_COMPOSE" "$DEPLOY_COMPOSE"; do
   done
 done
 
+# RACKULA_STORAGE_MODE wiring must exist in both files, with per-stack
+# defaults: root compose defaults to browser (API only runs with
+# --profile persist), the persist stack defaults to server.
+root_storage_line="RACKULA_STORAGE_MODE=\${RACKULA_STORAGE_MODE:-browser}"
+deploy_storage_line="RACKULA_STORAGE_MODE=\${RACKULA_STORAGE_MODE:-server}"
+
+if ! grep -F --quiet "$root_storage_line" "$ROOT_COMPOSE"; then
+  echo "Missing '$root_storage_line' in $ROOT_COMPOSE"
+  exit 1
+fi
+
+if ! grep -F --quiet "$deploy_storage_line" "$DEPLOY_COMPOSE"; then
+  echo "Missing '$deploy_storage_line' in $DEPLOY_COMPOSE"
+  exit 1
+fi
+
 echo "Compose persistence env parity check passed."

--- a/static/config.js
+++ b/static/config.js
@@ -1,0 +1,4 @@
+// Build-time default: browser storage. Container deployments overwrite this.
+// CROSS-REF: deploy/docker-entrypoint-wrapper.sh (Docker) and deploy/lxc/community-scripts
+// install/rackula-install.sh + ct/rackula.sh (LXC) write the runtime variants.
+window.__RACKULA_CONFIG__ = { storage: "browser" };


### PR DESCRIPTION
## **User description**
## Summary

- Container entrypoint validates RACKULA_STORAGE_MODE (allowlist browser|server, default browser) and writes window.__RACKULA_CONFIG__ to a tmpfs config.js; raw env never reaches the emitted JS
- nginx serves /config.js (exact-match location, no-cache, security headers, auth_request parity with the SPA shell); tmpfs target keeps read-only containers working
- index.html loads /config.js ahead of the bundle; static/config.js ships a browser-mode default so static hosts and vite preview serve a real file (no 404, e2e console assertions stay green)
- LXC: install writes server-mode config.js and the update script rewrites it after re-extract (the tarball default would otherwise silently flip the instance to browser mode)
- Compose: persist stack defaults server, root compose defaults browser with guidance to set server under --profile persist; parity check script asserts the wiring in both files
- Unraid CA skeletons, .env.example, SELF-HOSTING.md documented

Frontend consumption of window.__RACKULA_CONFIG__ is issue #2037 and is deliberately absent (no src/ logic changes).

Pre-PR review run locally (multi-angle); findings addressed: LXC update-path config loss, e2e 404, doc default contradiction, auth gating symmetry, compose parity coverage.

## Test Plan
- [x] npm run lint clean
- [x] npm run test:run: 2034 tests pass
- [x] npm run build: dist/config.js present, script tag preserved
- [x] e2e smoke (chromium): 4/4 pass
- [x] bash -n / sh -n on changed scripts; compose parity script passes

Closes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Let deployments choose browser or server storage mode at runtime**

### What Changed
- Adds a storage mode setting so the app can run in browser-only mode or save layouts through the API
- Container deployments now write the right runtime config at startup, while static builds ship a browser-mode default
- LXC installs and updates now always restore server mode, so persistence does not silently switch back after an update
- Docker Compose, Unraid templates, and self-hosting docs now show the storage mode setting and its defaults
- The persisted compose stack defaults to server mode; the regular compose setup defaults to browser mode
- `/config.js` is now served with no-cache behavior, and in Docker it is protected the same way as the main app

### Impact
`✅ Fewer broken persistence setups`
`✅ Clearer browser-only and server-side storage behavior`
`✅ Fewer surprises after container updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
