### PR TITLE
fix: surface CodeRabbit findings when the pre-push gate blocks a push

### DIFF
--- a/scripts/coderabbit-review-gate.bats
+++ b/scripts/coderabbit-review-gate.bats
@@ -7,12 +7,14 @@
 # CODERABBIT_BIN env var. Each stub emits a fixed NDJSON stream so the parsing
 # and allow/block decision can be verified without touching the network.
 
+# Resolve the gate under test and create a scratch dir for the per-test stub.
 setup() {
   GATE="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/coderabbit-review-gate.sh"
   STUB_DIR="$(mktemp -d)"
   STUB="$STUB_DIR/coderabbit"
 }
 
+# Remove the scratch dir created in setup.
 teardown() {
   rm -rf "$STUB_DIR"
 }
@@ -52,12 +54,24 @@ make_stub() {
   [[ "$output" == *"WARNING"* ]]
 }
 
-@test "real findings block the push" {
-  make_stub '{"type":"complete","status":"review_completed","findings":[{"title":"bug"},{"title":"smell"}]}' 0
+@test "real findings block the push and surface each finding" {
+  make_stub '{"type":"complete","status":"review_completed","findings":[{"file":"src/foo.ts","line":42,"title":"possible null deref"},{"path":"src/bar.ts","message":"unused import"}]}' 0
   run env CODERABBIT_BIN="$STUB" "$GATE"
   [ "$status" -eq 1 ]
   [[ "$output" == *"2 issue"* ]]
   [[ "$output" == *"Push blocked"* ]]
+  [[ "$output" == *"src/foo.ts:42"* ]]
+  [[ "$output" == *"possible null deref"* ]]
+  [[ "$output" == *"src/bar.ts"* ]]
+  [[ "$output" == *"unused import"* ]]
+}
+
+@test "findings with an unfamiliar shape still surface as raw JSON" {
+  make_stub '{"type":"complete","status":"review_completed","findings":[{"weird":"x","nested":{"y":1}}]}' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"1 issue"* ]]
+  [[ "$output" == *"weird"* ]]
 }
 
 @test "non-recoverable error blocks the push (fail-safe)" {

--- a/scripts/coderabbit-review-gate.sh
+++ b/scripts/coderabbit-review-gate.sh
@@ -63,10 +63,12 @@ fi
 decision=""
 note=""
 
-# Pull the terminal complete event, if any (last one wins).
-complete_findings="$(printf '%s\n' "$output" \
-  | jq -rc 'select(type=="object" and .type=="complete" and .status=="review_completed") | .findings | length' 2>/dev/null \
+# Pull the terminal complete event, if any (last one wins). Keep the whole event
+# object so its findings can be surfaced verbatim when the push is blocked.
+complete_event="$(printf '%s\n' "$output" \
+  | jq -rc 'select(type=="object" and .type=="complete" and .status=="review_completed")' 2>/dev/null \
   | tail -n1)"
+complete_findings="$(printf '%s\n' "$complete_event" | jq -r '.findings | length' 2>/dev/null)"
 
 if [ -n "$complete_findings" ]; then
   if [ "$complete_findings" -eq 0 ] 2>/dev/null; then
@@ -111,6 +113,25 @@ case "$decision" in
   findings)
     echo "" >&2
     echo "CodeRabbit found ${note} issue(s). Push blocked." >&2
+    echo "" >&2
+    # Surface the actual findings, not just the count, so the developer can act
+    # on them without re-running the review (restores the pre-extraction hook
+    # behaviour). Best-effort render of common fields; fall back to the raw
+    # finding JSON when the shape is unfamiliar.
+    rendered="$(printf '%s\n' "$complete_event" | jq -r '
+        .findings[]
+        | "  - "
+          + (((.file // .path // .location.path) // "?") | tostring)
+          + (((.line // .location.line)) as $l | if $l != null then ":" + ($l | tostring) else "" end)
+          + "  "
+          + (((.title // .message // .description // .body) // (. | tojson)) | tostring)
+      ' 2>/dev/null)"
+    if [ -n "$rendered" ]; then
+      printf '%s\n' "$rendered" >&2
+    else
+      printf '%s\n' "$complete_event" | jq -rc '.findings[]' 2>/dev/null >&2
+    fi
+    echo "" >&2
     echo "Fix the issues above or use 'git push --no-verify' to skip." >&2
     exit 1
     ;;


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #2144. Addresses the CodeAnt HIGH architect-review finding: the pre-push gate captured CodeRabbit's NDJSON output but printed only a count on a block, so a blocked push showed "found N issue(s)" with nothing actionable (and a misleading "Fix the issues above" when nothing was above). This regressed the prior hook, which streamed the review output.

## Changes
- `scripts/coderabbit-review-gate.sh`: keep the whole terminal `complete` event, and in the findings branch render each finding (file:line plus title/message, falling back to raw JSON for unfamiliar shapes) before blocking.
- `scripts/coderabbit-review-gate.bats`: the real-findings test now asserts each finding is surfaced (file:line + message), plus a new case for unfamiliar finding shapes. Added doc comments on setup/teardown (clears the docstring-coverage warning from #2144).

## Verification
- `bats scripts/coderabbit-review-gate.bats`: 9/9 pass
- `shellcheck scripts/coderabbit-review-gate.sh`: clean

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Show the actual CodeRabbit findings when a push is blocked**

### What Changed
- When CodeRabbit blocks a push, the gate now prints each finding instead of only showing the total count.
- Findings include the file and line when available, along with the finding text; unusual finding shapes are still shown as raw JSON.
- Test coverage now checks that blocked pushes surface individual findings and that unknown finding formats are still displayed.

### Impact
`✅ Clearer push-blocked messages`
`✅ Fewer retries to find review comments`
`✅ Easier recovery from unexpected finding formats`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
