### PR TITLE
test: tighten unit-aware position assertions in layout-device-actions suite (#2156)

### DIFF
--- a/src/tests/layout-device-actions.test.ts
+++ b/src/tests/layout-device-actions.test.ts
@@ -977,8 +977,10 @@ describe("Layout Store", () => {
       const result = store.duplicateDevice(rack!.id, 0);
 
       expect(result.device).toBeDefined();
-      // Duplicate should be placed in a valid position (not colliding with original)
-      expect(result.device!.position).not.toBe(10);
+      // Original 2U device occupies U10-U11, so the next slot above (U12) is the
+      // first valid, preferred position. Compare in internal units so a same-slot
+      // (U10) placement would fail this assertion.
+      expect(result.device!.position).toBe(toInternalUnits(12));
       // Should be on same face as original
       expect(result.device!.face).toBe("front");
     });


### PR DESCRIPTION
## **User description**
## Summary

Fixes a loose, non-unit-aware assertion in `layout-device-actions.test.ts` that compared an internal-units value against a human-unit literal, so it could pass even on a same-slot duplicate placement. Surfaced by CodeAnt on PR #2154; the assertion was moved verbatim during the #1080 split.

## Change

In the "places duplicate in next available slot on same face" test, replaced `expect(result.device!.position).not.toBe(10)` with `expect(result.device!.position).toBe(toInternalUnits(12))`. The original 2U device at U10 occupies U10-U11; the placement algorithm (`duplicateDevice` -> `findValidDropPositions`) deterministically picks the adjacent-above slot U12. Pinning the exact slot in internal units means a same or overlapping placement now fails the assertion.

Audited the rest of the suite: all other position assertions already compare in internal units (for example the "prefers adjacent slot" test uses `[toInternalUnits(9), toInternalUnits(11)]`). No other loose comparisons existed.

No real collision gap was revealed: tightening to the exact slot passes, confirming production code places the duplicate correctly above the original.

## Verification

- `npx vitest run src/tests/layout-device-actions.test.ts`: 79/79 pass
- `npx eslint` on the file: clean

Closes #2156

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Tighten the duplicate-placement test to check the exact slot**

### What Changed
- The duplicate-device test now checks for the exact expected position instead of only verifying that it is not the original slot.
- The assertion now matches the rack’s internal position units, so a same-slot or overlapping placement would fail the test.
- The duplicate is still expected to stay on the same face as the original device.

### Impact
`✅ Stronger layout test coverage`
`✅ Fewer false-positive test passes`
`✅ Safer duplicate placement checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
