### PR TITLE
fix: preserve container linkage on YAML export (#2129)

### DIFF
--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -75,7 +75,7 @@ export async function parseYaml<T = unknown>(yamlString: string): Promise<T> {
  * Field order: slug, manufacturer, model, part_number, u_height, slot_width, is_full_depth, is_powered,
  *              weight, weight_unit, airflow, front_image, rear_image, colour, category, tags,
  *              notes, serial_number, asset_tag, links, custom_fields, interfaces, power_ports,
- *              power_outlets, device_bays, inventory_items, subdevice_role, va_rating
+ *              power_outlets, device_bays, inventory_items, subdevice_role, slots, va_rating
  */
 function orderDeviceTypeFields(dt: DeviceType): Record<string, unknown> {
   const ordered: Record<string, unknown> = {};
@@ -127,6 +127,9 @@ function orderDeviceTypeFields(dt: DeviceType): Record<string, unknown> {
   if (dt.subdevice_role !== undefined)
     ordered.subdevice_role = dt.subdevice_role;
 
+  // --- Container Support ---
+  if (dt.slots !== undefined && dt.slots.length > 0) ordered.slots = dt.slots;
+
   // --- Power Device Properties ---
   if (dt.va_rating !== undefined) ordered.va_rating = dt.va_rating;
 
@@ -136,7 +139,7 @@ function orderDeviceTypeFields(dt: DeviceType): Record<string, unknown> {
 /**
  * Order PlacedDevice fields according to schema v1.0.0
  * Field order: id, device_type, name, position, face, slot_position, front_image, rear_image,
- *              parent_device, device_bay, notes, custom_fields
+ *              parent_device, device_bay, container_id, slot_id, notes, custom_fields
  */
 function orderPlacedDeviceFields(
   device: PlacedDevice,
@@ -161,6 +164,11 @@ function orderPlacedDeviceFields(
   if (device.parent_device !== undefined)
     ordered.parent_device = device.parent_device;
   if (device.device_bay !== undefined) ordered.device_bay = device.device_bay;
+
+  // --- Container Child Placement ---
+  if (device.container_id !== undefined)
+    ordered.container_id = device.container_id;
+  if (device.slot_id !== undefined) ordered.slot_id = device.slot_id;
 
   // --- Extension Fields ---
   if (device.notes !== undefined) ordered.notes = device.notes;

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { serializeLayoutToYaml, parseLayoutYaml } from "$lib/utils/yaml";
+import type { DeviceType } from "$lib/types";
 import {
+  createTestContainerChild,
   createTestDevice,
   createTestDeviceType,
   createTestLayout,
@@ -49,5 +51,56 @@ describe("YAML layout round-trip", () => {
     expect(restored.device_types[0]?.slot_width).toBe(1);
     expect(restored.racks[0]?.devices[0]?.slot_position).toBe("left");
     expect(restored.racks[0]?.devices[1]?.slot_position).toBe("right");
+  });
+
+  it("preserves container_id and slot_id for contained child devices", async () => {
+    const containerType: DeviceType = {
+      ...createTestDeviceType({
+        slug: "container-device",
+        u_height: 2,
+      }),
+      slots: [{ id: "slot-left", position: { row: 0, col: 0 } }],
+    };
+    const childType = createTestDeviceType({
+      slug: "child-device",
+      u_height: 1,
+    });
+
+    const layout = createTestLayout({
+      racks: [
+        createTestRack({
+          id: "rack-1",
+          devices: [
+            createTestDevice({
+              id: "container-1",
+              device_type: containerType.slug,
+              position: 10,
+            }),
+            createTestContainerChild({
+              id: "child-1",
+              device_type: childType.slug,
+              container_id: "container-1",
+              slot_id: "slot-left",
+            }),
+          ],
+        }),
+      ],
+      device_types: [containerType, childType],
+    });
+
+    const yaml = await serializeLayoutToYaml(layout);
+
+    // container_id/slot_id must be serialised so container membership survives save/load
+    expect(yaml).toContain("container_id");
+    expect(yaml).toContain("slot_id");
+
+    const restored = await parseLayoutYaml(yaml);
+    const restoredContainerType = restored.device_types.find(
+      (dt) => dt.slug === "container-device",
+    );
+    expect(restoredContainerType?.slots?.[0]?.id).toBe("slot-left");
+    const child = restored.racks[0]?.devices.find((d) => d.id === "child-1");
+    expect(child?.container_id).toBe("container-1");
+    expect(child?.slot_id).toBe("slot-left");
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

`orderPlacedDeviceFields()` in `src/lib/utils/yaml.ts` never serialized `container_id`/`slot_id`, so exporting a layout with devices placed inside containers and reimporting it silently converted contained children to rack-level devices (data loss). The Zod schema accepts both fields on import and `.refine()`s that they are set together.

## Changes
- `src/lib/utils/yaml.ts`: serialize `container_id` then `slot_id` in placed-device order (after `device_bay`, before `notes`/`custom_fields`, matching schema order), emitted only when defined. Also serialize a device type's `slots` (when non-empty) in device-type order so a container's slot definitions survive the round-trip.
- `src/tests/yaml-roundtrip.test.ts`: round-trip test asserting a contained child's `container_id`/`slot_id` and the container type's `slots` survive serialize -> reparse. TDD verified red before green.

## Scope note
#2135 (same-rack move keeps stale linkage) was already fixed and merged in PR #2141 (`createDetachContainerCommand` batched into the move, undo restores both fields, tests in `dnd-between-racks.test.ts`). Verified during this work; it will be closed separately. This PR carries only the #2129 export fix.

## Verification
- `npm run check`: 0 errors
- `npm run lint`: clean
- `npm run test:run`: pass (incl. new round-trip test)
- `npm run build`: pass

Closes #2129

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Keep container-linked devices and container slots when exporting YAML**

### What Changed
- Child devices now keep their container and slot assignment when a layout is exported and loaded again
- Device types now include their slot definitions in YAML, so container layouts survive a save/load round trip
- Exported fields now follow the expected order for both device types and placed devices

### Impact
`✅ Fewer lost container links`
`✅ Reliable YAML round-trips for container layouts`
`✅ Preserved slot assignments after export and reimport`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
