### PR TITLE
chore: sync gh-dev skill (/code-review pre-PR + agent-mode push gate)

### DIFF
--- a/.claude/skills/gh-dev/SKILL.md
+++ b/.claude/skills/gh-dev/SKILL.md
@@ -77,14 +77,12 @@ Use `WORKTREE_DIR` variable and subshells `(cd "$WORKTREE_DIR" && ...)` for all 
 ## Branch Checkout Rules
 
 **NEVER in main directory:**
-
 ```bash
 git checkout <branch>      # Changes branch for ALL agents
 git switch <branch>        # Same problem
 ```
 
 **ALWAYS use worktrees:**
-
 ```bash
 git worktree add .worktree/${REPO_NAME}-issue-<N> -b <type>/<N>-<desc>
 ```
@@ -125,17 +123,23 @@ START
                          Run verification
                                │
                                ▼
-                    ┌──── CodeRabbit Review ◀───┐
+                    ┌──── /code-review ◀────────┐
                     │          │                │
-                    │    Issues found?          │
+                    │    Findings?              │
                     │     yes      no           │
                     │      │       │            │
                     │      ▼       ▼            │
                     │   Fix all  Commit ────────┘
-                    │   issues     │
+                    │   findings   │
                     │      │       ▼
-                    └──────┘   Create PR
-                               │
+                    └──────┘   Push (pre-push
+                               CodeRabbit --agent
+                               gate; --no-verify
+                               only if transient)
+                                   │
+                                   ▼
+                               Create PR
+                                   │
                     ┌──────────┴──────────┐
                     ▼                     ▼
                  Success              Blocked
@@ -194,11 +198,11 @@ gh issue view <N> --json number,title,body,labels,assignees
 
 ### 2b. Complexity Assessment
 
-| Criteria       | Simple       | Complex                |
-| -------------- | ------------ | ---------------------- |
-| Size label     | `size:small` | `size:medium+`         |
-| Files affected | ≤3           | >3                     |
-| Type           | Bug fix      | Feature, architectural |
+| Criteria | Simple | Complex |
+|----------|--------|---------|
+| Size label | `size:small` | `size:medium+` |
+| Files affected | ≤3 | >3 |
+| Type | Bug fix | Feature, architectural |
 
 **Simple:** Proceed to Phase 3.
 **Complex:** Use Plan agent first.
@@ -230,84 +234,93 @@ Check CLAUDE.md for `### Verification Commands`. If found, run them:
 
 If not configured, skip or ask user.
 
-### 3d. CodeRabbit Review Loop
+### 3d. Local Code Review (before PR)
 
-**MANDATORY:** Run CodeRabbit review before committing. Address ALL feedback before proceeding.
+**MANDATORY before opening a PR.** Review the diff and resolve findings before pushing.
+
+**Do NOT run the CodeRabbit CLI here.** Repos that gate on CodeRabbit run it at push
+time via a pre-push hook in agent mode (see 3f). Running it manually first doubles the work.
 
 ```
 ┌─────────────────────────────────────────┐
-│          CODERABBIT REVIEW LOOP         │
+│            CODE REVIEW LOOP             │
 ├─────────────────────────────────────────┤
 │                                         │
-│  1. Run coderabbit review               │
+│  1. Run /code-review (or fallback)      │
 │         │                               │
 │         ▼                               │
-│  2. Issues found? ──no──▶ Proceed to    │
-│         │                   commit      │
+│  2. Findings? ──no──▶ Proceed to commit │
+│         │                               │
 │        yes                              │
+│         ▼                               │
+│  3. Fix each finding                    │
 │         │                               │
 │         ▼                               │
-│  3. Create tasks from feedback          │
-│         │                               │
-│         ▼                               │
-│  4. Implement fixes                     │
-│         │                               │
-│         ▼                               │
-│  5. Re-run verification commands        │
+│  4. Re-run verification commands        │
 │         │                               │
 │         └────────▶ Back to step 1       │
 │                                         │
 └─────────────────────────────────────────┘
 ```
 
-**Step 1: Run CodeRabbit**
+**Step 1: Run the review (auto-detect)**
 
-```bash
-(cd "$WORKTREE_DIR" && coderabbit --agent --type uncommitted 2>&1)
-```
+- **Preferred:** if a `/code-review` command is available in this environment, use it.
+  It reviews the current diff for correctness bugs plus reuse/simplification/efficiency
+  cleanups.
+- **Fallback:** if `/code-review` is unavailable, use the repo's configured reviewer
+  (check CLAUDE.md `### Review Command`). If none, self-review the diff against the
+  issue's acceptance criteria.
 
-**Step 2: Parse Output**
+**Step 2: Fix findings**
 
-CodeRabbit returns structured feedback with:
+Address each finding. For multiple findings, track them as tasks and mark completed as
+you go.
 
-- `File:` - affected file path
-- `Line:` - line range
-- `Type:` - issue type (potential_issue, nitpick, etc.)
-- `Prompt for AI Agent:` - description of what to fix
+**Step 3: Re-verify**
 
