### PR TITLE
refactor: route server-reconciliation image load through finalizeLayoutLoad (#2225)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -30,7 +30,6 @@
   } from "$lib/utils/share";
   import {
     loadSessionWithTimestamp,
-    clearSession,
     isServerNewer,
     setApiAvailable,
     initializePersistence,
@@ -39,6 +38,7 @@
     detectModeFlip,
     listSavedLayouts,
     loadSavedLayout,
+    finalizeLayoutLoad,
     handleLoad,
     handleSaveToServer,
   } from "$lib/storage";
@@ -51,7 +51,6 @@
     handleFitAll,
   } from "$lib/utils/app-actions";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
-  import { getImageStore } from "$lib/stores/images.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
@@ -368,44 +367,30 @@
               layout: serverLayout,
               images: serverImages,
               failedImagesCount,
+              failedKeys,
             } = await loadSavedLayout(mostRecent.id);
-            // Reset images: clear, reload bundled base, overlay decoded uploads.
-            const imageStore = getImageStore();
-            imageStore.clearAllImages();
-            imageStore.loadBundledImages();
-            for (const [deviceSlug, deviceImages] of serverImages) {
-              if (deviceImages.front) {
-                imageStore.setDeviceImage(
-                  deviceSlug,
-                  "front",
-                  deviceImages.front,
-                );
-              }
-              if (deviceImages.rear) {
-                imageStore.setDeviceImage(deviceSlug, "rear", deviceImages.rear);
-              }
-            }
-            layoutStore.loadLayout(serverLayout);
-            layoutStore.markClean();
-            if (failedImagesCount > 0) {
-              toastStore.showToast(
-                `Layout loaded with ${failedImagesCount} image${failedImagesCount > 1 ? "s" : ""} that couldn't be read`,
-                "warning",
+
+            if (failedKeys.length > 0) {
+              persistenceDebug.api(
+                "reconciliation: %d image(s) failed to read: %o",
+                failedKeys.length,
+                failedKeys,
               );
             }
 
-            // Clear stale localStorage to prevent future conflicts
-            clearSession();
+            // Share the image-reset / bundled-reload / custom-overlay / load /
+            // clear-session / fit-all sequence with the file and API load paths.
+            // Suppress the generic success toast: this path shows its own
+            // "Loaded ... from server" toast below. The partial-image warning
+            // (when failedImagesCount > 0) still fires.
+            finalizeLayoutLoad(serverLayout, serverImages, failedImagesCount, {
+              successMessage: null,
+            });
 
             toastStore.showToast(
               `Loaded "${mostRecent.name}" from server`,
               "success",
             );
-
-            // Reset view to center the loaded rack after DOM updates
-            requestAnimationFrame(() => {
-              canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
-            });
             return;
           }
 

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -28,7 +28,11 @@ export {
   detectModeFlip,
   type ModeFlip,
 } from "./working-copy";
-export { loadFromApi, loadFromFile } from "./load-pipeline";
+export {
+  finalizeLayoutLoad,
+  loadFromApi,
+  loadFromFile,
+} from "./load-pipeline";
 export {
   handleLoad,
   handleSaveToServer,

--- a/src/lib/storage/load-pipeline.ts
+++ b/src/lib/storage/load-pipeline.ts
@@ -16,6 +16,19 @@ import { openFilePicker } from "$lib/utils/file";
 import { layoutDebug } from "$lib/utils/debug";
 
 /**
+ * Options for {@link finalizeLayoutLoad}.
+ */
+export interface FinalizeLayoutLoadOptions {
+  /**
+   * Success toast message. Pass `null` to suppress the success toast entirely
+   * (used by the server-reconciliation path, which shows its own
+   * "Loaded ... from server" toast). The partial-image warning toast still
+   * shows when images failed to read, regardless of this option.
+   */
+  successMessage?: string | null;
+}
+
+/**
  * Common layout loading process
  * Updates stores, clears session, and fits view
  */
@@ -23,7 +36,9 @@ export function finalizeLayoutLoad(
   layout: Layout,
   images?: ImageStoreMap,
   failedImagesCount: number = 0,
+  options: FinalizeLayoutLoadOptions = {},
 ) {
+  const { successMessage = "Layout loaded successfully" } = options;
   const layoutStore = getLayoutStore();
   const imageStore = getImageStore();
   const toastStore = getToastStore();
@@ -64,8 +79,8 @@ export function finalizeLayoutLoad(
       `Layout loaded with ${failedImagesCount} image${failedImagesCount > 1 ? "s" : ""} that couldn't be read`,
       "warning",
     );
-  } else {
-    toastStore.showToast("Layout loaded successfully", "success");
+  } else if (successMessage !== null) {
+    toastStore.showToast(successMessage, "success");
   }
 }
 

--- a/src/tests/load-pipeline.test.ts
+++ b/src/tests/load-pipeline.test.ts
@@ -99,6 +99,30 @@ describe("load-pipeline", () => {
       );
       expect(mockImageStore.loadBundledImages).toHaveBeenCalled();
     });
