### PR TITLE
fix: mark layout clean after debounced auto-save success (#2057)

### DIFF
--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -34,6 +34,12 @@ let _errorToastId: string | undefined = undefined;
 let serverSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Bumped on every auto-save effect run. A debounced save captures the id at
+// schedule time; if a newer run bumps it while the save is in flight, the live
+// layout has edits this save did not persist, so its success must not clear the
+// dirty/session state for those newer edits.
+let _serverSaveScheduleId = 0;
+
 // After a durable save the pending session debounce must be cancelled, or it
 // resurrects the cleared session copy and triggers a false unload warning
 function cancelSessionSave(): void {
@@ -86,19 +92,26 @@ export function getStorageChipState() {
 // auto-save paths must leave the layout in the same state after a durable
 // server save - clean, failure counter reset, API marked available, session
 // cleared, and any lingering error toast dismissed.
-export function finalizeSuccessfulSave(): void {
+//
+// clearDirtyState is false for a stale debounced save: the save succeeded (so
+// the server is healthy and the failure counter/error toast clear), but newer
+// unsaved edits exist, so dirty and session state must be preserved for the
+// follow-up save.
+export function finalizeSuccessfulSave(clearDirtyState = true): void {
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
   _consecutiveSaveFailures = 0;
   setApiAvailable(true);
-  _saveStatus = "saved";
   if (_errorToastId) {
     toastStore.dismissToast(_errorToastId);
     _errorToastId = undefined;
   }
-  layoutStore.markClean();
-  cancelSessionSave();
-  clearSession();
+  if (clearDirtyState) {
+    _saveStatus = "saved";
+    layoutStore.markClean();
+    cancelSessionSave();
+    clearSession();
+  }
 }
 
 function handleSaveFailure(
@@ -294,6 +307,9 @@ export function initPersistenceEffects(): void {
 
   // Effect 2: Auto-save to server when API is available
   $effect(() => {
+    // Capture this run's schedule id; a later run (e.g. an edit during the
+    // in-flight save) bumps it and marks an earlier save's success stale.
+    const scheduleId = ++_serverSaveScheduleId;
     if (!isApiAvailable()) return;
     if (_consecutiveSaveFailures >= MAX_SAVE_FAILURES) return;
     const layout = layoutStore.layout;
@@ -314,7 +330,9 @@ export function initPersistenceEffects(): void {
       _saveStatus = "saving";
       try {
         await saveLayoutToServer(snapshot);
-        finalizeSuccessfulSave();
+        // Only clear dirty/session state if no newer save was scheduled while
+        // this one was in flight; otherwise newer unsaved edits exist.
+        finalizeSuccessfulSave(scheduleId === _serverSaveScheduleId);
       } catch (e) {
         persistenceDebug.api("Auto-save failed: %O", e);
         handlePersistenceError(e);

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -82,6 +82,25 @@ export function getStorageChipState() {
   };
 }
 
+// Shared success epilogue: the manual (handleSaveToServer) and debounced
+// auto-save paths must leave the layout in the same state after a durable
+// server save - clean, failure counter reset, API marked available, session
+// cleared, and any lingering error toast dismissed.
+export function finalizeSuccessfulSave(): void {
+  const layoutStore = getLayoutStore();
+  const toastStore = getToastStore();
+  _consecutiveSaveFailures = 0;
+  setApiAvailable(true);
+  _saveStatus = "saved";
+  if (_errorToastId) {
+    toastStore.dismissToast(_errorToastId);
+    _errorToastId = undefined;
+  }
+  layoutStore.markClean();
+  cancelSessionSave();
+  clearSession();
+}
+
 function handleSaveFailure(
   notify: boolean,
   action?: { label: string; onClick: () => void },
@@ -179,16 +198,7 @@ export async function handleSaveToServer(isManual = false): Promise<boolean> {
     }
     const snapshot = structuredClone($state.snapshot(layoutStore.layout));
     await saveLayoutToServer(snapshot);
-    _consecutiveSaveFailures = 0;
-    setApiAvailable(true);
-    _saveStatus = "saved";
-    if (_errorToastId) {
-      toastStore.dismissToast(_errorToastId);
-      _errorToastId = undefined;
-    }
-    layoutStore.markClean();
-    cancelSessionSave();
-    clearSession();
+    finalizeSuccessfulSave();
     if (isManual) {
       toastStore.showToast("Layout saved", "success", 3000);
     }
@@ -304,13 +314,7 @@ export function initPersistenceEffects(): void {
       _saveStatus = "saving";
       try {
         await saveLayoutToServer(snapshot);
-        _consecutiveSaveFailures = 0;
-        _saveStatus = "saved";
-        if (_errorToastId) {
-          getToastStore().dismissToast(_errorToastId);
-          _errorToastId = undefined;
-        }
-        clearSession();
+        finalizeSuccessfulSave();
       } catch (e) {
         persistenceDebug.api("Auto-save failed: %O", e);
         handlePersistenceError(e);

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -88,15 +88,23 @@ export function getStorageChipState() {
   };
 }
 
-// Shared success epilogue: the manual (handleSaveToServer) and debounced
-// auto-save paths must leave the layout in the same state after a durable
-// server save - clean, failure counter reset, API marked available, session
-// cleared, and any lingering error toast dismissed.
-//
-// clearDirtyState is false for a stale debounced save: the save succeeded (so
-// the server is healthy and the failure counter/error toast clear), but newer
-// unsaved edits exist, so dirty and session state must be preserved for the
-// follow-up save.
+/**
+ * Shared success epilogue for a durable server save, called by both the manual
+ * (handleSaveToServer) and debounced auto-save paths so a successful auto-save
+ * leaves the layout in the same state as a manual one.
+ *
+ * Always (server is healthy): resets the consecutive-failure counter, marks the
+ * API available, and dismisses any lingering error toast.
+ *
+ * When clearDirtyState is true (the default): also sets status to "saved", marks
+ * the layout clean, cancels the pending session debounce, and clears the session
+ * copy.
+ *
+ * @param clearDirtyState Pass false for a stale debounced save whose captured
+ *   snapshot is older than the live layout (newer unsaved edits arrived while the
+ *   save was in flight). The dirty flag and session state are then preserved for
+ *   the follow-up save so unload warnings and recovery data survive.
+ */
 export function finalizeSuccessfulSave(clearDirtyState = true): void {
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();

--- a/src/tests/persistence-manager-autosave.test.ts
+++ b/src/tests/persistence-manager-autosave.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  finalizeSuccessfulSave,
+  handlePersistenceError,
+  getConsecutiveSaveFailures,
+  resetPersistenceManager,
+} from "$lib/storage/manager.svelte";
+import { PersistenceError } from "$lib/storage/api";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
+import { setApiAvailable } from "$lib/storage/availability.svelte";
+
+// Avoid touching localStorage; finalizeSuccessfulSave clears the working copy.
+vi.mock("$lib/storage/working-copy", () => ({
+  saveSession: vi.fn(),
+  clearSession: vi.fn(),
+}));
+
+/**
+ * A successful server save must leave the layout clean regardless of which
+ * path performed it. The debounced auto-save and the manual save share
+ * finalizeSuccessfulSave, so a successful auto-save matches a manual one:
+ * dirty cleared, failure counter reset, lingering error toast dismissed.
+ * A failed save must NOT clear the dirty flag. Regression guard for #2057.
+ */
+describe("successful save epilogue", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetToastStore();
+    resetPersistenceManager();
+    setApiAvailable(true);
+  });
+
+  it("clears the dirty flag on save success", () => {
+    const layoutStore = getLayoutStore();
+    layoutStore.markDirty();
+    expect(layoutStore.isDirty).toBe(true);
+
+    finalizeSuccessfulSave();
+
+    expect(layoutStore.isDirty).toBe(false);
+  });
+
+  it("resets the consecutive-failure counter and dismisses the error toast", () => {
+    // Two failures leave a counter and a lingering error toast behind.
+    handlePersistenceError(new PersistenceError("boom", 503), true);
+    handlePersistenceError(new PersistenceError("boom", 503), true);
+    expect(getConsecutiveSaveFailures()).toBeGreaterThan(0);
+    const errorToast = getToastStore().toasts.at(-1);
+    expect(errorToast).toBeDefined();
+
+    finalizeSuccessfulSave();
+
+    expect(getConsecutiveSaveFailures()).toBe(0);
+    expect(
+      getToastStore().toasts.some((t) => t.id === errorToast?.id),
+    ).toBe(false);
+  });
+
+  it("leaves the layout dirty when a save fails", () => {
+    const layoutStore = getLayoutStore();
+    layoutStore.markDirty();
+
+    handlePersistenceError(new PersistenceError("boom", 503), true);
+
+    expect(layoutStore.isDirty).toBe(true);
+  });
+});

--- a/src/tests/persistence-manager-autosave.test.ts
+++ b/src/tests/persistence-manager-autosave.test.ts
@@ -65,4 +65,17 @@ describe("successful save epilogue", () => {
 
     expect(layoutStore.isDirty).toBe(true);
   });
+
+  it("records server health but preserves dirty state on a stale save", () => {
+    const layoutStore = getLayoutStore();
+    // A prior failure leaves a counter and error toast behind.
+    handlePersistenceError(new PersistenceError("boom", 503), true);
+    layoutStore.markDirty();
+
+    // Stale completion: the save succeeded, but newer edits arrived in flight.
+    finalizeSuccessfulSave(false);
+
+    expect(getConsecutiveSaveFailures()).toBe(0); // server health recorded
+    expect(layoutStore.isDirty).toBe(true); // newer unsaved edits preserved
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

The debounced server auto-save path (`Effect 2` in `manager.svelte.ts`) set save status, reset the failure counter, dismissed the error toast, and cleared the session on success, but never called `markClean()` (or `cancelSessionSave()`). The manual path (`handleSaveToServer`) did. So after a successful auto-save the layout stayed dirty, and unsaved-changes warnings plus any dirty-driven UI reported pending changes already on the server.

## Fix

Extract the shared success epilogue into `finalizeSuccessfulSave()` and call it from both the manual and auto-save success paths. A successful auto-save now leaves the layout in the same state as a successful manual save: clean, failure counter reset, API marked available, session cancelled and cleared, lingering error toast dismissed.

## Acceptance Criteria
- [x] Auto-save success runs the same post-save sequence as `handleSaveToServer` (both call `finalizeSuccessfulSave`)
- [x] Covered by a store-level test (dirty cleared after save success, failure counter reset, error toast dismissed; dirty preserved on failure)

## Test Plan
- [x] New `src/tests/persistence-manager-autosave.test.ts` (3 tests)
- [x] `npm run lint` clean, `npm run build` clean
- [x] Storage/persistence suites pass (42 tests)

## Notes
#2037 reworks this branching with an explicit mode model; if it lands first it may subsume parts of this. Interim parity fix.

Closes #2057


___

## **CodeAnt-AI Description**
**Keep the layout clean after a successful auto-save**

### What Changed
- Successful server saves now leave the layout marked as clean no matter whether the save was manual or triggered by auto-save
- Successful saves also reset the failure count, clear any lingering error toast, and keep the app marked as available
- A failed save still leaves unsaved changes in place

### Impact
`✅ Fewer unsaved-changes warnings after auto-save`
`✅ Clearer save status after recovery`
`✅ Less confusion between pending and already-saved changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
