### PR TITLE
feat: storage status chip in workspace toolbar (#2035)

### DIFF
--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -1,0 +1,200 @@
+<!--
+  StorageStatusChip Component
+  Workspace-wide storage status surfaced in the toolbar. Reads the single
+  durability source (getLayoutDurability) and never recomputes status itself.
+
+  Accessibility: state is conveyed by icon + text, never colour alone
+  (WCAG 1.4.1). The button's accessible name carries the current state, and a
+  visually-hidden live region announces settled state changes.
+-->
+<script lang="ts">
+  import { Popover } from "bits-ui";
+  import { IconCheck, IconClock, IconWarningTriangle } from "./icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import {
+    getLayoutDurability,
+    handleSaveAsArchive,
+    loadFromFile,
+  } from "$lib/storage";
+  import "$lib/styles/menu.css";
+
+  const durability = getLayoutDurability(getLayoutStore());
+
+  let open = $state(false);
+
+  // Announced only after the status settles. The save->saved debounce cascade
+  // produces several intermediate statuses in quick succession; announcing every
+  // one would spam a screen reader. We announce the label ~500ms after the last
+  // change, so only the settled state reaches the live region.
+  let announced = $state("");
+  $effect(() => {
+    const label = durability.label;
+    const timer = setTimeout(() => {
+      announced = label;
+    }, 500);
+    return () => clearTimeout(timer);
+  });
+
+  async function handleExportNow() {
+    // Export embeds images (#617) and round-trips unknown sections (#2208), so
+    // resetting changesSinceExport on export is honest: nothing is silently
+    // dropped. The chip therefore needs no separate image-dropping warning state.
+    await handleSaveAsArchive();
+    open = false;
+  }
+
+  async function handleRestore() {
+    await loadFromFile();
+    open = false;
+  }
+</script>
+
+<Popover.Root bind:open>
+  <Popover.Trigger
+    class="storage-chip storage-chip-{durability.status}"
+    aria-label={`Storage status: ${durability.label}`}
+    data-testid="storage-status-chip"
+  >
+    {#if durability.icon === "saved"}
+      <IconCheck size={ICON_SIZE.sm} />
+    {:else if durability.icon === "pending"}
+      <IconClock size={ICON_SIZE.sm} />
+    {:else}
+      <IconWarningTriangle size={ICON_SIZE.sm} />
+    {/if}
+    <span class="storage-chip-text">{durability.label}</span>
+  </Popover.Trigger>
+
+  <Popover.Portal>
+    <Popover.Content
+      class="menu-content menu-inline storage-chip-popover"
+      sideOffset={6}
+      align="end"
+    >
+      <p class="storage-chip-state">{durability.label}</p>
+      <p class="storage-chip-detail">
+        {durability.mode === "server" ? "Saved to server" : "Stored in this browser"}
+      </p>
+      <div class="storage-chip-actions">
+        <button
+          type="button"
+          class="storage-chip-action"
+          onclick={handleExportNow}
+          data-testid="storage-chip-export"
+        >
+          Export now
+        </button>
+        <button
+          type="button"
+          class="storage-chip-action"
+          onclick={handleRestore}
+          data-testid="storage-chip-restore"
+        >
+          Restore from file
+        </button>
+      </div>
+    </Popover.Content>
+  </Popover.Portal>
+</Popover.Root>
+
+<span class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+  {announced}
+</span>
+
+<style>
+  :global(.storage-chip) {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    height: 28px;
+    padding: 0 var(--space-2);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--colour-text);
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out),
+      color var(--duration-fast) var(--ease-out);
+  }
+
+  :global(.storage-chip:hover) {
+    background: var(--colour-surface-hover);
+  }
+
+  :global(.storage-chip:focus-visible) {
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--colour-bg),
+      0 0 0 4px var(--colour-focus-ring);
+  }
+
+  /* Colour reinforces, never replaces, the icon + text. */
+  :global(.storage-chip-saved) {
+    color: var(--colour-success);
+  }
+
+  :global(.storage-chip-pending) {
+    color: var(--colour-warning);
+  }
+
+  :global(.storage-chip-error) {
+    color: var(--colour-error);
+  }
+
+  :global(.storage-chip-text) {
+    white-space: nowrap;
+  }
+
+  :global(.storage-chip-popover) {
+    min-width: 200px;
+  }
+
+  .storage-chip-state {
+    margin: 0;
+    padding: var(--space-1) var(--space-2) 0;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text-inverse);
+  }
+
+  .storage-chip-detail {
+    margin: 0;
+    padding: 0 var(--space-2) var(--space-2);
+    font-size: var(--font-size-xs);
+    color: var(--colour-text-muted-inverse);
+  }
+
+  .storage-chip-actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .storage-chip-action {
+    display: flex;
+    align-items: center;
+    padding: var(--space-2);
+    border: none;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--colour-text-inverse);
+    font-size: var(--font-size-sm);
+    text-align: left;
+    cursor: pointer;
+    transition: background-color var(--duration-fast) var(--ease-out);
+  }
+
+  .storage-chip-action:hover {
+    background-color: var(--colour-overlay-hover);
+  }
+
+  .storage-chip-action:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--colour-focus-ring);
+  }
+</style>

