### PR TITLE
fix: pre-push hook treats CodeRabbit rate limit as transient, not a review failure (#2102)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,8 @@
 # Run CodeRabbit review before pushing
 # Uses --agent for token-efficient output (optimized for AI review)
 # Compares against origin/main to review commits being pushed
-# Blocks push if CodeRabbit finds issues
+# Blocks push on real findings; allows it on transient/recoverable errors
+# (e.g. rate limits). See scripts/coderabbit-review-gate.sh for the decision logic.
 
 # Match the repository's object format (sha1, sha256, ...)
 zero=$(git hash-object --stdin </dev/null | tr '[:xdigit:]' '0')
@@ -19,10 +20,4 @@ while IFS=' ' read -r local_ref local_sha remote_ref _rest; do
 done
 [ "$has_branch" -eq 0 ] && exit 0
 
-echo "Running CodeRabbit review on committed changes..."
-if ! coderabbit review --agent --type committed --base origin/main; then
-  echo ""
-  echo "CodeRabbit found issues. Push blocked."
-  echo "Fix the issues above or use 'git push --no-verify' to skip."
-  exit 1
-fi
+exec "$(git rev-parse --show-toplevel)/scripts/coderabbit-review-gate.sh"

--- a/scripts/coderabbit-review-gate.bats
+++ b/scripts/coderabbit-review-gate.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# coderabbit-review-gate.bats — Tests for scripts/coderabbit-review-gate.sh
+#
+# Run: bats scripts/coderabbit-review-gate.bats
+#
+# The gate is exercised by injecting a stub `coderabbit` binary via the
+# CODERABBIT_BIN env var. Each stub emits a fixed NDJSON stream so the parsing
+# and allow/block decision can be verified without touching the network.
+
+setup() {
+  GATE="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/coderabbit-review-gate.sh"
+  STUB_DIR="$(mktemp -d)"
+  STUB="$STUB_DIR/coderabbit"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR"
+}
+
+# Write a stub coderabbit that prints $1 to stdout and exits with code $2.
+make_stub() {
+  local body="$1"
+  local code="${2:-0}"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'cat <<'\''STUB_EOF'\''\n%s\nSTUB_EOF\n' "$body"
+    printf 'exit %s\n' "$code"
+  } >"$STUB"
+  chmod +x "$STUB"
+}
+
+@test "clean review (empty findings) allows the push" {
+  make_stub '{"type":"heartbeat","status":"reviewing"}
+{"type":"complete","status":"review_completed","findings":[]}' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No findings"* ]]
+}
+
+@test "rate_limit error allows the push with a warning" {
+  make_stub '{"type":"error","errorType":"rate_limit","message":"Rate limit exceeded","recoverable":true,"waitTime":"10 minutes and 29 seconds"}' 1
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING"* ]]
+  [[ "$output" == *"rate_limit"* ]]
+}
+
+@test "recoverable error (non-rate-limit) allows the push" {
+  make_stub '{"type":"error","errorType":"connection_failed","message":"network down","recoverable":true}' 1
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING"* ]]
+}
+
+@test "real findings block the push" {
+  make_stub '{"type":"complete","status":"review_completed","findings":[{"title":"bug"},{"title":"smell"}]}' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"2 issue"* ]]
+  [[ "$output" == *"Push blocked"* ]]
+}
+
+@test "non-recoverable error blocks the push (fail-safe)" {
+  make_stub '{"type":"error","errorType":"auth_failed","message":"bad token","recoverable":false}' 1
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fail-safe"* ]]
+}
+
+@test "empty output blocks the push (fail-safe)" {
+  make_stub '' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no parseable output"* ]] || [[ "$output" == *"fail-safe"* ]]
+}
+
+@test "garbage output blocks the push (fail-safe)" {
+  make_stub 'not json at all
+<<< partial garbage >>>' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fail-safe"* ]]
+}
+
+@test "no terminal event blocks the push (fail-safe)" {
+  make_stub '{"type":"heartbeat","status":"reviewing"}
+{"type":"heartbeat","status":"reviewing"}' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fail-safe"* ]]
+}

