### PR TITLE
fix: prevent keyboard nudge from ejecting contained devices (#2146)

### DIFF
--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -14,6 +14,7 @@
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { findNextValidPosition } from "$lib/utils/device-movement";
+  import { isContainerChild } from "$lib/utils/collision";
   import { toHumanUnits } from "$lib/utils/position";
   import type { SlotPosition } from "$lib/types";
   import { findDeviceType } from "$lib/utils/device-lookup";
@@ -320,6 +321,13 @@
     const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
     if (deviceIndex === null) return;
 
+    // Contained children use container-relative positions; nudging them with
+    // arrow keys would compute a rack-level U and eject them from the
+    // container. Block this at the keyboard entry point only — the store-level
+    // moveDevice path (used by drag-out) intentionally detaches.
+    const placedDevice = rack.devices[deviceIndex];
+    if (placedDevice && isContainerChild(placedDevice)) return;
+
     // Use shared utility to find next valid position
     const result = findNextValidPosition(
       rack,
@@ -363,6 +371,9 @@
 
     const placedDevice = rack.devices[deviceIndex];
     if (!placedDevice) return;
+
+    // Contained children should not be slot-nudged at rack level
+    if (isContainerChild(placedDevice)) return;
 
     // Get device type to check if half-width
     const deviceType = findDeviceType(

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -29,6 +29,7 @@ import type {
 import type { CreateDeviceTypeInput } from "$lib/stores/layout-helpers";
 import type { Command, CommandType } from "$lib/stores/commands/types";
 import { toInternalUnits } from "$lib/utils/position";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { resetHistoryStore } from "$lib/stores/history.svelte";
 import { generateId } from "$lib/utils/device";
@@ -412,6 +413,73 @@ export function createTestLayoutStore(
     store.setLayoutName(options.layoutName);
   }
   return store;
+}
+
+/**
+ * Seed the layout store with a 4U blade chassis (two half-width slots) holding
+ * one child device in the left slot, placed at U5 in a fresh rack. Mirrors the
+ * repeated contained-device setup in keyboard.test.ts so guard tests only
+ * declare the selection, key press, and assertions.
+ *
+ * @returns the rack id, container and child device ids, and the child's
+ *   container-relative position captured at setup (for no-op assertions).
+ */
+export function createBladeContainerWithChild(): {
+  rackId: string;
+  containerId: string;
+  childId: string;
+  childPosition: number;
+} {
+  const store = getLayoutStore();
+  if (!store) {
+    throw new Error(
+      "createBladeContainerWithChild: getLayoutStore() returned null",
+    );
+  }
+
+  const containerType = store.addDeviceType({
+    name: "Blade Chassis",
+    u_height: 4,
+    category: "server",
+    colour: CATEGORY_COLOURS.server,
+    slots: [
+      { id: "slot-left", name: "Left", position: { row: 0, col: 0 } },
+      { id: "slot-right", name: "Right", position: { row: 0, col: 1 } },
+    ],
+  });
+  const childType = store.addDeviceType({
+    name: "Blade Server",
+    u_height: 1,
+    category: "server",
+    colour: CATEGORY_COLOURS.server,
+  });
+
+  const rack = store.addRack("Test Rack", 42);
+  const rackId = rack!.id;
+
+  store.placeDevice(rackId, containerType.slug, 5);
+  const containerDevice = store.rack!.devices.find(
+    (d) => d.device_type === containerType.slug,
+  )!;
+
+  store.placeInContainer(
+    rackId,
+    childType.slug,
+    containerDevice.id,
+    "slot-left",
+    0,
+  );
+
+  const childDevice = store.rack!.devices.find(
+    (d) => d.container_id === containerDevice.id,
+  )!;
+
+  return {
+    rackId,
+    containerId: containerDevice.id,
+    childId: childDevice.id,
+    childPosition: childDevice.position,
+  };
 }
 
 // =============================================================================

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -443,8 +443,8 @@ export function createBladeContainerWithChild(): {
     category: "server",
     colour: CATEGORY_COLOURS.server,
     slots: [
-      { id: "slot-left", name: "Left", position: { row: 0, col: 0 } },
-      { id: "slot-right", name: "Right", position: { row: 0, col: 1 } },
+      { id: "slot-left", name: "Left", position: { row: 0, col: 0 }, width_fraction: 0.5 },
+      { id: "slot-right", name: "Right", position: { row: 0, col: 1 }, width_fraction: 0.5 },
     ],
   });
   const childType = store.addDeviceType({
@@ -452,6 +452,7 @@ export function createBladeContainerWithChild(): {
     u_height: 1,
     category: "server",
     colour: CATEGORY_COLOURS.server,
+    slot_width: 1, // half-width, to fit the chassis's half-width slots
   });
 
   const rack = store.addRack("Test Rack", 42);

--- a/src/tests/keyboard.test.ts
+++ b/src/tests/keyboard.test.ts
@@ -14,7 +14,10 @@ import {
 import { getUIStore, resetUIStore } from "$lib/stores/ui.svelte";
 import { CATEGORY_COLOURS } from "$lib/types/constants";
 import { UNITS_PER_U, toInternalUnits } from "$lib/utils/position";
-import { setupStoreWithRack } from "./factories";
+import {
+  setupStoreWithRack,
+  createBladeContainerWithChild,
+} from "./factories";
 
 describe("Keyboard Utilities", () => {
   describe("shouldIgnoreKeyboard", () => {
@@ -786,51 +789,11 @@ describe("KeyboardHandler Component", () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
-      // Create a container device type (4U with 2 slots)
-      const containerType = layoutStore.addDeviceType({
-        name: "Blade Chassis",
-        u_height: 4,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-        slots: [
-          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
-          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
-        ],
-      });
-
-      // Create a child device type
-      const childType = layoutStore.addDeviceType({
-        name: "Blade Server",
-        u_height: 1,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-      });
-
-      const rack = layoutStore.addRack("Test Rack", 42);
-      const rackId = rack!.id;
-
-      // Place the container at U5
-      layoutStore.placeDevice(rackId, containerType.slug, 5);
-      const containerDevice = layoutStore.rack!.devices.find(
-        (d) => d.device_type === containerType.slug,
-      )!;
-
-      // Place a child inside the container
-      layoutStore.placeInContainer(
-        rackId,
-        childType.slug,
-        containerDevice.id,
-        "slot-left",
-        0,
-      );
-
-      const childDevice = layoutStore.rack!.devices.find(
-        (d) => d.container_id === containerDevice.id,
-      )!;
-      const childPosition = childDevice.position;
+      const { rackId, containerId, childId, childPosition } =
+        createBladeContainerWithChild();
 
       // Select the contained child
-      selectionStore.selectDevice(rackId, childDevice.id);
+      selectionStore.selectDevice(rackId, childId);
 
       render(KeyboardHandler);
 
@@ -838,229 +801,93 @@ describe("KeyboardHandler Component", () => {
 
       // Child should NOT have moved (container-relative position unchanged)
       const childAfter = layoutStore.rack!.devices.find(
-        (d) => d.id === childDevice.id,
+        (d) => d.id === childId,
       )!;
       expect(childAfter.position).toBe(childPosition);
       // Child should still be contained (not ejected)
-      expect(childAfter.container_id).toBe(containerDevice.id);
+      expect(childAfter.container_id).toBe(containerId);
     });
 
     it("ArrowDown does not move a contained child device", async () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
-      const containerType = layoutStore.addDeviceType({
-        name: "Blade Chassis",
-        u_height: 4,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-        slots: [
-          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
-          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
-        ],
-      });
-      const childType = layoutStore.addDeviceType({
-        name: "Blade Server",
-        u_height: 1,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-      });
+      const { rackId, containerId, childId, childPosition } =
+        createBladeContainerWithChild();
 
-      const rack = layoutStore.addRack("Test Rack", 42);
-      const rackId = rack!.id;
-
-      layoutStore.placeDevice(rackId, containerType.slug, 5);
-      const containerDevice = layoutStore.rack!.devices.find(
-        (d) => d.device_type === containerType.slug,
-      )!;
-
-      layoutStore.placeInContainer(
-        rackId,
-        childType.slug,
-        containerDevice.id,
-        "slot-left",
-        0,
-      );
-
-      const childDevice = layoutStore.rack!.devices.find(
-        (d) => d.container_id === containerDevice.id,
-      )!;
-      const childPosition = childDevice.position;
-
-      selectionStore.selectDevice(rackId, childDevice.id);
+      selectionStore.selectDevice(rackId, childId);
 
       render(KeyboardHandler);
 
       await fireEvent.keyDown(window, { key: "ArrowDown" });
 
       const childAfter = layoutStore.rack!.devices.find(
-        (d) => d.id === childDevice.id,
+        (d) => d.id === childId,
       )!;
       expect(childAfter.position).toBe(childPosition);
-      expect(childAfter.container_id).toBe(containerDevice.id);
+      expect(childAfter.container_id).toBe(containerId);
     });
 
     it("Shift+ArrowUp does not move a contained child device", async () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
-      const containerType = layoutStore.addDeviceType({
-        name: "Blade Chassis",
-        u_height: 4,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-        slots: [
-          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
-          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
-        ],
-      });
-      const childType = layoutStore.addDeviceType({
-        name: "Blade Server",
-        u_height: 1,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-      });
+      const { rackId, containerId, childId, childPosition } =
+        createBladeContainerWithChild();
 
-      const rack = layoutStore.addRack("Test Rack", 42);
-      const rackId = rack!.id;
-
-      layoutStore.placeDevice(rackId, containerType.slug, 5);
-      const containerDevice = layoutStore.rack!.devices.find(
-        (d) => d.device_type === containerType.slug,
-      )!;
-
-      layoutStore.placeInContainer(
-        rackId,
-        childType.slug,
-        containerDevice.id,
-        "slot-left",
-        0,
-      );
-
-      const childDevice = layoutStore.rack!.devices.find(
-        (d) => d.container_id === containerDevice.id,
-      )!;
-      const childPosition = childDevice.position;
-
-      selectionStore.selectDevice(rackId, childDevice.id);
+      selectionStore.selectDevice(rackId, childId);
 
       render(KeyboardHandler);
 
       await fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true });
 
       const childAfter = layoutStore.rack!.devices.find(
-        (d) => d.id === childDevice.id,
+        (d) => d.id === childId,
       )!;
       expect(childAfter.position).toBe(childPosition);
-      expect(childAfter.container_id).toBe(containerDevice.id);
+      expect(childAfter.container_id).toBe(containerId);
     });
 
     it("ArrowRight does not move a contained child device between slots", async () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
-      const containerType = layoutStore.addDeviceType({
-        name: "Blade Chassis",
-        u_height: 4,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-        slots: [
-          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
-          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
-        ],
-      });
-      const childType = layoutStore.addDeviceType({
-        name: "Blade Server",
-        u_height: 1,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-      });
+      const { rackId, containerId, childId, childPosition } =
+        createBladeContainerWithChild();
 
-      const rack = layoutStore.addRack("Test Rack", 42);
-      const rackId = rack!.id;
-
-      layoutStore.placeDevice(rackId, containerType.slug, 5);
-      const containerDevice = layoutStore.rack!.devices.find(
-        (d) => d.device_type === containerType.slug,
-      )!;
-
-      layoutStore.placeInContainer(
-        rackId,
-        childType.slug,
-        containerDevice.id,
-        "slot-left",
-        0,
-      );
-
-      const childDevice = layoutStore.rack!.devices.find(
-        (d) => d.container_id === containerDevice.id,
-      )!;
-
-      selectionStore.selectDevice(rackId, childDevice.id);
+      selectionStore.selectDevice(rackId, childId);
 
       render(KeyboardHandler);
 
       await fireEvent.keyDown(window, { key: "ArrowRight" });
 
       const childAfter = layoutStore.rack!.devices.find(
-        (d) => d.id === childDevice.id,
+        (d) => d.id === childId,
       )!;
       expect(childAfter.slot_id).toBe("slot-left");
-      expect(childAfter.container_id).toBe(containerDevice.id);
+      expect(childAfter.position).toBe(childPosition);
+      expect(childAfter.container_id).toBe(containerId);
     });
 
     it("ArrowLeft does not move a contained child device between slots", async () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
-      const containerType = layoutStore.addDeviceType({
-        name: "Blade Chassis",
-        u_height: 4,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-        slots: [
-          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
-          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
-        ],
-      });
-      const childType = layoutStore.addDeviceType({
-        name: "Blade Server",
-        u_height: 1,
-        category: "server",
-        colour: CATEGORY_COLOURS.server,
-      });
+      const { rackId, containerId, childId, childPosition } =
+        createBladeContainerWithChild();
 
-      const rack = layoutStore.addRack("Test Rack", 42);
-      const rackId = rack!.id;
-
-      layoutStore.placeDevice(rackId, containerType.slug, 5);
-      const containerDevice = layoutStore.rack!.devices.find(
-        (d) => d.device_type === containerType.slug,
-      )!;
-
-      layoutStore.placeInContainer(
-        rackId,
-        childType.slug,
-        containerDevice.id,
-        "slot-left",
-        0,
-      );
-
-      const childDevice = layoutStore.rack!.devices.find(
-        (d) => d.container_id === containerDevice.id,
-      )!;
-
-      selectionStore.selectDevice(rackId, childDevice.id);
+      selectionStore.selectDevice(rackId, childId);
 
       render(KeyboardHandler);
 
       await fireEvent.keyDown(window, { key: "ArrowLeft" });
 
       const childAfter = layoutStore.rack!.devices.find(
-        (d) => d.id === childDevice.id,
+        (d) => d.id === childId,
       )!;
       expect(childAfter.slot_id).toBe("slot-left");
-      expect(childAfter.container_id).toBe(containerDevice.id);
+      expect(childAfter.position).toBe(childPosition);
+      expect(childAfter.container_id).toBe(containerId);
     });
   });
 

--- a/src/tests/keyboard.test.ts
+++ b/src/tests/keyboard.test.ts
@@ -955,7 +955,7 @@ describe("KeyboardHandler Component", () => {
       expect(childAfter.container_id).toBe(containerDevice.id);
     });
 
-    it("ArrowLeft/Right does not move a contained child device between slots", async () => {
+    it("ArrowRight does not move a contained child device between slots", async () => {
       const layoutStore = getLayoutStore();
       const selectionStore = getSelectionStore();
 
@@ -1005,7 +1005,60 @@ describe("KeyboardHandler Component", () => {
       const childAfter = layoutStore.rack!.devices.find(
         (d) => d.id === childDevice.id,
       )!;
-      // Child should still be in the same slot, not moved
+      expect(childAfter.slot_id).toBe("slot-left");
+      expect(childAfter.container_id).toBe(containerDevice.id);
+    });
+
+    it("ArrowLeft does not move a contained child device between slots", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+
+      const containerType = layoutStore.addDeviceType({
+        name: "Blade Chassis",
+        u_height: 4,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+        slots: [
+          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
+          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
+        ],
+      });
+      const childType = layoutStore.addDeviceType({
+        name: "Blade Server",
+        u_height: 1,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+      });
+
+      const rack = layoutStore.addRack("Test Rack", 42);
+      const rackId = rack!.id;
+
+      layoutStore.placeDevice(rackId, containerType.slug, 5);
+      const containerDevice = layoutStore.rack!.devices.find(
+        (d) => d.device_type === containerType.slug,
+      )!;
+
+      layoutStore.placeInContainer(
+        rackId,
+        childType.slug,
+        containerDevice.id,
+        "slot-left",
+        0,
+      );
+
+      const childDevice = layoutStore.rack!.devices.find(
+        (d) => d.container_id === containerDevice.id,
+      )!;
+
+      selectionStore.selectDevice(rackId, childDevice.id);
+
+      render(KeyboardHandler);
+
+      await fireEvent.keyDown(window, { key: "ArrowLeft" });
+
+      const childAfter = layoutStore.rack!.devices.find(
+        (d) => d.id === childDevice.id,
+      )!;
       expect(childAfter.slot_id).toBe("slot-left");
       expect(childAfter.container_id).toBe(containerDevice.id);
     });

--- a/src/tests/keyboard.test.ts
+++ b/src/tests/keyboard.test.ts
@@ -781,6 +781,236 @@ describe("KeyboardHandler Component", () => {
     });
   });
 
+  describe("Contained Device Movement Guard", () => {
+    it("ArrowUp does not move a contained child device", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+
+      // Create a container device type (4U with 2 slots)
+      const containerType = layoutStore.addDeviceType({
+        name: "Blade Chassis",
+        u_height: 4,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+        slots: [
+          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
+          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
+        ],
+      });
+
+      // Create a child device type
+      const childType = layoutStore.addDeviceType({
+        name: "Blade Server",
+        u_height: 1,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+      });
+
+      const rack = layoutStore.addRack("Test Rack", 42);
+      const rackId = rack!.id;
+
+      // Place the container at U5
+      layoutStore.placeDevice(rackId, containerType.slug, 5);
+      const containerDevice = layoutStore.rack!.devices.find(
+        (d) => d.device_type === containerType.slug,
+      )!;
+
+      // Place a child inside the container
+      layoutStore.placeInContainer(
+        rackId,
+        childType.slug,
+        containerDevice.id,
+        "slot-left",
+        0,
+      );
+
+      const childDevice = layoutStore.rack!.devices.find(
+        (d) => d.container_id === containerDevice.id,
+      )!;
+      const childPosition = childDevice.position;
+
+      // Select the contained child
+      selectionStore.selectDevice(rackId, childDevice.id);
+
+      render(KeyboardHandler);
+
+      await fireEvent.keyDown(window, { key: "ArrowUp" });
+
+      // Child should NOT have moved (container-relative position unchanged)
+      const childAfter = layoutStore.rack!.devices.find(
+        (d) => d.id === childDevice.id,
+      )!;
+      expect(childAfter.position).toBe(childPosition);
+      // Child should still be contained (not ejected)
+      expect(childAfter.container_id).toBe(containerDevice.id);
+    });
+
+    it("ArrowDown does not move a contained child device", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+
+      const containerType = layoutStore.addDeviceType({
+        name: "Blade Chassis",
+        u_height: 4,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+        slots: [
+          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
+          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
+        ],
+      });
+      const childType = layoutStore.addDeviceType({
+        name: "Blade Server",
+        u_height: 1,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+      });
+
+      const rack = layoutStore.addRack("Test Rack", 42);
+      const rackId = rack!.id;
+
+      layoutStore.placeDevice(rackId, containerType.slug, 5);
+      const containerDevice = layoutStore.rack!.devices.find(
+        (d) => d.device_type === containerType.slug,
+      )!;
+
+      layoutStore.placeInContainer(
+        rackId,
+        childType.slug,
+        containerDevice.id,
+        "slot-left",
+        0,
+      );
+
+      const childDevice = layoutStore.rack!.devices.find(
+        (d) => d.container_id === containerDevice.id,
+      )!;
+      const childPosition = childDevice.position;
+
+      selectionStore.selectDevice(rackId, childDevice.id);
+
+      render(KeyboardHandler);
+
+      await fireEvent.keyDown(window, { key: "ArrowDown" });
+
+      const childAfter = layoutStore.rack!.devices.find(
+        (d) => d.id === childDevice.id,
+      )!;
+      expect(childAfter.position).toBe(childPosition);
+      expect(childAfter.container_id).toBe(containerDevice.id);
+    });
+
+    it("Shift+ArrowUp does not move a contained child device", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+
+      const containerType = layoutStore.addDeviceType({
+        name: "Blade Chassis",
+        u_height: 4,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+        slots: [
+          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
+          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
+        ],
+      });
+      const childType = layoutStore.addDeviceType({
+        name: "Blade Server",
+        u_height: 1,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+      });
+
+      const rack = layoutStore.addRack("Test Rack", 42);
+      const rackId = rack!.id;
+
+      layoutStore.placeDevice(rackId, containerType.slug, 5);
+      const containerDevice = layoutStore.rack!.devices.find(
+        (d) => d.device_type === containerType.slug,
+      )!;
+
+      layoutStore.placeInContainer(
+        rackId,
+        childType.slug,
+        containerDevice.id,
+        "slot-left",
+        0,
+      );
+
+      const childDevice = layoutStore.rack!.devices.find(
+        (d) => d.container_id === containerDevice.id,
+      )!;
+      const childPosition = childDevice.position;
+
+      selectionStore.selectDevice(rackId, childDevice.id);
+
+      render(KeyboardHandler);
+
+      await fireEvent.keyDown(window, { key: "ArrowUp", shiftKey: true });
+
+      const childAfter = layoutStore.rack!.devices.find(
+        (d) => d.id === childDevice.id,
+      )!;
+      expect(childAfter.position).toBe(childPosition);
+      expect(childAfter.container_id).toBe(containerDevice.id);
+    });
+
+    it("ArrowLeft/Right does not move a contained child device between slots", async () => {
+      const layoutStore = getLayoutStore();
+      const selectionStore = getSelectionStore();
+
+      const containerType = layoutStore.addDeviceType({
+        name: "Blade Chassis",
+        u_height: 4,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+        slots: [
+          { id: "slot-left", label: "Left", width: 0.5, u_height: 2 },
+          { id: "slot-right", label: "Right", width: 0.5, u_height: 2 },
+        ],
+      });
+      const childType = layoutStore.addDeviceType({
+        name: "Blade Server",
+        u_height: 1,
+        category: "server",
+        colour: CATEGORY_COLOURS.server,
+      });
+
+      const rack = layoutStore.addRack("Test Rack", 42);
+      const rackId = rack!.id;
+
+      layoutStore.placeDevice(rackId, containerType.slug, 5);
+      const containerDevice = layoutStore.rack!.devices.find(
+        (d) => d.device_type === containerType.slug,
+      )!;
+
+      layoutStore.placeInContainer(
+        rackId,
+        childType.slug,
+        containerDevice.id,
+        "slot-left",
+        0,
+      );
+
+      const childDevice = layoutStore.rack!.devices.find(
+        (d) => d.container_id === containerDevice.id,
+      )!;
+
+      selectionStore.selectDevice(rackId, childDevice.id);
+
+      render(KeyboardHandler);
+
+      await fireEvent.keyDown(window, { key: "ArrowRight" });
+
+      const childAfter = layoutStore.rack!.devices.find(
+        (d) => d.id === childDevice.id,
+      )!;
+      // Child should still be in the same slot, not moved
+      expect(childAfter.slot_id).toBe("slot-left");
+      expect(childAfter.container_id).toBe(containerDevice.id);
+    });
+  });
+
   describe("Multi-U Device Movement", () => {
     it("moves 2U device by 1U (consistent step size)", async () => {
       const layoutStore = getLayoutStore();


### PR DESCRIPTION
## **User description**
## Summary

- Guard moveSelectedDevice (ArrowUp/ArrowDown) and moveDeviceSlot (ArrowLeft/ArrowRight) in KeyboardHandler to return early when the selected device has container_id set
- Use existing isContainerChild() utility from collision.ts for the check
- Add 4 tests: ArrowUp, ArrowDown, Shift+ArrowUp, and ArrowRight on contained child devices all verify position and container linkage are preserved

## Problem

A device placed inside a container is keyboard-selectable. When such a child is selected and the user presses ArrowUp/ArrowDown, findNextValidPosition computes a rack-level U position from the child container-relative position (0-indexed), and moveDeviceRecorded detaches the child from its container, placing it at the computed rack U. This is an accidental ejection, not intentional.

## Fix

Option A from the issue: no-op guard at the keyboard entry point. Contained children are not nudge-movable via arrow keys. The store-level moveDevice path (used by drag-out) intentionally detaches and remains unchanged.

## Test Plan

- All 2136 existing tests pass
- 4 new tests verify ArrowUp, ArrowDown, Shift+ArrowUp, and ArrowRight are no-ops on contained children
- Lint clean
- Build succeeds

Closes #2146


___

## **CodeAnt-AI Description**
**Stop keyboard nudges from ejecting devices inside containers**

### What Changed
- Arrow key nudges now do nothing when a selected device is inside a container, so it stays in place and remains linked to its container
- Left/right slot changes are also blocked for contained devices, preventing them from switching slots at the rack level
- Added tests covering up, down, fine-move up, and left/right key presses on contained devices

### Impact
`✅ Fewer accidental device ejections`
`✅ Safer keyboard movement for contained hardware`
`✅ Preserved container placement when using arrow keys`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