-**Step 3: Create Tasks**
-
-For each issue found, create a task with:
-
-- Subject: Brief description from the prompt
-- Description: Full CodeRabbit feedback including file/line
-
-**Step 4: Implement Fixes**
-
-Address each task in order. Mark completed as you go.
-
-**Step 5: Re-verify**
-
-After fixing all issues:
-
-1. Run verification commands again (lint, test, build)
-2. Run coderabbit again to confirm fixes
-3. Only proceed when coderabbit returns no issues
+After fixing, re-run verification commands (lint, test, build), then re-review. Only
+proceed when the review is clean.
 
 **Exit Conditions:**
+- **Success:** review returns no findings → proceed to commit
+- **Max iterations (3):** if findings persist after 3 cycles, ask the user whether to
+  proceed or abort
 
-- **Success:** CodeRabbit returns "Review completed" with no issues → proceed to commit
-- **Max iterations (3):** If issues persist after 3 cycles, ask user whether to proceed or abort
-
-### 3e. Commit and Push
+### 3e. Commit
 
 ```bash
 (cd "$WORKTREE_DIR" && git add -A && git commit -m "<type>: <desc>
 
-Fixes #<N>" && git push -u origin <branch>)
+Fixes #<N>")
 ```
 
-### 3f. Create PR
+### 3f. Push (mind the pre-push gate)
+
+```bash
+(cd "$WORKTREE_DIR" && git push -u origin <branch>)
+```
+
+Many repos run a **pre-push hook** that gates the push on an AI review. Detect one:
+
+```bash
+{ [ -f .husky/pre-push ] || [ -f .git/hooks/pre-push ]; } && echo "pre-push gate present"
+```
+
+When present, the hook typically runs **CodeRabbit in agent mode**
+(`coderabbit review --agent`, default-deny) and blocks the push on real findings.
+
+**If the push is blocked, classify the cause:**
+
+| Cause | What to do |
+|-------|-----------|
+| Real review findings reported | Address them (loop back to 3d), then push again. |
+| Timeout, CLI unavailable, or unparseable output (infra failure, not findings) | Retry once with `git push --no-verify` to bypass the gate. |
+
+Only use `--no-verify` for transient/infrastructure failures. **Never** bypass to skip
+real findings.
+
+### 3g. Create PR
 
 ```bash
 (cd "$WORKTREE_DIR" && gh pr create \
@@ -321,14 +334,14 @@ Fixes #<N>" && git push -u origin <branch>)
 Closes #<N>")
 ```
 
-### 3g. Merge
+### 3h. Merge
 
 ```bash
 gh pr checks <PR> --watch
 gh pr merge <PR> --squash --delete-branch --auto
 ```
 
-### 3h. Cleanup
+### 3i. Cleanup
 
 ```bash
 # Release lock if label exists
@@ -358,7 +371,7 @@ Check for more issues:
 
 ## Blocker Handling
 
-1. Commit WIP: `git commit -m "wip: partial #<N>" --no-verify && git push`
+1. Commit WIP: `git commit -m "wip: partial #<N>" --no-verify && git push --no-verify` (parking incomplete work; the review gate would block it)
 2. Release lock: `gh issue edit <N> --remove-label "in-progress"`
 3. Comment on issue with status, blocker, what was attempted
 4. Stop
@@ -371,17 +384,14 @@ If project has `## GitHub Workflow` section, read for:
 
 ### Verification Commands
 
-````markdown
+```markdown
 ### Verification Commands
-
 ```bash
 npm run lint
 npm run test:run
 npm run build
 ```
-````
-
-````
+```
 
 ### Branch Prefixes
 
@@ -390,14 +400,24 @@ npm run build
 - Bug: fix/
 - Feature: feat/
 - Chore: chore/
-````
+```
 
 ### Worktree Pattern
 
 ```markdown
 ### Worktree Pattern
-
 .worktree/<custom>-issue-<N>
+```
+
+### Review Command
+
+Used by step 3d when `/code-review` is unavailable in the environment.
+
+```markdown
+### Review Command
+```bash
+<repo-specific local review command>
+```
 ```
 
 ---
@@ -416,7 +436,6 @@ npm run build
 **Summary:** <what was done>
 
 **Files Changed:**
-
 - `file.ts`: <change>
 ```
 
@@ -429,10 +448,8 @@ npm run build
 **Blocked:** M issues
 
 **Completed:**
-
 1. #42: Title - PR #123
 
 **Blocked:**
-
 1. #44: Title - <reason>
 ```

--- a/.claude/skills/gh-dev/SKILL.md
+++ b/.claude/skills/gh-dev/SKILL.md
@@ -304,14 +304,22 @@ Fixes #<N>")
 (cd "$WORKTREE_DIR" && git push -u origin <branch>)
 ```
 
