### PR TITLE
fix: pre-pull api base image with retry to survive Docker Hub flakes (#2175)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Pre-pull base image
         working-directory: ./api
         run: |
-          image="$(awk '/^FROM/ { print $2; exit }' Dockerfile)"
+          image="$(awk '/^[[:space:]]*FROM[[:space:]]/ { print $2; exit }' Dockerfile)"
           echo "Base image: $image"
           for attempt in 1 2 3 4 5; do
             if docker pull "$image"; then
@@ -110,8 +110,9 @@ jobs:
               exit 0
             fi
             if [ "$attempt" -lt 5 ]; then
-              echo "::warning::Pull attempt $attempt for $image failed; retrying in $((attempt * 10))s"
-              sleep $((attempt * 10))
+              delay=$((2 ** (attempt - 1)))
+              echo "::warning::Pull attempt $attempt for $image failed; retrying in ${delay}s"
+              sleep "$delay"
             fi
           done
           echo "::error::Failed to pull $image after 5 attempts"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -94,6 +94,29 @@ jobs:
           tags: |
             type=ref,event=branch
 
+      # Pull the base image up front with bounded retry. The build-push-action
+      # below uses the default docker driver (no setup-buildx-action), which
+      # shares the host image store, so with pull: false (the default) the build
+      # reuses this locally-present image and skips the Docker Hub manifest HEAD
+      # that times out under transient registry flakes (#2175).
+      - name: Pre-pull base image
+        working-directory: ./api
+        run: |
+          image="$(awk '/^FROM/ { print $2; exit }' Dockerfile)"
+          echo "Base image: $image"
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$image"; then
+              echo "Pulled $image on attempt $attempt"
+              exit 0
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "::warning::Pull attempt $attempt for $image failed; retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "::error::Failed to pull $image after 5 attempts"
+          exit 1
+
       - name: Build and push API
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:


### PR DESCRIPTION
## **User description**
## Summary

The `build-api` job in `deploy-dev.yml` failed on
[run 27446042685](https://github.com/RackulaLives/Rackula/actions/runs/27446042685/job/81131112623)
with a transient Docker Hub timeout pulling its base image:

```
FROM oven/bun:1.3.10-alpine AS base
ERROR: failed to solve: DeadlineExceeded: ... Head "https://registry-1.docker.io/.../manifests/1.3.10-alpine": dial tcp 23.21.112.49:443: i/o timeout
```

Root cause: the job pulls its base image from Docker Hub anonymously with no
retry, so a single registry blip fails the whole dev deploy (`deploy` needs
`build-api`). 14 of the last 15 runs succeeded on the same `main` and Dockerfile,
confirming the failure is transient, not deterministic.

## Change

Add a pre-pull step with bounded retry/backoff before `build-push-action`. The
job uses no `setup-buildx-action`, so it runs the default docker driver, which
shares the host image store; with `pull: false` (the default) the build reuses
the locally-present image and skips the registry HEAD that times out. The base
image is read from `api/Dockerfile`'s `FROM` line, so it tracks the tag with no
drift. No new secrets or third-party actions.

## Test Plan

- [x] YAML parses (`yaml.safe_load`)
- [x] `awk` extraction yields `oven/bun:1.3.10-alpine` from `api/Dockerfile`
- [ ] Next push to `main` runs `build-api` green (pre-pull logs the base image and attempt count)

## Notes

`build-images.yml` (release-only) and `rebuild-images.yml` (monthly) build the
same base but use the container driver, so a host pre-pull does not apply; a
complementary hardening is authenticating Docker Hub pulls (needs
`DOCKERHUB_*` secrets, which do not exist yet). Tracked in #2175.

Closes #2175


___

## **CodeAnt-AI Description**
**Prevent dev deploys from failing on temporary Docker Hub pull errors**

### What Changed
- The dev API build now pulls its base image before the build starts, with retries and backoff if Docker Hub is temporarily unavailable
- If the image still cannot be pulled after several attempts, the job stops with a clear error instead of failing later during the build
- The base image name is taken from the API Dockerfile, so the pre-pull stays aligned with the image the build already uses

### Impact
`✅ Fewer dev deploy failures from Docker Hub flakes`
`✅ Clearer failure messages when the base image cannot be downloaded`
`✅ More reliable API builds in development`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
