### PR TITLE
chore: decide i18n approach — defer to M11, drop orphaned Paraglide runtime (#2184)

### DIFF
--- a/docs/reference/ADR-0002-i18n-deferred-to-m11.md
+++ b/docs/reference/ADR-0002-i18n-deferred-to-m11.md
@@ -1,0 +1,66 @@
+# ADR-0002: Internationalization Deferred to M11
+
+- **Status:** Accepted
+- **Date:** 2026-06-13
+- **Decision Owner:** Rackula maintainers
+- **Related:** #2184, M11 -- Internationalization, M14 -- Canvas UX Overhaul, M15 -- Storage Model
+
+## Context
+
+A vestigial Paraglide runtime existed under `src/lib/i18n/paraglide/`. Inspection showed it
+was orphaned generated output, not a working i18n layer:
+
+- The directory was entirely untracked and git-ignored (the generated tree carries its own
+  `.gitignore` of `*`), so CI and other contributors never saw it.
+- There was no `@inlang/paraglide-js` dependency in `package.json`.
+- There was no inlang project config (`project.inlang`) and no source message catalogues;
+  the generated message modules were empty stubs.
+- Nothing in `src` imported it.
+
+In parallel, M14 (Canvas UX Overhaul) and M15 (Storage Model) introduce the project's largest
+batch of new user-facing copy: the app menu (#2073), command registry text (#2096), storage
+status chip and toasts (#2035, #2038), and conflict and snapshot dialogs (#2041, #2042).
+
+M11 (Internationalization) already exists as a dedicated milestone. The open question was
+whether new M14/M15 strings should go through an i18n layer now, or be authored inline and
+retrofitted when M11 is prioritized.
+
+## Decision
+
+1. Delete the orphaned `src/lib/i18n/` directory. It is dead, untracked generated output with
+   no dependency, config, catalogue, or usage backing it.
+2. Do not adopt an i18n layer for M14/M15. New user-facing strings are authored inline as
+   literal English copy in components.
+3. Internationalization is owned by M11. When M11 is prioritized it adopts a clean i18n setup
+   (dependency, config, catalogues, component wiring) and retrofits existing strings then.
+
+## Rationale
+
+- The Paraglide output was never wired up; there is nothing of value to preserve and no
+  partial setup to build on.
+- Adopting i18n now would force every new M14/M15 string through catalogues and a standing
+  seven-locale translation commitment (en, de, fr, nl, it, es, pl) before i18n is a
+  prioritized milestone. For a solo maintainer that is front-loaded overhead with no near-term
+  payoff.
+- It matches the project's greenfield, simplicity-first philosophy: only implement what is
+  asked, and delete unused code completely.
+- A single clean adoption in M11 is cheaper and less error-prone than a half-wired adoption
+  now plus later rework.
+
+## Consequences
+
+### Positive
+
+- Dead code removed; no orphaned generated tree lingering on developer machines.
+- M14/M15 proceed without i18n overhead on every new string.
+- i18n adoption happens once, cleanly, when M11 is prioritized.
+
+### Negative
+
+- Strings authored during M14/M15 will need a retrofit pass into catalogues when M11 lands.
+  This is accepted: the retrofit is bounded and M11 already scopes it.
+
+### Follow-Up Work
+
+- M11 -- Internationalization: adopt the i18n toolchain, author catalogues, wire components,
+  and retrofit existing inline strings.


### PR DESCRIPTION
## **User description**
## Summary

Resolves the i18n decision from the 2026-06-12 milestone alignment audit.

**Decision: delete and defer to M11.** Recorded in `docs/reference/ADR-0002-i18n-deferred-to-m11.md`.

The `src/lib/i18n/paraglide/` tree was orphaned generated output, not a working i18n layer:
- Entirely untracked and git-ignored (the generated tree carries its own `.gitignore` of `*`), so CI and other contributors never saw it.
- No `@inlang/paraglide-js` dependency in `package.json`.
- No inlang project config and no source catalogues (message modules were empty stubs).
- No imports anywhere in `src`.

Adopting Paraglide now would force every new M14/M15 string through catalogues and a standing seven-locale commitment before i18n is a prioritized milestone. M11 (Internationalization) already exists to do this cleanly. New M14/M15 strings are authored inline; M11 retrofits when prioritized.

## Acceptance criteria

- [x] Decision recorded (ADR-0002): delete `src/lib/i18n/` and accept an M11 retrofit
- [x] `src/lib/i18n/` removed, no dead code

## Notes

The directory removal does not appear in the diff because it was never tracked (git-ignored generated output). It was removed from the local working tree; the repo only gains the ADR.

## Test Plan

- [x] `prettier --check` passes on the new ADR
- [x] `markdownlint-cli2` passes (0 errors)
- [x] No code paths touched (docs-only)

Closes #2184


___

## **CodeAnt-AI Description**
**Document the decision to defer i18n until M11 and keep new M14/M15 copy inline**

### What Changed
- Records that internationalization is postponed to M11, with a clear note that new M14/M15 user-facing text should be written inline for now
- Explains that the old Paraglide i18n tree was unused, untracked, and safe to remove
- Notes the expected follow-up: M11 will add a clean i18n setup and retrofit existing strings later

### Impact
`✅ Clearer i18n rollout plan`
`✅ Less overhead for new M14/M15 text`
`✅ No orphaned i18n dead code`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
