### PR TITLE
fix: load images embedded in YAML applied through the panel (#2220)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -309,6 +309,19 @@
           imageStore.setDeviceImage(key, "rear", deviceImages.rear);
         }
       }
+      // A pasted layout brings its own complete image set, so drop user images
+      // orphaned by it (keys the applied layout no longer uses). Valid keys are
+      // the layout's device-type slugs plus per-placement keys; image-free edits
+      // skip this block and leave the store untouched.
+      // getUsedDeviceTypeSlugs returns a fresh set we own, so we extend it in
+      // place with per-placement keys rather than allocating another set.
+      const usedImageKeys = layoutStore.getUsedDeviceTypeSlugs();
+      for (const rack of nextLayout.racks) {
+        for (const device of rack.devices) {
+          usedImageKeys.add(`placement-${device.id}`);
+        }
+      }
+      imageStore.cleanupOrphanedImages(usedImageKeys);
     }
     selectionStore.clearSelection();
     toastStore.showToast("YAML applied", "success");

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -302,6 +302,9 @@
     // image store is preserved untouched.
     if (images && images.size > 0) {
       for (const [key, deviceImages] of images) {
+        // Replace the whole key, not per-side: a paste that omits one side must
+        // not leave the previously stored opposite-side image behind.
+        imageStore.removeAllDeviceImages(key);
         if (deviceImages.front) {
           imageStore.setDeviceImage(key, "front", deviceImages.front);
         }

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -32,6 +32,7 @@
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
+  import type { ImageStoreMap } from "$lib/types/images";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
@@ -281,7 +282,11 @@
     handleFitAll();
   }
 
-  function handleYamlApply(nextLayout: Layout) {
+  function handleYamlApply(
+    nextLayout: Layout,
+    images?: ImageStoreMap,
+    failedImagesCount = 0,
+  ) {
     // Applying YAML edits the working copy; preserve export tracking
     // across loadLayout's reset so the chip state survives the apply.
     const backupState = {
@@ -291,8 +296,28 @@
     layoutStore.loadLayout(nextLayout);
     layoutStore.restoreBackupState(backupState);
     layoutStore.markDirty();
+    // Overlay any images decoded from the applied YAML (e.g. a pasted full
+    // layout that carries an embedded images section). The panel shows
+    // image-free YAML, so a structural edit carries no images and the existing
+    // image store is preserved untouched.
+    if (images && images.size > 0) {
+      for (const [key, deviceImages] of images) {
+        if (deviceImages.front) {
+          imageStore.setDeviceImage(key, "front", deviceImages.front);
+        }
+        if (deviceImages.rear) {
+          imageStore.setDeviceImage(key, "rear", deviceImages.rear);
+        }
+      }
+    }
     selectionStore.clearSelection();
     toastStore.showToast("YAML applied", "success");
+    if (failedImagesCount > 0) {
+      toastStore.showToast(
+        `Applied with ${failedImagesCount} image${failedImagesCount > 1 ? "s" : ""} that couldn't be read`,
+        "warning",
+      );
+    }
 
     if (viewportStore.isMobile) {
       dialogStore.closeSheet();

--- a/src/lib/components/LayoutYamlPanel.svelte
+++ b/src/lib/components/LayoutYamlPanel.svelte
@@ -4,10 +4,11 @@
   import { LayoutSchema } from "$lib/schemas";
   import { buildYamlFilename } from "$lib/utils/folder-structure";
   import {
-    parseLayoutYaml,
+    parseLayoutYamlWithImages,
     parseYaml,
     serializeLayoutToYaml,
   } from "$lib/utils/yaml";
+  import type { ImageStoreMap } from "$lib/types/images";
   import { layoutDebug } from "$lib/utils/debug";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { IconCopy, IconDownload } from "./icons";
@@ -16,7 +17,11 @@
   interface Props {
     open: boolean;
     layout: Layout;
-    onapply?: (layout: Layout) => void | Promise<void>;
+    onapply?: (
+      layout: Layout,
+      images?: ImageStoreMap,
+      failedImagesCount?: number,
+    ) => void | Promise<void>;
   }
 
   let { open, layout, onapply }: Props = $props();
@@ -33,7 +38,8 @@
   let schemaError = $state<string | null>(null);
   let showConflictPrompt = $state(false);
   let latestYamlAtConflict = $state<string | null>(null);
-  let pendingLayout = $state<Layout | null>(null);
+  type ParsedYaml = Awaited<ReturnType<typeof parseLayoutYamlWithImages>>;
+  let pendingLayout = $state<ParsedYaml | null>(null);
 
   let validationTimer: ReturnType<typeof setTimeout> | null = null;
   let validationRun = 0;
@@ -219,11 +225,11 @@
     URL.revokeObjectURL(url);
   }
 
-  async function commitParsedLayout(nextLayout: Layout): Promise<void> {
+  async function commitParsedLayout(parsed: ParsedYaml): Promise<void> {
     isApplying = true;
     try {
-      await onapply?.(nextLayout);
-      await syncFromLayout(nextLayout);
+      await onapply?.(parsed.layout, parsed.images, parsed.failedImagesCount);
+      await syncFromLayout(parsed.layout);
       isEditing = false;
       showConflictPrompt = false;
       latestYamlAtConflict = null;
@@ -240,9 +246,9 @@
     const intent = ++applyIntentId;
     debug("apply started, intent=%d", intent);
 
-    let parsedLayout: Layout;
+    let parsed: ParsedYaml;
     try {
-      parsedLayout = await parseLayoutYaml(yamlText);
+      parsed = await parseLayoutYamlWithImages(yamlText);
     } catch (error) {
       schemaError = toErrorMessage(error);
       return;
@@ -254,13 +260,13 @@
 
     if (latestYaml !== baselineYaml) {
       debug("conflict detected, baselineYaml differs from latestYaml");
-      pendingLayout = parsedLayout;
+      pendingLayout = parsed;
       latestYamlAtConflict = latestYaml;
       showConflictPrompt = true;
       return;
     }
 
-    await commitParsedLayout(parsedLayout);
+    await commitParsedLayout(parsed);
   }
 
   async function handleApplyAnyway(): Promise<void> {

--- a/src/tests/LayoutYamlPanel.test.ts
+++ b/src/tests/LayoutYamlPanel.test.ts
@@ -188,4 +188,44 @@ describe("LayoutYamlPanel", () => {
       );
     });
   });
+
+  it("passes images decoded from a pasted YAML to onapply", async () => {
+    const onApply = vi.fn();
+    render(LayoutYamlPanel, {
+      props: { open: true, layout: baseLayout, onapply: onApply },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("yaml-textarea")).toHaveDisplayValue(
+        /name: Baseline Layout/,
+      );
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Edit YAML" }));
+    const textarea = screen.getByTestId("yaml-textarea");
+
+    // A valid layout plus an embedded images section (real PNG magic bytes).
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 1, 2, 3,
+    ]);
+    let binary = "";
+    for (const b of pngBytes) binary += String.fromCharCode(b);
+    const pngDataUrl = `data:image/png;base64,${btoa(binary)}`;
+    const baseYaml = await yamlUtils.serializeLayoutToYaml(
+      createTestLayout({ name: "Pasted Layout" }),
+    );
+    const yamlWithImages = `${baseYaml}\nimages:\n  my-device:\n    front: "${pngDataUrl}"\n`;
+
+    await fireEvent.input(textarea, { target: { value: yamlWithImages } });
+    await waitForValidation(/YAML is valid/i);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Apply YAML" }));
+    await waitFor(() => {
+      expect(onApply).toHaveBeenCalledTimes(1);
+    });
+    const images = onApply.mock.calls[0]?.[1] as
+      | Map<string, unknown>
+      | undefined;
+    expect(images?.has("my-device")).toBe(true);
+  });
 });

--- a/src/tests/LayoutYamlPanel.test.ts
+++ b/src/tests/LayoutYamlPanel.test.ts
@@ -227,5 +227,7 @@ describe("LayoutYamlPanel", () => {
       | Map<string, unknown>
       | undefined;
     expect(images?.has("my-device")).toBe(true);
+    // The widened callback contract also carries the failed-image count.
+    expect(onApply.mock.calls[0]?.[2]).toBe(0);
   });
 });


