### PR TITLE
feat: round-trip unknown top-level sections through save (#2208)

### DIFF
--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -248,6 +248,43 @@ function orderMetadataFields(
 }
 
 /**
+ * Top-level layout keys the serializer recognises. Any other top-level key on a
+ * loaded layout is an unknown additive section (for example from a newer schema
+ * version) and is round-tripped verbatim so an older build never silently drops it
+ * on save (#2208).
+ */
+const KNOWN_TOP_LEVEL_KEYS = new Set<string>([
+  "metadata",
+  "version",
+  "name",
+  "racks",
+  "rack",
+  "rack_groups",
+  "device_types",
+  "settings",
+  "connections",
+  "cables",
+]);
+
+/**
+ * Copy any unrecognised top-level keys from the layout onto the serialized object,
+ * after the known fields, so additive sections survive a load and resave.
+ */
+function appendUnknownSections(
+  target: Record<string, unknown>,
+  layout: Layout,
+): void {
+  for (const [key, value] of Object.entries(
+    layout as unknown as Record<string, unknown>,
+  )) {
+    if (value === undefined) continue;
+    if (KNOWN_TOP_LEVEL_KEYS.has(key)) continue;
+    if (key in target) continue;
+    target[key] = value;
+  }
+}
+
+/**
  * Serialize a layout to YAML string
  * Excludes runtime-only fields (view) and orders fields according to schema v1.0.0
  * Includes metadata if present
@@ -288,6 +325,8 @@ export async function serializeLayoutToYaml(layout: Layout): Promise<string> {
   if (layout.cables !== undefined && layout.cables.length > 0) {
     layoutForSerialization.cables = layout.cables.map(orderCableFields);
   }
+
+  appendUnknownSections(layoutForSerialization, layout);
 
   return serializeToYaml(layoutForSerialization);
 }
@@ -338,6 +377,8 @@ export async function serializeLayoutToYamlWithMetadata(
   if (layout.cables !== undefined && layout.cables.length > 0) {
     layoutForSerialization.cables = layout.cables.map(orderCableFields);
   }
+
+  appendUnknownSections(layoutForSerialization, layout);
 
   return serializeToYaml(layoutForSerialization);
 }

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -248,10 +248,12 @@ function orderMetadataFields(
 }
 
 /**
- * Top-level layout keys the serializer recognises. Any other top-level key on a
- * loaded layout is an unknown additive section (for example from a newer schema
- * version) and is round-tripped verbatim so an older build never silently drops it
- * on save (#2208).
+ * Top-level keys the serializer writes explicitly above. Any other top-level key
+ * (an unknown additive section from a newer schema, or a recognised-but-not-yet-
+ * serialised field such as `connections`) is round-tripped by appendUnknownSections
+ * so it is never silently dropped on save (#2208). `connections` is deliberately
+ * NOT listed: neither serializer writes it yet, so excluding it lets the fallback
+ * preserve it until explicit serialization exists.
  */
 const KNOWN_TOP_LEVEL_KEYS = new Set<string>([
   "metadata",
@@ -262,9 +264,14 @@ const KNOWN_TOP_LEVEL_KEYS = new Set<string>([
   "rack_groups",
   "device_types",
   "settings",
-  "connections",
   "cables",
 ]);
+
+/**
+ * Reserved keys that must never be copied from untrusted parsed YAML onto a plain
+ * object: assigning them would mutate the prototype (prototype-pollution vector).
+ */
+const UNSAFE_KEYS = new Set<string>(["__proto__", "constructor", "prototype"]);
 
 /**
  * Copy any unrecognised top-level keys from the layout onto the serialized object,
@@ -278,6 +285,7 @@ function appendUnknownSections(
     layout as unknown as Record<string, unknown>,
   )) {
     if (value === undefined) continue;
+    if (UNSAFE_KEYS.has(key)) continue;
     if (KNOWN_TOP_LEVEL_KEYS.has(key)) continue;
     if (key in target) continue;
     target[key] = value;

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -153,4 +153,44 @@ describe("YAML unknown top-level section round-trip (#2208)", () => {
     // A clean layout has no stray top-level "future"/"unknown" markers.
     expect(yaml).not.toContain("undefined");
   });
+
+  it("preserves connections, which the serializer does not write explicitly", async () => {
+    const layout = {
+      ...createTestLayout(),
+      connections: [
+        {
+          id: "c1",
+          a_device_id: "d1",
+          a_interface: "eth0",
+          b_device_id: "d2",
+          b_interface: "eth0",
+        },
+      ],
+    } as unknown as Parameters<typeof serializeLayoutToYaml>[0];
+
+    const yaml = await serializeLayoutToYaml(layout);
+    expect(yaml).toContain("connections");
+    expect(yaml).toContain("c1");
+  });
+
+  it("does not copy prototype-polluting keys from a crafted layout", async () => {
+    const layout = createTestLayout() as unknown as Record<string, unknown>;
+    // Hostile own enumerable keys a crafted YAML file could carry.
+    Object.defineProperty(layout, "__proto__", {
+      value: { hacked: true },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    layout.constructor = { hacked: true };
+    layout.prototype = { hacked: true };
+
+    const yaml = await serializeLayoutToYaml(
+      layout as unknown as Parameters<typeof serializeLayoutToYaml>[0],
+    );
+
+    // None of the reserved keys are emitted, and the global prototype is intact.
+    expect(yaml).not.toContain("hacked");
+    expect((({}) as Record<string, unknown>).hacked).toBeUndefined();
+  });
 });

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -104,3 +104,53 @@ describe("YAML layout round-trip", () => {
     expect(child?.slot_id).toBe("slot-left");
   });
 });
+
+describe("YAML unknown top-level section round-trip (#2208)", () => {
+  it("preserves an unknown top-level section through a load and resave", async () => {
+    // Simulate a file written by a newer build that carries an additive section
+    // this build does not recognise.
+    const baseYaml = await serializeLayoutToYaml(createTestLayout());
+    const yamlWithUnknown = `${baseYaml}\nfuture_section:\n  hello: world\n  count: 3\n`;
+
+    // On load the unknown section rides onto the runtime layout (Zod passthrough).
+    const loaded = await parseLayoutYaml(yamlWithUnknown);
+
+    // On resave it must not be silently dropped by the serializer allowlist.
+    const resaved = await serializeLayoutToYaml(loaded);
+    expect(resaved).toContain("future_section");
+
+    const reloaded = (await parseLayoutYaml(resaved)) as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(reloaded.future_section).toEqual({ hello: "world", count: 3 });
+  });
+
+  it("re-emits unrecognised top-level keys present on a layout object", async () => {
+    const layout = {
+      ...createTestLayout(),
+      experimental_flag: 42,
+      annotations: [{ id: "a1", text: "note" }],
+    } as unknown as Parameters<typeof serializeLayoutToYaml>[0];
+
+    const yaml = await serializeLayoutToYaml(layout);
+    expect(yaml).toContain("experimental_flag");
+    expect(yaml).toContain("annotations");
+
+    const restored = (await parseLayoutYaml(yaml)) as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(restored.experimental_flag).toBe(42);
+    expect(restored.annotations).toEqual([{ id: "a1", text: "note" }]);
+  });
+
+  it("does not invent keys for a layout with no unknown sections", async () => {
+    const layout = createTestLayout();
+    const yaml = await serializeLayoutToYaml(layout);
+    const restored = await parseLayoutYaml(yaml);
+    expect(restored.name).toBe(layout.name);
+    // A clean layout has no stray top-level "future"/"unknown" markers.
+    expect(yaml).not.toContain("undefined");
+  });
+});


### PR DESCRIPTION
## **User description**
## What

Round-trip unknown top-level sections of a layout through save, so an older build cannot
silently drop a newer build's additive section when it resaves the file.

Closes #2208.

## Why

`serializeLayoutToYaml` (and `serializeLayoutToYamlWithMetadata`) build their output from a
fixed allowlist of top-level keys and never re-emit anything else. Unknown sections already
survive load (Zod `.passthrough()` plus the transform's `...rest` spread), but they were
discarded on the next save. So a same-major newer-minor file opened by an older build lost any
section that build did not recognise. This is the load-bearing data-safety mechanism behind the
additive/MINOR rule in the schema versioning policy (#1113): without it, "additive is
non-breaking" only holds within a single build generation.

Surfaced by the #1113 devil's-advocate review.

## Change

A small `appendUnknownSections` helper copies any top-level key not in the known set onto the
serialized object, after the known fields. The known set is the complete list of Layout
top-level fields (verified against the `Layout` interface), so no runtime-only data leaks.

## Tests

`src/tests/yaml-roundtrip.test.ts`: an unknown section present in a loaded YAML survives a
resave and re-parse; unrecognised keys on a layout object are re-emitted; a clean layout gains
no spurious keys.

## Follow-up note

When #617 adds the `images` section to the serializer, it should also add `images` to
`KNOWN_TOP_LEVEL_KEYS` so the explicit handling is not shadowed by this generic pass.


___

## **CodeAnt-AI Description**
Keep unknown top-level layout sections when saving

### What Changed
- Layout files now preserve unrecognized top-level sections when they are opened and saved again
- Layout exports also keep any extra top-level keys already present on the layout, instead of dropping them
- Clean layouts still save without adding new sections or stray keys

### Impact
`✅ Fewer lost layout sections after resave`
`✅ Safer opens of newer files in older builds`
`✅ Fewer data-loss surprises during layout editing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
