### PR TITLE
fix: pre-push gate renders findings from per-finding NDJSON events (#2161)

### DIFF
--- a/scripts/coderabbit-review-gate.bats
+++ b/scripts/coderabbit-review-gate.bats
@@ -69,13 +69,17 @@ make_stub() {
 }
 
 @test "finding count is derived from events even if complete count disagrees" {
+  # Three finding events but the complete event claims 99: the reported count must
+  # come from the events (3), proving finding_count takes precedence over the
+  # complete event's number.
   make_stub '{"type":"finding","severity":"major","fileName":"src/foo.ts","line":1,"codegenInstructions":"bug one"}
 {"type":"finding","severity":"major","fileName":"src/bar.ts","line":2,"codegenInstructions":"bug two"}
 {"type":"finding","severity":"major","fileName":"src/baz.ts","line":3,"codegenInstructions":"bug three"}
-{"type":"complete","status":"review_completed","findings":3}' 0
+{"type":"complete","status":"review_completed","findings":99}' 0
   run env CODERABBIT_BIN="$STUB" "$GATE"
   [ "$status" -eq 1 ]
   [[ "$output" == *"3 issue"* ]]
+  [[ "$output" != *"99 issue"* ]]
   [[ "$output" == *"bug one"* ]]
   [[ "$output" == *"bug two"* ]]
   [[ "$output" == *"bug three"* ]]
@@ -103,6 +107,14 @@ make_stub() {
   run env CODERABBIT_BIN="$STUB" "$GATE"
   [ "$status" -eq 1 ]
   [[ "$output" == *"4 issue"* ]]
+}
+
+@test "unparseable complete count blocks the push (fail-safe), never passes" {
+  make_stub '{"type":"complete","status":"review_completed","findings":null}' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fail-safe"* ]]
+  [[ "$output" != *"No findings"* ]]
 }
 
 @test "non-recoverable error blocks the push (fail-safe)" {

--- a/scripts/coderabbit-review-gate.bats
+++ b/scripts/coderabbit-review-gate.bats
@@ -31,9 +31,9 @@ make_stub() {
   chmod +x "$STUB"
 }
 
-@test "clean review (empty findings) allows the push" {
+@test "clean review (zero findings) allows the push" {
   make_stub '{"type":"heartbeat","status":"reviewing"}
-{"type":"complete","status":"review_completed","findings":[]}' 0
+{"type":"complete","status":"review_completed","findings":0}' 0
   run env CODERABBIT_BIN="$STUB" "$GATE"
   [ "$status" -eq 0 ]
   [[ "$output" == *"No findings"* ]]
@@ -55,7 +55,9 @@ make_stub() {
 }
 
 @test "real findings block the push and surface each finding" {
-  make_stub '{"type":"complete","status":"review_completed","findings":[{"file":"src/foo.ts","line":42,"title":"possible null deref"},{"path":"src/bar.ts","message":"unused import"}]}' 0
+  make_stub '{"type":"finding","severity":"major","fileName":"src/foo.ts","line":42,"codegenInstructions":"possible null deref"}
+{"type":"finding","severity":"minor","fileName":"src/bar.ts","codegenInstructions":"unused import"}
+{"type":"complete","status":"review_completed","findings":2}' 0
   run env CODERABBIT_BIN="$STUB" "$GATE"
   [ "$status" -eq 1 ]
   [[ "$output" == *"2 issue"* ]]
@@ -66,12 +68,41 @@ make_stub() {
   [[ "$output" == *"unused import"* ]]
 }
 
-@test "findings with an unfamiliar shape still surface as raw JSON" {
-  make_stub '{"type":"complete","status":"review_completed","findings":[{"weird":"x","nested":{"y":1}}]}' 0
+@test "finding count is derived from events even if complete count disagrees" {
+  make_stub '{"type":"finding","severity":"major","fileName":"src/foo.ts","line":1,"codegenInstructions":"bug one"}
+{"type":"finding","severity":"major","fileName":"src/bar.ts","line":2,"codegenInstructions":"bug two"}
+{"type":"finding","severity":"major","fileName":"src/baz.ts","line":3,"codegenInstructions":"bug three"}
+{"type":"complete","status":"review_completed","findings":3}' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"3 issue"* ]]
+  [[ "$output" == *"bug one"* ]]
+  [[ "$output" == *"bug two"* ]]
+  [[ "$output" == *"bug three"* ]]
+}
+
+@test "findings with an unfamiliar shape still surface" {
+  make_stub '{"type":"finding","weird":"x","nested":{"y":1}}
+{"type":"complete","status":"review_completed","findings":1}' 0
   run env CODERABBIT_BIN="$STUB" "$GATE"
   [ "$status" -eq 1 ]
   [[ "$output" == *"1 issue"* ]]
   [[ "$output" == *"weird"* ]]
+}
+
+@test "positive complete count with no finding events blocks without faking detail" {
+  make_stub '{"type":"complete","status":"review_completed","findings":4}' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"4 issue"* ]]
+  [[ "$output" == *"emitted no detail"* ]]
+}
+
+@test "string-typed complete count still blocks the push" {
+  make_stub '{"type":"complete","status":"review_completed","findings":"4"}' 0
+  run env CODERABBIT_BIN="$STUB" "$GATE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"4 issue"* ]]
 }
 
 @test "non-recoverable error blocks the push (fail-safe)" {

--- a/scripts/coderabbit-review-gate.sh
+++ b/scripts/coderabbit-review-gate.sh
@@ -3,11 +3,13 @@
 # errors apart from real review findings.
 #
 # Runs `coderabbit review --agent` (NDJSON output) and decides whether to block
-# the push by inspecting the emitted events:
+# the push by inspecting the emitted events. The CLI emits one event per finding
+# and a terminal "complete" event whose `findings` field is the COUNT:
 #
-#   {"type":"complete","status":"review_completed","findings":[...]}
-#       findings == []  -> clean pass        (exit 0)
-#       findings != []  -> real findings     (exit 1, BLOCK)
+#   {"type":"finding","severity":"major","fileName":"...","codegenInstructions":"..."}
+#   {"type":"complete","status":"review_completed","findings":<count>}
+#       count == 0  -> clean pass            (exit 0)
+#       count  > 0  -> real findings         (exit 1, BLOCK)
 #
 #   {"type":"error","errorType":"rate_limit","recoverable":true,...}
 #   {"type":"error","recoverable":true,...}        (any recoverable error)
@@ -63,19 +65,39 @@ fi
 decision=""
 note=""
 
-# Pull the terminal complete event, if any (last one wins). Keep the whole event
-# object so its findings can be surfaced verbatim when the push is blocked.
+# Pull the terminal complete event, if any (last one wins). Its presence is what
+# distinguishes a finished review from an interrupted/transient one.
 complete_event="$(printf '%s\n' "$output" \
   | jq -rc 'select(type=="object" and .type=="complete" and .status=="review_completed")' 2>/dev/null \
   | tail -n1)"
-complete_findings="$(printf '%s\n' "$complete_event" | jq -r '.findings | length' 2>/dev/null)"
 
-if [ -n "$complete_findings" ]; then
-  if [ "$complete_findings" -eq 0 ] 2>/dev/null; then
-    decision="pass"
-  else
+# Collect the per-finding events. The CLI emits each finding as its own event;
+# the complete event only carries a count. Count and render from these.
+finding_events="$(printf '%s\n' "$output" \
+  | jq -rc 'select(type=="object" and .type=="finding")' 2>/dev/null)"
+finding_count="$(printf '%s\n' "$finding_events" | grep -c '[^[:space:]]')"
+
+# Read the complete event's count (normally the integer 8, but tolerate a numeric
+# string too). This is a safety net so we never pass when the terminal event
+# reports findings but the individual finding events were missed: blocking on a
+# bad parse is safer than allowing a push past real findings.
+complete_count="$(printf '%s\n' "$complete_event" \
+  | jq -r '
+      .findings as $f
+      | if ($f | type) == "number" then $f
+        elif ($f | type) == "string" and ($f | test("^[0-9]+$")) then ($f | tonumber)
+        else 0 end' 2>/dev/null)"
+# Guarantee a clean integer so the arithmetic tests below cannot error.
+case "$complete_count" in
+  '' | *[!0-9]*) complete_count=0 ;;
+esac
+
+if [ -n "$complete_event" ]; then
+  if [ "$finding_count" -gt 0 ] || [ "$complete_count" -gt 0 ]; then
     decision="findings"
-    note="$complete_findings"
+    if [ "$finding_count" -gt 0 ]; then note="$finding_count"; else note="$complete_count"; fi
+  else
+    decision="pass"
   fi
 fi
 
@@ -115,21 +137,28 @@ case "$decision" in
     echo "CodeRabbit found ${note} issue(s). Push blocked." >&2
     echo "" >&2
     # Surface the actual findings, not just the count, so the developer can act
-    # on them without re-running the review (restores the pre-extraction hook
-    # behaviour). Best-effort render of common fields; fall back to the raw
-    # finding JSON when the shape is unfamiliar.
-    rendered="$(printf '%s\n' "$complete_event" | jq -r '
-        .findings[]
-        | "  - "
-          + (((.file // .path // .location.path) // "?") | tostring)
-          + (((.line // .location.line)) as $l | if $l != null then ":" + ($l | tostring) else "" end)
-          + "  "
-          + (((.title // .message // .description // .body) // (. | tojson)) | tostring)
+    # on them without re-running the review. Render each finding event as
+    # "severity file:line  summary". codegenInstructions can be long/multi-line,
+    # so collapse whitespace and trim. Fall back to raw JSON for unfamiliar shapes.
+    rendered="$(printf '%s\n' "$finding_events" | jq -r '
+        "  - "
+        + (if .severity then "[" + (.severity | tostring) + "] " else "" end)
+        + (((.fileName // .file // .path // .location.path) // "?") | tostring)
+        + (((.line // .location.line)) as $l | if $l != null then ":" + ($l | tostring) else "" end)
+        + "  "
+        + (((.codegenInstructions // .title // .message // .description // .body) // (. | tojson))
+            | tostring | gsub("\\s+"; " ") | .[0:200])
       ' 2>/dev/null)"
     if [ -n "$rendered" ]; then
       printf '%s\n' "$rendered" >&2
+    elif [ -n "${finding_events//[$'\t\r\n ']/}" ]; then
+      # Render failed but we have the raw events; dump them verbatim.
+      printf '%s\n' "$finding_events" >&2
     else
-      printf '%s\n' "$complete_event" | jq -rc '.findings[]' 2>/dev/null >&2
+      # The terminal count reported findings but no per-finding events were
+      # captured. Don't pretend to list them; point at the re-run instead.
+      echo "  (the review reported findings but emitted no detail to display;" >&2
+      echo "   re-run 'coderabbit review --agent --type committed --base ${base}' to see them)" >&2
     fi
     echo "" >&2
     echo "Fix the issues above or use 'git push --no-verify' to skip." >&2

--- a/scripts/coderabbit-review-gate.sh
+++ b/scripts/coderabbit-review-gate.sh
@@ -80,25 +80,31 @@ finding_count="$(printf '%s\n' "$finding_events" | grep -c '[^[:space:]]')"
 # Read the complete event's count (normally the integer 8, but tolerate a numeric
 # string too). This is a safety net so we never pass when the terminal event
 # reports findings but the individual finding events were missed: blocking on a
-# bad parse is safer than allowing a push past real findings.
+# bad parse is safer than allowing a push past real findings. An unreadable count
+# yields the sentinel -1, which is treated as ambiguous (block), never as zero.
 complete_count="$(printf '%s\n' "$complete_event" \
   | jq -r '
       .findings as $f
       | if ($f | type) == "number" then $f
         elif ($f | type) == "string" and ($f | test("^[0-9]+$")) then ($f | tonumber)
-        else 0 end' 2>/dev/null)"
-# Guarantee a clean integer so the arithmetic tests below cannot error.
+        else -1 end' 2>/dev/null)"
+# Guarantee a clean integer so the arithmetic tests below cannot error. Anything
+# that is not the -1 sentinel or a run of digits collapses to the -1 sentinel.
 case "$complete_count" in
-  '' | *[!0-9]*) complete_count=0 ;;
+  -1) ;;
+  '' | *[!0-9]*) complete_count=-1 ;;
 esac
 
 if [ -n "$complete_event" ]; then
   if [ "$finding_count" -gt 0 ] || [ "$complete_count" -gt 0 ]; then
     decision="findings"
     if [ "$finding_count" -gt 0 ]; then note="$finding_count"; else note="$complete_count"; fi
-  else
+  elif [ "$complete_count" -eq 0 ]; then
     decision="pass"
   fi
+  # else: a finished review whose count we could not read (-1 sentinel). Leave
+  # decision unset so the fail-safe block below blocks the push; an unreadable
+  # count is ambiguous, not a clean pass.
 fi
 
 # If there was no clean/findings verdict, look for a transient error event.


### PR DESCRIPTION
## **User description**
## Summary

`scripts/coderabbit-review-gate.sh` blocked correctly on real findings but printed "Fix the issues above" with nothing above. The CLI emits each finding as its own `finding` NDJSON event and the terminal `complete` event carries a numeric `findings` count. The gate did `.findings | length` on the complete event, which on the integer count returns the integer by luck (so the count was right), but `.findings[]` iterates a number and yields nothing, leaving the block empty.

## Changes

- Collect and count `finding` events; render each as `severity file:line  summary`, collapsing and trimming `codegenInstructions`.
- Read `complete.findings` as a numeric safety net (tolerating a numeric string) so a bad parse blocks rather than allows a push.
- When the count is positive but no detail events were captured, say so instead of printing a blank line.
- Update bats stubs to the real NDJSON shape and assert findings are surfaced; add coverage for the safety-net and string-count paths.

## Test Plan

- [x] `bats scripts/coderabbit-review-gate.bats` (12 passing)
- [x] `shellcheck scripts/coderabbit-review-gate.sh` clean

## Acceptance criteria

- [x] A blocked push prints each finding (severity + file + summary), not just a count
- [x] Count is derived from the actual events, not `.findings | length` on an integer
- [x] bats stubs match the real CLI NDJSON shape; tests assert findings are surfaced

Closes #2161

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show CodeRabbit review findings correctly when a push is blocked**

### What Changed
- Blocked pushes now show each review finding instead of only a count
- Findings are displayed with file location and a short summary so issues are actionable without re-running the review
- If the review reports findings but no detail is available, the gate now says that clearly instead of showing a blank list
- Reviews with zero findings still allow the push, and string-form counts are still treated as blocked reviews

### Impact
`✅ Clearer push-blocking review messages`
`✅ Fewer re-runs to find reported issues`
`✅ Safer handling of review results with missing details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
