### PR TITLE
chore(ts): fix svelte-check errors and drop deprecated baseUrl (#2105, #2104)

### DIFF
--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -929,12 +929,15 @@ function recoverSlotPositions<
   const recovery = new Map<string, "left" | "right">();
   const recoveredSlugs = new Set<string>();
   for (const group of groups.values()) {
+    const [d0, d1] = group;
     if (
       group.length === 2 &&
+      d0 &&
+      d1 &&
       group.every((d) => d.slot_position === undefined)
     ) {
-      recovery.set(group[0].id, "left");
-      recovery.set(group[1].id, "right");
+      recovery.set(d0.id, "left");
+      recovery.set(d1.id, "right");
       for (const d of group) recoveredSlugs.add(d.device_type);
     }
   }

--- a/src/lib/stores/commands/device.ts
+++ b/src/lib/stores/commands/device.ts
@@ -446,8 +446,7 @@ export function createCrossRackMoveCommand(
 
       // 3. Place children in target rack with remapped container_id
       childPlacedIndices.length = 0;
-      for (let i = 0; i < placedChildren.length; i++) {
-        const child = placedChildren[i];
+      placedChildren.forEach((child, i) => {
         const childToPlace: PlacedDevice =
           child.container_id && child.container_id !== actualParentId
             ? { ...child, container_id: actualParentId }
@@ -458,11 +457,12 @@ export function createCrossRackMoveCommand(
         // Re-key child placement image if child ID was remapped (#1478)
         const actualChild = store.getDeviceAtIndex(idx);
         const actualChildId = actualChild?.id ?? childToPlace.id;
-        if (actualChildId !== currentChildImageIds[i]) {
-          rekeyPlacementImage(currentChildImageIds[i], actualChildId);
+        const previousChildImageId = currentChildImageIds[i];
+        if (previousChildImageId && actualChildId !== previousChildImageId) {
+          rekeyPlacementImage(previousChildImageId, actualChildId);
           currentChildImageIds[i] = actualChildId;
         }
-      }
+      });
 
       // 4. Restore active rack
       store.setActiveRackId(savedActiveRack);
@@ -495,8 +495,7 @@ export function createCrossRackMoveCommand(
       currentSourceDeviceIds[0] = undoActualParentId;
 
       // 3. Place children back in source rack with remapped container_id
-      for (let i = 0; i < childrenCopies.length; i++) {
-        const child = childrenCopies[i];
+      childrenCopies.forEach((child, i) => {
         const childToPlace: PlacedDevice =
           child.container_id && child.container_id !== undoActualParentId
             ? { ...child, container_id: undoActualParentId }
@@ -506,12 +505,13 @@ export function createCrossRackMoveCommand(
         // Re-key child placement image and update source ID tracking if remapped (#1478)
         const actualChild = store.getDeviceAtIndex(undoChildIdx);
         const actualChildId = actualChild?.id ?? childToPlace.id;
-        if (actualChildId !== currentChildImageIds[i]) {
-          rekeyPlacementImage(currentChildImageIds[i], actualChildId);
+        const previousChildImageId = currentChildImageIds[i];
+        if (previousChildImageId && actualChildId !== previousChildImageId) {
+          rekeyPlacementImage(previousChildImageId, actualChildId);
           currentChildImageIds[i] = actualChildId;
         }
         currentSourceDeviceIds[i + 1] = actualChildId;
-      }
+      });
 
       // 4. Restore active rack
       store.setActiveRackId(savedActiveRack);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "forceConsistentCasingInFileNames": true,
 
     /* Path aliases */
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "$lib/*": ["src/lib/*"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,7 +44,7 @@ function getMaxWorkers(): number {
 const maxWorkers = getMaxWorkers();
 
 export default defineConfig({
-  plugins: [svelte({ hot: !process.env.VITEST })],
+  plugins: [svelte()],
   define: {
     // Inject version at build time (same as vite.config.ts)
     __APP_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## **User description**
## Summary

Makes `npm run check` reach 0 errors. Pure type/config cleanup, no behavior change.

### #2105 — 11 svelte-check errors
- `src/lib/stores/commands/device.ts`: converted index-based loops in the cross-rack container-placement command (execute + undo) to `forEach((child, i) => ...)`, which narrows `child` to `PlacedDevice` under `noUncheckedIndexedAccess` and makes the `childToPlace: PlacedDevice` ternary type-correct. Guarded the `currentChildImageIds[i]` access with a local `previousChildImageId` (type-narrowing only, behavior preserved).
- `src/lib/schemas/index.ts`: destructured `const [d0, d1] = group` and added `d0 && d1` to the existing `length === 2` guard to narrow under `noUncheckedIndexedAccess`.
- `vitest.config.ts`: removed the dead `hot` option (not a valid `@sveltejs/vite-plugin-svelte` 7.x option; HMR is already inert under Vitest).

### #2104 — tsconfig baseUrl deprecation (TS5101)
- Kept `baseUrl` + `paths` (svelte-check needs `baseUrl` to resolve the non-relative `$lib/*` paths entry) and added `"ignoreDeprecations": "6.0"` as a documented stopgap until the TS 7 path-resolution migration.

## Verification
- `npm run check`: 11 errors -> 0 errors, 0 warnings
- `npm run lint`: clean
- `npm run test:run`: 2116 tests pass
- `npm run build`: pass

Closes #2105
Closes #2104

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Fix TypeScript and test setup issues without changing app behavior

### What Changed
- Removed a deprecated test configuration option so the test setup matches the current tooling
- Tightened slot recovery and cross-rack move handling so type-checking passes cleanly
- Added a safer check before reusing saved slot IDs during recovery

### Impact
`✅ Cleaner build and check runs`
`✅ Fewer TypeScript and test setup warnings`
`✅ Lower risk of failing automated checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
