### PR TITLE
feat: conditional beforeunload on in-flight risk only (#2039)

### DIFF
--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -5,7 +5,15 @@
 -->
 <script lang="ts">
   import { onMount } from "svelte";
-  import { initPersistenceEffects, flushSessionSave } from "$lib/storage";
+  import {
+    initPersistenceEffects,
+    flushSessionSave,
+    isSessionSavePending,
+    isServerSavePending,
+    isApiAvailable,
+    hasEverConnectedToApi,
+    shouldWarnBeforeUnload,
+  } from "$lib/storage";
   import { getImageStore } from "$lib/stores/images.svelte";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
@@ -62,16 +70,30 @@
     }),
   );
 
+  // Warn only on genuine in-flight loss risk (see $lib/storage/unload-risk)
+  const warnBeforeUnload = $derived(
+    shouldWarnBeforeUnload({
+      warnOnUnsavedChanges: uiStore.warnOnUnsavedChanges,
+      sessionSavePending: isSessionSavePending(),
+      serverSavePending: isServerSavePending(),
+      serverMode: hasEverConnectedToApi(),
+      serverReachable: isApiAvailable(),
+      isDirty: layoutStore.isDirty,
+    }),
+  );
+
   function handleBeforeUnload(event: BeforeUnloadEvent) {
-    // Flush pending session save before the page unloads
+    // Last-chance flush of the pending session save before the page unloads
     flushSessionSave();
-
-    if (uiStore.warnOnUnsavedChanges && layoutStore.isDirty) {
-      event.preventDefault();
-      event.returnValue = "You have unsaved changes. Leave anyway?";
-      return event.returnValue;
-    }
+    event.preventDefault();
+    event.returnValue = "";
   }
-</script>
 
-<svelte:window onbeforeunload={handleBeforeUnload} />
+  // Attach the handler only while the risk condition holds and remove it as
+  // soon as the flush or save completes (Chrome guidance: never permanently)
+  $effect(() => {
+    if (!warnBeforeUnload) return;
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  });
+</script>

--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -10,7 +10,7 @@
     flushSessionSave,
     isSessionSavePending,
     isServerSavePending,
-    isApiAvailable,
+    getApiAvailableState,
     hasEverConnectedToApi,
     shouldWarnBeforeUnload,
   } from "$lib/storage";
@@ -85,7 +85,7 @@
       sessionSavePending: isSessionSavePending(),
       serverSavePending: isServerSavePending(),
       serverMode: hasEverConnectedToApi(),
-      serverReachable: isApiAvailable(),
+      serverReachable: getApiAvailableState(),
       isDirty: layoutStore.isDirty,
     }),
   );

--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -38,6 +38,13 @@
     }
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
+    // Last-chance flush on unload paths where visibilitychange may not fire
+    // (pagehide is bfcache-safe to keep attached, unlike beforeunload)
+    function handlePageHide() {
+      flushSessionSave();
+    }
+    window.addEventListener("pagehide", handlePageHide);
+
     // Load bundled images for starter library devices
     imageStore.loadBundledImages();
 
@@ -60,6 +67,7 @@
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("pagehide", handlePageHide);
     };
   });
 
@@ -82,9 +90,9 @@
     }),
   );
 
+  // Only shows the leave warning; flushing is handled by the always-attached
+  // visibilitychange and pagehide listeners above
   function handleBeforeUnload(event: BeforeUnloadEvent) {
-    // Last-chance flush of the pending session save before the page unloads
-    flushSessionSave();
     event.preventDefault();
     event.returnValue = "";
   }

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -8,6 +8,7 @@
 export {
   initializePersistence,
   isApiAvailable,
+  getApiAvailableState,
   setApiAvailable,
   hasEverConnectedToApi,
 } from "./availability.svelte";

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -31,4 +31,7 @@ export {
   shouldSaveToServer,
   initPersistenceEffects,
   flushSessionSave,
+  isSessionSavePending,
+  isServerSavePending,
 } from "./manager.svelte";
+export { shouldWarnBeforeUnload, type UnloadRiskState } from "./unload-risk";

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -35,6 +35,16 @@ let _errorToastId: string | undefined = undefined;
 let serverSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+// After a durable save the pending session debounce must be cancelled, or it
+// resurrects the cleared session copy and triggers a false unload warning
+function cancelSessionSave(): void {
+  if (saveDebounceTimer) {
+    clearTimeout(saveDebounceTimer);
+    saveDebounceTimer = null;
+    _sessionSavePending = false;
+  }
+}
+
 // Reactive mirrors of the timers, for the beforeunload risk condition
 let _sessionSavePending = $state(false);
 let _serverSavePending = $state(false);
