### PR TITLE
fix: harden PUT layout UUID-mismatch guard against circular-anchor YAML (#2067)

### DIFF
--- a/api/src/routes/layouts.test.ts
+++ b/api/src/routes/layouts.test.ts
@@ -1,0 +1,146 @@
+/**
+ * PUT /layouts/:uuid UUID-mismatch guard tests (#2067)
+ *
+ * Covers:
+ * - Normal metadata.id matching URL uuid (accepted)
+ * - metadata.id differing from URL uuid (rejected 400)
+ * - Circular-anchor YAML bypassing JSON.stringify guard (rejected 400)
+ * - Invalid YAML (rejected 400, not silently skipped)
+ * - Body without metadata (accepted, no guard applies)
+ * - Save target derives from URL uuid, not metadata.id
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp } from "../app";
+import type { EnvMap } from "../security";
+
+type App = Awaited<ReturnType<typeof createApp>>;
+
+const URL_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const OTHER_UUID = "660e8400-e29b-41d4-a716-446655440001";
+
+const originalDataDir = process.env.DATA_DIR;
+let testDir: string;
+let app: App;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "rackula-layouts-test-"));
+  process.env.DATA_DIR = testDir;
+  app = await createApp({
+    NODE_ENV: "test",
+    DATA_DIR: testDir,
+    RACKULA_RATE_LIMIT_ENABLED: "false",
+  } satisfies EnvMap);
+});
+
+afterEach(async () => {
+  if (originalDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = originalDataDir;
+  }
+
+  try {
+    await rm(testDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup failures
+  }
+});
+
+function layoutYaml(name: string, metadataId?: string): string {
+  const metadata = metadataId
+    ? `\nmetadata:\n  id: "${metadataId}"\n  name: "${name}"\n  schema_version: "1.0.0"`
+    : "";
+  return `version: "1.0.0"\nname: ${name}${metadata}\nracks: []`;
+}
+
+async function putLayout(uuid: string, body: string): Promise<Response> {
+  return app.request(`/layouts/${uuid}`, {
+    method: "PUT",
+    headers: { "Content-Type": "text/yaml" },
+    body,
+  });
+}
+
+describe("PUT /layouts/:uuid UUID-mismatch guard", () => {
+  it("accepts a layout where metadata.id matches URL uuid", async () => {
+    const res = await putLayout(URL_UUID, layoutYaml("Test", URL_UUID));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.id).toBe(URL_UUID);
+  });
+
+  it("rejects a layout where metadata.id differs from URL uuid", async () => {
+    const res = await putLayout(URL_UUID, layoutYaml("Test", OTHER_UUID));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("UUID mismatch");
+    expect(data.error).toContain(URL_UUID);
+    expect(data.error).toContain(OTHER_UUID);
+  });
+
+  it("rejects circular-anchor YAML that would bypass JSON.stringify guard", async () => {
+    // Self-referential YAML anchor: the metadata object anchors itself with
+    // &meta and references itself via *meta, creating a circular JS object.
+    // Previously, JSON.stringify threw on this, the empty catch swallowed it,
+    // and the UUID-mismatch guard was silently bypassed (#2067).
+    // Using matching metadata.id so the UUID-mismatch guard alone would NOT
+    // reject this — only the circular-reference guard catches it.
+    const circularYaml = [
+      'version: "1.0.0"',
+      "name: Circular",
+      "metadata: &meta",
+      '  id: "550e8400-e29b-41d4-a716-446655440000"',
+      "  name: Circular",
+      '  schema_version: "1.0.0"',
+      "  selfref: *meta",
+      "racks: []",
+    ].join("\n");
+
+    const res = await putLayout(URL_UUID, circularYaml);
+    // The circular-reference guard must fire; UUID-mismatch would not catch
+    // this because metadata.id matches the URL uuid.
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("circular references");
+  });
+
+  it("rejects invalid YAML with 400, not silently skipping", async () => {
+    const res = await putLayout(URL_UUID, "}}invalid yaml{{{");
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Invalid YAML");
+  });
+
+  it("accepts a layout without metadata section", async () => {
+    const res = await putLayout(URL_UUID, layoutYaml("No Metadata"));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.id).toBe(URL_UUID);
+  });
+});
+
+describe("PUT /layouts/:uuid save target derives from URL uuid", () => {
+  it("saves layout under the URL uuid, not the metadata.id", async () => {
+    // Even when metadata.id matches, the URL uuid should be authoritative
+    const res = await putLayout(URL_UUID, layoutYaml("Test", URL_UUID));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.id).toBe(URL_UUID);
+  });
+
+  it("does not create a layout folder under a mismatched metadata.id", async () => {
+    // PUT with a mismatched metadata.id must be rejected before saveLayout
+    const res = await putLayout(URL_UUID, layoutYaml("Test", OTHER_UUID));
+    expect(res.status).toBe(400);
+
+    // Verify no folder was created for either UUID
+    const entries = await readdir(testDir);
+    const otherFolder = entries.find((e) =>
+      e.toLowerCase().includes(OTHER_UUID.toLowerCase()),
+    );
+    expect(otherFolder).toBeUndefined();
+  });
+});

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -88,31 +88,43 @@ layouts.put("/:uuid", async (c) => {
     }
 
     // Validate that metadata.id matches the URL uuid (if metadata exists)
-    // This prevents accidentally overwriting a different layout
+    // This prevents accidentally overwriting a different layout.
+    // Parse once, read metadata.id directly — no JSON.stringify round-trip,
+    // which would throw on cyclic objects from YAML anchors and silently
+    // bypass this guard (see #2067).
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(
-        JSON.stringify(
-          await import("js-yaml").then((y) =>
-            y.load(yamlContent, { schema: y.JSON_SCHEMA }),
-          ),
-        ),
-      );
-      const layout = LayoutFileSchema.safeParse(parsed);
-      if (layout.success && layout.data.metadata?.id) {
-        if (
-          layout.data.metadata.id.toLowerCase() !==
-          uuidResult.data.toLowerCase()
-        ) {
-          return c.json(
-            {
-              error: `UUID mismatch: URL has ${uuidResult.data} but metadata.id has ${layout.data.metadata.id}`,
-            },
-            400,
-          );
-        }
-      }
+      parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return c.json({ error: `Invalid YAML: ${message}` }, 400);
+    }
+
+    // Reject non-serializable bodies (circular references from anchors)
+    try {
+      JSON.stringify(parsed);
     } catch {
-      // If we can't parse, let saveLayout handle the error
+      return c.json(
+        {
+          error:
+            "YAML body contains circular references and cannot be processed",
+        },
+        400,
+      );
+    }
+
+    const layout = LayoutFileSchema.safeParse(parsed);
+    if (layout.success && layout.data.metadata?.id) {
+      if (
+        layout.data.metadata.id.toLowerCase() !== uuidResult.data.toLowerCase()
+      ) {
+        return c.json(
+          {
+            error: `UUID mismatch: URL has ${uuidResult.data} but metadata.id has ${layout.data.metadata.id}`,
+          },
+          400,
+        );
+      }
     }
 
     const result = await saveLayout(

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -676,11 +676,12 @@ export async function saveLayout(
     throw new Error(`Invalid layout metadata: ${issues}`);
   }
 
-  // Determine UUID: use validated metadata.id > existingId > generate new
-  // Validate metadata.id before using it to prevent malformed UUIDs
+  // Determine UUID: prefer existingId (from URL) > validated metadata.id > generate new.
+  // The URL uuid is authoritative; metadata.id is used only for new layouts
+  // where no URL uuid is available yet.
   const metadataId = layout.data.metadata?.id;
   const validMetadataId = metadataId && isUuid(metadataId) ? metadataId : null;
-  const uuid = validMetadataId ?? existingUuid ?? crypto.randomUUID();
+  const uuid = existingUuid ?? validMetadataId ?? crypto.randomUUID();
   const layoutName = layout.data.metadata?.name ?? layout.data.name;
 
   const folderName = buildFolderName(layoutName, uuid);


### PR DESCRIPTION
## **User description**
## Summary

- The PUT `/layouts/:uuid` handler guarded against `metadata.id` mismatches by wrapping `yaml.load()` in `JSON.parse(JSON.stringify(...))`. A YAML body with self-referential anchors (`&meta` / `*meta`) makes `yaml.load()` return a cyclic object; `JSON.stringify` throws on it, and the empty `catch` swallowed the error, silently bypassing the guard. An authorised writer could overwrite a different layout folder than the URL addresses.
- Parse YAML once with `JSON_SCHEMA`, then check serialisability with `JSON.stringify` in a separate `try/catch` that returns 400 for circular references instead of silently swallowing.
- Invalid YAML now returns 400 at the route level rather than being deferred to `saveLayout`.
- `saveLayout` now prefers the URL uuid (`existingId`) over `metadata.id`, so the URL is always the authoritative save target (defense in depth).
- Removed the redundant dynamic `await import("js-yaml")` — the static import was already present at the top of the file.

## Test Plan

- [x] Circular-anchor YAML with matching metadata.id returns 400 (circular-reference guard fires independently)
- [x] Mismatched metadata.id returns 400 with "UUID mismatch" error
- [x] Matching metadata.id returns 201 (happy path)
- [x] Invalid YAML returns 400 (not silently skipped)
- [x] Layout without metadata section returns 201 (no guard applies)
- [x] Save target derives from URL uuid, not metadata.id
- [x] No folder created for mismatched metadata.id (rejected before saveLayout)
- [x] All 273 existing API tests pass
- [x] Lint clean

Closes #2067


___

## **CodeAnt-AI Description**
**Prevent layout saves from bypassing the UUID check**

### What Changed
- PUT requests for layouts now reject YAML bodies with circular references instead of skipping the UUID check
- Invalid YAML now returns a clear 400 error at the request level
- Layout saves always use the UUID from the URL, so a mismatched `metadata.id` cannot redirect the save to another folder
- Added coverage for matching IDs, mismatched IDs, circular YAML, invalid YAML, and layouts without metadata

### Impact
`✅ Fewer accidental layout overwrites`
`✅ Clearer layout upload errors`
`✅ Safer PUT layout updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
