### PR TITLE
chore: migrate E2E helpers to getByRole/getByLabel (#1420)

### DIFF
--- a/e2e/custom-device.spec.ts
+++ b/e2e/custom-device.spec.ts
@@ -20,20 +20,23 @@ test.describe("Custom Device Height (Issue #166)", () => {
   test.skip("custom 4U device renders with correct height after placement", async ({
     page,
   }) => {
-    const addDeviceButton = page.locator('[data-testid="btn-create-custom-device"]');
+    const addDeviceButton = page.getByTestId("btn-create-custom-device");
     await addDeviceButton.click();
 
-    await page.fill("#device-name", "RACKOWL 4U Server");
-    const heightInput = page.locator("#device-height");
+    const addDeviceDialog = page.getByRole("dialog", { name: "Add Device" });
+    await addDeviceDialog
+      .getByLabel("Name", { exact: true })
+      .fill("RACKOWL 4U Server");
+    const heightInput = addDeviceDialog.getByLabel("Height (U)");
     await heightInput.click();
     await heightInput.fill("4");
-    await page.selectOption("#device-category", "server");
+    await addDeviceDialog.getByLabel("Category").selectOption("server");
 
-    await page.click('[data-testid="btn-add-device"]');
+    await page.getByTestId("btn-add-device").click();
 
-    const customDevice = page.locator(
-      '.device-palette-item:has-text("RACKOWL 4U Server")',
-    );
+    const customDevice = page
+      .getByTestId("device-palette-item")
+      .filter({ hasText: "RACKOWL 4U Server" });
     await expect(customDevice).toBeVisible();
 
     const deviceCount = await page.locator(locators.device.paletteItem).count();
@@ -45,16 +48,19 @@ test.describe("Custom Device Height (Issue #166)", () => {
   test.skip("custom 2U device blocks correct number of rack positions", async ({
     page,
   }) => {
-    const addDeviceButton = page.locator('[data-testid="btn-create-custom-device"]');
+    const addDeviceButton = page.getByTestId("btn-create-custom-device");
     await addDeviceButton.click();
 
-    await page.fill("#device-name", "Test 2U Storage");
-    const heightInput = page.locator("#device-height");
+    const addDeviceDialog = page.getByRole("dialog", { name: "Add Device" });
+    await addDeviceDialog
+      .getByLabel("Name", { exact: true })
+      .fill("Test 2U Storage");
+    const heightInput = addDeviceDialog.getByLabel("Height (U)");
     await heightInput.click();
     await heightInput.fill("2");
-    await page.selectOption("#device-category", "storage");
+    await addDeviceDialog.getByLabel("Category").selectOption("storage");
 
-    await page.click('[data-testid="btn-add-device"]');
+    await page.getByTestId("btn-add-device").click();
 
     // TODO: drag custom device by name, verify 2U height (>30px)
   });

--- a/e2e/device-images.spec.ts
+++ b/e2e/device-images.spec.ts
@@ -70,7 +70,9 @@ test.describe("Device Images", () => {
 
     // Device should be added to library
     await expect(
-      page.locator('.device-palette-item:has-text("Server with Image")'),
+      page
+        .getByTestId("device-palette-item")
+        .filter({ hasText: "Server with Image" }),
     ).toBeVisible();
   });
 

--- a/e2e/device-metadata.spec.ts
+++ b/e2e/device-metadata.spec.ts
@@ -9,6 +9,8 @@ import {
   completeWizardWithClicks,
   PLATFORM_MODIFIER,
   locators,
+  startEditingDisplayName,
+  displayNameInput,
 } from "./helpers";
 
 /**
@@ -37,7 +39,6 @@ const TEST_METADATA_2 = {
   colour: "#6BCB77",
 };
 
-
 /**
  * Helper to wait for the saved indicator after a blur
  */
@@ -57,7 +58,9 @@ async function waitForSaved(page: Page, fieldType: "ip" | "notes") {
  * Helper to set device IP address
  */
 async function setDeviceIp(page: Page, ip: string, waitForSave = true) {
-  const ipInput = page.locator("#device-ip");
+  const ipInput = page
+    .getByTestId("drawer-device-edit")
+    .getByLabel("IP Address/Hostname");
   await ipInput.fill(ip);
   await ipInput.blur();
   if (waitForSave && ip.trim()) {
@@ -72,7 +75,7 @@ async function setDeviceIp(page: Page, ip: string, waitForSave = true) {
  * Helper to set device notes
  */
 async function setDeviceNotes(page: Page, notes: string, waitForSave = true) {
-  const notesInput = page.locator("#device-notes");
+  const notesInput = page.getByTestId("drawer-device-edit").getByLabel("Notes");
   await notesInput.fill(notes);
   await notesInput.blur();
   if (waitForSave && notes.trim()) {
@@ -88,8 +91,8 @@ async function setDeviceNotes(page: Page, notes: string, waitForSave = true) {
  */
 async function setDeviceName(page: Page, name: string) {
   // Click the display name button to start editing
-  await page.locator(locators.editPanel.displayNameButton).click();
-  const nameInput = page.locator(locators.editPanel.displayNameInput);
+  await startEditingDisplayName(page);
+  const nameInput = displayNameInput(page);
   await expect(nameInput).toBeVisible();
   await nameInput.fill(name);
   await nameInput.press("Enter");
@@ -103,7 +106,9 @@ async function setDeviceName(page: Page, name: string) {
 async function setDeviceColour(page: Page, colour: string) {
   // Click the colour row to open picker
   await page.locator(locators.deviceDetail.colourRowButton).click();
-  await expect(page.locator(locators.deviceDetail.colourPickerContainer)).toBeVisible();
+  await expect(
+    page.locator(locators.deviceDetail.colourPickerContainer),
+  ).toBeVisible();
 
   // Find the hex input and set the colour
   const hexInput = page.locator(locators.deviceDetail.colourPickerInput);
@@ -117,14 +122,24 @@ async function setDeviceColour(page: Page, colour: string) {
  * Helper to get current metadata values from the edit panel
  */
 async function getDeviceMetadata(page: Page) {
-  const ip = await page.locator("#device-ip").inputValue();
-  const notes = await page.locator("#device-notes").inputValue();
+  const ip = await page
+    .getByTestId("drawer-device-edit")
+    .getByLabel("IP Address/Hostname")
+    .inputValue();
+  const notes = await page
+    .getByTestId("drawer-device-edit")
+    .getByLabel("Notes")
+    .inputValue();
 
   // Get name from the display text (not the input which only shows when editing)
-  const name = (await page.locator(locators.deviceDetail.displayNameText).textContent()) ?? "";
+  const name =
+    (await page.locator(locators.deviceDetail.displayNameText).textContent()) ??
+    "";
 
   // Get colour from the colour info display
-  const colourText = await page.locator(locators.deviceDetail.colourInfo).textContent();
+  const colourText = await page
+    .locator(locators.deviceDetail.colourInfo)
+    .textContent();
   // Extract hex colour from text (e.g., "#FF6B6B custom")
   const colourMatch = colourText?.match(/#[A-Fa-f0-9]{6}/);
   const colour = colourMatch ? colourMatch[0] : "";
@@ -255,21 +270,30 @@ test.describe("Device Metadata Persistence", () => {
       await setDeviceIp(page, TEST_METADATA.ip);
 
       // Verify IP is set
-      let ip = await page.locator("#device-ip").inputValue();
+      let ip = await page
+        .getByTestId("drawer-device-edit")
+        .getByLabel("IP Address/Hostname")
+        .inputValue();
       expect(ip).toBe(TEST_METADATA.ip);
 
       // Clear the IP field
       await setDeviceIp(page, "", false);
 
       // Verify IP is cleared
-      ip = await page.locator("#device-ip").inputValue();
+      ip = await page
+        .getByTestId("drawer-device-edit")
+        .getByLabel("IP Address/Hostname")
+        .inputValue();
       expect(ip).toBe("");
 
       // Deselect and reselect to verify clear persisted
       await deselectDevice(page);
       await selectDevice(page, 0);
 
-      ip = await page.locator("#device-ip").inputValue();
+      ip = await page
+        .getByTestId("drawer-device-edit")
+        .getByLabel("IP Address/Hostname")
+        .inputValue();
       expect(ip).toBe("");
     });
 
@@ -286,7 +310,10 @@ test.describe("Device Metadata Persistence", () => {
       await setDeviceIp(page, "   ", false);
 
       // Verify IP is cleared (whitespace trimmed to empty)
-      const ip = await page.locator("#device-ip").inputValue();
+      const ip = await page
+        .getByTestId("drawer-device-edit")
+        .getByLabel("IP Address/Hostname")
+        .inputValue();
       expect(ip).toBe("");
     });
 
@@ -317,7 +344,9 @@ test.describe("Device Metadata Persistence", () => {
 
       // Scope assertions to the second rack container
       const secondRack = rackFronts.nth(1);
-      await expect(secondRack.locator(locators.rack.device).first()).toBeVisible();
+      await expect(
+        secondRack.locator(locators.rack.device).first(),
+      ).toBeVisible();
 
       // Click the device in the second rack specifically
       await secondRack.locator(locators.rack.device).first().click();

--- a/e2e/device-name.spec.ts
+++ b/e2e/device-name.spec.ts
@@ -5,6 +5,8 @@ import {
   PLATFORM_MODIFIER,
   loadFileFromDisk,
   locators,
+  startEditingDisplayName,
+  displayNameInput,
 } from "./helpers";
 
 test.describe("Device Custom Names", () => {
@@ -24,10 +26,10 @@ test.describe("Device Custom Names", () => {
     await expect(page.locator(locators.drawer.rightOpen)).toBeVisible();
 
     // Click the display name button to start editing
-    await page.locator(locators.editPanel.displayNameButton).click();
+    await startEditingDisplayName(page);
 
     // Input field should appear
-    const nameInput = page.locator(locators.editPanel.displayNameInput);
+    const nameInput = displayNameInput(page);
     await expect(nameInput).toBeVisible();
 
     // Clear and type new name
@@ -52,8 +54,8 @@ test.describe("Device Custom Names", () => {
     await expect(page.locator(locators.drawer.rightOpen)).toBeVisible();
 
     // Edit the name
-    await page.locator(locators.editPanel.displayNameButton).click();
-    const nameInput = page.locator(locators.editPanel.displayNameInput);
+    await startEditingDisplayName(page);
+    const nameInput = displayNameInput(page);
     await expect(nameInput).toBeVisible();
     await nameInput.fill("Storage Server");
     await nameInput.press("Enter");
@@ -111,8 +113,8 @@ test.describe("Device Custom Names", () => {
       .textContent();
 
     // Edit the name
-    await page.locator(locators.editPanel.displayNameButton).click();
-    const nameInput = page.locator(locators.editPanel.displayNameInput);
+    await startEditingDisplayName(page);
+    const nameInput = displayNameInput(page);
     await expect(nameInput).toBeVisible();
     await nameInput.fill("Custom Name");
     await nameInput.press("Enter");
@@ -161,8 +163,8 @@ test.describe("Device Custom Names", () => {
       .textContent();
 
     // Edit the name to something custom
-    await page.locator(locators.editPanel.displayNameButton).click();
-    let nameInput = page.locator(locators.editPanel.displayNameInput);
+    await startEditingDisplayName(page);
+    let nameInput = displayNameInput(page);
     await expect(nameInput).toBeVisible();
     await nameInput.fill("Custom Name");
     await nameInput.press("Enter");
@@ -173,8 +175,8 @@ test.describe("Device Custom Names", () => {
     );
 
     // Click again and clear the name
-    await page.locator(locators.editPanel.displayNameButton).click();
-    nameInput = page.locator(locators.editPanel.displayNameInput);
+    await startEditingDisplayName(page);
+    nameInput = displayNameInput(page);
     await expect(nameInput).toBeVisible();
     await nameInput.fill("");
     await nameInput.press("Enter");

--- a/e2e/dual-view.spec.ts
+++ b/e2e/dual-view.spec.ts
@@ -82,11 +82,9 @@ test.describe("Dual-View Rack Display", () => {
     await expect(page.locator(locators.rackView.rear)).toBeVisible();
 
     await expect(
-      page.locator('.rack-view-label:has-text("FRONT")'),
+      page.getByTestId("rack-front").getByText("FRONT"),
     ).toBeVisible();
-    await expect(
-      page.locator('.rack-view-label:has-text("REAR")'),
-    ).toBeVisible();
+    await expect(page.getByTestId("rack-rear").getByText("REAR")).toBeVisible();
 
     await expect(page.locator(locators.rackView.frontSvg)).toBeVisible();
     await expect(page.locator(locators.rackView.rearSvg)).toBeVisible();
@@ -108,7 +106,9 @@ test.describe("Dual-View Rack Display", () => {
       timeout: 5000,
     });
 
-    const frontDevices = await page.locator(locators.rackView.frontDevice).count();
+    const frontDevices = await page
+      .locator(locators.rackView.frontDevice)
+      .count();
     expect(frontDevices).toBeGreaterThan(0);
   });
 
@@ -121,7 +121,9 @@ test.describe("Dual-View Rack Display", () => {
       timeout: 5000,
     });
 
-    const rearDevices = await page.locator(locators.rackView.rearDevice).count();
+    const rearDevices = await page
+      .locator(locators.rackView.rearDevice)
+      .count();
     expect(rearDevices).toBeGreaterThan(0);
   });
 
@@ -176,8 +178,12 @@ test.describe("Dual-View Rack Display", () => {
 
     await dragDeviceToRackView(page, "front");
 
-    const frontDevices = await page.locator(locators.rackView.frontDevice).count();
-    const rearDevices = await page.locator(locators.rackView.rearDevice).count();
+    const frontDevices = await page
+      .locator(locators.rackView.frontDevice)
+      .count();
+    const rearDevices = await page
+      .locator(locators.rackView.rearDevice)
+      .count();
 
     expect(frontDevices).toBeGreaterThan(0);
 
@@ -202,7 +208,9 @@ test.describe("Dual-View Export", () => {
     await clickExport(page);
     await expect(page.locator(locators.dialog.root)).toBeVisible();
 
-    const viewSelect = page.locator("#export-view");
+    const viewSelect = page
+      .getByRole("dialog", { name: "Export" })
+      .getByLabel("View");
     await expect(viewSelect).toBeVisible();
 
     await expect(viewSelect.locator('option[value="both"]')).toBeAttached();
@@ -213,7 +221,10 @@ test.describe("Dual-View Export", () => {
   test("export with both views downloads file", async ({ page }) => {
     await clickExport(page);
 
-    await page.selectOption("#export-view", "both");
+    await page
+      .getByRole("dialog", { name: "Export" })
+      .getByLabel("View")
+      .selectOption("both");
 
     const downloadPromise = page.waitForEvent("download");
     await page.click('[data-testid="btn-export-confirm"]');
@@ -225,7 +236,10 @@ test.describe("Dual-View Export", () => {
   test("export with front view only downloads file", async ({ page }) => {
     await clickExport(page);
 
-    await page.selectOption("#export-view", "front");
+    await page
+      .getByRole("dialog", { name: "Export" })
+      .getByLabel("View")
+      .selectOption("front");
 
     const downloadPromise = page.waitForEvent("download");
     await page.click('[data-testid="btn-export-confirm"]');
@@ -237,7 +251,10 @@ test.describe("Dual-View Export", () => {
   test("export with rear view only downloads file", async ({ page }) => {
     await clickExport(page);
 
-    await page.selectOption("#export-view", "rear");
+    await page
+      .getByRole("dialog", { name: "Export" })
+      .getByLabel("View")
+      .selectOption("rear");
 
     const downloadPromise = page.waitForEvent("download");
     await page.click('[data-testid="btn-export-confirm"]');
@@ -251,8 +268,9 @@ test.describe("Dual-View Export", () => {
   }) => {
     await clickExport(page);
 
-    await page.selectOption("#export-format", "svg");
-    await page.selectOption("#export-view", "both");
+    const exportDialog = page.getByRole("dialog", { name: "Export" });
+    await exportDialog.getByLabel("Format").selectOption("svg");
+    await exportDialog.getByLabel("View").selectOption("both");
 
     const downloadPromise = page.waitForEvent("download");
     await page.click('[data-testid="btn-export-confirm"]');

--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -35,7 +35,9 @@ test.describe("Export Functionality", () => {
     await clickExport(page);
 
     // Should have format select dropdown with options
-    const formatSelect = page.locator("#export-format");
+    const formatSelect = page
+      .getByRole("dialog", { name: "Export" })
+      .getByLabel("Format");
     await expect(formatSelect).toBeVisible();
 
     // Verify options exist
@@ -48,7 +50,10 @@ test.describe("Export Functionality", () => {
     await clickExport(page);
 
     // Select PNG format (default, but be explicit)
-    await page.selectOption("#export-format", "png");
+    await page
+      .getByRole("dialog", { name: "Export" })
+      .getByLabel("Format")
+      .selectOption("png");
 
     // Set up download listener
     const downloadPromise = page.waitForEvent("download");
@@ -65,7 +70,10 @@ test.describe("Export Functionality", () => {
     await clickExport(page);
 
     // Select SVG format
-    await page.selectOption("#export-format", "svg");
+    await page
+      .getByRole("dialog", { name: "Export" })
+      .getByLabel("Format")
+      .selectOption("svg");
 
     // Set up download listener
     const downloadPromise = page.waitForEvent("download");
@@ -82,7 +90,10 @@ test.describe("Export Functionality", () => {
     await clickExport(page);
 
     // Select JPEG format
-    await page.selectOption("#export-format", "jpeg");
+    await page
+      .getByRole("dialog", { name: "Export" })
+      .getByLabel("Format")
+      .selectOption("jpeg");
 
     // Set up download listener
     const downloadPromise = page.waitForEvent("download");

--- a/e2e/helpers/device-actions.ts
+++ b/e2e/helpers/device-actions.ts
@@ -2,7 +2,7 @@
  * Shared device action helpers for E2E tests
  * Consolidates duplicated drag-drop and selection code
  */
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import { locators } from "./locators";
 
@@ -16,7 +16,11 @@ import { locators } from "./locators";
  */
 export async function dragDeviceToRack(
   page: Page,
-  options?: { yOffsetPercent?: number; deviceIndex?: number; rackIndex?: number },
+  options?: {
+    yOffsetPercent?: number;
+    deviceIndex?: number;
+    rackIndex?: number;
+  },
 ): Promise<number> {
   const yPercent = options?.yOffsetPercent ?? 10;
   const deviceIndex = options?.deviceIndex ?? 0;
@@ -137,7 +141,7 @@ export async function deleteSelectedDevice(page: Page): Promise<void> {
   const devices = page.locator(locators.rack.device);
   const countBeforeDelete = await devices.count();
 
-  await page.click('button[aria-label="Remove from rack"]');
+  await page.getByRole("button", { name: "Remove from rack" }).click();
 
   await expect(async () => {
     const countAfterDelete = await devices.count();
@@ -145,4 +149,25 @@ export async function deleteSelectedDevice(page: Page): Promise<void> {
   }).toPass({ timeout: 5000 });
 
   await expect(page.locator(locators.drawer.rightOpen)).not.toBeVisible();
+}
+
+/**
+ * Click the device display-name field to enter edit mode.
+ *
+ * In view mode the field is a button (aria-label "Edit display name"); clicking
+ * it swaps in the editable text input.
+ */
+export async function startEditingDisplayName(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Edit display name" }).click();
+}
+
+/**
+ * Locator for the device display-name input shown while editing.
+ *
+ * Scoped to the device-edit drawer so the "Name" label is unambiguous.
+ */
+export function displayNameInput(page: Page): Locator {
+  return page
+    .getByTestId("drawer-device-edit")
+    .getByLabel("Name", { exact: true });
 }

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -20,6 +20,8 @@ export {
   selectDevice,
   deselectDevice,
   deleteSelectedDevice,
+  startEditingDisplayName,
+  displayNameInput,
 } from "./device-actions";
 
 // Rack wizard setup

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -7,8 +7,14 @@
  * `.open`), and variant classes (`.toast--success`) stay as class selectors
  * because they are not the structural anchors covered by testids.
  *
+ * Interactive, user-facing controls (buttons, inputs, dialogs) are NOT listed
+ * here. They are reached with role/label locators (`getByRole`, `getByLabel`)
+ * at the call site, which doubles as an accessibility check and survives DOM
+ * restructuring. This registry holds only string selectors passed to
+ * `page.locator()`.
+ *
  * NOTE: `page.evaluate()` callbacks that use `document.querySelector` are
- * intentionally excluded — those run in the browser context and cannot
+ * intentionally excluded - those run in the browser context and cannot
  * reference this module.
  */
 export const locators = {
@@ -60,7 +66,6 @@ export const locators = {
     rightOpen: 'aside[data-testid="drawer-device-edit"].open',
     /** Variant without the `aside` element prefix (used in some specs) */
     rightOpenBare: '[data-testid="drawer-device-edit"].open',
-    rightRackHeight: '[data-testid="drawer-device-edit"] #rack-height',
   },
 
   canvas: {
@@ -86,11 +91,6 @@ export const locators = {
     dragHandleBar: ".drag-handle-bar",
     backdrop: ".backdrop",
     deviceLibraryFab: ".device-library-fab",
-  },
-
-  editPanel: {
-    displayNameButton: "button.display-name-display",
-    displayNameInput: "input#device-display-name",
   },
 
   deviceDetail: {

--- a/e2e/helpers/rack-setup.ts
+++ b/e2e/helpers/rack-setup.ts
@@ -159,7 +159,7 @@ export async function completeWizardWithClicks(
 
   // Fill name if provided
   if (options?.name) {
-    await page.getByLabel("Rack Name").fill(options.name);
+    await page.getByLabel("Rack Name", { exact: true }).fill(options.name);
   }
 
   // Select layout type

--- a/e2e/helpers/rack-setup.ts
+++ b/e2e/helpers/rack-setup.ts
@@ -100,7 +100,7 @@ export async function completeWizardWithKeyboard(
   options?: WizardOptions,
 ): Promise<void> {
   // Wait for wizard to be visible
-  await expect(page.locator('[role="dialog"]')).toBeVisible();
+  await expect(page.getByRole("dialog", { name: "New Rack" })).toBeVisible();
 
   // Step 1: Name field is auto-focused with default text selected
   if (options?.name) {
@@ -155,11 +155,11 @@ export async function completeWizardWithClicks(
   options?: WizardOptions,
 ): Promise<void> {
   // Wait for wizard
-  await expect(page.locator('[role="dialog"]')).toBeVisible();
+  await expect(page.getByRole("dialog", { name: "New Rack" })).toBeVisible();
 
   // Fill name if provided
   if (options?.name) {
-    await page.fill("#rack-name", options.name);
+    await page.getByLabel("Rack Name").fill(options.name);
   }
 
   // Select layout type

--- a/e2e/helpers/toolbar-actions.ts
+++ b/e2e/helpers/toolbar-actions.ts
@@ -23,7 +23,7 @@ export async function clickNewRack(page: Page): Promise<void> {
  * Click Save via the File menu dropdown.
  */
 export async function clickSave(page: Page): Promise<void> {
-  await page.click('button[aria-label="File menu"]');
+  await page.getByRole("button", { name: "File menu" }).click();
   const saveItem = page.locator('[data-testid="menu-save"]');
   await saveItem.waitFor({ state: "visible" });
   await saveItem.click();
@@ -33,7 +33,7 @@ export async function clickSave(page: Page): Promise<void> {
  * Click Load via the File menu dropdown.
  */
 export async function clickLoad(page: Page): Promise<void> {
-  await page.click('button[aria-label="File menu"]');
+  await page.getByRole("button", { name: "File menu" }).click();
   const loadItem = page.locator('[data-testid="menu-load"]');
   await loadItem.waitFor({ state: "visible" });
   await loadItem.click();

--- a/e2e/multi-rack.spec.ts
+++ b/e2e/multi-rack.spec.ts
@@ -25,7 +25,7 @@ test.describe("Multi-Rack Mode", () => {
 
     // Wizard should open directly — no ConfirmReplaceDialog
     await expect(page.getByRole("dialog", { name: "New Rack" })).toBeVisible();
-    await expect(page.getByLabel("Rack Name")).toBeVisible();
+    await expect(page.getByLabel("Rack Name", { exact: true })).toBeVisible();
   });
 
   test("can create a second rack", async ({ page }) => {
@@ -70,7 +70,7 @@ test.describe("Multi-Rack Mode", () => {
 
     // Wizard should NOT open — wait for hidden to ensure the warning path was taken
     // rather than racing against wizard mount
-    await expect(page.getByLabel("Rack Name")).toBeHidden();
+    await expect(page.getByLabel("Rack Name", { exact: true })).toBeHidden();
 
     // Toast warning should appear
     await expect(page.locator(locators.toast.warning)).toBeVisible();

--- a/e2e/multi-rack.spec.ts
+++ b/e2e/multi-rack.spec.ts
@@ -24,8 +24,8 @@ test.describe("Multi-Rack Mode", () => {
     await clickNewRack(page);
 
     // Wizard should open directly — no ConfirmReplaceDialog
-    await expect(page.locator(locators.dialog.root)).toBeVisible();
-    await expect(page.locator("#rack-name")).toBeVisible();
+    await expect(page.getByRole("dialog", { name: "New Rack" })).toBeVisible();
+    await expect(page.getByLabel("Rack Name")).toBeVisible();
   });
 
   test("can create a second rack", async ({ page }) => {
@@ -70,7 +70,7 @@ test.describe("Multi-Rack Mode", () => {
 
     // Wizard should NOT open — wait for hidden to ensure the warning path was taken
     // rather than racing against wizard mount
-    await expect(page.locator("#rack-name")).toBeHidden();
+    await expect(page.getByLabel("Rack Name")).toBeHidden();
 
     // Toast warning should appear
     await expect(page.locator(locators.toast.warning)).toBeVisible();

--- a/e2e/rack-configuration.spec.ts
+++ b/e2e/rack-configuration.spec.ts
@@ -10,7 +10,7 @@ import { gotoWithRack, clickNewRack, locators } from "./helpers";
 async function openWizardStep2(page: Page, name: string) {
   await clickNewRack(page);
   await expect(page.getByRole("dialog", { name: "New Rack" })).toBeVisible();
-  await page.getByLabel("Rack Name").fill(name);
+  await page.getByLabel("Rack Name", { exact: true }).fill(name);
   // Advance from step 1 (Name/Type) to step 2 (Width/Height)
   await page.click('[data-testid="btn-wizard-next"]');
 }

--- a/e2e/rack-configuration.spec.ts
+++ b/e2e/rack-configuration.spec.ts
@@ -9,8 +9,8 @@ import { gotoWithRack, clickNewRack, locators } from "./helpers";
  */
 async function openWizardStep2(page: Page, name: string) {
   await clickNewRack(page);
-  await expect(page.locator('[role="dialog"]')).toBeVisible();
-  await page.fill("#rack-name", name);
+  await expect(page.getByRole("dialog", { name: "New Rack" })).toBeVisible();
+  await page.getByLabel("Rack Name").fill(name);
   // Advance from step 1 (Name/Type) to step 2 (Width/Height)
   await page.click('[data-testid="btn-wizard-next"]');
 }

--- a/e2e/starter-library.spec.ts
+++ b/e2e/starter-library.spec.ts
@@ -197,12 +197,16 @@ test.describe("Starter Library", () => {
     await expect(paletteItem("1U Patch Panel")).not.toBeVisible();
     await expect(paletteItem("2U Patch Panel")).not.toBeVisible();
 
-    // Router and Firewall merged into Router/Firewall
-    // Note: "1U Router" must match exactly so it does not catch "1U Router/Firewall".
+    // Router and Firewall merged into a single "Router/Firewall" device.
+    // Both branches use exact text matching so neither catches the merged item.
     const routerOnlyItems = page
       .getByTestId("device-palette-item")
       .filter({ has: page.getByText("1U Router", { exact: true }) })
-      .or(paletteItem("1U Firewall"));
+      .or(
+        page
+          .getByTestId("device-palette-item")
+          .filter({ has: page.getByText("1U Firewall", { exact: true }) }),
+      );
     await expect(routerOnlyItems).toHaveCount(0);
   });
 

--- a/e2e/starter-library.spec.ts
+++ b/e2e/starter-library.spec.ts
@@ -183,36 +183,26 @@ test.describe("Starter Library", () => {
   });
 
   test("removed items are NOT present", async ({ page }) => {
+    const paletteItem = (name: string) =>
+      page.getByTestId("device-palette-item").filter({ hasText: name });
+
     // These items were removed from the library
-    await expect(
-      page.locator('.device-palette-item:has-text("1U Generic")'),
-    ).not.toBeVisible();
-    await expect(
-      page.locator('.device-palette-item:has-text("2U Generic")'),
-    ).not.toBeVisible();
-    await expect(
-      page.locator('.device-palette-item:has-text("4U Shelf")'),
-    ).not.toBeVisible();
-    await expect(
-      page.locator('.device-palette-item:has-text("0.5U Blanking Fan")'),
-    ).not.toBeVisible();
+    await expect(paletteItem("1U Generic")).not.toBeVisible();
+    await expect(paletteItem("2U Generic")).not.toBeVisible();
+    await expect(paletteItem("4U Shelf")).not.toBeVisible();
+    await expect(paletteItem("0.5U Blanking Fan")).not.toBeVisible();
 
     // Old names that were renamed
-    await expect(
-      page.locator('.device-palette-item:has-text("1U Switch")'),
-    ).not.toBeVisible();
-    await expect(
-      page.locator('.device-palette-item:has-text("1U Patch Panel")'),
-    ).not.toBeVisible();
-    await expect(
-      page.locator('.device-palette-item:has-text("2U Patch Panel")'),
-    ).not.toBeVisible();
+    await expect(paletteItem("1U Switch")).not.toBeVisible();
+    await expect(paletteItem("1U Patch Panel")).not.toBeVisible();
+    await expect(paletteItem("2U Patch Panel")).not.toBeVisible();
 
     // Router and Firewall merged into Router/Firewall
-    // Note: "1U Router" might partially match "1U Router/Firewall", so use exact
-    const routerOnlyItems = page.locator(
-      '.device-palette-item:text-is("1U Router"), .device-palette-item:has-text("1U Firewall")',
-    );
+    // Note: "1U Router" must match exactly so it does not catch "1U Router/Firewall".
+    const routerOnlyItems = page
+      .getByTestId("device-palette-item")
+      .filter({ has: page.getByText("1U Router", { exact: true }) })
+      .or(paletteItem("1U Firewall"));
     await expect(routerOnlyItems).toHaveCount(0);
   });
 

--- a/e2e/view-reset.spec.ts
+++ b/e2e/view-reset.spec.ts
@@ -45,7 +45,7 @@ test.describe("View Reset on Rack Changes", () => {
 
     // Create a new rack via wizard (multi-rack mode — no replace dialog)
     await clickNewRack(page);
-    await page.fill("#rack-name", "Test Rack");
+    await page.getByLabel("Rack Name").fill("Test Rack");
     await page.click('[data-testid="btn-wizard-next"]');
     await page.click('[data-testid="btn-height-24"]');
     await page.click('[data-testid="btn-wizard-next"]');
@@ -84,7 +84,9 @@ test.describe("View Reset on Rack Changes", () => {
     expect(transformBefore?.x).toBe(-300);
 
     // Click on a different height preset (e.g., 42U)
-    await page.locator('.drawer-right [data-testid="btn-preset-height-42"]').click();
+    await page
+      .locator('.drawer-right [data-testid="btn-preset-height-42"]')
+      .click();
 
     // Wait for the view to reset (transform should change from panned position)
     await expect
@@ -119,8 +121,11 @@ test.describe("View Reset on Rack Changes", () => {
     expect(transformBefore?.x).toBe(-200);
 
     // Use the numeric height input field to change height
-    await page.locator(locators.drawer.rightRackHeight).fill("36");
-    await page.locator(locators.drawer.rightRackHeight).blur();
+    const rackHeightInput = page
+      .getByTestId("drawer-device-edit")
+      .getByLabel("Height");
+    await rackHeightInput.fill("36");
+    await rackHeightInput.blur();
 
     // Wait for the view to reset (transform should change from panned position)
     await expect

--- a/e2e/view-reset.spec.ts
+++ b/e2e/view-reset.spec.ts
@@ -45,7 +45,7 @@ test.describe("View Reset on Rack Changes", () => {
 
     // Create a new rack via wizard (multi-rack mode — no replace dialog)
     await clickNewRack(page);
-    await page.getByLabel("Rack Name").fill("Test Rack");
+    await page.getByLabel("Rack Name", { exact: true }).fill("Test Rack");
     await page.click('[data-testid="btn-wizard-next"]');
     await page.click('[data-testid="btn-height-24"]');
     await page.click('[data-testid="btn-wizard-next"]');
@@ -123,7 +123,7 @@ test.describe("View Reset on Rack Changes", () => {
     // Use the numeric height input field to change height
     const rackHeightInput = page
       .getByTestId("drawer-device-edit")
-      .getByLabel("Height");
+      .getByLabel("Height", { exact: true });
     await rackHeightInput.fill("36");
     await rackHeightInput.blur();
 


### PR DESCRIPTION
## **User description**
## Summary

Migrates the Playwright E2E helper layer away from brittle CSS class / `#id` / `[role=...]` / `[aria-label=...]` string selectors to Playwright's role and label locators (`getByRole`, `getByLabel`, `getByTestId`). Role/label locators double as accessibility checks and survive DOM restructuring, so a passing selector also asserts the element kept its accessible name.

This is the foundation for the sibling E2E work (#1264 stale selectors, #1231 a11y coverage, #1227 undo/redo coverage, #1423 lint rule). The helper layer is now clean so those build on it.

Builds on #1419, which added `data-testid` to structural components.

## Acceptance criteria

- [x] No `:has-text()` selectors remain in helper modules
- [x] No `#id` selectors remain in helper modules (use `getByLabel` instead)
- [x] Spec files migrated to use semantic locators where possible
- [x] All E2E tests pass (110 passed, 6 skipped on chromium; webkit smoke on touched specs also green)
- [x] Migration prioritised by helper impact (device-actions, rack-setup, toolbar-actions)

## What changed

Helpers:
- `rack-setup`: wizard dialog via `getByRole("dialog", { name: "New Rack" })`; name field via `getByLabel("Rack Name")`
- `toolbar-actions`: File menu via `getByRole("button", { name: "File menu" })`
- `device-actions`: Remove button via `getByRole`; adds `startEditingDisplayName()` and `displayNameInput()` for the click-to-edit display-name flow (used 6x across specs)
- `locators`: drops the `#id` / interactive-class entries (`drawer.rightRackHeight`, `editPanel.*`). The registry now holds only structural string anchors passed to `page.locator()`; interactive controls are reached with role/label locators at the call site.

Specs migrated where a semantic target exists: rack name, rack height, device name, device IP/notes, export format/view, custom device form, device palette items, dual-view FRONT/REAR labels.

## Notes

- Ambiguous labels are scoped to their dialog/drawer to avoid Playwright strict-mode collisions (e.g. "View" collides with the "Reset View" toolbar button, so export selects are scoped to the Export dialog; the display-name "Name" input uses `{ exact: true }` so it does not match "IP Address/Hostname").
- The `waitForSaved` helper's `label:has-text(...)` selectors target a non-semantic `.saved-indicator` leaf with no role/testid; left for the sibling stale-selectors issue (#1264).
- Does not add the ESLint enforcement rule, which is tracked separately in #1423.

Closes #1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Use role and label locators in E2E tests**

### What Changed
- E2E helpers now click and fill the same user-facing controls through their visible labels and roles instead of page IDs and CSS selectors
- The device name edit flow now uses dedicated helpers to open the name field and edit it inside the device drawer
- Export, rack setup, and metadata tests now target the dialog or drawer the user sees, including format, view, rack name, IP address, notes, and height fields
- Device and palette checks now use test IDs with visible text filters, which makes the test expectations less dependent on page structure

### Impact
`✅ Fewer flaky E2E failures after layout changes`
`✅ Stronger coverage of accessible labels and dialog names`
`✅ More reliable export and device-edit test flows`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
