### PR TITLE
feat(ci): shard full E2E suite across 4 parallel runners

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -12,14 +12,17 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
-  full-test:
-    name: full-test
+  lint-unit:
+    name: lint-unit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Check compose parity
         run: bash scripts/check-compose-persist-parity.sh
@@ -39,6 +42,29 @@ jobs:
       - name: Run unit tests
         run: npm run test:run
 
+  e2e:
+    name: e2e (shard ${{ matrix.shard }}/4)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -49,21 +75,68 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium webkit
 
-      - name: Run full E2E tests
-        run: npm run test:e2e
+      - name: Run E2E shard
+        run: npm run test:e2e -- --shard=${{ matrix.shard }}/4
 
-      - name: Upload Playwright report
+      - name: Upload blob report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
+        if: ${{ !cancelled() }}
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 7
+
+  merge-reports:
+    name: merge-reports
+    needs: e2e
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: blob-report-*
+          path: all-blob-reports
+          merge-multiple: true
+
+      - name: Merge into HTML report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
 
+  notify-on-failure:
+    name: notify-on-failure
+    needs: [lint-unit, e2e, merge-reports]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
       - name: Notify on failure
-        if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           EXISTING=$(gh issue list --label ci-failure --state open --limit 1 --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: 2,
-  reporter: [["html", { open: "never" }]],
+  // CI uses the blob reporter so sharded runs (test-full.yml) can be merged
+  // into a single HTML report with `npx playwright merge-reports`.
+  reporter: process.env.CI
+    ? [["github"], ["blob"]]
+    : [["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:4173",
     trace: "on-first-retry",


### PR DESCRIPTION
## **User description**
Closes #1999

## Summary

Splits the weekly full E2E suite (test-full.yml) across 4 parallel runners using Playwright's `--shard`, with blob report merging and the existing failure notification preserved.

## Changes

- `test-full.yml` restructured into four jobs:
  - `lint-unit`: compose parity check, lint, unit tests (runs in parallel with E2E, no longer serialized in front of it)
  - `e2e`: matrix of 4 shards (`--shard=N/4`), `fail-fast: false` so every shard reports, each uploads its blob report artifact
  - `merge-reports`: downloads all blob artifacts and runs `npx playwright merge-reports --reporter html`, uploading the same `playwright-report` artifact name as before
  - `notify-on-failure`: the existing ci-failure issue create/comment logic, now a separate job gated on `failure()` across the whole chain, so any shard failure still triggers the notification
- `e2e/playwright.config.ts`: CI now uses `github` + `blob` reporters; local runs keep the HTML reporter. Note: Playwright resolves the default `blob-report`/`playwright-report` output dirs relative to the nearest `package.json` (repo root), verified locally, so artifact paths are root-relative.
- Playwright browser caching from spike #1994 is preserved unchanged in each shard (same cache key, restore-keys).

## Shard count rationale

The full suite is ~9m36s of E2E wall clock (348 test cases across 6 projects). Each shard pays fixed overhead (npm ci, browser install from cache, app build via webServer, roughly 2-3 min), so shards have diminishing returns. 4 shards gives ~2.4 min of test execution per shard plus overhead, an expected wall clock of roughly 4-5 min vs 9m36s, comfortably past the 50% reduction target without burning runner minutes on 6+ mostly-overhead jobs.

## Merge-blocking semantics

test-full.yml is not a PR-gating workflow (schedule/workflow_call/workflow_dispatch only; nothing currently calls it via workflow_call). The workflow run as a whole still fails if any shard, lint-unit, or merge-reports fails, so any future workflow_call consumer sees the same all-or-nothing result as before.

## Security

- Triggers unchanged (no `pull_request_target`, no untrusted checkout)
- Workflow-level permissions reduced to `contents: read`; `issues: write` is now scoped to the notify job only
- All checkouts use `persist-credentials: false`

## Verification

- `actionlint` passes on the workflow
- `npx playwright test --list` works: 348 tests, `--shard=1/4` lists 87
- End-to-end local check with `CI=1`: ran a sharded subset, blob zip written to `blob-report/report-chromium-...-2.zip`, then `merge-reports --reporter html` produced `playwright-report/index.html`
- Prettier and ESLint pass on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Run the full E2E suite in parallel and keep one merged report**

### What Changed
- The weekly full E2E run now splits across 4 shards instead of running as one long job
- Lint and unit tests run alongside E2E instead of waiting for it to finish first
- CI now saves shard results, merges them into a single HTML report, and uploads that merged report
- Failure notifications still fire when any part of the full run fails
- CI permissions are narrowed so issue updates are only allowed for the failure notification step

### Impact
`✅ Shorter full E2E runs`
`✅ Faster feedback from lint and unit tests`
`✅ One combined test report for failed shard runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
