### PR TITLE
fix: clear stale container linkage on cross-rack moves (#2128)

### DIFF
--- a/src/lib/stores/commands/device.ts
+++ b/src/lib/stores/commands/device.ts
@@ -333,12 +333,18 @@ export function createCrossRackMoveCommand(
   const parentCopy = structuredClone(parentDevice);
   const childrenCopies = children.map((c) => structuredClone(c));
 
-  // Build the placed device for the target rack (updated position/face/slot)
+  // Build the placed device for the target rack (updated position/face/slot).
+  // Clear container linkage: the moved device's own container never moves with
+  // it (the move set is the device plus its children), so container_id/slot_id
+  // would point at a container that only exists in the source rack. parentCopy
+  // keeps the original linkage so undo restores the device into its container.
   const placedParent: PlacedDevice = {
     ...parentCopy,
     position: targetPosition,
     face,
     slot_position: slotPosition ?? parentCopy.slot_position ?? "full",
+    container_id: undefined,
+    slot_id: undefined,
   };
 
   // Children inherit the parent's new face and keep their relative positions

--- a/src/tests/dnd-between-racks.test.ts
+++ b/src/tests/dnd-between-racks.test.ts
@@ -9,7 +9,7 @@ import {
 import { toInternalUnits } from "$lib/utils/position";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { resetHistoryStore } from "$lib/stores/history.svelte";
-import { createTestDeviceType } from "./factories";
+import { createTestContainerType, createTestDeviceType } from "./factories";
 
 // Helper to create a placed device with internal unit position
 function pd(
@@ -504,6 +504,69 @@ describe("DnD Between Racks", () => {
         .getRackById(rackB.id)!
         .devices.find((d) => d.container_id === movedParent!.id);
       expect(movedChild).toBeDefined();
+    });
+
+    /** Place a container in rack A with a child device inside its slot */
+    function placeContainedChild() {
+      const containerType = createTestContainerType({ slug: "test-shelf" });
+      const childType = createTestDeviceType({
+        slug: "test-mini-pc",
+        u_height: 1,
+        slot_width: 1,
+        is_full_depth: false,
+      });
+      store.addDeviceTypeRaw(containerType);
+      store.addDeviceTypeRaw(childType);
+
+      store.placeDevice(rackA.id, containerType.slug, 5);
+      const container = store.getRackById(rackA.id)!.devices[0]!;
+      const placed = store.placeInContainer(
+        rackA.id,
+        childType.slug,
+        container.id,
+        "slot-left",
+        0,
+      );
+      expect(placed).toBe(true);
+      const childIndex = store
+        .getRackById(rackA.id)!
+        .devices.findIndex((d) => d.container_id === container.id);
+      return { container, childType, childIndex };
+    }
+
+    it("clears container linkage when moving a contained device to another rack", () => {
+      const { childType, childIndex } = placeContainedChild();
+
+      const result = store.moveDeviceToRack(
+        rackA.id,
+        childIndex,
+        rackB.id,
+        10,
+        "front",
+      );
+
+      expect(result).toBe(true);
+      const moved = findDevice(store.getRackById(rackB.id)!, childType.slug);
+      expect(moved).toBeDefined();
+      expect(moved!.container_id).toBeUndefined();
+      expect(moved!.slot_id).toBeUndefined();
+      expect(moved!.position).toBe(toInternalUnits(10));
+    });
+
+    it("undo restores a moved contained device into its original container", () => {
+      const { container, childType, childIndex } = placeContainedChild();
+
+      store.moveDeviceToRack(rackA.id, childIndex, rackB.id, 10, "front");
+      store.undo();
+
+      expect(
+        findDevice(store.getRackById(rackB.id)!, childType.slug),
+      ).toBeUndefined();
+      const restored = findDevice(store.getRackById(rackA.id)!, childType.slug);
+      expect(restored).toBeDefined();
+      expect(restored!.container_id).toBe(container.id);
+      expect(restored!.slot_id).toBe("slot-left");
+      expect(restored!.position).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## **User description**
Closes #2128

## Summary

Moving a device that sits inside a container to another rack kept container_id/slot_id on the target-rack placement, leaving it linked to a container that exists only in the source rack (pre-existing bug surfaced by CodeRabbit on #2125, tracked as #2128).

The linkage is cleared on placedParent inside createCrossRackMoveCommand rather than on the snapshot in moveDeviceToRack: parentCopy keeps the original linkage so undo restores the device into its container in the source rack. Redo replays execute(), which places the already-detached placedParent.

## Verification

- TDD: both tests written first against the phase 4 base and confirmed failing, then green (32/32 in dnd-between-racks.test.ts after rebase onto main)
- Full suite, lint, and check ran via the pre-commit gate
- Code-review pass before PR: no blocking findings; one adjacent pre-existing bug discovered and filed separately (#2129, YAML export drops container linkage)


___

## **CodeAnt-AI Description**
**Clear container links when moving a contained device to another rack**

### What Changed
- Devices moved out of a container now arrive in the new rack without keeping a stale container or slot link.
- Undo still puts the device back into its original container and slot in the source rack.
- Added coverage for moving a contained device across racks and restoring it with undo.

### Impact
`✅ Fewer broken container links after rack moves`
`✅ Correct undo for contained devices`
`✅ Clearer cross-rack move behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
