### PR TITLE
refactor: decompose Canvas.svelte markup and swipe handlers (#1610)

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,11 +1,10 @@
 <!--
   Canvas Component
-  Main content area displaying racks
-  Multi-rack mode: displays all racks with active selection indicator
-  Uses panzoom for zoom and pan functionality
+  Viewport shell for the rack designer: owns the panzoom container, swipe and
+  long-press gesture wiring, and the onboarding hint. Rack rendering lives in
+  RackCanvasView; gesture math lives in the canvas-* utils (#1610).
 -->
 <script lang="ts">
-  import { onDestroy } from "svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import {
@@ -14,34 +13,22 @@
     ZOOM_MAX,
   } from "$lib/stores/canvas.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
-  import { debug, appDebug } from "$lib/utils/debug";
-  import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
-  import {
-    classifyRackSwipeGesture,
-    useLongPress,
-    type RackSwipeDirection,
-  } from "$lib/utils/gestures";
-  import {
-    resolveSwipeTargetRackId,
-    exceedsHorizontalPanLock,
-    isRackInteractionTarget,
-  } from "$lib/utils/canvas-coordinates";
+  import { getPlacementStore } from "$lib/stores/placement.svelte";
+  import { debug } from "$lib/utils/debug";
+  import { useLongPress } from "$lib/utils/gestures";
+  import { isRackInteractionTarget } from "$lib/utils/canvas-coordinates";
   import { createCanvasPanzoom } from "$lib/utils/panzoom-lifecycle";
+  import { createRackSwipeController } from "$lib/utils/canvas-swipe.svelte";
   import { dispatchContextMenuAtPoint } from "$lib/utils/context-menu";
-  import { hapticSuccess, hapticTap } from "$lib/utils/haptics";
-  import RackDualView from "./RackDualView.svelte";
-  import BayedRackView from "./BayedRackView.svelte";
+  import { hapticTap } from "$lib/utils/haptics";
+  import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
+  import type { DeviceFace, SlotPosition } from "$lib/types";
+  import RackCanvasView from "./RackCanvasView.svelte";
   import WelcomeScreen from "./WelcomeScreen.svelte";
   import CanvasContextMenu from "./CanvasContextMenu.svelte";
-  import type { DeviceFace, SlotPosition } from "$lib/types";
-  import { resolveSelectedDevice } from "$lib/utils/device-selection";
-  import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
-  // Note: PlacementIndicator removed - placement UI now integrated into Rack.svelte
 
   const ONBOARDING_HINT_KEY = "Rackula_onboarding_hint_dismissed";
-
-  // Multi-rack mode: use active rack ID from store
 
   interface Props {
     partyMode?: boolean;
@@ -127,58 +114,10 @@
   const uiStore = getUIStore();
   const viewportStore = getViewportStore();
   const placementStore = getPlacementStore();
-  const mobileDebug = appDebug.mobile;
-
-  const SWIPE_SWITCH_ANIMATION_MS = 200;
-  const TOUCH_MOVE_LOG_INTERVAL_MS = 120;
-  const TOUCH_LISTENER_OPTIONS: AddEventListenerOptions = {
-    // Capture keeps swipe tracking robust even if child components stop bubbling.
-    // Because listeners are passive and never call stopPropagation/preventDefault,
-    // child touch handlers still run and panzoom keeps gesture ownership.
-    capture: true,
-    passive: true,
-  };
-
-  interface SwipeGestureState {
-    startX: number;
-    startY: number;
-    currentX: number;
-    currentY: number;
-    startTime: number;
-    isMultiTouch: boolean;
-  }
-
-  // Note: handlePlacementCancel removed - now handled in Rack.svelte
-
-  // Handle mobile tap-to-place (uses active rack)
-  function handlePlacementTap(
-    rackId: string,
-    event: CustomEvent<{ position: number; face: "front" | "rear" }>,
-  ) {
-    const device = placementStore.pendingDevice;
-    if (!device) return;
-
-    const { position, face } = event.detail;
-    const success = layoutStore.placeDevice(
-      rackId,
-      device.slug,
-      position,
-      face,
-    );
-
-    if (success) {
-      hapticSuccess();
-      placementStore.completePlacement();
-      // Reset view to show full rack after placement completes
-      canvasStore.fitAll(layoutStore.racks);
-    }
-  }
 
   // Multi-rack mode: access all racks
   const racks = $derived(layoutStore.racks);
-  const activeRackId = $derived(layoutStore.activeRackId);
   const hasRacks = $derived(layoutStore.rackCount > 0);
-  const rackGroups = $derived(layoutStore.rack_groups);
   const allRacksEmpty = $derived(racks.every((r) => r.devices.length === 0));
   let hintDismissed = $state(safeGetItem(ONBOARDING_HINT_KEY) === "1");
 
@@ -187,34 +126,33 @@
     hintDismissed = true;
   }
 
-  // Organize racks: grouped racks in their groups, then ungrouped racks
-  const organizedRacks = $derived.by(() => {
-    const groupedRackIds = new Set(rackGroups.flatMap((g) => g.rack_ids));
-    const ungroupedRacks = racks.filter((r) => !groupedRackIds.has(r.id));
-
-    // Build group entries with their racks
-    const groupEntries = rackGroups
-      .map((group) => ({
-        group,
-        racks: group.rack_ids
-          .map((id) => racks.find((r) => r.id === id))
-          .filter((r): r is (typeof racks)[0] => r !== undefined),
-      }))
-      .filter((entry) => entry.racks.length > 0);
-
-    return { groupEntries, ungroupedRacks };
-  });
-
   // Panzoom container reference
   let panzoomContainer: HTMLDivElement | null = $state(null);
   let canvasContainer: HTMLDivElement | null = $state(null);
-  let swipeGesture: SwipeGestureState | null = null;
-  let swipeAnimationDirection: RackSwipeDirection | null = $state(null);
-  let swipeAnimationTimeout: ReturnType<typeof setTimeout> | null = null;
-  let swipeAnimationEpoch = 0;
-  let lastTouchMoveLogAt = 0;
   let canvasLongPressPoint = $state<{ x: number; y: number } | null>(null);
   let canvasLongPressTarget = $state<Element | null>(null);
+
+  // Swipe-to-switch-rack gesture state machine. Reads live store values via
+  // getters so the same controller instance stays correct as racks change.
+  const swipeController = createRackSwipeController({
+    isMobile: () => viewportStore.isMobile,
+    getRacks: () => layoutStore.racks,
+    getRackGroups: () => layoutStore.rack_groups,
+    isPlacing: () => placementStore.isPlacing,
+    getActiveRackId: () => layoutStore.activeRackId,
+    setActiveRack: (id) => layoutStore.setActiveRack(id),
+    selectRack: (id) => selectionStore.selectRack(id),
+    focusRack: (rackIds, allRacks, groups, rightOffset) =>
+      canvasStore.focusRack(rackIds, allRacks, groups, rightOffset),
+  });
+
+  const TOUCH_LISTENER_OPTIONS: AddEventListenerOptions = {
+    // Capture keeps swipe tracking robust even if child components stop bubbling.
+    // Because listeners are passive and never call stopPropagation/preventDefault,
+    // child touch handlers still run and panzoom keeps gesture ownership.
+    capture: true,
+    passive: true,
+  };
 
   // Keep touch listener lifecycle synced to the current bound canvas element.
   // We intentionally use passive listeners and never call preventDefault here so
@@ -230,44 +168,44 @@
 
     element.addEventListener(
       "touchstart",
-      handleCanvasTouchStart,
+      swipeController.handleTouchStart,
       TOUCH_LISTENER_OPTIONS,
     );
     element.addEventListener(
       "touchmove",
-      handleCanvasTouchMove,
+      swipeController.handleTouchMove,
       TOUCH_LISTENER_OPTIONS,
     );
     element.addEventListener(
       "touchend",
-      handleCanvasTouchEnd,
+      swipeController.handleTouchEnd,
       TOUCH_LISTENER_OPTIONS,
     );
     element.addEventListener(
       "touchcancel",
-      handleCanvasTouchCancel,
+      swipeController.handleTouchCancel,
       TOUCH_LISTENER_OPTIONS,
     );
 
     return () => {
       element.removeEventListener(
         "touchstart",
-        handleCanvasTouchStart,
+        swipeController.handleTouchStart,
         TOUCH_LISTENER_OPTIONS,
       );
       element.removeEventListener(
         "touchmove",
-        handleCanvasTouchMove,
+        swipeController.handleTouchMove,
         TOUCH_LISTENER_OPTIONS,
       );
       element.removeEventListener(
         "touchend",
-        handleCanvasTouchEnd,
+        swipeController.handleTouchEnd,
         TOUCH_LISTENER_OPTIONS,
       );
       element.removeEventListener(
         "touchcancel",
-        handleCanvasTouchCancel,
+        swipeController.handleTouchCancel,
         TOUCH_LISTENER_OPTIONS,
       );
       canvasStore.setCanvasElement(null);
@@ -310,13 +248,6 @@
     return cleanup;
   });
 
