### PR TITLE
docs: spike #2132 rackula-api Workers portability + storage backend

### DIFF
--- a/docs/research/2132-codebase.md
+++ b/docs/research/2132-codebase.md
@@ -1,0 +1,594 @@
+# Spike #2132 — Rackula API Codebase Inventory: Portability to Cloudflare Workers
+
+## Executive Summary
+The rackula-api is a Bun/Hono-based persistence layer tightly coupled to Node.js filesystem APIs and native dependencies. Current architecture requires substantial refactoring to port to Cloudflare Workers: the storage layer is built entirely around `node:fs/promises`, quota enforcement scans the filesystem, and authentication depends on the `@node-rs/argon2` native binding. This document catalogs the current implementation with exact file paths and line citations to guide portability assessment.
+
+---
+
+## 1. Runtime & Environment Access
+
+### Entry Point: `/src/index.ts`
+- **Lines 13–20:** Port and data directory read from `process.env`:
+  ```typescript
+  const portEnv = process.env.RACKULA_API_PORT ?? process.env.PORT ?? "3001";
+  // ...
+  logger.info(`Data directory: ${process.env.DATA_DIR ?? "./data"}`);
+  ```
+  - `RACKULA_API_PORT` or `PORT` environment variable (defaults to "3001")
+  - `DATA_DIR` environment variable (defaults to "./data")
+
+- **Line 9:** Creates app via `createApp()` (async, awaited)
+- **Lines 22–25:** Exports Bun server object with `port` and `fetch` properties:
+  ```typescript
+  export default {
+    port,
+    fetch: app.fetch.bind(app),
+  };
+  ```
+  Directly invokes Bun.serve via the default export pattern.
+
+### App Creation: `/src/app.ts`
+- **Lines 277–279:** `createApp()` function accepts optional `env: EnvMap = process.env` parameter
+  - Allows dependency injection for testing
+  - Falls back to `process.env` in production
+- **Line 281:** Resolves `securityConfig` via `resolveApiSecurityConfig(env)`
+- **Line 286:** Calls `bootstrapLocalCredentials(env)` when `authMode=local`
+- **Line 289:** **Mutates env:** `delete env.RACKULA_LOCAL_PASSWORD` (scrubs plaintext password after hashing)
+
+### Environment Variables Summary
+| Variable | Source | Default | Usage |
+|----------|--------|---------|-------|
+| `RACKULA_API_PORT` | index.ts:13 | "3001" | Port binding |
+| `PORT` | index.ts:13 | "3001" | Fallback port (legacy) |
+| `DATA_DIR` | filesystem.ts:29, index.ts:20 | "./data" | Layout/asset storage root |
+| `NODE_ENV` | logger.ts:26, security/config.ts:multiple | undefined | Dev/prod mode detection |
+| `LOG_LEVEL` | logger.ts:29 | "info" | Pino logging level |
+| `NODE_ENV` | logger.ts:26 | undefined | TTY detection for pretty output |
+| `RACKULA_LOCAL_PASSWORD` | local-auth.ts:81 | required (if AUTH_MODE=local) | Plaintext; deleted after hashing |
+| `RACKULA_LOCAL_USERNAME` | local-auth.ts:71 | required (if AUTH_MODE=local) | Local auth username |
+| `CORS_ORIGIN` | security/config.ts:301 | undefined | Required in production; `*` allowed in dev |
+| `AUTH_MODE` | security/config.ts (resolveAuthMode) | "none" | "none", "oidc", or "local" |
+| `RACKULA_AUTH_SESSION_COOKIE_SECURE` | security/config.ts | undefined | HTTPS-only cookie flag |
+| `RACKULA_API_WRITE_TOKEN` | security middleware | undefined | Bearer token for PUT/DELETE |
+| `ALLOW_INSECURE_CORS` | security/config.ts:319 | undefined | Allow wildcard CORS in production |
+| `APP_VERSION`, `APP_COMMIT`, `APP_BUILD_TIME` | app.ts:68–72 | from package.json or "" | Build metadata for /version endpoint |
+
+### Hono `c.env` / Worker Bindings
+- **Not used.** The codebase does not reference `c.env` (Hono's Worker binding mechanism). All config comes from `process.env`.
+
+### Node-Only APIs Used
+
+#### In Production Code:
+- **`node:fs/promises`** (filesystem.ts, assets.ts, quota.ts):
+  - `readdir`, `readFile`, `writeFile`, `stat`, `mkdir`, `open`, `rm`, `rename`, `unlink`
+  - All layout YAML persistence, snapshot management, asset uploads
+  
+- **`node:path`** (filesystem.ts, assets.ts, quota.ts):
+  - `join`, `dirname` — folder/file path construction
+  
+- **`node:crypto`** (multiple security modules):
+  - `createHmac`, `randomUUID`, `timingSafeEqual`, `randomBytes` — session tokens, CSRF, rate limit keying
+  - **WebCrypto-compatible** (SubtleCrypto equivalents exist in Workers)
+  
+- **`process.env`** (multiple):
+  - Direct environment variable reads; **no Hono `c.env` fallback**
+  
+- **No `Bun.*` runtime APIs in production code.**
+  - Exception: index.ts exports a Bun server object (the default export pattern)
+
+#### In Test Code (non-blocking for Workers port):
+- **`node:fs/promises`**: `mkdtemp`, `utimes` in snapshots.test.ts and storage tests
+- **`node:os`**: `tmpdir()` in filesystem.test.ts:17
+- **`@types/bun`**: Test runner (bun:test)
+
+---
+
+## 2. Auth & Native Dependencies
+
+### Primary Issue: `@node-rs/argon2`
+- **Import:** `/src/local-auth.ts:1`
+  ```typescript
+  import { hash, verify, Algorithm } from "@node-rs/argon2";
+  ```
+- **Usage:** Lines 42–66
+  - `hashPassword()`: Hashes plaintext via Argon2id with 64 MiB memory, 3 time cost, 4 parallelism (OWASP-recommended)
+  - `verifyPasswordHash()`: Constant-time verification against stored hash
+  - Both are async and called in critical path (local auth bootstrap and login verification)
+
+### Auth Flow & Dependencies
+
+#### Local Auth (AUTH_MODE=local)
+1. **Bootstrap** (`app.ts:286`):
+   - Calls `bootstrapLocalCredentials(env)` → **calls `hashPassword()` (async)**
+   - Stores hash in `securityConfig.localCredentials.passwordHash`
+   - Scrubs plaintext password from env (`delete env.RACKULA_LOCAL_PASSWORD`)
+
+2. **Login** (`app.ts:744–748`):
+   - POST `/auth/login` handler calls `verifyCredentials(username, password, localCredentials)`
+   - `verifyCredentials()` → **calls `verifyPasswordHash()` (async)**
+   - Compares hash using `timingSafeEqual` (node:crypto, WebCrypto-compatible)
+
+3. **Transitive dependencies:**
+   - `/src/local-auth.ts` is imported by `/src/app.ts` → **bundled when app loads**
+   - If any route handler directly imports the auth route (not current), argon2 would be pulled in
+
+#### OIDC Auth
+- Uses `better-auth` npm package
+- Not directly coupled to argon2
+- **Does not use argon2 when AUTH_MODE=oidc**
+
+#### Session Token Signing (all auth modes)
+- `/src/security/tokens.ts:1,34–39`: Uses `node:crypto.createHmac` + `randomUUID`
+- **WebCrypto-compatible:** SubtleCrypto supports HMAC-SHA256
+
+#### CSRF/Origin Protection
+- `/src/security/csrf.ts` (not fully read): Uses `node:crypto.createHash`, `timingSafeEqual`
+- `/src/security/origin-policy.ts:17`: Uses `createHash`, `timingSafeEqual`
+- **WebCrypto-compatible**
+
+### Security Config Resolution (`/src/security/config.ts`)
+- **Lines 1–2:** Imports `createHmac`, `randomBytes` from `node:crypto`
+- **Line 62:** Uses `randomBytes()` to generate ephemeral auth log hash key
+- **Line 301:** Reads `CORS_ORIGIN` env variable
+- **Lines 305–315:** Validates CORS origin; throws in production without explicit origin
+- **Returns:** `ApiSecurityConfig` object with all security settings
+
+---
+
+## 3. Storage Module
+
+### Module Structure: `/src/storage/`
+
+#### **filesystem.ts** (450 lines)
+**Exports:**
+- `ensureDataDir()` — Creates `DATA_DIR` if missing
+- `findFolderByUuid(uuid: string)` — Scans DATA_DIR for folder matching UUID suffix
+- `listLayouts()` — Lists all layouts (new UUID folders + legacy flat files)
+- `getLayout(id: string)` — Reads layout YAML and its `updatedAt` (file mtime, ISO 8601)
+- `saveLayout(yamlContent, existingId?, echoedUpdatedAt?)` — Create/update layout with echo-based conflict detection
+- `deleteLayout(uuid: string)` — Deletes layout folder and all contents
+- `listSnapshots(uuid: string)` — Lists pre-overwrite snapshots for a layout
+- `saveSnapshot(uuid: string, yamlContent: string)` — Stores losing local copy before overwrite
+
+**Key Patterns:**
+1. **updatedAt derivation (lines 234, 286, 296, 310, 348, 359, 373, 472, 496, 582, 749)**:
+   - Derived from `stats.mtime.toISOString()`
+   - File system modification time is the source of truth
+   - Returned to clients in response headers and JSON bodies
+
+2. **Echo-based conflict detection (lines 697–707):**
+   ```typescript
+   if (echoedUpdatedAt && existingFolder) {
+     const existingYamlFilename = await findYamlInFolder(existingFolder);
+     if (existingYamlFilename) {
+       const existingYamlPath = join(existingFolder, existingYamlFilename);
+       const existingStats = await stat(existingYamlPath);
+       if (existingStats.mtime.toISOString() !== echoedUpdatedAt) {
+         const existingContent = await readFile(existingYamlPath, "utf-8");
+         await writeSnapshot(existingFolder, existingContent);
+       }
+     }
+   }
+   ```
+   - **Pattern:** Client echoes last-seen `updatedAt` in `X-Rackula-Updated-At` header (or request body)
+   - **If mtime differs:** Existing YAML is snapshoted before overwrite ("last write wins")
+   - **Never rejects:** Saves always succeed; conflicts are captured as snapshots for recovery
+
+3. **Snapshot storage (lines 168–203):**
+   - Location: `{folderPath}/snapshots/{name}~YYYYMMDD-HHMMSS.yaml`
+   - Atomic creation via `writeFile(..., { flag: "wx" })` (exclusive create)
+   - Suffixes auto-increment on collision: `-1`, `-2`, etc.
+   - Automatic pruning: keeps only 5 most recent (MAX_SNAPSHOTS_PER_LAYOUT, line 33)
+   - Sorting by mtime, then by snapshot name desc (lines 154–156)
+
+4. **Folder naming:**
+   - New format: `{layout.name}-{UUID}` (e.g., "Production-550e8400-e29b-41d4-a716-446655440000")
+   - Legacy format: `{slug}.yaml` or `{slug}.yml` (flat file in DATA_DIR)
+   - Migration on save: renames folder if layout name changes (lines 710–737)
+
+5. **File descriptor stat ordering (lines 464–475, 745–749):**
+   - Opens file, stats, reads content on same descriptor
+   - Ensures returned `updatedAt` reflects this write (not concurrent writer's mtime)
+
+#### **quota.ts** (154 lines)
+**Exports:**
+- `checkLayoutQuota(dataDir: string, maxLayouts: number)` — Counts layouts; allows/denies new creation
+- `checkAssetQuota(layoutDir: string, maxAssetsPerLayout: number)` — Counts images per layout
+
+**Quota Enforcement:**
+1. **Layout quota (lines 38–84):**
+   - Counts UUID-suffixed folders AND legacy `.yaml`/`.yml` files in DATA_DIR
+   - `maxLayouts=0` means unlimited
+   - Allows write if `layoutCount < maxLayouts`
+
+2. **Asset quota (lines 98–153):**
+   - Counts image files (png, jpg, jpeg, webp) in `{layoutDir}/assets/{deviceSlug}/`
+   - Only counts direct device subdirectory level
+   - `maxAssetsPerLayout=0` means unlimited
+   - Allows write if `assetCount < maxAssetsPerLayout`
+
+**Error handling:**
+- ENOENT (directory doesn't exist) → allow write, return `allowed: true` (not an enforcement failure)
+- Permission errors, I/O failures → rethrow (must not silently disable quota)
+
+#### **assets.ts** (340 lines)
+**Exports:**
+- `saveAsset(layoutId, deviceSlug, face, data, contentType)` — Upload image (front/rear)
+- `getAsset(layoutId, deviceSlug, face)` — Download image
+- `deleteAsset(layoutId, deviceSlug, face)` — Delete one image
+- `deleteLayoutAssets(layoutId)` — Delete all assets for layout
+- `listLayoutAssets(layoutId)` — List all assets with metadata
+
+**Storage Structure:**
+- Base: `{DATA_DIR}/{layoutFolder}/assets/{deviceSlug}/{face}.{ext}`
+- Example: `data/Production-550e8400/assets/dell_r640/front.png`
+- Allowed extensions: `png`, `jpg`, `webp`
+- Allowed image types: `image/png`, `image/jpeg`, `image/webp`
+
+**Asset Upload Pattern (lines 152–210):**
+1. Validate image type and size (5 MB max)
+2. Compute destination path via `buildAssetPath()` (validates layout UUID, device slug, ext)
+3. Create device folder with `mkdir(..., { recursive: true })`
+4. **Atomic write:** Write to temp file (`{assetPath}.{uuid}.tmp`), then rename
+5. Clean up old extension files (migration: `.jpg` → `.png`)
+6. On error: clean up temp file
+
+---
+
+## 4. Routes / Contract Surface
+
+### Layout Routes: `/src/routes/layouts.ts`
+
+| Method | Path | Handler | Requires Auth | Write-Token | Notes |
+|--------|------|---------|---------------|-------------|-------|
+| `GET` | `/layouts` | `listLayouts()` | ✗ | ✗ | Returns `{ layouts: [...] }` |
+| `GET` | `/layouts/:uuid` | `getLayout(uuid)` | ✗ | ✗ | Returns YAML in body; `X-Rackula-Updated-At` header |
+| `PUT` | `/layouts/:uuid` | `saveLayout(uuid, echoedUpdatedAt?)` | ✗ | ✓ | Body: YAML; header: `X-Rackula-Updated-At` (echoed); response: `{ id, updatedAt, message, status 200/201 }` |
+| `DELETE` | `/layouts/:uuid` | `deleteLayout(uuid)` + `deleteLayoutAssets(uuid)` | ✗ | ✓ | Returns `{ status: "deleted" }` |
+| `GET` | `/layouts/:uuid/snapshots` | `listSnapshots(uuid)` | ✗ | ✗ | Returns `{ snapshots: [ { filename, timestamp, size }, ... ] }` |
+| `POST` | `/layouts/:uuid/snapshots` | `saveSnapshot(uuid, yamlContent)` | ✗ | ✓ | Body: YAML; response: `{ filename }` |
+
+**All routes also mounted at `/api/layouts` (alias via `app.route()` in app.ts:886).**
+
+**Echo-based Conflict Detection (lines 118–122):**
+```typescript
+const result = await saveLayout(
+  yamlContent,
+  uuidResult.data,
+  c.req.header(UPDATED_AT_HEADER),  // Client echoes this
+);
+```
+- Client sends `X-Rackula-Updated-At` header on PUT
+- Mismatch triggers pre-overwrite snapshot (filesystem.ts:697–707)
+
+### Asset Routes: `/src/routes/assets.ts`
+
+| Method | Path | Handler | Requires Auth | Write-Token | Notes |
+|--------|------|---------|---------------|-------------|-------|
+| `GET` | `/assets/:layoutId/:deviceSlug/:face` | `getAsset()` | ✗ | ✗ | Returns image binary; `Cache-Control: public, max-age=3600` |
+| `PUT` | `/assets/:layoutId/:deviceSlug/:face` | `saveAsset()` | ✗ | ✓ | Body: image binary; validates Content-Type, Content-Length, actual size |
+| `DELETE` | `/assets/:layoutId/:deviceSlug/:face` | `deleteAsset()` | ✗ | ✓ | Returns `{ message: "Asset deleted" }` (or 404 if not found) |
+
+**All routes also mounted at `/api/assets` (alias via `app.route()` in app.ts:887).**
+
+**Face parameter:** Restricted to `"front"` or `"rear"` (routes/assets.ts:30–32).
+
+### Non-Data Routes: `/src/app.ts`
+
+| Method | Path | Handler | Public | Notes |
+|--------|------|---------|--------|-------|
+| `GET` | `/health` | Returns `HEALTH_RESPONSE` | ✓ | `{ ok: true, status: "ok", service: "rackula-persistence-api", version: 1 }` |
+| `GET` | `/version` | `resolveVersionInfo()` | ✓ | `{ version, commit, buildTime }` — unauthenticated (see AUTH_PUBLIC_PATHS) |
+| `GET` | `/auth/login` | OIDC or local form | ✓ | Routes also at `/api/auth/login` |
+| `GET` | `/auth/callback` | OIDC callback handler | ✓ | Routes also at `/api/auth/callback` |
+| `GET` | `/auth/check` | Verify session | ✓ | Returns 204 (valid) or 401 (invalid); routes also at `/api/auth/check` |
+| `POST` | `/auth/logout` | Invalidate session | ✓ | Returns 204; routes also at `/api/auth/logout` |
+| `POST` | `/auth/login` | Local auth login (username/password) | ✓ | JSON body: `{ username, password }`; response `{ ok: true }` or error |
+
+**Health & version endpoints:** Explicitly public (not gated by auth middleware) — seen in AUTH_PUBLIC_PATHS pattern.
+
+### Middleware Order (app.ts:318–875)
+
+1. **Line 318:** Hono logger
+2. **Lines 320–327:** CORS (origin, methods, headers, exposed headers)
+3. **Lines 331–346:** Rate limiting (if enabled)
+4. **Lines 400–411:** Auth gate (if authEnabled)
+5. **Lines 413–421:** CSRF protection
+6. **Lines 426–433:** Origin policy
+7. **Lines 810–824:** Write-auth token validation + admin authorization (on `/layouts/*`, `/assets/*`, `/api/layouts/*`, `/api/assets/*`)
+8. **Lines 845–860:** Body size limits (assets: 5 MB, layouts: 1 MB)
+9. **Lines 866–875:** Storage quota enforcement
+
+---
+
+## 5. CORS & Config
+
+### CORS Setup: `/src/app.ts:320–327`
+```typescript
+cors({
+  origin: securityConfig.corsOrigin,
+  allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  allowHeaders: ["Content-Type", "Authorization", UPDATED_AT_HEADER],
+  exposeHeaders: [UPDATED_AT_HEADER],
+}),
+```
+- Uses Hono's `cors()` middleware
+- `origin` is resolved from `CORS_ORIGIN` environment variable
+- Special header `X-Rackula-Updated-At` is explicitly allowed and exposed
+
+### CORS_ORIGIN Validation: `/src/security/config.ts:301–320`
+
+```typescript
+const configuredOrigin = env.CORS_ORIGIN?.trim();
+let corsOrigin: string | string[];
+if (!configuredOrigin) {
+  corsOrigin = "*";
+} else {
+  corsOrigin = parseCorsOrigins(configuredOrigin);
+}
+
+if (isProduction && !hasWildcardOrigin(corsOrigin) && !allowInsecureCors) {
+  // Allow specific origins
+} else if (isProduction && hasWildcardOrigin(corsOrigin) && !allowInsecureCors) {
+  throw new Error(
+    "Refusing to start in production without CORS_ORIGIN. Set CORS_ORIGIN=https://your-domain.com (or ALLOW_INSECURE_CORS=true to explicitly allow wildcard CORS)."
+  );
+}
+```
+
+**Rules:**
+- **Development:** Defaults to `*` (wildcard) if CORS_ORIGIN not set
+- **Production without ALLOW_INSECURE_CORS=true:**
+  - **REQUIRED:** Explicit `CORS_ORIGIN` (or comma-separated list)
+  - **Rejects wildcard `*`** unless explicitly opt-in via `ALLOW_INSECURE_CORS=true`
+- **Auth-enabled mode:** Requires explicit origins (wildcard not allowed even with ALLOW_INSECURE_CORS) — lines 402–407
+
+---
+
+## 6. Test Harness (Current)
+
+### Test Runner: **Bun Test**
+- **Package.json scripts (lines 12):** `"test": "bun test"`
+- **Test discovery:** `*.test.ts` files in `/src` and subdirectories
+- **Framework:** `bun:test` (built-in Bun testing, similar to Jest API)
+
+### Test Files & Coverage
+- **`snapshots.test.ts`** (pre-overwrite conflict detection)
+  - Tests echo-based `X-Rackula-Updated-At` header matching
+  - Snapshot listing, pruning, and invisibility to quota
+  - Integration with app via `createApp()`
+  - Temp directory setup via `mkdtemp()`, cleanup with `rm()`
+
+- **`filesystem.test.ts`** (layout storage layer)
+  - YAML read/write, UUID-based folder discovery
+  - Legacy flat-file migration
+  - Asset folder co-location
+
+- **`quota.test.ts`** (layout and asset quota checking)
+  - Layout counting (UUID folders + legacy files)
+  - Asset image counting per layout
+  - Error handling (ENOENT vs I/O errors)
+
+- **`security.test.ts`** (comprehensive security)
+  - Config resolution (CORS_ORIGIN, AUTH_MODE, etc.)
+  - Auth gate middleware
+  - CSRF protection
+  - Rate limiting
+  - Session token signing/verification
+  - Auth gate on layout and asset routes
+
+- **`local-auth.test.ts`** (argon2 password hashing)
+  - Password hash/verify with Argon2id
+  - Login rate limiting
+
+- **`security-hardening.test.ts`** (security edge cases)
+  - Various attack vectors (CSRF, origin spoofing, etc.)
+
+- **`deploy-config.test.ts`** (env config parsing)
+  - Validates config resolution in various environments
+
+### Test Execution
+```bash
+bun test
+```
+- Runs all `*.test.ts` files
+- Uses `describe()`, `it()`, `expect()` API
+- Async/await support
+- Temp directory cleanup in `afterEach()` hooks
+
+### Key Test Patterns
+- **Temp directory per test:** `mkdtemp(join(tmpdir(), "rackula-...-test-"))` (snapshots.test.ts:36)
+- **Env isolation:** Save/restore `process.env` in beforeEach/afterEach
+- **App creation with test config:** `createApp(buildEnv({ overrides }))`
+- **HTTP request via Hono:** `app.request(path, { method, headers, body })`
+
+---
+
+## 7. Pino Logging
+
+### Configuration: `/src/logger.ts`
+
+```typescript
+const usePrettyOutput =
+  process.env.NODE_ENV !== "production" && Boolean(process.stdout.isTTY);
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
+  ...(usePrettyOutput
+    ? {
+        transport: {
+          target: "pino-pretty",
+          options: { colorize: true, ignore: "pid,hostname" },
+        },
+      }
+    : {}),
+});
+```
+
+**Rules:**
+1. **Pretty output transport (pino-pretty):**
+   - **Enabled if:** `NODE_ENV !== "production"` AND `process.stdout.isTTY`
+   - **Disabled if:** Production OR non-interactive (CI, systemd, Docker)
+   - Options: colorize, ignore pid/hostname
+
+2. **Log level:**
+   - Controlled by `LOG_LEVEL` env var (defaults to "info")
+   - Debug tracing is opt-in (not emitted in production by default)
+
+3. **Output format:**
+   - **Development + TTY:** Pretty printed (via pino-pretty worker thread)
+   - **Everywhere else:** Structured JSON to stdout (no worker thread)
+
+### Pino Dependency
+- **Package.json:** `pino: ^10.3.1`
+- **Dev dependency:** `pino-pretty: ^13.1.3` (devDependency, not in production)
+- **Workers compatibility:** pino-pretty uses a worker thread (Node.js feature); not available in Workers
+- **Fallback:** Structured JSON mode (no transport) is Workers-compatible
+
+### Transports
+- **No file transports:** Logs to stdout only
+- **No external sinks:** No integration with external logging services
+
+---
+
+## Portability Risk Summary
+
+| Concern | Current Implementation | Workers-Compatible? | Notes & Blockers |
+|---------|------------------------|---------------------|------------------|
+| **File I/O** | All fs via `node:fs/promises` | ✗ **BLOCKER** | Storage layer entirely filesystem-dependent (layouts, assets, snapshots, quota counting). Requires external storage (R2, D1, KV, Durable Objects). |
+| **Path manipulation** | `node:path.join()`, `node:path.dirname()` | ✓ Partial | Use string manipulation or minimal polyfill; low complexity. |
+| **Environment access** | `process.env` reads only | ✓ Medium lift | Switch to `c.env` (Hono Workers bindings). Requires conditional code paths for runtime detection. |
+| **Native dependencies** | `@node-rs/argon2` | ✗ **BLOCKER** | Argon2 native binding incompatible with Workers. Require server-side hashing (post-login) OR switch to WebCrypto-based algorithm (scrypt, PBKDF2). |
+| **Crypto operations** | `node:crypto` HMAC, randomUUID, timingSafeEqual | ✓ Full | All operations have WebCrypto equivalents (SubtleCrypto). No code changes needed. |
+| **Filesystem stat (mtime)** | File modification time for `updatedAt` | ✗ **BLOCKER** | Echo-based conflict detection **requires** a source of truth for `updatedAt`. Workers storage backends (KV, D1) must expose a timestamp field or app must manage it separately. |
+| **Atomic file operations** | `writeFile(..., { flag: "wx" })` for exclusive create | ✗ **BLOCKER** | Snapshot collision avoidance relies on atomic EEXIST detection. Must be reimplemented with transactional DB writes or KV compare-and-set. |
+| **Logging** | Pino with optional pino-pretty transport | ✓ Partial | Pino works; pino-pretty (worker thread) must be disabled in Workers. JSON mode only. |
+| **Test runner** | Bun Test | ✗ **BLOCKER** | Bun Test not available in Workers environment. Tests require migration to Vitest or Jest. |
+| **Process ports** | `process.env.RACKULA_API_PORT` binding | ✓ Partial | Workers don't bind ports; only `fetch` handler. Config still exists but unused. |
+| **Folder rename (migration)** | `node:fs.rename()` on folder path change | ✗ **BLOCKER** | Layout renaming cannot atomically move folder in external storage. Requires delete + recreate or app-level metadata tracking. |
+| **Snapshot pruning** | Scans `readdir()`, sorts by mtime, deletes oldest | ✗ **BLOCKER** | External storage backends don't expose mtime for traversal. Requires DB-backed manifest of snapshots + deletion logic. |
+| **Quota enforcement** | Scans filesystem for directory/file counts | ✗ **BLOCKER** | Dynamic quota counting on every write is incompatible with serverless. Must pre-compute or use database rowcount queries. |
+| **Session invalidation** | In-memory cache (`sessions.ts`) | ✗ **BLOCKER** | Logout tokens stored in Node process memory; lost on restart. Workers have no persistent process memory. Requires distributed session store (KV, D1). |
+
+---
+
+## Key Technical Debt for Workers Migration
+
+### 1. **Storage Backend Architecture**
+- **Current:** Local filesystem only (`DATA_DIR`/`node:fs/promises`)
+- **Required for Workers:**
+  - **Option A:** Cloudflare R2 (object storage for layouts/assets) + D1 (SQLite for metadata: updatedAt, snapshots manifest, quota accounting)
+  - **Option B:** D1 only (BLOB columns for layout YAML, asset images; slower for large images)
+  - **Option C:** Durable Objects (state machine per layout; new architecture)
+
+### 2. **Timestamp Source of Truth**
+- **Current:** `stat.mtime.toISOString()` from filesystem
+- **Required:** Explicit timestamp field in database or R2 object metadata
+- **Challenge:** Multiple replica writes or concurrent clients; must establish write-win ordering
+
+### 3. **Password Hashing Migration**
+- **Current:** `@node-rs/argon2` (Argon2id, 64 MiB cost)
+- **Options:**
+  - **Option A:** Server-side: Move hashing to a server-side service (e.g., Auth0, Firebase Auth); API validates session tokens, not passwords
+  - **Option B:** Client-side: Pre-hash in browser via WASM (argon2-wasm npm package); API accepts hash, no password verification
+  - **Option C:** Degrade to PBKDF2 or scrypt via WebCrypto (lower security, acceptable if combined with rate limiting)
+
+### 4. **Atomic Snapshot Collision Avoidance**
+- **Current:** `writeFile(..., { flag: "wx" })` (exclusive create) + counter suffix retry logic
+- **Required:** Transactional DB write or KV conditional put
+- **Trade-off:** Suffix collision rate becomes acceptable risk if DB has millisecond precision timestamp
+
+### 5. **Session Invalidation State**
+- **Current:** In-memory cache in `security/sessions.ts`
+- **Required:** Distributed session store (KV with TTL, or D1 with cleanup job)
+
+### 6. **Auth Bootstrap (Local Mode)**
+- **Current:** Synchronous `process.env` read + async `hashPassword()` during `createApp()`
+- **Challenge:** Argon2 hashing incompatible with Workers; must pre-hash credentials or use a server-side service
+
+---
+
+## File Inventory: Storage Module
+
+```
+api/src/storage/
+├── assets.ts          (340 lines) — Device image upload/download
+├── assets.test.ts     — Asset route tests
+├── filesystem.ts      (780+ lines) — Layout YAML CRUD + snapshots
+├── filesystem.test.ts — Filesystem storage tests
+├── quota.ts           (154 lines) — Per-user quota enforcement
+└── quota.test.ts      — Quota validation tests
+```
+
+---
+
+## File Inventory: Security Module
+
+```
+api/src/security/
+├── config.ts          — Env resolution (CORS, auth modes, session config)
+├── config.test.ts     — Config parsing tests
+├── tokens.ts          — Session token signing/verification (HMAC-SHA256)
+├── middleware.ts      — Auth gate, CSRF protection
+├── middleware.test.ts
+├── csrf.ts            — CSRF token validation
+├── origin-policy.ts   — Origin checking on mutating requests
+├── origin-policy.test.ts
+├── rate-limit.ts      — In-memory rate limiting
+├── rate-limit.test.ts
+├── rate-limit-middleware.ts — Rate limit middleware integration
+├── rate-limit-middleware.test.ts
+├── sessions.ts        — In-memory logout token cache
+├── types.ts           — Security type definitions
+├── storage-quota-middleware.ts — Quota enforcement middleware
+├── storage-quota-middleware.test.ts
+├── request-utils.ts   — Request header parsing
+└── index.ts           — Public exports
+```
+
+---
+
+## Entry Point Code Flow
+
+```
+index.ts (Bun)
+  └─> createApp() [app.ts]
+      ├─> resolveApiSecurityConfig(env) [security/config.ts]
+      ├─> bootstrapLocalCredentials(env) [if AUTH_MODE=local]
+      │   └─> hashPassword() [local-auth.ts → @node-rs/argon2]
+      ├─> createAuth(secret, env) [auth/config.ts → better-auth]
+      ├─> Mount middleware:
+      │   ├─> honoLogger()
+      │   ├─> cors(securityConfig.corsOrigin)
+      │   ├─> createRateLimitMiddleware()
+      │   ├─> createAuthGateMiddleware() [if authEnabled]
+      │   ├─> createCsrfProtectionMiddleware()
+      │   ├─> createOriginPolicyMiddleware()
+      │   └─> createStorageQuotaMiddleware()
+      ├─> Mount routes:
+      │   ├─> /health, /version (public)
+      │   ├─> /auth/* (auth endpoints)
+      │   ├─> /layouts/* → layouts.ts
+      │   │   └─> saveLayout() [filesystem.ts]
+      │   │       ├─> getLayout()
+      │   │       ├─> saveSnapshot() [if echo mismatch]
+      │   │       └─> stat() [for mtime → updatedAt]
+      │   └─> /assets/* → assets.ts
+      │       └─> saveAsset() [assets.ts]
+      │           └─> writeFile() atomic + rename()
+      └─> return app (Hono instance)
+
+(Bun exports)
+  └─> { port, fetch: app.fetch.bind(app) }
+```
+
+---
+
+## Next Steps for Spike Execution
+
+1. **Establish storage backend prototype** — Test R2 + D1 for layout/asset/snapshot data model
+2. **Design timestamp mechanism** — Determine updatedAt source and concurrency conflict resolution
+3. **Evaluate auth migration path** — Server-side hashing vs. client pre-hash vs. WebCrypto downgrade
+4. **Prototype session store** — KV-backed logout token cache with TTL
+5. **Audit rate limiting** — Ensure in-memory rate limiter can be reimplemented with shared state (KV or Durable Objects)
+6. **Plan test migration** — Vitest + MSW for mocking Cloudflare APIs

--- a/docs/research/2132-external.md
+++ b/docs/research/2132-external.md
@@ -1,0 +1,605 @@
+# Spike #2132 — External Research (Cloudflare storage + Workers portability)
+
+Research date: 2026-06-12. All figures verified against official Cloudflare
+documentation (developers.cloudflare.com) unless otherwise noted. Where a
+number could not be confirmed from an official source, this is flagged
+explicitly.
+
+Confidence legend: **High** = stated on an official Cloudflare docs/limits/pricing
+page; **Medium** = official changelog/blog or strong corroboration; **Low** =
+community/third-party only, treat as directional.
+
+---
+
+## A. Workers Platform (free tier + nodejs_compat)
+
+### Free-plan request and compute limits
+
+- **Requests/day (free):** 100,000 / day, reset at midnight UTC. Exceeding it
+  returns Error 1027.
+  Source: <https://developers.cloudflare.com/workers/platform/limits/> — **High**
+- **CPU time per invocation (free):** 10 ms per request. Average Worker uses
+  ~2.2 ms/request.
+  Source: <https://developers.cloudflare.com/workers/platform/limits/> — **High**
+- **CPU time per invocation (paid / Standard):** up to 5 minutes (300,000 ms),
+  configurable via the `cpu_ms` limit in Wrangler (max 300,000).
+  Source: <https://developers.cloudflare.com/workers/platform/limits/> and
+  <https://developers.cloudflare.com/workers/wrangler/configuration/> — **High**
+- **Memory:** 128 MB per isolate (same on free and paid).
+  Source: <https://developers.cloudflare.com/workers/platform/limits/> — **High**
+- **Duration:** No hard wall-clock limit for HTTP-triggered Workers (runs as long
+  as the client stays connected); Cron / Durable Object alarms / Queue consumers
+  cap at 15 minutes wall time. Note this is wall time, not CPU time — the 10 ms
+  CPU budget still applies on free.
+  Source: <https://developers.cloudflare.com/workers/platform/limits/> — **High**
+
+### Subrequest limits
+
+- **Free plan:** 50 *external* subrequests per invocation, plus up to 1,000
+  subrequests to Cloudflare services (KV, R2, D1, DO, etc.) per invocation.
+- **Paid plan:** 10,000 by default, configurable up to 10,000,000 via the
+  `subrequests` limit.
+  Source (changelog, 2026-02-11):
+  <https://developers.cloudflare.com/changelog/post/2026-02-11-subrequests-limit/>
+  and <https://developers.cloudflare.com/workers/wrangler/configuration/> — **High**
+
+> Relevance for rackula-api: an autosave that writes layout + snapshot + reads a
+> quota row is a handful of *Cloudflare-service* subrequests (counts against the
+> 1,000 budget, not the 50 external budget). No concern at this scale.
+
+### `nodejs_compat` — Node API support as of 2026
+
+With `nodejs_compat` enabled (compatibility date 2024-09-23 or later), the
+following are natively supported by the Workers runtime:
+
+| Node API        | Status         | Notes |
+|-----------------|----------------|-------|
+| `node:crypto`   | Supported      | Backed by BoringSSL. |
+| `Buffer`        | Supported      | |
+| `node:path`     | Supported      | |
+| `node:stream`   | Supported      | |
+| `node:fs`       | Supported, **but virtual + non-persistent** | See below. |
+
+Source: <https://developers.cloudflare.com/workers/runtime-apis/nodejs/> — **High**
+
+**`node:fs` is NOT a usable storage backend.** As of compatibility date
+`2025-09-01`+ (or `nodejs_compat` + `enable_nodejs_fs_module`), `node:fs` exposes
+a *virtual* file system:
+
+- The bundle directory (`/bundle`) is **read-only** — it contains the Worker's
+  own modules, for reading config/templates only.
+- `/tmp` is writable but **"not persistent and unique to each request"** — files
+  written in one request are not visible in subsequent or concurrent requests.
+- `fs.glob*` and `fs.watch*` are not implemented.
+
+Source: <https://developers.cloudflare.com/workers/runtime-apis/nodejs/fs/> and
+changelog <https://developers.cloudflare.com/changelog/post/2025-08-15-nodejs-fs/>
+— **High**
+
+> Implication: a filesystem driver written against `node:fs` will compile on
+> Workers but cannot persist anything. The CF driver MUST target a real storage
+> binding (R2/D1/KV/DO). `node:fs` is only viable for the **Bun/local** driver.
+
+### Hono dual entry: Bun + Workers from one codebase
+
+Yes — idiomatic and well supported. The application body (`const app = new Hono()`
++ routes) is identical across runtimes; only the export shape differs:
+
+```ts
+// app.ts — shared, runtime-agnostic
+import { Hono } from "hono";
+export const app = new Hono();
+// ... routes ...
+
+// worker.ts — Cloudflare Workers entry
+import { app } from "./app";
+export default app;                 // Hono apps expose .fetch; CF calls it
+// (equivalently: export default { fetch: app.fetch })
+
+// server.ts — Bun entry
+import { app } from "./app";
+export default { port: 3000, fetch: app.fetch };
+// or simply `export default app` under Bun
+```
+
+Hono explicitly markets "one codebase, any runtime" (Node, Bun, Deno, Workers,
+Lambda); only the import + final `export default` vary.
+Sources: <https://hono.dev/docs/getting-started/cloudflare-workers>,
+<https://hono.dev/docs/getting-started/bun> — **High**
+
+The practical friction is not the entry shape but **bindings**: on Workers, KV/R2/
+D1/DO arrive on `env` (`c.env.MY_BUCKET`); under Bun they don't exist. This is the
+real argument for putting storage behind a driver interface and selecting the
+driver per runtime, rather than sprinkling `c.env` access through handlers.
+
+---
+
+## B. Workers KV
+
+### Free-tier limits
+
+| Metric | Free-tier limit | Source | Confidence |
+|--------|-----------------|--------|------------|
+| Reads / day | 100,000 | limits page | High |
+| Writes / day (to different keys) | 1,000 | limits page | High |
+| Deletes / day | (not separately documented; counts within write/op limits) | limits page | Medium |
+| Lists / day | (not separately documented) | limits page | Medium |
+| Per-key write rate | 1 write / second / key | limits page | High |
+| Storage (account & per namespace) | 1 GB | limits page | High |
+| Max value size | 25 MiB | limits page | High |
+| Max key size | 512 bytes | limits page | High |
+| Max key metadata | 1,024 bytes | limits page | High |
+| Namespaces / account | 1,000 (free and paid) | changelog | High |
+
+Sources: <https://developers.cloudflare.com/kv/platform/limits/>;
+namespaces from
+<https://developers.cloudflare.com/changelog/post/2025-01-27-kv-increased-namespaces-limits/>
+
+> The 1,000 writes/day free cap is the headline blocker for rackula-api.
+> Autosave double-writes (layout + snapshot) burn 2 writes per save. ~500 saves/
+> day across all users exhausts the free write budget. KV's free write ceiling is
+> too low for a frequent-autosave workload even before the consistency problem.
+
+### Consistency model (critical for the echo model)
+
+KV is **eventually consistent**, and this disqualifies it for the echo/
+compare-then-write design:
+
+- "KV achieves high performance by being eventually-consistent."
+- At the location where the write happens, the change is *usually* immediately
+  visible — but this is **"not guaranteed and ... not advised to rely on."**
+- In other global locations, **"changes may take up to 60 seconds or more to be
+  visible"** as cached copies time out.
+- No atomic operations; "KV is not ideal for applications where you need ...
+  atomic operations or where values must be read and written in a single
+  transaction." Cloudflare points such use cases to Durable Objects.
+
+Source: <https://developers.cloudflare.com/kv/concepts/how-kv-works/> — **High**
+
+> Verdict for the echo model: **KV cannot provide the read-after-write guarantee
+> the compare-then-write needs.** A read of stored `updatedAt` could return a
+> value up to 60s+ stale, so the server would mis-decide whether to snapshot.
+> Rule KV out as the primary store for layouts.
+
+---
+
+## C. D1
+
+### Free-tier limits
+
+| Metric | Free-tier limit | Source | Confidence |
+|--------|-----------------|--------|------------|
+| Rows read / day | 5 million / day | pricing page | High |
+| Rows written / day | 100,000 / day | pricing page | High |
+| Storage (total, account) | 5 GB | pricing + limits | High |
+| Max database size | 500 MB | limits page | High |
+| Databases / account | 10 | limits page | High |
+| Queries per Worker invocation | 50 | limits page | High |
+| Time Travel (point-in-time restore) | 7 days | limits page | High |
+
+Sources: <https://developers.cloudflare.com/d1/platform/pricing/> and
+<https://developers.cloudflare.com/d1/platform/limits/>
+
+> Capacity check for rackula-api: 100,000 row writes/day is generous. An autosave
+> that writes 1 layout row + 1 snapshot row + bumps a quota count is ~3 row
+> writes/save -> ~33,000 saves/day on free. Comfortable headroom vs KV's 1,000.
+
+### Consistency
+
+- **Single-primary architecture.** "All write queries are still forwarded to the
+  primary database instance." Read replicas are async copies that serve reads.
+- **Reads against the primary are current** (the primary holds all committed
+  changes). Read-after-write is consistent **when reads go to the primary**.
+- **The hazard is read replicas**: a write to the primary followed by a read that
+  is routed to a not-yet-updated replica returns stale data.
+- **Sessions API gives sequential consistency / "read-my-own-writes"**: within a
+  session, "if you write to the database, all subsequent reads will see the
+  write," enforced via bookmarks (the replica waits until at least as
+  up-to-date as the bookmark).
+
+Source: <https://developers.cloudflare.com/d1/best-practices/read-replication/>
+— **High**; read replication public beta announced 2025-04-10
+(<https://developers.cloudflare.com/changelog/post/2025-04-10-d1-read-replication-beta/>)
+
+> For the echo model: D1 gives read-after-write consistency provided you either
+> (a) don't enable read replication, or (b) use the Sessions API with a bookmark.
+> Read replication is **opt-in**, so a default D1 database with no replicas is
+> single-node and read-after-write consistent. That satisfies the echo
+> requirement without DO-level serialization, though D1 does not by itself
+> serialize concurrent writers to the same layout (see note below).
+
+**GA status:** Could not find an explicit "GA" statement on the D1 limits or
+pricing pages as of 2026-06-12. D1 has been generally available since April 2024
+(announced at Cloudflare Developer Week 2024); read *replication* is in public
+beta. Flagging the GA wording as **unconfirmed from the pages fetched** — treat
+core D1 as GA, read replication as beta. — **Medium**
+
+### Suitability for layout YAML + snapshots + quota
+
+Good fit:
+- Layout YAML stored as a `TEXT` blob column (max row size 2 MB — see limits page;
+  rack-layout YAML is far smaller). Source:
+  <https://developers.cloudflare.com/d1/platform/limits/> — **High**
+- Up-to-5 snapshots per layout = snapshot rows keyed by `(layout_id, n)`; trimming
+  to 5 is a simple `DELETE ... ORDER BY created_at` or modulo slot.
+- Quota count = an integer column / counter row, read+written transactionally in
+  the same SQL statement (D1 supports SQL transactions / batches).
+- One SQL query can do compare-then-write atomically:
+  `UPDATE layouts SET yaml=?, updated_at=? WHERE id=? AND updated_at=?` returns
+  affected-rows, letting you detect the echo mismatch *without a separate read*.
+
+---
+
+## D. R2
+
+### Free-tier limits
+
+| Metric | Free-tier limit | Source | Confidence |
+|--------|-----------------|--------|------------|
+| Storage | 10 GB-month / month | pricing page | High |
+| Class A ops (writes/lists: PUT, POST, LIST, etc.) | 1 million / month | pricing page | High |
+| Class B ops (reads: GET, HEAD) | 10 million / month | pricing page | High |
+| Egress | Free | pricing page | High |
+| Max object size | 5 TiB (effectively 4.995 TiB) | limits page | High |
+| Max objects per bucket | Unlimited | limits page | High |
+| Max custom metadata / object | 8,192 bytes | limits page | High |
+
+Sources: <https://developers.cloudflare.com/r2/pricing/> and
+<https://developers.cloudflare.com/r2/platform/limits/>
+
+> Capacity check: Class A (writes) at 1M/month is the binding constraint. Autosave
+> double-write (layout PUT + snapshot PUT) = 2 Class A ops/save -> ~500,000
+> saves/month on free. Far more headroom than KV; egress being free is a real win
+> for read-heavy load patterns.
+
+### Consistency
+
+R2 provides **strong global read-after-write consistency**:
+
+- After a PUT, "readers will immediately see the latest object globally" (PUT then
+  GET is strongly consistent).
+- List-after-write is also strongly consistent: a list "will list all objects at
+  that point in time."
+- **Caveat:** consistency is relaxed only when accessing via a **custom domain with
+  caching enabled** (cache TTL governs visibility). This does **not** affect Worker
+  binding access or the S3 API — "The cache does not affect access via Worker API
+  bindings or the S3 API."
+
+Source: <https://developers.cloudflare.com/r2/reference/consistency/> — **High**
+
+> For the echo model: R2 binding access is strongly consistent, so a read of the
+> stored object's `updatedAt` (from custom metadata) immediately after a write is
+> correct. This satisfies the echo read-after-write requirement.
+
+### Conditional writes (directly useful for the echo/compare-then-write model)
+
+The R2 Workers binding supports conditional operations via an `R2Conditional`
+(`onlyIf`) passed to `get()` and `put()`:
+
+- `etagMatches` / `etagDoesNotMatch` (If-Match / If-None-Match semantics)
+- `uploadedBefore` / `uploadedAfter` (time-based)
+- Alternatively a `Headers` object with standard conditional headers (all RFC 7232
+  conditional headers except `If-Range`).
+- If a `put()` condition fails, it returns `null` (not an `R2Object`) — a clean
+  signal for "someone else wrote since you last read."
+
+Source: <https://developers.cloudflare.com/r2/api/workers/workers-api-reference/>
+— **High**
+
+Metadata for storing `updatedAt`:
+- `customMetadata` (`Record<string, string>`) — user-defined key/value, ideal for
+  `updatedAt`.
+- `httpMetadata` (`R2HTTPMetadata`) — standard HTTP headers.
+
+Source: <https://developers.cloudflare.com/r2/api/workers/workers-api-reference/>
+— **High**
+
+> Echo-model fit: PUT with `onlyIf: { etagMatches: <last-seen-etag> }` implements
+> compare-then-write optimistically. On mismatch, `put()` returns `null`; the
+> handler then reads current object -> snapshots it -> retries the write. This
+> mirrors the echo model (never hard-reject) without needing a Durable Object,
+> **as long as** the etag/updatedAt comparison is the only serialization needed.
+> Caveat: R2 conditional PUT is optimistic, not a lock; two concurrent writers can
+> both read the same etag and one's conditional PUT fails — exactly the desired
+> behaviour (loser snapshots and retries). It does not by itself *serialize*
+> concurrent writers in submission order.
+
+---
+
+## E. Durable Objects (per-layout serialization)
+
+### Free-plan availability
+
+- **Durable Objects are available on the Workers Free plan** (free tier launched
+  2025-04-07).
+  Source: <https://developers.cloudflare.com/changelog/post/2025-04-07-durable-objects-free-tier/>
+  — **High**
+- **Only the SQLite-backed storage backend is available on free.** The
+  key-value DO storage backend is Paid-plan only.
+  Source: <https://developers.cloudflare.com/durable-objects/platform/pricing/> — **High**
+
+### Free-tier limits
+
+| Metric | Free-tier limit | Source | Confidence |
+|--------|-----------------|--------|------------|
+| Requests / day | 100,000 / day | DO pricing page | High |
+| Compute duration / day | 13,000 GB-s / day | DO pricing page | High |
+| SQLite rows read / day | 5 million / day | DO pricing page | High |
+| SQLite rows written / day | 100,000 / day | DO pricing page | High |
+| SQLite stored data | 5 GB (total) | DO pricing page | High |
+
+Source: <https://developers.cloudflare.com/durable-objects/platform/pricing/>
+
+Note: SQLite *storage* billing for DOs began January 2026 (target 2026-01-07), but
+**Workers Free plan users are not charged** for storage; compute (requests +
+duration) has always been metered.
+Source: <https://developers.cloudflare.com/changelog/post/2025-12-12-durable-objects-sqlite-storage-billing/>
+— **High**
+
+### Pattern: one DO per layout id
+
+Idiomatic, yes. The canonical pattern is to derive a DO instance from the layout
+id (`env.LAYOUT_DO.idFromName(layoutId)`), so all compare-then-write traffic for a
+given layout routes to a single object. A DO is single-threaded and processes
+requests serially, giving you true per-layout write serialization (not just
+optimistic concurrency). It can also hold the layout + snapshots in its own
+embedded SQLite, eliminating a separate store.
+
+Cloudflare itself recommends DOs for exactly this ("atomic operations ... read and
+written in a single transaction") in the KV docs.
+Source: <https://developers.cloudflare.com/kv/concepts/how-kv-works/> — **High**
+
+### Cost/complexity tradeoff for a solo maintainer
+
+- **Pro:** strongest guarantee — strict per-layout serialization, plus colocated
+  storage, plus alarms for snapshot trimming.
+- **Con:** highest conceptual + operational overhead. DOs add a class definition,
+  a migration entry in `wrangler.jsonc`, the `idFromName`/stub routing dance, and
+  a programming model (RPC/fetch into the object) that does NOT exist under Bun —
+  so the Bun/local driver and the DO driver diverge significantly, weakening the
+  "one contract, two runtimes" goal.
+- **Assessment:** For a small autosave app, **D1 single-node or R2 conditional
+  PUT already deliver read-after-write consistency**, which is the hard
+  requirement. Strict submission-order serialization is a *nice-to-have* the echo
+  model can live without (the model is "snapshot-then-write, never reject", which
+  optimistic conditional writes satisfy). Recommend treating DO-per-layout as a
+  later optimization if real write contention shows up, not a v1 requirement.
+
+---
+
+## F. Password Hashing on Workers (argon2 replacement)
+
+**`@node-rs/argon2` will not run on Workers.** It ships a native `.node` addon
+(Rust compiled to a Node native binary); Workers run JS/WASM only and do not load
+native Node addons.
+Source: <https://github.com/cloudflare/workerd/discussions/1905> — **Medium**
+(community/maintainer discussion; corroborated by the WASM-only architecture in
+<https://developers.cloudflare.com/workers/runtime-apis/webassembly/>)
+
+Viable replacements:
+
+| Option | How | Bundle | CPU cost | Security | Verdict |
+|--------|-----|--------|----------|----------|---------|
+| **argon2id via WASM (`hash-wasm`, CF-adapted)** | Rust Argon2 compiled to WASM | ~12 kB gzipped | Tunable; low-memory params (~16 KiB, 4 iters, p=2) measured ~6-9 ms p50-p99 on Workers | Memory-hard (best class) but only if params are strong; the cited low-mem params are weaker than typical server argon2 | **Recommended** if free-tier CPU budget can be respected; preferred for new Workers password auth |
+| **WebCrypto PBKDF2** | `crypto.subtle.deriveBits`, SHA-256 | 0 (built-in) | ~100 ms CPU at 100k iterations (community-reported) | OWASP-acceptable at high iteration counts, but not memory-hard | Simplest, zero-dep, but ~100 ms blows the **10 ms free CPU limit** |
+| **Rust/WASM Argon2 in a separate Worker via Service Binding** | dedicated hashing Worker | n/a | ~100 ms CPU in that Worker | Strong (full argon2id params) | Most robust, most complex; overkill for solo maintainer |
+| **Pure-JS argon2/scrypt (noble, Lucia)** | JS only | small | ~2,000 ms (scrypt) to ~14,000 ms (argon2id) CPU | Strong algorithm, unusable runtime | **Reject** — exceeds even paid CPU comfort |
+
+Sources:
+- hash-wasm Argon2 bundle ~12 kB gzipped + CF-Workers measured CPU figures:
+  <https://github.com/Daninet/hash-wasm/discussions/56>,
+  <https://github.com/7Hazard/cf-hash-wasm> — **Low/Medium** (third-party
+  benchmarks, not official; verify by measuring in our own Worker)
+- PBKDF2 ~100 ms CPU / 10 ms free limit collision, and JS argon2/scrypt CPU
+  figures: <https://mli.puffinsystems.com/blog/lucia-auth-cloudflare-argon2>,
+  <https://tjenwellens.eu/blog/password-hashing-on-cloudflare-pages/> — **Low**
+
+**Key CPU-budget concern.** The free plan's 10 ms CPU/request limit is brutal for
+password hashing. Memory-hard argon2 with *server-grade* parameters easily exceeds
+it. The cited ~6-9 ms WASM figures used **deliberately weak** params (16 KiB
+memory). Realistically, password hashing on rackula-api should run on a **paid
+Worker** (5-minute CPU ceiling) OR accept weakened-but-tuned argon2id params on
+free and document the tradeoff. **Flag:** these CPU numbers are third-party and
+parameter-dependent — measure with our chosen params before committing. — **Low**
+
+> Recommendation: target `hash-wasm` argon2id (WASM, ~12 kB) as the Workers
+> replacement for `@node-rs/argon2`. Store the full PHC parameter string with each
+> hash so parameters can evolve. Plan for paid-tier CPU if strong params are
+> required; PBKDF2 is the only zero-dep fallback but is not memory-hard and still
+> risks the free CPU limit.
+
+---
+
+## G. Logging on Workers
+
+### Does pino run on Workers?
+
+pino's default (Node) transport relies on Node internals (worker threads, sonic-
+boom file descriptors) that don't fit the Workers model. The practical path used
+by the community is **`pino/browser`** with a custom `write` that emits JSON to
+`console.log`:
+
+```ts
+import pino from "pino/browser";
+const log = pino({ browser: { write: (o) => console.log(JSON.stringify(o)) } });
+```
+
+This works but you lose pino's transport/redaction pipeline; you're effectively
+using pino as a thin JSON shaper over `console.log`.
+Source (pino issue on Workers usage):
+<https://github.com/pinojs/pino/issues/2035> — **Low/Medium** (community)
+
+### Idiomatic Workers logging
+
+Cloudflare's idiom is **structured JSON via `console.log`**, captured by **Workers
+Logs**:
+
+- Logging a JSON object (`console.log({ key: value })`) causes Workers Logs to
+  **automatically extract and index the fields**, enabling field-based filtering.
+- **Workers Logs is on both Free and Paid plans.**
+- **Free tier:** 200,000 log events / day, 3 days retention.
+  Source: <https://developers.cloudflare.com/workers/observability/logs/workers-logs/>
+  — **High**
+- For longer retention / export to external sinks, use **Logpush** (push logs to
+  R2/S3/HTTP endpoints) — generally a paid feature for Workers Logpush.
+
+> Recommendation: drop the pino dependency on the Workers path and log structured
+> JSON with `console.log({...})`, letting Workers Logs index it. Keep pino on the
+> Bun/local path if desired, or unify on a tiny logger interface (one `log(obj)`
+> function) so the driver layer doesn't care which runtime it's in. This keeps the
+> "one contract" goal intact and avoids shimming pino transports into workerd.
+
+---
+
+## H. Contract Test Harness
+
+### Can one shared spec run under both `bun test`/vitest (FS driver) and the Workers runtime (CF driver)?
+
+Yes, with the standard 2026 setup, but they run under **two different runners/
+configs**, not one process:
+
+- **Workers side:** `@cloudflare/vitest-pool-workers` runs Vitest tests **inside
+  workerd** (via modern Miniflare), giving tests real access to Workers runtime
+  APIs and bindings (KV/R2/D1/DO). Helpers come from `cloudflare:test`
+  (e.g. `env`, `SELF`) and `cloudflare:workers`.
+  - Requires **Vitest 4.1+**.
+  - Miniflare config is overridable via the `miniflare` key in the vitest config.
+  Sources: <https://developers.cloudflare.com/workers/testing/vitest-integration/>,
+  <https://developers.cloudflare.com/workers/testing/vitest-integration/configuration/>,
+  <https://www.npmjs.com/package/@cloudflare/vitest-pool-workers> — **High**
+- **FS/Bun side:** the same `*.contract.test.ts` spec file can run under plain
+  Vitest (Node) or `bun test`, exercising the filesystem driver.
+
+### Recommended pattern
+
+Write the contract spec against the **driver interface**, injecting the driver via
+a factory/fixture, not against `c.env` directly:
+
+```ts
+// storage.contract.ts — shared, imported by both runners
+export function runStorageContract(makeDriver: () => StorageDriver) {
+  describe("storage contract", () => {
+    it("read-after-write returns latest updatedAt", async () => { ... });
+    it("echo mismatch snapshots before write", async () => { ... });
+    // ...
+  });
+}
+
+// fs.contract.test.ts (runs under bun test / node vitest)
+runStorageContract(() => new FsDriver(tmpDir));
+
+// cf.contract.test.ts (runs under vitest-pool-workers / workerd)
+import { env } from "cloudflare:test";
+runStorageContract(() => new R2Driver(env.LAYOUTS)); // or D1Driver(env.DB)
+```
+
+### Friction to expect (2026)
+
+- **Two configs, two commands.** The Workers pool needs its own
+  `vitest.config` (project) with `poolOptions.workers`; the FS spec runs under the
+  default Node/Bun runner. You can't put both in a single pool run; use Vitest
+  *projects* (workspaces) or two npm scripts.
+- **`bun test` vs Vitest divergence.** The project currently uses `bun test`.
+  `vitest-pool-workers` is a **Vitest** pool — it does not plug into `bun test`.
+  Either (a) run the FS contract under Vitest too (so one spec import works in both
+  Vitest projects), or (b) keep `bun test` for FS and accept that the CF contract
+  runs under a separate Vitest invocation. Option (a) is cleaner for a single
+  shared spec file. — **Medium** (inference from runner architecture; the shared-
+  spec-across-both-runners pattern is not documented verbatim by Cloudflare)
+- **Version coupling.** Known 2026 init failures with specific Vitest 4.1.x +
+  Miniflare 4.x combos; pin versions.
+  Source: <https://github.com/cloudflare/workers-sdk/issues/13581> — **Medium**
+- **`cloudflare:test` imports** only resolve inside the Workers pool — guard them
+  so the FS runner never imports that module (keep them in `cf.contract.test.ts`,
+  not in the shared spec).
+
+> Recommendation: standardize the contract spec on **Vitest** (not `bun test`) so a
+> single spec file can be driven by both a Node/FS Vitest project and a
+> `vitest-pool-workers` project. Keep `bun test` only for non-contract unit tests
+> if desired, but the cross-runtime contract suite should be Vitest-based.
+
+---
+
+## Free-Tier Numbers Table
+
+| Resource | Metric | Free-tier limit | Source URL | Confidence |
+|----------|--------|-----------------|------------|------------|
+| Workers | Requests / day | 100,000 / day | https://developers.cloudflare.com/workers/platform/limits/ | High |
+| Workers | CPU time / request (free) | 10 ms | https://developers.cloudflare.com/workers/platform/limits/ | High |
+| Workers | CPU time / request (paid) | up to 5 min (300,000 ms) | https://developers.cloudflare.com/workers/platform/limits/ | High |
+| Workers | Memory / isolate | 128 MB | https://developers.cloudflare.com/workers/platform/limits/ | High |
+| Workers | Subrequests (free) | 50 external + 1,000 to CF services | https://developers.cloudflare.com/changelog/post/2026-02-11-subrequests-limit/ | High |
+| KV | Reads / day | 100,000 | https://developers.cloudflare.com/kv/platform/limits/ | High |
+| KV | Writes / day | 1,000 | https://developers.cloudflare.com/kv/platform/limits/ | High |
+| KV | Per-key write rate | 1 / sec / key | https://developers.cloudflare.com/kv/platform/limits/ | High |
+| KV | Storage | 1 GB | https://developers.cloudflare.com/kv/platform/limits/ | High |
+| KV | Max value size | 25 MiB | https://developers.cloudflare.com/kv/platform/limits/ | High |
+| KV | Max key size | 512 bytes | https://developers.cloudflare.com/kv/platform/limits/ | High |
+| KV | Max metadata | 1,024 bytes | https://developers.cloudflare.com/kv/platform/limits/ | High |
+| D1 | Rows read / day | 5 million | https://developers.cloudflare.com/d1/platform/pricing/ | High |
+| D1 | Rows written / day | 100,000 | https://developers.cloudflare.com/d1/platform/pricing/ | High |
+| D1 | Storage (account) | 5 GB | https://developers.cloudflare.com/d1/platform/limits/ | High |
+| D1 | Max DB size | 500 MB | https://developers.cloudflare.com/d1/platform/limits/ | High |
+| D1 | Databases / account | 10 | https://developers.cloudflare.com/d1/platform/limits/ | High |
+| R2 | Storage | 10 GB-month / month | https://developers.cloudflare.com/r2/pricing/ | High |
+| R2 | Class A ops (writes) / month | 1 million | https://developers.cloudflare.com/r2/pricing/ | High |
+| R2 | Class B ops (reads) / month | 10 million | https://developers.cloudflare.com/r2/pricing/ | High |
+| R2 | Egress | Free | https://developers.cloudflare.com/r2/pricing/ | High |
+| R2 | Max custom metadata / object | 8,192 bytes | https://developers.cloudflare.com/r2/platform/limits/ | High |
+| Durable Objects | Available on free? | Yes (SQLite backend only) | https://developers.cloudflare.com/durable-objects/platform/pricing/ | High |
+| Durable Objects | Requests / day | 100,000 | https://developers.cloudflare.com/durable-objects/platform/pricing/ | High |
+| Durable Objects | Compute / day | 13,000 GB-s | https://developers.cloudflare.com/durable-objects/platform/pricing/ | High |
+| Durable Objects | SQLite rows written / day | 100,000 | https://developers.cloudflare.com/durable-objects/platform/pricing/ | High |
+| Durable Objects | SQLite storage | 5 GB | https://developers.cloudflare.com/durable-objects/platform/pricing/ | High |
+| Workers Logs | Events / day (free) | 200,000 | https://developers.cloudflare.com/workers/observability/logs/workers-logs/ | High |
+| Workers Logs | Retention (free) | 3 days | https://developers.cloudflare.com/workers/observability/logs/workers-logs/ | High |
+
+---
+
+## Consistency Comparison Table
+
+| Store | Read-after-write | Write serialization | Conditional writes | Echo-model fit |
+|-------|------------------|---------------------|--------------------|----------------|
+| **KV** | Eventually consistent — write may be invisible up to 60s+ in other locations; even same-location immediacy is "not guaranteed". <https://developers.cloudflare.com/kv/concepts/how-kv-works/> | None (no atomic ops/transactions); per-key cap 1 write/sec. | No native compare-and-set; only optimistic-on-metadata at best. | **Poor — disqualified.** Stale reads break compare-then-write. |
+| **D1** | Consistent against the **primary**; single-primary architecture. Read replicas (opt-in) can be stale unless Sessions API + bookmark used. <https://developers.cloudflare.com/d1/best-practices/read-replication/> | SQL transactions/batches; conditional UPDATE (`WHERE updated_at=?`) detects mismatch atomically. Not a distributed lock, but single-primary ordering. | Via SQL: `UPDATE ... WHERE id=? AND updated_at=?` returns affected rows = optimistic compare-and-set. | **Strong.** Read-after-write holds (no replicas, or Sessions API); echo logic is one SQL statement. |
+| **R2** | **Strong global read-after-write** for PUT then GET via bindings/S3 API (cache only relaxes it on cached custom domains). <https://developers.cloudflare.com/r2/reference/consistency/> | Optimistic only — conditional PUT, no lock/ordering across concurrent writers. | Yes — `onlyIf` etagMatches/etagDoesNotMatch/uploadedBefore/uploadedAfter (If-Match/If-None-Match); failed PUT returns null. <https://developers.cloudflare.com/r2/api/workers/workers-api-reference/> | **Strong.** Strongly consistent read + native conditional PUT map directly onto echo (loser snapshots + retries). |
+| **Durable Object** (for reference) | Strongly consistent (single-threaded, serialized). KV docs recommend DO for atomic read-write. | **True serialization** — one DO per layout id processes requests serially. | Implement any compare logic in-object; transactional SQLite. | **Strongest**, but highest complexity and diverges most from the Bun driver. |
+
+---
+
+## Bottom line for the architecture decision
+
+1. **KV is out** for the layout store: 1,000 writes/day free cap + eventual
+   consistency both break the autosave + echo-model requirements.
+2. **R2 and D1 both satisfy** the hard requirement (strong read-after-write):
+   - **R2**: strong consistency + native conditional PUT (`onlyIf` etag) + free
+     egress + custom metadata for `updatedAt`. Cleanest match to "compare-then-
+     write, snapshot on mismatch, never reject." Best free-tier write headroom for
+     this workload.
+   - **D1**: strong on a single-node DB; echo check collapses to one conditional
+     SQL `UPDATE`; natural home for snapshot rows + quota counter. Slightly richer
+     for querying/listing user layouts.
+3. **Durable Objects** give true serialization but add the most complexity and
+   diverge hardest from the Bun driver; recommend deferring unless real write
+   contention appears.
+4. **Portability:** `node:fs` is virtual + non-persistent on Workers, so the FS
+   driver is local/Bun-only and the CF driver must bind R2/D1/DO. Hono dual-entry
+   is clean; the real seam is the storage driver interface, which also keeps the
+   contract test suite runnable on both sides (standardize it on Vitest, not
+   `bun test`).
+5. **Auxiliary swaps for the Workers target:** replace `@node-rs/argon2` (native
+   addon, won't bundle) with `hash-wasm` argon2id (WASM, ~12 kB) — but measure CPU
+   against the 10 ms free limit and plan for paid CPU if strong params are needed;
+   replace pino's Node transport with structured `console.log` JSON captured by
+   Workers Logs (free: 200k events/day, 3-day retention).
+
+### Items flagged as not fully verified
+- D1 explicit "GA" wording: not found on the fetched limits/pricing pages; core D1
+  is GA since 2024, read replication is public beta (2025-04-10). — **Medium**
+- Password-hashing CPU figures (hash-wasm ~6-9 ms, PBKDF2 ~100 ms, JS argon2/scrypt
+  thousands of ms): third-party benchmarks, parameter-dependent. Must be
+  re-measured with our chosen argon2id params before relying on them. — **Low**
+- KV per-day **delete/list** counts and pino-on-Workers specifics: not separately
+  documented on official pages; treat as Medium/Low.
+- The "single shared spec file across both runners" pattern is an inference from
+  the runner architecture; Cloudflare does not document it verbatim. — **Medium**

--- a/docs/research/spike-2132-workers-portability.md
+++ b/docs/research/spike-2132-workers-portability.md
@@ -1,0 +1,475 @@
+# Spike #2132: rackula-api on Workers, portability and storage backend
+
+Date: 2026-06-12
+Parent epic: #1985 (move dev d.racku.la full stack to Cloudflare Workers)
+Feeds: #2133 (Workers entry + CF storage driver), #2134 (dev cutover)
+Supporting research: `docs/research/2132-codebase.md`, `docs/research/2132-external.md`
+
+---
+
+## Executive summary
+
+rackula-api can run on Cloudflare Workers behind one storage-driver seam without
+forking the application. The hard requirement is the echo model's read-after-write
+consistency for layout writes. That single requirement rules out Workers KV as the
+layout store and points to R2 as the cleanest backend.
+
+Decisions:
+
+1. Storage backend: R2 is the single Workers store for layouts, snapshots, and
+   layout quota. D1 and Durable Objects are not used in v1. KV is needed only as a
+   fallback for in-memory state (session blocklist, rate-limit) if a self-contained
+   app auth mode runs without Cloudflare Access; under the recommended Access posture
+   no KV namespace is required.
+2. Concurrency: the echo compare-then-write is made safe with R2's native
+   conditional PUT (`onlyIf: { etagMatches }`), optimistic concurrency, no Durable
+   Object. DO-per-layout is deferred unless real write contention appears.
+3. updatedAt: becomes an app-managed ISO 8601 string stored in R2 `customMetadata`,
+   replacing filesystem `stat.mtime`. The wire contract (`X-Rackula-Updated-At`) is
+   unchanged.
+4. Driver seam: dependency injection, not entry-level dynamic import. The Workers
+   entry never imports the native or filesystem modules, so `@node-rs/argon2` and
+   `node:fs` stay out of the Workers bundle by construction.
+5. Password hashing: swap `@node-rs/argon2` for hash-wasm argon2id on the Workers
+   path. CPU must be measured against the 10 ms free-tier limit; the dev Worker may
+   need the paid plan to keep server-grade parameters.
+6. Logging: structured `console.log` JSON on Workers, captured by Workers Logs.
+   pino stays on the Bun path. Both sit behind a one-method logger interface.
+7. CORS: set `CORS_ORIGIN=https://d.racku.la`. The dev Worker serves the SPA and the
+   API from one origin, so CORS is effectively a no-op, and the production guard that
+   refuses a wildcard is left untouched.
+8. Tests: standardize the storage contract spec on Vitest. One shared spec runs
+   under a Node project (filesystem driver) and a `@cloudflare/vitest-pool-workers`
+   project (R2 driver).
+
+Scope boundaries confirmed: the Workers driver covers layouts CRUD, snapshots, and
+layout quota only. Assets routes and legacy flat-file migration stay filesystem-only
+for self-host. Production (count.racku.la) stays Bun/container; the dev Worker is the
+proving ground for the one-contract-two-runtimes model.
+
+---
+
+## The hard requirement: the echo model
+
+The layout PUT path uses an echo model (`api/src/storage/filesystem.ts:697-707`).
+The client sends its last-seen `updatedAt` in `X-Rackula-Updated-At`. The server
+reads the stored `updatedAt`, and if it differs, snapshots the existing version
+before overwriting. It never rejects a write. Recovery is by snapshot, not by 409.
+
+This needs read-after-write consistency: the read of stored `updatedAt` immediately
+before the write must reflect the last committed write. If that read can be stale,
+the server mis-decides whether to snapshot, and concurrent saves silently lose data
+without a snapshot. Today `updatedAt` is the filesystem `mtime`, which is trivially
+consistent on a single host. Any Workers backend has to preserve that guarantee.
+
+Autosave makes writes frequent and each save can double-write (layout plus
+snapshot), so write-throughput limits and per-key write caps also matter.
+
+---
+
+## Storage backend decision
+
+### Criteria
+
+| Criterion | Why it matters |
+|-----------|----------------|
+| Read-after-write consistency | Echo model reads stored updatedAt then writes; stale reads lose data |
+| Free-tier write headroom | Autosave double-writes; needs to survive a frequent-save workload |
+| Per-layout write serialization | Compare-then-write is a read-modify-write; concurrent writers race |
+| updatedAt as stored metadata | mtime goes away; the backend must hold an explicit timestamp |
+| Distance from the filesystem driver | Solo maintainer: thinner seam means one mental model, shared contract tests |
+
+### Scoring
+
+| Backend | Read-after-write | Free write headroom | Conditional write | Distance from FS driver | Verdict |
+|---------|------------------|---------------------|-------------------|-------------------------|---------|
+| KV | Eventual, up to 60s+ stale | 1,000 writes/day | None (no atomic ops) | Close (blob) | Rejected |
+| D1 | Strong on single-node primary | 100,000 row-writes/day | SQL `WHERE updated_at=?` | Far (rows, schema, migrations) | Viable, not chosen |
+| R2 | Strong global read-after-write | 1M Class A/month | Native `onlyIf` etag | Closest (object = file) | Chosen |
+| Durable Objects | Strong, serialized | 100,000 row-writes/day | In-object | Farthest (no Bun equivalent) | Deferred |
+
+Sources for every figure: `docs/research/2132-external.md` (each cited to
+developers.cloudflare.com, verified 2026-06-12).
+
+### Why R2
+
+R2 mirrors the current filesystem blob-per-file model almost one to one. A layout is
+an object, a snapshot is an object under a prefix, the display name lives in metadata
+instead of the folder name. The filesystem driver already thinks in files at paths;
+R2 thinks in objects at keys. That makes the driver seam the thinnest of the four
+options, which is the dominant factor for a solo maintainer and for keeping the
+contract test suite meaningful across both runtimes.
+
+R2 also satisfies the hard requirement directly:
+
+- Strong global read-after-write through Worker bindings (the cache caveat applies
+  only to cached custom domains, not binding access).
+- Native conditional PUT via `onlyIf: { etagMatches }`, which is exactly the
+  compare-then-write primitive the echo model needs, and which also replaces the
+  filesystem `wx` exclusive-create atomicity trick.
+- `customMetadata` (8,192 bytes per object) holds the app-managed `updatedAt`.
+- Free egress and 1M Class A writes per month, far more headroom than KV.
+
+### Why not D1, and why not R2 plus D1
+
+D1 works (strong on a single-node database, echo collapses to one conditional
+`UPDATE ... WHERE updated_at=?`). It is rejected because its relational strengths go
+unused here: the contract is blob CRUD plus list plus snapshots plus a simple count.
+R2 `list` with a prefix covers listing and counting. Choosing D1 would mean modeling
+a filesystem as rows for no functional gain, and it diverges further from the Bun
+filesystem driver (schema, migrations, YAML-as-TEXT).
+
+R2 plus D1 (blobs in R2, metadata in D1) is rejected for a sharper reason: it
+reintroduces the consistency problem we are trying to remove. A single layout write
+would have to update two stores with no cross-store transaction, so a crash between
+the R2 PUT and the D1 row update leaves them disagreeing about `updatedAt`. One store
+means no cross-store consistency to manage. Keep it to one store.
+
+### Concurrency: optimistic, not locked
+
+The echo compare-then-write is a read-modify-write and races under concurrent
+writers. R2 conditional PUT makes the final write atomic against concurrent
+modification: capture the object's etag during the read, then
+`put(key, body, { onlyIf: { etagMatches: readEtag } })`. If another writer committed
+in between, the PUT returns `null`; the handler re-reads, snapshots the now-current
+version, and retries. That is precisely the echo model's "never reject, snapshot the
+loser, retry" behaviour, achieved with optimistic concurrency and no Durable Object.
+
+The client-facing token stays `updatedAt` (the ISO string in `X-Rackula-Updated-At`);
+the etag is used only inside the driver for the conditional PUT, so the wire contract
+does not change.
+
+Durable-Object-per-layout would give true submission-order serialization, but it adds
+a class definition, a wrangler migration, the stub-routing model, and a programming
+model with no Bun equivalent, weakening the one-contract goal. For a small autosave
+app where optimistic concurrency already prevents silent loss, that complexity is not
+justified in v1. Defer it to a fast-follow only if contention is observed.
+
+### Key scheme (resolves the folder-rename blocker)
+
+The filesystem driver renames the layout folder when the layout name changes
+(`{name}-{uuid}`), and R2 has no rename. Resolve this by keying R2 objects on the
+UUID only and storing the display name in the YAML and in `customMetadata`:
+
+```
+layouts/{uuid}/layout.yaml                 (object; customMetadata.updatedAt, name)
+layouts/{uuid}/snapshots/{timestamp}.yaml  (objects; list + delete-oldest to prune 5)
+```
+
+The routes are already keyed by `:uuid`, so the contract surface is unchanged and the
+rename blocker disappears.
+
+---
+
+## Auxiliary state: depends on the auth posture
+
+The codebase inventory surfaced two pieces of state that live in Node process memory
+today and would be lost on every Worker isolate:
+
+- Session-invalidation blocklist (`api/src/security/sessions.ts`): logout tokens.
+- Rate-limit counters (`api/src/security/rate-limit.ts`).
+
+How much this matters depends entirely on the auth posture (see the authentication
+section). Under the recommended dev posture (Cloudflare Access as the edge gate,
+`AUTH_MODE=none`):
+
+- There are no app-level sessions to invalidate. The session blocklist is moot.
+- Rate limiting stays per-isolate and accepted-degraded, because Cloudflare Access is
+  the real abuse boundary in front of the Worker. This matches the decision already in
+  #2134 and needs no extra binding.
+
+So under the recommended posture, no KV namespace is required at all. KV becomes
+relevant only if a self-contained app auth mode (`local` or `oidc`) is run without
+Access in front; in that case the session blocklist and rate-limit counters move to
+KV, where eventual consistency is fine (a logout that takes a few seconds to propagate
+is acceptable) and the 1,000 writes/day cap is not a concern at this volume.
+
+The general rule still holds: split storage by consistency requirement. Layouts need
+strong read-after-write, so R2. Anything that tolerates eventual consistency (and is
+actually needed) goes to KV, never to R2 or a Durable Object.
+
+---
+
+## Driver seam and entry-point strategy
+
+The issue framed the mechanism choice as injection versus entry-level dynamic import.
+Use dependency injection.
+
+Extract small interfaces and inject the implementation at the entry point:
+
+- `StorageDriver`: layouts CRUD, snapshots, layout-quota count. Bun entry constructs
+  the filesystem driver; Workers entry constructs the R2 driver from `env`.
+- `PasswordHasher`: `hash`, `verify`. Bun entry injects the `@node-rs/argon2` hasher;
+  Workers entry injects the hash-wasm hasher.
+- `Logger`: one `log(obj)` method. Bun injects pino; Workers injects console JSON.
+- `SessionStore` and `RateLimiter`: in-memory on Bun; KV-backed on Workers.
+
+Routes receive the driver through the Hono context or a closure and never import
+`node:fs` or read `c.env` directly. Because the Workers entry never imports the
+filesystem or native-addon modules, `node:fs` and `@node-rs/argon2` never enter the
+Workers bundle. This is cleaner than entry-level dynamic import, which is a workaround
+for static-import bundling and leaves conditional-import seams in the code.
+
+Hono dual-entry is idiomatic: the app body is identical, only the export shape differs
+(`export default app` style for both Bun and Workers; bindings arrive on `c.env` only
+on Workers, which is exactly why the storage access goes behind the driver).
+
+---
+
+## Password hashing on Workers
+
+`@node-rs/argon2` ships a native `.node` addon and will not bundle on Workers. The
+chosen replacement is hash-wasm argon2id (WASM, about 12 kB gzipped), injected only
+on the Workers path. Store the full PHC parameter string with each hash so parameters
+can evolve.
+
+Caveat to carry into #2133: the free plan's 10 ms CPU-per-request limit is hostile to
+memory-hard hashing at server-grade parameters. The third-party benchmarks in the
+external research used deliberately weak parameters to fit. Before committing, measure
+hash-wasm argon2id with our intended parameters inside a real Worker. If strong
+parameters exceed the free CPU budget, the dev Worker runs on the paid plan (5-minute
+CPU ceiling). PBKDF2 via WebCrypto is the only zero-dependency fallback but is not
+memory-hard and still risks the free CPU limit; treat it as a last resort.
+
+Note: dev auth mode is often `none`, in which case hashing is not on the hot path at
+all. The hasher seam still matters so the Workers bundle never pulls in the native
+addon.
+
+---
+
+## Logging on Workers
+
+pino's Node transport (worker threads, file descriptors) does not fit Workers. On the
+Workers path, log structured JSON with `console.log({ ... })`, which Workers Logs
+indexes by field automatically (free tier: 200,000 events/day, 3-day retention). Keep
+pino on the Bun path. Both sit behind the one-method logger interface so the route and
+driver code does not know which runtime it is in.
+
+---
+
+## CORS posture
+
+The dev Worker serves the SPA static assets and the API from the same origin
+(d.racku.la), so same-origin fetches do not exercise CORS. Set
+`CORS_ORIGIN=https://d.racku.la` anyway: it satisfies the config guard, and it is
+correct for any cross-origin preview URL. Leave the production guard that refuses to
+start on a wildcard untouched; this spike does not weaken it.
+
+---
+
+## Test harness
+
+Standardize the storage contract on Vitest. Write the contract once against the
+`StorageDriver` interface and drive it from two Vitest projects:
+
+```ts
+// storage-contract.ts  (shared, imported by both projects)
+export function runStorageContract(makeDriver: () => StorageDriver) {
+  describe("storage contract", () => {
+    it("read-after-write returns the latest updatedAt", async () => { /* ... */ });
+    it("echo mismatch snapshots before write", async () => { /* ... */ });
+    it("prunes snapshots to five", async () => { /* ... */ });
+    it("layout quota counts existing layouts", async () => { /* ... */ });
+  });
+}
+
+// fs.contract.test.ts        (Node project)
+runStorageContract(() => new FsDriver(tmpDir));
+
+// cf.contract.test.ts        (vitest-pool-workers project)
+import { env } from "cloudflare:test";
+runStorageContract(() => new R2Driver(env.LAYOUTS));
+```
+
+Notes for #2133:
+
+- Migrate the storage tests from `bun test` to Vitest so one spec file runs under both
+  projects. `@cloudflare/vitest-pool-workers` is a Vitest pool and does not plug into
+  `bun test`. Other non-contract unit tests can stay on `bun test` if desired.
+- Requires Vitest 4.1+; pin the Vitest and vitest-pool-workers versions together
+  (there are known init failures with specific 4.1.x plus Miniflare combos).
+- Keep `cloudflare:test` imports inside `cf.contract.test.ts` only; they do not resolve
+  in the Node project.
+
+---
+
+## Free-tier capacity check
+
+| Resource | Free limit | Workload | Headroom |
+|----------|------------|----------|----------|
+| Workers requests | 100,000/day | dev traffic | Ample |
+| R2 Class A (writes) | 1,000,000/month | 2 ops/save -> ~500,000 saves/month | Ample |
+| R2 Class B (reads) | 10,000,000/month | reads on load | Ample |
+| R2 storage | 10 GB | YAML blobs are tiny | Ample |
+| KV writes | 1,000/day | only if app auth without Access (else unused) | Fine (low volume) |
+| Workers CPU (free) | 10 ms/request | argon2id hashing | At risk: measure, maybe paid |
+
+The only free-tier pressure point is CPU for password hashing. Everything else has
+wide headroom at dev scale.
+
+---
+
+## Portability blockers and resolutions
+
+| Blocker (from codebase inventory) | Resolution |
+|-----------------------------------|------------|
+| All storage via `node:fs/promises` | R2 driver behind StorageDriver; fs driver stays Bun-only |
+| `@node-rs/argon2` native addon | hash-wasm argon2id injected on Workers path; native never imported there |
+| `updatedAt` from `stat.mtime` | app-managed ISO string in R2 customMetadata |
+| `writeFile({flag:"wx"})` atomicity | R2 conditional PUT (`onlyIf` etag) |
+| Folder rename on name change | key R2 objects by UUID; name is metadata, no rename |
+| Snapshot pruning by mtime scan | R2 list with prefix; sort by uploaded; delete oldest beyond 5 |
+| Quota by filesystem scan | R2 list with prefix and count |
+| In-memory session blocklist | Moot under Access + AUTH_MODE=none; KV with TTL only if app auth runs without Access |
+| In-memory rate limiter | Per-isolate accepted-degraded (Access is the abuse boundary, per #2134); KV only if app auth runs without Access |
+| pino-pretty worker thread | console.log JSON on Workers; pino on Bun |
+| `bun test` not in Workers | Vitest contract spec, two projects |
+| `node:crypto` HMAC, randomUUID | already WebCrypto-compatible, no change |
+| `node:path` | WebCompat or trivial string joins |
+
+---
+
+## What feeds the implementation issues
+
+#2133 (Workers entry + CF storage driver) should adopt:
+
+- Extract `StorageDriver` (layouts CRUD, snapshots, layout quota) and inject it.
+- Implement `R2Driver` keyed by UUID, updatedAt in customMetadata, conditional PUT for
+  the echo write.
+- Extract `PasswordHasher`; inject `@node-rs/argon2` on Bun, hash-wasm argon2id on
+  Workers; measure CPU against the 10 ms free limit, plan for paid if needed.
+- Extract `Logger`; pino on Bun, console JSON on Workers.
+- Leave session blocklist and rate-limit as-is under the recommended Access posture
+  (no app sessions; rate-limit accepted-degraded per #2134). Put them behind interfaces
+  with KV implementations only if a self-contained app auth mode without Access is
+  needed.
+- Migrate the storage contract tests to Vitest; add a vitest-pool-workers project.
+- Keep assets routes and legacy flat-file migration filesystem-only (out of the
+  Workers driver).
+
+#2134 (dev cutover) should adopt:
+
+- `CORS_ORIGIN=https://d.racku.la`; one Worker serves SPA assets plus API (same origin).
+- Provision R2 bucket binding and KV namespace bindings in `wrangler.jsonc`.
+- Decide the dev auth mode (likely `none`); if `local`, the hash-wasm CPU caveat applies.
+
+Coordinate with #2067 (the only open issue editing the layout PUT path) so the echo
+logic moves behind the StorageDriver cleanly rather than being edited twice.
+
+---
+
+## Authentication in front of the storage (bonus)
+
+First, an important framing: R2 has no public endpoint in this design. The bucket is
+reachable only through the Worker's binding (`env.LAYOUTS`), not over the internet, so
+"authentication in front of the storage" really means authentication in front of the
+Worker. The Worker is the only door to the bucket. There is no second perimeter to
+secure as long as no public r2.dev or custom domain is attached to the bucket.
+
+That leaves three layers, which compose:
+
+### Layer 1: edge gate (who can reach the Worker at all)
+
+Recommended for dev: Cloudflare Access (Zero Trust) in front of the dev Worker. Access
+authenticates the user at Cloudflare's edge (Google SSO, GitHub, one-time PIN) and
+injects a signed JWT in the `Cf-Access-Jwt-Assertion` header. The Worker validates it
+against the team's public keys:
+
+```ts
+import { jwtVerify, createRemoteJWKSet } from "jose"; // Workers-compatible
+const JWKS = createRemoteJWKSet(new URL(`${env.TEAM_DOMAIN}/cdn-cgi/access/certs`));
+const token = request.headers.get("cf-access-jwt-assertion");
+const { payload } = await jwtVerify(token, JWKS, {
+  issuer: env.TEAM_DOMAIN,
+  audience: env.POLICY_AUD, // the Access application AUD tag
+});
+// payload.email / payload.sub identify the user
+```
+
+Source: developers.cloudflare.com one-click Access for Workers (2025-10-03 changelog)
+and the secure-MCP-servers guide, verified 2026-06-12.
+
+Why this is the right default for dev:
+
+- It eliminates password hashing on Workers entirely, which removes the one genuine
+  free-tier pain point (argon2id versus the 10 ms CPU limit). No `@node-rs/argon2`, no
+  hash-wasm, no PHC parameter tuning.
+- SSO with no password storage, which suits a small trusted audience (maintainer plus
+  testers). The free Zero Trust plan covers a small team; verify the current seat
+  allotment before relying on it.
+- The app's own `AUTH_MODE` can then be `none`, and the Worker simply trusts and reads
+  the verified Access identity.
+
+### Layer 2: app auth mode (when there is no edge gate)
+
+The existing `AUTH_MODE` values still map onto Workers, in order of fit:
+
+- `none` plus Cloudflare Access: recommended for dev. Auth is delegated to the edge.
+- `local` (username/password): self-contained gate with no edge dependency. Requires
+  the hash-wasm argon2id hasher and the CPU caveat from the password-hashing section.
+  Use only if a self-hosted-style password gate is needed without Access.
+- `oidc` (better-auth): better-auth needs a database adapter and server-side session
+  storage. On Workers that pulls in a D1 or KV adapter, reintroducing a store this
+  spike deliberately avoided for layouts. For dev SSO, prefer Cloudflare Access over
+  app-level OIDC. Keep `oidc` for the Bun self-host path if it is wanted there.
+
+The session signing itself is already portable: HMAC-signed cookies use `node:crypto`,
+which has a WebCrypto equivalent, so the cookie model needs no change. Only the
+session-invalidation blocklist and rate-limit counters move to KV (see the consistency
+split section).
+
+### Layer 3: mutation gate (defense in depth, unchanged)
+
+Keep `RACKULA_API_WRITE_TOKEN` as a Worker secret (`wrangler secret put`), bound on
+`env`. It gates PUT and DELETE on layouts independently of the identity layer, so a
+read-only viewer cannot mutate even if it reaches the Worker. CSRF and origin-policy
+middleware run unchanged.
+
+### Per-user data isolation (forward-looking)
+
+Today the storage is single-tenant: one shared namespace, layouts not isolated per
+user. That parity is fine for the dev cutover. If the future true-API epic wants
+per-user isolation, derive the tenant from the verified identity (the Access JWT `sub`
+or the session subject) and prefix R2 keys with it:
+
+```
+users/{sub}/layouts/{uuid}/layout.yaml
+```
+
+The key scheme chosen above (`layouts/{uuid}/...`) is a clean prefix-extension away
+from this, so no rework is needed to add isolation later. Note this only as a seam;
+it is out of scope for #2133 and #2134.
+
+### Recommendation
+
+For the dev Worker: Cloudflare Access as the edge gate, `AUTH_MODE=none` in the app,
+the write-token secret for mutations, CSRF and origin-policy unchanged, and KV for the
+session blocklist and rate-limit state. This is the least code, removes the argon2-on-
+Workers problem, and is free at dev scale. Keep `local` and `oidc` as documented
+fallbacks, and keep the Bun self-host path on `@node-rs/argon2` for users who run their
+own instance without Cloudflare in front.
+
+---
+
+## Items flagged as not fully verified
+
+- D1 explicit GA wording was not found on the fetched pages; core D1 is GA since 2024,
+  read replication is public beta. Does not affect the decision (D1 not chosen).
+- Password-hashing CPU figures are third-party and parameter-dependent. Must be
+  re-measured with our argon2id parameters in a real Worker before relying on them.
+- The single-shared-spec-across-both-runners pattern is inferred from runner
+  architecture, not documented verbatim by Cloudflare. Validate during #2133.
+- KV per-day delete and list counts are not separately documented; low risk at dev
+  volume.
+
+---
+
+## Recommendation
+
+Proceed with #2133 on this basis: one StorageDriver seam, R2 as the single strong-
+consistency store for layouts and snapshots and quota, KV for the eventual-consistency
+auxiliary state, dependency injection for the storage driver, password hasher, logger,
+session store, and rate limiter, hash-wasm argon2id on Workers with a CPU measurement
+gate, and a Vitest contract suite that runs against both the filesystem and R2 drivers.
+This keeps production on Bun, makes the dev Worker the proving ground for the
+one-contract-two-runtimes model, and changes no wire contract.


### PR DESCRIPTION
## **User description**
## Spike #2132: rackula-api on Workers, portability and storage backend

Research deliverables for the dev-on-Workers move (#1985). No app code changes; docs only.

### Decisions
- Storage: R2 as the single Workers store for layouts + snapshots + layout quota. KV ruled out (eventual consistency + 1,000 writes/day cap break the echo model); D1 and R2+D1 rejected (relational strengths unused; two stores reintroduce a cross-store consistency problem); Durable Objects deferred.
- Echo compare-then-write via R2 conditional PUT (`onlyIf: { etagMatches }`), optimistic concurrency, no Durable Object. Replaces the filesystem `wx` atomicity trick.
- R2 keys by UUID (`layouts/{uuid}/...`); name in metadata removes the folder-rename blocker. `updatedAt` becomes app-managed ISO in customMetadata, replacing `stat.mtime`. Wire contract unchanged.
- Driver seam: dependency injection (StorageDriver + PasswordHasher + Logger), not entry-level dynamic import. Workers entry never imports filesystem or native-addon modules, so `node:fs` and `@node-rs/argon2` stay out of the bundle by construction.
- hash-wasm argon2id on Workers (CPU caveat vs the 10 ms free limit); console-JSON logging; Vitest contract harness (Node FS project + vitest-pool-workers R2 project).
- Bonus: Cloudflare Access as the dev edge gate (`AUTH_MODE=none`) removes argon2-on-Workers entirely. Aligns with #2134.

### Files
- `docs/research/spike-2132-workers-portability.md` (main findings)
- `docs/research/2132-codebase.md` (current API inventory, file:line cited)
- `docs/research/2132-external.md` (Cloudflare limits/semantics, cited to developers.cloudflare.com, verified 2026-06-12)

Supporting docs (2132-codebase.md, 2132-external.md) are raw research and use freer formatting; the main findings doc follows house style.

Feeds #2133 (impl) and #2134 (cutover). Closes #2132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the Workers portability plan for rackula-api**

### What Changed
- Added a full research summary for moving rackula-api to Cloudflare Workers, including the storage choice, auth, logging, and testing approach
- Recorded the main decision to use R2 as the single Workers store for layouts, snapshots, and quota data, with KV, D1, and Durable Objects left out of v1
- Documented how the current filesystem-based layout flow maps to Workers, including keeping `updatedAt` as stored metadata and preserving the existing echo-based save behavior
- Added supporting research on Cloudflare limits and runtime behavior, plus a codebase inventory showing the current portability blockers and follow-up tasks

### Impact
`✅ Clearer Workers migration plan`
`✅ Faster implementation planning for #2133 and #2134`
`✅ Fewer storage design reversals during the cutover`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
