### PR TITLE
feat: explicit storage mode in frontend, remove probe-and-guess (#2037)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,10 +34,13 @@
     isServerNewer,
     setApiAvailable,
     initializePersistence,
-    hasEverConnectedToApi,
+    getStorageMode,
+    getServerInstanceLabel,
+    detectModeFlip,
     listSavedLayouts,
     loadSavedLayout,
     handleLoad,
+    handleSaveToServer,
   } from "$lib/storage";
   import {
     maybeSave,
@@ -66,6 +69,7 @@
   import { DRAWER_WIDTH } from "$lib/constants/layout";
   import { Tooltip } from "bits-ui";
   import { debounce } from "$lib/utils/debounce";
+  import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
 
   // Sidebar size configuration (in pixels)
   interface Props {
@@ -170,6 +174,54 @@
     }, 10_000);
   }
 
+  // localStorage flag: the browser-mode first-run notice is shown once per device.
+  const FIRST_RUN_NOTICE_KEY = "rackula.browserMode.firstRunSeen";
+
+  // Startup must emit at most one storage toast (epic #2071 signal coherence).
+  // First-run notice, mode-flip notice, and server-drop toast are mutually
+  // exclusive; this guard dedups them.
+  let storageToastShown = false;
+
+  function showStorageToast(
+    message: string,
+    type: "info" | "warning",
+    duration: number,
+    action?: { label: string; onClick: () => void },
+  ): void {
+    if (storageToastShown) return;
+    storageToastShown = true;
+    toastStore.showToast(message, type, duration, action);
+  }
+
+  // Browser mode only: a one-time notice explaining where layouts live.
+  function maybeShowFirstRunNotice(): void {
+    if (safeGetItem(FIRST_RUN_NOTICE_KEY) === "true") return;
+    safeSetItem(FIRST_RUN_NOTICE_KEY, "true");
+    showStorageToast(
+      "Layouts are saved in this browser. Export to a file to keep a copy.",
+      "info",
+      8000,
+    );
+  }
+
+  // Restore an autosaved working copy into the store and recenter the view.
+  function restoreLocalSession(
+    session: NonNullable<ReturnType<typeof loadSessionWithTimestamp>>,
+  ): void {
+    layoutStore.loadLayout(session.layout);
+    // Autosaved sessions are not explicitly saved, so they start dirty.
+    layoutStore.markDirty();
+    layoutStore.restoreBackupState({
+      changesSinceExport: session.changesSinceExport,
+      hasEverExported: session.hasEverExported,
+    });
+    requestAnimationFrame(() => {
+      if (!canvasStore.restoreViewport()) {
+        canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
+      }
+    });
+  }
+
   // Auto-open new rack dialog when no racks exist (first-load experience)
   // Also handles loading shared layouts from URL params
   // Uses onMount to run once on initial load, not reactively
@@ -187,16 +239,20 @@
       );
     }
 
-    // Start API health check immediately so all startup paths (including share links)
-    // initialize persistence and can enable server autosave when available.
-    const persistenceInitPromise = initializePersistence().catch((error) => {
-      console.error(
-        "Persistence initialization failed; continuing without server persistence:",
-        error,
-      );
-      setApiAvailable(false);
-      return false;
-    });
+    const serverMode = getStorageMode() === "server";
+
+    // Server mode only: probe the API so server autosave/load can enable when
+    // reachable. Browser mode skips the probe entirely (no server to reach).
+    const persistenceInitPromise = serverMode
+      ? initializePersistence().catch((error) => {
+          console.error(
+            "Persistence initialization failed; continuing without server persistence:",
+            error,
+          );
+          setApiAvailable(false);
+          return false;
+        })
+      : Promise.resolve(false);
 
     // Priority 1: Check for shared layout in URL (highest priority)
     const shareParam = getShareParam();
@@ -220,11 +276,37 @@
       }
     }
 
-    // Get localStorage session data (with timestamp if available)
+    // Get localStorage session data (with timestamp and stored mode if available)
     const localSession = loadSessionWithTimestamp();
 
-    // Priority 2: With no local session, show Start Screen immediately.
-    // It handles loading/offline state while API health check resolves.
+    // Browser mode: no server compare. Restore the working copy if present,
+    // otherwise show the Start Screen. Surface a server->browser flip notice when
+    // the saved copy came from a server deployment (never silently degrade), else
+    // a one-time first-run notice. No offline toasts ever in browser mode.
+    if (!serverMode) {
+      if (!localSession) {
+        layoutStore.resetLayout();
+        maybeShowFirstRunNotice();
+        showStartScreen = true;
+        return;
+      }
+      if (detectModeFlip(localSession.storageMode) === "server-to-browser") {
+        showStorageToast(
+          "This deployment now stores layouts in your browser; your previous server library is not loaded here.",
+          "warning",
+          0,
+        );
+      } else {
+        maybeShowFirstRunNotice();
+      }
+      restoreLocalSession(localSession);
+      return;
+    }
+
+    // Server mode below.
+
+    // No local session: show the Start Screen immediately. It handles the
+    // loading/offline state while the health check resolves.
     // Reset layout to clear any stale hasStarted flag from a previous session (#1326)
     if (!localSession) {
       layoutStore.resetLayout();
@@ -232,16 +314,38 @@
       return;
     }
 
+    const instanceLabel = getServerInstanceLabel();
     const apiAvailable = await persistenceInitPromise;
     // initializePersistence() resolves to false for the common API-unavailable
