### PR TITLE
chore: cloud-safe superpowers bootstrap (CLAUDE.md + setup script)

### DIFF
--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -16,17 +16,20 @@
 #
 # Assumes `claude` is on PATH and authenticated in the environment.
 
-set -u
+set -euo pipefail
 
-# Add a marketplace only if not already known.
+# Add a marketplace only if its exact name is not already configured. Match the
+# quoted name in --json output so a substring (such as a source URL) cannot
+# falsely satisfy the check and skip the add.
 add_marketplace() {
-  claude plugin marketplace list 2>/dev/null | grep -qF "$1" ||
+  claude plugin marketplace list --json 2>/dev/null | grep -qF "\"$1\"" ||
     claude plugin marketplace add "$2"
 }
 
-# Install a plugin only if it is not already installed.
+# Install a plugin only if its exact id (plugin@marketplace) is not installed.
+# Match the quoted id in --json output, not a name prefix.
 install_plugin() {
-  claude plugin list --installed 2>/dev/null | grep -qF "${1%@*}" ||
+  claude plugin list --json 2>/dev/null | grep -qF "\"$1\"" ||
     claude plugin install "$1"
 }
 

--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Cloud setup script for Rackula on claude.ai/code.
+#
+# This is NOT a Claude Code hook. Paste its contents into the environment's
+# "Setup script" field in the claude.ai/code web UI (Environment settings).
+# It runs as root BEFORE Claude Code launches, which is the only point at which
+# plugins can be installed so their SessionStart hooks fire on the first session.
+#
+# Why this exists: in cloud sessions, plugins declared in committed
+# .claude/settings.json are silently ignored (no interactive trust dialog, and
+# the marketplace clone races session start). See anthropics/claude-code#63028.
+# Installing here, before launch, is the validated workaround.
+#
+# After the first session in an environment the filesystem is cached, so this
+# runs once and persists to later sessions.
+#
+# Assumes `claude` is on PATH and authenticated in the environment.
+
+set -u
+
+# Add a marketplace only if not already known.
+add_marketplace() {
+  claude plugin marketplace list 2>/dev/null | grep -qF "$1" ||
+    claude plugin marketplace add "$2"
+}
+
+# Install a plugin only if it is not already installed.
+install_plugin() {
+  claude plugin list --installed 2>/dev/null | grep -qF "${1%@*}" ||
+    claude plugin install "$1"
+}
+
+# Superpowers: skills library plus the using-superpowers SessionStart bootstrap.
+add_marketplace "superpowers-marketplace" "obra/superpowers-marketplace"
+install_plugin "superpowers@superpowers-marketplace"
+
+# code-review: Anthropic's official plugin marketplace.
+add_marketplace "claude-code-plugins" "https://github.com/anthropics/claude-code.git"
+install_plugin "code-review@claude-code-plugins"
+
+# claude-mem: best-effort. Verify the marketplace name resolves in cloud.
+add_marketplace "thedotmack" "thedotmack/claude-mem"
+install_plugin "claude-mem@thedotmack"
+
+echo "Rackula cloud plugins ready."

--- a/.claude/cloud-setup.sh
+++ b/.claude/cloud-setup.sh
@@ -34,12 +34,13 @@ install_plugin() {
 add_marketplace "superpowers-marketplace" "obra/superpowers-marketplace"
 install_plugin "superpowers@superpowers-marketplace"
 
-# code-review: Anthropic's official plugin marketplace.
+# code-review: Anthropic's official plugin marketplace. Stateless, useful in cloud.
 add_marketplace "claude-code-plugins" "https://github.com/anthropics/claude-code.git"
 install_plugin "code-review@claude-code-plugins"
 
-# claude-mem: best-effort. Verify the marketplace name resolves in cloud.
-add_marketplace "thedotmack" "thedotmack/claude-mem"
-install_plugin "claude-mem@thedotmack"
+# Note: claude-mem is deliberately NOT installed here. Its memory store is local
+# (~/.claude-mem, a localhost worker + SQLite/vector DB) with no sync, so a cloud
+# session would start with an empty database and any new observations would be
+# lost when the ephemeral container is torn down. Run it locally only.
 
 echo "Rackula cloud plugins ready."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,7 +514,8 @@ This section is the cloud-safe restatement of the superpowers bootstrap. In loca
 a SessionStart hook injects the using-superpowers skill automatically. In claude.ai/code
 cloud sessions that hook may not fire, because cloud does not auto-install plugins from
 committed settings (a known open issue, anthropics/claude-code#63028). To install the
-plugins in cloud, paste `.claude/cloud-setup.sh` into the environment Setup script field.
+plugins in cloud, paste the contents of `.claude/cloud-setup.sh` into the environment Setup
+script field.
 The core rule is restated here, where it is always read.
 
 Core rule: if there is even a small chance a skill applies, invoke it via the Skill tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,6 +510,18 @@ layoutDebug.device("placed device %s at U%d", slug, position);
 
 ## Skill Routing
 
+This section is the cloud-safe restatement of the superpowers bootstrap. In local sessions
+a SessionStart hook injects the using-superpowers skill automatically. In claude.ai/code
+cloud sessions that hook may not fire, because cloud does not auto-install plugins from
+committed settings (a known open issue, anthropics/claude-code#63028). To install the
+plugins in cloud, paste `.claude/cloud-setup.sh` into the environment Setup script field.
+The core rule is restated here, where it is always read.
+
+Core rule: if there is even a small chance a skill applies, invoke it via the Skill tool
+before responding, including before asking clarifying questions. Process skills such as
+`/superpowers:brainstorming` and `/superpowers:systematic-debugging` come before
+implementation skills.
+
 **Before starting any task, check if a skill applies:**
 
 | Task Type                 | Skill                                         | Why                                     |


### PR DESCRIPTION
## Summary

Makes the superpowers workflow usable in claude.ai/code cloud sessions, where plugins declared in committed `.claude/settings.json` are silently ignored (no trust dialog, and the marketplace clone races session start: anthropics/claude-code#63028). Result today: the `using-superpowers` SessionStart injection never fires in cloud.

Two-part fix:

- **`.claude/cloud-setup.sh`** (new): paste into the claude.ai/code environment Setup script field. It runs as root before Claude Code launches, which is the only point at which plugins install in time for their SessionStart hooks to fire on the first session. Idempotent; installs superpowers and code-review.
- **`CLAUDE.md`** (Skill Routing): restates the `using-superpowers` core rule where cloud always reads it, as a fallback that does not depend on the hook firing. Points to the setup script.

claude-mem is deliberately excluded from the cloud script: its memory store is local (`~/.claude-mem`, a localhost worker plus SQLite/vector DB) with no sync, so a cloud session would start empty and lose any new observations. It stays a local-only plugin.

## Background

Verified against primary sources:
- anthropics/claude-code#63028 (open): declared plugins inactive on first cloud session; only a session restart re-arms hooks.
- obra/superpowers#262 (closed not-planned): installing the plugin from inside a web agent hangs. The pre-launch setup script avoids that path.

## Test Plan

- [x] `bash -n` and `shellcheck` clean on cloud-setup.sh
- [x] Pre-push CodeRabbit gate passed
- [ ] Live cloud check: paste setup script into the environment, start a session, confirm the `<EXTREMELY_IMPORTANT> You have superpowers` block appears (hook fired) and `superpowers:brainstorming` is available (skills loaded)