-  onDestroy(() => {
-    if (swipeAnimationTimeout) {
-      clearTimeout(swipeAnimationTimeout);
-      swipeAnimationTimeout = null;
-    }
-  });
-
   // Initialize panzoom reactively when container becomes available
   $effect(() => {
     if (panzoomContainer) {
@@ -339,6 +270,9 @@
     }
   });
 
+  // Clear the swipe animation timer when the canvas unmounts.
+  $effect(() => () => swipeController.dispose());
+
   function handleCanvasClick(event: MouseEvent) {
     // Only clear selection if clicking directly on the canvas (not on a rack)
     if (event.target === event.currentTarget) {
@@ -346,105 +280,9 @@
     }
   }
 
-  function handleRackSelect(event: CustomEvent<{ rackId: string }>) {
-    const { rackId } = event.detail;
-    layoutStore.setActiveRack(rackId);
-    selectionStore.selectRack(rackId);
-    onrackselect?.(event);
-  }
-
-  function handleGroupSelect(event: CustomEvent<{ groupId: string }>) {
-    const { groupId } = event.detail;
-    const group = layoutStore.getRackGroupById(groupId);
-    if (!group || group.rack_ids.length === 0) return;
-    const activeRackInGroup =
-      activeRackId && group.rack_ids.includes(activeRackId)
-        ? activeRackId
-        : group.rack_ids[0];
-    layoutStore.setActiveRack(activeRackInGroup ?? null);
-    selectionStore.selectGroup(groupId, activeRackInGroup);
-  }
-
-  function handleDeviceSelect(
-    rackId: string,
-    event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
-  ) {
-    // Resolve the placed device by its UUID when available. The legacy
-    // (slug, position) fallback is ambiguous for two half-width devices sharing
-    // the same U (#1680), where it always resolved to the left device and left
-    // the right one unselectable.
-    const targetRack = layoutStore.getRackById(rackId);
-    if (targetRack) {
-      const device = resolveSelectedDevice(targetRack, event.detail);
-      if (device) {
-        layoutStore.setActiveRack(rackId);
-        selectionStore.selectDevice(rackId, device.id);
-      }
-    }
-    ondeviceselect?.(event);
-  }
-
   function handleNewRack() {
     onnewrack?.();
   }
-
-  function handleDeviceDrop(
-    event: CustomEvent<{
-      rackId: string;
-      slug: string;
-      position: number;
-      face: "front" | "rear";
-      slot_position?: SlotPosition;
-    }>,
-  ) {
-    const { rackId, slug, position, face, slot_position } = event.detail;
-    layoutStore.placeDevice(rackId, slug, position, face, slot_position);
-    ondevicedrop?.(event);
-  }
-
-  function handleDeviceMove(
-    event: CustomEvent<{
-      rackId: string;
-      deviceIndex: number;
-      newPosition: number;
-      slot_position?: SlotPosition;
-    }>,
-  ) {
-    const { rackId, deviceIndex, newPosition, slot_position } = event.detail;
-    layoutStore.moveDevice(rackId, deviceIndex, newPosition, slot_position);
-    ondevicemove?.(event);
-  }
-
-  function handleDeviceMoveRack(
-    event: CustomEvent<{
-      sourceRackId: string;
-      sourceIndex: number;
-      targetRackId: string;
-      targetPosition: number;
-      face: DeviceFace;
-      slot_position?: SlotPosition;
-    }>,
-  ) {
-    const {
-      sourceRackId,
-      sourceIndex,
-      targetRackId,
-      targetPosition,
-      face,
-      slot_position,
-    } = event.detail;
-    layoutStore.moveDeviceToRack(
-      sourceRackId,
-      sourceIndex,
-      targetRackId,
-      targetPosition,
-      face,
-      slot_position,
-    );
-    ondevicemoverack?.(event);
-  }
-
-  // NOTE: handleRackViewChange removed in v0.4 (dual-view mode - always show both)
 
   // Screen reader accessible description of rack contents
   const rackDescription = $derived.by(() => {
@@ -476,161 +314,6 @@
       selectionStore.clearSelection();
     }
   }