-    // case (checkApiHealth returns false rather than rejecting), so the offline
-    // toast is shown here rather than only in the catch handler above.
-    if (!apiAvailable && hasEverConnectedToApi()) {
-      toastStore.showToast(
-        "Server unavailable — working offline",
+    // case (checkApiHealth returns false rather than rejecting). In server mode
+    // a down server is surfaced with an instance-named drop toast, and the
+    // working copy keeps continuity.
+    if (!apiAvailable) {
+      showStorageToast(
+        `Cannot reach ${instanceLabel}. Working from your local copy; reload to retry.`,
         "warning",
         0,
       );
+    }
+
+    // browser->server flip: the working copy's UUID is unknown to the server, so
+    // offer to upload it as a new server layout rather than shadowing it with the
+    // server list. Only meaningful while the server is reachable.
+    const flip = detectModeFlip(localSession.storageMode);
+    if (apiAvailable && flip === "browser-to-server") {
+      restoreLocalSession(localSession);
+      showStorageToast(
+        "This deployment now stores layouts on the server. Upload your local copy to keep it here.",
+        "info",
+        0,
+        {
+          label: "Upload",
+          onClick: () => {
+            void handleSaveToServer(true);
+          },
+        },
+      );
+      return;
     }
 
     // Priority 3: When API and local session are both available,
@@ -264,9 +368,7 @@
             layoutStore.markClean();
 
             // Clear stale localStorage to prevent future conflicts
-            if (localSession) {
-              clearSession();
-            }
+            clearSession();
 
             toastStore.showToast(
               `Loaded "${mostRecent.name}" from server`,
@@ -301,41 +403,25 @@
           return;
         }
       } catch (error) {
-        // If server check fails, fall through to localStorage
+        // If server check fails, fall through to the local working copy.
         persistenceDebug.api(
           "failed to load saved layouts from server: %O",
           error,
         );
         // Treat server data failures as offline and fall back gracefully.
         setApiAvailable(false);
-        if (hasEverConnectedToApi()) {
-          toastStore.showToast(
-            "Server unavailable — working offline",
-            "warning",
-            0,
-          );
-        }
+        showStorageToast(
+          `Cannot reach ${instanceLabel}. Working from your local copy; reload to retry.`,
+          "warning",
+          0,
+        );
       }
     }
 
-    // Priority 4: No API or no server layouts - check localStorage autosave
-    if (localSession) {
-      layoutStore.loadLayout(localSession.layout);
-      // Mark as dirty since this is an autosaved session (not explicitly saved)
-      layoutStore.markDirty();
-      layoutStore.restoreBackupState({
-        changesSinceExport: localSession.changesSinceExport,
-        hasEverExported: localSession.hasEverExported,
-      });
-      // Don't show new rack dialog - user has work in progress
-      // Restore saved viewport if available, otherwise fit all racks
-      requestAnimationFrame(() => {
-        if (!canvasStore.restoreViewport()) {
-          canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
-        }
-      });
-      return;
-    }
+    // Priority 4: No reachable server or no server layouts - restore the
+    // localStorage working copy for continuity.
+    restoreLocalSession(localSession);
+    return;
   });
 
   // Refit canvas on orientation change (mobile/tablet only).

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -245,8 +245,8 @@
     // reachable. Browser mode skips the probe entirely (no server to reach).
     const persistenceInitPromise = serverMode
       ? initializePersistence().catch((error) => {
-          console.error(
-            "Persistence initialization failed; continuing without server persistence:",
+          persistenceDebug.api(
+            "persistence initialization failed; continuing without server persistence: %O",
             error,
           );
           setApiAvailable(false);

--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -11,7 +11,7 @@
     isSessionSavePending,
     isServerSavePending,
     getApiAvailableState,
-    hasEverConnectedToApi,
+    getStorageMode,
     shouldWarnBeforeUnload,
   } from "$lib/storage";
   import { getImageStore } from "$lib/stores/images.svelte";
@@ -84,7 +84,7 @@
       warnOnUnsavedChanges: uiStore.warnOnUnsavedChanges,
       sessionSavePending: isSessionSavePending(),
       serverSavePending: isServerSavePending(),
-      serverMode: hasEverConnectedToApi(),
+      serverMode: getStorageMode() === "server",
       serverReachable: getApiAvailableState(),
       isDirty: layoutStore.isDirty,
     }),

--- a/src/lib/components/StartScreen.svelte
+++ b/src/lib/components/StartScreen.svelte
@@ -12,7 +12,7 @@
     type SavedLayoutItem,
     PersistenceError,
     initializePersistence,
-    hasEverConnectedToApi,
+    getStorageMode,
     loadFromApi,
     loadFromFile,
   } from "$lib/storage";
@@ -46,18 +46,26 @@
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
 
+  const serverMode = getStorageMode() === "server";
+
   let layouts = $state<SavedLayoutItem[]>([]);
-  let loading = $state(true);
+  let loading = $state(serverMode);
   let error = $state<string | null>(null);
   let apiAvailable = $state(true);
   let deletingId = $state<string | null>(null);
 
