### PR TITLE
fix: correct misleading circuit-open save toast copy (#2058, #2084)

### DIFF
--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -99,7 +99,7 @@ function handleSaveFailure(
       toastStore.dismissToast(_errorToastId);
     }
     _errorToastId = toastStore.showToast(
-      "Server save unavailable — working offline. Use Ctrl+S to retry.",
+      "Server unavailable. Working offline; changes saved locally. Reload to retry.",
       "warning",
       0,
       action,

--- a/src/tests/persistence-manager-circuit.test.ts
+++ b/src/tests/persistence-manager-circuit.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  handlePersistenceError,
+  resetPersistenceManager,
+} from "$lib/storage/manager.svelte";
+import { PersistenceError } from "$lib/storage/api";
+import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
+import { setApiAvailable } from "$lib/storage/availability.svelte";
+
+/**
+ * When the circuit breaker opens (3 consecutive offline failures), the toast
+ * must not promise a manual retry it cannot deliver. Ctrl+S falls back to an
+ * archive download while the API is unavailable, so the copy points at the
+ * working recovery path (reload) instead. Regression guard for #2058/#2084.
+ */
+describe("circuit-breaker offline toast", () => {
+  beforeEach(() => {
+    resetToastStore();
+    resetPersistenceManager();
+    setApiAvailable(true);
+  });
+
+  it("does not promise a Ctrl+S retry once the circuit is open", () => {
+    // Three consecutive 5xx failures trip the breaker.
+    for (let i = 0; i < 3; i++) {
+      handlePersistenceError(new PersistenceError("boom", 503), true);
+    }
+
+    const toast = getToastStore().toasts.at(-1);
+    expect(toast?.duration).toBe(0); // persistent
+    expect(toast?.message).not.toMatch(/Ctrl\+S/i);
+    expect(toast?.message).toMatch(/working offline/i);
+    expect(toast?.message).toMatch(/reload/i);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

When the circuit breaker marks the API unavailable after repeated save failures, the persistent toast said "Use Ctrl+S to retry". But Ctrl+S (`maybeSave`) gates on `shouldSaveToServer()` = `isApiAvailable()`, which is false while the breaker is open, so it silently downloads a YAML archive instead of retrying the server save.

While confirming the recovery path, I also found the 30s health poll (`Effect 3`) is itself guarded by `_consecutiveSaveFailures >= MAX_SAVE_FAILURES` and so does not run once the breaker is open. Nothing resets the failure counter except a successful save, so there is no timed auto-retry in this state either. The only recovery is a successful save (the toast's Retry action when present, or a reload).

Per maintainer decision, behaviour is left unchanged and the copy is corrected:

> Server unavailable. Working offline; changes saved locally. Reload to retry.

This also drops a stray em dash from the old string.

## Acceptance Criteria
- [x] Toast copy no longer promises a retry it cannot deliver (decision: correct the copy, keep behaviour)
- [x] Test covering the circuit-open toast copy

## Test Plan
- [x] New `src/tests/persistence-manager-circuit.test.ts`
- [x] `npm run lint` clean

## Notes
#2084 is a duplicate of this issue (same bug, same location); both closed here. #2037 reworks the save-mode model and will revisit this branch.

Closes #2058
Closes #2084


___

## **CodeAnt-AI Description**
**Correct the offline save toast when server retries are unavailable**

### What Changed
- When saving fails repeatedly and the app switches to offline mode, the persistent warning now says changes are saved locally and points users to reload instead of retrying with Ctrl+S.
- Added a regression test to ensure the offline toast no longer promises a retry that cannot work.

### Impact
`✅ Clearer offline save instructions`
`✅ Fewer misleading retry prompts`
`✅ Better protection against repeat save confusion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