-
-  function triggerSwipeAnimation(direction: RackSwipeDirection) {
-    if (swipeAnimationTimeout) {
-      clearTimeout(swipeAnimationTimeout);
-      swipeAnimationTimeout = null;
-    }
-
-    const epoch = ++swipeAnimationEpoch;
-    swipeAnimationDirection = null;
-
-    Promise.resolve().then(() => {
-      if (epoch !== swipeAnimationEpoch) return;
-
-      swipeAnimationDirection = direction;
-      swipeAnimationTimeout = setTimeout(() => {
-        if (epoch !== swipeAnimationEpoch) return;
-        swipeAnimationDirection = null;
-        swipeAnimationTimeout = null;
-      }, SWIPE_SWITCH_ANIMATION_MS);
-    });
-  }
-
-  function switchRackFromSwipe(direction: RackSwipeDirection) {
-    if (!viewportStore.isMobile || racks.length < 2) {
-      return;
-    }
-
-    const targetRackId = resolveSwipeTargetRackId(
-      racks.map((rack) => rack.id),
-      layoutStore.activeRackId,
-      direction,
-    );
-    if (!targetRackId) {
-      return;
-    }
-
-    triggerSwipeAnimation(direction);
-    layoutStore.setActiveRack(targetRackId);
-    selectionStore.selectRack(targetRackId);
-    canvasStore.focusRack([targetRackId], racks, rackGroups, 0);
-  }
-
-  function handleCanvasTouchStart(event: TouchEvent) {
-    if (
-      !viewportStore.isMobile ||
-      racks.length < 2 ||
-      placementStore.isPlacing ||
-      event.touches.length !== 1
-    ) {
-      swipeGesture = null;
-      return;
-    }
-
-    const touch = event.touches[0];
-    if (!touch) {
-      swipeGesture = null;
-      return;
-    }
-
-    swipeGesture = {
-      startX: touch.clientX,
-      startY: touch.clientY,
-      currentX: touch.clientX,
-      currentY: touch.clientY,
-      startTime: performance.now(),
-      isMultiTouch: false,
-    };
-    lastTouchMoveLogAt = 0;
-    if (mobileDebug.enabled) {
-      mobileDebug(
-        "canvas touchstart: x=%d y=%d",
-        swipeGesture.startX,
-        swipeGesture.startY,
-      );
-    }
-  }
-
-  function handleCanvasTouchMove(event: TouchEvent) {
-    if (!swipeGesture) return;
-
-    if (event.touches.length !== 1) {
-      swipeGesture.isMultiTouch = true;
-      if (mobileDebug.enabled) {
-        mobileDebug("canvas touchmove: multitouch detected");
-      }
-      return;
-    }
-
-    const touch = event.touches[0];
-    if (!touch) return;
-
-    swipeGesture.currentX = touch.clientX;
-    swipeGesture.currentY = touch.clientY;
-    if (mobileDebug.enabled) {
-      const now = performance.now();
-      if (now - lastTouchMoveLogAt >= TOUCH_MOVE_LOG_INTERVAL_MS) {
-        mobileDebug(
-          "canvas touchmove: x=%d y=%d",
-          swipeGesture.currentX,
-          swipeGesture.currentY,
-        );
-        lastTouchMoveLogAt = now;
-      }
-    }
-  }
-
-  function handleCanvasTouchEnd(event: TouchEvent) {
-    if (!swipeGesture) return;
-
-    const changedTouch = event.changedTouches[0];
-    const endX = changedTouch?.clientX ?? swipeGesture.currentX;
-    const endY = changedTouch?.clientY ?? swipeGesture.currentY;
-    const durationMs = performance.now() - swipeGesture.startTime;
-    const horizontalLock = exceedsHorizontalPanLock(swipeGesture.startX, endX);
-
-    if (!horizontalLock) {
-      if (mobileDebug.enabled) {
-        mobileDebug("canvas touchend: below horizontal lock threshold");
-      }
-      swipeGesture = null;
-      return;
-    }
-
-    const direction = classifyRackSwipeGesture({
-      startX: swipeGesture.startX,
-      startY: swipeGesture.startY,
-      endX,
-      endY,
-      durationMs,
-      isMultiTouch: swipeGesture.isMultiTouch,
-    });
-
-    if (mobileDebug.enabled) {
-      mobileDebug(
-        "canvas touchend: direction=%s duration=%dms",
-        direction ?? "none",
-        Math.round(durationMs),
-      );
-    }
-
-    swipeGesture = null;
-
-    if (!direction) return;
-    if (mobileDebug.enabled) {
-      mobileDebug("Swipe detected: %s, switching rack", direction);
-    }
-    switchRackFromSwipe(direction);
-  }
-
-  function handleCanvasTouchCancel() {
-    if (mobileDebug.enabled) {
-      mobileDebug("canvas touchcancel: gesture reset");
-    }
-    swipeGesture = null;
-  }
 </script>
 
 <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -- these warnings appear in Vite build but not ESLint -->
@@ -653,8 +336,6 @@
     onclick={handleCanvasClick}
     onkeydown={handleCanvasKeydown}
   >
