### PR TITLE
docs: spike #2179 browser-mode multi-layout storage schema

### DIFF
--- a/docs/research/spike-2179-browser-multilayout-storage-schema.md
+++ b/docs/research/spike-2179-browser-multilayout-storage-schema.md
@@ -1,0 +1,190 @@
+# Spike #2179: Browser-mode Multi-layout Storage Schema
+
+Date: 2026-06-14
+Parent epic: #2017 (Canvas UX Overhaul, milestone M14)
+Pairs with: spike #2018 (interaction model, which does not own persistence)
+
+---
+
+## Problem
+
+Five planned issues presume a durable browser-mode multi-layout store that nothing defines.
+Today the app persists exactly one localStorage key, `Rackula:autosave`, holding a single
+`SessionData` blob (`src/lib/storage/working-copy.ts`); #2034 put the `changesSinceExport`
+counter inside that same blob. The tab strip (#2079), lazy restore (#2080), sidebar library
+(#2082), export-all per-layout counter reset (#2045), and the storage chip rollup (#2035) all
+need per-layout persisted copies and a per-layout durability source. This spike defines that
+schema.
+
+## Decisions (maintainer-steered, 2026-06-14)
+
+- Backend: localStorage only for now. The hybrid IndexedDB option (layout bodies in IndexedDB,
+  index in localStorage) is tabled as a follow-up triggered by observed quota failures.
+  Rationale: browser-only mode may be retired once the Cloudflare Workers storage migration
+  lands, so the investment here is kept minimal and dependency-free.
+- Existing data: one-time adoption. On first launch under the new schema the old
+  `Rackula:autosave` slot is read once, seeded as the first layout, then deleted. A single
+  import, not an ongoing legacy path, so it stays within the greenfield principle.
+- Quota posture: trust the model (inherited from #2018 and #2019). Never auto-evict a user's
+  layout; on a failed write keep the in-memory copy and surface the state through the chip,
+  never silently lose work.
+
+## Current state this replaces
+
+`src/lib/storage/working-copy.ts`:
+- `saveSession(layout, backup)` writes one `SessionData { layout, savedAt, changesSinceExport,
+  hasEverExported, storageMode }` to `Rackula:autosave` via `safeSetItem` (which already
+  returns false on `QuotaExceededError`).
+- `loadSessionWithTimestamp()` reads and migrates it (keeps the v0.6 to v0.7 body migration in
+  `migrateLayout`).
+- `clearSession()`, `detectModeFlip()`, `isServerNewer()` round out the module.
+`src/lib/utils/safe-storage.ts` provides `safeGetItem`, `safeGetItemWithStatus` (distinguishes
+missing from unavailable), `safeSetItem` (false on quota/unavailable), `safeRemoveItem`.
+
+## Schema
+
+Three key families under the existing `Rackula:` namespace.
+
+### 1. Workspace index, one key: `Rackula:workspace`
+
+```jsonc
+{
+  "schemaVersion": 2,
+  "activeId": "uuid-or-null",
+  "openTabs": ["uuid-a", "uuid-b"],   // ordered open set (the session working set)
+  "library": {                          // every layout that exists (the durable list)
+    "uuid-a": {
+      "name": "Homelab",
+      "updatedAt": "2026-06-14T09:00:00.000Z",
+      "changesSinceExport": 0,
+      "hasEverExported": true,
+      "storageMode": "browser"
+    }
+  }
+}
+```
+
+- Small (no layout bodies), so it is read synchronously at launch to paint tab shells (#2080)
+  and the sidebar list (#2082) before any body is parsed.
+- Per-layout durability (`changesSinceExport`, `hasEverExported`) lives here so the chip
+  rollup (#2035), tab dots (#2079), and sidebar dots (#2082) all read one source without
+  loading bodies. No second bookkeeping.
+- `openTabs` is the session working set and is a subset of `library`. Closing a tab removes an
+  id from `openTabs` only; the `library` entry and the body persist (this is #2079's
+  "closing keeps the layout").
+
+### 2. Per-layout body, one key each: `Rackula:layout:<id>`
+
+```jsonc
+{
+  "schemaVersion": 2,
+  "layout": { /* full Layout, including base64 images */ },
+  "savedAt": "2026-06-14T09:00:00.000Z"
+}
+```
+
+- Loaded lazily on tab focus. Holds the full layout, the large part (base64 device images,
+  #617).
+
+### 3. Legacy single slot: `Rackula:autosave`
+
+Removed after one-time adoption (below). Not read again afterwards.
+
+Layout id is the layout's `metadata.id` (a UUID) where present, else a freshly generated one,
+so the same identity is reusable across browser and server modes.
+
+## Operations (the module that replaces working-copy.ts for browser mode)
+
+Index-only operations (cheap, no body read/write):
+- `loadIndex()` / `getOpenSet()`: `{ activeId, openTabs }` and the `library` map.
+- `listLibrary()`: library entries (id, name, updatedAt, durability) with no bodies.
+- `setOpenSet(openTabs, activeId)`: tab open, close, reorder, switch. Index-only.
+- `updateDurability(id, { changesSinceExport, hasEverExported })`: e.g. `markExported` per
+  layout (#2045) without rewriting the body.
+- `renameLayout(id, name)`: index-only, live-syncs the tab title (#2018).
+- `deleteLayout(id)`: removes the body key, the library entry, and drops the id from
+  `openTabs`. This is the sidebar Delete, distinct from tab close.
+
+Body operations:
+- `loadLayoutBody(id)`: reads `Rackula:layout:<id>`, runs the existing `migrateLayout`, returns
+  the Layout or an unreadable marker (which #2018 renders as the on-focus orphan/error state).
+- `saveLayoutBody(id, layout)`: writes the body and updates the index entry (`updatedAt`,
+  durability). Returns false on quota (propagated from `safeSetItem`).
+- `createLayout(name)`: new id, an empty body, and a library entry.
+
+## One-time adoption (off `Rackula:autosave`)
+
+On launch in browser mode, if `Rackula:workspace` is absent:
+- If `Rackula:autosave` is present: `loadSessionWithTimestamp()`, create a library entry under
+  the layout's id, write its body, set `openTabs = [id]` and `activeId = id`, carry over
+  `changesSinceExport` and `hasEverExported`, then `safeRemoveItem("Rackula:autosave")`.
+- Else: empty workspace (`activeId = null`, `openTabs = []`, `library = {}`).
+
+Adoption runs once. Afterwards `Rackula:workspace` exists and the old key is gone, so no legacy
+code path lingers.
+
+Returning-user vs fresh-install (feeds #2018 and #2081): set a persisted
+`Rackula:everHadLayouts` flag the first time a layout is created or adopted. An empty workspace
+with the flag set is lost-data-empty (recovery state); without it, fresh-install-empty
+(WelcomeScreen).
+
+## Quota strategy
+
+- The localStorage cap is roughly 5MB. Base64 images (#617) times N layouts is the risk that
+  pushes a browser-mode workspace past it.
+- Detection: `safeSetItem` already returns false on `QuotaExceededError`; `saveLayoutBody`
+  surfaces that boolean.
+- Posture (trust the model): on a failed write, do not auto-evict any layout. Keep the
+  in-memory copy, mark that layout not-durable, and surface it through:
+  - the chip (#2035), which is amber/error because not every open layout is in its durable
+    home;
+  - a user-facing prompt to Export or remove layouts to free space.
+- No silent data loss: a body that failed to write stays in memory and remains exportable.
+- Escape valve and follow-up trigger: when quota failures show up in real use, lift the tabled
+  hybrid plan (IndexedDB for bodies, this index stays in localStorage). The `schemaVersion`
+  field plus the body/index split keep that migration localized to `loadLayoutBody` and
+  `saveLayoutBody`. File the IndexedDB follow-up issue at that point. Browser mode may be
+  retired first via the Cloudflare Workers migration, in which case the follow-up is moot.
+
+## Twin-tab guard re-key (#2044)
+
+- Web Lock name is per layout: `rackula:layout:<id>` (matches #2018's per-layout pause). One
+  editable in-app tab per layout; editing layout A locks only A.
+- Storage events: a write to `Rackula:layout:<id>` notifies other tabs watching that id (the
+  body changed, so offer Reload for that one layout). A write to `Rackula:workspace` notifies
+  all tabs of library and open-set changes (a layout deleted elsewhere becomes the #2018
+  orphan).
+- Per-key writes mean no app-wide write lock is needed; if one is added later, scope it to the
+  index-key writes only.
+
+## Durability rollup (one source for #2035, #2079, #2082)
+
+- `getDurability(id) -> { changesSinceExport, hasEverExported, backed }` reads the index;
+  `backed` is `changesSinceExport === 0` (the #2019 chip rule: green only at zero changes since
+  export).
+- Chip (#2035) is green only when every id in `openTabs` is `backed`. Tab dots (#2079) and
+  sidebar dots (#2082) read the same per-id value.
+
+## Schema versioning
+
+- `schemaVersion: 2` (version 1 is the implicit single-slot `Rackula:autosave` format). The
+  index and bodies carry the field; the existing `migrateLayout` still handles body content
+  migration (v0.6 to v0.7). The body/index split isolates a future IndexedDB swap behind the
+  two body operations.
+
+## Handoff to presuming issues
+
+| Issue | What it consumes |
+| --- | --- |
+| #2079 tab strip | `setOpenSet` for open/close/reorder/switch (index-only); close keeps the body; tab dots from `getDurability` |
+| #2080 lazy restore | `getOpenSet` + `listLibrary` paint shells; `loadLayoutBody` on focus; unreadable body becomes the #2018 orphan/error |
+| #2082 sidebar library | `listLibrary` is the durable list; dots from `getDurability`; `renameLayout` / `deleteLayout` |
+| #2045 export-all | per-layout `updateDurability(id, { changesSinceExport: 0, hasEverExported: true })` |
+| #2035 chip | rollup over `openTabs` via `getDurability` |
+| #2044 twin-tab guard | per-layout Web Lock `rackula:layout:<id>` + the storage-event keys above |
+
+## Out of scope
+
+- IndexedDB / hybrid backend (tabled; quota-triggered follow-up).
+- Server-mode persistence (unchanged; this schema is browser-mode only).
+- Undo/redo across tab switch and restore (#2182).

--- a/docs/research/spike-2179-browser-multilayout-storage-schema.md
+++ b/docs/research/spike-2179-browser-multilayout-storage-schema.md
@@ -43,7 +43,7 @@ missing from unavailable), `safeSetItem` (false on quota/unavailable), `safeRemo
 
 ## Schema
 
-Three key families under the existing `Rackula:` namespace.
+Four key families under the existing `Rackula:` namespace.
 
 ### 1. Workspace index, one key: `Rackula:workspace`
 
@@ -58,6 +58,7 @@ Three key families under the existing `Rackula:` namespace.
       "updatedAt": "2026-06-14T09:00:00.000Z",
       "changesSinceExport": 0,
       "hasEverExported": true,
+      "writeFailed": false,
       "storageMode": "browser"
     }
   }
@@ -66,9 +67,9 @@ Three key families under the existing `Rackula:` namespace.
 
 - Small (no layout bodies), so it is read synchronously at launch to paint tab shells (#2080)
   and the sidebar list (#2082) before any body is parsed.
-- Per-layout durability (`changesSinceExport`, `hasEverExported`) lives here so the chip
-  rollup (#2035), tab dots (#2079), and sidebar dots (#2082) all read one source without
-  loading bodies. No second bookkeeping.
+- Per-layout durability (`changesSinceExport`, `hasEverExported`, `writeFailed`) lives here so
+  the chip rollup (#2035), tab dots (#2079), and sidebar dots (#2082) all read one source without
+  loading bodies. No second bookkeeping. (`writeFailed` semantics: see Durability rollup.)
 - `openTabs` is the session working set and is a subset of `library`. Closing a tab removes an
   id from `openTabs` only; the `library` entry and the body persist (this is #2079's
   "closing keeps the layout").
@@ -86,7 +87,15 @@ Three key families under the existing `Rackula:` namespace.
 - Loaded lazily on tab focus. Holds the full layout, the large part (base64 device images,
   #617).
 
-### 3. Legacy single slot: `Rackula:autosave`
+### 3. First-layout marker, one key: `Rackula:everHadLayouts`
+
+A standalone flag, value `"1"`, set the first time any layout is created or adopted and never
+cleared. It is a separate key on purpose: it must survive a wipe of `Rackula:workspace` so the
+app can tell a returning user whose data was lost (flag present, workspace empty or missing) from
+a genuine fresh install (flag absent). The launch flow reads it to route the empty state (lost-
+data recovery vs WelcomeScreen, feeding #2018 and #2081).
+
+### 4. Legacy single slot: `Rackula:autosave`
 
 Removed after one-time adoption (below). Not read again afterwards.
 
@@ -102,8 +111,11 @@ Index-only operations (cheap, no body read/write):
 - `updateDurability(id, { changesSinceExport, hasEverExported })`: e.g. `markExported` per
   layout (#2045) without rewriting the body.
 - `renameLayout(id, name)`: index-only, live-syncs the tab title (#2018).
-- `deleteLayout(id)`: removes the body key, the library entry, and drops the id from
-  `openTabs`. This is the sidebar Delete, distinct from tab close.
+- `deleteLayout(id)`: removes the body key and the library entry. It does not drop the id from
+  `openTabs`: per #2018, deleting a layout that is currently open leaves the tab in place as a
+  recoverable orphan (offering Save as new), so whether the tab closes is the interaction
+  layer's call, not a side effect of the storage delete. This is the sidebar Delete, distinct
+  from tab close.
 
 Body operations:
 - `loadLayoutBody(id)`: reads `Rackula:layout:<id>`, runs the existing `migrateLayout`, returns
@@ -117,11 +129,17 @@ Body operations:
 On launch in browser mode, if `Rackula:workspace` is absent:
 - If `Rackula:autosave` is present: `loadSessionWithTimestamp()`, create a library entry under
   the layout's id, write its body, set `openTabs = [id]` and `activeId = id`, carry over
-  `changesSinceExport` and `hasEverExported`, then `safeRemoveItem("Rackula:autosave")`.
+  `changesSinceExport` and `hasEverExported`. Only after both the body write and the index write
+  succeed (`safeSetItem` returned true for each), `safeRemoveItem("Rackula:autosave")`. If either
+  write fails (quota or storage unavailable), keep the legacy slot intact as the durable fallback
+  and surface the failure per the quota strategy; never delete the only copy on a failed
+  migration.
 - Else: empty workspace (`activeId = null`, `openTabs = []`, `library = {}`).
 
-Adoption runs once. Afterwards `Rackula:workspace` exists and the old key is gone, so no legacy
-code path lingers.
+Adoption runs once and is idempotent: it only proceeds when `Rackula:workspace` is absent, and it
+deletes the legacy slot only after the new writes have landed, so a failed or interrupted run
+retries cleanly on the next launch. After a successful run `Rackula:workspace` exists and the old
+key is gone, so no legacy code path lingers.
 
 Returning-user vs fresh-install (feeds #2018 and #2081): set a persisted
 `Rackula:everHadLayouts` flag the first time a layout is created or adopted. An empty workspace
@@ -135,9 +153,10 @@ with the flag set is lost-data-empty (recovery state); without it, fresh-install
 - Detection: `safeSetItem` already returns false on `QuotaExceededError`; `saveLayoutBody`
   surfaces that boolean.
 - Posture (trust the model): on a failed write, do not auto-evict any layout. Keep the
-  in-memory copy, mark that layout not-durable, and surface it through:
-  - the chip (#2035), which is amber/error because not every open layout is in its durable
-    home;
+  in-memory copy, set the layout's `writeFailed` flag in the index (see Durability rollup), and
+  surface it through:
+  - the chip (#2035), which goes to an error state because that layout's working copy cannot be
+    persisted;
   - a user-facing prompt to Export or remove layouts to free space.
 - No silent data loss: a body that failed to write stays in memory and remains exportable.
 - Escape valve and follow-up trigger: when quota failures show up in real use, lift the tabled
@@ -159,11 +178,18 @@ with the flag set is lost-data-empty (recovery state); without it, fresh-install
 
 ## Durability rollup (one source for #2035, #2079, #2082)
 
-- `getDurability(id) -> { changesSinceExport, hasEverExported, backed }` reads the index;
-  `backed` is `changesSinceExport === 0` (the #2019 chip rule: green only at zero changes since
-  export).
-- Chip (#2035) is green only when every id in `openTabs` is `backed`. Tab dots (#2079) and
-  sidebar dots (#2082) read the same per-id value.
+- `getDurability(id) -> { changesSinceExport, hasEverExported, backed, writeFailed }` reads the
+  index. `backed` is the export-durability signal: `changesSinceExport === 0` (the #2019 chip
+  rule, green only at zero changes since export). `writeFailed` records whether the last attempt
+  to persist this layout's body to localStorage failed (quota or unavailable); `saveLayoutBody`
+  sets it on failure and clears it on the next successful write, and it is persisted in the index
+  entry so it survives reload. The two signals are distinct: `changesSinceExport` tracks edits
+  not yet exported to a file; `writeFailed` tracks whether the browser working copy could be
+  saved at all.
+- Chip (#2035): error when any open layout has `writeFailed` (its working copy cannot be saved
+  locally); otherwise green only when every id in `openTabs` is `backed`; otherwise amber. Tab
+  dots (#2079) and sidebar dots (#2082) read the same per-id values, so the error, amber, and
+  green states come from one source, not three.
 
 ## Schema versioning
 

--- a/docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
@@ -426,6 +426,18 @@ per layout via a layout-id Web Lock with an at-most-one-editable-tab-per-layout 
 404 on a deleted server layout falls through to Save as new (#2041). Undo across switch and
 restore (#2182) and the browser per-layout storage schema (#2179) are designed separately.
 
+Spike #2179 resolved the browser-mode multi-layout storage schema (see
+docs/research/spike-2179-browser-multilayout-storage-schema.md). localStorage only for now
+(IndexedDB tabled as a quota-triggered follow-up, since browser mode may be retired with the
+Cloudflare Workers migration): one workspace index key (`Rackula:workspace`: schemaVersion,
+activeId, ordered openTabs, and a library map carrying per-layout name, updatedAt, and the
+durability counters) read synchronously at launch to paint tab shells, plus one body key per
+layout (`Rackula:layout:<id>`) loaded lazily on focus. The old single `Rackula:autosave` slot is
+adopted once into the first layout then deleted. Closing a tab drops it from openTabs only; the
+body and library entry persist. Quota failures never auto-evict; they surface through the chip.
+The twin-tab Web Lock and storage events re-key per layout id, and the index is the single
+durability source for the chip rollup (#2035), tab dots (#2079), and sidebar dots (#2082).
+
 A 2026-06-10 scope review of surfaces left untouched by the shell list added six items
 and three guard rails. Dialogs unify on one primitive with three sizes (S 420, M 560,
 L 720) that renders as a bottom sheet on mobile, replacing nine ad hoc dialog widths


### PR DESCRIPTION
## **User description**
## Summary

Design spike #2179: the browser-mode multi-layout storage schema the tabs work presumes (epic #2017, M14). Docs only, no code. Unblocks #2079, #2080, #2082, #2045, #2035.

Decisions (maintainer-steered):
- localStorage only for now. Hybrid IndexedDB tabled as a quota-triggered follow-up, since browser mode may be retired with the Cloudflare Workers migration. No new dependency.
- One workspace index key (Rackula:workspace: schemaVersion, activeId, ordered openTabs, library map with per-layout name/updatedAt/durability) read synchronously at launch to paint tab shells, plus one body key per layout (Rackula:layout:<id>) loaded lazily on focus.
- One-time adoption of the legacy Rackula:autosave slot into the first layout, then delete it. A single import, not a legacy path.
- Trust-the-model quota posture: never auto-evict; surface write failures through the chip.
- Per-layout Web Lock and storage-event re-key for #2044; the index is the single durability source for the chip (#2035), tab dots (#2079), and sidebar dots (#2082).

## Files

- docs/research/spike-2179-browser-multilayout-storage-schema.md
- docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md (storage-schema decision-log entry)

## Issue enrichment (no new issues)

Schema acceptance criteria handed to #2079, #2080, #2082, #2045, #2035, and #2044 as comments.

## Test Plan

Design spike, verified documentarily:
- [x] Schema defines key structure, operations, one-time adoption, quota posture, twin-tab re-key, and durability rollup
- [x] Each presuming issue (#2079/#2080/#2082/#2045/#2035) has a defined contract
- [x] House style clean (no em/en dashes, smart quotes, emoji)

Closes #2179

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Define the browser-mode storage plan for multiple layouts**

### What Changed
- Adds the documented storage scheme for browser mode with one shared workspace index and one saved body per layout
- Notes that closing a tab removes it from the open tab list but keeps its saved layout
- Describes one-time import of the old single saved session into the new layout-based format, then removal of the old storage entry
- Clarifies that failed saves do not delete layouts automatically and should surface a space warning instead
- Links the new schema to tab dots, sidebar dots, the storage chip, and per-layout reload/lock behavior

### Impact
`✅ Clearer browser-mode layout storage rules`
`✅ Fewer lost-layout surprises after tab close`
`✅ Clearer low-space warnings during layout saves`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