-Many repos run a **pre-push hook** that gates the push on an AI review. Detect one:
+Some repos run a **pre-push hook** that gates the push on a CodeRabbit review.
+Detect a *CodeRabbit* gate specifically (not just any pre-push hook):
 
 ```bash
-{ [ -f .husky/pre-push ] || [ -f .git/hooks/pre-push ]; } && echo "pre-push gate present"
+HOOK_FILE=""
+[ -f .husky/pre-push ] && HOOK_FILE=".husky/pre-push"
+[ -f .git/hooks/pre-push ] && HOOK_FILE=".git/hooks/pre-push"
+if [ -n "$HOOK_FILE" ] && grep -qi "coderabbit" "$HOOK_FILE"; then
+  echo "CodeRabbit pre-push gate detected"
+fi
 ```
 
-When present, the hook typically runs **CodeRabbit in agent mode**
+When present, the hook runs **CodeRabbit in agent mode**
 (`coderabbit review --agent`, default-deny) and blocks the push on real findings.
+The `--no-verify` fallback below applies **only to a CodeRabbit gate**. If a hook
+runs other checks (tests, lint), do not bypass them blindly.
 
 **If the push is blocked, classify the cause:**
 
@@ -386,14 +394,14 @@ If project has `## GitHub Workflow` section, read for:
 
 ### Verification Commands
 
-```markdown
+````markdown
 ### Verification Commands
 ```bash
 npm run lint
 npm run test:run
 npm run build
 ```
-```
+````
 
 ### Branch Prefixes
 
@@ -415,12 +423,12 @@ npm run build
 
 Used by step 3d when `/code-review` is unavailable in the environment.
 
-```markdown
+````markdown
 ### Review Command
 ```bash
 <repo-specific local review command>
 ```
-```
+````
 
 ---
 

--- a/.claude/skills/gh-dev/SKILL.md
+++ b/.claude/skills/gh-dev/SKILL.md
@@ -66,7 +66,8 @@ gh issue edit <N> --remove-label "in-progress"
 **MANDATORY:** Always create a worktree for issue work. Never work directly on main.
 
 ```bash
-git worktree add .worktree/${REPO_NAME}-issue-<N> -b <type>/<N>-<desc> origin/main
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+git worktree add .worktree/${REPO_NAME}-issue-<N> -b <type>/<N>-<desc> origin/${BASE_BRANCH}
 WORKTREE_DIR="$(pwd)/.worktree/${REPO_NAME}-issue-<N>"
 ```
 
@@ -164,8 +165,10 @@ START
 ```bash
 CURRENT=$(git branch --show-current)
 if [ "$CURRENT" != "main" ] && [ "$CURRENT" != "master" ]; then
-  echo "WARNING: Main directory on branch: $CURRENT"
-  git checkout main || git checkout master
+  echo "ABORT: Shared checkout is on '$CURRENT', not main/master."
+  echo "Do NOT switch branches here; other worktrees/agents may depend on it."
+  echo "Restore it manually, then re-run."
+  exit 1
 fi
 ```
 
@@ -347,8 +350,7 @@ gh pr merge <PR> --squash --delete-branch --auto
 # Release lock if label exists
 gh issue edit <N> --remove-label "in-progress" 2>/dev/null || true
 
-# Return to main, clean worktree
-git checkout main || git checkout master
+# Refresh main (shared checkout is already on main) and clean worktree
 git pull
 git worktree remove .worktree/${REPO_NAME}-issue-<N>
 git worktree prune


### PR DESCRIPTION
## **User description**
## Summary

Syncs the repo's committed copy of the `gh-dev` skill (`.claude/skills/gh-dev/SKILL.md`) up to the current global copy, so cloud sessions and the repo run the same workflow. The repo copy had drifted to a stale, pre-edit version.

What the workflow now does:

- **Step 3d** runs `/code-review` before opening a PR (auto-detected, with a self-review / repo-command fallback) instead of a manual CodeRabbit CLI loop.
- **Push step** is pre-push-gate aware: documents that the husky hook runs CodeRabbit in agent mode (default-deny via `scripts/coderabbit-review-gate.sh`), and that `git push --no-verify` is reserved for transient/infra failures (timeout, CLI unavailable, unparseable output), never to skip real findings.
- Renumbers Phase 3 subsections (3e-3i) and adds a `### Review Command` CLAUDE.md override for the `/code-review` fallback.

## Test Plan

- [x] Repo copy is byte-identical to the global `~/.claude/skills/gh-dev/SKILL.md`
- [x] Phase 3 subsection headers are sequential (3a-3i)
- [x] Guardrail pressure-tested with subagents: bypasses with `--no-verify` only on transient failures, refuses to bypass real findings
- [x] Pre-push CodeRabbit gate passed on this branch


___

## **CodeAnt-AI Description**
**Sync the gh-dev workflow with local code review and push gating**

### What Changed
- Replaces the old manual CodeRabbit review loop with a local review step that uses `/code-review` when available, or a repo-defined fallback when it is not
- Clarifies that push-time review gates can block the push, and that `--no-verify` is only for transient failures like timeouts or unavailable tooling
- Updates the workflow order and cleanup guidance so the review happens before PR creation, with clearer fallback and blocker handling instructions

### Impact
`✅ Fewer blocked pushes from avoidable review retries`
`✅ Clearer pre-PR review flow for contributors`
`✅ Safer bypass behavior during transient push failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
