### PR TITLE
fix: make block-main-edits hook worktree-aware

### DIFF
--- a/.claude/hooks/block-main-edits.sh
+++ b/.claude/hooks/block-main-edits.sh
@@ -3,16 +3,15 @@
 # inside this project. Edits to files outside CLAUDE_PROJECT_DIR (e.g. global
 # ~/.claude config or other repos) are always allowed - the branch of this
 # project says nothing about them.
+#
+# Worktree-aware: the branch that matters is the one checked out in the worktree
+# that actually CONTAINS the target file, not the main checkout. A linked
+# worktree (e.g. under .worktree/) sits on a feature branch even while the
+# primary checkout is on main, so edits there must be allowed.
 set -euo pipefail
 
 # Capture the hook payload (JSON with tool_input.file_path, session_id, cwd).
 INPUT=$(cat)
-
-# Only the project's main/master branch is guarded.
-BRANCH=$(git -C "${CLAUDE_PROJECT_DIR:-.}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
-  exit 0
-fi
 
 # Project root as provided by the harness (same path namespace as file_path).
 # Do NOT resolve symlinks here: file_path and CLAUDE_PROJECT_DIR share the
@@ -31,10 +30,29 @@ if [ -z "$FILE_PATH" ] || [ -z "$PROJECT_DIR" ]; then
   exit 0
 fi
 
-# Block only when the edit targets a file inside the project.
+# Only files inside the project are guarded. Anything outside (global config,
+# other repos) is always allowed.
 case "$FILE_PATH" in
-  "$PROJECT_DIR"/*)
-    cat <<BLOCK
+  "$PROJECT_DIR"/*) ;;
+  *) exit 0 ;;
+esac
+
+# Resolve the branch of the worktree that OWNS the target file. Walk up to the
+# nearest existing ancestor directory first, because the file (or its parent
+# dir) may not exist yet on a new Write. A linked worktree reports its own
+# feature branch here, which is the whole point of this check.
+DIR=$(dirname "$FILE_PATH")
+while [ "$DIR" != "/" ] && [ ! -d "$DIR" ]; do
+  DIR=$(dirname "$DIR")
+done
+BRANCH=$(git -C "$DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# Only the project's main/master branch is guarded.
+if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
+  exit 0
+fi
+
+cat <<BLOCK
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
@@ -43,8 +61,3 @@ case "$FILE_PATH" in
   }
 }
 BLOCK
-    ;;
-  *)
-    exit 0
-    ;;
-esac


### PR DESCRIPTION
## **User description**
## Summary

Makes `.claude/hooks/block-main-edits.sh` worktree-aware. Follow-up to #2237.

The guard checked the main checkout's branch and blocked any edit under the project dir, which wrongly blocked edits in linked worktrees nested under the project (the `.worktree/Rackula-issue-NNNN` paths the gh-dev and dev-issue skills prescribe). Those worktrees are on feature branches even while the primary checkout is on main, so issue work from a main checkout was being blocked.

Now the hook resolves the branch of the worktree that actually contains the target file (walking up to the nearest existing ancestor for not-yet-created files) and blocks only when that branch is main/master.

## Behaviour

| Target | Before | After |
| --- | --- | --- |
| File in the main tree (on main) | blocked | blocked |
| File in a nested feature-branch worktree | blocked (bug) | allowed |
| File outside the project dir | allowed | allowed |
| New file in a not-yet-created dir on main | blocked | blocked |

## Test Plan

Simulated the hook with payloads for each case above:
- [x] main-tree file on main -> deny
- [x] feature-branch worktree file -> allow
- [x] file outside project dir -> allow
- [x] new file / new dir on main -> deny
- [x] empty file_path -> allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Allow edits in linked worktrees while keeping main-branch protection**

### What Changed
- Edits inside linked worktrees are now allowed when that worktree is on a feature branch, instead of being blocked just because the main checkout is on `main`
- Files in the main project checkout on `main` or `master` are still blocked
- Edits outside the project directory remain allowed
- New files and files in new folders are checked using the nearest existing parent path, so they are handled correctly

### Impact
`✅ Fewer blocked edits in feature worktrees`
`✅ Safer protection for main-branch project files`
`✅ Smoother issue worktree flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