--- a/scripts/coderabbit-review-gate.sh
+++ b/scripts/coderabbit-review-gate.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# coderabbit-review-gate.sh — pre-push CodeRabbit gate that tells transient
+# errors apart from real review findings.
+#
+# Runs `coderabbit review --agent` (NDJSON output) and decides whether to block
+# the push by inspecting the emitted events:
+#
+#   {"type":"complete","status":"review_completed","findings":[...]}
+#       findings == []  -> clean pass        (exit 0)
+#       findings != []  -> real findings     (exit 1, BLOCK)
+#
+#   {"type":"error","errorType":"rate_limit","recoverable":true,...}
+#   {"type":"error","recoverable":true,...}        (any recoverable error)
+#   {"type":"error","errorType":"<network/connection>",...}
+#       transient                            (exit 0, WARN + allow)
+#
+#   anything else: empty output, unparseable JSON, an "error" event that is not
+#   recoverable, or no terminal event at all
+#       FAIL SAFE                            (exit 1, BLOCK)
+#
+# Default-deny: only an explicit clean pass or an explicit transient/recoverable
+# error allows the push. Everything ambiguous blocks.
+#
+# Env:
+#   CODERABBIT_BIN   override the coderabbit binary (default: coderabbit). Used
+#                    by tests to inject a stub. May contain a command + args.
+#   CODERABBIT_BASE  base ref to compare against (default: origin/main).
+
+set -u
+
+bin="${CODERABBIT_BIN:-coderabbit}"
+base="${CODERABBIT_BASE:-origin/main}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "coderabbit-review-gate: 'jq' is required to parse review output. Push blocked." >&2
+  echo "Install jq, or use 'git push --no-verify' to skip the gate." >&2
+  exit 1
+fi
+
+echo "Running CodeRabbit review on committed changes..."
+
+# Capture the raw NDJSON stream. We do not block on the CLI's own exit code:
+# a rate-limited run exits non-zero but is still a transient outcome we want to
+# parse and forgive. The decision is driven entirely by the emitted events.
+output="$(${bin} review --agent --type committed --base "${base}" 2>/dev/null)"
+
+# Empty output is never a clean pass. Default-deny.
+if [ -z "${output//[$'\t\r\n ']/}" ]; then
+  echo "" >&2
+  echo "CodeRabbit produced no parseable output. Push blocked (fail-safe)." >&2
+  echo "Re-run 'coderabbit review --agent' locally, or use 'git push --no-verify' to skip." >&2
+  exit 1
+fi
+
+# Inspect the stream. Process events newest-relevant-first:
+#   1. A clean complete event allows the push.
+#   2. A complete event with findings blocks.
+#   3. A recoverable/transient error event warns and allows.
+#   4. Anything else falls through to the fail-safe block.
+#
+# `decision` is set by the jq pass below to one of: pass | findings | transient.
+# `note` carries a human-readable detail (finding count or error reason).
+decision=""
+note=""
+
+# Pull the terminal complete event, if any (last one wins).
+complete_findings="$(printf '%s\n' "$output" \
+  | jq -rc 'select(type=="object" and .type=="complete" and .status=="review_completed") | .findings | length' 2>/dev/null \
+  | tail -n1)"
+
+if [ -n "$complete_findings" ]; then
+  if [ "$complete_findings" -eq 0 ] 2>/dev/null; then
+    decision="pass"
+  else
+    decision="findings"
+    note="$complete_findings"
+  fi
+fi
+
+# If there was no clean/findings verdict, look for a transient error event.
+if [ -z "$decision" ]; then
+  transient="$(printf '%s\n' "$output" \
+    | jq -rc '
+        select(type=="object" and .type=="error")
+        | select(
+            (.recoverable == true)
+            or (.errorType == "rate_limit")
+            or (.errorType // "" | test("(?i)(rate|network|connection|timeout|econn|enotfound|temporar)"))
+          )
+        | (.errorType // "error")
+      ' 2>/dev/null \
+    | tail -n1)"
+  if [ -n "$transient" ]; then
+    decision="transient"
+    note="$transient"
+  fi
+fi
+
+case "$decision" in
+  pass)
+    echo "CodeRabbit review complete. No findings."
+    exit 0
+    ;;
+  transient)
+    echo "" >&2
+    echo "WARNING: CodeRabbit review could not complete (${note})." >&2
+    echo "This is a transient/recoverable error, not a review failure, so the push is allowed." >&2
+    echo "Please re-review locally later: 'coderabbit review --agent --type committed --base ${base}'." >&2
+    exit 0
+    ;;
+  findings)
+    echo "" >&2
+    echo "CodeRabbit found ${note} issue(s). Push blocked." >&2
+    echo "Fix the issues above or use 'git push --no-verify' to skip." >&2
+    exit 1
+    ;;
+  *)
+    echo "" >&2
+    echo "CodeRabbit output could not be classified as a clean pass or a transient error. Push blocked (fail-safe)." >&2
+    echo "Inspect with 'coderabbit review --agent --type committed --base ${base}', or use 'git push --no-verify' to skip." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## **User description**
## Summary

The husky pre-push hook ran `coderabbit review --agent` and blocked the push on any non-zero exit. A rate-limit response (`{"type":"error","errorType":"rate_limit","recoverable":true,...}`) exits non-zero, so clean pushes were wrongly blocked and the only workaround was `git push --no-verify` (which also skips the gate when it is useful).

## Changes
- New `scripts/coderabbit-review-gate.sh`: parses the CLI's NDJSON stream with `jq` (anchored on `.type`/`.findings`/`.errorType`/`.recoverable`), ignores the CLI's own exit code, and decides:
  - `complete` + empty findings -> allow (clean)
  - `complete` + findings -> block (real findings)
  - `error` with `recoverable: true` / `rate_limit` / network-class errorType -> warn + allow (transient)
  - empty, unparseable, unknown, non-recoverable, or no terminal event -> **block (fail-safe / default-deny)**. Also blocks if `jq` is missing.
  - `CODERABBIT_BIN` / `CODERABBIT_BASE` env overrides for testing.
- `.husky/pre-push`: keeps the tag/delete-skip logic, then `exec`s the gate script.
- New `scripts/coderabbit-review-gate.bats`: 8 cases (matches the repo's existing bats convention).

Secure-coding: default-deny on ambiguity; a malformed/empty response never silently passes a push.

## Verification
- `bats scripts/coderabbit-review-gate.bats`: 8/8 pass
- Manual: rate_limit -> allow+warn; real findings -> block; garbage/empty -> block
- `shellcheck` clean; `npm run lint` clean

Closes #2102

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Treat CodeRabbit rate-limit and other transient review errors as non-blocking**

### What Changed
- Pushes no longer get blocked when CodeRabbit hits a recoverable error such as a rate limit or network issue
- Real review findings still block the push
- Empty, unclear, or malformed review output now blocks the push instead of passing silently
- Added tests covering clean reviews, transient errors, real findings, and fail-safe blocking cases

### Impact
`✅ Fewer blocked pushes during CodeRabbit rate limits`
`✅ Fewer push failures from temporary network issues`
`✅ Safer review gate for unclear or broken output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