@@ -156,6 +166,7 @@ export async function handleSaveToServer(isManual = false): Promise<boolean> {
       _errorToastId = undefined;
     }
     layoutStore.markClean();
+    cancelSessionSave();
     clearSession();
     if (isManual) {
       toastStore.showToast("Layout saved", "success", 3000);
@@ -175,6 +186,7 @@ export async function handleSaveAsArchive(): Promise<boolean> {
   try {
     const filename = await downloadYamlFile(layoutStore.layout);
     layoutStore.markClean();
+    cancelSessionSave();
     clearSession();
     toastStore.showToast(`Saved ${filename}`, "success", 3000);
     return true;
@@ -206,9 +218,7 @@ export async function handleLoad(): Promise<void> {
 export function flushSessionSave(): void {
   const layoutStore = getLayoutStore();
   if (saveDebounceTimer && layoutStore.hasRack) {
-    clearTimeout(saveDebounceTimer);
-    saveDebounceTimer = null;
-    _sessionSavePending = false;
+    cancelSessionSave();
     saveSession(layoutStore.layout);
   }
 }
@@ -234,24 +244,14 @@ export function initPersistenceEffects(): void {
         _sessionSavePending = false;
       }, 1000);
     } else {
-      if (saveDebounceTimer) {
-        clearTimeout(saveDebounceTimer);
-        saveDebounceTimer = null;
-        _sessionSavePending = false;
-      }
+      cancelSessionSave();
       // Only clear session if we previously had a rack — prevents wiping
       // localStorage before App.onMount restores the session on page load
       if (hasEverHadRack) {
         clearSession();
       }
     }
-    return () => {
-      if (saveDebounceTimer) {
-        clearTimeout(saveDebounceTimer);
-        saveDebounceTimer = null;
-        _sessionSavePending = false;
-      }
-    };
+    return cancelSessionSave;
   });
 
   // Effect 2: Auto-save to server when API is available
