### PR TITLE
feat: enrich post-deploy smoke tests with Playwright browser verification (#1997)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -173,11 +173,53 @@ jobs:
   smoke-test:
     needs: deploy
     runs-on: [self-hosted, vps-rackula]
-    permissions: {}
+    timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
-      - name: Verify deployment
+      # Fast curl gate: fails immediately if the server or API is unreachable,
+      # before we spend time spinning up a browser.
+      - name: Verify deployment responds
         run: |
           sleep 5
           curl -sf --retry 5 --retry-delay 3 https://d.racku.la
           curl -sf --retry 5 --retry-delay 3 https://d.racku.la/api/layouts
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-chromium-
+
+      - name: Install Playwright chromium
+        # --with-deps installs OS libraries via apt and needs root; fall back to a
+        # plain browser install when the self-hosted runner already has them.
+        run: npx playwright install --with-deps chromium || npx playwright install chromium
+
+      - name: Browser smoke test against deployed app
+        env:
+          SMOKE_TEST_URL: https://d.racku.la
+        run: npm run test:e2e:smoke
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: deploy-dev-smoke-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,11 +54,14 @@ jobs:
   smoke-test:
     needs: [deploy]
     runs-on: [self-hosted, vps-rackula]
-    timeout-minutes: 5
-    permissions: {}
+    timeout-minutes: 10
+    permissions:
+      contents: read
 
     steps:
-      - name: Verify deployment
+      # Fast curl gate: fails immediately if the server is unreachable, before we
+      # spend time spinning up a browser.
+      - name: Verify deployment responds
         run: |
           sleep 5
           curl -sf --retry 5 --retry-delay 3 https://count.racku.la
@@ -74,6 +77,9 @@ jobs:
           # image version is validated separately by the verify-version-alignment
           # job, which runs the image in an ephemeral container.
           #
+          # The browser smoke test below checks version.json is well-formed; this
+          # step additionally asserts it matches the released tag.
+          #
           # Extract .version from JSON without depending on jq being installed
           # on the self-hosted runner.
           extract_version() {
@@ -85,3 +91,42 @@ jobs:
           echo "frontend=${fe} expected=${VERSION}"
           [ "$fe" = "$VERSION" ] || { echo "::error::Live frontend version '${fe}' != '${VERSION}'"; exit 1; }
           echo "✓ Live frontend reports ${VERSION}"
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-chromium-
+
+      - name: Install Playwright chromium
+        # --with-deps installs OS libraries via apt and needs root; fall back to a
+        # plain browser install when the self-hosted runner already has them.
+        run: npx playwright install --with-deps chromium || npx playwright install chromium
+
+      - name: Browser smoke test against deployed app
+        env:
+          SMOKE_TEST_URL: https://count.racku.la
+        run: npm run test:e2e:smoke
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: deploy-prod-smoke-report
+          path: playwright-report/
+          retention-days: 7

--- a/e2e/deploy-smoke.spec.ts
+++ b/e2e/deploy-smoke.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "./helpers/base-test";
+import type { Page } from "@playwright/test";
+import { gotoWithRack, locators, RACK_WITH_DEVICE_SHARE } from "./helpers";
+
+/**
+ * Post-deploy smoke tests.
+ *
+ * These verify a *live deployed* environment in a real browser, going beyond the
+ * curl health check the deploy workflows previously relied on. They confirm the
+ * deployed bundle actually boots and renders, not just that the server answers.
+ *
+ * Run against a deployed URL via the SMOKE_TEST_URL env var:
+ *
+ *   SMOKE_TEST_URL=https://d.racku.la npm run test:e2e:smoke
+ *
+ * The smoke config (playwright.smoke.config.ts) runs ONLY this spec in deploy
+ * mode (SMOKE_TEST_URL set). The local-build smoke set (smoke.spec.ts,
+ * basic-workflow.spec.ts) stays on the local preview server, where state-mutating
+ * flows are safe. Deploy mode stays read-only and fast (chromium, under 30s).
+ *
+ * @see https://github.com/RackulaLives/Rackula/issues/1997
+ */
+
+/**
+ * Collects unhandled page errors during a test. Production bundles can fail in
+ * ways dev/unit runs never see (ESM chunk init order, minification), so a clean
+ * boot is the core post-deploy signal.
+ */
+function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  return errors;
+}
+
+test.describe("Post-deploy smoke", () => {
+  test("app shell boots and renders at the root path", async ({ page }) => {
+    const errors = collectPageErrors(page);
+
+    // A brand-new visitor (no share link, no saved session) is the most faithful
+    // post-deploy check: it exercises the real entry path of the deployed app.
+    await page.goto("/");
+
+    // The toolbar and canvas shell render unconditionally once Svelte mounts,
+    // regardless of whether the start screen or a restored layout is shown. Their
+    // presence proves the JS bundle loaded and the app initialised.
+    await expect(page.locator(locators.toolbar.root)).toBeVisible();
+    await expect(page.locator(locators.canvas.root)).toBeVisible();
+
+    // First-time visitors land on the start screen; returning visitors restore a
+    // saved layout (canvas shows a rack). Accept either to stay deployment-state
+    // agnostic - both prove the app booted past the shell.
+    await expect(
+      page
+        .locator(locators.startScreen.root)
+        .or(page.locator(locators.rack.container).first()),
+    ).toBeVisible();
+
+    // eslint-disable-next-line no-restricted-syntax -- behavioral test: a clean production boot means zero uncaught errors
+    expect(
+      errors,
+      `Deployed app threw JavaScript errors on load: ${errors.join("; ")}`,
+    ).toHaveLength(0);
+  });
+
+  test("canvas renders a shared layout", async ({ page }) => {
+    const errors = collectPageErrors(page);
+
+    // Loading a self-contained share link forces the deployed app to decode and
+    // render an actual rack, verifying the canvas works end to end without
+    // depending on any saved session on the deployed environment.
+    await gotoWithRack(page, RACK_WITH_DEVICE_SHARE);
+
+    await expect(page.locator(locators.rack.container).first()).toBeVisible();
+    await expect(page.locator(locators.rack.device).first()).toBeVisible();
+
+    // eslint-disable-next-line no-restricted-syntax -- behavioral test: rendering a shared layout must not throw
+    expect(
+      errors,
+      `Deployed app threw JavaScript errors while rendering a layout: ${errors.join("; ")}`,
+    ).toHaveLength(0);
+  });
+
+  test("version endpoint reports a well-formed build", async ({ request }) => {
+    // version.json is emitted at build time and served statically, so it proves
+    // the deployed bundle is the one we expect without executing any JS.
+    const response = await request.get("/version.json");
+    expect(response.ok()).toBe(true);
+
+    const body = (await response.json()) as {
+      version?: unknown;
+      commit?: unknown;
+      buildTime?: unknown;
+    };
+
+    expect(typeof body.version).toBe("string");
+    expect(body.version).not.toBe("");
+    expect(typeof body.commit).toBe("string");
+    expect(typeof body.buildTime).toBe("string");
+    // buildTime is an ISO timestamp; a valid parse guards against truncated or
+    // placeholder values slipping through.
+    expect(Number.isNaN(Date.parse(body.buildTime as string))).toBe(false);
+  });
+});

--- a/e2e/deploy-smoke.spec.ts
+++ b/e2e/deploy-smoke.spec.ts
@@ -25,6 +25,9 @@ import { gotoWithRack, locators, RACK_WITH_DEVICE_SHARE } from "./helpers";
  * Collects unhandled page errors during a test. Production bundles can fail in
  * ways dev/unit runs never see (ESM chunk init order, minification), so a clean
  * boot is the core post-deploy signal.
+ *
+ * @param page - The Playwright page to monitor.
+ * @returns An array that accumulates error messages as they occur.
  */
 function collectPageErrors(page: Page): string[] {
   const errors: string[] = [];
@@ -92,12 +95,15 @@ test.describe("Post-deploy smoke", () => {
       buildTime?: unknown;
     };
 
+    // version comes from package.json and is always present and non-empty.
     expect(typeof body.version).toBe("string");
     expect(body.version).not.toBe("");
+    // commit may legitimately be an empty string in Docker builds (no .git), so
+    // we assert only its type, not non-emptiness.
     expect(typeof body.commit).toBe("string");
     expect(typeof body.buildTime).toBe("string");
     // buildTime is an ISO timestamp; a valid parse guards against truncated or
     // placeholder values slipping through.
-    expect(Number.isNaN(Date.parse(body.buildTime as string))).toBe(false);
+    expect(Date.parse(body.buildTime as string)).not.toBeNaN();
   });
 });

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -68,6 +68,10 @@ export const locators = {
     panzoomContainer: ".panzoom-container",
   },
 
