### PR TITLE
feat: embed custom images as base64 in YAML save and load (#617)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -51,6 +51,7 @@
     handleFitAll,
   } from "$lib/utils/app-actions";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getImageStore } from "$lib/stores/images.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
@@ -363,9 +364,35 @@
           // Compare timestamps: load server data if it's newer than localStorage
           // or if localStorage has no timestamp (legacy data)
           if (isServerNewer(localSession.savedAt, mostRecent.updatedAt)) {
-            const serverLayout = await loadSavedLayout(mostRecent.id);
+            const {
+              layout: serverLayout,
+              images: serverImages,
+              failedImagesCount,
+            } = await loadSavedLayout(mostRecent.id);
+            // Reset images: clear, reload bundled base, overlay decoded uploads.
+            const imageStore = getImageStore();
+            imageStore.clearAllImages();
+            imageStore.loadBundledImages();
+            for (const [deviceSlug, deviceImages] of serverImages) {
+              if (deviceImages.front) {
+                imageStore.setDeviceImage(
+                  deviceSlug,
+                  "front",
+                  deviceImages.front,
+                );
+              }
+              if (deviceImages.rear) {
+                imageStore.setDeviceImage(deviceSlug, "rear", deviceImages.rear);
+              }
+            }
             layoutStore.loadLayout(serverLayout);
             layoutStore.markClean();
+            if (failedImagesCount > 0) {
+              toastStore.showToast(
+                `Layout loaded with ${failedImagesCount} image${failedImagesCount > 1 ? "s" : ""} that couldn't be read`,
+                "warning",
+              );
+            }
 
             // Clear stale localStorage to prevent future conflicts
             clearSession();

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -5,7 +5,13 @@
  */
 import { isApiAvailable } from "./availability.svelte";
 import type { Layout } from "$lib/types";
-import { serializeLayoutToYaml, parseLayoutYaml } from "$lib/utils/yaml";
+import type { ImageStoreMap } from "$lib/types/images";
+import {
+  serializeLayoutToYaml,
+  parseLayoutYamlWithImages,
+} from "$lib/utils/yaml";
+import { encodeUserImagesToYaml } from "$lib/utils/image-encoding";
+import { getImageStore } from "$lib/stores/images.svelte";
 import { persistenceDebug } from "$lib/utils/debug";
 import { z } from "zod";
 
@@ -243,10 +249,14 @@ export async function listSavedLayouts(): Promise<SavedLayoutItem[]> {
 }
 
 /**
- * Load a layout by UUID
+ * Load a layout by UUID, decoding any embedded user images (#617).
  * @param uuid - The layout's UUID (stable identity)
  */
-export async function loadSavedLayout(uuid: string): Promise<Layout> {
+export async function loadSavedLayout(uuid: string): Promise<{
+  layout: Layout;
+  images: ImageStoreMap;
+  failedImagesCount: number;
+}> {
   log("loadSavedLayout: uuid=%s", uuid);
 
   if (!isApiAvailable()) {
@@ -285,7 +295,9 @@ export async function loadSavedLayout(uuid: string): Promise<Layout> {
     yamlContent.length,
   );
   try {
-    return parseLayoutYaml(yamlContent);
+    const { layout, images, failedImagesCount } =
+      await parseLayoutYamlWithImages(yamlContent);
+    return { layout, images, failedImagesCount };
   } catch (error) {
     log("loadSavedLayout: failed to parse uuid=%s %O", uuid, error);
     throw new PersistenceError("Layout data is corrupted - could not parse");
@@ -325,7 +337,11 @@ export async function saveLayoutToServer(layout: Layout): Promise<string> {
     );
   }
 
-  const yamlContent = await serializeLayoutToYaml(layout);
+  // Embed user images so server-mode saves do not silently drop them (#617).
+  // The 1MB server PUT cap then trips loudly for image-heavy layouts; that is
+  // intentional until storage quotas exist (see image-encoding.ts SIZE DIVERGENCE).
+  const { serialized } = encodeUserImagesToYaml(getImageStore().getUserImages());
+  const yamlContent = await serializeLayoutToYaml(layout, serialized);
   log(
     "saveLayoutToServer: uuid=%s yamlSize=%d bytes",
     uuid,

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -11,7 +11,6 @@ import {
   parseLayoutYamlWithImages,
 } from "$lib/utils/yaml";
 import { encodeUserImagesToYaml } from "$lib/utils/image-encoding";
-import { getImageStore } from "$lib/stores/images.svelte";
 import { persistenceDebug } from "$lib/utils/debug";
 import { z } from "zod";
 
@@ -256,6 +255,7 @@ export async function loadSavedLayout(uuid: string): Promise<{
   layout: Layout;
   images: ImageStoreMap;
   failedImagesCount: number;
+  failedKeys: string[];
 }> {
   log("loadSavedLayout: uuid=%s", uuid);
 
@@ -295,9 +295,9 @@ export async function loadSavedLayout(uuid: string): Promise<{
     yamlContent.length,
   );
   try {
-    const { layout, images, failedImagesCount } =
+    const { layout, images, failedImagesCount, failedKeys } =
       await parseLayoutYamlWithImages(yamlContent);
-    return { layout, images, failedImagesCount };
+    return { layout, images, failedImagesCount, failedKeys };
   } catch (error) {
     log("loadSavedLayout: failed to parse uuid=%s %O", uuid, error);
     throw new PersistenceError("Layout data is corrupted - could not parse");
@@ -310,7 +310,10 @@ export async function loadSavedLayout(uuid: string): Promise<{
  * @param layout - The layout to save (must have metadata.id for existing layouts)
  * @returns The saved layout UUID
  */
-export async function saveLayoutToServer(layout: Layout): Promise<string> {
+export async function saveLayoutToServer(
+  layout: Layout,
+  userImages: ImageStoreMap,
+): Promise<string> {
   log("saveLayoutToServer: name=%s", layout.name);
 
   if (!isApiAvailable()) {
@@ -340,7 +343,7 @@ export async function saveLayoutToServer(layout: Layout): Promise<string> {
   // Embed user images so server-mode saves do not silently drop them (#617).
   // The 1MB server PUT cap then trips loudly for image-heavy layouts; that is
   // intentional until storage quotas exist (see image-encoding.ts SIZE DIVERGENCE).
-  const { serialized } = encodeUserImagesToYaml(getImageStore().getUserImages());
+  const { serialized } = encodeUserImagesToYaml(userImages);
   const yamlContent = await serializeLayoutToYaml(layout, serialized);
   log(
     "saveLayoutToServer: uuid=%s yamlSize=%d bytes",

--- a/src/lib/storage/load-pipeline.ts
+++ b/src/lib/storage/load-pipeline.ts
@@ -76,8 +76,8 @@ export async function loadFromApi(uuid: string) {
   const toastStore = getToastStore();
 
   try {
-    const layout = await loadSavedLayout(uuid);
-    finalizeLayoutLoad(layout);
+    const { layout, images, failedImagesCount } = await loadSavedLayout(uuid);
+    finalizeLayoutLoad(layout, images, failedImagesCount);
     return true;
   } catch (e) {
     let message: string;

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -13,6 +13,7 @@ import {
 import { saveSession, clearSession } from "./working-copy";
 import { loadFromFile } from "./load-pipeline";
 import { getLayoutStore } from "$lib/stores/layout.svelte";
+import { getImageStore } from "$lib/stores/images.svelte";
 import { getToastStore } from "$lib/stores/toast.svelte";
 import { dialogStore } from "$lib/stores/dialogs.svelte";
 import { downloadYamlFile } from "$lib/utils/archive";
@@ -262,12 +263,22 @@ export async function handleSaveAsArchive(): Promise<boolean> {
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
   try {
-    const filename = await downloadYamlFile(layoutStore.layout);
+    const { filename, oversized } = await downloadYamlFile(
+      layoutStore.layout,
+      getImageStore().getUserImages(),
+    );
     layoutStore.markClean();
     layoutStore.markExported();
     cancelSessionSave();
     clearSession();
     toastStore.showToast(`Saved ${filename}`, "success", 3000);
+    if (oversized > 0) {
+      toastStore.showToast(
+        `${oversized} image${oversized > 1 ? "s" : ""} exceed 100KB; consider optimising them to keep files small.`,
+        "warning",
+        6000,
+      );
+    }
     return true;
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -238,6 +238,7 @@ export async function handleSaveToServer(isManual = false): Promise<boolean> {
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
   try {
+    const scheduleId = ++_serverSaveScheduleId;
     _saveStatus = "saving";
     if (serverSaveTimer) {
       clearTimeout(serverSaveTimer);
@@ -247,7 +248,7 @@ export async function handleSaveToServer(isManual = false): Promise<boolean> {
     const snapshot = structuredClone($state.snapshot(layoutStore.layout));
     const imagesSnapshot = getImageStore().getUserImages();
     await saveLayoutToServer(snapshot, imagesSnapshot);
-    finalizeSuccessfulSave();
+    finalizeSuccessfulSave(scheduleId === _serverSaveScheduleId);
     if (isManual) {
       toastStore.showToast("Layout saved", "success", 3000);
     }

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -245,7 +245,8 @@ export async function handleSaveToServer(isManual = false): Promise<boolean> {
       _serverSavePending = false;
     }
     const snapshot = structuredClone($state.snapshot(layoutStore.layout));
-    await saveLayoutToServer(snapshot);
+    const imagesSnapshot = getImageStore().getUserImages();
+    await saveLayoutToServer(snapshot, imagesSnapshot);
     finalizeSuccessfulSave();
     if (isManual) {
       toastStore.showToast("Layout saved", "success", 3000);
@@ -365,6 +366,7 @@ export function initPersistenceEffects(): void {
       clearTimeout(serverSaveTimer);
     }
     const snapshot = structuredClone($state.snapshot(layout));
+    const imagesSnapshot = getImageStore().getUserImages();
     _serverSavePending = true;
     serverSaveTimer = setTimeout(async () => {
       // Clear pending state before the await: a stale continuation must not
@@ -374,7 +376,7 @@ export function initPersistenceEffects(): void {
       _serverSavePending = false;
       _saveStatus = "saving";
       try {
-        await saveLayoutToServer(snapshot);
+        await saveLayoutToServer(snapshot, imagesSnapshot);
         // Only clear dirty/session state if no newer save was scheduled while
         // this one was in flight; otherwise newer unsaved edits exist.
         finalizeSuccessfulSave(scheduleId === _serverSaveScheduleId);

--- a/src/lib/utils/archive.ts
+++ b/src/lib/utils/archive.ts
@@ -29,7 +29,9 @@ import {
   serializeLayoutToYamlWithMetadata,
   serializeLayoutToYaml,
   parseLayoutYaml,
+  parseLayoutYamlWithImages,
 } from "./yaml";
+import { encodeUserImagesToYaml } from "./image-encoding";
 import { generateId } from "./device";
 import {
   buildFolderName,
@@ -349,14 +351,25 @@ export async function extractFolderArchive(
   const isZip = header[0] === 0x50 && header[1] === 0x4b;
 
   if (!isZip) {
+    // Whole-file cap before parse. Local YAML load allows up to 5MB
+    // (MAX_YAML_BYTES) while the server PUT caps a layout at 1MB, so
+    // image-heavy YAML that loads locally fails server save loudly. That
+    // mismatch is intentional until storage quotas exist (#617).
     if (blob.size > LIMITS.MAX_YAML_BYTES) {
       throw new Error(
         `Layout file too large (${Math.round(blob.size / 1024 / 1024)}MB). Max size is ${Math.round(LIMITS.MAX_YAML_BYTES / 1024 / 1024)}MB.`,
       );
     }
     const yamlText = await blob.text();
-    const layout = await parseLayoutYaml(yamlText);
-    return { layout, images: new Map(), failedImages: [] };
+    const { layout, images, failedImagesCount } =
+      await parseLayoutYamlWithImages(yamlText);
+    // finalizeLayoutLoad uses failedImages.length, so surface the count as that
+    // many entries; the placeholder strings are never read individually.
+    const failedImages = Array.from(
+      { length: failedImagesCount },
+      (_, i) => `embedded-image-${i}`,
+    );
+    return { layout, images, failedImages };
   }
 
   // Guardrail: Max ZIP size
@@ -744,12 +757,22 @@ export async function downloadArchive(
 }
 
 /**
- * Save a layout as a standalone YAML file.
- * Returns the filename used.
+ * Save a layout as a standalone YAML file, embedding user-uploaded device
+ * images as base64 data URLs (#617) so the plain-YAML save no longer drops them.
+ *
+ * Returns the filename used and the count of images that exceeded the save
+ * warning threshold (~100KB), so the caller can surface a single non-blocking
+ * "consider optimising" toast.
  */
-export async function downloadYamlFile(layout: Layout): Promise<string> {
+export async function downloadYamlFile(
+  layout: Layout,
+  userImages?: ImageStoreMap,
+): Promise<{ filename: string; oversized: number }> {
   const { fileSave } = await import("browser-fs-access");
-  const yamlContent = await serializeLayoutToYaml(layout);
+  const { serialized, oversized } = userImages
+    ? encodeUserImagesToYaml(userImages)
+    : { serialized: undefined, oversized: 0 };
+  const yamlContent = await serializeLayoutToYaml(layout, serialized);
   const blob = new Blob([yamlContent], { type: "text/yaml;charset=utf-8" });
   const filename = buildYamlFilename(layout.name);
   await fileSave(blob, {
@@ -757,7 +780,7 @@ export async function downloadYamlFile(layout: Layout): Promise<string> {
     extensions: [".yaml"],
     description: "Rackula Layout",
   });
-  return filename;
+  return { filename, oversized };
 }
 
 // Re-export folder structure utilities for convenience

--- a/src/lib/utils/image-encoding.ts
+++ b/src/lib/utils/image-encoding.ts
@@ -50,8 +50,8 @@ const MIME_TO_EXT: Record<string, string> = {
 /**
  * Detect an image MIME type purely from leading magic bytes.
  *
- * Recognises PNG, JPEG, WebP, and GIF. Returns null for anything unrecognised,
- * including SVG/text (which start with "<"), so callers can reject untrusted or
+ * Recognises PNG, JPEG, and WebP. Returns null for anything unrecognised
+ * (including GIF, SVG, and text starting with "<"), so callers can reject untrusted or
  * disallowed content without trusting any declared prefix.
  */
 export function detectImageMime(bytes: Uint8Array): string | null {
@@ -89,17 +89,6 @@ export function detectImageMime(bytes: Uint8Array): string | null {
     bytes[11] === 0x50
   ) {
     return "image/webp";
-  }
-
-  // GIF: 47 49 46 38 ("GIF8")
-  if (
-    bytes.length >= 4 &&
-    bytes[0] === 0x47 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x38
-  ) {
-    return "image/gif";
   }
 
   return null;
@@ -251,6 +240,9 @@ export function decodeYamlImages(raw: unknown): {
         continue;
       }
 
+      const declaredMimeMatch = /^data:([^;,]+)[^,]*;base64,/i.exec(faceValue);
+      const declaredMime = declaredMimeMatch?.[1]?.toLowerCase();
+
       const bytes = decodeDataUrl(faceValue);
       if (!bytes) {
         failedImagesCount++;
@@ -266,7 +258,11 @@ export function decodeYamlImages(raw: unknown): {
       }
 
       const detected = detectImageMime(bytes);
-      if (!detected || !SUPPORTED_IMAGE_FORMATS.includes(detected)) {
+      if (
+        !detected ||
+        !SUPPORTED_IMAGE_FORMATS.includes(detected) ||
+        declaredMime !== detected
+      ) {
         failedImagesCount++;
         failedKeys.push(key);
         continue;

--- a/src/lib/utils/image-encoding.ts
+++ b/src/lib/utils/image-encoding.ts
@@ -1,0 +1,284 @@
+/**
+ * Image encoding for the plain-YAML save/load path (#617)
+ *
+ * User-uploaded device images are embedded as base64 data URLs in the YAML so
+ * the default `.rackula.yaml` save no longer drops them. On load the payload is
+ * sniffed by magic bytes (never trusting the declared MIME), validated against
+ * the allowed raster formats, and stripped if bad so one corrupt image never
+ * rejects the whole file.
+ *
+ * SIZE DIVERGENCE (intentional, until storage quotas are designed):
+ * Local YAML load allows images up to MAX_IMAGE_SIZE_BYTES (5MB) each, while the
+ * server PUT caps an entire layout at 1MB. So an image-heavy YAML that loads
+ * fine locally will fail the server save loudly. That mismatch is deliberate:
+ * local files are trusted, the server is shared storage.
+ *
+ * This module is intentionally neutral: it imports only from $lib/types so it
+ * can be used by both yaml.ts and archive.ts without circular imports.
+ */
+
+import type { ImageData, ImageStoreMap } from "$lib/types/images";
+import {
+  SUPPORTED_IMAGE_FORMATS,
+  MAX_IMAGE_SIZE_BYTES,
+} from "$lib/types/constants";
+
+/** Faces serialized per device key. */
+export interface SerializedFaces {
+  front?: string;
+  rear?: string;
+}
+
+/** Map of store key to its serialized image faces. */
+export type SerializedImages = Record<string, SerializedFaces>;
+
+/**
+ * Warn-on-save threshold: images larger than this trigger a single
+ * non-blocking toast so users can optimise before files balloon.
+ */
+const SAVE_WARN_BYTES = 100 * 1024;
+
+const FACES: readonly ("front" | "rear")[] = ["front", "rear"];
+
+/** MIME type to file extension for deriving filenames. */
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+};
+
+/**
+ * Detect an image MIME type purely from leading magic bytes.
+ *
+ * Recognises PNG, JPEG, WebP, and GIF. Returns null for anything unrecognised,
+ * including SVG/text (which start with "<"), so callers can reject untrusted or
+ * disallowed content without trusting any declared prefix.
+ */
+export function detectImageMime(bytes: Uint8Array): string | null {
+  // PNG: 89 50 4E 47
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+
+  // JPEG: FF D8 FF
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+
+  // WebP: "RIFF" at 0-3 and "WEBP" at 8-11
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+
+  // GIF: 47 49 46 38 ("GIF8")
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x38
+  ) {
+    return "image/gif";
+  }
+
+  return null;
+}
+
+/**
+ * Reserved keys that must never be copied from untrusted parsed YAML onto a plain
+ * object: assigning them would mutate the prototype (prototype-pollution vector).
+ * Mirrors the serializer's UNSAFE_KEYS guard (#2208).
+ */
+const UNSAFE_KEYS = new Set<string>(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Decode the base64 payload of a `data:<mime>;base64,<payload>` URL.
+ * Returns null if the string is not a base64 data URL or fails to decode.
+ */
+export function decodeDataUrl(value: string): Uint8Array<ArrayBuffer> | null {
+  const match = /^data:[^,]*;base64,(.*)$/s.exec(value);
+  if (!match) return null;
+  const payload = match[1] ?? "";
+  try {
+    const binary = atob(payload);
+    const buffer = new ArrayBuffer(binary.length);
+    const bytes = new Uint8Array(buffer);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Estimate the decoded byte length of a base64 data URL without allocating the
+ * full buffer (cheap oversized check). Returns null if not a base64 data URL.
+ */
+export function dataUrlByteLength(value: string): number | null {
+  const match = /^data:[^,]*;base64,(.*)$/s.exec(value);
+  if (!match) return null;
+  const payload = match[1] ?? "";
+  const len = payload.length;
+  if (len === 0) return 0;
+  let padding = 0;
+  if (payload.endsWith("==")) padding = 2;
+  else if (payload.endsWith("=")) padding = 1;
+  return Math.floor((len * 3) / 4) - padding;
+}
+
+/**
+ * Encode a map of user images into the YAML `images` record.
+ *
+ * Uses each ImageData's existing `dataUrl` (already a base64 data URL), so this
+ * is synchronous. Counts faces whose underlying image exceeds the save warning
+ * threshold (~100KB) into `oversized`.
+ */
+export function encodeUserImagesToYaml(images: ImageStoreMap): {
+  serialized: SerializedImages;
+  oversized: number;
+} {
+  const serialized: SerializedImages = {};
+  let oversized = 0;
+
+  for (const [key, deviceImages] of images) {
+    const faces: SerializedFaces = {};
+
+    for (const face of FACES) {
+      const image = deviceImages[face];
+      const dataUrl = image?.dataUrl;
+      if (!image || !dataUrl) continue;
+
+      faces[face] = dataUrl;
+
+      const size = image.blob?.size ?? dataUrlByteLength(dataUrl) ?? 0;
+      if (size > SAVE_WARN_BYTES) {
+        oversized++;
+      }
+    }
+
+    if (faces.front || faces.rear) {
+      serialized[key] = faces;
+    }
+  }
+
+  return { serialized, oversized };
+}
+
+/**
+ * Decode and validate the `images` section parsed from untrusted YAML.
+ *
+ * Each face value must be a base64 data URL whose decoded bytes sniff to an
+ * allowed raster format and stay within MAX_IMAGE_SIZE_BYTES. Anything that
+ * fails (not a string, malformed data URL, unknown/disallowed MIME via magic
+ * bytes, or oversized) is skipped and counted in `failedImagesCount` so the
+ * existing "N images couldn't be read" toast fires. A bad image never rejects
+ * the layout.
+ *
+ * The decoded `dataUrl` keeps the ORIGINAL string verbatim (not rebuilt from the
+ * sniffed MIME) so a load -> save cycle is byte-stable. The detected MIME is
+ * still used for the Blob type and filename extension.
+ *
+ * `failedKeys` lists the store keys whose face was rejected, so callers can log
+ * them to help a confused user. `failedImagesCount` is the count the existing
+ * toast uses.
+ */
+export function decodeYamlImages(raw: unknown): {
+  images: ImageStoreMap;
+  failedImagesCount: number;
+  failedKeys: string[];
+} {
+  const images: ImageStoreMap = new Map();
+  const failedKeys: string[] = [];
+  let failedImagesCount = 0;
+
+  if (raw === null || typeof raw !== "object") {
+    return { images, failedImagesCount, failedKeys };
+  }
+
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    // Defense-in-depth: never read reserved/prototype keys off untrusted YAML.
+    if (UNSAFE_KEYS.has(key)) continue;
+    if (value === null || typeof value !== "object") {
+      continue;
+    }
+    const faceRecord = value as Record<string, unknown>;
+
+    for (const face of FACES) {
+      if (!(face in faceRecord)) continue;
+      const faceValue = faceRecord[face];
+
+      // Malformed shape (missing/non-string) counts as a failed image.
+      if (typeof faceValue !== "string") {
+        failedImagesCount++;
+        failedKeys.push(key);
+        continue;
+      }
+
+      // Reject oversized faces BEFORE allocating: the cheap base64 length check
+      // skips multi-MB payloads without an atob() allocation.
+      const estimatedSize = dataUrlByteLength(faceValue);
+      if (estimatedSize !== null && estimatedSize > MAX_IMAGE_SIZE_BYTES) {
+        failedImagesCount++;
+        failedKeys.push(key);
+        continue;
+      }
+
+      const bytes = decodeDataUrl(faceValue);
+      if (!bytes) {
+        failedImagesCount++;
+        failedKeys.push(key);
+        continue;
+      }
+
+      // Backstop the pre-alloc estimate after the exact decode.
+      if (bytes.byteLength > MAX_IMAGE_SIZE_BYTES) {
+        failedImagesCount++;
+        failedKeys.push(key);
+        continue;
+      }
+
+      const detected = detectImageMime(bytes);
+      if (!detected || !SUPPORTED_IMAGE_FORMATS.includes(detected)) {
+        failedImagesCount++;
+        failedKeys.push(key);
+        continue;
+      }
+
+      const ext = MIME_TO_EXT[detected] ?? "png";
+      const imageData: ImageData = {
+        blob: new Blob([bytes], { type: detected }),
+        // Keep the original data URL verbatim for a byte-stable round-trip.
+        dataUrl: faceValue,
+        filename: `${key}-${face}.${ext}`,
+      };
+
+      const existing = images.get(key) ?? {};
+      images.set(key, { ...existing, [face]: imageData });
+    }
+  }
+
+  return { images, failedImagesCount, failedKeys };
+}

--- a/src/lib/utils/image-encoding.ts
+++ b/src/lib/utils/image-encoding.ts
@@ -164,6 +164,9 @@ export function encodeUserImagesToYaml(images: ImageStoreMap): {
   let oversized = 0;
 
   for (const [key, deviceImages] of images) {
+    // Never write reserved/prototype keys into the plain serialized object: a
+    // device id of "__proto__" would otherwise mutate the prototype on assignment.
+    if (UNSAFE_KEYS.has(key)) continue;
     const faces: SerializedFaces = {};
 
     for (const face of FACES) {
@@ -227,7 +230,9 @@ export function decodeYamlImages(raw: unknown): {
     const faceRecord = value as Record<string, unknown>;
 
     for (const face of FACES) {
-      if (!(face in faceRecord)) continue;
+      // Own properties only: `in` would read a face injected via the prototype
+      // chain (e.g. a crafted YAML `__proto__: { front: ... }`).
+      if (!Object.hasOwn(faceRecord, face)) continue;
       const faceValue = faceRecord[face];
 
       // Malformed shape (missing/non-string) counts as a failed image.

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -17,6 +17,11 @@ import type {
 } from "$lib/types";
 import { LayoutSchema, type LayoutZod } from "$lib/schemas";
 import { layoutDebug } from "$lib/utils/debug";
+import {
+  decodeYamlImages,
+  type SerializedImages,
+} from "$lib/utils/image-encoding";
+import type { ImageStoreMap } from "$lib/types/images";
 
 /**
  * Warn if any rack contains duplicate device IDs before serialization (#1363)
@@ -295,9 +300,17 @@ function appendUnknownSections(
 /**
  * Serialize a layout to YAML string
  * Excludes runtime-only fields (view) and orders fields according to schema v1.0.0
- * Includes metadata if present
+ * Includes metadata if present.
+ *
+ * When `encodedImages` is provided and non-empty, embeds user-uploaded device
+ * images as base64 data URLs in a trailing `images:` section (#617). Setting
+ * `images` explicitly here means appendUnknownSections sees `key in target` and
+ * does not double-emit it (#2208 interaction).
  */
-export async function serializeLayoutToYaml(layout: Layout): Promise<string> {
+export async function serializeLayoutToYaml(
+  layout: Layout,
+  encodedImages?: SerializedImages,
+): Promise<string> {
   warnDuplicateDeviceIds(layout);
 
   const layoutForSerialization: Record<string, unknown> = {};
@@ -334,6 +347,13 @@ export async function serializeLayoutToYaml(layout: Layout): Promise<string> {
     layoutForSerialization.cables = layout.cables.map(orderCableFields);
   }
 
+  // Embed user images explicitly so appendUnknownSections skips the `images`
+  // key (key in target) instead of double-emitting it (#617 / #2208). Set last
+  // so the base64 section trails the structural layout in the file.
+  if (encodedImages && Object.keys(encodedImages).length > 0) {
+    layoutForSerialization.images = encodedImages;
+  }
+
   appendUnknownSections(layoutForSerialization, layout);
 
   return serializeToYaml(layoutForSerialization);
@@ -341,6 +361,7 @@ export async function serializeLayoutToYaml(layout: Layout): Promise<string> {
 
 /**
  * Serialize a layout to YAML string with metadata section (#919)
+ * Stays base64-free: the ZIP path carries images as asset files, never inline.
  * Used for folder-based ZIP exports with UUID-based naming.
  *
  * Output format:
@@ -413,18 +434,31 @@ function toRuntimeLayout(parsed: LayoutZod): Layout {
 }
 
 /**
- * Parse YAML string to layout
- * Validates against schema and adds runtime defaults
+ * Validate a parsed YAML object against the layout schema and convert it to a
+ * runtime Layout.
+ *
+ * The top-level `images` key (base64 user images, #617) is deleted from the
+ * parsed object BEFORE schema validation so the base64 never rides onto the
+ * runtime Layout and appendUnknownSections never re-emits it on resave. The
+ * stripped value is returned to the caller so it can be decoded separately.
  */
-export async function parseLayoutYaml(yamlString: string): Promise<Layout> {
-  // Parse YAML (may throw on invalid syntax)
-  const parsed = await parseYaml(yamlString);
+function validateParsedLayout(parsed: unknown): {
+  layout: Layout;
+  rawImages: unknown;
+} {
+  let rawImages: unknown;
 
-  // Validate against schema - result.data is typed as LayoutZod
+  if (parsed !== null && typeof parsed === "object") {
+    const obj = parsed as Record<string, unknown>;
+    if ("images" in obj) {
+      rawImages = obj.images;
+      delete obj.images;
+    }
+  }
+
   const result = LayoutSchema.safeParse(parsed);
 
   if (!result.success) {
-    // Format error message with details
     const errors = result.error.issues
       .map((issue) => {
         const path = issue.path.join(".");
@@ -435,6 +469,45 @@ export async function parseLayoutYaml(yamlString: string): Promise<Layout> {
     throw new Error(`Invalid layout: ${errors}`);
   }
 
-  // Convert to runtime Layout type with defaults
-  return toRuntimeLayout(result.data);
+  return { layout: toRuntimeLayout(result.data), rawImages };
+}
+
+/**
+ * Parse YAML string to layout
+ * Validates against schema and adds runtime defaults.
+ * Strips and discards any embedded `images` section (use
+ * parseLayoutYamlWithImages to recover them).
+ */
+export async function parseLayoutYaml(yamlString: string): Promise<Layout> {
+  const parsed = await parseYaml(yamlString);
+  return validateParsedLayout(parsed).layout;
+}
+
+/**
+ * Parse YAML string to layout AND decode any embedded user images (#617).
+ *
+ * The `images` section is stripped before schema validation, then decoded and
+ * validated (magic-byte sniff, size cap) by decodeYamlImages. A bad image is
+ * counted in `failedImagesCount` (for the load toast) and never rejects the
+ * layout. `failedKeys` lists which store keys failed, logged for support.
+ */
+export async function parseLayoutYamlWithImages(yamlString: string): Promise<{
+  layout: Layout;
+  images: ImageStoreMap;
+  failedImagesCount: number;
+  failedKeys: string[];
+}> {
+  const parsed = await parseYaml(yamlString);
+  const { layout, rawImages } = validateParsedLayout(parsed);
+  const { images, failedImagesCount, failedKeys } = decodeYamlImages(rawImages);
+
+  if (failedKeys.length > 0) {
+    layoutDebug.state(
+      "parseLayoutYamlWithImages: %d image(s) rejected for keys %o",
+      failedImagesCount,
+      failedKeys,
+    );
+  }
+
+  return { layout, images, failedImagesCount, failedKeys };
 }

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -450,7 +450,7 @@ function validateParsedLayout(parsed: unknown): {
 
   if (parsed !== null && typeof parsed === "object") {
     const obj = parsed as Record<string, unknown>;
-    if ("images" in obj) {
+    if (Object.hasOwn(obj, "images")) {
       rawImages = obj.images;
       delete obj.images;
     }

--- a/src/tests/load-pipeline.test.ts
+++ b/src/tests/load-pipeline.test.ts
@@ -104,7 +104,11 @@ describe("load-pipeline", () => {
   describe("loadFromApi", () => {
     it("fetches from API and finalizes load on success", async () => {
       const layout = createTestLayout({ name: "API Load" });
-      vi.mocked(persistenceApi.loadSavedLayout).mockResolvedValue(layout);
+      vi.mocked(persistenceApi.loadSavedLayout).mockResolvedValue({
+        layout,
+        images: new Map(),
+        failedImagesCount: 0,
+      });
 
       const result = await loadFromApi("uuid-1");
 

--- a/src/tests/yaml-images.test.ts
+++ b/src/tests/yaml-images.test.ts
@@ -398,4 +398,17 @@ describe("image-encoding security hardening (#2221)", () => {
     expect(images.size).toBe(0);
     expect(failedImagesCount).toBe(0);
   });
+
+  it("rejects a data URL whose declared MIME lies about the sniffed bytes", () => {
+    // Declared image/png, but the bytes are JPEG (FF D8 FF).
+    const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0, 1, 2, 3]);
+    const lyingDataUrl = `data:image/png;base64,${bytesToBase64(jpegBytes)}`;
+
+    const { images, failedImagesCount } = decodeYamlImages({
+      dev: { front: lyingDataUrl },
+    });
+
+    expect(images.size).toBe(0);
+    expect(failedImagesCount).toBe(1);
+  });
 });

--- a/src/tests/yaml-images.test.ts
+++ b/src/tests/yaml-images.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectImageMime,
+  encodeUserImagesToYaml,
+  decodeYamlImages,
+} from "$lib/utils/image-encoding";
+import {
+  serializeLayoutToYaml,
+  parseLayoutYamlWithImages,
+  parseLayoutYaml,
+} from "$lib/utils/yaml";
+import type { ImageData, ImageStoreMap } from "$lib/types/images";
+import { MAX_IMAGE_SIZE_BYTES } from "$lib/types/constants";
+import { createTestLayout, createTestDeviceType, createTestRack } from "./factories";
+
+// Real PNG magic bytes (89 50 4E 47 0D 0A 1A 0A) so detectImageMime accepts it.
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** Base64-encode raw bytes (no data: prefix). */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary);
+}
+
+/** Build a valid PNG data URL from arbitrary trailing bytes. */
+function makePngDataUrl(extraBytes: number[] = [0, 1, 2, 3]): string {
+  const bytes = new Uint8Array([...PNG_MAGIC, ...extraBytes]);
+  return `data:image/png;base64,${bytesToBase64(bytes)}`;
+}
+
+/** Create a user ImageData backed by a real PNG payload. */
+function makeUserImage(filename = "custom-front.png"): ImageData {
+  const bytes = new Uint8Array([...PNG_MAGIC, 0, 1, 2, 3]);
+  return {
+    blob: new Blob([bytes], { type: "image/png" }),
+    dataUrl: makePngDataUrl(),
+    filename,
+  };
+}
+
+describe("detectImageMime", () => {
+  it("detects PNG from magic bytes", () => {
+    expect(detectImageMime(new Uint8Array(PNG_MAGIC))).toBe("image/png");
+  });
+
+  it("detects JPEG from magic bytes", () => {
+    expect(detectImageMime(new Uint8Array([0xff, 0xd8, 0xff, 0xe0]))).toBe(
+      "image/jpeg",
+    );
+  });
+
+  it("detects WebP from RIFF/WEBP container", () => {
+    const bytes = new Uint8Array(12);
+    // "RIFF" at 0-3, "WEBP" at 8-11
+    bytes.set([0x52, 0x49, 0x46, 0x46], 0);
+    bytes.set([0x57, 0x45, 0x42, 0x50], 8);
+    expect(detectImageMime(bytes)).toBe("image/webp");
+  });
+
+  it("returns null for SVG/text content", () => {
+    const svg = new TextEncoder().encode("<svg xmlns='...'></svg>");
+    expect(detectImageMime(svg)).toBeNull();
+  });
+
+  it("returns null for unknown bytes", () => {
+    expect(detectImageMime(new Uint8Array([0x00, 0x01, 0x02, 0x03]))).toBeNull();
+  });
+});
+
+describe("encodeUserImagesToYaml", () => {
+  it("embeds user image faces in the serialized record", () => {
+    const images: ImageStoreMap = new Map([
+      ["my-server", { front: makeUserImage("my-server-front.png") }],
+    ]);
+
+    const { serialized, oversized } = encodeUserImagesToYaml(images);
+
+    expect(serialized["my-server"]?.front).toBe(makePngDataUrl());
+    expect(serialized["my-server"]?.rear).toBeUndefined();
+    expect(oversized).toBe(0);
+  });
+
+  it("encodes both faces when present", () => {
+    const images: ImageStoreMap = new Map([
+      [
+        "my-server",
+        { front: makeUserImage("front.png"), rear: makeUserImage("rear.png") },
+      ],
+    ]);
+
+    const { serialized } = encodeUserImagesToYaml(images);
+
+    expect(serialized["my-server"]?.front).toBeDefined();
+    expect(serialized["my-server"]?.rear).toBeDefined();
+  });
+
+  it("reports oversized when a face exceeds ~100KB", () => {
+    const bigBytes = new Uint8Array([...PNG_MAGIC, ...new Array(120 * 1024).fill(0)]);
+    const big: ImageData = {
+      blob: new Blob([bigBytes], { type: "image/png" }),
+      dataUrl: `data:image/png;base64,${bytesToBase64(bigBytes)}`,
+      filename: "big.png",
+    };
+    const images: ImageStoreMap = new Map([["big-device", { front: big }]]);
+
+    const { oversized } = encodeUserImagesToYaml(images);
+
+    expect(oversized).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("YAML image round-trip", () => {
+  it("embeds and restores a user image with equivalent bytes", async () => {
+    const deviceType = createTestDeviceType({ slug: "my-server" });
+    const layout = createTestLayout({
+      racks: [createTestRack({ id: "rack-1" })],
+      device_types: [deviceType],
+    });
+
+    const images: ImageStoreMap = new Map([
+      ["my-server", { front: makeUserImage("my-server-front.png") }],
+    ]);
+    const { serialized } = encodeUserImagesToYaml(images);
+
+    const yaml = await serializeLayoutToYaml(layout, serialized);
+    expect(yaml).toContain("images:");
+    expect(yaml).toContain("my-server");
+
+    const result = await parseLayoutYamlWithImages(yaml);
+
+    expect(result.failedImagesCount).toBe(0);
+    expect(result.images.has("my-server")).toBe(true);
+
+    const restoredFront = result.images.get("my-server")?.front;
+    expect(restoredFront?.blob).toBeInstanceOf(Blob);
+    expect(restoredFront?.blob?.type).toBe("image/png");
+
+    const restoredBytes = new Uint8Array(
+      await restoredFront!.blob!.arrayBuffer(),
+    );
+    expect(Array.from(restoredBytes.slice(0, 8))).toEqual(PNG_MAGIC);
+  });
+
+  it("does not leak the base64 images key onto the runtime layout", async () => {
+    const layout = createTestLayout({
+      device_types: [createTestDeviceType({ slug: "my-server" })],
+    });
+    const images: ImageStoreMap = new Map([
+      ["my-server", { front: makeUserImage() }],
+    ]);
+    const { serialized } = encodeUserImagesToYaml(images);
+
+    const yaml = await serializeLayoutToYaml(layout, serialized);
+
+    // parseLayoutYamlWithImages strips images from the layout object
+    const result = await parseLayoutYamlWithImages(yaml);
+    expect((result.layout as Record<string, unknown>).images).toBeUndefined();
+
+    // parseLayoutYaml (the plain path) must also strip it
+    const plainLayout = await parseLayoutYaml(yaml);
+    expect((plainLayout as Record<string, unknown>).images).toBeUndefined();
+  });
+});
+
+describe("decodeYamlImages validation", () => {
+  it("strips an SVG-declared image and counts it as failed", async () => {
+    const svgPayload = btoa("<svg xmlns='http://www.w3.org/2000/svg'></svg>");
+    const raw = {
+      "evil-device": { front: `data:image/svg+xml;base64,${svgPayload}` },
+    };
+
+    const { images, failedImagesCount } = decodeYamlImages(raw);
+
+    expect(failedImagesCount).toBe(1);
+    expect(images.has("evil-device")).toBe(false);
+  });
+
+  it("strips a magic-byte mismatch (declared png, text payload)", () => {
+    const textPayload = btoa("just some text, not an image");
+    const raw = {
+      "liar-device": { front: `data:image/png;base64,${textPayload}` },
+    };
+
+    const { images, failedImagesCount } = decodeYamlImages(raw);
+
+    expect(failedImagesCount).toBe(1);
+    expect(images.has("liar-device")).toBe(false);
+  });
+
+  it("strips an oversized image exceeding MAX_IMAGE_SIZE_BYTES", () => {
+    const bigBytes = new Uint8Array([
+      ...PNG_MAGIC,
+      ...new Array(MAX_IMAGE_SIZE_BYTES + 16).fill(0),
+    ]);
+    const raw = {
+      "huge-device": {
+        front: `data:image/png;base64,${bytesToBase64(bigBytes)}`,
+      },
+    };
+
+    const { images, failedImagesCount } = decodeYamlImages(raw);
+
+    expect(failedImagesCount).toBe(1);
+    expect(images.has("huge-device")).toBe(false);
+  });
+
+  it("accepts a valid PNG and rejects a sibling bad face independently", () => {
+    const goodPng = makePngDataUrl();
+    const badText = `data:image/png;base64,${btoa("not an image")}`;
+    const raw = {
+      "mixed-device": { front: goodPng, rear: badText },
+    };
+
+    const { images, failedImagesCount } = decodeYamlImages(raw);
+
+    expect(failedImagesCount).toBe(1);
+    expect(images.get("mixed-device")?.front).toBeDefined();
+    expect(images.get("mixed-device")?.rear).toBeUndefined();
+  });
+
+  it("counts malformed (non-string) entries as failures", () => {
+    const raw = {
+      "bad-shape": { front: 42 },
+    };
+
+    const { images, failedImagesCount } = decodeYamlImages(raw);
+
+    expect(failedImagesCount).toBe(1);
+    expect(images.has("bad-shape")).toBe(false);
+  });
+
+  it("returns an empty result for non-object input", () => {
+    expect(decodeYamlImages(undefined).failedImagesCount).toBe(0);
+    expect(decodeYamlImages(undefined).images.size).toBe(0);
+    expect(decodeYamlImages("nope").images.size).toBe(0);
+  });
+});
+
+describe("layout still loads when an embedded image is bad", () => {
+  it("parses the layout even if every image is rejected", async () => {
+    const layout = createTestLayout({
+      name: "Survives Bad Image",
+      device_types: [createTestDeviceType({ slug: "my-server" })],
+    });
+    const yaml = await serializeLayoutToYaml(layout, {
+      "my-server": {
+        front: `data:image/svg+xml;base64,${btoa("<svg></svg>")}`,
+      },
+    });
+
+    const result = await parseLayoutYamlWithImages(yaml);
+
+    expect(result.layout.name).toBe("Survives Bad Image");
+    expect(result.failedImagesCount).toBe(1);
+    expect(result.images.size).toBe(0);
+    // failedKeys names the device whose face was rejected, for support logging.
+    expect(result.failedKeys).toContain("my-server");
+  });
+});
+
+describe("decodeYamlImages oversized handling", () => {
+  it("rejects an oversized face before allocating the decode buffer", () => {
+    // A base64 payload whose estimated length exceeds the cap must be skipped
+    // by the cheap pre-alloc check, never reaching atob.
+    const overCapBase64Chars = Math.ceil((MAX_IMAGE_SIZE_BYTES + 1024) / 3) * 4;
+    const hugePayload = "A".repeat(overCapBase64Chars);
+    const raw = {
+      "huge-device": { front: `data:image/png;base64,${hugePayload}` },
+    };
+
+    const { images, failedImagesCount, failedKeys } = decodeYamlImages(raw);
+
+    expect(failedImagesCount).toBe(1);
+    expect(images.has("huge-device")).toBe(false);
+    expect(failedKeys).toContain("huge-device");
+  });
+
+  it("skips reserved prototype keys defensively", () => {
+    const raw = JSON.parse(
+      `{"__proto__": {"front": "x"}, "good": {"front": "${makePngDataUrl()}"}}`,
+    );
+
+    const { images, failedImagesCount } = decodeYamlImages(raw);
+
+    expect(failedImagesCount).toBe(0);
+    expect(images.has("good")).toBe(true);
+    expect(Object.getPrototypeOf(images)).toBe(Map.prototype);
+  });
+});
+
+describe("save warns about oversized embedded images", () => {
+  it("reports an oversized count the save path surfaces as a warning toast", () => {
+    // encodeUserImagesToYaml.oversized drives the single non-blocking warning
+    // toast the save manager shows; here we assert the count it returns.
+    const bigBytes = new Uint8Array([
+      ...PNG_MAGIC,
+      ...new Array(150 * 1024).fill(0),
+    ]);
+    const big: ImageData = {
+      blob: new Blob([bigBytes], { type: "image/png" }),
+      dataUrl: `data:image/png;base64,${bytesToBase64(bigBytes)}`,
+      filename: "big.png",
+    };
+    const images: ImageStoreMap = new Map([["big-device", { front: big }]]);
+
+    const { oversized } = encodeUserImagesToYaml(images);
+
+    expect(oversized).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("server-path round-trip", () => {
+  it("survives serialize (server save) -> parseWithImages (server load)", async () => {
+    // Mirrors the server path: saveLayoutToServer serializes with embedded
+    // images, loadSavedLayout reads them back via parseLayoutYamlWithImages.
+    const layout = createTestLayout({
+      name: "Server Layout",
+      device_types: [createTestDeviceType({ slug: "srv" })],
+    });
+    const { serialized } = encodeUserImagesToYaml(
+      new Map([["srv", { front: makeUserImage("srv-front.png") }]]),
+    );
+
+    const yaml = await serializeLayoutToYaml(layout, serialized);
+    const result = await parseLayoutYamlWithImages(yaml);
+
+    expect(result.failedImagesCount).toBe(0);
+    expect(result.images.has("srv")).toBe(true);
+    const restored = result.images.get("srv")?.front;
+    expect(restored?.blob?.type).toBe("image/png");
+    const restoredBytes = new Uint8Array(await restored!.blob!.arrayBuffer());
+    expect(Array.from(restoredBytes.slice(0, 8))).toEqual(PNG_MAGIC);
+  });
+});
+
+describe("#2208 interaction: images stays off the runtime layout", () => {
+  it("loads images-bearing YAML, resaves, and emits images exactly once", async () => {
+    const layout = createTestLayout({
+      name: "2208 Layout",
+      device_types: [createTestDeviceType({ slug: "dev-a" })],
+    });
+    const { serialized } = encodeUserImagesToYaml(
+      new Map([["dev-a", { front: makeUserImage("dev-a-front.png") }]]),
+    );
+
+    // First serialize (a save with images embedded).
+    const firstYaml = await serializeLayoutToYaml(layout, serialized);
+
+    // Load it back: the runtime layout must NOT carry a raw images property.
+    const loaded = await parseLayoutYamlWithImages(firstYaml);
+    expect((loaded.layout as Record<string, unknown>).images).toBeUndefined();
+
+    // Resave the loaded (image-free) runtime layout, re-embedding the decoded
+    // store. The images section must be emitted once, not duplicated by
+    // appendUnknownSections.
+    const { serialized: reSerialized } = encodeUserImagesToYaml(loaded.images);
+    const resavedYaml = await serializeLayoutToYaml(
+      loaded.layout,
+      reSerialized,
+    );
+
+    const imagesKeyOccurrences = resavedYaml
+      .split("\n")
+      .filter((line) => /^images:/.test(line)).length;
+    expect(imagesKeyOccurrences).toBe(1);
+
+    // And the resaved file still round-trips the image.
+    const reloaded = await parseLayoutYamlWithImages(resavedYaml);
+    expect(reloaded.images.has("dev-a")).toBe(true);
+    expect((reloaded.layout as Record<string, unknown>).images).toBeUndefined();
+  });
+});

--- a/src/tests/yaml-images.test.ts
+++ b/src/tests/yaml-images.test.ts
@@ -373,3 +373,29 @@ describe("#2208 interaction: images stays off the runtime layout", () => {
     expect((reloaded.layout as Record<string, unknown>).images).toBeUndefined();
   });
 });
+
+describe("image-encoding security hardening (#2221)", () => {
+  it("encode skips a reserved __proto__ image key without polluting the prototype", () => {
+    const map: ImageStoreMap = new Map();
+    map.set("__proto__", { front: makeUserImage() });
+    map.set("real-device", { front: makeUserImage() });
+
+    const { serialized } = encodeUserImagesToYaml(map);
+
+    // The reserved key never lands as an entry, and the prototype is intact.
+    expect(Object.hasOwn(serialized, "__proto__")).toBe(false);
+    expect((({}) as Record<string, unknown>).front).toBeUndefined();
+    // A normal device is still serialized.
+    expect(Object.hasOwn(serialized, "real-device")).toBe(true);
+  });
+
+  it("decode ignores a face injected via the prototype chain", () => {
+    // A per-device value whose `front` lives on the prototype, not as an own
+    // property, as a crafted YAML `__proto__: { front: ... }` would produce.
+    const faceRecord = Object.create({ front: makePngDataUrl() });
+    const { images, failedImagesCount } = decodeYamlImages({ dev: faceRecord });
+
+    expect(images.size).toBe(0);
+    expect(failedImagesCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## **User description**
## What
Embeds custom user-uploaded device images as base64 data URLs in `.rackula.yaml` so they survive save/load. Closes #617.

## Coverage (every layout-persisting path)
- Local file save (`downloadYamlFile`) and server PUT (`saveLayoutToServer`) both embed images.
- File load and server GET (`loadSavedLayout`) both decode them.
- ZIP-inner-YAML and share-links stay image-free (ZIP carries asset files; share-links are size-limited).

## Security / data safety (untrusted load path)
- Magic-byte MIME sniff; rejects image/svg+xml and unknown types (XSS, #102), never trusts the declared `data:` prefix.
- Per-image and whole-file size caps; oversized rejected before allocation.
- Crash-safe base64 decode: one bad image is stripped and counted (warning toast), never rejects the file.
- Prototype-pollution guard on decode keys.
- `images` is stripped from the runtime Layout before validation, so it never collides with #2208's unknown-section round-trip (regression test: load to resave emits `images` exactly once; runtime Layout carries no raw `images`).

## Notes
- `schema_version` stays "1.0": images is additive/MINOR per the #1113 policy (docs/reference/SCHEMA.md).
- Size divergence (5MB local load vs 1MB server cap) is intentional and documented.
- Follow-up #2220: the raw-YAML editor panel is image-free and drops images on Apply; tracked separately.

## Review
Built via the staged adversarial loop: /devils-advocate design gate (surfaced the server-path coverage gap and robustness fixes, both implemented) + /code-review medium diff gate (wiring clean, security posture sound; one regex-robustness fix applied, one follow-up filed). 86 tests green across suites, lint + build clean.


___

## **CodeAnt-AI Description**
**Embed custom images in YAML saves and restore them on load**

### What Changed
- Plain YAML saves now include user-uploaded device images, so they are kept when a layout is saved and loaded again.
- Loading a YAML file or server-saved layout now restores embedded images and shows a warning if any image could not be read, while still opening the layout.
- Server saves and archive exports now surface oversized embedded images with a non-blocking warning instead of dropping them silently.
- Embedded images are kept out of the runtime layout data, so resaving does not duplicate the images section.

### Impact
`✅ Fewer lost custom images`
`✅ Clearer image import warnings`
`✅ Safer layout reloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
