### PR TITLE
fix(test): tune Playwright retries and add github/list reporters (#2000, #2001)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,12 +9,14 @@ export default defineConfig({
   testDir: ".",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: 2,
+  retries: 1,
   // CI uses the blob reporter so sharded runs (test-full.yml) can be merged
-  // into a single HTML report with `npx playwright merge-reports`.
+  // into a single HTML report with `npx playwright merge-reports`. The github
+  // reporter annotates PRs with failure locations; list shows live progress
+  // locally.
   reporter: process.env.CI
     ? [["github"], ["blob"]]
-    : [["html", { open: "never" }]],
+    : [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:4173",
     trace: "on-first-retry",

--- a/e2e/playwright.dev.config.ts
+++ b/e2e/playwright.dev.config.ts
@@ -24,8 +24,8 @@ export default defineConfig({
   testDir: ".",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: 2,
-  reporter: [["html", { open: "never" }]],
+  retries: 0,
+  reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:5173",
     trace: "on-first-retry",

--- a/e2e/playwright.smoke.config.ts
+++ b/e2e/playwright.smoke.config.ts
@@ -21,12 +21,16 @@ export default defineConfig({
   testMatch: ["smoke.spec.ts", "basic-workflow.spec.ts"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: 2,
+  retries: 1,
   timeout: 60000,
   expect: {
     timeout: 15000,
   },
-  reporter: [["html", { open: "never" }]],
+  // Smoke is single-shard, so no blob reporter. The github reporter annotates
+  // PRs with failure locations in CI; list shows live progress locally.
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: smokeTestUrl || "http://localhost:4173",
     trace: "on-first-retry",


### PR DESCRIPTION
## **User description**
## Summary

Two small M02 `area:testing` config issues, combined because they touch the same
three `e2e/*.config.ts` files.

- #2000: reduce Playwright retries. `playwright.config.ts` and
  `playwright.smoke.config.ts` go 2 -> 1; `playwright.dev.config.ts` goes 2 -> 0.
  Trims wasted reruns (up to 3 runs per failing test today).
- #2001: finish reporter coverage. `playwright.config.ts` already had
  `github` + `blob` in CI (shipped with the #1999 sharding work), so only the
  remainder was outstanding: add the `github` reporter to the single-shard smoke
  config (no `blob` needed) for inline PR failure annotations, and add the `list`
  reporter to local runs across all three configs for live console progress.

## Context

While triaging M02 `area:testing`, the browser-caching issue (#1996) was found
already implemented and was closed; #567 was closed as superseded by #1997;
#2003 and #1997 were moved to M04 (blocked on infra that does not yet exist).
This PR lands the only genuinely outstanding config work.

## Test Plan

- [x] All three configs parse and enumerate tests via `playwright test --config <cfg> --list` (348 / 12 / 174 tests)
- [x] CI reporter path for the sharded config is unchanged (`github` + `blob`)
- [ ] CI run shows `github` annotations on failure; `list` prints progress locally

Closes #2000
Closes #2001


___

## **CodeAnt-AI Description**
Reduce wasted test reruns and show clearer Playwright feedback in CI and locally

### What Changed
- Failed Playwright tests now retry fewer times, so broken tests stop rerunning as often
- CI runs now add PR failure annotations for the main and smoke test suites
- Local test runs now show live progress in the console for all three Playwright configs
- The dev test config no longer retries failures

### Impact
`✅ Fewer wasted test reruns`
`✅ Clearer PR failure annotations`
`✅ Faster visible test progress locally`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
