### PR TITLE
fix: cover bayed racks and missing closest in canvas pan gating (#2120)

### DIFF
--- a/src/lib/utils/canvas-coordinates.ts
+++ b/src/lib/utils/canvas-coordinates.ts
@@ -100,11 +100,12 @@ export function panBlockReason(
   const isDraggableElement =
     target.draggable === true ||
     target.getAttribute?.("draggable") === "true" ||
-    target.closest?.('[draggable="true"]') !== null;
+    (target.closest?.('[draggable="true"]') ?? null) !== null;
 
   if (isDraggableElement) return "draggable";
 
-  const isWithinRack = target.closest?.(".rack-dual-view") !== null;
+  const isWithinRack =
+    (target.closest?.(".rack-dual-view, .bayed-rack-view") ?? null) !== null;
   if (isWithinRack) return "rack-area";
 
   return null;

--- a/src/tests/canvas-coordinates.test.ts
+++ b/src/tests/canvas-coordinates.test.ts
@@ -149,10 +149,26 @@ describe("panBlockReason", () => {
     expect(
       panBlockReason(
         stubTarget({
-          closest: (selector) => (selector === ".rack-dual-view" ? {} : null),
+          closest: (selector) =>
+            selector.includes(".rack-dual-view") ? {} : null,
         }),
       ),
     ).toBe("rack-area");
+  });
+
+  it("blocks pan inside a bayed rack area", () => {
+    expect(
+      panBlockReason(
+        stubTarget({
+          closest: (selector) =>
+            selector.includes(".bayed-rack-view") ? {} : null,
+        }),
+      ),
+    ).toBe("rack-area");
+  });
+
+  it("allows pan when the target does not support closest", () => {
+    expect(panBlockReason(stubTarget({ closest: undefined }))).toBeNull();
   });
 
   it("prioritises draggable over rack area", () => {


### PR DESCRIPTION
## **User description**
Closes #2120

## Summary

Two latent pan-gating bugs in panBlockReason(), pre-existing in Canvas.svelte and surfaced by CodeAnt review on PR #2111:

- The rack-area check tested only .rack-dual-view; BayedRackView renders as a sibling with .bayed-rack-view, so mousedown inside a bayed rack started a canvas pan instead of rack interaction. Selector now matches both, consistent with isRackInteractionTarget.
- closest?.() !== null evaluated to true when closest is undefined, misclassifying targets without closest support as draggable. Results are now normalized with ?? null.

## Verification

- TDD: two new unit tests written first and confirmed failing for the predicted reasons, then green after the fix (31/31 in canvas-coordinates.test.ts)
- ESLint clean; full suite via pre-commit gate


___

## **CodeAnt-AI Description**
**Fix canvas panning on bayed racks and targets without drag support**

### What Changed
- Clicking or pressing inside bayed rack areas no longer starts a canvas pan; these areas are now treated the same as other rack views.
- Elements that do not support `closest` are no longer mistaken for draggable items, so pan blocking only applies when drag support is actually present.
- Added coverage for bayed rack areas and targets without `closest` support.

### Impact
`✅ Fewer accidental canvas pans`
`✅ Correct rack interaction on bayed views`
`✅ Safer pointer handling on non-standard elements`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