+  startScreen: {
+    root: '[data-testid="start-screen"]',
+  },
+
   dialog: {
     root: ".dialog",
     title: ".dialog-title",

--- a/e2e/playwright.smoke.config.ts
+++ b/e2e/playwright.smoke.config.ts
@@ -6,19 +6,27 @@ const smokeTestUrl = process.env.SMOKE_TEST_URL;
  * Playwright configuration for smoke tests.
  *
  * Two modes:
- * - Local mode (no SMOKE_TEST_URL): builds locally and serves on port 4173
- * - Deploy mode (SMOKE_TEST_URL set): tests against a live URL
+ * - Local mode (no SMOKE_TEST_URL): builds locally, serves on port 4173, and runs
+ *   the local-build smoke set (smoke.spec.ts, basic-workflow.spec.ts). These
+ *   exercise full UI flows, including state-mutating drag-and-drop, which is safe
+ *   against a throwaway local server.
+ * - Deploy mode (SMOKE_TEST_URL set): tests against a live URL and runs ONLY the
+ *   post-deploy smoke set (deploy-smoke.spec.ts). These are read-only and fast:
+ *   they verify the deployed bundle boots, renders, and serves a well-formed
+ *   version endpoint, without mutating state on a live environment.
  *
  * @example
  * # Local/CI smoke tests (local build)
  * npm run test:e2e:smoke
  *
- * # Test production
- * SMOKE_TEST_URL=https://count.racku.la npm run test:e2e:smoke
+ * # Post-deploy smoke against a live URL
+ * SMOKE_TEST_URL=https://d.racku.la npm run test:e2e:smoke
  */
 export default defineConfig({
   testDir: ".",
-  testMatch: ["smoke.spec.ts", "basic-workflow.spec.ts"],
+  testMatch: smokeTestUrl
+    ? ["deploy-smoke.spec.ts"]
+    : ["smoke.spec.ts", "basic-workflow.spec.ts"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: 1,


### PR DESCRIPTION
## **User description**
## Summary

The post-deploy smoke jobs in `deploy-dev.yml` and `deploy-prod.yml` previously did only a curl health check (plus a version-string compare on prod). They never confirmed the deployed bundle actually boots and renders in a browser.

This adds real Playwright browser verification of the deployed app, on the existing self-hosted `vps-rackula` runner, chromium-only, running in well under 30s.

## What changed

- New `e2e/deploy-smoke.spec.ts` (runs against a live URL via `SMOKE_TEST_URL`):
  - app shell boots and renders at the root path (toolbar + canvas visible, zero uncaught JS errors)
  - canvas renders a self-contained shared layout (decode + render end to end, no API dependency)
  - `version.json` endpoint reports a well-formed build (`version`, `commit`, `buildTime`)
- `e2e/playwright.smoke.config.ts` now selects only the read-only deploy spec in deploy mode (`SMOKE_TEST_URL` set), and keeps the existing local-build set (`smoke.spec.ts`, `basic-workflow.spec.ts`) for local runs where state-mutating drag-and-drop is safe.
- `e2e/helpers/locators.ts`: added `startScreen.root` (`[data-testid="start-screen"]`).
- Both deploy workflows: after the fast curl gate, install chromium (Playwright-cached) and run `npm run test:e2e:smoke` with `SMOKE_TEST_URL` pointed at the deployed env. Reports upload on failure.

## Design notes

- Root-path test accepts either the start screen (first-time visitor) or a restored layout, so it is deployment-state agnostic. This also works on prod, which is static-only (`/api` returns 503): the start-screen shell renders without the API.
- The share-link test uses a fully self-contained layout (inline custom device type), so it needs no server-side device library and works on static prod.
- `commit` is type-checked only (not asserted non-empty) because Docker builds emit an empty commit by design.
- Action pins, Node version, and cache keys match the existing `test.yml` smoke job exactly.

## Test Plan

- [x] Built and ran `SMOKE_TEST_URL=<local-preview> npm run test:e2e:smoke` against a local preview: 3/3 pass in ~1.3s.
- [x] Confirmed config selects only `deploy-smoke.spec.ts` in deploy mode and the local set otherwise (`--list`).
- [x] `npm run lint` clean.
- [x] Local /code-review clean; CodeRabbit pre-push review clean.

Closes #1997


___

## **CodeAnt-AI Description**
**Add live browser smoke checks after deployment**

### What Changed
- Post-deploy checks now open the deployed site in a browser to confirm the app shell loads, the canvas appears, and the page does not throw startup errors
- The smoke test also opens a shared layout to confirm the canvas can render real content end to end
- Deploy checks now verify `version.json` is well formed, and the production workflow still confirms the live site reports the released version tag
- Deploy smoke runs are split from local smoke tests so live environments use read-only checks only
- Failed deploy smoke runs now save a Playwright report for review

### Impact
`✅ Fewer silent bad deploys`
`✅ Clearer post-deploy failures`
`✅ Safer checks on live environments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
