### PR TITLE
chore: unify no-rack toast wording across export and share (#2061)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -527,7 +527,7 @@
 
   async function handleRackContextExport(rackIds: string[]) {
     if (rackIds.length === 0) {
-      toastStore.showToast("No racks to export", "warning");
+      toastStore.showToast("No rack to export", "warning");
       return;
     }
 

--- a/src/lib/utils/app-actions.ts
+++ b/src/lib/utils/app-actions.ts
@@ -115,7 +115,7 @@ export async function handleExport(): Promise<void> {
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
   if (!layoutStore.hasRack) {
-    toastStore.showToast("No racks to export", "warning");
+    toastStore.showToast("No rack to export", "warning");
     return;
   }
   await prepareExportQrCode();


### PR DESCRIPTION
## **User description**
## Summary

The `hasRack` guard surfaced three phrasings for the same condition: "No racks to export", "No rack to share", and "No rack to export". Standardised on the singular "No rack to {verb}" form so all guard toasts match.

Changed the two plural "No racks to export" occurrences to "No rack to export":
- `src/lib/utils/app-actions.ts` (`handleExport`)
- `src/App.svelte` (`handleRackContextExport`)

`handleShare` ("No rack to share") and `handleExportSubmit` ("No rack to export") were already singular and unchanged.

## Acceptance Criteria
- [x] All hasRack guard toasts use consistent wording ("No rack to export" / "No rack to share")
- [x] No test asserts the old strings (verified: no unit or e2e test references these toast strings)

## Test Plan
- [x] `npm run lint` clean
- [x] Existing unit tests pass

Closes #2061


___

## **CodeAnt-AI Description**
**Use the same no-rack warning wording when exporting**

### What Changed
- Export actions now show the singular warning, “No rack to export,” instead of “No racks to export”
- The rack-context export warning uses the same wording, so both export paths match

### Impact
`✅ Consistent export warnings`
`✅ Clearer no-rack messages`
`✅ Fewer wording mismatches in the UI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
