### PR TITLE
chore: use singular category display names (#2219)

### DIFF
--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -193,17 +193,17 @@ export function getFirstMatch(
  */
 export function getCategoryDisplayName(category: DeviceCategory): string {
   const names: Record<DeviceCategory, string> = {
-    server: "Servers",
+    server: "Server",
     network: "Network",
-    firewall: "Firewalls",
-    "patch-panel": "Patch Panels",
+    firewall: "Firewall",
+    "patch-panel": "Patch Panel",
     power: "Power",
     storage: "Storage",
     kvm: "KVM",
     "av-media": "AV/Media",
     cooling: "Cooling",
-    shelf: "Shelves",
-    blank: "Blanks",
+    shelf: "Shelf",
+    blank: "Blank",
     "cable-management": "Cable Management",
     chassis: "Chassis",
     other: "Other",


### PR DESCRIPTION
## **User description**
## Summary

Change category display names from plural to singular in `getCategoryDisplayName()` (`src/lib/utils/deviceFilters.ts`). This display name feeds the device palette section headers and the edit-panel Category row, where a singular label reads as a category name rather than a collection.

Changed:
- server: Servers -> Server
- firewall: Firewalls -> Firewall
- patch-panel: Patch Panels -> Patch Panel
- shelf: Shelves -> Shelf
- blank: Blanks -> Blank

Unchanged (already singular or uncountable): Network, Power, Storage, KVM, AV/Media, Cooling, Cable Management, Chassis, Other.

## Test Plan

- [x] `npm run lint` (no issues)
- [x] `npm run check` (0 errors, 0 warnings)
- [x] `npm run test:run` (2184 passed)
- [x] `npm run build` (succeeds)
- [x] `npx prettier --check` on changed file (formatted)
- [x] Grepped src/ for assertions on plural strings: none found, no tests needed updating

No new tests added: this is a trivial static string-map change, and a test asserting the new strings would violate the project's "don't test static data" rule.

Closes #2219


___

## **CodeAnt-AI Description**
Show singular category names in the device UI

### What Changed
- Category labels now use singular names in the device palette and edit panel, such as Server, Firewall, Patch Panel, Shelf, and Blank
- Categories that were already singular or uncountable stay the same

### Impact
`✅ Clearer category labels`
`✅ Less confusing device palette headers`
`✅ Cleaner edit-panel category names`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
