### PR TITLE
refactor: extract App.svelte dialog and rack action bodies (#2025)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -46,7 +46,6 @@
     maybeSave,
     maybeSaveAs,
     maybeExport,
-    prepareExportQrCode,
     handleShare,
     handleFitAll,
   } from "$lib/utils/app-actions";
@@ -58,6 +57,12 @@
     handleImportFromNetBox,
     handleOpenYamlEditor,
   } from "$lib/utils/dialog-actions";
+  import {
+    handleRackContextDuplicate,
+    handleRackContextDelete,
+    handleRackContextExport,
+    handleRackContextFocus,
+  } from "$lib/utils/rack-actions";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
@@ -75,7 +80,6 @@
   import { VERSION } from "$lib/version";
   import { persistenceDebug } from "$lib/utils/debug";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
-  import { DRAWER_WIDTH } from "$lib/constants/layout";
   import { Tooltip } from "bits-ui";
   import { debounce } from "$lib/utils/debounce";
   import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
@@ -563,49 +567,6 @@
 
   function handleRackContextRename(rackId: string) {
     handleRackContextEdit(rackId);
-  }
-
-  function handleRackContextDuplicate(rackId: string) {
-    const result = layoutStore.duplicateRack(rackId);
-    if (result.error) {
-      toastStore.showToast(result.error, "error");
-    } else {
-      toastStore.showToast("Rack duplicated", "success");
-      handleFitAll();
-    }
-  }
-
-  function handleRackContextDelete(rackId: string) {
-    const rack = layoutStore.getRackById(rackId);
-    if (rack) {
-      layoutStore.setActiveRack(rackId);
-      selectionStore.selectRack(rackId);
-      dialogStore.deleteTarget = { type: "rack", name: rack.name };
-      dialogStore.open("confirmDelete");
-    }
-  }
-
-  async function handleRackContextExport(rackIds: string[]) {
-    if (rackIds.length === 0) {
-      toastStore.showToast("No rack to export", "warning");
-      return;
-    }
-
-    await prepareExportQrCode();
-
-    dialogStore.exportSelectedRackIds = rackIds;
-    dialogStore.open("export");
-  }
-
-  function handleRackContextFocus(rackIds: string[]) {
-    if (rackIds.length === 0) return;
-    const rightOffset = uiStore.rightDrawerOpen ? DRAWER_WIDTH : 0;
-    canvasStore.focusRack(
-      rackIds,
-      layoutStore.racks,
-      layoutStore.rack_groups,
-      rightOffset,
-    );
   }
 
   // DialogOrchestrator component reference for delegating calls

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -50,6 +50,14 @@
     handleShare,
     handleFitAll,
   } from "$lib/utils/app-actions";
+  import {
+    handleNewRack,
+    handleDelete,
+    handleHelp,
+    handleAddDevice,
+    handleImportFromNetBox,
+    handleOpenYamlEditor,
+  } from "$lib/utils/dialog-actions";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
@@ -510,45 +518,6 @@
   // --- Thin wrappers for Toolbar/Canvas/KeyboardHandler callbacks ---
   // These delegate to dialogStore; the actual dialog logic lives in DialogOrchestrator.
 
-  function handleNewRack() {
-    if (!layoutStore.canAddRack) {
-      toastStore.showToast("Maximum number of racks reached", "warning");
-      return;
-    }
-    dialogStore.open("newRack");
-  }
-
-  function handleDelete() {
-    if (selectionStore.isRackSelected && selectionStore.selectedRackId) {
-      const rack = layoutStore.getRackById(selectionStore.selectedRackId);
-      if (rack) {
-        dialogStore.deleteTarget = { type: "rack", name: rack.name };
-        dialogStore.open("confirmDelete");
-      }
-    } else if (selectionStore.isDeviceSelected) {
-      if (
-        selectionStore.selectedRackId !== null &&
-        selectionStore.selectedDeviceId !== null
-      ) {
-        const rack = layoutStore.getRackById(selectionStore.selectedRackId);
-        const deviceIndex = selectionStore.getSelectedDeviceIndex(
-          rack?.devices ?? [],
-        );
-        if (rack && deviceIndex !== null && rack.devices[deviceIndex]) {
-          const device = rack.devices[deviceIndex];
-          const deviceDef = layoutStore.device_types.find(
-            (d) => d.slug === device?.device_type,
-          );
-          dialogStore.deleteTarget = {
-            type: "device",
-            name: deviceDef?.model ?? deviceDef?.slug ?? "Device",
-          };
-          dialogStore.open("confirmDelete");
-        }
-      }
-    }
-  }
-
   function handleToggleTheme() {
     uiStore.toggleTheme();
   }
@@ -563,31 +532,10 @@
     uiStore.toggleAnnotations();
   }
 
