### PR TITLE
fix: restore half-U stacking for 0.5U devices (#2152)

### DIFF
--- a/src/lib/utils/device-movement.ts
+++ b/src/lib/utils/device-movement.ts
@@ -61,17 +61,26 @@ export function findNextValidPosition(
     return { success: false, newPosition: null, reason: "no_valid_position" };
   }
 
-  // Movement increment in internal units:
-  // If stepOverride is provided (in human U), convert it; otherwise use 1U
-  const moveIncrementInternal = stepOverride
-    ? toInternalUnits(stepOverride)
-    : UNITS_PER_U;
+  // Device height in internal units (used for boundary checks and to detect
+  // 0.5U-class devices).
+  const deviceHeightInternal = heightToInternalUnits(deviceType.u_height);
+
+  // Movement increment in internal units.
+  // 0.5U-class devices (height an odd multiple of 1/2U) step by half a U so
+  // they snap to half-U boundaries (multiples of 3) and stack cleanly, never
+  // to 1/3U hole offsets. Whole-U devices keep the 1U default and respect the
+  // fine stepOverride (e.g. 1/3U via Shift+Arrow).
+  const isHalfU = deviceHeightInternal % UNITS_PER_U === UNITS_PER_U / 2;
+  const moveIncrementInternal = isHalfU
+    ? UNITS_PER_U / 2
+    : stepOverride
+      ? toInternalUnits(stepOverride)
+      : UNITS_PER_U;
 
   // Calculate initial target position (all positions are in internal units)
   let newPosition = placedDevice.position + direction * moveIncrementInternal;
 
   // Boundary values in internal units
-  const deviceHeightInternal = heightToInternalUnits(deviceType.u_height);
   const maxValidTop = rack.height * UNITS_PER_U + (UNITS_PER_U - 1);
 
   // Check if we're already at the boundary before any movement

--- a/src/lib/utils/dragdrop.ts
+++ b/src/lib/utils/dragdrop.ts
@@ -54,25 +54,36 @@ export type DropFeedback = "valid" | "invalid" | "blocked";
  * @param rackHeight - Rack height in U
  * @param uHeight - Height of one U in pixels
  * @param rackPadding - Top padding of rack SVG
- * @returns Target U position (1-indexed, 1 is at bottom)
+ * @param snapHalfU - Snap to half-U slots (for 0.5U devices) instead of whole-U
+ * @returns Target U position (1-indexed, 1 is at bottom; X.5 when half-U snapping)
  */
 export function calculateDropPosition(
   mouseY: number,
   rackHeight: number,
   uHeight: number,
   _rackPadding: number,
+  snapHalfU: boolean = false,
 ): number {
   // SVG coordinate system: y=0 at top
   // U1 is at bottom, U{rackHeight} is at top
   // Total rack height in pixels = rackHeight * uHeight
   const totalHeight = rackHeight * uHeight;
 
-  // Calculate which U the mouse is over
-  // mouseY=0 -> top -> U{rackHeight}
-  // mouseY=totalHeight -> bottom -> U1
-
   // First, clamp mouseY to valid range
   const clampedY = Math.max(0, Math.min(mouseY, totalHeight));
+
+  if (snapHalfU) {
+    // Sub-U devices (0.5U) snap to half-U slots: each U splits into a lower
+    // and an upper half. Half-slots are indexed from the top of the rack;
+    // an even slot is the upper half of its U, an odd slot the lower half.
+    const halfSlot = Math.min(
+      Math.floor(clampedY / (uHeight / 2)),
+      rackHeight * 2 - 1,
+    );
+    const uNum = rackHeight - Math.floor(halfSlot / 2);
+    const bottom = halfSlot % 2 === 0 ? uNum + 0.5 : uNum;
+    return Math.max(1, Math.min(bottom, rackHeight + 0.5));
+  }
 
   // Calculate U from bottom (U1 = bottom)
   // At y=totalHeight, U=1. At y=0, U=rackHeight

--- a/src/lib/utils/rack-drop-coordinator.ts
+++ b/src/lib/utils/rack-drop-coordinator.ts
@@ -172,6 +172,7 @@ export function resolveDropTarget(
     dims.rackHeight,
     dims.uHeight,
     dims.rackPadding,
+    !Number.isInteger(device.u_height),
   );
 
   const deviceSlotWidth = device.slot_width ?? 2;
@@ -242,6 +243,7 @@ export function resolveDropAction(
     dims.rackHeight,
     dims.uHeight,
     dims.rackPadding,
+    !Number.isInteger(dragData.device.u_height),
   );
 
   const deviceSlotWidth = dragData.device.slot_width ?? 2;

--- a/src/tests/device-movement.test.ts
+++ b/src/tests/device-movement.test.ts
@@ -11,7 +11,7 @@ import {
   getDeviceWithType,
 } from "$lib/utils/device-movement";
 import type { Rack, DeviceType, PlacedDevice } from "$lib/types";
-import { toInternalUnits } from "$lib/utils/position";
+import { toInternalUnits, UNITS_PER_U } from "$lib/utils/position";
 
 // Helper to create a placed device with internal unit position
 function pd(
@@ -324,38 +324,39 @@ describe("Device Movement Utility", () => {
       });
     });
 
-    describe("0.5U Device Support", () => {
-      it("moves 0.5U device up by 1U (consistent step size)", () => {
+    describe("0.5U Device Support (#2152: snaps to half-U, not 1/3U)", () => {
+      it("moves a 0.5U device up by half a U onto a half-U boundary", () => {
         const rack = createTestRack(42, [pd("half-u-patch", 10, "front")]);
         const deviceTypes = createDeviceTypes();
 
         const result = findNextValidPosition(rack, deviceTypes, 0, 1);
 
         expect(result.success).toBe(true);
-        expect(result.newPosition).toBe(toInternalUnits(11));
-        expect(result.reason).toBe("moved");
+        expect(result.newPosition).toBe(toInternalUnits(10.5));
+        // half-U boundaries are multiples of 3 internal units
+        expect(result.newPosition! % (UNITS_PER_U / 2)).toBe(0);
       });
 
-      it("moves 0.5U device down by 1U (consistent step size)", () => {
+      it("moves a 0.5U device down by half a U", () => {
         const rack = createTestRack(42, [pd("half-u-patch", 10.5, "front")]);
         const deviceTypes = createDeviceTypes();
 
         const result = findNextValidPosition(rack, deviceTypes, 0, -1);
 
         expect(result.success).toBe(true);
-        expect(result.newPosition).toBe(toInternalUnits(9.5));
-        expect(result.reason).toBe("moved");
+        expect(result.newPosition).toBe(toInternalUnits(10));
       });
 
-      it("uses stepOverride for sub-U movement (0.5U)", () => {
-        const rack = createTestRack(42, [pd("half-u-patch", 10, "front")]);
+      it("never lands a 0.5U device on a 1/3U offset, even with a 1/3U fine step", () => {
+        const rack = createTestRack(42, [pd("half-u-patch", 5, "front")]);
         const deviceTypes = createDeviceTypes();
 
-        const result = findNextValidPosition(rack, deviceTypes, 0, 1, 0.5);
+        // A 1/3U step would land at internal 32 (U5 1/3); half-U snapping forces 33 (U5 1/2)
+        const result = findNextValidPosition(rack, deviceTypes, 0, 1, 1 / 3);
 
         expect(result.success).toBe(true);
-        expect(result.newPosition).toBe(toInternalUnits(10.5));
-        expect(result.reason).toBe("moved");
+        expect(result.newPosition).toBe(toInternalUnits(5.5));
+        expect(result.newPosition! % (UNITS_PER_U / 2)).toBe(0);
       });
     });
 

--- a/src/tests/dragdrop.test.ts
+++ b/src/tests/dragdrop.test.ts
@@ -93,6 +93,26 @@ describe("Drag and Drop Utilities", () => {
     });
   });
 
+  describe("calculateDropPosition half-U snapping (#2152)", () => {
+    // 12U rack, U_HEIGHT=22, totalHeight=264. y=0 is U12 (top), y=264 is U1.
+    // The U5 band spans y in [154, 176): upper half [154, 165), lower half [165, 176).
+
+    it("snaps a 0.5U device to the upper half when the cursor is in the upper part of a U", () => {
+      const position = calculateDropPosition(160, 12, U_HEIGHT, RACK_PADDING, true);
+      expect(position).toBe(5.5);
+    });
+
+    it("snaps a 0.5U device to the lower half when the cursor is in the lower part of a U", () => {
+      const position = calculateDropPosition(170, 12, U_HEIGHT, RACK_PADDING, true);
+      expect(position).toBe(5);
+    });
+
+    it("leaves whole-U devices on whole-U boundaries when snapHalfU is false", () => {
+      const position = calculateDropPosition(160, 12, U_HEIGHT, RACK_PADDING, false);
+      expect(position).toBe(5);
+    });
+  });
+
   describe("getDropFeedback", () => {
     const mockDevice: DeviceType = {
       slug: "device-1",

--- a/src/tests/half-u-stacking.test.ts
+++ b/src/tests/half-u-stacking.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Half-U stacking (#2152)
+ *
+ * Two 0.5U devices (e.g. Mikrotik RB5009) must be able to share a single U as
+ * the lower and upper half. These end-to-end guards exercise the store,
+ * collision, undo, and share round-trip so the stacked pair survives intact.
+ *
+ * This is a disposable M02 regression guard. The M03 carrier-first epic
+ * replaces sub-U placement and can delete this file wholesale.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getHistoryStore,
+  resetHistoryStore,
+} from "$lib/stores/history.svelte";
+import { encodeLayout, decodeLayout } from "$lib/utils/share";
+import { toInternalUnits, UNITS_PER_U } from "$lib/utils/position";
+import { createTestDeviceType } from "./factories";
+
+const HALF_U = UNITS_PER_U / 2; // 3 internal units
+
+function setup() {
+  const store = getLayoutStore();
+  if (!store) throw new Error("getLayoutStore() returned null");
+  const rack = store.addRack("Test Rack", 42);
+  if (!rack) throw new Error("addRack() failed");
+  store.addDeviceTypeRaw(
+    createTestDeviceType({
+      slug: "rb5009",
+      model: "RB5009",
+      u_height: 0.5,
+      category: "network",
+    }),
+  );
+  return { store, rackId: rack.id };
+}
+
+function sortedPositions(store: ReturnType<typeof getLayoutStore>): number[] {
+  return store!.layout.racks[0]!.devices
+    .map((d) => d.position)
+    .sort((a, b) => a - b);
+}
+
+describe("half-U stacking (#2152)", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetHistoryStore();
+  });
+
+  it("stacks two 0.5U devices as the lower and upper half of one U", () => {
+    const { store, rackId } = setup();
+
+    expect(store.placeDevice(rackId, "rb5009", 5)).toBe(true); // lower half U5
+    expect(store.placeDevice(rackId, "rb5009", 5.5)).toBe(true); // upper half U5
+
+    const positions = sortedPositions(store);
+    expect(positions).toEqual([toInternalUnits(5), toInternalUnits(5.5)]); // [30, 33]
+    // Both sit on half-U boundaries (multiples of 3), never a 1/3U-only offset.
+    for (const p of positions) {
+      expect(p % HALF_U).toBe(0);
+    }
+  });
+
+  it("rejects a third 0.5U device once both halves of a U are filled", () => {
+    const { store, rackId } = setup();
+    store.placeDevice(rackId, "rb5009", 5);
+    store.placeDevice(rackId, "rb5009", 5.5);
+
+    expect(store.placeDevice(rackId, "rb5009", 5)).toBe(false);
+    expect(store.placeDevice(rackId, "rb5009", 5.5)).toBe(false);
+    expect(sortedPositions(store)).toEqual([
+      toInternalUnits(5),
+      toInternalUnits(5.5),
+    ]);
+  });
+
+  it("undo removes the upper-half device and restores the prior state", () => {
+    const { store, rackId } = setup();
+    store.placeDevice(rackId, "rb5009", 5);
+    store.placeDevice(rackId, "rb5009", 5.5);
+
+    expect(getHistoryStore().undo()).toBe(true);
+
+    expect(sortedPositions(store)).toEqual([toInternalUnits(5)]);
+  });
+
+  it("preserves the stacked pair across a share encode/decode round-trip", () => {
+    const { store, rackId } = setup();
+    store.placeDevice(rackId, "rb5009", 5);
+    store.placeDevice(rackId, "rb5009", 5.5);
+
+    const encoded = encodeLayout(store.layout);
+    expect(encoded).toBeTruthy();
+    const { layout } = decodeLayout(encoded!);
+    expect(layout).not.toBeNull();
+
+    const positions = layout!.racks[0]!.devices
+      .map((d) => d.position)
+      .sort((a, b) => a - b);
+    expect(positions).toEqual([toInternalUnits(5), toInternalUnits(5.5)]);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Restores the ability to place two 0.5U devices (e.g. Mikrotik RB5009) in the same U as a lower/upper half. They had regressed to scattering across 1/3U hole offsets ("U5 1/3" / "U4 2/3") instead of stacking as "U5" / "U5 1/2".

This is the narrow, disposable M02 regression patch. The structural fix lives in the separate M03 carrier-first epic (`docs/superpowers/specs/2026-06-12-carrier-first-sub-u-design.md`) and is not touched here.

## Root cause

Input snapping only. The collision model and the internal 6-unit grid already support two 0.5U devices at internal 30 and 33 (they do not overlap, and a third is rejected). Nothing could land a device on the half-U boundary (internal multiples of 3):

- Drag: `calculateDropPosition` floored to whole-U.
- Keyboard: `findNextValidPosition` stepped 1U (default, #793) or 1/3U (Shift, #762), so a 0.5U device only reached whole-U or 1/3U-hole offsets.

## Changes

- `dragdrop.ts`: `calculateDropPosition` gains a `snapHalfU` flag that snaps the device bottom to half-U slots.
- `rack-drop-coordinator.ts`: both call sites pass `snapHalfU` for non-integer-height devices, covering native DnD, pointer drag, touch, and click-to-place.
- `device-movement.ts`: `findNextValidPosition` steps 0.5U-class devices by half a U, ignoring the 1/3U fine override so they snap only to multiples of 3.

Whole-U devices are unaffected. Collision, position labels, and persistence are unchanged (internal 33 round-trips as U5 1/2).

## Tests

- `device-movement.test.ts`: 0.5U devices step to half-U boundaries, never 1/3U offsets.
- `dragdrop.test.ts`: `calculateDropPosition` half-U snapping (upper/lower half), whole-U unaffected.
- `half-u-stacking.test.ts` (new): end-to-end guards: two 0.5U devices stack in one U, a third is rejected, undo restores, and the pair survives a share round-trip.

Full suite: 2129 passed. Lint clean. Build passes.

Closes #2152


___

## **CodeAnt-AI Description**
**Restore half-U stacking for 0.5U devices**

### What Changed
- 0.5U devices now snap to the lower or upper half of a U instead of landing on 1/3U offsets
- Drag-and-drop, click-to-place, and keyboard movement all keep these devices on half-U boundaries
- A 1/3U fine step no longer moves 0.5U devices off the half-U grid
- Added regression tests to cover stacking, blocking a third device, undo, and share import/export

### Impact
`✅ Correct placement for 0.5U devices`
`✅ Fewer failed or misplaced drag-and-drop actions`
`✅ Reliable share links for stacked sub-U layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
