### PR TITLE
chore(ts): remove @ts-nocheck from 6 maintainer-side component files

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,7 +3,6 @@
   Main application component
 -->
 <script lang="ts">
-  // @ts-nocheck
   import { onMount, untrack } from "svelte";
   import AnimationDefs from "$lib/components/AnimationDefs.svelte";
   import Toolbar from "$lib/components/Toolbar.svelte";

--- a/src/lib/components/AddDeviceForm.svelte
+++ b/src/lib/components/AddDeviceForm.svelte
@@ -6,7 +6,7 @@
   import Dialog from "./Dialog.svelte";
   import ImageUpload from "./ImageUpload.svelte";
   import Switch from "./Switch.svelte";
-  import type { DeviceCategory } from "$lib/types";
+  import type { DeviceCategory, RackWidth } from "$lib/types";
   import type { ImageData } from "$lib/types/images";
   import {
     ALL_CATEGORIES,
@@ -28,7 +28,7 @@
       notes: string;
       isFullDepth: boolean;
       isHalfWidth: boolean;
-      rackWidths: number[];
+      rackWidths: RackWidth[];
       frontImage?: ImageData;
       rearImage?: ImageData;
     }) => void;
@@ -52,7 +52,7 @@
   }
 
   // Convert option to rack_widths array