+
+    it("suppresses the success toast when successMessage is null", () => {
+      const layout = createTestLayout({ name: "Server Reconcile" });
+      finalizeLayoutLoad(layout, undefined, 0, { successMessage: null });
+
+      // Layout still loads, but the generic success toast is withheld so the
+      // server-reconciliation path can show its own "Loaded ... from server".
+      expect(layoutStore.layout.name).toBe("Server Reconcile");
+      expect(toastStore.toasts.some((t) => t.type === "success")).toBe(false);
+    });
+
+    it("still warns about failed images when successMessage is null", () => {
+      const layout = createTestLayout({ name: "Server Partial" });
+      finalizeLayoutLoad(layout, undefined, 2, { successMessage: null });
+
+      expect(toastStore.toasts).toContainEqual(
+        expect.objectContaining({
+          message: "Layout loaded with 2 images that couldn't be read",
+          type: "warning",
+        }),
+      );
+      // The warning fires but the generic success toast stays suppressed.
+      expect(toastStore.toasts.some((t) => t.type === "success")).toBe(false);
+    });
   });
 
   describe("loadFromApi", () => {


### PR DESCRIPTION
## **User description**
## Summary

The startup server-reconciliation path in `App.svelte` duplicated the image reset / bundled-reload / custom-overlay / load / clear-session / fit-all / partial-image-toast sequence that `finalizeLayoutLoad` (`src/lib/storage/load-pipeline.ts`) already centralizes. This routes that path through the shared helper so there is one image-load implementation for local-file load, API load, and server reconciliation.

## Changes

- `finalizeLayoutLoad` gains an `options` parameter (`FinalizeLayoutLoadOptions { successMessage?: string | null }`). Pass `successMessage: null` to suppress the generic success toast; the partial-image warning toast still fires when images fail to read.
- The server-reconciliation block in `App.svelte` now calls `finalizeLayoutLoad(serverLayout, serverImages, failedImagesCount, { successMessage: null })`, keeps its own `Loaded "..." from server` toast, and logs `failedKeys` via `persistenceDebug.api` for the targeted partial-image warning.
- Removed the now-unused `clearSession` and `getImageStore` imports from `App.svelte`.
- Re-exported `finalizeLayoutLoad` from the `$lib/storage` barrel.

## Acceptance criteria

- [x] Server-reconciliation and normal loads share one image-load implementation (toast-suppression option on `finalizeLayoutLoad`).
- [x] No duplicate success toast on the server-reconciliation path (generic toast suppressed; only the server-specific toast shows).
- [x] `failedKeys` is logged on this path for the targeted warning.

## Behaviour

No behaviour change. Toast order is preserved (partial-image warning, then the server success toast). `finalizeLayoutLoad` additionally calls `selectionStore.clearSelection()`, which is a no-op at startup reconciliation (no selection exists yet).

## Test Plan

- [x] `npm run test:run -- src/tests/load-pipeline.test.ts` (9 passed; 2 new tests cover `successMessage: null` suppression and the partial-image warning still firing)
- [x] `npm run test:run -- src/tests/App.startScreen.test.ts src/tests/App.cleanupPrompt.test.ts` (7 passed)
- [x] `npm run lint` (clean)
- [x] `npm run build` (succeeds)

Closes #2225


___

## **CodeAnt-AI Description**
**Route server-loaded layouts through the shared load flow**

### What Changed
- Server reconciliation now uses the same layout-loading flow as file and API loads, so images are reset, restored, and the view is fitted the same way in every path
- The server-loaded path keeps its own `Loaded "..." from server` success message and no longer shows the generic success toast
- If some images cannot be read, the warning still appears
- Added coverage for suppressing the generic success message while keeping the partial-image warning

### Impact
`✅ Consistent layout loading after server sync`
`✅ Fewer duplicate success messages`
`✅ Clearer partial-image warnings during restore`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
