### PR TITLE
fix(api): make layout updatedAt strictly monotonic to stop snapshot data loss (#2233)

### DIFF
--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -738,22 +738,48 @@ export async function saveLayout(
     const existingFolder = await findFolderByUuid(uuid);
     let isNew = existingFolder === null;
 
+    // mtime of the copy this save overwrites. updatedAt is derived from the
+    // file mtime, but mtime resolution is coarse (often 1ms), so two writes
+    // can land on the same tick. The new write must report an mtime strictly
+    // greater than the copy it replaces; otherwise the next echoed updatedAt
+    // (the overwritten copy's mtime) could equal the now-stored copy's mtime,
+    // making the divergence check below read the two copies as identical and
+    // overwrite a diverged copy without snapshotting it.
+    let overwrittenMtimeMs: number | undefined;
+
     // Pre-overwrite snapshot: when the client's echoed updatedAt does not
     // match the stored copy, the copies diverged. Capture the stored YAML
     // before overwriting it.
-    if (echoedUpdatedAt && existingFolder) {
+    if (existingFolder) {
       const existingYamlFilename = await findYamlInFolder(existingFolder);
       if (existingYamlFilename) {
         const existingYamlPath = join(existingFolder, existingYamlFilename);
-        const handle = await open(existingYamlPath, "r");
+        // A concurrent delete between the listing and this open leaves no copy
+        // to snapshot or to outrank, so a missing file degrades to "no prior
+        // copy" rather than failing the save.
+        let handle;
         try {
-          const existingStats = await handle.stat();
-          if (existingStats.mtime.toISOString() !== echoedUpdatedAt) {
-            const existingContent = await handle.readFile("utf-8");
-            await writeSnapshot(existingFolder, existingContent);
+          handle = await open(existingYamlPath, "r");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            throw error;
           }
-        } finally {
-          await handle.close();
+          handle = undefined;
+        }
+        if (handle) {
+          try {
+            const existingStats = await handle.stat();
+            overwrittenMtimeMs = existingStats.mtime.getTime();
+            if (
+              echoedUpdatedAt &&
+              existingStats.mtime.toISOString() !== echoedUpdatedAt
+            ) {
+              const existingContent = await handle.readFile("utf-8");
+              await writeSnapshot(existingFolder, existingContent);
+            }
+          } finally {
+            await handle.close();
+          }
         }
       }
     }
@@ -797,8 +823,23 @@ export async function saveLayout(
     const handle = await open(yamlPath, "w");
     try {
       await handle.writeFile(yamlContent, "utf-8");
-      const stats = await handle.stat();
-      return { id: uuid, isNew, updatedAt: stats.mtime.toISOString() };
+      let stats = await handle.stat();
+      let mtime = stats.mtime;
+      // Guarantee a strictly newer mtime than the copy this write replaced, so
+      // updatedAt is monotonic per layout even when the filesystem clock has
+      // not advanced since the previous write. This keeps the echoed-updatedAt
+      // divergence check honest under coarse mtime resolution. Only mtime is
+      // bumped; atime is preserved since storage never reads it.
+      if (
+        overwrittenMtimeMs !== undefined &&
+        mtime.getTime() <= overwrittenMtimeMs
+      ) {
+        const bumped = new Date(overwrittenMtimeMs + 1);
+        await handle.utimes(stats.atime, bumped);
+        stats = await handle.stat();
+        mtime = stats.mtime;
+      }
+      return { id: uuid, isNew, updatedAt: mtime.toISOString() };
     } finally {
       await handle.close();
     }

--- a/api/src/storage/storage-contract.ts
+++ b/api/src/storage/storage-contract.ts
@@ -124,6 +124,35 @@ export function runStorageContract(makeDriver: MakeDriver): void {
       }
     });
 
+    it("issues a strictly newer updatedAt on every overwrite", async () => {
+      const { driver, cleanup } = await makeDriver();
+      try {
+        // updatedAt is the token clients echo to detect divergence. mtime
+        // resolution is coarse, so back-to-back writes can land on the same
+        // tick; if two stored copies share a token the echoed-updatedAt check
+        // reads them as identical and a diverged copy is overwritten without a
+        // snapshot. Each overwrite must therefore report a strictly newer
+        // token than the copy it replaced, even with no real-time gap between
+        // saves.
+        let echoed: string | undefined;
+        let previous: string | undefined;
+        for (let i = 0; i < 12; i += 1) {
+          const { updatedAt } = await driver.saveLayout(
+            TEST_ID,
+            layoutYaml(`v${i}`),
+            echoed,
+          );
+          if (previous !== undefined) {
+            expect(updatedAt > previous).toBe(true);
+          }
+          previous = updatedAt;
+          echoed = updatedAt;
+        }
+      } finally {
+        await cleanup();
+      }
+    });
+
     it("serializes concurrent saves to the same id across UUID casing", async () => {
       const { driver, cleanup } = await makeDriver();
       try {


### PR DESCRIPTION
## **User description**
## Summary

The `api (typecheck + tests)` job failed intermittently on the storage-contract test "never loses a diverged copy when a stale-echo write races a concurrent write" (#2233). Systematic debugging traced it to a real data-loss bug in `saveLayout`, not just flaky test timing.

## Root cause (evidence-first)

`updatedAt` is the layout file's mtime, which clients echo back to detect divergent concurrent writes. mtime resolution is coarse (~1ms on the dev box; similar on CI), so two writes to the same layout can land on the **same mtime tick**. When the copy being overwritten happens to share an mtime with the echoed token, the divergence check `existingStats.mtime.toISOString() !== echoedUpdatedAt` reads two genuinely different copies as identical, and a diverged copy gets overwritten **without** a snapshot.

The per-layout write lock from #2193 closed the TOCTOU window, but the divergence *signal* (mtime equality) was itself unreliable under coarse resolution.

Reproduced against the real filesystem driver: 5/600 concurrent-race iterations lost a diverged copy, every failure correlated with an mtime collision. Sequential rapid saves produced a non-monotonic token in 50/50 runs.

## Fix

- Capture the overwritten copy's mtime unconditionally (previously only read when an echo was present).
- After writing, bump the new file's mtime forward by 1ms if it did not advance past the copy it replaced. `updatedAt` is now strictly monotonic per layout, so an echoed token can never collide with a later stored copy.
- `atime` is preserved (storage never reads it); a concurrent delete of the existing yaml degrades to "no prior copy" instead of throwing.

The bumped mtime persists to disk, so a later `getLayout` returns the same token the save returned (verified: 0 mismatches over 600 saves).

## Test

Added a driver-agnostic contract test asserting strictly-increasing `updatedAt` across rapid sequential saves. It fails deterministically on the old code (5/5) and passes on the fixed code; the future R2 driver (#2133) inherits the invariant.

## Verification

- `bun test` full API suite: 278 pass, 0 fail (across repeated runs)
- Storage-contract suite: 0 failures across 25 full runs
- Concurrent-race probe: 0/3000 failures (was 5/600 before the fix)
- `tsc --noEmit` clean, prettier clean

This addresses the issue's note that "if the race is in the production snapshot logic rather than the test, that is a higher-severity data-safety finding" - it was. The fix lands the data-safety correction directly.

Closes #2233

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent snapshot loss when two saves happen too close together**

### What Changed
- Layout saves now keep each `updatedAt` value strictly newer than the version they replace, so a later save cannot reuse the same timestamp as an overwritten copy.
- If a layout is replaced and the previous file is still present, its content is still snapshotted before overwrite when the client’s echoed timestamp does not match.
- A missing layout file during save no longer fails the whole write; the save continues as if there was no prior copy.
- Added a contract test that checks `updatedAt` keeps increasing across rapid back-to-back saves.

### Impact
`✅ Fewer lost layout snapshots`
`✅ Safer concurrent saves`
`✅ Clearer layout version tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
