### PR TITLE
fix: guard rack-bound undo commands against deleted racks

### DIFF
--- a/src/lib/stores/layout/recorded-rack-actions.ts
+++ b/src/lib/stores/layout/recorded-rack-actions.ts
@@ -31,25 +31,26 @@ function bindCommandToRack(
   rackId: string,
   inner: Command,
 ): Command {
+  const runOnRack = (action: () => void) => {
+    // If the bound rack is gone, the raw mutators would fall back to the
+    // first rack and mutate the wrong one — no-op instead.
+    if (!ctx.findRack(rackId)) return;
+    const previousActiveId = ctx.getActiveRackId();
+    ctx.setActiveRackId(rackId);
+    try {
+      action();
+    } finally {
+      ctx.setActiveRackId(previousActiveId);
+    }
+  };
+
   return {
     ...inner,
     execute() {
-      const previousActiveId = ctx.getActiveRackId();
-      ctx.setActiveRackId(rackId);
-      try {
-        inner.execute();
-      } finally {
-        ctx.setActiveRackId(previousActiveId);
-      }
+      runOnRack(() => inner.execute());
     },
     undo() {
-      const previousActiveId = ctx.getActiveRackId();
-      ctx.setActiveRackId(rackId);
-      try {
-        inner.undo();
-      } finally {
-        ctx.setActiveRackId(previousActiveId);
-      }
+      runOnRack(() => inner.undo());
     },
   };
 }

--- a/src/tests/rack-undo.test.ts
+++ b/src/tests/rack-undo.test.ts
@@ -9,8 +9,14 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
-import { resetHistoryStore } from "$lib/stores/history.svelte";
-import { createTestDeviceType } from "./factories";
+import { getHistoryStore, resetHistoryStore } from "$lib/stores/history.svelte";
+import { updateRackRecorded } from "$lib/stores/layout/recorded-rack-actions";
+import type { LayoutStateAccess } from "$lib/stores/layout/types";
+import {
+  createTestDeviceType,
+  createTestLayout,
+  createTestRack,
+} from "./factories";
 
 describe("Rack Add/Delete Undo/Redo", () => {
   beforeEach(() => {
@@ -293,6 +299,42 @@ describe("Rack Add/Delete Undo/Redo", () => {
           .devices.some((d) => d.device_type === "test-server"),
       ).toBe(true);
       expect(store.getRackById(rackB.id)!.devices.length).toBe(0);
+    });
+
+    it("no-ops undo when the bound rack no longer exists", () => {
+      const rackA = createTestRack({ id: "rack-a", name: "Rack A" });
+      const rackB = createTestRack({ id: "rack-b", name: "Rack B" });
+      let layout = createTestLayout({ racks: [rackA, rackB] });
+      let activeRackId: string | null = "rack-b";
+      const ctx: LayoutStateAccess = {
+        getLayout: () => layout,
+        setLayout: (l) => {
+          layout = l;
+        },
+        getActiveRackId: () => activeRackId,
+        setActiveRackId: (id) => {
+          activeRackId = id;
+        },
+        markDirty: () => {},
+        markStarted: () => {},
+        getRackGroups: () => layout.rack_groups ?? [],
+        findRack: (id) => layout.racks.find((r) => r.id === id),
+        findRackIndex: (id) => layout.racks.findIndex((r) => r.id === id),
+      };
+
+      updateRackRecorded(ctx, "rack-a", { name: "Rack A Renamed" });
+      expect(layout.racks.find((r) => r.id === "rack-a")!.name).toBe(
+        "Rack A Renamed",
+      );
+
+      // Remove the bound rack outside the history system, then undo.
+      // Without an existence guard the raw mutators fall back to the
+      // first rack and would rename rack B to "Rack A".
+      layout = { ...layout, racks: layout.racks.filter((r) => r.id !== "rack-a") };
+      getHistoryStore().undo();
+
+      expect(layout.racks.find((r) => r.id === "rack-b")!.name).toBe("Rack B");
+      expect(activeRackId).toBe("rack-b");
     });
 
     it("keeps the active rack unchanged across batch update execute and undo", () => {


### PR DESCRIPTION
## **User description**
## Summary
- Addresses the CodeAnt review comment on #2137: `bindCommandToRack` activated its bound rack ID without verifying the rack still exists, so a stale ID let the raw mutators fall back to the first rack and undo/redo could silently mutate the wrong rack.
- Adds a rack-existence guard that no-ops execute/undo when the bound rack is missing, restoring the previous active rack untouched.
- Adds a regression test proving the failure mode (without the guard, undo renames the surviving rack).

## Test Plan
- [x] npm run lint
- [x] npm run test:run (2113 passed)
- [x] npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep undo and redo from changing the wrong rack when the target rack is gone**

### What Changed
- Undo and redo now do nothing if the rack they were tied to has been deleted
- The active rack is still restored after the command runs, so users stay on the same rack
- Added a test that shows deleted-rack undo no longer renames or mutates a different rack

### Impact
`✅ Safer rack undo`
`✅ Fewer wrong-rack edits`
`✅ Fewer data surprises after deleting racks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
