### PR TITLE
fix: resolve container type via global device type lookup (#2127)

### DIFF
--- a/src/lib/stores/layout/device-actions.ts
+++ b/src/lib/stores/layout/device-actions.ts
@@ -172,8 +172,9 @@ export function placeInContainer(
   const layout = ctx.getLayout();
 
   // Find device types
-  const containerType = layout.device_types.find(
-    (d) => d.slug === container.device_type,
+  const containerType = findDeviceType(
+    container.device_type,
+    layout.device_types,
   );
   const childType = findDeviceType(deviceTypeSlug, layout.device_types);
 

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -2151,6 +2151,57 @@ describe("Layout Store", () => {
 
       expect(success).toBe(false);
     });
+
+    it("places child when container type is missing from layout but resolvable globally (#2127)", () => {
+      const store = getLayoutStore();
+
+      // Load a layout where the container device references a starter
+      // library type that is NOT embedded in layout.device_types
+      store.loadLayout({
+        version: "0.7.0",
+        name: "Container Lookup Test",
+        racks: [
+          {
+            id: "rack-1",
+            name: "Test Rack",
+            height: 42,
+            width: 19,
+            desc_units: false,
+            form_factor: "4-post-cabinet",
+            starting_unit: 1,
+            position: 0,
+            devices: [
+              {
+                id: "container-1",
+                device_type: "shelf-1u-2slot", // starter library container
+                position: 60,
+                face: "front" as const,
+              },
+            ],
+          },
+        ],
+        device_types: [],
+        settings: {
+          display_mode: "label",
+          show_labels_on_images: false,
+        },
+      });
+
+      const success = store.placeInContainer(
+        "rack-1",
+        "generic-mini-pc", // starter library mini device
+        "container-1",
+        "left",
+        0,
+      );
+
+      expect(success).toBe(true);
+      const child = store.layout.racks[0]!.devices.find(
+        (d) => d.container_id === "container-1",
+      );
+      expect(child).toBeDefined();
+      expect(child!.slot_id).toBe("left");
+    });
   });
 
   describe("placeDevice with brand pack devices", () => {


### PR DESCRIPTION
## **User description**
Closes #2127

## Summary

placeInContainer resolved the container's device type only from layout.device_types while the child type used the global findDeviceType helper (layout, then starter library, then brand packs). A container whose type was not embedded in the layout rejected valid child placements. Both lookups now go through findDeviceType.

Pre-existing asymmetry surfaced by CodeRabbit on PR #2125 (phase 4 extraction) and verified as moved-not-changed there; this is the follow-up fix.

## Verification

- TDD: failing test first (container type resolvable globally but absent from layout.device_types), green after the one-line unification
- Full unit suite green post-rebase onto main (2044 passed), ESLint clean

Note: the implementing agent and its in-flight code-review pass were interrupted by a terminal crash; the rebase, full-suite verification, and this PR were completed during session recovery.


___

## **CodeAnt-AI Description**
**Allow placing devices into containers even when the container type is defined outside the layout**

### What Changed
- Containers now recognize their device type from the full device-type lookup, not only from types listed in the current layout
- This fixes failed placements when a valid container comes from the starter library or brand packs
- Added a test showing a child device can now be placed into a globally defined container type that is missing from the layout

### Impact
`✅ Fewer blocked device placements`
`✅ Works with starter library containers`
`✅ Clearer placement behavior in imported layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
