### PR TITLE
chore: delete deprecated loadSession() and migrate its tests (#2059)

### DIFF
--- a/src/lib/storage/working-copy.ts
+++ b/src/lib/storage/working-copy.ts
@@ -134,17 +134,6 @@ export function saveSession(layout: Layout, backup: BackupState): boolean {
 }
 
 /**
- * Load the autosaved layout from localStorage.
- * Handles migration from legacy formats (v0.6.x → v0.7.0+).
- * @returns The saved layout, or null if none exists or parsing failed
- * @deprecated Use loadSessionWithTimestamp() for new code that needs conflict resolution
- */
-export function loadSession(): Layout | null {
-  const result = loadSessionWithTimestamp();
-  return result?.layout ?? null;
-}
-
-/**
  * Load the autosaved layout from localStorage with timestamp information.
  * Handles migration from:
  * - Legacy formats (v0.6.x → v0.7.0+)

--- a/src/tests/session-storage.test.ts
+++ b/src/tests/session-storage.test.ts
@@ -129,7 +129,7 @@ describe("Session Storage", () => {
     });
   });
 
-  describe("loadSession", () => {
+  describe("loadSessionWithTimestamp - error handling", () => {
     it("returns null when no session exists", () => {
       expect(loadSessionWithTimestamp()).toBeNull();
     });
@@ -138,7 +138,9 @@ describe("Session Storage", () => {
       // Save a session first
       localStorage.setItem(STORAGE_KEY, JSON.stringify(mockLayout));
 
-      expect(loadSessionWithTimestamp()?.layout).toEqual(mockLayout);
+      const loaded = loadSessionWithTimestamp();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.layout).toEqual(mockLayout);
     });
 
     it("returns null on invalid JSON", () => {
@@ -260,23 +262,19 @@ describe("Session Storage", () => {
   });
 
   describe("Integration", () => {
-    it("round-trips save and load", () => {
+    it("round-trips save and load with timestamp metadata", () => {
       saveSession(mockLayout, noBackup);
       const loaded = loadSessionWithTimestamp();
-      expect(loaded?.layout).toEqual(mockLayout);
-    });
-
-    it("round-trips save and loadWithTimestamp", () => {
-      saveSession(mockLayout, noBackup);
-      const result = loadSessionWithTimestamp();
-      expect(result).not.toBeNull();
-      expect(result!.layout).toEqual(mockLayout);
-      expect(result!.savedAt).toBeDefined();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.layout).toEqual(mockLayout);
+      expect(loaded!.savedAt).toBeDefined();
     });
 
     it("clear removes saved session", () => {
       saveSession(mockLayout, noBackup);
-      expect(loadSessionWithTimestamp()?.layout).toEqual(mockLayout);
+      const loaded = loadSessionWithTimestamp();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.layout).toEqual(mockLayout);
 
       clearSession();
       expect(loadSessionWithTimestamp()).toBeNull();

--- a/src/tests/session-storage.test.ts
+++ b/src/tests/session-storage.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   saveSession,
-  loadSession,
   loadSessionWithTimestamp,
   clearSession,
   isServerNewer,
@@ -132,26 +131,22 @@ describe("Session Storage", () => {
 
   describe("loadSession", () => {
     it("returns null when no session exists", () => {
-      const result = loadSession();
-      expect(result).toBeNull();
+      expect(loadSessionWithTimestamp()).toBeNull();
     });
 
     it("loads saved layout from localStorage", () => {
       // Save a session first
       localStorage.setItem(STORAGE_KEY, JSON.stringify(mockLayout));
 
-      const result = loadSession();
-      expect(result).toEqual(mockLayout);
+      expect(loadSessionWithTimestamp()?.layout).toEqual(mockLayout);
     });
 
     it("returns null on invalid JSON", () => {
       // Store invalid JSON
       localStorage.setItem(STORAGE_KEY, "invalid-json");
 
-      const result = loadSession();
-
       // Should return null on parse error (logs via debug logger)
-      expect(result).toBeNull();
+      expect(loadSessionWithTimestamp()).toBeNull();
     });
 
     it("handles localStorage errors gracefully", () => {
@@ -161,10 +156,8 @@ describe("Session Storage", () => {
         throw new Error("Storage error");
       });
 
-      const result = loadSession();
-
       // Should return null on error (logs via debug logger)
-      expect(result).toBeNull();
+      expect(loadSessionWithTimestamp()).toBeNull();
 
       // Restore original implementation
       localStorage.getItem = originalGetItem;
@@ -269,8 +262,8 @@ describe("Session Storage", () => {
   describe("Integration", () => {
     it("round-trips save and load", () => {
       saveSession(mockLayout, noBackup);
-      const loaded = loadSession();
-      expect(loaded).toEqual(mockLayout);
+      const loaded = loadSessionWithTimestamp();
+      expect(loaded?.layout).toEqual(mockLayout);
     });
 
     it("round-trips save and loadWithTimestamp", () => {
@@ -283,10 +276,10 @@ describe("Session Storage", () => {
 
     it("clear removes saved session", () => {
       saveSession(mockLayout, noBackup);
-      expect(loadSession()).toEqual(mockLayout);
+      expect(loadSessionWithTimestamp()?.layout).toEqual(mockLayout);
 
       clearSession();
-      expect(loadSession()).toBeNull();
+      expect(loadSessionWithTimestamp()).toBeNull();
     });
   });
 
@@ -317,15 +310,15 @@ describe("Session Storage", () => {
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(legacyData));
 
-      const result = loadSession();
+      const loaded = loadSessionWithTimestamp();
 
-      expect(result).not.toBeNull();
-      expect(result!.racks).toBeDefined();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.layout.racks).toBeDefined();
       // eslint-disable-next-line no-restricted-syntax -- migration should produce exactly 1 rack
-      expect(result!.racks).toHaveLength(1);
-      expect(result!.racks[0].name).toBe("Main Rack");
+      expect(loaded!.layout.racks).toHaveLength(1);
+      expect(loaded!.layout.racks[0].name).toBe("Main Rack");
       // Legacy 'rack' property should not exist on migrated layout
-      expect((result as Record<string, unknown>).rack).toBeUndefined();
+      expect((loaded!.layout as Record<string, unknown>).rack).toBeUndefined();
     });
 
     it("handles modern racks array format unchanged", () => {
@@ -355,11 +348,11 @@ describe("Session Storage", () => {
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(modernData));
 
-      const result = loadSession();
+      const loaded = loadSessionWithTimestamp();
 
-      expect(result).not.toBeNull();
+      expect(loaded).not.toBeNull();
       // eslint-disable-next-line no-restricted-syntax -- verifying migration preserves exact count
-      expect(result!.racks).toHaveLength(1);
+      expect(loaded!.layout.racks).toHaveLength(1);
     });
 
     it("migrates position values for pre-0.7.0 layouts", () => {
@@ -404,12 +397,12 @@ describe("Session Storage", () => {
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(legacyData));
 
-      const result = loadSession();
+      const loaded = loadSessionWithTimestamp();
 
-      expect(result).not.toBeNull();
+      expect(loaded).not.toBeNull();
       // Position values should be multiplied by UNITS_PER_U
-      expect(result!.racks[0].devices[0].position).toBe(1 * UNITS_PER_U);
-      expect(result!.racks[0].devices[1].position).toBe(10 * UNITS_PER_U);
+      expect(loaded!.layout.racks[0].devices[0].position).toBe(1 * UNITS_PER_U);
+      expect(loaded!.layout.racks[0].devices[1].position).toBe(10 * UNITS_PER_U);
     });
 
     it("does not migrate container child positions", () => {
@@ -456,13 +449,13 @@ describe("Session Storage", () => {
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(legacyData));
 
-      const result = loadSession();
+      const loaded = loadSessionWithTimestamp();
 
-      expect(result).not.toBeNull();
+      expect(loaded).not.toBeNull();
       // Container position should be migrated
-      expect(result!.racks[0].devices[0].position).toBe(5 * UNITS_PER_U);
+      expect(loaded!.layout.racks[0].devices[0].position).toBe(5 * UNITS_PER_U);
       // Child position should NOT be migrated (remains 2)
-      expect(result!.racks[0].devices[1].position).toBe(2);
+      expect(loaded!.layout.racks[0].devices[1].position).toBe(2);
     });
 
     it("does not migrate positions for v0.7.0+ layouts", () => {
@@ -501,21 +494,19 @@ describe("Session Storage", () => {
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(modernData));
 
-      const result = loadSession();
+      const loaded = loadSessionWithTimestamp();
 
-      expect(result).not.toBeNull();
+      expect(loaded).not.toBeNull();
       // Position should remain unchanged
-      expect(result!.racks[0].devices[0].position).toBe(6);
+      expect(loaded!.layout.racks[0].devices[0].position).toBe(6);
     });
 
     it("returns null for non-object parsed data", () => {
       // Store valid JSON but not an object (array case)
       localStorage.setItem(STORAGE_KEY, JSON.stringify([1, 2, 3]));
 
-      const result = loadSession();
-
       // Should return null for non-object data (logs via debug logger)
-      expect(result).toBeNull();
+      expect(loadSessionWithTimestamp()).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Deletes the deprecated `loadSession()` wrapper from `src/lib/storage/working-copy.ts` and migrates its tests to `loadSessionWithTimestamp()`. No app code used the wrapper (App.svelte already uses `loadSessionWithTimestamp()`); it existed solely for assertions in `session-storage.test.ts`. Project policy is to delete unused surface completely.

This is M15 Stage 1 and a prerequisite for #2037 (both touch this module).

## Changes

- Removed `loadSession()` and its `@deprecated` JSDoc from working-copy.ts.
- Migrated 13 call sites in `session-storage.test.ts`, preserving exact pass/fail semantics: null cases assert the wrapper (`loadSessionWithTimestamp()` is null), layout cases read `?.layout`, and not-null-plus-property-access cases capture the result and read `loaded!.layout.X`. The capture avoids the `null?.layout === undefined` trap that would otherwise weaken `.toBeNull()` / `.not.toBeNull()` checks.
- Dropped the now-unused `loadSession` import; preserved the existing `no-restricted-syntax` justifications.

## Verification

- `npx vitest run src/tests/session-storage.test.ts`: 29/29 pass
- `npx eslint` on both changed files: clean
- `grep -rn "loadSession(" src`: only `loadSessionWithTimestamp(` call sites remain

Closes #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove the deprecated session-loading shortcut and align tests with the timestamped session loader**

### What Changed
- Removed the old session-loading shortcut so the app now relies on the timestamped loader directly
- Updated session storage tests to use the timestamped session result for saved layouts, legacy data migration, and clear-session checks
- Kept the same session-saving and migration behavior covered by the tests

### Impact
`✅ Fewer stale session-loading paths`
`✅ Clearer session recovery behavior`
`✅ Lower maintenance risk in session storage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