@@ -268,6 +268,11 @@ export function initPersistenceEffects(): void {
     const snapshot = structuredClone($state.snapshot(layout));
     _serverSavePending = true;
     serverSaveTimer = setTimeout(async () => {
+      // Clear pending state before the await: a stale continuation must not
+      // clobber a newer scheduled save. The synchronous "saving" status keeps
+      // isServerSavePending() true for the in-flight phase.
+      serverSaveTimer = null;
+      _serverSavePending = false;
       _saveStatus = "saving";
       try {
         await saveLayoutToServer(snapshot);
@@ -282,8 +287,6 @@ export function initPersistenceEffects(): void {
         persistenceDebug.api("Auto-save failed: %O", e);
         handlePersistenceError(e);
       }
-      serverSaveTimer = null;
-      _serverSavePending = false;
     }, 2000);
     return () => {
       if (serverSaveTimer) {

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -35,6 +35,18 @@ let _errorToastId: string | undefined = undefined;
 let serverSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Reactive mirrors of the timers, for the beforeunload risk condition
+let _sessionSavePending = $state(false);
+let _serverSavePending = $state(false);
+
+export function isSessionSavePending(): boolean {
+  return _sessionSavePending;
+}
+
+export function isServerSavePending(): boolean {
+  return _serverSavePending || _saveStatus === "saving";
+}
+
 export function getConsecutiveSaveFailures(): number {
   return _consecutiveSaveFailures;
 }
@@ -132,6 +144,7 @@ export async function handleSaveToServer(isManual = false): Promise<boolean> {
     if (serverSaveTimer) {
       clearTimeout(serverSaveTimer);
       serverSaveTimer = null;
+      _serverSavePending = false;
     }
     const snapshot = structuredClone($state.snapshot(layoutStore.layout));
     await saveLayoutToServer(snapshot);
@@ -195,6 +208,7 @@ export function flushSessionSave(): void {
   if (saveDebounceTimer && layoutStore.hasRack) {
     clearTimeout(saveDebounceTimer);
     saveDebounceTimer = null;
+    _sessionSavePending = false;
     saveSession(layoutStore.layout);
   }
 }
@@ -213,14 +227,17 @@ export function initPersistenceEffects(): void {
       if (saveDebounceTimer) {
         clearTimeout(saveDebounceTimer);
       }
+      _sessionSavePending = true;
       saveDebounceTimer = setTimeout(() => {
         saveSession(currentLayout);
         saveDebounceTimer = null;
+        _sessionSavePending = false;
       }, 1000);
     } else {
       if (saveDebounceTimer) {
         clearTimeout(saveDebounceTimer);
         saveDebounceTimer = null;
+        _sessionSavePending = false;
       }
       // Only clear session if we previously had a rack — prevents wiping
       // localStorage before App.onMount restores the session on page load
@@ -232,6 +249,7 @@ export function initPersistenceEffects(): void {
       if (saveDebounceTimer) {
         clearTimeout(saveDebounceTimer);
         saveDebounceTimer = null;
+        _sessionSavePending = false;
       }
     };
   });
@@ -248,6 +266,7 @@ export function initPersistenceEffects(): void {
       clearTimeout(serverSaveTimer);
     }
     const snapshot = structuredClone($state.snapshot(layout));
+    _serverSavePending = true;
     serverSaveTimer = setTimeout(async () => {
       _saveStatus = "saving";
       try {
@@ -264,11 +283,13 @@ export function initPersistenceEffects(): void {
         handlePersistenceError(e);
       }
       serverSaveTimer = null;
+      _serverSavePending = false;
     }, 2000);
     return () => {
       if (serverSaveTimer) {
         clearTimeout(serverSaveTimer);
         serverSaveTimer = null;
+        _serverSavePending = false;
       }
     };
   });
@@ -313,4 +334,6 @@ export function resetPersistenceManager(): void {
     clearTimeout(saveDebounceTimer);
     saveDebounceTimer = null;
   }
+  _serverSavePending = false;
+  _sessionSavePending = false;
 }

--- a/src/lib/storage/unload-risk.ts
+++ b/src/lib/storage/unload-risk.ts
@@ -18,8 +18,8 @@ export interface UnloadRiskState {
   serverSavePending: boolean;
   /** This install persists to the API (approximated by ever having connected) */
   serverMode: boolean;
-  /** The API is currently reachable */
-  serverReachable: boolean;
+  /** The API is currently reachable (null = not checked yet, treated as reachable) */
+  serverReachable: boolean | null;
   /** The layout has changes not yet saved to its durable home */
   isDirty: boolean;
 }
@@ -27,9 +27,9 @@ export interface UnloadRiskState {
 export function shouldWarnBeforeUnload(state: UnloadRiskState): boolean {
   if (!state.warnOnUnsavedChanges) return false;
   if (state.sessionSavePending) return true;
+  // null = health check pending, not confirmed unreachable — treat as reachable
+  const serverDown = state.serverReachable === false;
   return (
-    state.serverMode &&
-    state.isDirty &&
-    (!state.serverReachable || state.serverSavePending)
+    state.serverMode && state.isDirty && (serverDown || state.serverSavePending)
   );
 }

--- a/src/lib/storage/unload-risk.ts
+++ b/src/lib/storage/unload-risk.ts
@@ -1,0 +1,35 @@
+/**
+ * beforeunload risk predicate
+ * Decides whether leaving the page right now could lose data. The handler
+ * is attached only while this returns true (Chrome guidance: never attach
+ * beforeunload permanently). Genuine in-flight loss means a debounced
+ * session save that has not flushed yet, or in server mode a dirty layout
+ * while the server is unreachable or a save is mid-flight. Dirty-but-
+ * persisted changes in browser mode are safe in the localStorage working
+ * copy and never warn.
+ */
+
+export interface UnloadRiskState {
+  /** User setting: warn on unsaved changes (gates the whole warning) */
+  warnOnUnsavedChanges: boolean;
+  /** A debounced localStorage session save is scheduled but not yet flushed */
+  sessionSavePending: boolean;
+  /** A server save is debounce-pending or mid-flight */
+  serverSavePending: boolean;
+  /** This install persists to the API (approximated by ever having connected) */
+  serverMode: boolean;
+  /** The API is currently reachable */
+  serverReachable: boolean;
+  /** The layout has changes not yet saved to its durable home */
+  isDirty: boolean;
+}
+
+export function shouldWarnBeforeUnload(state: UnloadRiskState): boolean {
+  if (!state.warnOnUnsavedChanges) return false;
+  if (state.sessionSavePending) return true;
+  return (
+    state.serverMode &&
+    state.isDirty &&
+    (!state.serverReachable || state.serverSavePending)
+  );
+}

--- a/src/lib/utils/app-actions.ts
+++ b/src/lib/utils/app-actions.ts
@@ -104,7 +104,8 @@ export async function prepareExportQrCode(): Promise<void> {
     } else {
       dialogStore.exportQrCodeDataUrl = undefined;
     }
-  } catch {
+  } catch (error) {
+    appDebug.export("QR code preparation failed: %O", error);
     dialogStore.exportQrCodeDataUrl = undefined;
   }
 }

--- a/src/tests/unload-risk.test.ts
+++ b/src/tests/unload-risk.test.ts
@@ -10,7 +10,7 @@ function riskState(overrides: Partial<UnloadRiskState> = {}): UnloadRiskState {
     sessionSavePending: false,
     serverSavePending: false,
     serverMode: false,
-    serverReachable: false,
+    serverReachable: null,
     isDirty: false,
     ...overrides,
   };
@@ -91,6 +91,19 @@ describe("shouldWarnBeforeUnload", () => {
           isDirty: false,
           serverReachable: true,
           serverSavePending: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not warn when API availability is unknown (null) and dirty in server mode", () => {
+    // null = health check pending, not confirmed unreachable
+    expect(
+      shouldWarnBeforeUnload(
+        riskState({
+          serverMode: true,
+          isDirty: true,
+          serverReachable: null,
         }),
       ),
     ).toBe(false);

--- a/src/tests/unload-risk.test.ts
+++ b/src/tests/unload-risk.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldWarnBeforeUnload,
+  type UnloadRiskState,
+} from "$lib/storage/unload-risk";
+
+function riskState(overrides: Partial<UnloadRiskState> = {}): UnloadRiskState {
+  return {
+    warnOnUnsavedChanges: true,
+    sessionSavePending: false,
+    serverSavePending: false,
+    serverMode: false,
+    serverReachable: false,
+    isDirty: false,
+    ...overrides,
+  };
+}
+
+describe("shouldWarnBeforeUnload", () => {
+  it("returns false when nothing is at risk", () => {
+    expect(shouldWarnBeforeUnload(riskState())).toBe(false);
+  });
+
+  it("returns false when the user setting is off, even with every risk present", () => {
+    expect(
+      shouldWarnBeforeUnload(
+        riskState({
+          warnOnUnsavedChanges: false,
+          sessionSavePending: true,
+          serverSavePending: true,
+          serverMode: true,
+          serverReachable: false,
+          isDirty: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("warns while a debounced session save is pending", () => {
+    expect(
+      shouldWarnBeforeUnload(riskState({ sessionSavePending: true })),
+    ).toBe(true);
+  });
+
+  it("does not warn on a dirty layout in browser mode (working copy is persisted)", () => {
+    expect(shouldWarnBeforeUnload(riskState({ isDirty: true }))).toBe(false);
+  });
+
+  it("warns in server mode when dirty and the server is unreachable", () => {
+    expect(
+      shouldWarnBeforeUnload(
+        riskState({ serverMode: true, isDirty: true, serverReachable: false }),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns in server mode when dirty and a save is in flight", () => {
+    expect(
+      shouldWarnBeforeUnload(
+        riskState({
+          serverMode: true,
+          isDirty: true,
+          serverReachable: true,
+          serverSavePending: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn in server mode when dirty, reachable, and no save in flight", () => {
+    expect(
+      shouldWarnBeforeUnload(
+        riskState({ serverMode: true, isDirty: true, serverReachable: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not warn in server mode when clean, even while unreachable", () => {
+    expect(
+      shouldWarnBeforeUnload(
+        riskState({ serverMode: true, isDirty: false, serverReachable: false }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not warn on an in-flight save when the layout is clean", () => {
+    expect(
+      shouldWarnBeforeUnload(
+        riskState({
+          serverMode: true,
+          isDirty: false,
+          serverReachable: true,
+          serverSavePending: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- beforeunload warning attaches only when genuine in-flight loss is possible (pending debounced session save, or dirty while server unreachable), detaches after flush; gated by the existing warn-on-unsaved-changes toggle
- Session-save flush moved to an always-attached pagehide listener (separate from the conditional warning)
- New cancelSessionSave() helper cancels the session debounce after markClean()/clearSession(), stopping session resurrection and unload-risk false positives after a manual save
- visibilitychange flush preserved; attach/detach predicate extracted to a pure, unit-tested function

Stacked on PR #2050 (storage seam). Base will retarget to main once #2050 merges. Implemented and reviewed via a multi-lens adversarial workflow (correctness + regression) with a fix pass.

## Test Plan
- [x] npm run lint clean
- [x] npm run test:run: 2043 tests pass
- [x] npm run build

Closes #2039

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Warn only when leaving the page could actually lose changes**

### What Changed
- The leave-page warning now appears only when there is a real risk of losing data, such as a pending session save or a server save that is still pending or in flight.
- Closing or navigating away still flushes pending session saves on `visibilitychange` and `pagehide`, so users do not lose changes when the warning is turned off.
- Manual saves and archive exports now clear pending session saves, preventing stale warnings after the layout has already been made durable.
- Added coverage for the warning behavior across saved, unsaved, offline, and server-save-in-progress states.

### Impact
`✅ Fewer false leave-page warnings`
`✅ Safer tab close and navigation`
`✅ Fewer lost changes after manual save`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
