### PR TITLE
fix: scope main-branch edit guard to project files

### DIFF
--- a/.claude/hooks/block-main-edits.sh
+++ b/.claude/hooks/block-main-edits.sh
@@ -1,23 +1,50 @@
 #!/usr/bin/env bash
-# PreToolUse hook: Block Edit/Write on main branch.
-# Forces all work onto feature branches.
+# PreToolUse hook: Block Edit/Write on the main/master branch, but ONLY for files
+# inside this project. Edits to files outside CLAUDE_PROJECT_DIR (e.g. global
+# ~/.claude config or other repos) are always allowed - the branch of this
+# project says nothing about them.
 set -euo pipefail
 
-# Drain stdin to satisfy the hook contract (JSON with tool_input, session_id, cwd).
-# The payload is not needed — we only check the current branch name.
-cat > /dev/null
+# Capture the hook payload (JSON with tool_input.file_path, session_id, cwd).
+INPUT=$(cat)
 
-# Get current branch
+# Only the project's main/master branch is guarded.
 BRANCH=$(git -C "${CLAUDE_PROJECT_DIR:-.}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
+  exit 0
+fi
 
-if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
-  cat <<BLOCK
+# Project root as provided by the harness (same path namespace as file_path).
+# Do NOT resolve symlinks here: file_path and CLAUDE_PROJECT_DIR share the
+# harness namespace, so /var vs /private/var style resolution would break the
+# prefix match. Just strip any trailing slash.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+PROJECT_DIR="${PROJECT_DIR%/}"
+FILE_PATH=$(printf '%s' "$INPUT" \
+  | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+  | head -1 \
+  | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//; s/"$//' \
+  || true)
+
+# If we can't determine the target or the project root, do not block.
+if [ -z "$FILE_PATH" ] || [ -z "$PROJECT_DIR" ]; then
+  exit 0
+fi
+
+# Block only when the edit targets a file inside the project.
+case "$FILE_PATH" in
+  "$PROJECT_DIR"/*)
+    cat <<BLOCK
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "block",
-    "permissionDecisionReason": "You are on the '${BRANCH}' branch. Create a feature branch or worktree before editing files. Use: git checkout -b <branch-name>"
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "You are on the '${BRANCH}' branch. Create a feature branch or worktree before editing project files. Use: git checkout -b <branch-name>"
   }
 }
 BLOCK
-fi
+    ;;
+  *)
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
## **User description**
## What

`.claude/hooks/block-main-edits.sh` was emitting an invalid PreToolUse decision and is now fixed and scoped.

## Why

Two bugs in one hook:

1. It output `"permissionDecision": "block"` - `block` is not a legal value (only `allow`/`deny`/`ask`). The JSON parsed but failed the root schema, so Claude Code logged a repeated `Hook JSON output validation failed - (root): Invalid input` and the block **failed open** (no guard at all).
2. It blocked **every** Edit/Write while this project was on `main`, including edits to global `~/.claude` config and unrelated repos, since it only checked the branch and never the target path.

## Fix

- `block` -> `deny` (valid schema, guard now actually enforces).
- Scope the guard to files inside `CLAUDE_PROJECT_DIR`; out-of-project edits pass through.
- Compare against `CLAUDE_PROJECT_DIR` without `pwd -P` symlink resolution (avoids `/var` vs `/private/var` prefix mismatches).

## Verification

Tested against a throwaway repo pinned to `main`:

- in-project + main -> deny (valid JSON)
- out-of-project + main -> allow
- in-project + feature branch -> allow
- missing `file_path` -> allow
- `shellcheck` clean

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Block project edits on the main branch without affecting unrelated files**

### What Changed
- The main-branch edit guard now uses a valid deny response, so it actually blocks protected edits instead of failing open.
- It now blocks only files inside the current project, while edits to global Claude settings or other repositories are allowed.
- If the target file cannot be determined, the hook lets the edit continue instead of stopping it.

### Impact
`✅ Fewer unprotected main-branch edits`
`✅ Less blocking of global config changes`
`✅ Fewer false edit rejections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