-  /** Only show offline warning if user previously had API working */
-  let showOfflineWarning = $derived(!apiAvailable && hasEverConnectedToApi());
+  /** Only show offline warning in server mode when the server is unreachable */
+  let showOfflineWarning = $derived(serverMode && !apiAvailable);
 
   onMount(async () => {
-    // Initialize persistence and check API health
-    // This updates the global persistence store state
+    // Browser mode never has a server library: skip the health check entirely.
+    if (!serverMode) {
+      loading = false;
+      return;
+    }
+
+    // Server mode: check API health (updates the global persistence store) and
+    // load the saved-layout list when reachable.
     apiAvailable = await initializePersistence();
 
     if (apiAvailable) {
@@ -186,7 +194,7 @@
           Continue
         </button>
       </div>
-    {:else}
+    {:else if serverMode}
       <section class="saved-layouts">
         <h2>
           <IconFolderBold size={18} />

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -26,6 +26,25 @@ function normalizeApiBaseUrl(raw: string | undefined): string {
 
 const API_BASE_URL: string = normalizeApiBaseUrl(import.meta.env.VITE_API_URL);
 
+/**
+ * Human-readable label for the server instance, used in offline/recovery toasts.
+ * Prefers the API host when the base URL is absolute, falls back to the page
+ * host, then to a generic phrase when neither is available.
+ */
+export function getServerInstanceLabel(): string {
+  try {
+    if (/^https?:\/\//i.test(API_BASE_URL)) {
+      return new URL(API_BASE_URL).host;
+    }
+  } catch {
+    // fall through to page host
+  }
+  if (typeof window !== "undefined" && window.location?.host) {
+    return window.location.host;
+  }
+  return "the server";
+}
+
 /** Default timeout for API requests (10 seconds) */
 const API_TIMEOUT_MS = 10_000;
 

--- a/src/lib/storage/availability.svelte.ts
+++ b/src/lib/storage/availability.svelte.ts
@@ -1,33 +1,29 @@
 /**
  * Persistence Store
- * Manages runtime API availability detection
+ * Manages the explicit storage mode and runtime API availability.
  *
- * This replaces the build-time VITE_PERSIST_ENABLED flag with runtime detection.
- * The same Docker image can now work with or without the API sidecar by
- * checking /health at startup.
+ * The storage mode is read from runtime config (window.__RACKULA_CONFIG__),
+ * not probed. The app runs in exactly one mode: "browser" (default) or
+ * "server". Availability (apiAvailable) only tracks whether the server is
+ * currently reachable while in server mode.
  */
 
 import { checkApiHealth } from "./api";
 import { persistenceDebug } from "$lib/utils/debug";
-import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
 
 const log = persistenceDebug.health;
 
-/** localStorage key for tracking if API was ever successfully connected */
-const API_CONNECTED_KEY = "rackula.persistence.apiConnected";
+export type StorageMode = "browser" | "server";
 
 /**
- * Check if user has ever successfully connected to persistence API
+ * The single source of truth for the storage mode. Reads
+ * window.__RACKULA_CONFIG__.storage; returns "server" only when the value is
+ * exactly "server", otherwise "browser" (including missing or unknown values).
+ * No other module re-derives the mode: everything reads this accessor.
  */
-export function hasEverConnectedToApi(): boolean {
-  return safeGetItem(API_CONNECTED_KEY) === "true";
-}
-
-/**
- * Mark that user has successfully connected to persistence API
- */
-function markApiConnected(): void {
-  safeSetItem(API_CONNECTED_KEY, "true");
+export function getStorageMode(): StorageMode {
+  if (typeof window === "undefined") return "browser";
+  return window.__RACKULA_CONFIG__?.storage === "server" ? "server" : "browser";
 }
 
 // Reactive state for API availability
@@ -52,7 +48,7 @@ export function getApiAvailableState(): boolean | null {
 
 /**
  * Perform initial API health check
- * Call this once on app startup
+ * Call this once on app startup (server mode only)
  *
  * Thread-safe: multiple concurrent calls will share the same pending check
  */
@@ -75,9 +71,6 @@ export async function initializePersistence(): Promise<boolean> {
   pendingCheck = checkApiHealth()
     .then((result) => {
       apiAvailable = result;
-      if (result) {
-        markApiConnected();
-      }
       log("initializePersistence: API availability determined: %s", result);
       return result;
     })
@@ -89,10 +82,7 @@ export async function initializePersistence(): Promise<boolean> {
 }
 
 /**
- * Set API availability state directly (for error recovery)
- * Note: Does NOT call markApiConnected() because this is for temporary
- * overrides, not confirmed API connectivity. Only health checks should
- * mark the API as "ever connected".
+ * Set API availability state directly (for error recovery).
  */
 export function setApiAvailable(available: boolean): void {
   log("setApiAvailable: setting to %s", available);

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -10,19 +10,23 @@ export {
   isApiAvailable,
   getApiAvailableState,
   setApiAvailable,
-  hasEverConnectedToApi,
+  getStorageMode,
+  type StorageMode,
 } from "./availability.svelte";
 export {
   listSavedLayouts,
   loadSavedLayout,
   deleteSavedLayout,
   PersistenceError,
+  getServerInstanceLabel,
   type SavedLayoutItem,
 } from "./api";
 export {
   loadSessionWithTimestamp,
   clearSession,
   isServerNewer,
+  detectModeFlip,
+  type ModeFlip,
 } from "./working-copy";
 export { loadFromApi, loadFromFile } from "./load-pipeline";
 export {

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -2,9 +2,14 @@ import {
   isApiAvailable,
   setApiAvailable,
   getApiAvailableState,
-  hasEverConnectedToApi,
+  getStorageMode,
 } from "./availability.svelte";
-import { saveLayoutToServer, checkApiHealth, PersistenceError } from "./api";
+import {
+  saveLayoutToServer,
+  checkApiHealth,
+  PersistenceError,
+  getServerInstanceLabel,
+} from "./api";
 import { saveSession, clearSession } from "./working-copy";
 import { loadFromFile } from "./load-pipeline";
 import { getLayoutStore } from "$lib/stores/layout.svelte";
@@ -164,6 +169,28 @@ export function handlePersistenceError(
   const toastStore = getToastStore();
   const action = onRetry ? { label: "Retry", onClick: onRetry } : undefined;
   if (e instanceof PersistenceError) {
+    // Auth expiry (401): the server is reachable but the Access session lapsed.
+    // This is distinct from server-down: do not trip the offline circuit breaker
+    // and do not flip to offline. Surface a re-authenticate affordance instead of
+    // the retry/backup "working offline" treatment.
+    if (e.statusCode === 401) {
+      _saveStatus = "error";
+      if (_errorToastId) {
+        toastStore.dismissToast(_errorToastId);
+      }
+      _errorToastId = toastStore.showToast(
+        "Your session expired. Reload to re-authenticate; your changes are saved locally.",
+        "warning",
+        0,
+        {
+          label: "Reload",
+          onClick: () => {
+            if (typeof window !== "undefined") window.location.reload();
+          },
+        },
+      );
+      return;
+    }
     // Storage quota rejections (507 asset limit, 429 layout limit). The server is
     // reachable and the data is intact, so this is a recoverable error state, not
     // offline: do not flip to offline or trip the circuit breaker, and 507 must
@@ -256,11 +283,11 @@ export async function handleSaveAsArchive(): Promise<boolean> {
 }
 
 export function shouldSaveToServer(): boolean {
-  return isApiAvailable();
+  return getStorageMode() === "server" && isApiAvailable();
 }
 
 export async function handleLoad(): Promise<void> {
-  if (isApiAvailable()) {
+  if (getStorageMode() === "server") {
     dialogStore.open("load");
   } else {
     await loadFromFile();
@@ -359,7 +386,7 @@ export function initPersistenceEffects(): void {
     const apiState = getApiAvailableState();
     if (apiState === null) return;
     if (apiState === true) return;
-    if (!hasEverConnectedToApi()) return;
+    if (getStorageMode() !== "server") return;
     if (_saveStatus === "disabled") return;
     if (_consecutiveSaveFailures >= MAX_SAVE_FAILURES) return;
 
@@ -370,6 +397,17 @@ export function initPersistenceEffects(): void {
         persistenceDebug.health("API health check passed, marking available");
         setApiAvailable(true);
         _saveStatus = "idle";
+        const toastStore = getToastStore();
+        if (_errorToastId) {
+          toastStore.dismissToast(_errorToastId);
+          _errorToastId = undefined;
+        }
+        // Quiet recovery notice on resync (auto-dismisses).
+        toastStore.showToast(
+          `Reconnected to ${getServerInstanceLabel()}.`,
+          "success",
+          3000,
+        );
       } else {
         persistenceDebug.health("API health check failed, still offline");
       }

--- a/src/lib/storage/working-copy.ts
+++ b/src/lib/storage/working-copy.ts
@@ -7,6 +7,7 @@ import {
   safeRemoveItem,
 } from "$lib/utils/safe-storage";
 import { sessionDebug } from "$lib/utils/debug";
+import { getStorageMode, type StorageMode } from "./availability.svelte";
 
 const log = sessionDebug.storage;
 const STORAGE_KEY = "Rackula:autosave";
@@ -20,6 +21,7 @@ interface SessionData {
   savedAt: string; // ISO 8601 timestamp
   changesSinceExport: number;
   hasEverExported: boolean;
+  storageMode: StorageMode; // mode this copy was saved under
 }
 
 /**
@@ -30,6 +32,8 @@ export interface SessionLoadResult {
   savedAt: string | null; // null for legacy data without timestamp
   changesSinceExport: number;
   hasEverExported: boolean;
+  /** Storage mode the copy was saved under (defaults to "browser" if missing) */
+  storageMode: StorageMode;
 }
 
 /**
@@ -107,6 +111,15 @@ function migrateLayout(raw: Record<string, unknown>): Layout | null {
 }
 
 /**
+ * Coerce a stored storageMode value to a valid StorageMode.
+ * Missing or unknown values default to "browser" (legacy sessions predate the
+ * field and were always browser-stored).
+ */
+function parseStorageMode(value: unknown): StorageMode {
+  return value === "server" ? "server" : "browser";
+}
+
+/**
  * Save the current layout to localStorage with timestamp.
  * @param layout - The layout to save
  * @param backup - Backup state persisted alongside the layout
@@ -119,6 +132,7 @@ export function saveSession(layout: Layout, backup: BackupState): boolean {
       savedAt: new Date().toISOString(),
       changesSinceExport: backup.changesSinceExport,
       hasEverExported: backup.hasEverExported,
+      storageMode: getStorageMode(),
     };
     const serialized = JSON.stringify(sessionData);
     if (!safeSetItem(STORAGE_KEY, serialized)) {
@@ -186,6 +200,7 @@ export function loadSessionWithTimestamp(): SessionLoadResult | null {
             ? obj.changesSinceExport
             : 0,
         hasEverExported: obj.hasEverExported === true,
+        storageMode: parseStorageMode(obj.storageMode),
       };
     }
 
@@ -197,6 +212,7 @@ export function loadSessionWithTimestamp(): SessionLoadResult | null {
       savedAt: null, // No timestamp for legacy data
       changesSinceExport: 0,
       hasEverExported: false,
+      storageMode: "browser",
     };
   } catch (error) {
     log("failed to load session: %O", error);
@@ -209,6 +225,22 @@ export function loadSessionWithTimestamp(): SessionLoadResult | null {
  */
 export function clearSession(): void {
   safeRemoveItem(STORAGE_KEY);
+}
+
+/** Result of comparing the session's saved mode to the configured mode. */
+export type ModeFlip = "none" | "server-to-browser" | "browser-to-server";
+
+/**
+ * Compare the mode a session was saved under to the currently configured mode.
+ * A flip means the deployment changed storage backend between visits, which must
+ * be surfaced rather than silently degrading data.
+ * @param sessionMode - The mode the loaded session was saved under
+ * @returns "server-to-browser", "browser-to-server", or "none"
+ */
+export function detectModeFlip(sessionMode: StorageMode): ModeFlip {
+  const current = getStorageMode();
+  if (sessionMode === current) return "none";
+  return sessionMode === "server" ? "server-to-browser" : "browser-to-server";
 }
 
 /**

--- a/src/tests/App.cleanupPrompt.test.ts
+++ b/src/tests/App.cleanupPrompt.test.ts
@@ -31,7 +31,7 @@ const persistenceStoreMocks = vi.hoisted(() => ({
   isApiAvailable: vi.fn(() => false),
   setApiAvailable: vi.fn(),
   getApiAvailableState: vi.fn(() => false),
-  hasEverConnectedToApi: vi.fn(() => false),
+  getStorageMode: vi.fn(() => "server" as "browser" | "server"),
 }));
 
 const persistenceApiMocks = vi.hoisted(() => ({
@@ -40,6 +40,7 @@ const persistenceApiMocks = vi.hoisted(() => ({
   listSavedLayouts: vi.fn(async () => []),
   loadSavedLayout: vi.fn(),
   deleteSavedLayout: vi.fn(async () => undefined),
+  getServerInstanceLabel: vi.fn(() => "test-host"),
   PersistenceError: class PersistenceError extends Error {
     statusCode?: number;
     constructor(message: string, statusCode?: number) {
@@ -55,6 +56,7 @@ const sessionStorageMocks = vi.hoisted(() => ({
   loadSessionWithTimestamp: vi.fn(() => null),
   clearSession: vi.fn(),
   isServerNewer: vi.fn(() => false),
+  detectModeFlip: vi.fn(() => "none" as "none" | "server-to-browser" | "browser-to-server"),
 }));
 
 const archiveMocks = vi.hoisted(() => ({
@@ -81,7 +83,7 @@ vi.mock("$lib/storage/availability.svelte", () => ({
   isApiAvailable: persistenceStoreMocks.isApiAvailable,
   setApiAvailable: persistenceStoreMocks.setApiAvailable,
   getApiAvailableState: persistenceStoreMocks.getApiAvailableState,
-  hasEverConnectedToApi: persistenceStoreMocks.hasEverConnectedToApi,
+  getStorageMode: persistenceStoreMocks.getStorageMode,
 }));
 
 vi.mock("$lib/storage/api", () => ({
@@ -90,6 +92,7 @@ vi.mock("$lib/storage/api", () => ({
   listSavedLayouts: persistenceApiMocks.listSavedLayouts,
   loadSavedLayout: persistenceApiMocks.loadSavedLayout,
   deleteSavedLayout: persistenceApiMocks.deleteSavedLayout,
+  getServerInstanceLabel: persistenceApiMocks.getServerInstanceLabel,
   PersistenceError: persistenceApiMocks.PersistenceError,
 }));
 
@@ -98,6 +101,7 @@ vi.mock("$lib/storage/working-copy", () => ({
   loadSessionWithTimestamp: sessionStorageMocks.loadSessionWithTimestamp,
   clearSession: sessionStorageMocks.clearSession,
   isServerNewer: sessionStorageMocks.isServerNewer,
+  detectModeFlip: sessionStorageMocks.detectModeFlip,
 }));
 
 vi.mock("$lib/utils/archive", async () => {
@@ -133,8 +137,8 @@ function resetHoistedMocks(): void {
   persistenceStoreMocks.setApiAvailable.mockReset();
   persistenceStoreMocks.getApiAvailableState.mockReset();
   persistenceStoreMocks.getApiAvailableState.mockReturnValue(false);
-  persistenceStoreMocks.hasEverConnectedToApi.mockReset();
-  persistenceStoreMocks.hasEverConnectedToApi.mockReturnValue(false);
+  persistenceStoreMocks.getStorageMode.mockReset();
+  persistenceStoreMocks.getStorageMode.mockReturnValue("server");
 
   persistenceApiMocks.saveLayoutToServer.mockReset();
   persistenceApiMocks.saveLayoutToServer.mockResolvedValue("layout-1");
@@ -152,6 +156,8 @@ function resetHoistedMocks(): void {
   sessionStorageMocks.clearSession.mockReset();
   sessionStorageMocks.isServerNewer.mockReset();
   sessionStorageMocks.isServerNewer.mockReturnValue(false);
+  sessionStorageMocks.detectModeFlip.mockReset();
+  sessionStorageMocks.detectModeFlip.mockReturnValue("none");
 
   archiveMocks.downloadYamlFile.mockReset();
   archiveMocks.downloadYamlFile.mockResolvedValue("cleanup-test.rackula.yaml");
@@ -198,6 +204,7 @@ describe("App cleanup prompt flow", { retry: 2, timeout: 30000 }, () => {
       savedAt: new Date("2026-02-09T00:00:00.000Z").toISOString(),
       changesSinceExport: 0,
       hasEverExported: false,
+      storageMode: "server",
     });
   });
 

--- a/src/tests/App.startScreen.test.ts
+++ b/src/tests/App.startScreen.test.ts
@@ -31,7 +31,7 @@ const persistenceStoreMocks = vi.hoisted(() => ({
   isApiAvailable: vi.fn(() => true),
   setApiAvailable: vi.fn(),
   getApiAvailableState: vi.fn(() => true),
-  hasEverConnectedToApi: vi.fn(() => true),
+  getStorageMode: vi.fn(() => "server" as "browser" | "server"),
 }));
 
 const persistenceApiMocks = vi.hoisted(() => ({
@@ -40,6 +40,7 @@ const persistenceApiMocks = vi.hoisted(() => ({
   listSavedLayouts: vi.fn(async () => []),
   loadSavedLayout: vi.fn(),
   deleteSavedLayout: vi.fn(async () => undefined),
+  getServerInstanceLabel: vi.fn(() => "test-host"),
   PersistenceError: class PersistenceError extends Error {
     statusCode?: number;
     constructor(message: string, statusCode?: number) {
@@ -55,6 +56,7 @@ const sessionStorageMocks = vi.hoisted(() => ({
   loadSessionWithTimestamp: vi.fn(() => null),
   clearSession: vi.fn(),
   isServerNewer: vi.fn(() => false),
+  detectModeFlip: vi.fn(() => "none" as "none" | "server-to-browser" | "browser-to-server"),
 }));
 
 vi.mock("$lib/utils/share", async () => {
@@ -77,7 +79,7 @@ vi.mock("$lib/storage/availability.svelte", () => ({
   isApiAvailable: persistenceStoreMocks.isApiAvailable,
   setApiAvailable: persistenceStoreMocks.setApiAvailable,
   getApiAvailableState: persistenceStoreMocks.getApiAvailableState,
-  hasEverConnectedToApi: persistenceStoreMocks.hasEverConnectedToApi,
+  getStorageMode: persistenceStoreMocks.getStorageMode,
 }));
 
 vi.mock("$lib/storage/api", () => ({
@@ -86,6 +88,7 @@ vi.mock("$lib/storage/api", () => ({
   listSavedLayouts: persistenceApiMocks.listSavedLayouts,
   loadSavedLayout: persistenceApiMocks.loadSavedLayout,
   deleteSavedLayout: persistenceApiMocks.deleteSavedLayout,
+  getServerInstanceLabel: persistenceApiMocks.getServerInstanceLabel,
   PersistenceError: persistenceApiMocks.PersistenceError,
 }));
 
@@ -94,6 +97,7 @@ vi.mock("$lib/storage/working-copy", () => ({
   loadSessionWithTimestamp: sessionStorageMocks.loadSessionWithTimestamp,
   clearSession: sessionStorageMocks.clearSession,
   isServerNewer: sessionStorageMocks.isServerNewer,
+  detectModeFlip: sessionStorageMocks.detectModeFlip,
 }));
 
 // Full-App renders flake under full-suite memory pressure: the worker GC-thrashes
@@ -125,6 +129,8 @@ describe("App Start Screen integration", { retry: 2, timeout: 30000 }, () => {
     persistenceStoreMocks.initializePersistence.mockResolvedValue(true);
     persistenceStoreMocks.isApiAvailable.mockReset();
     persistenceStoreMocks.isApiAvailable.mockReturnValue(true);
+    persistenceStoreMocks.getStorageMode.mockReset();
+    persistenceStoreMocks.getStorageMode.mockReturnValue("server");
 
     persistenceApiMocks.listSavedLayouts.mockReset();
     persistenceApiMocks.listSavedLayouts.mockResolvedValue([]);
@@ -133,6 +139,8 @@ describe("App Start Screen integration", { retry: 2, timeout: 30000 }, () => {
     sessionStorageMocks.loadSessionWithTimestamp.mockReset();
     sessionStorageMocks.loadSessionWithTimestamp.mockReturnValue(null);
     sessionStorageMocks.clearSession.mockReset();
+    sessionStorageMocks.detectModeFlip.mockReset();
+    sessionStorageMocks.detectModeFlip.mockReturnValue("none");
   });
 
   it("shows Start Screen on load when API is available and no share link", async () => {
@@ -165,6 +173,7 @@ describe("App Start Screen integration", { retry: 2, timeout: 30000 }, () => {
       savedAt: new Date("2026-02-11T00:00:00.000Z").toISOString(),
       changesSinceExport: 0,
       hasEverExported: false,
+      storageMode: "server",
     });
 
     render(App);

--- a/src/tests/persistence-manager-mode.test.ts
+++ b/src/tests/persistence-manager-mode.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const loadPipelineMocks = vi.hoisted(() => ({
+  loadFromFile: vi.fn(async () => true),
+  loadFromApi: vi.fn(async () => true),
+}));
+
+vi.mock("$lib/storage/load-pipeline", () => ({
+  loadFromFile: loadPipelineMocks.loadFromFile,
+  loadFromApi: loadPipelineMocks.loadFromApi,
+}));
+
+// finalizeSuccessfulSave touches the working copy; stub it out.
+vi.mock("$lib/storage/working-copy", () => ({
+  saveSession: vi.fn(),
+  clearSession: vi.fn(),
+}));
+
+import {
+  shouldSaveToServer,
+  handleLoad,
+  handlePersistenceError,
+  getConsecutiveSaveFailures,
+  resetPersistenceManager,
+} from "$lib/storage/manager.svelte";
+import { PersistenceError } from "$lib/storage/api";
+import { setApiAvailable } from "$lib/storage/availability.svelte";
+import { dialogStore } from "$lib/stores/dialogs.svelte";
+import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
+
+function setMode(mode: "browser" | "server"): void {
+  window.__RACKULA_CONFIG__ = { storage: mode };
+}
+
+/**
+ * The app's storage destination is decided by the explicit mode, not by probing.
+ * Even with the API reachable, browser mode never saves to the server and load
+ * uses the file picker. Locks issue #2037 AC (b).
+ */
+describe("storage-mode branching in the persistence manager", () => {
+  const original = window.__RACKULA_CONFIG__;
+
+  beforeEach(() => {
+    resetToastStore();
+    resetPersistenceManager();
+    dialogStore.close();
+    loadPipelineMocks.loadFromFile.mockClear();
+    loadPipelineMocks.loadFromApi.mockClear();
+  });
+
+  afterEach(() => {
+    window.__RACKULA_CONFIG__ = original;
+  });
+
+  it("shouldSaveToServer is false in browser mode even when the API is available", () => {
+    setMode("browser");
+    setApiAvailable(true);
+    expect(shouldSaveToServer()).toBe(false);
+  });
+
+  it("shouldSaveToServer is true in server mode only when the API is available", () => {
+    setMode("server");
+    setApiAvailable(true);
+    expect(shouldSaveToServer()).toBe(true);
+
+    setApiAvailable(false);
+    expect(shouldSaveToServer()).toBe(false);
+  });
+
+  it("handleLoad uses the file picker in browser mode", async () => {
+    setMode("browser");
+    setApiAvailable(true);
+    await handleLoad();
+    expect(loadPipelineMocks.loadFromFile).toHaveBeenCalledTimes(1);
+    expect(dialogStore.isOpen("load")).toBe(false);
+  });
+
+  it("handleLoad opens the server load dialog in server mode", async () => {
+    setMode("server");
+    setApiAvailable(true);
+    await handleLoad();
+    expect(loadPipelineMocks.loadFromFile).not.toHaveBeenCalled();
+    expect(dialogStore.isOpen("load")).toBe(true);
+  });
+});
+
+/**
+ * An expired Access session (HTTP 401) is not the same as a server being down.
+ * It must surface a re-authenticate affordance, must not trip the offline
+ * circuit breaker, and must not be retried as an offline failure. Locks #2037 AC (d).
+ */
+describe("auth (401) versus server-down (5xx) handling", () => {
+  beforeEach(() => {
+    resetToastStore();
+    resetPersistenceManager();
+    setMode("server");
+    setApiAvailable(true);
+  });
+
+  it("does not trip the circuit breaker on repeated 401s", () => {
+    for (let i = 0; i < 5; i++) {
+      handlePersistenceError(new PersistenceError("Unauthorized", 401), true);
+    }
+    expect(getConsecutiveSaveFailures()).toBe(0);
+  });
+
+  it("surfaces a re-authenticate affordance, not an offline toast, on 401", () => {
+    handlePersistenceError(new PersistenceError("Unauthorized", 401), true);
+    const toast = getToastStore().toasts.at(-1);
+    expect(toast?.message).toMatch(/re-?authenticate|sign in|session/i);
+    expect(toast?.message).not.toMatch(/working offline/i);
+  });
+
+  it("still treats a 500 as a server-down failure that increments the counter", () => {
+    handlePersistenceError(new PersistenceError("boom", 500), true);
+    expect(getConsecutiveSaveFailures()).toBe(1);
+    const toast = getToastStore().toasts.at(-1);
+    expect(toast?.message).toMatch(/backend unavailable|working offline/i);
+  });
+});

--- a/src/tests/session-storage.test.ts
+++ b/src/tests/session-storage.test.ts
@@ -4,6 +4,7 @@ import {
   loadSessionWithTimestamp,
   clearSession,
   isServerNewer,
+  detectModeFlip,
 } from "$lib/storage/working-copy";
 import type { Layout } from "$lib/types";
 import { UNITS_PER_U } from "$lib/types/constants";
@@ -505,6 +506,66 @@ describe("Session Storage", () => {
 
       // Should return null for non-object data (logs via debug logger)
       expect(loadSessionWithTimestamp()).toBeNull();
+    });
+  });
+
+  /**
+   * The session records the storage mode it was saved under so startup can
+   * detect a deployment mode flip and never silently degrade. Locks #2037 AC (c).
+   */
+  describe("storage mode persistence and flip detection", () => {
+    const originalConfig = window.__RACKULA_CONFIG__;
+
+    afterEach(() => {
+      window.__RACKULA_CONFIG__ = originalConfig;
+    });
+
+    it("persists the current storage mode and round-trips it", () => {
+      window.__RACKULA_CONFIG__ = { storage: "server" };
+      saveSession(mockLayout, noBackup);
+
+      const loaded = loadSessionWithTimestamp();
+      expect(loaded).not.toBeNull();
+      expect(loaded!.storageMode).toBe("server");
+    });
+
+    it("saves browser as the mode under browser config", () => {
+      window.__RACKULA_CONFIG__ = { storage: "browser" };
+      saveSession(mockLayout, noBackup);
+
+      const loaded = loadSessionWithTimestamp();
+      expect(loaded!.storageMode).toBe("browser");
+    });
+
+    it("defaults a legacy session without a stored mode to browser", () => {
+      // Pre-2037 sessions have no storageMode field.
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          layout: mockLayout,
+          savedAt: "2026-02-01T12:00:00.000Z",
+        }),
+      );
+
+      const loaded = loadSessionWithTimestamp();
+      expect(loaded!.storageMode).toBe("browser");
+    });
+
+    it("detects a server-to-browser flip", () => {
+      window.__RACKULA_CONFIG__ = { storage: "browser" };
+      expect(detectModeFlip("server")).toBe("server-to-browser");
+    });
+
+    it("detects a browser-to-server flip", () => {
+      window.__RACKULA_CONFIG__ = { storage: "server" };
+      expect(detectModeFlip("browser")).toBe("browser-to-server");
+    });
+
+    it("reports no flip when the modes match", () => {
+      window.__RACKULA_CONFIG__ = { storage: "browser" };
+      expect(detectModeFlip("browser")).toBe("none");
+      window.__RACKULA_CONFIG__ = { storage: "server" };
+      expect(detectModeFlip("server")).toBe("none");
     });
   });
 });

--- a/src/tests/storage-mode.test.ts
+++ b/src/tests/storage-mode.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getStorageMode } from "$lib/storage/availability.svelte";
+
+/**
+ * Storage mode is read explicitly from runtime config (window.__RACKULA_CONFIG__),
+ * not probed. "server" only when the config says exactly "server"; everything
+ * else (including missing/unknown values) is "browser". This is the single
+ * source other modules read. Locks issue #2037 AC (a).
+ */
+describe("getStorageMode", () => {
+  const original = window.__RACKULA_CONFIG__;
+
+  beforeEach(() => {
+    delete window.__RACKULA_CONFIG__;
+  });
+
+  afterEach(() => {
+    window.__RACKULA_CONFIG__ = original;
+  });
+
+  it("returns 'server' only when config.storage is exactly 'server'", () => {
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+    expect(getStorageMode()).toBe("server");
+  });
+
+  it("returns 'browser' when config.storage is 'browser'", () => {
+    window.__RACKULA_CONFIG__ = { storage: "browser" };
+    expect(getStorageMode()).toBe("browser");
+  });
+
+  it("returns 'browser' when config is missing entirely", () => {
+    delete window.__RACKULA_CONFIG__;
+    expect(getStorageMode()).toBe("browser");
+  });
+
+  it("returns 'browser' when storage key is undefined", () => {
+    window.__RACKULA_CONFIG__ = { env: "dev" };
+    expect(getStorageMode()).toBe("browser");
+  });
+
+  it("treats unknown storage values as 'browser'", () => {
+    window.__RACKULA_CONFIG__ = { storage: "Server" };
+    expect(getStorageMode()).toBe("browser");
+    window.__RACKULA_CONFIG__ = { storage: "cloud" };
+    expect(getStorageMode()).toBe("browser");
+    window.__RACKULA_CONFIG__ = { storage: "" };
+    expect(getStorageMode()).toBe("browser");
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Replaces runtime probe-and-guess storage detection with an explicit storage mode read from `window.__RACKULA_CONFIG__.storage` (browser default). M15 Stage 2; builds on #2036 (config injection), #2180, and #2059.

## Changes

- New single mode source `getStorageMode()` in `availability.svelte.ts`. Removed `hasEverConnectedToApi`, `markApiConnected`, `API_CONNECTED_KEY`, and the probe-and-guess health-poll gate.
- Mode-driven branching: `shouldSaveToServer()` and `handleLoad()` require server mode; PersistenceEffects beforeunload uses the explicit mode.
- Startup (`App.svelte`): browser mode skips the probe and shows a one-time first-run notice with no offline toasts; server mode keeps the health check, empty-list first run, and server-down continuity from the working copy.
- Toasts: removed both generic "Server unavailable - working offline" startup toasts; added an instance-named server-drop toast and a quiet recovery toast on resync; at most one storage toast at startup.
- Session blob now records the storage mode. Startup detects a mode flip: server to browser surfaces a notice (never silent); browser to server offers to upload the working copy as a new server layout via PUT (never shadows it with the server list).
- Auth vs server-down: a 401 surfaces a re-authenticate affordance and does not trip the offline circuit breaker; 5xx and network errors keep the existing server-down handling.

## Out of scope (tracked separately)

Storage chip (#2035), backup nudge (#2038), echo-based conflict and Zod save-response validation (#2041/#2062), twin-tab guard (#2044).

## Decisions (flagged on the issue)

- 401 re-auth affordance uses a Reload action (Access typically re-auths on fresh load); the 401 toast shows regardless of the notify flag.
- Instance label derived from the API host (`new URL(API_BASE_URL).host`, fallback `window.location.host`, fallback "the server").
- First-run notice flag key: `rackula.browserMode.firstRunSeen`.
- Once Cloudflare Access fronts the API (#2134), confirm Access returns 401 (not a 302 redirect) on the API path so the re-auth affordance triggers; otherwise expiry surfaces as server-down.

## Verification

- `npm run test:run`: 2165 pass
- `npm run lint`: clean
- `npm run build`: clean
- `grep -rn hasEverConnectedToApi src`: none; `markApiConnected` / `API_CONNECTED_KEY`: none

Closes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Use the configured storage mode to decide whether layouts stay in the browser or use the server

### What Changed
- The app now reads one explicit storage mode at startup instead of guessing from previous server access
- Browser mode skips server checks, saves and loads from local storage, and shows a one-time notice explaining where layouts live
- Server mode keeps server loading and autosave, shows a named server-unavailable message when the server cannot be reached, and shows a brief reconnection notice when it comes back
- If a saved working copy was created under a different storage mode, startup now warns the user instead of silently loading the wrong source
- An expired sign-in now shows a reload prompt to re-authenticate instead of being treated like the server is down

### Impact
`✅ Clearer browser-only storage behavior`
`✅ Fewer silent data mismatches after deployment changes`
`✅ Clearer recovery after server outages and expired sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
