### PR TITLE
fix: neutralize spreadsheet formula injection in CSV export (#2200)

### DIFF
--- a/src/lib/utils/export/data.ts
+++ b/src/lib/utils/export/data.ts
@@ -3,17 +3,19 @@ import { formatPosition } from "$lib/utils/position";
 
 /**
  * Leading characters that spreadsheet applications (Excel, Google Sheets,
- * LibreOffice) treat as the start of a formula. Device names and device-type
- * model/manufacturer can come from user-entered or imported (NetBox) data, so
- * a value beginning with one of these is neutralized to prevent CSV / formula
- * injection when the file is opened in a spreadsheet.
+ * LibreOffice) treat as the start of a formula. Tab, carriage return, and line
+ * feed are included because they are stripped as ignorable leading whitespace,
+ * which would otherwise let a value like `\n=2+2` reach the formula parser.
+ * Device names and device-type model/manufacturer can come from user-entered or
+ * imported (NetBox) data, so a value beginning with one of these is neutralized
+ * to prevent CSV / formula injection when the file is opened in a spreadsheet.
  */
-const FORMULA_TRIGGERS = new Set(["=", "+", "-", "@", "\t", "\r"]);
+const FORMULA_TRIGGERS = new Set(["=", "+", "-", "@", "\t", "\r", "\n"]);
 
 /**
  * Escape a CSV field value
- * - Prefixes a leading formula trigger (=, +, -, @, tab, carriage return) with
- *   a single quote so the cell is treated as text, not a formula
+ * - Prefixes a leading formula trigger (=, +, -, @, tab, carriage return, line
+ *   feed) with a single quote so the cell is treated as text, not a formula
  * - Wraps in quotes if contains comma, quote, newline, or carriage return
  * - Doubles any existing quotes
  */

--- a/src/lib/utils/export/data.ts
+++ b/src/lib/utils/export/data.ts
@@ -14,7 +14,7 @@ const FORMULA_TRIGGERS = new Set(["=", "+", "-", "@", "\t", "\r"]);
  * Escape a CSV field value
  * - Prefixes a leading formula trigger (=, +, -, @, tab, carriage return) with
  *   a single quote so the cell is treated as text, not a formula
- * - Wraps in quotes if contains comma, quote, or newline
+ * - Wraps in quotes if contains comma, quote, newline, or carriage return
  * - Doubles any existing quotes
  */
 function escapeCSVField(value: string): string {
@@ -22,7 +22,8 @@ function escapeCSVField(value: string): string {
   if (
     sanitized.includes(",") ||
     sanitized.includes('"') ||
-    sanitized.includes("\n")
+    sanitized.includes("\n") ||
+    sanitized.includes("\r")
   ) {
     return `"${sanitized.replace(/"/g, '""')}"`;
   }

--- a/src/lib/utils/export/data.ts
+++ b/src/lib/utils/export/data.ts
@@ -2,15 +2,31 @@ import type { Rack, DeviceType } from "$lib/types";
 import { formatPosition } from "$lib/utils/position";
 
 /**
+ * Leading characters that spreadsheet applications (Excel, Google Sheets,
+ * LibreOffice) treat as the start of a formula. Device names and device-type
+ * model/manufacturer can come from user-entered or imported (NetBox) data, so
+ * a value beginning with one of these is neutralized to prevent CSV / formula
+ * injection when the file is opened in a spreadsheet.
+ */
+const FORMULA_TRIGGERS = new Set(["=", "+", "-", "@", "\t", "\r"]);
+
+/**
  * Escape a CSV field value
+ * - Prefixes a leading formula trigger (=, +, -, @, tab, carriage return) with
+ *   a single quote so the cell is treated as text, not a formula
  * - Wraps in quotes if contains comma, quote, or newline
  * - Doubles any existing quotes
  */
 function escapeCSVField(value: string): string {
-  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
-    return `"${value.replace(/"/g, '""')}"`;
+  const sanitized = FORMULA_TRIGGERS.has(value.charAt(0)) ? `'${value}` : value;
+  if (
+    sanitized.includes(",") ||
+    sanitized.includes('"') ||
+    sanitized.includes("\n")
+  ) {
+    return `"${sanitized.replace(/"/g, '""')}"`;
   }
-  return value;
+  return sanitized;
 }
 
 /**

--- a/src/tests/export-csv-formula-injection.test.ts
+++ b/src/tests/export-csv-formula-injection.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { exportToCSV } from "$lib/utils/export/data";
+import {
+  createTestRack,
+  createTestDeviceType,
+  createTestDevice,
+} from "./factories";
+
+// CSV columns: Position,Name,Model,Manufacturer,U_Height,Category,Face
+// The first data row is index 1 (index 0 is the header).
+function dataCell(csv: string, column: number): string {
+  return csv.split("\n")[1].split(",")[column];
+}
+
+describe("exportToCSV formula injection", () => {
+  it.each(["=2+2", "+CMD|'/C calc'!A0", "-5+5", "@SUM(A1)"])(
+    "neutralizes a leading formula trigger in the device name: %s",
+    (payload) => {
+      const deviceType = createTestDeviceType({ slug: "srv", model: "Model" });
+      const rack = createTestRack({
+        devices: [createTestDevice({ device_type: "srv", name: payload })],
+      });
+
+      expect(dataCell(exportToCSV(rack, [deviceType]), 1)).toBe(`'${payload}`);
+    },
+  );
+
+  it("neutralizes a leading formula trigger in the device-type manufacturer", () => {
+    const deviceType = createTestDeviceType({
+      slug: "srv",
+      model: "Model",
+      manufacturer: "=HYPERLINK(0)",
+    });
+    const rack = createTestRack({
+      devices: [createTestDevice({ device_type: "srv", name: "Server" })],
+    });
+
+    expect(dataCell(exportToCSV(rack, [deviceType]), 3)).toBe("'=HYPERLINK(0)");
+  });
+
+  it("leaves a benign value untouched", () => {
+    const deviceType = createTestDeviceType({ slug: "srv", model: "Model" });
+    const rack = createTestRack({
+      devices: [createTestDevice({ device_type: "srv", name: "Server 1" })],
+    });
+
+    expect(dataCell(exportToCSV(rack, [deviceType]), 1)).toBe("Server 1");
+  });
+});

--- a/src/tests/export-csv-formula-injection.test.ts
+++ b/src/tests/export-csv-formula-injection.test.ts
@@ -13,8 +13,10 @@ function dataCell(csv: string, column: number): string {
 }
 
 describe("exportToCSV formula injection", () => {
-  it.each(["=2+2", "+CMD|'/C calc'!A0", "-5+5", "@SUM(A1)"])(
-    "neutralizes a leading formula trigger in the device name: %s",
+  // Triggers that are neutralized but do not also require CSV quoting (a tab is
+  // not a delimiter per RFC 4180, so the field is left unquoted).
+  it.each(["=2+2", "+CMD|'/C calc'!A0", "-5+5", "@SUM(A1)", "\tTAB"])(
+    "neutralizes a leading formula trigger in the device name: %j",
     (payload) => {
       const deviceType = createTestDeviceType({ slug: "srv", model: "Model" });
       const rack = createTestRack({
@@ -24,6 +26,17 @@ describe("exportToCSV formula injection", () => {
       expect(dataCell(exportToCSV(rack, [deviceType]), 1)).toBe(`'${payload}`);
     },
   );
+
+  it("neutralizes and quotes a leading carriage return in the device name", () => {
+    const deviceType = createTestDeviceType({ slug: "srv", model: "Model" });
+    const rack = createTestRack({
+      devices: [createTestDevice({ device_type: "srv", name: "\rROW" })],
+    });
+
+    // A carriage return must be quote-wrapped so a spreadsheet reader cannot
+    // treat it as a CSV row break.
+    expect(dataCell(exportToCSV(rack, [deviceType]), 1)).toBe(`"'\rROW"`);
+  });
 
   it("neutralizes a leading formula trigger in the device-type manufacturer", () => {
     const deviceType = createTestDeviceType({

--- a/src/tests/export-csv-formula-injection.test.ts
+++ b/src/tests/export-csv-formula-injection.test.ts
@@ -38,6 +38,18 @@ describe("exportToCSV formula injection", () => {
     expect(dataCell(exportToCSV(rack, [deviceType]), 1)).toBe(`"'\rROW"`);
   });
 
+  it("neutralizes and quotes a leading line feed in the device name", () => {
+    const deviceType = createTestDeviceType({ slug: "srv", model: "Model" });
+    const rack = createTestRack({
+      devices: [createTestDevice({ device_type: "srv", name: "\n=2+2" })],
+    });
+
+    // A leading line feed is ignorable whitespace in spreadsheets, so the
+    // following formula must still be neutralized and the field quoted. The
+    // embedded newline rules out the dataCell line-split helper here.
+    expect(exportToCSV(rack, [deviceType])).toContain(`"'\n=2+2"`);
+  });
+
   it("neutralizes a leading formula trigger in the device-type manufacturer", () => {
     const deviceType = createTestDeviceType({
       slug: "srv",


### PR DESCRIPTION
## **User description**
## Summary

`escapeCSVField` in `src/lib/utils/export/data.ts` quoted values containing commas, quotes, or newlines but did not neutralize spreadsheet formula prefixes. A device name or device-type model/manufacturer like `=2+2` or `+CMD|'/C calc'!A0` (user-entered or imported from NetBox) was written to the CSV unchanged and evaluated as a formula when opened in Excel, Google Sheets, or LibreOffice (CSV / formula injection).

The fix prefixes a leading formula trigger (`=`, `+`, `-`, `@`, tab, carriage return) with a single quote so the cell is treated as text, then applies the existing comma/quote/newline quoting on the sanitized value. Numeric columns (position, U-height) bypass `escapeCSVField`, so neutralizing `-` does not corrupt them.

## Test Plan

- [x] New `src/tests/export-csv-formula-injection.test.ts`: asserts leading `=`/`+`/`-`/`@` neutralized in device name, neutralized in device-type manufacturer, and benign values left untouched (6 cases pass)
- [x] `npx eslint` clean on changed files
- [x] `tsc --noEmit` clean on changed files

Closes #2200


___

## **CodeAnt-AI Description**
**Stop spreadsheet formulas from running in exported CSV files**

### What Changed
- CSV export now treats values that start with spreadsheet formula characters as plain text, so device names and device type details cannot be executed when opened in Excel, Google Sheets, or LibreOffice
- Existing CSV quoting still applies after this protection, so commas, quotes, and newlines continue to export correctly
- Added tests that cover unsafe names, unsafe manufacturer values, and normal values that should stay unchanged

### Impact
`✅ Safer CSV exports`
`✅ Fewer spreadsheet formula attacks`
`✅ Clearer device data downloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