-  function optionToRackWidths(option: RackWidthOption): number[] {
+  function optionToRackWidths(option: RackWidthOption): RackWidth[] {
     switch (option) {
       case "10":
         return [10];
@@ -351,7 +351,12 @@
       <button type="button" class="btn btn-secondary" onclick={handleCancel}>
         Cancel
       </button>
-      <button type="submit" class="btn btn-primary" data-testid="btn-add-device" onclick={handleSubmit}>
+      <button
+        type="submit"
+        class="btn btn-primary"
+        data-testid="btn-add-device"
+        onclick={handleSubmit}
+      >
         Add
       </button>
     </div>

--- a/src/lib/components/CleanupPromptDialog.svelte
+++ b/src/lib/components/CleanupPromptDialog.svelte
@@ -7,7 +7,7 @@
 
   interface Props {
     open: boolean;
-    operation?: "save" | "export" | null;
+    operation?: "save" | "saveAs" | "export" | null;
     unusedCount: number;
     onreview?: () => void;
     onkeepall?: () => void;
@@ -68,7 +68,7 @@
   const operationAction = $derived(
     operation === "export"
       ? "exporting"
-      : operation === "save"
+      : operation === "save" || operation === "saveAs"
         ? "saving"
         : "continuing",
   );
@@ -89,8 +89,8 @@
     </p>
 
     <p class="message hint">
-      Review & Clean Up opens a checklist where you can choose which unused types
-      to delete first.
+      Review & Clean Up opens a checklist where you can choose which unused
+      types to delete first.
     </p>
 
     <div class="dont-ask-again">

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -4,7 +4,6 @@
   Uses exclusive accordion (only one section open at a time)
 -->
 <script lang="ts">
-  // @ts-nocheck
   import { Accordion } from "bits-ui";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
@@ -166,9 +165,10 @@
       pendingToastId = null;
     }
 
+    const firstDeleted = deletedTypes[0];
     const message =
-      deletedTypes.length === 1
-        ? `Deleted "${deletedTypes[0].model ?? deletedTypes[0].slug}"`
+      deletedTypes.length === 1 && firstDeleted
+        ? `Deleted "${firstDeleted.model ?? firstDeleted.slug}"`
         : `Deleted ${deletedTypes.length} device types`;
 
     const actionLabel = deletedTypes.length === 1 ? "Undo" : "Undo All";
@@ -332,7 +332,7 @@
 
         // During search, compute match info
         const matchCount = section.devices.length;
-        const firstMatch = section.devices[0] ?? null;
+        const firstMatch = section.devices[0];
         const isEmpty = matchCount === 0;
 
         return {
@@ -353,7 +353,7 @@
       .map((cat) => {
         const devices = sortDevicesByBrandThenModel(grouped.get(cat) ?? []);
         const matchCount = devices.length;
-        const firstMatch = devices[0] ?? null;
+        const firstMatch = devices[0];
         const isEmpty = matchCount === 0;
 
         return {

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -4,7 +4,6 @@
   Draggable for placement into racks
 -->
 <script lang="ts">
-  // @ts-nocheck
   import type { DeviceType } from "$lib/types";
   import IconGrip from "./icons/IconGrip.svelte";
   import IconTrash from "./icons/IconTrash.svelte";

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -5,7 +5,6 @@
   All dependencies are accessed via module imports and singleton stores (zero props).
 -->
 <script lang="ts">
-  // @ts-nocheck
   import { NewRackWizard, type CreateRackData } from "$lib/components/wizard";
   import AddDeviceForm from "$lib/components/AddDeviceForm.svelte";
   import ImportFromNetBoxDialog from "$lib/components/ImportFromNetBoxDialog.svelte";

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -17,7 +17,6 @@
   - rack-context-menu-handlers: context menu UI delegation
 -->
 <script lang="ts">
-  // @ts-nocheck
   import type {
     Rack as RackType,
     DeviceType,
@@ -149,7 +148,6 @@
   }: Props = $props();
 
   // --- Drag state ---
-  let _draggingDeviceIndex = $state<number | null>(null);
   let justFinishedDrag = $state(false);
   let dragDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
   let shiftKeyHeld = $state(false);
@@ -355,9 +353,7 @@
       setContainerHoverInfo: (i) => {
         containerHoverInfo = i;
       },
-      clearDraggingIndex: () => {
-        _draggingDeviceIndex = null;
-      },
+      clearDraggingIndex: () => {},
       onDragFinished: setDragFinished,
       layoutStore,
       toastStore,
@@ -440,7 +436,6 @@
     ondragleave={(e) => onDragLeave(e, handlerCtx)}
     ondrop={(e) => {
       onDrop(e, handlerCtx);
-      _draggingDeviceIndex = null;
     }}
     ontouchend={(e) => {
       if (!viewportStore.isMobile || !placementStore.isPlacing) return;
@@ -509,16 +504,12 @@
             selectedChildId={selectedDeviceId}
             isDragOverContainer={isHoveredContainer}
             dragTargetSlotId={isHoveredContainer
-              ? containerHoverInfo.targetSlotId
+              ? (containerHoverInfo?.targetSlotId ?? null)
               : null}
             isDragTargetValid={isHoveredContainer &&
-              containerHoverInfo.isValidTarget}
+              containerHoverInfo?.isValidTarget === true}
             onselect={ondeviceselect}
-            ondragstart={() => {
-              _draggingDeviceIndex = originalIndex;
-            }}
             ondragend={() => {
-              _draggingDeviceIndex = null;
               setDragFinished();
             }}
             onduplicate={(e) =>
@@ -547,10 +538,11 @@
 
     <!-- Layer 4: Placement header (mobile) -->
     {#if isPlacementMode && placementStore.pendingDevice}
+      {@const pendingDevice = placementStore.pendingDevice}
       <RackPlacementHeader
         rackWidth={RACK_WIDTH}
         rackPadding={RACK_PADDING}
-        deviceModel={placementStore.pendingDevice.model}
+        deviceModel={pendingDevice.model ?? pendingDevice.slug}
         oncancel={handleCancelPlacement}
       />
     {/if}

--- a/src/lib/components/RackList.svelte
+++ b/src/lib/components/RackList.svelte
@@ -3,7 +3,6 @@
   Displays list of all racks with selection, delete, and context menu actions
 -->
 <script lang="ts">
-  // @ts-nocheck
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
@@ -66,8 +65,9 @@
 
   // Get the first rack in a group (for height info)
   function getGroupFirstRack(group: { rack_ids: string[] }) {
-    if (!group.rack_ids || group.rack_ids.length === 0) return undefined;
-    return layoutStore.getRackById(group.rack_ids[0]);
+    const firstRackId = group.rack_ids?.[0];
+    if (!firstRackId) return undefined;
+    return layoutStore.getRackById(firstRackId);
   }
 
   function handleRackClick(rackId: string) {
@@ -77,10 +77,11 @@
 
   function handleGroupClick(groupId: string) {
     const group = rackGroups.find((g) => g.id === groupId);
-    if (group && group.rack_ids.length > 0) {
+    const firstRackId = group?.rack_ids[0];
+    if (firstRackId) {
       // Select the first rack in the group to make the whole group active
-      layoutStore.setActiveRack(group.rack_ids[0]);
-      selectionStore.selectRack(group.rack_ids[0]);
+      layoutStore.setActiveRack(firstRackId);
+      selectionStore.selectRack(firstRackId);
     }
   }
 
@@ -127,10 +128,11 @@
   }
 
   function confirmDelete() {
-    if (rackToDelete) {
-      if (rackToDelete.isGroup) {
+    const target = rackToDelete;
+    if (target) {
+      if (target.isGroup) {
         // Delete all racks in the group, then the group
-        const group = rackGroups.find((g) => g.id === rackToDelete.id);
+        const group = rackGroups.find((g) => g.id === target.id);
         if (group) {
           // Delete racks first
           for (const rackId of group.rack_ids) {
@@ -139,15 +141,15 @@
           // Group auto-deletes when last rack removed
         }
         toastStore.showToast(
-          `Deleted "${rackToDelete.name}"${rackToDelete.deviceCount ? ` (${rackToDelete.deviceCount} devices removed)` : ""}`,
+          `Deleted "${target.name}"${target.deviceCount ? ` (${target.deviceCount} devices removed)` : ""}`,
           "info",
         );
       } else {
         const deviceCount =
-          layoutStore.getRackById(rackToDelete.id)?.devices.length ?? 0;
-        layoutStore.deleteRack(rackToDelete.id);
+          layoutStore.getRackById(target.id)?.devices.length ?? 0;
+        layoutStore.deleteRack(target.id);
         toastStore.showToast(
-          `Deleted "${rackToDelete.name}"${deviceCount > 0 ? ` (${deviceCount} devices removed)` : ""}`,
+          `Deleted "${target.name}"${deviceCount > 0 ? ` (${deviceCount} devices removed)` : ""}`,
           "info",
         );
       }


### PR DESCRIPTION
## **User description**
## Summary

Removes `// @ts-nocheck` from the 6 maintainer-side component files and fixes the revealed strict-mode errors with real type narrowing (no new suppressions). Part of the M04 TypeScript suppression burndown (#1609).

In-scope files (6): `App.svelte`, `DevicePalette.svelte`, `DevicePaletteItem.svelte`, `DialogOrchestrator.svelte`, `Rack.svelte`, `RackList.svelte`.

Explicitly out of scope: `ExportDialog.svelte` and `ImportFromNetBoxDialog.svelte` belong to #1707 (assigned to an external contributor) and are left untouched. `Toolbar.svelte` stays descoped (M14 #2072/#2074 remove that surface).

## Fixes by file

- App.svelte: suppression removed, no real errors remained once unmasked.
- DevicePalette.svelte: `firstMatch` uses `undefined` (matches `DeviceSection.firstMatch?: DeviceType`); guarded a possibly-undefined first deleted device.
- DevicePaletteItem.svelte: suppression removed (`ondelete` already in Props).
- DialogOrchestrator.svelte: `rackWidths` now flows as `RackWidth[]`; cleanup-prompt `operation` accepts `"saveAs"`.
- Rack.svelte: deleted the never-read `_draggingDeviceIndex` state and its writers; guarded `containerHoverInfo`; narrowed the pending device.
- RackList.svelte: captured `group.rack_ids[0]` and `rackToDelete` into locals so they narrow to `string` before use.

Two supporting type-only edits were required to avoid suppressions, each forced by `DialogOrchestrator`: `AddDeviceForm` (`rackWidths`/`optionToRackWidths` typed `RackWidth[]`) and `CleanupPromptDialog` (`operation` union gains `"saveAs"`).

## Two intentional behaviour deltas (were masked by the suppressions)

Both surfaced when the type errors were fixed; both are corrections, not regressions, and align with existing conventions. Flagged for transparency:

1. CleanupPromptDialog: the Save As cleanup prompt (reachable via `maybeSaveAs`) now reads "remove them before saving?" instead of the generic "before continuing?". The `"saveAs"` case previously fell through to the default verb.
2. Rack.svelte: a device type with no `model` now shows its `slug` in the mobile placement header (the `model ?? slug` pattern used everywhere else: EditPanel, DevicePalette, DragTooltip) instead of an empty value.

## Verification

- `npm run check`: 0 errors, 0 warnings (ExportDialog, ImportFromNetBoxDialog, Toolbar still carry their suppressions, as intended)
- `npm run lint`: clean
- `npm run build`: clean
- `npm run test:run`: 2148/2148 pass

No tests added (type-only chore; the type checker is the verification).

Closes #2194

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove TypeScript suppressions from maintainer screens and fix a few dialog and rack edge cases**

### What Changed
- Removed strict-type suppressions from key maintainer screens so the affected dialogs and rack views now work with real type checks.
- The cleanup prompt now treats “Save As” like saving, so the message matches the action users are actually taking.
- The add-device flow now keeps rack-size choices in the expected format for downstream use.
- Rack list and rack view handling now cover empty or missing values more safely, including group selection, delete flows, and mobile placement labels.
- Deleting a single device type now shows the deleted item’s name consistently in the undo toast.

### Impact
`✅ Clearer save and export prompts`
`✅ Fewer rack list and placement edge-case errors`
`✅ More reliable delete undo messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
