### PR TITLE
chore: replace waitForTimeout with assertion-based waits in E2E tests (#2002)

### DIFF
--- a/e2e/android-chrome.spec.ts
+++ b/e2e/android-chrome.spec.ts
@@ -43,7 +43,10 @@ async function setupMobileViewport(
     sessionStorage.setItem("rackula-mobile-warning-dismissed", "true");
   });
   await page.goto(`/?l=${EMPTY_RACK_SHARE}`);
-  await page.locator(locators.rack.container).first().waitFor({ state: "visible" });
+  await page
+    .locator(locators.rack.container)
+    .first()
+    .waitFor({ state: "visible" });
 }
 
 /**
@@ -322,7 +325,9 @@ test.describe("Touch Interactions", () => {
     // Open bottom sheet to expose palette items on mobile, then close it
     await mobileDragDeviceToRack(page);
     await page.keyboard.press("Escape");
-    await expect(page.locator(locators.mobile.bottomSheet)).not.toBeVisible({ timeout: 2000 });
+    await expect(page.locator(locators.mobile.bottomSheet)).not.toBeVisible({
+      timeout: 2000,
+    });
 
     const rackDevice = page.locator(locators.rack.device).first();
     await expect(rackDevice).toBeVisible({ timeout: 5000 });
@@ -373,23 +378,25 @@ test.describe("Long-Press Gesture", () => {
     const rackDevice = page.locator(locators.rack.device).first();
     await expect(rackDevice).toBeVisible({ timeout: 5000 });
 
-    const box = await rackDevice.boundingBox();
-    if (box) {
-      // Simulate long-press via mouse events (touchscreen.tap requires hasTouch).
-      // useLongPress fires after 500ms; 600ms gives headroom for timing variance.
-      const startPos = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
-      await page.mouse.move(startPos.x, startPos.y);
-      await page.mouse.down();
-      // 600ms simulates Android long-press threshold — timing is the behaviour under test
-      await page.waitForTimeout(600);
-      await page.mouse.up();
-    }
-
     // Feature #1086: long-press on a placed device opens the app's device context menu.
     // This confirms the gesture fires and the native browser context menu is suppressed
     // in favour of the app's own menu (see RackDevice.svelte handleLongPress / useLongPress).
     const contextMenu = page.locator('[role="menu"]');
-    await expect(contextMenu).toBeVisible({ timeout: 3000 });
+
+    const box = await rackDevice.boundingBox();
+    if (box) {
+      // Simulate long-press via mouse events (touchscreen.tap requires hasTouch).
+      // useLongPress fires its callback after 500ms while the pointer is still
+      // held, so wait for the menu to appear instead of sleeping a fixed 600ms.
+      const startPos = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+      await page.mouse.move(startPos.x, startPos.y);
+      await page.mouse.down();
+      await expect(contextMenu).toBeVisible({ timeout: 3000 });
+      await page.mouse.up();
+    }
+
+    // Menu stays open after pointer release
+    await expect(contextMenu).toBeVisible();
   });
 });
 
@@ -417,7 +424,9 @@ test.describe("Foldable Devices", () => {
         } else {
           await expect(devicesTab).toHaveCount(0);
         }
-        await expect(page.locator(locators.mobile.deviceLibraryFab)).toHaveCount(0);
+        await expect(
+          page.locator(locators.mobile.deviceLibraryFab),
+        ).toHaveCount(0);
       },
     );
   }
@@ -442,7 +451,10 @@ test.describe("WebView Compatibility", () => {
     // Reload and verify no critical errors
     await page.reload();
     await page.waitForLoadState("networkidle");
-    await page.locator(locators.rack.container).first().waitFor({ state: "visible", timeout: 5000 });
+    await page
+      .locator(locators.rack.container)
+      .first()
+      .waitFor({ state: "visible", timeout: 5000 });
 
     const criticalErrors = errors.filter(
       (e) => !e.includes("warning") && !e.includes("deprecated"),

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -97,8 +97,28 @@ test.describe("Persistence", () => {
       timeout: 5000,
     });
 
-    // Small delay to let the session storage debounce flush
-    await page.waitForTimeout(1500);
+    // Wait for the debounced session save (1s) to flush the placed device
+    // to localStorage, instead of sleeping for a fixed duration
+    await page.waitForFunction(
+      () => {
+        const raw = localStorage.getItem("Rackula:autosave");
+        if (!raw) return false;
+        try {
+          const session = JSON.parse(raw) as {
+            layout?: { racks?: { devices?: unknown[] }[] };
+          };
+          return (
+            session.layout?.racks?.some(
+              (rack) => (rack.devices?.length ?? 0) > 0,
+            ) ?? false
+          );
+        } catch {
+          return false;
+        }
+      },
+      undefined,
+      { timeout: 10000 },
+    );
 
     // Reload
     await page.reload();


### PR DESCRIPTION
## **User description**
## Summary

Replaces the two remaining `page.waitForTimeout()` hard sleeps in E2E specs with waits on observable effects:

- `e2e/persistence.spec.ts`: the 1500ms sleep for the session-storage debounce is now a `page.waitForFunction` that waits for the debounced session save (1s) to flush the placed device into `localStorage` (`Rackula:autosave`).
- `e2e/android-chrome.spec.ts`: the 600ms long-press sleep is now an assertion-based hold: pointer down, `expect(contextMenu).toBeVisible()` (useLongPress fires its callback after 500ms while the pointer is still held), then pointer up. A follow-up assertion confirms the menu stays open after release.

No assertions were loosened; the long-press test now additionally verifies the menu survives pointer release.

Closes #2002

## Verification

- `npm run lint`: no issues
- `npx playwright test --config e2e/playwright.config.ts persistence.spec.ts android-chrome.spec.ts --project chromium --project android-chrome --project android-tablet`: 80 passed, 0 failed, 2 skipped
- `npx playwright test --config e2e/playwright.config.ts persistence.spec.ts --project webkit`: 6 passed, 0 failed
- `grep -rn waitForTimeout e2e/`: no matches remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Replace fixed waits in end-to-end tests with checks for real app behavior**

### What Changed
- Long-press tests now wait for the device menu to appear while the press is still held, then confirm it stays open after release.
- Session restore tests now wait for saved layout data to show up in local storage before reloading, instead of using a fixed delay.
- Mobile and foldable device checks keep the same coverage, with formatting-only updates in the test code.

### Impact
`✅ Less flaky end-to-end tests`
`✅ Fewer false failures from timing delays`
`✅ More reliable session restore checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
