### PR TITLE
feat: dev-only build info toast (#2106)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -42,6 +42,7 @@ LABEL org.opencontainers.image.title="Rackula"
 # API_WRITE_TOKEN: Optional bearer token injected for PUT/DELETE API requests (runtime env)
 # RACKULA_AUTH_MODE: Auth mode toggle for app/API anonymous access gate (none|oidc|local)
 # RACKULA_STORAGE_MODE: Frontend storage mode written to config.js at startup (browser|server; default: browser)
+# RACKULA_ENV: Deployment environment written to config.js at startup (dev shows the dev build toast; unset means production, so no default)
 # RACKULA_LISTEN_PORT: Port nginx listens on inside the container (default: 8080)
 # RACKULA_ENABLE_IPV6: IPv6 listen auto-detection (auto|true|false; default: auto)
 # NGINX_RESOLVER: DNS resolver for nginx upstream resolution (default: 127.0.0.11 for Docker; override for Kubernetes)

--- a/deploy/docker-entrypoint-wrapper.sh
+++ b/deploy/docker-entrypoint-wrapper.sh
@@ -99,8 +99,26 @@ case "$storage_mode" in
     ;;
 esac
 
+# Deployment environment -- only "dev" is recognized; it enables the dev
+# build toast in the frontend. Absent or empty means production (no env key
+# emitted), so prod deployments need no configuration.
+raw_env="${RACKULA_ENV:-}"
+rackula_env="$(printf '%s' "$raw_env" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+
+case "$rackula_env" in
+  "" | "dev") ;;
+  *)
+    echo "WARN: Invalid RACKULA_ENV '$raw_env'; ignoring (treated as production)" >&2
+    rackula_env=""
+    ;;
+esac
+
 mkdir -p /tmp/rackula-config