-    <!-- Note: Mobile placement indicator now integrated into Rack.svelte -->
-
     <!-- Hidden description for screen readers -->
     {#if deviceListDescription}
       <p id="canvas-device-list" class="sr-only">{deviceListDescription}</p>
@@ -675,135 +356,23 @@
 
     {#if hasRacks}
       <div class="panzoom-container" bind:this={panzoomContainer}>
-        <!-- Multi-rack mode: render racks with visual grouping -->
-        <div
-          class="racks-wrapper"
-          class:swipe-next={swipeAnimationDirection === "next"}
-          class:swipe-previous={swipeAnimationDirection === "previous"}
-        >
-          <!-- Render grouped racks with group labels -->
-          {#each organizedRacks.groupEntries as { group, racks: groupRacks } (group.id)}
-            {#if group.layout_preset === "bayed"}
-              <!-- Bayed/touring racks use special stacked view -->
-              <BayedRackView
-                {group}
-                racks={groupRacks}
-                deviceLibrary={layoutStore.device_types}
-                {activeRackId}
-                selectedDeviceId={selectionStore.selectedType === "device"
-                  ? selectionStore.selectedDeviceId
-                  : null}
-                selectedRackId={selectionStore.selectedType === "rack"
-                  ? selectionStore.selectedRackId
-                  : null}
-                displayMode={uiStore.displayMode}
-                showLabelsOnImages={uiStore.showLabelsOnImages}
-                showAnnotations={uiStore.showAnnotations}
-                annotationField={uiStore.annotationField}
-                {partyMode}
-                {enableLongPress}
-                ongroupselect={(e) => handleGroupSelect(e)}
-                ondeviceselect={(e) => handleDeviceSelect(e.detail.rackId, e)}
-                ondevicedrop={(e) => handleDeviceDrop(e)}
-                ondevicemove={(e) => handleDeviceMove(e)}
-                ondevicemoverack={(e) => handleDeviceMoveRack(e)}
-                onplacementtap={(e) => handlePlacementTap(e.detail.rackId, e)}
-                onlongpress={(e) => onracklongpress?.(e)}
-                onfocus={(rackIds) => onrackfocus?.(rackIds)}
-                onexport={(rackIds) => onrackexport?.(rackIds)}
-                onedit={(rackId) => onrackedit?.(rackId)}
-                onrename={(rackId) => onrackrename?.(rackId)}
-                onduplicate={(rackId) => onrackduplicate?.(rackId)}
-                ondelete={(rackId) => onrackdelete?.(rackId)}
-              />
-            {:else}
-              <!-- Standard row layout for non-bayed groups -->
-              <div class="rack-group">
-                <div class="group-label">{group.name ?? "Group"}</div>
-                <div class="group-racks">
-                  {#each groupRacks as rack (rack.id)}
-                    {@const isActive = rack.id === activeRackId}
-                    {@const isSelected =
-                      selectionStore.selectedType === "rack" &&
-                      selectionStore.selectedRackId === rack.id}
-                    <div class="rack-wrapper" class:active={isActive}>
-                      <RackDualView
-                        {rack}
-                        deviceLibrary={layoutStore.device_types}
-                        selected={isSelected}
-                        {isActive}
-                        selectedDeviceId={selectionStore.selectedType ===
-                          "device" && selectionStore.selectedRackId === rack.id
-                          ? selectionStore.selectedDeviceId
-                          : null}
-                        displayMode={uiStore.displayMode}
-                        showLabelsOnImages={uiStore.showLabelsOnImages}
-                        showAnnotations={uiStore.showAnnotations}
-                        annotationField={uiStore.annotationField}
-                        showBanana={uiStore.showBanana}
-                        {partyMode}
-                        {enableLongPress}
-                        onselect={(e) => handleRackSelect(e)}
-                        ondeviceselect={(e) => handleDeviceSelect(rack.id, e)}
-                        ondevicedrop={(e) => handleDeviceDrop(e)}
-                        ondevicemove={(e) => handleDeviceMove(e)}
-                        ondevicemoverack={(e) => handleDeviceMoveRack(e)}
-                        onplacementtap={(e) => handlePlacementTap(rack.id, e)}
-                        onlongpress={(e) => onracklongpress?.(e)}
-                        onfocus={() => onrackfocus?.([rack.id])}
-                        onexport={() => onrackexport?.([rack.id])}
-                        onedit={() => onrackedit?.(rack.id)}
-                        onrename={() => onrackrename?.(rack.id)}
-                        onduplicate={() => onrackduplicate?.(rack.id)}
-                        ondelete={() => onrackdelete?.(rack.id)}
-                      />
-                    </div>
-                  {/each}
-                </div>
-              </div>
-            {/if}
-          {/each}
-
-          <!-- Render ungrouped racks -->
-          {#each organizedRacks.ungroupedRacks as rack (rack.id)}
-            {@const isActive = rack.id === activeRackId}
-            {@const isSelected =
-              selectionStore.selectedType === "rack" &&
-              selectionStore.selectedRackId === rack.id}
-            <div class="rack-wrapper" class:active={isActive}>
-              <RackDualView
-                {rack}
-                deviceLibrary={layoutStore.device_types}
-                selected={isSelected}
-                {isActive}
-                selectedDeviceId={selectionStore.selectedType === "device" &&
-                selectionStore.selectedRackId === rack.id
-                  ? selectionStore.selectedDeviceId
-                  : null}
-                displayMode={uiStore.displayMode}
-                showLabelsOnImages={uiStore.showLabelsOnImages}
-                showAnnotations={uiStore.showAnnotations}
-                annotationField={uiStore.annotationField}
-                showBanana={uiStore.showBanana}
-                {partyMode}
-                {enableLongPress}
-                onselect={(e) => handleRackSelect(e)}
-                ondeviceselect={(e) => handleDeviceSelect(rack.id, e)}
-                ondevicedrop={(e) => handleDeviceDrop(e)}
-                ondevicemove={(e) => handleDeviceMove(e)}
-                ondevicemoverack={(e) => handleDeviceMoveRack(e)}
-                onplacementtap={(e) => handlePlacementTap(rack.id, e)}
-                onlongpress={(e) => onracklongpress?.(e)}
-                onfocus={() => onrackfocus?.([rack.id])}
-                onexport={() => onrackexport?.([rack.id])}
-                onedit={() => onrackedit?.(rack.id)}
-                onrename={() => onrackrename?.(rack.id)}
-                onduplicate={() => onrackduplicate?.(rack.id)}
-                ondelete={() => onrackdelete?.(rack.id)}
-              />
-            </div>
-          {/each}
-        </div>
+        <RackCanvasView
+          {partyMode}
+          {enableLongPress}
+          swipeAnimationDirection={swipeController.animationDirection}
+          {onrackselect}
+          {ondeviceselect}
+          {ondevicedrop}
+          {ondevicemove}
+          {ondevicemoverack}
+          {onracklongpress}
+          {onrackfocus}
+          {onrackexport}
+          {onrackedit}
+          {onrackrename}
+          {onrackduplicate}
+          {onrackdelete}
+        />
       </div>
     {:else}
       <WelcomeScreen onclick={handleNewRack} />
@@ -834,86 +403,6 @@
     cursor: grabbing;
   }
 
-  .racks-wrapper {
-    /* Multi-rack mode: horizontal layout of all racks */
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start; /* Prevent shorter racks from stretching to match tallest */
-    gap: var(--space-6);
-    padding: var(--space-4);
-  }
-
-  .racks-wrapper.swipe-next {
-    animation: rack-swipe-next 200ms var(--ease-out, ease-out);
-  }
-
-  .racks-wrapper.swipe-previous {
-    animation: rack-swipe-previous 200ms var(--ease-out, ease-out);
-  }
-
-  @keyframes rack-swipe-next {
-    0% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-    50% {
-      opacity: 0.9;
-      transform: translateX(-18px);
-    }
-    100% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-  }
-
-  @keyframes rack-swipe-previous {
-    0% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-    50% {
-      opacity: 0.9;
-      transform: translateX(18px);
-    }
-    100% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-  }
-
-  .rack-wrapper {
-    /* Individual rack container - selection styling handled by RackDualView */
-    display: inline-block;
-    border-radius: var(--radius-lg);
-  }
-
-  /* Rack group visual container (for non-bayed groups; bayed uses BayedRackView) */
-  .rack-group {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
-    padding: var(--space-3);
-    border: 2px dashed var(--colour-border);
-    border-radius: var(--radius-lg);
-    background: var(--colour-surface-overlay, rgba(40, 42, 54, 0.3));
-  }
-
-  .group-label {
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-semibold, 600);
-    color: var(--colour-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 0 var(--space-1);
-  }
-
-  .group-racks {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start; /* Prevent shorter racks from stretching */
-    gap: var(--space-4);
-  }
-
   /* Party mode: animated gradient background */
   @keyframes party-bg {
     0% {
@@ -937,11 +426,6 @@
   /* Respect reduced motion preference */
   @media (prefers-reduced-motion: reduce) {
     .canvas.party-mode {
-      animation: none;
-    }
-
-    .racks-wrapper.swipe-next,
-    .racks-wrapper.swipe-previous {
       animation: none;
     }
   }

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -1,0 +1,444 @@
+<!--
+  RackCanvasView
+  Renders all racks inside the panzoom viewport: grouped racks (standard or
+  bayed) and ungrouped racks. Owns the device drop/move/select handlers that
+  delegate to the layout store and bubble events up to the host. Extracted from
+  Canvas.svelte (#1610) so Canvas just owns the viewport shell.
+-->
+<script lang="ts">
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getSelectionStore } from "$lib/stores/selection.svelte";
+  import { getCanvasStore } from "$lib/stores/canvas.svelte";
+  import { getUIStore } from "$lib/stores/ui.svelte";
+  import { getPlacementStore } from "$lib/stores/placement.svelte";
+  import { hapticSuccess } from "$lib/utils/haptics";
+  import { resolveSelectedDevice } from "$lib/utils/device-selection";
+  import type { RackSwipeDirection } from "$lib/utils/gestures";
+  import type { DeviceFace, SlotPosition } from "$lib/types";
+  import RackDualView from "./RackDualView.svelte";
+  import BayedRackView from "./BayedRackView.svelte";
+
+  interface Props {
+    partyMode?: boolean;
+    enableLongPress?: boolean;
+    /** Active slide animation while switching racks via swipe. */
+    swipeAnimationDirection?: RackSwipeDirection | null;
+    onrackselect?: (event: CustomEvent<{ rackId: string }>) => void;
+    ondeviceselect?: (
+      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+    ) => void;
+    ondevicedrop?: (
+      event: CustomEvent<{
+        rackId: string;
+        slug: string;
+        position: number;
+        face: "front" | "rear";
+        slot_position?: SlotPosition;
+      }>,
+    ) => void;
+    ondevicemove?: (
+      event: CustomEvent<{
+        rackId: string;
+        deviceIndex: number;
+        newPosition: number;
+        slot_position?: SlotPosition;
+      }>,
+    ) => void;
+    ondevicemoverack?: (
+      event: CustomEvent<{
+        sourceRackId: string;
+        sourceIndex: number;
+        targetRackId: string;
+        targetPosition: number;
+        face: DeviceFace;
+        slot_position?: SlotPosition;
+      }>,
+    ) => void;
+    onracklongpress?: (event: CustomEvent<{ rackId: string }>) => void;
+    onrackfocus?: (rackIds: string[]) => void;
+    onrackexport?: (rackIds: string[]) => void;
+    onrackedit?: (rackId: string) => void;
+    onrackrename?: (rackId: string) => void;
+    onrackduplicate?: (rackId: string) => void;
+    onrackdelete?: (rackId: string) => void;
+  }
+
+  let {
+    partyMode = false,
+    enableLongPress = false,
+    swipeAnimationDirection = null,
+    onrackselect,
+    ondeviceselect,
+    ondevicedrop,
+    ondevicemove,
+    ondevicemoverack,
+    onracklongpress,
+    onrackfocus,
+    onrackexport,
+    onrackedit,
+    onrackrename,
+    onrackduplicate,
+    onrackdelete,
+  }: Props = $props();
+
+  const layoutStore = getLayoutStore();
+  const selectionStore = getSelectionStore();
+  const canvasStore = getCanvasStore();
+  const uiStore = getUIStore();
+  const placementStore = getPlacementStore();
+
+  const racks = $derived(layoutStore.racks);
+  const activeRackId = $derived(layoutStore.activeRackId);
+  const rackGroups = $derived(layoutStore.rack_groups);
+
+  // Organize racks: grouped racks in their groups, then ungrouped racks
+  const organizedRacks = $derived.by(() => {
+    const groupedRackIds = new Set(rackGroups.flatMap((g) => g.rack_ids));
+    const ungroupedRacks = racks.filter((r) => !groupedRackIds.has(r.id));
+
+    // Build group entries with their racks
+    const groupEntries = rackGroups
+      .map((group) => ({
+        group,
+        racks: group.rack_ids
+          .map((id) => racks.find((r) => r.id === id))
+          .filter((r): r is (typeof racks)[0] => r !== undefined),
+      }))
+      .filter((entry) => entry.racks.length > 0);
+
+    return { groupEntries, ungroupedRacks };
+  });
+
+  // Handle mobile tap-to-place (uses active rack)
+  function handlePlacementTap(
+    rackId: string,
+    event: CustomEvent<{ position: number; face: "front" | "rear" }>,
+  ) {
+    const device = placementStore.pendingDevice;
+    if (!device) return;
+
+    const { position, face } = event.detail;
+    const success = layoutStore.placeDevice(rackId, device.slug, position, face);
+
+    if (success) {
+      hapticSuccess();
+      placementStore.completePlacement();
+      // Reset view to show full rack after placement completes
+      canvasStore.fitAll(layoutStore.racks);
+    }
+  }
+
+  function handleRackSelect(event: CustomEvent<{ rackId: string }>) {
+    const { rackId } = event.detail;
+    layoutStore.setActiveRack(rackId);
+    selectionStore.selectRack(rackId);
+    onrackselect?.(event);
+  }
+
+  function handleGroupSelect(event: CustomEvent<{ groupId: string }>) {
+    const { groupId } = event.detail;
+    const group = layoutStore.getRackGroupById(groupId);
+    if (!group || group.rack_ids.length === 0) return;
+    const activeRackInGroup =
+      activeRackId && group.rack_ids.includes(activeRackId)
+        ? activeRackId
+        : group.rack_ids[0];
+    layoutStore.setActiveRack(activeRackInGroup ?? null);
+    selectionStore.selectGroup(groupId, activeRackInGroup);
+  }
+
+  function handleDeviceSelect(
+    rackId: string,
+    event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+  ) {
+    // Resolve the placed device by its UUID when available. The legacy
+    // (slug, position) fallback is ambiguous for two half-width devices sharing
+    // the same U (#1680), where it always resolved to the left device and left
+    // the right one unselectable.
+    const targetRack = layoutStore.getRackById(rackId);
+    if (targetRack) {
+      const device = resolveSelectedDevice(targetRack, event.detail);
+      if (device) {
+        layoutStore.setActiveRack(rackId);
+        selectionStore.selectDevice(rackId, device.id);
+      }
+    }
+    ondeviceselect?.(event);
+  }
+
+  function handleDeviceDrop(
+    event: CustomEvent<{
+      rackId: string;
+      slug: string;
+      position: number;
+      face: "front" | "rear";
+      slot_position?: SlotPosition;
+    }>,
+  ) {
+    const { rackId, slug, position, face, slot_position } = event.detail;
+    layoutStore.placeDevice(rackId, slug, position, face, slot_position);
+    ondevicedrop?.(event);
+  }
+
+  function handleDeviceMove(
+    event: CustomEvent<{
+      rackId: string;
+      deviceIndex: number;
+      newPosition: number;
+      slot_position?: SlotPosition;
+    }>,
+  ) {
+    const { rackId, deviceIndex, newPosition, slot_position } = event.detail;
+    layoutStore.moveDevice(rackId, deviceIndex, newPosition, slot_position);
+    ondevicemove?.(event);
+  }
+
+  function handleDeviceMoveRack(
+    event: CustomEvent<{
+      sourceRackId: string;
+      sourceIndex: number;
+      targetRackId: string;
+      targetPosition: number;
+      face: DeviceFace;
+      slot_position?: SlotPosition;
+    }>,
+  ) {
+    const {
+      sourceRackId,
+      sourceIndex,
+      targetRackId,
+      targetPosition,
+      face,
+      slot_position,
+    } = event.detail;
+    layoutStore.moveDeviceToRack(
+      sourceRackId,
+      sourceIndex,
+      targetRackId,
+      targetPosition,
+      face,
+      slot_position,
+    );
+    ondevicemoverack?.(event);
+  }
+</script>
+
+<!-- Multi-rack mode: render racks with visual grouping -->
+<div
+  class="racks-wrapper"
+  class:swipe-next={swipeAnimationDirection === "next"}
+  class:swipe-previous={swipeAnimationDirection === "previous"}
+>
+  <!-- Render grouped racks with group labels -->
+  {#each organizedRacks.groupEntries as { group, racks: groupRacks } (group.id)}
+    {#if group.layout_preset === "bayed"}
+      <!-- Bayed/touring racks use special stacked view -->
+      <BayedRackView
+        {group}
+        racks={groupRacks}
+        deviceLibrary={layoutStore.device_types}
+        {activeRackId}
+        selectedDeviceId={selectionStore.selectedType === "device"
+          ? selectionStore.selectedDeviceId
+          : null}
+        selectedRackId={selectionStore.selectedType === "rack"
+          ? selectionStore.selectedRackId
+          : null}
+        displayMode={uiStore.displayMode}
+        showLabelsOnImages={uiStore.showLabelsOnImages}
+        showAnnotations={uiStore.showAnnotations}
+        annotationField={uiStore.annotationField}
+        {partyMode}
+        {enableLongPress}
+        ongroupselect={(e) => handleGroupSelect(e)}
+        ondeviceselect={(e) => handleDeviceSelect(e.detail.rackId, e)}
+        ondevicedrop={(e) => handleDeviceDrop(e)}
+        ondevicemove={(e) => handleDeviceMove(e)}
+        ondevicemoverack={(e) => handleDeviceMoveRack(e)}
+        onplacementtap={(e) => handlePlacementTap(e.detail.rackId, e)}
+        onlongpress={(e) => onracklongpress?.(e)}
+        onfocus={(rackIds) => onrackfocus?.(rackIds)}
+        onexport={(rackIds) => onrackexport?.(rackIds)}
+        onedit={(rackId) => onrackedit?.(rackId)}
+        onrename={(rackId) => onrackrename?.(rackId)}
+        onduplicate={(rackId) => onrackduplicate?.(rackId)}
+        ondelete={(rackId) => onrackdelete?.(rackId)}
+      />
+    {:else}
+      <!-- Standard row layout for non-bayed groups -->
+      <div class="rack-group">
+        <div class="group-label">{group.name ?? "Group"}</div>
+        <div class="group-racks">
+          {#each groupRacks as rack (rack.id)}
+            {@const isActive = rack.id === activeRackId}
+            {@const isSelected =
+              selectionStore.selectedType === "rack" &&
+              selectionStore.selectedRackId === rack.id}
+            <div class="rack-wrapper" class:active={isActive}>
+              <RackDualView
+                {rack}
+                deviceLibrary={layoutStore.device_types}
+                selected={isSelected}
+                {isActive}
+                selectedDeviceId={selectionStore.selectedType === "device" &&
+                selectionStore.selectedRackId === rack.id
+                  ? selectionStore.selectedDeviceId
+                  : null}
+                displayMode={uiStore.displayMode}
+                showLabelsOnImages={uiStore.showLabelsOnImages}
+                showAnnotations={uiStore.showAnnotations}
+                annotationField={uiStore.annotationField}
+                showBanana={uiStore.showBanana}
+                {partyMode}
+                {enableLongPress}
+                onselect={(e) => handleRackSelect(e)}
+                ondeviceselect={(e) => handleDeviceSelect(rack.id, e)}
+                ondevicedrop={(e) => handleDeviceDrop(e)}
+                ondevicemove={(e) => handleDeviceMove(e)}
+                ondevicemoverack={(e) => handleDeviceMoveRack(e)}
+                onplacementtap={(e) => handlePlacementTap(rack.id, e)}
+                onlongpress={(e) => onracklongpress?.(e)}
+                onfocus={() => onrackfocus?.([rack.id])}
+                onexport={() => onrackexport?.([rack.id])}
+                onedit={() => onrackedit?.(rack.id)}
+                onrename={() => onrackrename?.(rack.id)}
+                onduplicate={() => onrackduplicate?.(rack.id)}
+                ondelete={() => onrackdelete?.(rack.id)}
+              />
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  {/each}
+
+  <!-- Render ungrouped racks -->
+  {#each organizedRacks.ungroupedRacks as rack (rack.id)}
+    {@const isActive = rack.id === activeRackId}
+    {@const isSelected =
+      selectionStore.selectedType === "rack" &&
+      selectionStore.selectedRackId === rack.id}
+    <div class="rack-wrapper" class:active={isActive}>
+      <RackDualView
+        {rack}
+        deviceLibrary={layoutStore.device_types}
+        selected={isSelected}
+        {isActive}
+        selectedDeviceId={selectionStore.selectedType === "device" &&
+        selectionStore.selectedRackId === rack.id
+          ? selectionStore.selectedDeviceId
+          : null}
+        displayMode={uiStore.displayMode}
+        showLabelsOnImages={uiStore.showLabelsOnImages}
+        showAnnotations={uiStore.showAnnotations}
+        annotationField={uiStore.annotationField}
+        showBanana={uiStore.showBanana}
+        {partyMode}
+        {enableLongPress}
+        onselect={(e) => handleRackSelect(e)}
+        ondeviceselect={(e) => handleDeviceSelect(rack.id, e)}
+        ondevicedrop={(e) => handleDeviceDrop(e)}
+        ondevicemove={(e) => handleDeviceMove(e)}
+        ondevicemoverack={(e) => handleDeviceMoveRack(e)}
+        onplacementtap={(e) => handlePlacementTap(rack.id, e)}
+        onlongpress={(e) => onracklongpress?.(e)}
+        onfocus={() => onrackfocus?.([rack.id])}
+        onexport={() => onrackexport?.([rack.id])}
+        onedit={() => onrackedit?.(rack.id)}
+        onrename={() => onrackrename?.(rack.id)}
+        onduplicate={() => onrackduplicate?.(rack.id)}
+        ondelete={() => onrackdelete?.(rack.id)}
+      />
+    </div>
+  {/each}
+</div>
+
+<style>
+  .racks-wrapper {
+    /* Multi-rack mode: horizontal layout of all racks */
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start; /* Prevent shorter racks from stretching to match tallest */
+    gap: var(--space-6);
+    padding: var(--space-4);
+  }
+
+  .racks-wrapper.swipe-next {
+    animation: rack-swipe-next 200ms var(--ease-out, ease-out);
+  }
+
+  .racks-wrapper.swipe-previous {
+    animation: rack-swipe-previous 200ms var(--ease-out, ease-out);
+  }
+
+  @keyframes rack-swipe-next {
+    0% {
+      opacity: 1;
+      transform: translateX(0);
+    }
+    50% {
+      opacity: 0.9;
+      transform: translateX(-18px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes rack-swipe-previous {
+    0% {
+      opacity: 1;
+      transform: translateX(0);
+    }
+    50% {
+      opacity: 0.9;
+      transform: translateX(18px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  .rack-wrapper {
+    /* Individual rack container - selection styling handled by RackDualView */
+    display: inline-block;
+    border-radius: var(--radius-lg);
+  }
+
+  /* Rack group visual container (for non-bayed groups; bayed uses BayedRackView) */
+  .rack-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    border: 2px dashed var(--colour-border);
+    border-radius: var(--radius-lg);
+    background: var(--colour-surface-overlay, rgba(40, 42, 54, 0.3));
+  }
+
+  .group-label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold, 600);
+    color: var(--colour-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0 var(--space-1);
+  }
+
+  .group-racks {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start; /* Prevent shorter racks from stretching */
+    gap: var(--space-4);
+  }
+
+  /* Respect reduced motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .racks-wrapper.swipe-next,
+    .racks-wrapper.swipe-previous {
+      animation: none;
+    }
+  }
+</style>

--- a/src/lib/utils/canvas-swipe.svelte.ts
+++ b/src/lib/utils/canvas-swipe.svelte.ts
@@ -1,0 +1,250 @@
+/**
+ * Rack swipe controller
+ *
+ * Owns the mobile swipe-to-switch-rack gesture state machine extracted from
+ * Canvas.svelte (#1610). It tracks a single-finger horizontal swipe,
+ * classifies it, and switches the active rack with a brief slide animation.
+ * The caller wires the touch listeners to the canvas element and reads
+ * `animationDirection` for the CSS class; all gesture bookkeeping stays here.
+ */
+import {
+  classifyRackSwipeGesture,
+  type RackSwipeDirection,
+} from "$lib/utils/gestures";
+import {
+  resolveSwipeTargetRackId,
+  exceedsHorizontalPanLock,
+} from "$lib/utils/canvas-coordinates";
+import { appDebug } from "$lib/utils/debug";
+import type { Rack, RackGroup } from "$lib/types";
+
+const SWIPE_SWITCH_ANIMATION_MS = 200;
+const TOUCH_MOVE_LOG_INTERVAL_MS = 120;
+
+interface SwipeGestureState {
+  startX: number;
+  startY: number;
+  currentX: number;
+  currentY: number;
+  startTime: number;
+  isMultiTouch: boolean;
+}
+
+/**
+ * Reactive data and actions the controller needs. Getters keep the controller
+ * decoupled from the stores' reactive internals so it reads live values each
+ * time a gesture is evaluated.
+ */
+export interface RackSwipeDeps {
+  isMobile: () => boolean;
+  getRacks: () => Rack[];
+  getRackGroups: () => RackGroup[];
+  isPlacing: () => boolean;
+  getActiveRackId: () => string | null;
+  setActiveRack: (id: string) => void;
+  selectRack: (id: string) => void;
+  focusRack: (
+    rackIds: string[],
+    racks: Rack[],
+    rackGroups: RackGroup[],
+    rightOffset: number,
+  ) => void;
+}
+
+export interface RackSwipeController {
+  /** Animation class direction for the current switch, or null when idle. */
+  readonly animationDirection: RackSwipeDirection | null;
+  handleTouchStart: (event: TouchEvent) => void;
+  handleTouchMove: (event: TouchEvent) => void;
+  handleTouchEnd: (event: TouchEvent) => void;
+  handleTouchCancel: () => void;
+  /** Clear any pending animation timer. Call from the host's onDestroy. */
+  dispose: () => void;
+}
+
+export function createRackSwipeController(
+  deps: RackSwipeDeps,
+): RackSwipeController {
+  const mobileDebug = appDebug.mobile;
+
+  let swipeGesture: SwipeGestureState | null = null;
+  let animationDirection = $state<RackSwipeDirection | null>(null);
+  let animationTimeout: ReturnType<typeof setTimeout> | null = null;
+  let animationEpoch = 0;
+  let lastTouchMoveLogAt = 0;
+
+  function triggerSwipeAnimation(direction: RackSwipeDirection) {
+    if (animationTimeout) {
+      clearTimeout(animationTimeout);
+      animationTimeout = null;
+    }
+
+    const epoch = ++animationEpoch;
+    animationDirection = null;
+
+    // Restart the animation on the next microtask so consecutive swipes
+    // re-trigger the CSS keyframes instead of being deduped by Svelte.
+    Promise.resolve().then(() => {
+      if (epoch !== animationEpoch) return;
+
+      animationDirection = direction;
+      animationTimeout = setTimeout(() => {
+        if (epoch !== animationEpoch) return;
+        animationDirection = null;
+        animationTimeout = null;
+      }, SWIPE_SWITCH_ANIMATION_MS);
+    });
+  }
+
+  function switchRackFromSwipe(direction: RackSwipeDirection) {
+    const racks = deps.getRacks();
+    if (!deps.isMobile() || racks.length < 2) {
+      return;
+    }
+
+    const targetRackId = resolveSwipeTargetRackId(
+      racks.map((rack) => rack.id),
+      deps.getActiveRackId(),
+      direction,
+    );
+    if (!targetRackId) {
+      return;
+    }
+
+    triggerSwipeAnimation(direction);
+    deps.setActiveRack(targetRackId);
+    deps.selectRack(targetRackId);
+    deps.focusRack([targetRackId], racks, deps.getRackGroups(), 0);
+  }
+
+  function handleTouchStart(event: TouchEvent) {
+    if (
+      !deps.isMobile() ||
+      deps.getRacks().length < 2 ||
+      deps.isPlacing() ||
+      event.touches.length !== 1
+    ) {
+      swipeGesture = null;
+      return;
+    }
+
+    const touch = event.touches[0];
+    if (!touch) {
+      swipeGesture = null;
+      return;
+    }
+
+    swipeGesture = {
+      startX: touch.clientX,
+      startY: touch.clientY,
+      currentX: touch.clientX,
+      currentY: touch.clientY,
+      startTime: performance.now(),
+      isMultiTouch: false,
+    };
+    lastTouchMoveLogAt = 0;
+    if (mobileDebug.enabled) {
+      mobileDebug(
+        "canvas touchstart: x=%d y=%d",
+        swipeGesture.startX,
+        swipeGesture.startY,
+      );
+    }
+  }
+
+  function handleTouchMove(event: TouchEvent) {
+    if (!swipeGesture) return;
+
+    if (event.touches.length !== 1) {
+      swipeGesture.isMultiTouch = true;
+      if (mobileDebug.enabled) {
+        mobileDebug("canvas touchmove: multitouch detected");
+      }
+      return;
+    }
+
+    const touch = event.touches[0];
+    if (!touch) return;
+
+    swipeGesture.currentX = touch.clientX;
+    swipeGesture.currentY = touch.clientY;
+    if (mobileDebug.enabled) {
+      const now = performance.now();
+      if (now - lastTouchMoveLogAt >= TOUCH_MOVE_LOG_INTERVAL_MS) {
+        mobileDebug(
+          "canvas touchmove: x=%d y=%d",
+          swipeGesture.currentX,
+          swipeGesture.currentY,
+        );
+        lastTouchMoveLogAt = now;
+      }
+    }
+  }
+
+  function handleTouchEnd(event: TouchEvent) {
+    if (!swipeGesture) return;
+
+    const changedTouch = event.changedTouches[0];
+    const endX = changedTouch?.clientX ?? swipeGesture.currentX;
+    const endY = changedTouch?.clientY ?? swipeGesture.currentY;
+    const durationMs = performance.now() - swipeGesture.startTime;
+    const horizontalLock = exceedsHorizontalPanLock(swipeGesture.startX, endX);
+
+    if (!horizontalLock) {
+      if (mobileDebug.enabled) {
+        mobileDebug("canvas touchend: below horizontal lock threshold");
+      }
+      swipeGesture = null;
+      return;
+    }
+
+    const direction = classifyRackSwipeGesture({
+      startX: swipeGesture.startX,
+      startY: swipeGesture.startY,
+      endX,
+      endY,
+      durationMs,
+      isMultiTouch: swipeGesture.isMultiTouch,
+    });
+
+    if (mobileDebug.enabled) {
+      mobileDebug(
+        "canvas touchend: direction=%s duration=%dms",
+        direction ?? "none",
+        Math.round(durationMs),
+      );
+    }
+
+    swipeGesture = null;
+
+    if (!direction) return;
+    if (mobileDebug.enabled) {
+      mobileDebug("Swipe detected: %s, switching rack", direction);
+    }
+    switchRackFromSwipe(direction);
+  }
+
+  function handleTouchCancel() {
+    if (mobileDebug.enabled) {
+      mobileDebug("canvas touchcancel: gesture reset");
+    }
+    swipeGesture = null;
+  }
+
+  return {
+    get animationDirection() {
+      return animationDirection;
+    },
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+    handleTouchCancel,
+    dispose() {
+      if (animationTimeout) {
+        clearTimeout(animationTimeout);
+        animationTimeout = null;
+      }
+      swipeGesture = null;
+    },
+  };
+}

--- a/src/lib/utils/canvas-swipe.svelte.ts
+++ b/src/lib/utils/canvas-swipe.svelte.ts
@@ -240,6 +240,10 @@ export function createRackSwipeController(
     handleTouchEnd,
     handleTouchCancel,
     dispose() {
+      // Invalidate any microtask still queued by triggerSwipeAnimation so it
+      // no-ops on its epoch guard instead of writing state or scheduling a new
+      // timer after teardown.
+      animationEpoch++;
       if (animationTimeout) {
         clearTimeout(animationTimeout);
         animationTimeout = null;

--- a/src/tests/canvas-swipe.test.ts
+++ b/src/tests/canvas-swipe.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the rack swipe controller (#1610)
+ *
+ * Covers the mobile swipe-to-switch-rack state machine extracted from
+ * Canvas.svelte: when a single-finger horizontal flick switches the active
+ * rack and when the gesture is rejected (not mobile, too few racks, placing,
+ * multi-touch, or below the horizontal pan-lock threshold). The underlying
+ * gesture math is covered in canvas-coordinates.test.ts and gestures.test.ts;
+ * here we assert the controller's wiring to the store actions.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  createRackSwipeController,
+  type RackSwipeDeps,
+  type RackSwipeController,
+} from "$lib/utils/canvas-swipe.svelte";
+import type { Rack } from "$lib/types";
+
+let active: RackSwipeController | null = null;
+
+afterEach(() => {
+  active?.dispose();
+  active = null;
+});
+
+function makeRacks(...ids: string[]): Rack[] {
+  return ids.map((id) => ({ id })) as unknown as Rack[];
+}
+
+function makeController(overrides: Partial<RackSwipeDeps> = {}) {
+  const deps: RackSwipeDeps = {
+    isMobile: () => true,
+    getRacks: () => makeRacks("r1", "r2"),
+    getRackGroups: () => [],
+    isPlacing: () => false,
+    getActiveRackId: () => "r1",
+    setActiveRack: vi.fn(),
+    selectRack: vi.fn(),
+    focusRack: vi.fn(),
+    ...overrides,
+  };
+  const controller = createRackSwipeController(deps);
+  active = controller;
+  return { controller, deps };
+}
+
+function touchStart(x: number, y: number): TouchEvent {
+  return { touches: [{ clientX: x, clientY: y }] } as unknown as TouchEvent;
+}
+
+function touchMove(x: number, y: number, fingers = 1): TouchEvent {
+  const touches = fingers === 1 ? [{ clientX: x, clientY: y }] : [{}, {}];
+  return { touches } as unknown as TouchEvent;
+}
+
+function touchEnd(x: number, y: number): TouchEvent {
+  return {
+    touches: [],
+    changedTouches: [{ clientX: x, clientY: y }],
+  } as unknown as TouchEvent;
+}
+
+/** Run a complete single-finger horizontal flick from startX to endX. */
+function flick(controller: RackSwipeController, startX: number, endX: number) {
+  controller.handleTouchStart(touchStart(startX, 100));
+  controller.handleTouchMove(touchMove(endX, 100));
+  controller.handleTouchEnd(touchEnd(endX, 100));
+}
+
+describe("rack swipe controller", () => {
+  it("switches to the adjacent rack on a leftward flick past the threshold", () => {
+    const { controller, deps } = makeController();
+    flick(controller, 220, 120); // dx = -100: leftward "next"
+
+    expect(deps.setActiveRack).toHaveBeenCalledWith("r2");
+    expect(deps.selectRack).toHaveBeenCalledWith("r2");
+    expect(deps.focusRack).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches on a rightward flick (wraps to the other rack)", () => {
+    const { controller, deps } = makeController();
+    flick(controller, 120, 220); // dx = +100: rightward "previous", wraps r1 -> r2
+
+    expect(deps.setActiveRack).toHaveBeenCalledWith("r2");
+    expect(deps.selectRack).toHaveBeenCalledWith("r2");
+  });
+
+  it("ignores gestures when not on mobile", () => {
+    const { controller, deps } = makeController({ isMobile: () => false });
+    flick(controller, 220, 120);
+
+    expect(deps.setActiveRack).not.toHaveBeenCalled();
+  });
+
+  it("ignores gestures with fewer than two racks", () => {
+    const { controller, deps } = makeController({
+      getRacks: () => makeRacks("only"),
+    });
+    flick(controller, 220, 120);
+
+    expect(deps.setActiveRack).not.toHaveBeenCalled();
+  });
+
+  it("ignores gestures while placing a device", () => {
+    const { controller, deps } = makeController({ isPlacing: () => true });
+    flick(controller, 220, 120);
+
+    expect(deps.setActiveRack).not.toHaveBeenCalled();
+  });
+
+  it("does not switch when the swipe stays below the horizontal pan lock", () => {
+    const { controller, deps } = makeController();
+    flick(controller, 200, 210); // dx = +10, under the 20px pan lock
+
+    expect(deps.setActiveRack).not.toHaveBeenCalled();
+  });
+
+  it("does not switch when a second finger joins mid-gesture", () => {
+    const { controller, deps } = makeController();
+    controller.handleTouchStart(touchStart(220, 100));
+    controller.handleTouchMove(touchMove(120, 100, 2)); // multi-touch
+    controller.handleTouchEnd(touchEnd(120, 100));
+
+    expect(deps.setActiveRack).not.toHaveBeenCalled();
+  });
+
+  it("resets the gesture on touch cancel so a later release does nothing", () => {
+    const { controller, deps } = makeController();
+    controller.handleTouchStart(touchStart(220, 100));
+    controller.handleTouchCancel();
+    controller.handleTouchEnd(touchEnd(120, 100));
+
+    expect(deps.setActiveRack).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Finishes the Canvas.svelte decomposition for #1610. PR #2111 already extracted
the coordinate math (`canvas-coordinates.ts`) and panzoom lifecycle
(`panzoom-lifecycle.ts`) with unit tests. This PR removes the remaining bulk by
extracting the markup and handlers, leaving Canvas.svelte as a viewport shell.

- `Canvas.svelte`: 988 -> 471 LOC (under the 500 target).
- `RackCanvasView.svelte` (new): rack-rendering markup (grouped + ungrouped),
  the `organizedRacks` derivation, and the device drop/move/select and
  placement-tap handlers. Pulls stores from context; takes the public callback
  props as passthroughs so Canvas's external API is unchanged.
- `canvas-swipe.svelte.ts` (new): the mobile swipe-to-switch-rack state machine,
  moved verbatim so behaviour is preserved. The touch listeners stay on the
  outer canvas element (same swipe area); only the state and decisions moved.
- `canvas-swipe.test.ts` (new): 8 tests for gating (not mobile, < 2 racks,
  placing, multi-touch, below pan-lock, cancel) and rack switching.

## Acceptance criteria

- [x] `Canvas.svelte` reduced to <500 LOC (471).
- [x] Coordinate transforms in `canvas-coordinates.ts` with unit tests (#2111).
- [x] Panzoom lifecycle isolated from rendering (#2111).
- [x] Existing E2E tests unchanged (validated in CI).
- [x] No behaviour change: pure structural refactor.
- [x] Debug namespaces (`rackula:canvas:transform`, `rackula:canvas:panzoom`,
      `rackula:app:mobile`) preserved.
- [ ] **<12 imports: not met (18).** See note below.

### Note on the <12 imports target (AC amendment)

Canvas now imports 6 stores + 8 utils + 3 components + 1 type = 18 statements.
Reaching <12 would require either a store/util barrel convention the codebase
does not use, or bundling the panzoom + swipe + long-press DOM wiring into
additional composables. Per maintainer direction we are shipping the
decomposition as-is (the structural goal is met) rather than introducing
abstraction purely to lower the count. The import target is treated as amended.

## Test plan

- [x] `npm run check` (clean for changed files)
- [x] `npm run lint` (clean)
- [x] `npm run test:run` (2140 passed)
- [x] `npm run build` (success)
- [ ] E2E in CI

Closes #1610


___

## **CodeAnt-AI Description**
**Keep canvas interactions the same while splitting rack rendering and swipe handling out of the main view**

### What Changed
- Rack rendering is moved out of the main canvas view, while grouped racks, ungrouped racks, and rack actions still behave the same
- Mobile swipe-to-switch-rack handling is kept intact, including the same swipe-to-rack change behavior and the same cases where the gesture is ignored
- The canvas still resets the view after a successful device placement and still clears the swipe animation when the view closes
- Added tests that cover rack swipe switching and the main cases where the swipe is rejected

### Impact
`✅ Preserved rack switching on mobile swipe`
`✅ Kept rack selection and placement behavior unchanged`
`✅ Added coverage for swipe gesture edge cases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
