### PR TITLE
feat: API pre-overwrite snapshots with echoed updatedAt conflict detection (#2040)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -2,7 +2,7 @@ import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { logger as honoLogger } from "hono/logger";
 import { bodyLimit } from "hono/body-limit";
-import layouts from "./routes/layouts";
+import layouts, { UPDATED_AT_HEADER } from "./routes/layouts";
 import assets from "./routes/assets";
 import {
   createSignedAuthSessionToken,
@@ -321,7 +321,8 @@ export async function createApp(
     cors({
       origin: securityConfig.corsOrigin,
       allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-      allowHeaders: ["Content-Type", "Authorization"],
+      allowHeaders: ["Content-Type", "Authorization", UPDATED_AT_HEADER],
+      exposeHeaders: [UPDATED_AT_HEADER],
     }),
   );
 

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -2,28 +2,36 @@
  * Layout API routes (UUID-based)
  *
  * When accessed directly (e.g., docker run -p 3001:3001 rackula-api):
- * GET    /layouts       - List all layouts
- * GET    /layouts/:uuid - Get layout by UUID
- * PUT    /layouts/:uuid - Create or update layout
- * DELETE /layouts/:uuid - Delete layout
+ * GET    /layouts                 - List all layouts
+ * GET    /layouts/:uuid           - Get layout by UUID
+ * PUT    /layouts/:uuid           - Create or update layout
+ * DELETE /layouts/:uuid           - Delete layout
+ * GET    /layouts/:uuid/snapshots - List pre-overwrite snapshots
+ * POST   /layouts/:uuid/snapshots - Upload a losing local copy as a snapshot
  *
- * When accessed through nginx proxy (recommended):
- * GET    /api/layouts       - List all layouts
- * GET    /api/layouts/:uuid - Get layout by UUID
- * PUT    /api/layouts/:uuid - Create or update layout
- * DELETE /api/layouts/:uuid - Delete layout
- * (nginx strips /api prefix before forwarding to API)
+ * When accessed through nginx proxy (recommended), the same routes are
+ * available under /api/layouts (nginx strips /api before forwarding).
+ *
+ * GET and PUT layout responses carry the stored copy's updatedAt in the
+ * X-Rackula-Updated-At header. Clients echo it on PUT; a mismatch with the
+ * stored copy snapshots the existing YAML before the overwrite.
  */
 import { Hono } from "hono";
+import * as yaml from "js-yaml";
 import { UuidSchema, LayoutFileSchema } from "../schemas/layout";
 import {
   listLayouts,
   getLayout,
   saveLayout,
   deleteLayout,
+  listSnapshots,
+  saveSnapshot,
 } from "../storage/filesystem";
 import { deleteLayoutAssets } from "../storage/assets";
 import { logger } from "../logger";
+
+/** Header carrying the layout's updatedAt for echo-based conflict detection. */
+export const UPDATED_AT_HEADER = "X-Rackula-Updated-At";
 
 const layouts = new Hono();
 
@@ -48,12 +56,15 @@ layouts.get("/:uuid", async (c) => {
   }
 
   try {
-    const content = await getLayout(uuidResult.data);
-    if (!content) {
+    const layout = await getLayout(uuidResult.data);
+    if (!layout) {
       return c.json({ error: "Layout not found" }, 404);
     }
 
-    return c.text(content, 200, { "Content-Type": "text/yaml" });
+    return c.text(layout.content, 200, {
+      "Content-Type": "text/yaml",
+      [UPDATED_AT_HEADER]: layout.updatedAt,
+    });
   } catch (error) {
     logger.error({ err: error }, `Failed to get layout ${uuidResult.data}`);
     return c.json({ error: "Failed to get layout" }, 500);
@@ -104,11 +115,17 @@ layouts.put("/:uuid", async (c) => {
       // If we can't parse, let saveLayout handle the error
     }
 
-    const result = await saveLayout(yamlContent, uuidResult.data);
+    const result = await saveLayout(
+      yamlContent,
+      uuidResult.data,
+      c.req.header(UPDATED_AT_HEADER),
+    );
 
+    c.header(UPDATED_AT_HEADER, result.updatedAt);
     return c.json(
       {
         id: result.id,
+        updatedAt: result.updatedAt,
         message: result.isNew ? "Layout created" : "Layout updated",
       },
       result.isNew ? 201 : 200,
@@ -161,6 +178,72 @@ layouts.delete("/:uuid", async (c) => {
   } catch (error) {
     logger.error({ err: error }, `Failed to delete layout ${uuidResult.data}`);
     return c.json({ error: "Failed to delete layout" }, 500);
+  }
+});
+
+// List pre-overwrite snapshots for a layout
+layouts.get("/:uuid/snapshots", async (c) => {
+  const uuid = c.req.param("uuid");
+
+  const uuidResult = UuidSchema.safeParse(uuid);
+  if (!uuidResult.success) {
+    return c.json({ error: "Invalid layout UUID format" }, 400);
+  }
+
+  try {
+    const snapshots = await listSnapshots(uuidResult.data);
+    if (snapshots === null) {
+      return c.json({ error: "Layout not found" }, 404);
+    }
+
+    return c.json({ snapshots });
+  } catch (error) {
+    logger.error(
+      { err: error },
+      `Failed to list snapshots for layout ${uuidResult.data}`,
+    );
+    return c.json({ error: "Failed to list snapshots" }, 500);
+  }
+});
+
+// Upload a losing local copy as a snapshot
+layouts.post("/:uuid/snapshots", async (c) => {
+  const uuid = c.req.param("uuid");
+
+  const uuidResult = UuidSchema.safeParse(uuid);
+  if (!uuidResult.success) {
+    return c.json({ error: "Invalid layout UUID format" }, 400);
+  }
+
+  try {
+    const yamlContent = await c.req.text();
+
+    if (!yamlContent.trim()) {
+      return c.json({ error: "Request body is empty" }, 400);
+    }
+
+    try {
+      yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return c.json({ error: `Invalid YAML: ${message}` }, 400);
+    }
+
+    const result = await saveSnapshot(uuidResult.data, yamlContent);
+    if (!result) {
+      return c.json({ error: "Layout not found" }, 404);
+    }
+
+    return c.json(
+      { filename: result.filename, message: "Snapshot saved" },
+      201,
+    );
+  } catch (error) {
+    logger.error(
+      { err: error },
+      `Failed to save snapshot for layout ${uuidResult.data}`,
+    );
+    return c.json({ error: "Failed to save snapshot" }, 500);
   }
 });
 

--- a/api/src/security/middleware.ts
+++ b/api/src/security/middleware.ts
@@ -7,7 +7,7 @@ import {
 } from "./tokens";
 import type { ApiSecurityConfig, AuthSessionClaims } from "./types";
 
-const WRITE_METHODS = new Set(["PUT", "DELETE"]);
+const WRITE_METHODS = new Set(["POST", "PUT", "DELETE"]);
 const _AUTH_PUBLIC_PATHS = new Set([
   "/health",
   "/api/health",

--- a/api/src/security/rate-limit-middleware.ts
+++ b/api/src/security/rate-limit-middleware.ts
@@ -1,7 +1,7 @@
 /**
  * Hono middleware for IP-based rate limiting on API routes.
  *
- * Applies separate limits for read (GET, HEAD) and write (PUT, DELETE) requests.
+ * Applies separate limits for read (GET, HEAD) and write (POST, PUT, DELETE) requests.
  * Health, version, and auth endpoints are exempt. OPTIONS (CORS preflight) requests
  * are also exempt to avoid blocking browser cross-origin checks.
  *
@@ -12,13 +12,13 @@ import type { MiddlewareHandler } from "hono";
 import { AUTH_PUBLIC_PATHS } from "./middleware";
 import { createRateLimiter } from "./rate-limit";
 
-const WRITE_METHODS = new Set(["PUT", "DELETE"]);
+const WRITE_METHODS = new Set(["POST", "PUT", "DELETE"]);
 
 /**
  * Configuration for the rate limit middleware.
  */
 export interface RateLimitMiddlewareConfig {
-  /** Max write (PUT/DELETE) requests per IP per window. */
+  /** Max write (POST/PUT/DELETE) requests per IP per window. */
   writeMaxRequests: number;
   /** Write rate limit window in milliseconds. */
   writeWindowMs: number;
@@ -86,7 +86,7 @@ export interface RateLimitMiddleware extends MiddlewareHandler {
 /**
  * Create a rate limiting middleware for Hono.
  *
- * Creates two independent rate limiters: one for write operations (PUT, DELETE)
+ * Creates two independent rate limiters: one for write operations (POST, PUT, DELETE)
  * and one for read operations (GET, HEAD). OPTIONS requests and public paths
  * (health, version, auth) are exempt.
  *

--- a/api/src/snapshots.test.ts
+++ b/api/src/snapshots.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Pre-overwrite snapshot tests (#2040)
+ *
+ * Covers echoed-updatedAt conflict detection on PUT, snapshot listing and
+ * upload routes, pruning, auth gating, and invisibility of the snapshots
+ * folder to quota counting and layout discovery.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp } from "./app";
+import { checkLayoutQuota } from "./storage/quota";
+import type { EnvMap } from "./security";
+
+type App = Awaited<ReturnType<typeof createApp>>;
+
+const UPDATED_AT_HEADER = "X-Rackula-Updated-At";
+const TEST_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const UNKNOWN_UUID = "00000000-0000-0000-0000-000000000999";
+const STALE_UPDATED_AT = "1999-01-01T00:00:00.000Z";
+const TEST_TOKEN = "test-write-token";
+
+const originalDataDir = process.env.DATA_DIR;
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "rackula-snapshots-test-"));
+  process.env.DATA_DIR = testDir;
+});
+
+afterEach(async () => {
+  if (originalDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = originalDataDir;
+  }
+
+  try {
+    await rm(testDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup failures
+  }
+});
+
+function buildEnv(overrides: EnvMap = {}): EnvMap {
+  return {
+    NODE_ENV: "test",
+    DATA_DIR: testDir,
+    RACKULA_RATE_LIMIT_ENABLED: "false",
+    ...overrides,
+  };
+}
+
+function createLayoutYaml(name: string, marker: string): string {
+  return `version: "1.0.0"\nname: ${name}\ndescription: ${marker}\nracks: []`;
+}
+
+async function putLayout(
+  app: App,
+  uuid: string,
+  body: string,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return app.request(`/layouts/${uuid}`, {
+    method: "PUT",
+    headers: { "Content-Type": "text/yaml", ...headers },
+    body,
+  });
+}
+
+async function postSnapshot(
+  app: App,
+  uuid: string,
+  body: string,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return app.request(`/layouts/${uuid}/snapshots`, {
+    method: "POST",
+    headers: { "Content-Type": "text/yaml", ...headers },
+    body,
+  });
+}
+
+/**
+ * Read snapshot filenames directly from disk for the layout folder
+ * matching the given UUID. Returns [] when no folder or no snapshots exist.
+ */
+async function snapshotFilesOnDisk(uuid: string): Promise<string[]> {
+  const entries = await readdir(testDir, { withFileTypes: true });
+  const folder = entries.find(
+    (entry) =>
+      entry.isDirectory() && entry.name.toLowerCase().endsWith(uuid),
+  );
+  if (!folder) {
+    return [];
+  }
+
+  try {
+    return await readdir(join(testDir, folder.name, "snapshots"));
+  } catch {
+    return [];
+  }
+}
+
+async function readSnapshotContents(uuid: string): Promise<string[]> {
+  const entries = await readdir(testDir, { withFileTypes: true });
+  const folder = entries.find(
+    (entry) =>
+      entry.isDirectory() && entry.name.toLowerCase().endsWith(uuid),
+  );
+  if (!folder) {
+    return [];
+  }
+
+  const snapshotsDir = join(testDir, folder.name, "snapshots");
+  const files = await readdir(snapshotsDir);
+  return Promise.all(
+    files.map((file) => readFile(join(snapshotsDir, file), "utf-8")),
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("PUT echoed updatedAt conflict detection", () => {
+  it("first save without header creates no snapshot and returns updatedAt", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await putLayout(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v1"),
+    );
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.id).toBe(TEST_UUID);
+    expect(new Date(body.updatedAt).toISOString()).toBe(body.updatedAt);
+    expect(response.headers.get(UPDATED_AT_HEADER)).toBe(body.updatedAt);
+    expect(await snapshotFilesOnDisk(TEST_UUID)).toEqual([]);
+  });
+
+  it("first save with an echoed header creates no snapshot", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await putLayout(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v1"),
+      { [UPDATED_AT_HEADER]: STALE_UPDATED_AT },
+    );
+
+    expect(response.status).toBe(201);
+    expect(await snapshotFilesOnDisk(TEST_UUID)).toEqual([]);
+  });
+
+  it("overwrite without header creates no snapshot (legacy client)", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await putLayout(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v2"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await snapshotFilesOnDisk(TEST_UUID)).toEqual([]);
+
+    const stored = await app.request(`/layouts/${TEST_UUID}`);
+    expect(await stored.text()).toContain("v2");
+  });
+
+  it("overwrite with matching echoed updatedAt creates no snapshot", async () => {
+    const app = await createApp(buildEnv());
+    const first = await putLayout(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v1"),
+    );
+    const { updatedAt } = await first.json();
+
+    const response = await putLayout(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v2"),
+      { [UPDATED_AT_HEADER]: updatedAt },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await snapshotFilesOnDisk(TEST_UUID)).toEqual([]);
+
+    const stored = await app.request(`/layouts/${TEST_UUID}`);
+    expect(await stored.text()).toContain("v2");
+  });
+
+  it("mismatched echoed updatedAt snapshots the existing copy then writes", async () => {
+    const app = await createApp(buildEnv());
+    const v1 = createLayoutYaml("My Layout", "v1");
+    const v2 = createLayoutYaml("My Layout", "v2");
+    await putLayout(app, TEST_UUID, v1);
+
+    const response = await putLayout(app, TEST_UUID, v2, {
+      [UPDATED_AT_HEADER]: STALE_UPDATED_AT,
+    });
+
+    // Last write wins: the save is never rejected
+    expect(response.status).toBe(200);
+
+    const snapshots = await snapshotFilesOnDisk(TEST_UUID);
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: one mismatch produces exactly one snapshot
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatch(/^my-layout~\d{8}-\d{6}(-\d+)?\.yaml$/);
+
+    const contents = await readSnapshotContents(TEST_UUID);
+    expect(contents[0]).toBe(v1);
+
+    const stored = await app.request(`/layouts/${TEST_UUID}`);
+    expect(await stored.text()).toContain("v2");
+  });
+});
+
+describe("snapshot pruning", () => {
+  it("prunes to the 5 most recent snapshots", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    for (let i = 2; i <= 8; i += 1) {
+      await sleep(2);
+      const response = await putLayout(
+        app,
+        TEST_UUID,
+        createLayoutYaml("My Layout", `v${i}`),
+        { [UPDATED_AT_HEADER]: STALE_UPDATED_AT },
+      );
+      expect(response.status).toBe(200);
+    }
+
+    const snapshots = await snapshotFilesOnDisk(TEST_UUID);
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: retention bound is exactly 5 snapshots
+    expect(snapshots).toHaveLength(5);
+
+    // 7 mismatch saves snapshot v1..v7; pruning keeps the newest 5 (v3..v7)
+    const contents = await readSnapshotContents(TEST_UUID);
+    const markers = contents
+      .map((content) => content.match(/description: (v\d+)/)?.[1])
+      .sort();
+    expect(markers).toEqual(["v3", "v4", "v5", "v6", "v7"]);
+  });
+
+  it("manual uploads count toward the prune bound", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    for (let i = 1; i <= 6; i += 1) {
+      await sleep(2);
+      const response = await postSnapshot(
+        app,
+        TEST_UUID,
+        createLayoutYaml("My Layout", `local-${i}`),
+      );
+      expect(response.status).toBe(201);
+    }
+
+    const snapshots = await snapshotFilesOnDisk(TEST_UUID);
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: retention bound is exactly 5 snapshots
+    expect(snapshots).toHaveLength(5);
+  });
+});
+
+describe("GET /layouts/:uuid/snapshots", () => {
+  it("lists snapshots with filename, timestamp, and size, newest first", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+    for (let i = 2; i <= 3; i += 1) {
+      await sleep(2);
+      await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", `v${i}`), {
+        [UPDATED_AT_HEADER]: STALE_UPDATED_AT,
+      });
+    }
+
+    const response = await app.request(`/layouts/${TEST_UUID}/snapshots`);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: two mismatch saves produce exactly two snapshots
+    expect(body.snapshots).toHaveLength(2);
+    for (const snapshot of body.snapshots) {
+      expect(typeof snapshot.filename).toBe("string");
+      expect(new Date(snapshot.timestamp).toISOString()).toBe(
+        snapshot.timestamp,
+      );
+      expect(snapshot.size).toBeGreaterThan(0);
+    }
+    expect(
+      body.snapshots[0].timestamp >= body.snapshots[1].timestamp,
+    ).toBe(true);
+  });
+
+  it("returns an empty list when the layout has no snapshots", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await app.request(`/layouts/${TEST_UUID}/snapshots`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ snapshots: [] });
+  });
+
+  it("returns 404 for an unknown layout", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await app.request(`/layouts/${UNKNOWN_UUID}/snapshots`);
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 for an invalid uuid", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await app.request("/layouts/not-a-uuid/snapshots");
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("POST /layouts/:uuid/snapshots", () => {
+  it("stores an uploaded losing copy as a snapshot", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+    const losingCopy = createLayoutYaml("My Layout", "losing-local-copy");
+
+    const response = await postSnapshot(app, TEST_UUID, losingCopy);
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.filename).toMatch(/^my-layout~\d{8}-\d{6}(-\d+)?\.yaml$/);
+
+    const contents = await readSnapshotContents(TEST_UUID);
+    expect(contents).toContain(losingCopy);
+  });
+
+  it("returns 404 for an unknown layout", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await postSnapshot(
+      app,
+      UNKNOWN_UUID,
+      createLayoutYaml("My Layout", "v1"),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 for an empty body", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await postSnapshot(app, TEST_UUID, "   ");
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for unparseable YAML", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await postSnapshot(app, TEST_UUID, "not valid yaml: [");
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid uuid", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await postSnapshot(app, "not-a-uuid", "version: 1");
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("snapshot route auth gating", () => {
+  it("rejects snapshot upload without write token when token auth is enabled", async () => {
+    const app = await createApp(
+      buildEnv({ RACKULA_API_WRITE_TOKEN: TEST_TOKEN }),
+    );
+
+    const response = await postSnapshot(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v1"),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects snapshot upload with a wrong write token", async () => {
+    const app = await createApp(
+      buildEnv({ RACKULA_API_WRITE_TOKEN: TEST_TOKEN }),
+    );
+
+    const response = await postSnapshot(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v1"),
+      { Authorization: "Bearer wrong-token" },
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it("accepts snapshot upload with a valid write token", async () => {
+    const app = await createApp(
+      buildEnv({ RACKULA_API_WRITE_TOKEN: TEST_TOKEN }),
+    );
+    const authHeader = { Authorization: `Bearer ${TEST_TOKEN}` };
+    await putLayout(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v1"),
+      authHeader,
+    );
+
+    const response = await postSnapshot(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "losing-copy"),
+      authHeader,
+    );
+    expect(response.status).toBe(201);
+  });
+
+  it("does not serve snapshot listings without a session when auth is enabled", async () => {
+    const app = await createApp(
+      buildEnv({
+        RACKULA_AUTH_MODE: "oidc",
+        RACKULA_AUTH_SESSION_SECRET:
+          "rackula-auth-session-secret-for-tests-0123456789",
+        CORS_ORIGIN: "https://rack.example.com",
+      }),
+    );
+
+    const response = await app.request(`/layouts/${TEST_UUID}/snapshots`);
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("snapshot folder invisibility", () => {
+  it("snapshots are invisible to checkLayoutQuota", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+    for (let i = 2; i <= 6; i += 1) {
+      await sleep(2);
+      await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", `v${i}`), {
+        [UPDATED_AT_HEADER]: STALE_UPDATED_AT,
+      });
+    }
+    expect((await snapshotFilesOnDisk(TEST_UUID)).length).toBeGreaterThan(0);
+
+    const quota = await checkLayoutQuota(testDir, 2);
+    expect(quota.current).toBe(1);
+    expect(quota.allowed).toBe(true);
+  });
+
+  it("snapshots are invisible to layout discovery (findYamlInFolder)", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+    const latest = createLayoutYaml("My Layout", "v2");
+    await putLayout(app, TEST_UUID, latest, {
+      [UPDATED_AT_HEADER]: STALE_UPDATED_AT,
+    });
+    expect((await snapshotFilesOnDisk(TEST_UUID)).length).toBeGreaterThan(0);
+
+    const single = await app.request(`/layouts/${TEST_UUID}`);
+    expect(single.status).toBe(200);
+    expect(await single.text()).toBe(latest);
+
+    const list = await app.request("/layouts");
+    const body = await list.json();
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: snapshots must never surface as layouts
+    expect(body.layouts).toHaveLength(1);
+    expect(body.layouts[0].id).toBe(TEST_UUID);
+    expect(body.layouts[0].name).toBe("My Layout");
+  });
+});
+
+describe("updatedAt echo surface", () => {
+  it("PUT and GET expose the same updatedAt as the list endpoint", async () => {
+    const app = await createApp(buildEnv());
+
+    const put = await putLayout(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "v1"),
+    );
+    const { updatedAt } = await put.json();
+
+    const single = await app.request(`/layouts/${TEST_UUID}`);
+    expect(single.headers.get(UPDATED_AT_HEADER)).toBe(updatedAt);
+
+    const list = await app.request("/layouts");
+    const body = await list.json();
+    expect(body.layouts[0].updatedAt).toBe(updatedAt);
+  });
+});

--- a/api/src/snapshots.test.ts
+++ b/api/src/snapshots.test.ts
@@ -6,7 +6,15 @@
  * folder to quota counting and layout discovery.
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createApp } from "./app";
@@ -250,6 +258,51 @@ describe("snapshot pruning", () => {
     expect(markers).toEqual(["v3", "v4", "v5", "v6", "v7"]);
   });
 
+  it("prunes the base snapshot before its suffixed siblings when mtimes tie", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const entries = await readdir(testDir, { withFileTypes: true });
+    const folder = entries.find(
+      (entry) =>
+        entry.isDirectory() && entry.name.toLowerCase().endsWith(TEST_UUID),
+    );
+    if (!folder) {
+      throw new Error("layout folder not found");
+    }
+
+    // Forge a same-second collision set with identical mtimes: the base
+    // file is the oldest write, suffixes 1-5 are progressively newer.
+    const snapshotsDir = join(testDir, folder.name, "snapshots");
+    await mkdir(snapshotsDir, { recursive: true });
+    const names = [
+      "my-layout~20260101-000000.yaml",
+      ...[1, 2, 3, 4, 5].map((n) => `my-layout~20260101-000000-${n}.yaml`),
+    ];
+    for (const name of names) {
+      await writeFile(join(snapshotsDir, name), `marker: ${name}`, "utf-8");
+    }
+    const sharedMtime = new Date("2026-01-01T00:00:00Z");
+    for (const name of names) {
+      await utimes(join(snapshotsDir, name), sharedMtime, sharedMtime);
+    }
+
+    // A new upload prunes 7 files down to 5: the two oldest of the tied
+    // set (base, then -1) must go.
+    const response = await postSnapshot(
+      app,
+      TEST_UUID,
+      createLayoutYaml("My Layout", "new"),
+    );
+    expect(response.status).toBe(201);
+
+    const remaining = await snapshotFilesOnDisk(TEST_UUID);
+    expect(remaining).not.toContain("my-layout~20260101-000000.yaml");
+    expect(remaining).not.toContain("my-layout~20260101-000000-1.yaml");
+    expect(remaining).toContain("my-layout~20260101-000000-2.yaml");
+    expect(remaining).toContain("my-layout~20260101-000000-5.yaml");
+  });
+
   it("manual uploads count toward the prune bound", async () => {
     const app = await createApp(buildEnv());
     await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
@@ -372,6 +425,17 @@ describe("POST /layouts/:uuid/snapshots", () => {
     const response = await postSnapshot(app, "not-a-uuid", "version: 1");
     expect(response.status).toBe(400);
   });
+
+  it("returns 413 for a body over the layout size limit", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const oversized = createLayoutYaml("My Layout", "x".repeat(1024 * 1024));
+    const response = await postSnapshot(app, TEST_UUID, oversized);
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: "Layout data too large" });
+  });
 });
 
 describe("snapshot route auth gating", () => {
@@ -421,6 +485,19 @@ describe("snapshot route auth gating", () => {
       authHeader,
     );
     expect(response.status).toBe(201);
+  });
+
+  it("serves snapshot listings without a token in write-token mode", async () => {
+    const app = await createApp(
+      buildEnv({ RACKULA_API_WRITE_TOKEN: TEST_TOKEN }),
+    );
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"), {
+      Authorization: `Bearer ${TEST_TOKEN}`,
+    });
+
+    const response = await app.request(`/layouts/${TEST_UUID}/snapshots`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ snapshots: [] });
   });
 
   it("does not serve snapshot listings without a session when auth is enabled", async () => {

--- a/api/src/storage/filesystem.test.ts
+++ b/api/src/storage/filesystem.test.ts
@@ -177,7 +177,8 @@ describe("saveLayout and getLayout", () => {
     expect(result.isNew).toBe(true);
 
     const retrieved = await getLayout(result.id);
-    expect(retrieved).toBe(yamlContent);
+    expect(retrieved?.content).toBe(yamlContent);
+    expect(retrieved?.updatedAt).toBe(result.updatedAt);
   });
 
   it("detects existing layout as not new", async () => {
@@ -209,7 +210,7 @@ describe("saveLayout and getLayout", () => {
     // UUID remains stable and content is updated
     expect(renamed.id).toBe(created.id);
     const current = await getLayout(created.id);
-    expect(current).toContain("Renamed");
+    expect(current?.content).toContain("Renamed");
   });
 
   it("returns null for non-existent layout", async () => {

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -28,6 +28,16 @@ function getDataDir(): string {
   return process.env.DATA_DIR ?? "./data";
 }
 
+const SNAPSHOTS_DIR = "snapshots";
+const MAX_SNAPSHOTS_PER_LAYOUT = 5;
+
+/** Snapshot entry returned by {@link listSnapshots}. */
+export interface SnapshotListItem {
+  filename: string;
+  timestamp: string;
+  size: number;
+}
+
 function isSafeLegacySlug(id: string): boolean {
   if (!id || id.includes("/") || id.includes("\\") || id.includes(".")) {
     return false;
@@ -93,6 +103,133 @@ async function findYamlInFolder(folderPath: string): Promise<string | null> {
   const files = await readdir(folderPath);
   const yamlFile = files.find((f) => f.endsWith(".rackula.yaml"));
   return yamlFile ?? null;
+}
+
+/**
+ * Format a snapshot timestamp as YYYYMMDD-HHMMSS (UTC, Syncthing naming)
+ */
+function formatSnapshotTimestamp(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+    `-${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`
+  );
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Delete oldest snapshots so at most MAX_SNAPSHOTS_PER_LAYOUT remain
+ */
+async function pruneSnapshots(snapshotsDir: string): Promise<void> {
+  const entries = await readdir(snapshotsDir, { withFileTypes: true });
+  const files: Array<{ name: string; mtimeMs: number }> = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const stats = await stat(join(snapshotsDir, entry.name));
+    files.push({ name: entry.name, mtimeMs: stats.mtimeMs });
+  }
+
+  files.sort((a, b) => b.mtimeMs - a.mtimeMs || b.name.localeCompare(a.name));
+  for (const file of files.slice(MAX_SNAPSHOTS_PER_LAYOUT)) {
+    await rm(join(snapshotsDir, file.name), { force: true });
+  }
+}
+
+/**
+ * Write a snapshot into {folderPath}/snapshots/{name}~YYYYMMDD-HHMMSS.yaml
+ * The base name derives from the stored layout's YAML filename (already
+ * sanitized by buildYamlFilename when it was written). Prunes to the
+ * MAX_SNAPSHOTS_PER_LAYOUT most recent. Returns the snapshot filename.
+ */
+async function writeSnapshot(
+  folderPath: string,
+  yamlContent: string,
+): Promise<string> {
+  const yamlFilename = await findYamlInFolder(folderPath);
+  const baseName = yamlFilename
+    ? yamlFilename.replace(/\.rackula\.yaml$/i, "")
+    : "untitled";
+
+  const snapshotsDir = join(folderPath, SNAPSHOTS_DIR);
+  await mkdir(snapshotsDir, { recursive: true });
+
+  const timestamp = formatSnapshotTimestamp(new Date());
+  let filename = `${baseName}~${timestamp}.yaml`;
+  let suffix = 1;
+  while (await fileExists(join(snapshotsDir, filename))) {
+    filename = `${baseName}~${timestamp}-${suffix}.yaml`;
+    suffix += 1;
+  }
+
+  await writeFile(join(snapshotsDir, filename), yamlContent, "utf-8");
+  await pruneSnapshots(snapshotsDir);
+  return filename;
+}
+
+/**
+ * List snapshots for a layout, newest first
+ * Returns null when the layout does not exist
+ */
+export async function listSnapshots(
+  uuid: string,
+): Promise<SnapshotListItem[] | null> {
+  const folder = await findFolderByUuid(uuid);
+  if (!folder) {
+    return null;
+  }
+
+  const snapshotsDir = join(folder, SNAPSHOTS_DIR);
+  let entries;
+  try {
+    entries = await readdir(snapshotsDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  const snapshots: SnapshotListItem[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const stats = await stat(join(snapshotsDir, entry.name));
+    snapshots.push({
+      filename: entry.name,
+      timestamp: stats.mtime.toISOString(),
+      size: stats.size,
+    });
+  }
+
+  return snapshots.sort(
+    (a, b) =>
+      b.timestamp.localeCompare(a.timestamp) ||
+      b.filename.localeCompare(a.filename),
+  );
+}
+
+/**
+ * Store an uploaded losing copy as a snapshot for a layout
+ * Returns null when the layout does not exist
+ */
+export async function saveSnapshot(
+  uuid: string,
+  yamlContent: string,
+): Promise<{ filename: string } | null> {
+  const folder = await findFolderByUuid(uuid);
+  if (!folder) {
+    return null;
+  }
+
+  const filename = await writeSnapshot(folder, yamlContent);
+  return { filename };
 }
 
 /**
@@ -282,9 +419,12 @@ export async function layoutExists(uuid: string): Promise<boolean> {
 
 /**
  * Get a single layout by UUID or legacy slug
- * Returns the YAML content or null if not found
+ * Returns the YAML content and its updatedAt (file mtime, ISO 8601),
+ * or null if not found
  */
-export async function getLayout(id: string): Promise<string | null> {
+export async function getLayout(
+  id: string,
+): Promise<{ content: string; updatedAt: string } | null> {
   // First try UUID lookup (new format)
   if (isUuid(id)) {
     const folder = await findFolderByUuid(id);
@@ -292,7 +432,10 @@ export async function getLayout(id: string): Promise<string | null> {
       const yamlFilename = await findYamlInFolder(folder);
       if (yamlFilename) {
         try {
-          return await readFile(join(folder, yamlFilename), "utf-8");
+          const yamlPath = join(folder, yamlFilename);
+          const content = await readFile(yamlPath, "utf-8");
+          const stats = await stat(yamlPath);
+          return { content, updatedAt: stats.mtime.toISOString() };
         } catch {
           return null;
         }
@@ -311,7 +454,9 @@ export async function getLayout(id: string): Promise<string | null> {
 
   for (const path of legacyPaths) {
     try {
-      return await readFile(path, "utf-8");
+      const content = await readFile(path, "utf-8");
+      const stats = await stat(path);
+      return { content, updatedAt: stats.mtime.toISOString() };
     } catch {
       // Continue to next
     }
@@ -327,7 +472,7 @@ export async function getLayout(id: string): Promise<string | null> {
 async function migrateLegacyLayout(
   oldSlug: string,
   yamlContent: string,
-): Promise<{ id: string; isNew: boolean }> {
+): Promise<{ id: string; isNew: boolean; updatedAt: string }> {
   if (!isSafeLegacySlug(oldSlug)) {
     throw new Error("Invalid legacy layout id");
   }
@@ -369,7 +514,9 @@ async function migrateLegacyLayout(
     await mkdir(folderPath, { recursive: true });
 
     // Write YAML to new location
-    await writeFile(join(folderPath, yamlFilename), yamlContent, "utf-8");
+    const yamlPath = join(folderPath, yamlFilename);
+    await writeFile(yamlPath, yamlContent, "utf-8");
+    const stats = await stat(yamlPath);
 
     // Move assets if they exist in old location
     try {
@@ -395,7 +542,7 @@ async function migrateLegacyLayout(
       }
     }
 
-    return { id: uuid, isNew: false };
+    return { id: uuid, isNew: false, updatedAt: stats.mtime.toISOString() };
   } catch (error) {
     if (assetsMoved) {
       try {
@@ -443,12 +590,20 @@ async function legacyLayoutExists(slug: string): Promise<boolean> {
  * Save a layout (create or update)
  * Creates folder structure: /data/{Name}-{UUID}/{name}.rackula.yaml
  * Also handles migration from legacy flat YAML format
- * Returns the layout UUID and whether it was a new layout
+ *
+ * When `echoedUpdatedAt` (the updatedAt the client last received from the
+ * server) differs from the stored copy's current updatedAt, the existing
+ * YAML is copied into the layout's snapshots folder before the write.
+ * Last write wins; the save is never rejected.
+ *
+ * Returns the layout UUID, whether it was a new layout, and the stored
+ * file's updatedAt (mtime, ISO 8601) for clients to echo on the next save
  */
 export async function saveLayout(
   yamlContent: string,
   existingId?: string,
-): Promise<{ id: string; isNew: boolean }> {
+  echoedUpdatedAt?: string,
+): Promise<{ id: string; isNew: boolean; updatedAt: string }> {
   await ensureDataDir();
 
   const existingUuid =
@@ -499,6 +654,21 @@ export async function saveLayout(
   const existingFolder = await findFolderByUuid(uuid);
   let isNew = existingFolder === null;
 
+  // Pre-overwrite snapshot: when the client's echoed updatedAt does not
+  // match the stored copy, the copies diverged. Capture the stored YAML
+  // before overwriting it.
+  if (echoedUpdatedAt && existingFolder) {
+    const existingYamlFilename = await findYamlInFolder(existingFolder);
+    if (existingYamlFilename) {
+      const existingYamlPath = join(existingFolder, existingYamlFilename);
+      const existingStats = await stat(existingYamlPath);
+      if (existingStats.mtime.toISOString() !== echoedUpdatedAt) {
+        const existingContent = await readFile(existingYamlPath, "utf-8");
+        await writeSnapshot(existingFolder, existingContent);
+      }
+    }
+  }
+
   // Handle rename: if the folder name changed (name change), rename the folder
   if (existingFolder && existingFolder !== folderPath) {
     // Handle concurrent folder changes gracefully.
@@ -533,9 +703,11 @@ export async function saveLayout(
   await mkdir(folderPath, { recursive: true });
 
   // Write the YAML file
-  await writeFile(join(folderPath, yamlFilename), yamlContent, "utf-8");
+  const yamlPath = join(folderPath, yamlFilename);
+  await writeFile(yamlPath, yamlContent, "utf-8");
+  const stats = await stat(yamlPath);
 
-  return { id: uuid, isNew };
+  return { id: uuid, isNew, updatedAt: stats.mtime.toISOString() };
 }
 
 /**

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -8,6 +8,7 @@ import {
   writeFile,
   stat,
   mkdir,
+  open,
   rm,
   rename,
 } from "node:fs/promises";
@@ -116,13 +117,26 @@ function formatSnapshotTimestamp(date: Date): string {
   );
 }
 
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await stat(path);
-    return true;
-  } catch {
-    return false;
+const SNAPSHOT_NAME_PATTERN = /~(\d{8}-\d{6})(?:-(\d+))?\.yaml$/;
+
+/**
+ * Compare snapshot filenames newest-first using the embedded timestamp and
+ * numeric collision suffix (no suffix sorts oldest within a timestamp).
+ * Plain localeCompare would rank the suffix-less base file above its
+ * suffixed siblings, inverting the order for same-timestamp snapshots.
+ */
+function compareSnapshotNamesDesc(a: string, b: string): number {
+  const matchA = SNAPSHOT_NAME_PATTERN.exec(a);
+  const matchB = SNAPSHOT_NAME_PATTERN.exec(b);
+  if (!matchA || !matchB) {
+    return b.localeCompare(a);
   }
+  const [, timestampA = "", suffixA] = matchA;
+  const [, timestampB = "", suffixB] = matchB;
+  return (
+    timestampB.localeCompare(timestampA) ||
+    Number(suffixB ?? 0) - Number(suffixA ?? 0)
+  );
 }
 
 /**
@@ -137,7 +151,9 @@ async function pruneSnapshots(snapshotsDir: string): Promise<void> {
     files.push({ name: entry.name, mtimeMs: stats.mtimeMs });
   }
 
-  files.sort((a, b) => b.mtimeMs - a.mtimeMs || b.name.localeCompare(a.name));
+  files.sort(
+    (a, b) => b.mtimeMs - a.mtimeMs || compareSnapshotNamesDesc(a.name, b.name),
+  );
   for (const file of files.slice(MAX_SNAPSHOTS_PER_LAYOUT)) {
     await rm(join(snapshotsDir, file.name), { force: true });
   }
@@ -164,12 +180,24 @@ async function writeSnapshot(
   const timestamp = formatSnapshotTimestamp(new Date());
   let filename = `${baseName}~${timestamp}.yaml`;
   let suffix = 1;
-  while (await fileExists(join(snapshotsDir, filename))) {
-    filename = `${baseName}~${timestamp}-${suffix}.yaml`;
-    suffix += 1;
+  // Exclusive create (wx) makes the existence check and the write one
+  // atomic step so concurrent snapshot writes cannot overwrite each other.
+  for (;;) {
+    try {
+      await writeFile(join(snapshotsDir, filename), yamlContent, {
+        encoding: "utf-8",
+        flag: "wx",
+      });
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+      filename = `${baseName}~${timestamp}-${suffix}.yaml`;
+      suffix += 1;
+    }
   }
 
-  await writeFile(join(snapshotsDir, filename), yamlContent, "utf-8");
   await pruneSnapshots(snapshotsDir);
   return filename;
 }
@@ -211,7 +239,7 @@ export async function listSnapshots(
   return snapshots.sort(
     (a, b) =>
       b.timestamp.localeCompare(a.timestamp) ||
-      b.filename.localeCompare(a.filename),
+      compareSnapshotNamesDesc(a.filename, b.filename),
   );
 }
 
@@ -433,9 +461,18 @@ export async function getLayout(
       if (yamlFilename) {
         try {
           const yamlPath = join(folder, yamlFilename);
-          const content = await readFile(yamlPath, "utf-8");
-          const stats = await stat(yamlPath);
-          return { content, updatedAt: stats.mtime.toISOString() };
+          const handle = await open(yamlPath, "r");
+          try {
+            // Stat before read on the same descriptor: a write landing
+            // between the two leaves the content newer than the reported
+            // updatedAt, so the next echoed PUT mismatches and snapshots
+            // instead of silently masking the concurrent write.
+            const stats = await handle.stat();
+            const content = await handle.readFile("utf-8");
+            return { content, updatedAt: stats.mtime.toISOString() };
+          } finally {
+            await handle.close();
+          }
         } catch {
           return null;
         }
@@ -702,12 +739,17 @@ export async function saveLayout(
   // Create folder if it doesn't exist
   await mkdir(folderPath, { recursive: true });
 
-  // Write the YAML file
+  // Write the YAML file. Stat the same descriptor so the returned
+  // updatedAt belongs to this write, not to a concurrent writer's file.
   const yamlPath = join(folderPath, yamlFilename);
-  await writeFile(yamlPath, yamlContent, "utf-8");
-  const stats = await stat(yamlPath);
-
-  return { id: uuid, isNew, updatedAt: stats.mtime.toISOString() };
+  const handle = await open(yamlPath, "w");
+  try {
+    await handle.writeFile(yamlContent, "utf-8");
+    const stats = await handle.stat();
+    return { id: uuid, isNew, updatedAt: stats.mtime.toISOString() };
+  } finally {
+    await handle.close();
+  }
 }
 
 /**


### PR DESCRIPTION
## **User description**
## Summary

- PUT accepts an echoed X-Rackula-Updated-At header; on mismatch with the stored copy the existing YAML is snapshotted to {layout-folder}/snapshots/{name}~YYYYMMDD-HHMMSS.yaml before the write (last-write-wins, never rejected). Absent header means plain overwrite, no snapshot
- Snapshots pruned to 5 most recent per layout; folder invisible to checkLayoutQuota and findYamlInFolder by construction (proven by tests)
- GET /layouts/:uuid/snapshots lists snapshots; POST /layouts/:uuid/snapshots uploads a losing local copy, both behind the same writeAuth and body limits as PUT
- PUT and GET responses echo the layout's current updatedAt (ISO 8601) so clients can round-trip it

## Review notes

The implementation went through a three-lens adversarial review (security, correctness, test quality) and a fix pass before this PR. Fixes applied:
- POST added to the rate limiter's write tier (was defaulting to the looser read tier)
- Snapshot prune/list comparator rewritten: localeCompare tie-break deleted the wrong file on same-mtime collisions
- TOCTOU between content read and stat closed with fd-based stat-before-read; atomic wx-flag snapshot writes with EEXIST retry
- Added 413 body-limit and tokenless-GET auth tests

Deliberately out of scope (filed separately): a pre-existing circular-YAML bypass of the PUT UUID-mismatch guard, unchanged by this diff.

## Test Plan
- [x] api bun run typecheck clean
- [x] api bun test: 263 pass (23 new in snapshots.test.ts)
- [x] root ESLint and Prettier clean on changed files

Closes #2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add layout snapshots and conflict-aware overwrite tracking**

### What Changed
- Saving a layout can now preserve the previous version as a snapshot when the server detects the copy the user last saw is out of date
- Layout reads and save responses now return the current `updatedAt` value so clients can send it back on the next save
- New snapshot routes let users list saved snapshots and upload a local losing copy for a layout
- Snapshot uploads now follow the same access rules and body size limits as other write actions
- Snapshot storage keeps only the 5 newest copies and avoids removing the wrong file when multiple snapshots share the same timestamp

### Impact
`✅ Fewer accidental overwrites`
`✅ Easier recovery after conflicting saves`
`✅ Shorter rollback after a bad edit`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