-  function handleHelp() {
-    dialogStore.open("help");
-  }
-
-  function handleAddDevice() {
-    dialogStore.closeSheet();
-    dialogStore.open("addDevice");
-  }
-
-  function handleImportFromNetBox() {
-    dialogStore.open("importNetBox");
-  }
-
   function handleImportDevices() {
     // Delegates to DialogOrchestrator's hidden file input via dialogStore
     // The DialogOrchestrator handles the actual file input click
     dialogOrchestrator.handleImportDevices();
-  }
-
-  function handleOpenYamlEditor() {
-    if (viewportStore.isMobile) {
-      dialogStore.openSheet("yamlEditor");
-      return;
-    }
-    dialogStore.open("yamlEditor");
   }
 
   function handleOpenCleanupDialog() {

--- a/src/lib/utils/dialog-actions.ts
+++ b/src/lib/utils/dialog-actions.ts
@@ -1,0 +1,81 @@
+/**
+ * Dialog-entry actions: parameterless verbs that open (or guard the opening
+ * of) the app's dialogs. Each resolves its own store singletons internally so
+ * a future command registry can call them as `run:` targets.
+ */
+import { getLayoutStore } from "$lib/stores/layout.svelte";
+import { getSelectionStore } from "$lib/stores/selection.svelte";
+import { getToastStore } from "$lib/stores/toast.svelte";
+import { getViewportStore } from "$lib/utils/viewport.svelte";
+import { dialogStore } from "$lib/stores/dialogs.svelte";
+
+/** Open the New Rack dialog; warns when the rack limit is reached. */
+export function handleNewRack(): void {
+  const layoutStore = getLayoutStore();
+  const toastStore = getToastStore();
+  if (!layoutStore.canAddRack) {
+    toastStore.showToast("Maximum number of racks reached", "warning");
+    return;
+  }
+  dialogStore.open("newRack");
+}
+
+/** Open the confirm-delete dialog for the selected rack or device. */
+export function handleDelete(): void {
+  const layoutStore = getLayoutStore();
+  const selectionStore = getSelectionStore();
+  if (selectionStore.isRackSelected && selectionStore.selectedRackId) {
+    const rack = layoutStore.getRackById(selectionStore.selectedRackId);
+    if (rack) {
+      dialogStore.deleteTarget = { type: "rack", name: rack.name };
+      dialogStore.open("confirmDelete");
+    }
+  } else if (selectionStore.isDeviceSelected) {
+    if (
+      selectionStore.selectedRackId !== null &&
+      selectionStore.selectedDeviceId !== null
+    ) {
+      const rack = layoutStore.getRackById(selectionStore.selectedRackId);
+      const deviceIndex = selectionStore.getSelectedDeviceIndex(
+        rack?.devices ?? [],
+      );
+      if (rack && deviceIndex !== null && rack.devices[deviceIndex]) {
+        const device = rack.devices[deviceIndex];
+        const deviceDef = layoutStore.device_types.find(
+          (d) => d.slug === device?.device_type,
+        );
+        dialogStore.deleteTarget = {
+          type: "device",
+          name: deviceDef?.model ?? deviceDef?.slug ?? "Device",
+        };
+        dialogStore.open("confirmDelete");
+      }
+    }
+  }
+}
+
+/** Open the keyboard-shortcuts help dialog. */
+export function handleHelp(): void {
+  dialogStore.open("help");
+}
+
+/** Close any open sheet, then open the Add Device dialog. */
+export function handleAddDevice(): void {
+  dialogStore.closeSheet();
+  dialogStore.open("addDevice");
+}
+
+/** Open the import-from-NetBox dialog. */
+export function handleImportFromNetBox(): void {
+  dialogStore.open("importNetBox");
+}
+
+/** Open the YAML editor as a sheet on mobile, otherwise as a dialog. */
+export function handleOpenYamlEditor(): void {
+  const viewportStore = getViewportStore();
+  if (viewportStore.isMobile) {
+    dialogStore.openSheet("yamlEditor");
+    return;
+  }
+  dialogStore.open("yamlEditor");
+}

--- a/src/lib/utils/rack-actions.ts
+++ b/src/lib/utils/rack-actions.ts
@@ -1,0 +1,70 @@
+/**
+ * Rack context-menu actions invoked from the canvas and rack list. Each
+ * resolves its own store singletons internally so a future command registry
+ * can call them with an event-derived rack id.
+ */
+import { getLayoutStore } from "$lib/stores/layout.svelte";
+import { getSelectionStore } from "$lib/stores/selection.svelte";
+import { getUIStore } from "$lib/stores/ui.svelte";
+import { getCanvasStore } from "$lib/stores/canvas.svelte";
+import { getToastStore } from "$lib/stores/toast.svelte";
+import { dialogStore } from "$lib/stores/dialogs.svelte";
+import { DRAWER_WIDTH } from "$lib/constants/layout";
+import { handleFitAll, prepareExportQrCode } from "./app-actions";
+
+/** Duplicate a rack, then fit all on success or toast the error. */
+export function handleRackContextDuplicate(rackId: string): void {
+  const layoutStore = getLayoutStore();
+  const toastStore = getToastStore();
+  const result = layoutStore.duplicateRack(rackId);
+  if (result.error) {
+    toastStore.showToast(result.error, "error");
+  } else {
+    toastStore.showToast("Rack duplicated", "success");
+    handleFitAll();
+  }
+}
+
+/** Select a rack and open the confirm-delete dialog targeting it. */
+export function handleRackContextDelete(rackId: string): void {
+  const layoutStore = getLayoutStore();
+  const selectionStore = getSelectionStore();
+  const rack = layoutStore.getRackById(rackId);
+  if (rack) {
+    layoutStore.setActiveRack(rackId);
+    selectionStore.selectRack(rackId);
+    dialogStore.deleteTarget = { type: "rack", name: rack.name };
+    dialogStore.open("confirmDelete");
+  }
+}
+
+/** Open the export dialog for the given racks; warns if none are selected. */
+export async function handleRackContextExport(
+  rackIds: string[],
+): Promise<void> {
+  const toastStore = getToastStore();
+  if (rackIds.length === 0) {
+    toastStore.showToast("No rack to export", "warning");
+    return;
+  }
+
+  await prepareExportQrCode();
+
+  dialogStore.exportSelectedRackIds = rackIds;
+  dialogStore.open("export");
+}
+
+/** Focus the canvas on the given racks, accounting for the right drawer. */
+export function handleRackContextFocus(rackIds: string[]): void {
+  const layoutStore = getLayoutStore();
+  const uiStore = getUIStore();
+  const canvasStore = getCanvasStore();
+  if (rackIds.length === 0) return;
+  const rightOffset = uiStore.rightDrawerOpen ? DRAWER_WIDTH : 0;
+  canvasStore.focusRack(
+    rackIds,
+    layoutStore.racks,
+    layoutStore.rack_groups,
+    rightOffset,
+  );
+}


### PR DESCRIPTION
## **User description**
## Summary

Decomposition of `App.svelte` (M04), behaviour-preserving. Extracts the
dialog-entry verbs and reusable rack-action bodies into two new modules that
mirror the existing `src/lib/utils/app-actions.ts` pattern (plain exported
functions that resolve their store singletons internally).

- `src/lib/utils/dialog-actions.ts` -- `handleNewRack`, `handleDelete`,
  `handleHelp`, `handleAddDevice`, `handleImportFromNetBox`, `handleOpenYamlEditor`
  (parameterless verbs, ready to be `run:` targets for the M14 command registry #2096).
- `src/lib/utils/rack-actions.ts` -- `handleRackContextDuplicate`,
  `handleRackContextDelete`, `handleRackContextExport`, `handleRackContextFocus`.

`App.svelte` drops from 891 to 800 lines; now-unused `DRAWER_WIDTH` and
`prepareExportQrCode` imports removed.

## Scope (partial -- issue stays open)

This is the **dialog half** only, per the #2025 alignment audit (2026-06-12):

- **Deferred -- persistence wiring:** the ~220-line startup/autosave `onMount`
  block stays in `App.svelte`. M15 #2041 and #2044 rewrite those same paths in
  `src/lib/storage/manager.svelte.ts`; extracting now would be double work and a
  merge-conflict magnet. It lands with that M15 work.
- **Left in App.svelte deliberately -- rack interaction wrappers:**
  `handleRackLongPress`, `handleRackContextEdit`, `handleRackContextRename`.
  M14 #2018 (tabs) and #2075 (floating verb bars) rewrite how these are invoked,
  so their signatures are rewrite-bait, not survivors. Only the reusable action
  bodies were extracted.

## Test plan

- [x] `npm run lint` -- clean
- [x] `npm run test:run` -- full suite (2209 tests) passes, no test files modified
- [x] `npm run check` -- no new type errors (one pre-existing `@types/qrcode` error unrelated)
- [x] No import cycle (`rack-actions` -> `app-actions` only)

Part of #2025 (dialog half; persistence half deferred to #2041/#2044).


___

## **CodeAnt-AI Description**
**Move dialog and rack actions out of the main app file**

### What Changed
- Moved the app’s dialog-opening actions into a separate module, including new rack, delete, help, add device, NetBox import, and YAML editor actions
- Moved rack context actions into a separate module for duplicate, delete, export, and focus behavior
- Removed now-unused imports from the main app file while keeping the same app behavior

### Impact
`✅ Easier future command shortcuts`
`✅ Fewer changes needed in the main app file`
`✅ Lower risk of action wiring regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