--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -12,11 +12,8 @@
   import { IconCheck, IconClock, IconWarningTriangle } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
-  import {
-    getLayoutDurability,
-    handleSaveAsArchive,
-    loadFromFile,
-  } from "$lib/storage";
+  import { getLayoutDurability, loadFromFile } from "$lib/storage";
+  import { maybeSaveAs } from "$lib/utils/app-actions";
   import "$lib/styles/menu.css";
 
   const durability = getLayoutDurability(getLayoutStore());
@@ -36,11 +33,13 @@
     return () => clearTimeout(timer);
   });
 
-  async function handleExportNow() {
-    // Export embeds images (#617) and round-trips unknown sections (#2208), so
-    // resetting changesSinceExport on export is honest: nothing is silently
-    // dropped. The chip therefore needs no separate image-dropping warning state.
-    await handleSaveAsArchive();
+  function handleExportNow() {
+    // Routes through maybeSaveAs so the cleanup prompt and promptCleanupOnSave
+    // preference apply consistently with the other save paths. Export embeds
+    // images (#617) and round-trips unknown sections (#2208), so resetting
+    // changesSinceExport on export is honest and the chip needs no separate
+    // image-dropping warning state.
+    maybeSaveAs();
     open = false;
   }
 

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -9,6 +9,7 @@
   import Tooltip from "./Tooltip.svelte";
   import FileMenu from "./FileMenu.svelte";
   import SettingsMenu from "./SettingsMenu.svelte";
+  import StorageStatusChip from "./StorageStatusChip.svelte";
   import LogoLockup from "./LogoLockup.svelte";
   import {
     IconUndoBold,
@@ -387,6 +388,8 @@
   <!-- Right: Dropdown menus (desktop) / quick file actions (mobile) -->
   {#if !viewportStore.isMobile}
     <div class="toolbar-section toolbar-right">
+      <StorageStatusChip />
+
       <FileMenu
         onsave={handleSave}
         onsaveas={handleSaveAs}

--- a/src/lib/components/icons/IconClock.svelte
+++ b/src/lib/components/icons/IconClock.svelte
@@ -1,0 +1,27 @@
+<!--
+  Clock icon for pending/in-progress status
+  Based on Lucide clock icon
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+    class?: string;
+  }
+  let { size = 20, class: className = "" }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+  class={className}
+>
+  <circle cx="12" cy="12" r="9" />
+  <polyline points="12 7 12 12 15 14" />
+</svg>

--- a/src/lib/components/icons/IconWarningTriangle.svelte
+++ b/src/lib/components/icons/IconWarningTriangle.svelte
@@ -1,0 +1,28 @@
+<!--
+  Warning triangle icon for error status
+  Based on Lucide triangle-alert icon
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+    class?: string;
+  }
+  let { size = 20, class: className = "" }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+  class={className}
+>
+  <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" />
+  <line x1="12" y1="9" x2="12" y2="13" />
+  <line x1="12" y1="17" x2="12.01" y2="17" />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -66,6 +66,8 @@ export { default as IconCheck } from "./IconCheck.svelte";
 
 // Status icons
 export { default as IconCloudOff } from "./IconCloudOff.svelte";
+export { default as IconClock } from "./IconClock.svelte";
+export { default as IconWarningTriangle } from "./IconWarningTriangle.svelte";
 
 // =============================================================================
 // Phosphor Bold Icons (for toolbar - higher visual weight)

--- a/src/lib/storage/durability.svelte.ts
+++ b/src/lib/storage/durability.svelte.ts
@@ -1,0 +1,167 @@
+/**
+ * Layout durability: the single source of truth for storage status.
+ *
+ * Every storage-status surface (the toolbar chip today; the multi-layout tab
+ * dots #2079 and sidebar #2082 tomorrow) derives its state from here and
+ * nowhere else. The status formula lives in one pure function so it can be unit
+ * tested and reused without DOM.
+ *
+ * This module lives in storage/ (not stores/layout/persistence.ts) on purpose:
+ * it reads the persistence manager, which would create a manager <-> persistence
+ * import cycle if the formula lived in the store layer.
+ */
+
+import {
+  getStorageChipState,
+  type SaveStatus,
+} from "./manager.svelte";
+import {
+  getApiAvailableState,
+  getStorageMode,
+  type StorageMode,
+} from "./availability.svelte";
+import type { LayoutStore } from "$lib/stores/layout.svelte";
+
+const MAX_SAVE_FAILURES = 3;
+
+export type DurabilityStatus = "saved" | "pending" | "error";
+
+export interface LayoutDurability {
+  status: DurabilityStatus;
+  mode: StorageMode;
+  changesSinceExport: number;
+  hasEverExported: boolean;
+  isHealthy: boolean;
+  label: string;
+  icon: DurabilityStatus;
+}
+
+/**
+ * The status formula. Pure: same inputs always yield the same status/label/icon,
+ * with no reads of module state. This is the only place that decides what
+ * "durable" means.
+ *
+ * Browser mode treats the local file export as the durability boundary: a layout
+ * is durable only when it has been exported and nothing has changed since.
+ * Server mode treats the server save as the boundary: changesSinceExport is
+ * reset only on export (not on a server save), so server mode never reads it.
+ */
+export function computeLayoutStatus(
+  saveStatus: SaveStatus,
+  consecutiveSaveFailures: number,
+  storageMode: StorageMode,
+  apiAvailable: boolean | null,
+  changesSinceExport: number,
+  hasEverExported: boolean,
+): { status: DurabilityStatus; label: string; icon: DurabilityStatus } {
+  if (storageMode === "browser") {
+    // Durable iff exported AND no edits since. The hasEverExported guard is
+    // critical: a never-exported cold start has changesSinceExport === 0 yet is
+    // not durable. Browser mode never reads saveStatus / apiAvailable.
+    if (changesSinceExport === 0 && hasEverExported) {
+      return { status: "saved", label: "Saved", icon: "saved" };
+    }
+    return { status: "pending", label: "Unsaved changes", icon: "pending" };
+  }
+
+  // Server mode, ordered most-severe first.
+  if (consecutiveSaveFailures >= MAX_SAVE_FAILURES) {
+    return { status: "error", label: "Server unavailable", icon: "error" };
+  }
+  if (apiAvailable === null) {
+    return { status: "pending", label: "Checking connection", icon: "pending" };
+  }
+  if (apiAvailable === false) {
+    return { status: "error", label: "Offline", icon: "error" };
+  }
+  if (saveStatus === "error") {
+    return { status: "error", label: "Save error", icon: "error" };
+  }
+  if (saveStatus === "saving") {
+    return { status: "pending", label: "Saving", icon: "pending" };
+  }
+  if (saveStatus === "saved") {
+    return { status: "saved", label: "Saved", icon: "saved" };
+  }
+  return { status: "pending", label: "Pending save", icon: "pending" };
+}
+
+/**
+ * Reactive durability for a layout store. Returns an object whose property reads
+ * pull live reactive state (mirroring getStorageChipState's getter-object
+ * idiom), so a component that reads these properties inside a reactive context
+ * stays in sync as save state, API availability, or export state change. Do not
+ * destructure: that snapshots the values and breaks reactivity.
+ */
+export function getLayoutDurability(layoutStore: LayoutStore): LayoutDurability {
+  // Per-layout export tracking comes from the passed store (each layout owns its
+  // own changesSinceExport / hasEverExported, ready for the multi-layout
+  // workspace #2017). Save state and the failure circuit breaker come from the
+  // persistence manager, which tracks the active save today.
+  const chip = getStorageChipState();
+  const compute = () =>
+    computeLayoutStatus(
+      chip.saveStatus,
+      chip.consecutiveSaveFailures,
+      getStorageMode(),
+      getApiAvailableState(),
+      layoutStore.changesSinceExport,
+      layoutStore.hasEverExported,
+    );
+  return {
+    get mode(): StorageMode {
+      return getStorageMode();
+    },
+    get changesSinceExport(): number {
+      return layoutStore.changesSinceExport;
+    },
+    get hasEverExported(): boolean {
+      return layoutStore.hasEverExported;
+    },
+    get status(): DurabilityStatus {
+      return compute().status;
+    },
+    get isHealthy(): boolean {
+      return this.status !== "error";
+    },
+    get label(): string {
+      return compute().label;
+    },
+    get icon(): DurabilityStatus {
+      return compute().icon;
+    },
+  };
+}
+
+/**
+ * Worst-wins rollup over many layouts (forward-compat for multi-layout tab dots
+ * #2079 and sidebar #2082): a single error or pending child surfaces at the
+ * workspace level. An empty workspace is "All saved". There is one active layout
+ * today, so this is exercised by tests rather than the live UI.
+ */
+export function rollupDurabilities(
+  durabilities: LayoutDurability[],
+): LayoutDurability {
+  const SEVERITY: Record<DurabilityStatus, number> = {
+    saved: 0,
+    pending: 1,
+    error: 2,
+  };
+  const worst = durabilities.reduce<LayoutDurability | null>((acc, d) => {
+    if (!acc || SEVERITY[d.status] > SEVERITY[acc.status]) return d;
+    return acc;
+  }, null);
+
+  if (!worst) {
+    return {
+      status: "saved",
+      mode: getStorageMode(),
+      changesSinceExport: 0,
+      hasEverExported: false,
+      isHealthy: true,
+      label: "All saved",
+      icon: "saved",
+    };
+  }
+  return worst;
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -46,3 +46,10 @@ export {
   isServerSavePending,
 } from "./manager.svelte";
 export { shouldWarnBeforeUnload, type UnloadRiskState } from "./unload-risk";
+export {
+  computeLayoutStatus,
+  getLayoutDurability,
+  rollupDurabilities,
+  type DurabilityStatus,
+  type LayoutDurability,
+} from "./durability.svelte";

--- a/src/tests/StorageStatusChip.test.ts
+++ b/src/tests/StorageStatusChip.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import StorageStatusChip from "$lib/components/StorageStatusChip.svelte";
+
+/**
+ * The chip is presentational; the only behaviour worth asserting (per the
+ * project testing rules) is that its accessible name carries the current
+ * storage state, so non-sighted users get the state, not just a colour.
+ *
+ * A fresh layout store in browser mode has never been exported, so the chip's
+ * accessible name reflects the pending "Unsaved changes" state.
+ */
+describe("StorageStatusChip", () => {
+  it("exposes the current storage state in its accessible name", () => {
+    render(StorageStatusChip);
+    const chip = screen.getByRole("button", { name: /storage status/i });
+    expect(chip).toHaveAccessibleName(/unsaved changes/i);
+  });
+});

--- a/src/tests/durability.test.ts
+++ b/src/tests/durability.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeLayoutStatus,
+  rollupDurabilities,
+  type LayoutDurability,
+} from "$lib/storage/durability.svelte";
+import type { SaveStatus } from "$lib/storage/manager.svelte";
+import type { StorageMode } from "$lib/storage/availability.svelte";
+
+/**
+ * The storage status formula is the single source of truth for the chip (and,
+ * later, the multi-layout tab dots #2079 / sidebar #2082). These tests lock the
+ * two correctness-critical pieces: the per-layout status formula and the
+ * worst-wins rollup. They assert returned status/label/icon, never DOM or
+ * colour, per the project testing rules.
+ */
+
+const BROWSER: StorageMode = "browser";
+const SERVER: StorageMode = "server";
+
+function status(
+  saveStatus: SaveStatus,
+  consecutiveSaveFailures: number,
+  storageMode: StorageMode,
+  apiAvailable: boolean | null,
+  changesSinceExport: number,
+  hasEverExported: boolean,
+) {
+  return computeLayoutStatus(
+    saveStatus,
+    consecutiveSaveFailures,
+    storageMode,
+    apiAvailable,
+    changesSinceExport,
+    hasEverExported,
+  );
+}
+
+describe("computeLayoutStatus — browser mode", () => {
+  it("is saved only when exported and no changes since", () => {
+    const result = status("idle", 0, BROWSER, null, 0, true);
+    expect(result.status).toBe("saved");
+    expect(result.icon).toBe("saved");
+    expect(result.label).toBe("Saved");
+  });
+
+  it("a never-exported cold start (0 changes) is pending, not saved", () => {
+    // hasEverExported guard: 0 changes alone does not mean durable.
+    const result = status("idle", 0, BROWSER, null, 0, false);
+    expect(result.status).toBe("pending");
+    expect(result.icon).toBe("pending");
+    expect(result.label).toBe("Unsaved changes");
+  });
+
+  it("is pending when there are changes since the last export", () => {
+    const result = status("idle", 0, BROWSER, null, 3, true);
+    expect(result.status).toBe("pending");
+    expect(result.label).toBe("Unsaved changes");
+  });
+
+  it("ignores saveStatus and apiAvailable in browser mode", () => {
+    // Even a server "error" / unreachable API is irrelevant in browser mode.
+    const exported = status("error", 5, BROWSER, false, 0, true);
+    expect(exported.status).toBe("saved");
+    const dirty = status("saved", 0, BROWSER, true, 1, true);
+    expect(dirty.status).toBe("pending");
+  });
+});
+
+describe("computeLayoutStatus — server mode", () => {
+  it("trips to error after the circuit breaker opens (>= 3 failures)", () => {
+    const result = status("saving", 3, SERVER, true, 0, false);
+    expect(result.status).toBe("error");
+    expect(result.label).toBe("Server unavailable");
+  });
+
+  it("is pending while the health check has not resolved (apiAvailable null)", () => {
+    const result = status("idle", 0, SERVER, null, 0, false);
+    expect(result.status).toBe("pending");
+    expect(result.label).toBe("Checking connection");
+  });
+
+  it("is error when the API is known unreachable", () => {
+    const result = status("idle", 0, SERVER, false, 0, false);
+    expect(result.status).toBe("error");
+    expect(result.label).toBe("Offline");
+  });
+
+  it("is error when the last save failed but the server is reachable", () => {
+    const result = status("error", 0, SERVER, true, 0, false);
+    expect(result.status).toBe("error");
+    expect(result.label).toBe("Save error");
+  });
+
+  it("is pending while a save is in flight", () => {
+    const result = status("saving", 0, SERVER, true, 0, false);
+    expect(result.status).toBe("pending");
+    expect(result.label).toBe("Saving");
+  });
+
+  it("is saved when the last save succeeded", () => {
+    const result = status("saved", 0, SERVER, true, 0, false);
+    expect(result.status).toBe("saved");
+    expect(result.label).toBe("Saved");
+  });
+
+  it("is pending for any other reachable, non-saving state", () => {
+    const result = status("idle", 0, SERVER, true, 0, false);
+    expect(result.status).toBe("pending");
+    expect(result.label).toBe("Pending save");
+  });
+
+  it("never uses changesSinceExport in server mode", () => {
+    // changesSinceExport is reset only on export, not on a server save, so it
+    // must not influence server-mode status. A reachable, saved server with a
+    // high changesSinceExport is still "saved".
+    const result = status("saved", 0, SERVER, true, 99, false);
+    expect(result.status).toBe("saved");
+  });
+});
+
+describe("rollupDurabilities — worst-wins", () => {
+  function durability(status: LayoutDurability["status"]): LayoutDurability {
+    return {
+      status,
+      mode: BROWSER,
+      changesSinceExport: 0,
+      hasEverExported: true,
+      isHealthy: status !== "error",
+      label: status,
+      icon: status,
+    };
+  }
+
+  it("an empty workspace rolls up to saved", () => {
+    const result = rollupDurabilities([]);
+    expect(result.status).toBe("saved");
+    expect(result.label).toBe("All saved");
+  });
+
+  it("error beats pending and saved", () => {
+    const result = rollupDurabilities([
+      durability("saved"),
+      durability("pending"),
+      durability("error"),
+    ]);
+    expect(result.status).toBe("error");
+  });
+
+  it("pending beats saved", () => {
+    const result = rollupDurabilities([
+      durability("saved"),
+      durability("pending"),
+    ]);
+    expect(result.status).toBe("pending");
+  });
+
+  it("all saved rolls up to saved", () => {
+    const result = rollupDurabilities([durability("saved"), durability("saved")]);
+    expect(result.status).toBe("saved");
+  });
+});


### PR DESCRIPTION
## **User description**
## What
A workspace-wide storage status chip in the toolbar whose dot answers "is my work in its durable home". Closes #2035.

## Single source of truth
New `src/lib/storage/durability.svelte.ts` holds the only storage-status logic:
- `computeLayoutStatus(...)` pure formula. Browser mode is saved only when `changesSinceExport === 0 AND hasEverExported` (a never-exported cold start is not durable). Server mode keys off save status and reachability, with a distinct "Checking connection" pending state while the health check is `null`, and never reads `changesSinceExport` (that counter resets only on export).
- `getLayoutDurability(layoutStore)` exposes it reactively (getter-object idiom, like `getStorageChipState`).
- `rollupDurabilities(...)` worst-wins, forward-compat for M14 tab dots (#2079) and sidebar (#2082) so they read one source.

## Chip + a11y
`StorageStatusChip.svelte`: icon + text per state (never colour-only, WCAG 1.4.1); a button whose accessible name includes the state; a `role="status" aria-live="polite"` live region announcing the settled state (debounced to avoid saving->saved spam); a bits-ui popover (focus-trap + Escape) with Export-now and Restore-from-file actions.

## Notes
- #617 (images in YAML) + #2208 (unknown-section round-trip) make the default export honest, so no separate image-dropping warning state is needed.
- Design hardened by an adversarial design-gate review (the `hasEverExported` guard, null-health = checking, single-source `durability.svelte.ts` to avoid a manager<->persistence cycle).

## Tests
`durability.test.ts` (16): the formula across browser/server states + worst-wins rollup. `StorageStatusChip.test.ts`: accessible name reflects state.


___

## **CodeAnt-AI Description**
**Add a storage status chip to the workspace toolbar**

### What Changed
- Added a workspace toolbar chip that shows whether the current layout is saved, still has unsaved changes, or has a storage problem.
- The chip uses text and icons for each state, includes the current status in its accessible name, and announces status changes for screen readers.
- Opening the chip now shows actions to export the layout or restore it from a file.
- The toolbar now includes the new chip on desktop, alongside the existing file and sharing actions.
- Added status icons for pending and error states, plus tests that cover the saved/pending/error rules and workspace rollup behavior.

### Impact
`✅ Clearer save status in the toolbar`
`✅ Fewer missed unsaved changes`
`✅ Better screen reader status updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