-printf 'window.__RACKULA_CONFIG__ = { storage: "%s" };\n' "$storage_mode" >/tmp/rackula-config/config.js
+if [ "$rackula_env" = "dev" ]; then
+  printf 'window.__RACKULA_CONFIG__ = { storage: "%s", env: "dev" };\n' "$storage_mode" >/tmp/rackula-config/config.js
+else
+  printf 'window.__RACKULA_CONFIG__ = { storage: "%s" };\n' "$storage_mode" >/tmp/rackula-config/config.js
+fi
 
 # Default resolver for nginx upstream DNS resolution.
 # Docker uses 127.0.0.11 (embedded DNS). Override via NGINX_RESOLVER for other

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -78,6 +78,7 @@ function update_script() {
     cp /opt/rackula/config/nginx.service.d-override.conf /etc/systemd/system/nginx.service.d/override.conf
     # Rewrite runtime storage mode config: the tarball ships a browser-mode default.
     # CROSS-REF: keep in sync with install/rackula-install.sh and static/config.js.
+    # env key omitted intentionally: absent RACKULA_ENV means production (no dev build toast)
     printf 'window.__RACKULA_CONFIG__ = { storage: "server" };\n' >/opt/rackula/frontend/config.js
     chown -R root:root /opt/rackula/frontend
     find /opt/rackula/frontend -type d -exec chmod 755 {} \;

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -77,6 +77,7 @@ cp "$SECURITY_HEADERS_SRC" /etc/nginx/snippets/security-headers.conf
 # Runtime storage mode config consumed by index.html. The LXC always
 # provisions the API alongside the frontend, so server mode is fixed.
 # CROSS-REF: keep in sync with ct/rackula.sh update_script and static/config.js.
+# env key omitted intentionally: absent RACKULA_ENV means production (no dev build toast)
 printf 'window.__RACKULA_CONFIG__ = { storage: "server" };\n' >/opt/rackula/frontend/config.js
 
 chown -R root:root /opt/rackula/frontend

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -56,6 +56,12 @@
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { createKonamiDetector } from "$lib/utils/konami";
+  import {
+    formatDevBuildMessage,
+    getRuntimeEnv,
+    shouldShowDevBuildToast,
+  } from "$lib/utils/dev-build-toast";
+  import { VERSION } from "$lib/version";
   import { persistenceDebug } from "$lib/utils/debug";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
   import { DRAWER_WIDTH } from "$lib/constants/layout";
@@ -169,6 +175,19 @@
   // Also handles loading shared layouts from URL params
   // Uses onMount to run once on initial load, not reactively
   onMount(async () => {
+    // Dev environments only: show build info toast on load (#2106)
+    if (shouldShowDevBuildToast(getRuntimeEnv(), import.meta.env.DEV)) {
+      const commitHash =
+        typeof __COMMIT_HASH__ !== "undefined" ? __COMMIT_HASH__ : "";
+      const buildTime =
+        typeof __BUILD_TIME__ !== "undefined" ? __BUILD_TIME__ : "";
+      toastStore.showToast(
+        formatDevBuildMessage(VERSION, commitHash, buildTime),
+        "info",
+        8000,
+      );
+    }
+
     // Start API health check immediately so all startup paths (including share links)
     // initialize persistence and can enable server autosave when available.
     const persistenceInitPromise = initializePersistence().catch((error) => {

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -34,4 +34,15 @@ declare const __COMMIT_HASH__: string;
 declare const __BRANCH_NAME__: string;
 declare const __GIT_DIRTY__: boolean;
 
+// Runtime deployment config injected via /config.js
+// CROSS-REF: static/config.js, deploy/docker-entrypoint-wrapper.sh
+declare global {
+  interface Window {
+    __RACKULA_CONFIG__?: {
+      storage?: string;
+      env?: string;
+    };
+  }
+}
+
 export {};

--- a/src/lib/utils/dev-build-toast.ts
+++ b/src/lib/utils/dev-build-toast.ts
@@ -1,0 +1,60 @@
+/**
+ * Dev Build Toast
+ *
+ * Decides whether to show the dev-environment build info toast on app load
+ * and formats its message. Detection is runtime via window.__RACKULA_CONFIG__
+ * (written by container entrypoints), with the local Vite dev server always
+ * showing the toast.
+ */
+
+import { formatRelativeTime } from "./buildTime";
+
+/**
+ * Read the deployment environment from the runtime config.
+ * Returns undefined outside the browser or when the key is absent.
+ */
+export function getRuntimeEnv(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.__RACKULA_CONFIG__?.env;
+}
+
+/**
+ * Decide whether the dev build toast should be shown.
+ *
+ * @param configEnv - env value from the runtime config (window.__RACKULA_CONFIG__.env)
+ * @param isViteDev - true when running under the local Vite dev server (import.meta.env.DEV)
+ * @returns true only for the dev environment; absent or any other value suppresses
+ */
+export function shouldShowDevBuildToast(
+  configEnv: string | undefined,
+  isViteDev: boolean,
+): boolean {
+  if (isViteDev) return true;
+  return configEnv === "dev";
+}
+
+/**
+ * Format the dev build toast message, omitting unavailable build details.
+ *
+ * @param version - app version (e.g. "26.5.0")
+ * @param commitHash - short commit hash, or "" when unavailable
+ * @param buildTime - ISO 8601 build timestamp, or "" when unavailable
+ * @param now - current time (defaults to new Date())
+ * @returns e.g. "Dev build v26.5.0 (9e14975e, built 23 min ago)"
+ */
+export function formatDevBuildMessage(
+  version: string,
+  commitHash: string,
+  buildTime: string,
+  now: Date = new Date(),
+): string {
+  const details: string[] = [];
+  if (commitHash) {
+    details.push(commitHash);
+  }
+  if (buildTime) {
+    details.push(`built ${formatRelativeTime(buildTime, now)} ago`);
+  }
+  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
+  return `Dev build v${version}${suffix}`;
+}

--- a/src/tests/dev-build-toast.test.ts
+++ b/src/tests/dev-build-toast.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Dev Build Toast Tests
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  shouldShowDevBuildToast,
+  formatDevBuildMessage,
+} from "$lib/utils/dev-build-toast";
+
+describe("shouldShowDevBuildToast", () => {
+  it("shows when runtime config env is dev", () => {
+    expect(shouldShowDevBuildToast("dev", false)).toBe(true);
+  });
+
+  it("suppresses when runtime config env is absent", () => {
+    expect(shouldShowDevBuildToast(undefined, false)).toBe(false);
+  });
+
+  it("suppresses when runtime config env is prod", () => {
+    expect(shouldShowDevBuildToast("prod", false)).toBe(false);
+  });
+
+  it("suppresses garbage env values", () => {
+    expect(shouldShowDevBuildToast("development", false)).toBe(false);
+    expect(shouldShowDevBuildToast("DEV ", false)).toBe(false);
+    expect(shouldShowDevBuildToast("", false)).toBe(false);
+  });
+
+  it("shows in vite dev mode regardless of runtime config", () => {
+    expect(shouldShowDevBuildToast(undefined, true)).toBe(true);
+    expect(shouldShowDevBuildToast("prod", true)).toBe(true);
+  });
+});
+
+describe("formatDevBuildMessage", () => {
+  const now = new Date("2026-06-10T12:23:00Z");
+
+  it("formats version, commit hash, and relative build time", () => {
+    expect(
+      formatDevBuildMessage("26.5.0", "9e14975e", "2026-06-10T12:00:00Z", now),
+    ).toBe("Dev build v26.5.0 (9e14975e, built 23 min ago)");
+  });
+
+  it("omits missing commit hash", () => {
+    expect(
+      formatDevBuildMessage("26.5.0", "", "2026-06-10T12:00:00Z", now),
+    ).toBe("Dev build v26.5.0 (built 23 min ago)");
+  });
+
+  it("omits missing build time", () => {
+    expect(formatDevBuildMessage("26.5.0", "9e14975e", "", now)).toBe(
+      "Dev build v26.5.0 (9e14975e)",
+    );
+  });
+
+  it("degrades to version only when both are missing", () => {
+    expect(formatDevBuildMessage("26.5.0", "", "", now)).toBe(
+      "Dev build v26.5.0",
+    );
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Info toast on app load showing version, short commit hash, and time since build, for example: Dev build v26.5.0 (9e14975e, built 23 min ago)
- Shown only when the runtime config injects RACKULA_ENV=dev (window.__RACKULA_CONFIG__.env, same entrypoint mechanism as RACKULA_STORAGE_MODE) or under the local Vite dev server
- Absent or invalid RACKULA_ENV defaults to production: no toast, WARN only on invalid non-empty values
- Docker entrypoint wired; LXC config writers documented (absent env is the intentional prod default); no CF Worker deploy path exists yet
- Pure decision/format helpers with 9 unit tests (TDD, red then green)

## Test plan

- [x] npm run lint clean
- [x] npm run test:run: 2061 tests passing (9 new)
- [x] npm run build succeeds
- [x] Entrypoint exercised standalone: absent/empty emits no env key; dev and " DEV " emit env: "dev"; prod warns and omits

Closes #2106

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show a dev-only build info toast on app load**

### What Changed
- A build info toast now appears on startup in development, showing the app version and, when available, the short commit hash and how long ago the build was made
- The toast is shown in the local dev server and when the runtime config explicitly marks the app as `dev`
- Production deployments stay quiet by default, and invalid environment values are ignored instead of triggering the toast
- Deployment scripts now pass the environment setting into the frontend config only when needed

### Impact
`✅ Clearer dev build identification`
`✅ Fewer unexpected toasts in production`
`✅ Easier verification of deployed versions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