### PR DESCRIPTION
## **User description**
## What
Loads images embedded in a YAML layout applied through the editor panel. Closes #2220.

## Investigation
The original report ("LayoutYamlPanel drops images on Apply") is a false positive for normal use: the panel shows image-free YAML, and on Apply `DialogOrchestrator.handleYamlApply` calls `layoutStore.loadLayout`, which does not touch the image store. So images keyed by device survive a structural edit and still embed on the next save.

The one real gap: if a user pastes a complete external `.rackula.yaml` that contains an embedded `images:` section, `handleApply` used `parseLayoutYaml` (which strips/ignores `images`), so those pasted images were never decoded.

## Change
- `LayoutYamlPanel.handleApply` now uses `parseLayoutYamlWithImages` and passes the decoded images + failed count to `onapply`.
- `DialogOrchestrator.handleYamlApply` overlays any decoded images onto the store (via `setDeviceImage`) and warns when some couldn't be read. Image-free edits decode no images, so the existing store is preserved untouched.

## Tests
`LayoutYamlPanel.test.ts`: applying a YAML with an embedded `images:` section passes the decoded images to `onapply`. Image decode/validation itself is covered by `yaml-images.test.ts` (#617).


___

## **CodeAnt-AI Description**
**Keep embedded images when applying pasted YAML**

### What Changed
- Applying YAML from the editor now keeps any embedded device images included in a pasted layout
- If some images in the pasted YAML cannot be read, the app still applies the layout and shows a warning
- Normal YAML edits still leave existing images unchanged

### Impact
`✅ Fewer lost device images after YAML edits`
`✅ Safer paste-and-apply for full layout files`
`✅ Clearer warnings for unreadable images`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
