### PR TITLE
fix: bind target rack into rack-scoped undo commands (#2126)

### DIFF
--- a/src/lib/stores/layout/recorded-rack-actions.ts
+++ b/src/lib/stores/layout/recorded-rack-actions.ts
@@ -12,10 +12,47 @@ import {
   createUpdateRackCommand,
   createClearRackCommand,
   createBatchCommand,
+  type Command,
 } from "../commands";
 import type { LayoutStateAccess } from "./types";
 import { getCommandStoreAdapter } from "./command-adapters";
 import { getTargetRack, getRackById } from "./rack-actions";
+
+/**
+ * Bind a command to a specific rack. The raw mutators behind rack commands
+ * operate on whichever rack is active, so execute/undo must activate the
+ * target rack first and restore the previously active rack afterwards.
+ * Mirrors what createCrossRackMoveCommand does with getActiveRackId() so
+ * undo/redo targets the intended rack regardless of which rack is active
+ * at undo time (#2126).
+ */
+function bindCommandToRack(
+  ctx: LayoutStateAccess,
+  rackId: string,
+  inner: Command,
+): Command {
+  return {
+    ...inner,
+    execute() {
+      const previousActiveId = ctx.getActiveRackId();
+      ctx.setActiveRackId(rackId);
+      try {
+        inner.execute();
+      } finally {
+        ctx.setActiveRackId(previousActiveId);
+      }
+    },
+    undo() {
+      const previousActiveId = ctx.getActiveRackId();
+      ctx.setActiveRackId(rackId);
+      try {
+        inner.undo();
+      } finally {
+        ctx.setActiveRackId(previousActiveId);
+      }
+    },
+  };
+}
 
 /**
  * Update rack settings with undo/redo support
@@ -31,9 +68,6 @@ export function updateRackRecorded(
   const targetRack = getRackById(ctx, rackId);
   if (!targetRack) return;
 
-  // Set active rack so Raw functions target the correct rack
-  ctx.setActiveRackId(rackId);
-
   // Capture before state
   const before: Partial<Omit<Rack, "devices" | "view">> = {};
   for (const key of Object.keys(updates) as (keyof Omit<
@@ -46,7 +80,11 @@ export function updateRackRecorded(
   const history = getHistoryStore();
   const adapter = getCommandStoreAdapter(ctx);
 
-  const command = createUpdateRackCommand(before, updates, adapter);
+  const command = bindCommandToRack(
+    ctx,
+    rackId,
+    createUpdateRackCommand(before, updates, adapter),
+  );
   history.execute(command);
   ctx.markDirty();
 }
@@ -90,21 +128,15 @@ export function updateRacksBatchRecorded(
     }
     if (!differs) continue;
 
-    // Each sub-command sets the active rack first because updateRackRaw
-    // targets whichever rack is active.
-    const inner = createUpdateRackCommand(before, updates, adapter);
+    // Each sub-command activates its target rack because updateRackRaw
+    // targets whichever rack is active, then restores the previous one.
     commands.push({
-      type: "UPDATE_RACK" as const,
+      ...bindCommandToRack(
+        ctx,
+        rackId,
+        createUpdateRackCommand(before, updates, adapter),
+      ),
       description,
-      timestamp: Date.now(),
-      execute() {
-        ctx.setActiveRackId(rackId);
-        inner.execute();
-      },
-      undo() {
-        ctx.setActiveRackId(rackId);
-        inner.undo();
-      },
     });
   }
 
@@ -125,17 +157,18 @@ export function clearRackRecorded(
   ctx: LayoutStateAccess,
   rackId?: string,
 ): void {
-  if (rackId) {
-    ctx.setActiveRackId(rackId);
-  }
-  const target = getTargetRack(ctx);
-  if (!target || target.rack.devices.length === 0) return;
+  const targetRack = getTargetRack(ctx, rackId)?.rack;
+  if (!targetRack || targetRack.devices.length === 0) return;
 
-  const devices = [...target.rack.devices];
+  const devices = [...targetRack.devices];
   const history = getHistoryStore();
   const adapter = getCommandStoreAdapter(ctx);
 
-  const command = createClearRackCommand(devices, adapter);
+  const command = bindCommandToRack(
+    ctx,
+    targetRack.id,
+    createClearRackCommand(devices, adapter),
+  );
   history.execute(command);
   ctx.markDirty();
 }

--- a/src/tests/rack-undo.test.ts
+++ b/src/tests/rack-undo.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { createTestDeviceType } from "./factories";
 
 describe("Rack Add/Delete Undo/Redo", () => {
   beforeEach(() => {
@@ -231,6 +232,85 @@ describe("Rack Add/Delete Undo/Redo", () => {
       expect(afterUndo!.rack_ids).toContain(rack1!.id);
       expect(afterUndo!.rack_ids).toContain(rack2!.id);
       expect(afterUndo!.rack_ids).toContain(rack3!.id);
+    });
+  });
+
+  describe("rack-targeted undo binding (#2126)", () => {
+    it("undoes a rack update on the original rack after switching active rack", () => {
+      const store = getLayoutStore();
+      const rackA = store.addRack("Rack A", 42)!;
+      const rackB = store.addRack("Rack B", 42)!;
+      store.setActiveRack(rackA.id);
+      store.clearHistory();
+
+      store.updateRackRecorded(rackA.id, { name: "Rack A Renamed" });
+      expect(store.getRackById(rackA.id)!.name).toBe("Rack A Renamed");
+
+      // Switch to another rack, then undo
+      store.setActiveRack(rackB.id);
+      store.undo();
+
+      // The original rack reverts; the other rack is untouched
+      expect(store.getRackById(rackA.id)!.name).toBe("Rack A");
+      expect(store.getRackById(rackB.id)!.name).toBe("Rack B");
+
+      // Redo also targets the original rack regardless of active rack
+      store.redo();
+      expect(store.getRackById(rackA.id)!.name).toBe("Rack A Renamed");
+      expect(store.getRackById(rackB.id)!.name).toBe("Rack B");
+    });
+
+    it("undoes a rack clear into the original rack after switching active rack", () => {
+      const store = getLayoutStore();
+      const rackA = store.addRack("Rack A", 42)!;
+      const rackB = store.addRack("Rack B", 42)!;
+      store.addDeviceTypeRaw(
+        createTestDeviceType({ slug: "test-server", u_height: 1 }),
+      );
+      expect(store.placeDevice(rackA.id, "test-server", 5)).toBe(true);
+      expect(
+        store
+          .getRackById(rackA.id)!
+          .devices.some((d) => d.device_type === "test-server"),
+      ).toBe(true);
+      store.clearHistory();
+
+      store.clearRackRecorded(rackA.id);
+      expect(
+        store
+          .getRackById(rackA.id)!
+          .devices.some((d) => d.device_type === "test-server"),
+      ).toBe(false);
+
+      // Switch to another rack, then undo
+      store.setActiveRack(rackB.id);
+      store.undo();
+
+      // Devices restore into the original rack, not the active one
+      expect(
+        store
+          .getRackById(rackA.id)!
+          .devices.some((d) => d.device_type === "test-server"),
+      ).toBe(true);
+      expect(store.getRackById(rackB.id)!.devices.length).toBe(0);
+    });
+
+    it("keeps the active rack unchanged across batch update execute and undo", () => {
+      const store = getLayoutStore();
+      const result = store.addBayedRackGroup("Bay Group", 2, 42)!;
+      const [bay1] = result.racks;
+      store.setActiveRack(bay1.id);
+      store.clearHistory();
+
+      // desc_units on a bayed group member fans out to a batch update
+      store.updateRack(bay1.id, { desc_units: true });
+      expect(store.activeRackId).toBe(bay1.id);
+
+      store.undo();
+      expect(store.activeRackId).toBe(bay1.id);
+
+      store.redo();
+      expect(store.activeRackId).toBe(bay1.id);
     });
   });
 


### PR DESCRIPTION
## **User description**
Closes #2126

## Summary

updateRackRecorded, updateRacksBatchRecorded, and clearRackRecorded resolved their target rack from whichever rack was active at undo time, so undoing after switching racks mutated the wrong rack, and batch updates left the active selection on the last processed rack.

A bindCommandToRack wrapper now captures the target rack id, sets it inside execute/undo, and restores the previously active rack in a finally block so the restore survives a throwing command. Mirrors the pattern createCrossRackMoveCommand already used.

Pre-existing bugs surfaced by CodeRabbit on PR #2125 (phase 4 extraction) and verified as moved-not-changed there; this is the follow-up fix.

## Verification

- TDD: undo-after-rack-switch tests written first (update, clear, and batch active-rack stability), red then green
- Full unit suite green post-rebase onto main (2048 passed), ESLint clean

Note: the implementing agent was interrupted by a terminal crash after staging its code-review hardening (the try/finally restore); recovery folded that into the commit, rebased onto main, and re-verified.


___

## **CodeAnt-AI Description**
**Keep undo and redo tied to the rack you changed**

### What Changed
- Undo and redo now apply rack updates, clears, and batch changes to the same rack that was edited, even if the user switches to another rack first.
- Clearing a rack now uses the intended rack directly, so devices are restored to the correct place on undo.
- Batch rack updates now preserve the currently selected rack instead of leaving the selection on the last rack touched.
- Added tests for undoing rack updates, rack clears, and batch updates after changing the active rack.

### Impact
`✅ Fewer wrong-rack undo actions`
`✅ Correct device restore after rack clears`
`✅ Stable rack selection during batch edits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
