### PR TITLE
chore: add data-testid to structural components (#1419)

### DIFF
--- a/e2e/helpers/device-actions.ts
+++ b/e2e/helpers/device-actions.ts
@@ -28,10 +28,14 @@ export async function dragDeviceToRack(
 
   await page.evaluate(
     ({ yPercent, deviceIndex, rackIndex }) => {
-      const deviceItems = document.querySelectorAll(".device-palette-item");
+      const deviceItems = document.querySelectorAll(
+        '[data-testid="device-palette-item"]',
+      );
       const deviceItem = deviceItems[deviceIndex];
       // Use front-view SVGs so rackIndex maps directly to rack number
-      const rackSvgs = document.querySelectorAll(".rack-front .rack-svg");
+      const rackSvgs = document.querySelectorAll(
+        '[data-testid="rack-front"] .rack-svg',
+      );
       const rack = rackSvgs[rackIndex];
       if (!rack) {
         throw new Error(

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -1,8 +1,11 @@
 /**
- * Centralised CSS selector strings for E2E tests.
+ * Centralised selector strings for E2E tests.
  *
- * Every raw `.class-name` selector used in helpers and spec files should live
- * here so that a CSS class rename only requires a single-file change.
+ * Structural elements (canvas, racks, devices, drawers, dialogs, context menus,
+ * toasts, mobile nav) are addressed by `data-testid` so a CSS class rename only
+ * affects styling, not tests. Leaf elements, state modifiers (`.selected`,
+ * `.open`), and variant classes (`.toast--success`) stay as class selectors
+ * because they are not the structural anchors covered by testids.
  *
  * NOTE: `page.evaluate()` callbacks that use `document.querySelector` are
  * intentionally excluded — those run in the browser context and cannot
@@ -12,12 +15,13 @@ export const locators = {
   rack: {
     container: ".rack-container",
     svg: ".rack-svg",
-    device: ".rack-device",
-    deviceRect: ".rack-device .device-rect",
-    deviceName: ".rack-device .device-name",
-    deviceForeignObject: ".rack-device foreignObject",
-    deviceText: ".rack-device text",
-    deviceSelected: ".rack-device.selected",
+    device: '[data-testid="rack-device"]',
+    deviceRect: '[data-testid="rack-device"] .device-rect',
+    deviceName: '[data-testid="rack-device"] .device-name',
+    deviceForeignObject: '[data-testid="rack-device"] foreignObject',
+    deviceText: '[data-testid="rack-device"] text',
+    deviceSelected: '[data-testid="rack-device"].selected',
+    dropZone: '[data-testid="rack-drop-zone"]',
     uLabel: ".u-label",
     item: ".rack-item",
   },
@@ -25,18 +29,19 @@ export const locators = {
   rackView: {
     dualView: ".rack-dual-view",
     dualViewName: ".rack-dual-view-name",
-    front: ".rack-front",
-    rear: ".rack-rear",
-    frontDevice: ".rack-front .rack-device",
-    rearDevice: ".rack-rear .rack-device",
-    frontDeviceSelected: ".rack-front .rack-device.selected",
-    frontSvg: ".rack-front .rack-svg",
-    rearSvg: ".rack-rear .rack-svg",
-    rearBlockedSlot: ".rack-rear .blocked-slot",
+    front: '[data-testid="rack-front"]',
+    rear: '[data-testid="rack-rear"]',
+    frontDevice: '[data-testid="rack-front"] [data-testid="rack-device"]',
+    rearDevice: '[data-testid="rack-rear"] [data-testid="rack-device"]',
+    frontDeviceSelected:
+      '[data-testid="rack-front"] [data-testid="rack-device"].selected',
+    frontSvg: '[data-testid="rack-front"] .rack-svg',
+    rearSvg: '[data-testid="rack-rear"] .rack-svg',
+    rearBlockedSlot: '[data-testid="rack-rear"] .blocked-slot',
   },
 
   device: {
-    paletteItem: ".device-palette-item",
+    paletteItem: '[data-testid="device-palette-item"]',
     palette: ".device-palette",
   },
 
@@ -48,34 +53,36 @@ export const locators = {
   },
 
   sidebar: {
-    pane: ".sidebar-pane",
+    pane: '[data-testid="drawer-left"]',
   },
 
   drawer: {
-    rightOpen: "aside.drawer-right.open",
+    rightOpen: 'aside[data-testid="drawer-device-edit"].open',
     /** Variant without the `aside` element prefix (used in some specs) */
-    rightOpenBare: ".drawer-right.open",
-    rightRackHeight: ".drawer-right #rack-height",
+    rightOpenBare: '[data-testid="drawer-device-edit"].open',
+    rightRackHeight: '[data-testid="drawer-device-edit"] #rack-height',
   },
 
   canvas: {
-    root: ".canvas",
+    root: '[data-testid="rack-canvas"]',
     panzoomContainer: ".panzoom-container",
   },
 
   dialog: {
     root: ".dialog",
     title: ".dialog-title",
+    newRack: '[data-testid="dialog-new-rack"]',
   },
 
   toast: {
-    root: ".toast",
+    root: '[data-testid="toast-message"]',
     success: ".toast--success",
     warning: ".toast--warning",
   },
 
   mobile: {
-    bottomSheet: ".bottom-sheet",
+    bottomNav: '[data-testid="mobile-bottom-nav"]',
+    bottomSheet: '[data-testid="mobile-bottom-sheet"]',
     dragHandleBar: ".drag-handle-bar",
     backdrop: ".backdrop",
     deviceLibraryFab: ".device-library-fab",
@@ -97,6 +104,7 @@ export const locators = {
   },
 
   contextMenu: {
-    content: ".context-menu-content",
+    content: '[data-testid="ctx-menu"]',
+    item: '[data-testid="ctx-menu-item"]',
   },
 } as const;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -727,6 +727,7 @@
             onResize={handleSidebarResize}
             id="sidebar-pane"
             class="sidebar-pane"
+            data-testid="drawer-left"
           >
             <SidebarTabs
               activeTab={uiStore.sidebarTab}

--- a/src/lib/components/BottomSheet.svelte
+++ b/src/lib/components/BottomSheet.svelte
@@ -140,6 +140,7 @@
       class="bottom-sheet"
       class:open
       class:dragging={isDragging}
+      data-testid="mobile-bottom-sheet"
       style:transform={isDragging ? `translateY(${translateY}px)` : ""}
       role="dialog"
       tabindex="-1"

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -328,6 +328,7 @@
   <div
     class="canvas"
     class:party-mode={partyMode}
+    data-testid="rack-canvas"
     role="application"
     aria-label={rackDescription}
     aria-describedby={deviceListDescription ? "canvas-device-list" : undefined}

--- a/src/lib/components/CanvasContextMenu.svelte
+++ b/src/lib/components/CanvasContextMenu.svelte
@@ -57,9 +57,14 @@
   </ContextMenu.Trigger>
 
   <ContextMenu.Portal>
-    <ContextMenu.Content class="context-menu-content" sideOffset={5}>
+    <ContextMenu.Content
+      class="context-menu-content"
+      data-testid="ctx-menu"
+      sideOffset={5}
+    >
       <ContextMenu.Item
         class="context-menu-item"
+        data-testid="ctx-menu-item"
         onSelect={handleSelect(onnewrack)}
       >
         <span class="context-menu-label">New Rack</span>
@@ -69,6 +74,7 @@
 
       <ContextMenu.Item
         class="context-menu-item"
+        data-testid="ctx-menu-item"
         onSelect={handleSelect(onfitall)}
       >
         <span class="context-menu-label">Fit All</span>
@@ -77,6 +83,7 @@
 
       <ContextMenu.Item
         class="context-menu-item"
+        data-testid="ctx-menu-item"
         onSelect={handleSelect(onresetzoom)}
       >
         <span class="context-menu-label">Reset Zoom</span>
@@ -86,6 +93,7 @@
 
       <ContextMenu.Item
         class="context-menu-item"
+        data-testid="ctx-menu-item"
         onSelect={handleSelect(ontoggletheme)}
       >
         <span class="context-menu-label"

--- a/src/lib/components/DeviceContextMenu.svelte
+++ b/src/lib/components/DeviceContextMenu.svelte
@@ -104,11 +104,13 @@
   <ContextMenu.Portal>
     <ContextMenu.Content
       class="context-menu-content"
+      data-testid="ctx-menu"
       sideOffset={5}
       customAnchor={virtualAnchor}
     >
       <ContextMenu.Item
         class="context-menu-item"
+        data-testid="ctx-menu-item"
         onSelect={handleSelect(onedit)}
       >
         <span class="context-menu-label">Edit</span>
@@ -116,6 +118,7 @@
 
       <ContextMenu.Item
         class="context-menu-item"
+        data-testid="ctx-menu-item"
         onSelect={handleSelect(onduplicate)}
       >
         <span class="context-menu-label">Duplicate</span>
@@ -126,6 +129,7 @@
 
       <ContextMenu.Item
         class="context-menu-item"
+        data-testid="ctx-menu-item"
         disabled={!canMoveUp}
         onSelect={handleSelect(onmoveup)}
       >
@@ -135,6 +139,7 @@
 
       <ContextMenu.Item
         class="context-menu-item"
+        data-testid="ctx-menu-item"
         disabled={!canMoveDown}
         onSelect={handleSelect(onmovedown)}
       >
@@ -146,6 +151,7 @@
 
       <ContextMenu.Item
         class="context-menu-item context-menu-item--destructive"
+        data-testid="ctx-menu-item"
         onSelect={handleSelect(ondelete)}
       >
         <span class="context-menu-label">Delete</span>

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -11,6 +11,7 @@
     open: boolean;
     title: string;
     width?: string;
+    testid?: string;
     showClose?: boolean;
     onclose?: () => void;
     children?: Snippet;
@@ -21,6 +22,7 @@
     open = $bindable(),
     title,
     width = "400px",
+    testid,
     showClose = true,
     onclose,
     children,
@@ -44,7 +46,11 @@
 <Dialog.Root {open} onOpenChange={handleOpenChange}>
   <Dialog.Portal>
     <Dialog.Overlay class="dialog-backdrop" data-testid="dialog-backdrop" />
-    <Dialog.Content class="dialog" style="--dialog-width: {normalizedWidth};">
+    <Dialog.Content
+      class="dialog"
+      data-testid={testid}
+      style="--dialog-width: {normalizedWidth};"
+    >
       <div class="dialog-header">
         <Dialog.Title class="dialog-title">{title}</Dialog.Title>
         <div class="dialog-header-actions">

--- a/src/lib/components/Drawer.svelte
+++ b/src/lib/components/Drawer.svelte
@@ -11,6 +11,7 @@
     open: boolean;
     title: string;
     id?: string;
+    testid?: string;
     showClose?: boolean;
     showHeader?: boolean;
     onclose?: () => void;
@@ -22,6 +23,7 @@
     open,
     title,
     id,
+    testid,
     showClose = true,
     showHeader = true,
     onclose,
@@ -31,6 +33,7 @@
 
 <aside
   {id}
+  data-testid={testid}
   class="drawer drawer-{side}"
   class:open
   aria-label={title}

--- a/src/lib/components/EditPanel.svelte
+++ b/src/lib/components/EditPanel.svelte
@@ -128,6 +128,7 @@
   side="right"
   open={uiStore.rightDrawerOpen}
   title="Edit"
+  testid="drawer-device-edit"
   showClose={false}
   onclose={handleClose}
 >

--- a/src/lib/components/NewRackForm.svelte
+++ b/src/lib/components/NewRackForm.svelte
@@ -121,6 +121,7 @@
   {open}
   title="New Rack"
   width="var(--dialog-width-md)"
+  testid="dialog-new-rack"
   showClose={false}
   onclose={oncancel}
 >

--- a/src/lib/components/PaletteDeviceContextMenu.svelte
+++ b/src/lib/components/PaletteDeviceContextMenu.svelte
@@ -52,11 +52,13 @@
   <ContextMenu.Portal>
     <ContextMenu.Content
       class="context-menu-content"
+      data-testid="ctx-menu"
       sideOffset={5}
       customAnchor={virtualAnchor}
     >
       <ContextMenu.Item
         class="context-menu-item context-menu-item--destructive"
+        data-testid="ctx-menu-item"
         onSelect={() => {
           ondelete?.();
           open = false;

--- a/src/lib/components/RackContextMenu.svelte
+++ b/src/lib/components/RackContextMenu.svelte
@@ -69,10 +69,15 @@
   </ContextMenu.Trigger>
 
   <ContextMenu.Portal>
-    <ContextMenu.Content class="context-menu-content" sideOffset={5}>
+    <ContextMenu.Content
+      class="context-menu-content"
+      data-testid="ctx-menu"
+      sideOffset={5}
+    >
       {#if onexport}
         <ContextMenu.Item
           class="context-menu-item"
+          data-testid="ctx-menu-item"
           onSelect={handleSelect(onexport)}
         >
           <span class="context-menu-label">Export...</span>
@@ -92,6 +97,7 @@
       {#if onedit}
         <ContextMenu.Item
           class="context-menu-item"
+          data-testid="ctx-menu-item"
           onSelect={handleSelect(onedit)}
         >
           <span class="context-menu-label">Edit Rack</span>
@@ -101,6 +107,7 @@
       {#if onrename}
         <ContextMenu.Item
           class="context-menu-item"
+          data-testid="ctx-menu-item"
           onSelect={handleSelect(onrename)}
         >
           <span class="context-menu-label">Rename</span>
@@ -110,6 +117,7 @@
       {#if onduplicate}
         <ContextMenu.Item
           class="context-menu-item"
+          data-testid="ctx-menu-item"
           onSelect={handleSelect(onduplicate)}
         >
           <span class="context-menu-label">Duplicate Rack</span>
@@ -123,6 +131,7 @@
       {#if ondelete}
         <ContextMenu.Item
           class="context-menu-item context-menu-item--destructive"
+          data-testid="ctx-menu-item"
           onSelect={handleSelect(ondelete)}
         >
           <span class="context-menu-label">Delete Rack</span>

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -560,6 +560,7 @@
   bind:this={groupElement}
   data-device-id={device.slug}
   data-device-position={position}
+  data-testid="rack-device"
   transform="translate({RAIL_WIDTH + slotXOffset}, {yPosition})"
   class="rack-device"
   class:selected

--- a/src/lib/components/RackDropZone.svelte
+++ b/src/lib/components/RackDropZone.svelte
@@ -74,6 +74,7 @@
   width={isHalfWidth ? interiorWidth / 2 - 4 : interiorWidth - 4}
   height={height * uHeight - 2}
   class="drop-preview"
+  data-testid="rack-drop-zone"
   class:drop-valid={feedback === "valid"}
   class:drop-invalid={feedback === "invalid"}
   class:drop-blocked={feedback === "blocked"}

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -292,7 +292,7 @@
       {/if}
 
       <!-- Front view -->
-      <div class="rack-front" role="presentation">
+      <div class="rack-front" data-testid="rack-front" role="presentation">
         <Rack
           {rack}
           {deviceLibrary}
@@ -321,7 +321,7 @@
 
       <!-- Rear view (conditionally shown based on rack.show_rear) -->
       {#if rack.show_rear}
-        <div class="rack-rear" role="presentation">
+        <div class="rack-rear" data-testid="rack-rear" role="presentation">
           <Rack
             {rack}
             {deviceLibrary}

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -52,6 +52,7 @@
 
 <div
   class="toast toast--{toast.type}"
+  data-testid="toast-message"
   class:toast--exiting={isExiting}
   class:toast--success-glow={toast.type === "success" && !isExiting}
   role={toast.type === "success" || toast.type === "info" ? "status" : "alert"}

--- a/src/lib/components/mobile/MobileBottomNav.svelte
+++ b/src/lib/components/mobile/MobileBottomNav.svelte
@@ -31,7 +31,12 @@
 </script>
 
 {#if viewportStore.isMobile}
-  <nav class="bottom-nav" class:hidden aria-label="Mobile navigation">
+  <nav
+    class="bottom-nav"
+    class:hidden
+    data-testid="mobile-bottom-nav"
+    aria-label="Mobile navigation"
+  >
     <button
       class="nav-tab"
       class:active={activeTab === "file"}


### PR DESCRIPTION
## **User description**
## Summary

Adds stable `data-testid` attributes to structural UI regions and points the centralised E2E locators at them instead of CSS classes, so styling/refactor changes no longer break tests. Implements #1419 (from spike #1393, depends on the now-closed #1418).

All component changes are additive: existing classes, state modifiers, and ARIA attributes are untouched, so specs that reference classes directly keep working.

### TestIds added

| TestId | Component |
|--------|-----------|
| `rack-canvas` | Canvas.svelte |
| `rack-device` | RackDevice.svelte |
| `rack-front` / `rack-rear` | RackDualView.svelte |
| `rack-drop-zone` | RackDropZone.svelte |
| `drawer-device-edit` | EditPanel via shared Drawer (new `testid` prop) |
| `drawer-left` | App.svelte sidebar Pane |
| `dialog-new-rack` | NewRackForm via shared Dialog (new `testid` prop) |
| `ctx-menu` / `ctx-menu-item` | Canvas, Rack, Device, PaletteDevice context menus |
| `toast-message` | Toast.svelte |
| `mobile-bottom-nav` | MobileBottomNav.svelte |
| `mobile-bottom-sheet` | BottomSheet.svelte |

### Notes / deviations from the spike table

- The palette item already had `data-testid="device-palette-item"`, which fits the established `{scope}-{element}-{qualifier}` convention better than the spike's `palette-item`. Kept the existing one rather than adding a duplicate.
- `ctx-menu` / `ctx-menu-item` were applied to all four context-menu components, not just two. The spike listed a single generic `ContextMenu`, but there are four variants (canvas, rack, device, palette device). The existing `ctx-menu-focus` testid on the rack Focus item is preserved.
- Generic shared wrappers (`Drawer`, `Dialog`) forward a `testid` prop so the scoped testid lives at the call site; the generic `.dialog` / `.context-menu-content` classes stay for styling.
- `locators.ts`: structural selectors now use `data-testid`; leaf elements, state modifiers (`.selected`, `.open`), and variant classes (`.toast--success`) intentionally stay as class selectors.
- `device-actions.ts` `page.evaluate` queries migrated to `data-testid`.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run check` (no new errors; one pre-existing unrelated `qrcode` types error)
- [x] `npm run test:e2e` full suite green: 334 passed across chromium, webkit, and mobile projects

Closes #1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make structural UI regions easier to target in tests**

### What Changed
- Added stable identifiers to key app areas like the canvas, racks, drawers, dialogs, context menus, toast messages, and mobile navigation
- Updated E2E selectors to use those identifiers so style or layout changes no longer break test targeting
- Kept existing state-based and leaf-level selectors in place where they still describe the UI correctly

### Impact
`✅ Fewer test failures after style changes`
`✅ More stable end-to-end checks`
`✅ Safer UI refactors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
