### PR TITLE
chore: add accessibility E2E coverage (#1231)

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * Accessibility E2E coverage.
+ *
+ * These tests exercise real assistive-technology behaviour rather than DOM
+ * structure: focusable controls are reached by role/name, focus trapping and
+ * restoration are verified through the active element, and live regions are
+ * found by their ARIA role. Touch-target sizing is measured against the WCAG
+ * 2.5.5 minimum on a mobile viewport.
+ *
+ * @see docs/guides/ACCESSIBILITY.md
+ * @see https://github.com/RackulaLives/Rackula/issues/1231
+ */
+import { test, expect } from "./helpers/base-test";
+import type { Page } from "@playwright/test";
+import {
+  gotoWithRack,
+  EMPTY_RACK_SHARE,
+  clickNewRack,
+  locators,
+} from "./helpers";
+
+/** WCAG 2.5.5 Target Size (Level AAA) / 2.5.8 (Level AA) minimum. */
+const MIN_TOUCH_TARGET_PX = 44;
+
+/** A representative phone viewport for mobile-only accessibility checks. */
+const MOBILE_VIEWPORT = { width: 412, height: 915 };
+
+/**
+ * Load the app at a phone viewport with a rack preloaded, dismissing the
+ * mobile warning before navigation so it never intercepts interactions.
+ */
+async function gotoMobileWithRack(page: Page): Promise<void> {
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.addInitScript(() => {
+    sessionStorage.setItem("rackula-mobile-warning-dismissed", "true");
+  });
+  await page.goto(`/?l=${EMPTY_RACK_SHARE}`);
+  await page
+    .locator(locators.rack.container)
+    .first()
+    .waitFor({ state: "visible" });
+}
+
+/**
+ * Resolve the accessible role and name of the currently focused element.
+ * Runs in the browser so it reflects what an assistive technology would expose.
+ */
+async function activeElementInfo(page: Page): Promise<{
+  role: string | null;
+  name: string | null;
+  tag: string;
+  testid: string | null;
+}> {
+  return page.evaluate(() => {
+    const el = document.activeElement as HTMLElement | null;
+    if (!el) return { role: null, name: null, tag: "", testid: null };
+    // Prefer the explicit accessible name. Fall back to own text only for leaf
+    // elements so a focused container does not report its whole subtree's text.
+    const ownText = el.children.length === 0 ? el.textContent?.trim() : "";
+    const name =
+      el.getAttribute("aria-label") ||
+      (ownText && ownText.length > 0 ? ownText : null) ||
+      el.getAttribute("title") ||
+      null;
+    return {
+      role: el.getAttribute("role"),
+      name,
+      tag: el.tagName.toLowerCase(),
+      testid: el.getAttribute("data-testid"),
+    };
+  });
+}
+
+test.describe("Accessibility", () => {
+  test.describe("Keyboard navigation", () => {
+    test.beforeEach(async ({ page }) => {
+      await gotoWithRack(page);
+    });
+
+    test("Tab reaches the major interactive regions by role and name", async ({
+      page,
+      browserName,
+    }) => {
+      // WebKit does not move keyboard focus through buttons via Tab by default
+      // (macOS "Full Keyboard Access" is off), so a Tab sweep over button
+      // controls is not meaningful there. Chromium exercises the full path.
+      test.skip(
+        browserName === "webkit",
+        "WebKit skips buttons in Tab order by default (macOS keyboard setting)",
+      );
+
+      // Start from a known anchor: the brand/about button leads the toolbar.
+      // It carries a Tooltip wrapper that duplicates the accessible name, so
+      // anchor on the button itself by testid.
+      const about = page.getByTestId("btn-logo-about");
+      await expect(about).toHaveAttribute("aria-label", "About & Shortcuts");
+      await about.focus();
+      await expect(about).toBeFocused();
+
+      // Walk forward with Tab and record what each stop is. A keyboard user
+      // must be able to reach controls without the focus ring vanishing into a
+      // non-interactive void, and the toolbar's Export action must be on the
+      // path. We track the Export button by its testid so an unrelated element
+      // whose name merely contains "export" cannot satisfy the check.
+      let sawInteractiveControl = false;
+      let reachedExportButton = false;
+
+      for (let i = 0; i < 25; i++) {
+        await page.keyboard.press("Tab");
+        const info = await activeElementInfo(page);
+
+        // Focus must always land on something focusable, never <body>.
+        expect(info.tag).not.toBe("body");
+
+        if (info.testid === "btn-export") reachedExportButton = true;
+
+        // Native controls and ARIA widgets are the keyboard-operable surface.
+        const interactiveTags = ["button", "input", "a", "select", "textarea"];
+        if (
+          interactiveTags.includes(info.tag) ||
+          info.role === "button" ||
+          info.role === "tab" ||
+          info.role === "option"
+        ) {
+          sawInteractiveControl = true;
+        }
+
+        if (reachedExportButton) break;
+      }
+
+      expect(sawInteractiveControl).toBe(true);
+      // The Export toolbar action must be reachable in a single forward sweep.
+      expect(reachedExportButton).toBe(true);
+    });
+
+    test("canvas exposes an application region with a descriptive name", async ({
+      page,
+    }) => {
+      // The canvas advertises role="application" so screen-reader users know it
+      // is an interactive drawing surface, and carries a non-empty accessible
+      // name describing the rack contents. We assert the role and a meaningful
+      // name rather than exact text, since the description is content-derived.
+      const canvas = page.getByRole("application");
+      await expect(canvas).toBeVisible();
+
+      const name = await canvas.getAttribute("aria-label");
+      expect(name?.trim()).toBeTruthy();
+    });
+  });
+
+  test.describe("Dialog focus management", () => {
+    test.beforeEach(async ({ page }) => {
+      await gotoWithRack(page);
+    });
+
+    test("dialog traps Tab focus within its content", async ({
+      page,
+      browserName,
+    }) => {
+      // Tab-based focus traversal relies on the browser visiting buttons in Tab
+      // order, which WebKit disables by default. The trap itself is enforced by
+      // bits-ui in JS; Chromium verifies it cycles correctly.
+      test.skip(
+        browserName === "webkit",
+        "WebKit skips buttons in Tab order by default (macOS keyboard setting)",
+      );
+
+      await clickNewRack(page);
+
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+
+      // Tab repeatedly; focus must stay inside the dialog on every stop.
+      // A trapped dialog cycles through its own controls and never lets focus
+      // escape to the page behind the modal.
+      for (let i = 0; i < 20; i++) {
+        await page.keyboard.press("Tab");
+        const focusInDialog = await dialog.evaluate((node) =>
+          node.contains(document.activeElement),
+        );
+        expect(focusInDialog).toBe(true);
+      }
+
+      // Shift+Tab (reverse cycle) must also stay trapped.
+      for (let i = 0; i < 20; i++) {
+        await page.keyboard.press("Shift+Tab");
+        const focusInDialog = await dialog.evaluate((node) =>
+          node.contains(document.activeElement),
+        );
+        expect(focusInDialog).toBe(true);
+      }
+    });
+
+    test("closing a dialog restores focus to its trigger", async ({
+      page,
+      browserName,
+    }) => {
+      // WebKit does not give buttons DOM focus on activation by default, so
+      // there is no trigger focus to restore. The restoration itself is bits-ui
+      // behaviour; Chromium verifies it end to end for a keyboard user.
+      test.skip(
+        browserName === "webkit",
+        "WebKit does not focus buttons on activation by default (macOS keyboard setting)",
+      );
+
+      // Switch to the Racks tab and open the wizard from the New Rack button
+      // via keyboard, so the trigger genuinely holds focus before the dialog
+      // opens, the way a keyboard user would experience it.
+      await page.getByTestId("sidebar-tab-racks").click();
+      const trigger = page.getByTestId("btn-new-rack");
+      await trigger.focus();
+      await expect(trigger).toBeFocused();
+      await page.keyboard.press("Enter");
+
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+
+      await page.keyboard.press("Escape");
+      await expect(dialog).not.toBeVisible();
+
+      // Focus must return to the control that opened the dialog so keyboard
+      // users are not dumped back at the top of the document.
+      await expect(trigger).toBeFocused();
+    });
+  });
+
+  test.describe("Live regions", () => {
+    test("a status live region announces tap-to-place on mobile", async ({
+      page,
+    }) => {
+      // Mobile uses tap-to-place: selecting a palette device arms placement and
+      // surfaces a role="status" / aria-live header so the pending device is
+      // announced. Desktop has no equivalent flow, so this is mobile-scoped.
+      await gotoMobileWithRack(page);
+
+      // Open the device library and arm a device for placement.
+      await page.getByRole("button", { name: "Devices" }).click();
+      await expect(
+        page.locator(locators.device.paletteItem).first(),
+      ).toBeVisible();
+      await page.locator(locators.device.paletteItem).first().click();
+
+      // The placement header is a polite status region naming the pending
+      // device. The dual-view renders front and rear copies, so scope to the
+      // first match. getByRole finds the live region regardless of markup.
+      const status = page
+        .getByRole("status")
+        .filter({ hasText: /tap to place/i })
+        .first();
+      await expect(status).toBeVisible();
+    });
+  });
+
+  test.describe("Touch targets", () => {
+    test("mobile bottom navigation meets the minimum touch-target size", async ({
+      page,
+    }) => {
+      await gotoMobileWithRack(page);
+
+      const nav = page.getByRole("navigation", { name: /mobile navigation/i });
+      await expect(nav).toBeVisible();
+
+      // Every actionable button in the bottom nav must be large enough to tap
+      // reliably, per WCAG 2.5.5. Measuring each one catches a single
+      // undersized control rather than an aggregate average.
+      const buttons = nav.getByRole("button");
+      const count = await buttons.count();
+      expect(count).toBeGreaterThan(0);
+
+      for (let i = 0; i < count; i++) {
+        const button = buttons.nth(i);
+        await expect(button).toBeVisible();
+        const box = await button.boundingBox();
+        expect(box).not.toBeNull();
+        if (box) {
+          expect(box.width).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET_PX);
+          expect(box.height).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET_PX);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Adds `e2e/accessibility.spec.ts` with Playwright coverage for accessibility behaviour. Tests use accessible role/name/label locators and the shared `e2e/helpers/` layer (migrated in #1420), asserting real assistive-technology behaviour rather than DOM structure.

## Test cases

- Keyboard navigation: a forward Tab sweep from the toolbar reaches interactive controls and the Export action without focus falling into a non-interactive void (Export tracked by testid, not a loose name match).
- Canvas landmark: the canvas exposes `role="application"` with a non-empty, content-derived accessible name.
- Dialog focus trapping: Tab and Shift+Tab stay within the New Rack wizard dialog.
- Focus restoration: closing the dialog returns focus to the trigger that opened it (opened via keyboard so the trigger genuinely holds focus).
- Live region: arming tap-to-place on mobile surfaces a `role="status"` region naming the pending device.
- Touch targets: every mobile bottom-nav button meets the 44px WCAG 2.5.5 minimum.

## Notes

- No new dependencies. The five cases map to targeted role/name and focus-state assertions, so an axe-core scan was not warranted given the project's simplicity-first and anti-test-bloat stance.
- The Tab-traversal and focus-restoration tests are skipped on WebKit, where keyboard focus does not visit buttons by default (a macOS "Full Keyboard Access" setting, not an app defect). Chromium exercises the full keyboard paths; the live-region, canvas-landmark, and touch-target tests run on both engines.

## Doc drift observed (not changed here)

`docs/guides/ACCESSIBILITY.md` states the Canvas carries `aria-label="Rack layout canvas"`, but the code binds a dynamic content description (e.g. "1 rack with 0 devices total"). The dynamic name is better a11y; the doc is stale. Flagging for a separate docs fix rather than expanding this test-only PR.

## Test plan

- [x] `npm run lint` clean
- [x] New spec passes on chromium and webkit (9 passed, 3 webkit skips)
- [x] `npm run test:e2e` full suite passes (349 passed, 0 failed)
- [x] No `waitForTimeout()` calls
- [x] Uses shared helpers from `e2e/helpers/`

Closes #1231


___

## **CodeAnt-AI Description**
Add end-to-end coverage for keyboard, dialog, mobile live region, and touch-target accessibility

### What Changed
- Added Playwright coverage that checks keyboard users can reach key controls, including the Export action, without focus getting lost
- Verifies the canvas is exposed as an interactive region with a meaningful accessible name
- Confirms the New Rack dialog keeps Tab focus inside it and returns focus to the trigger after closing
- Checks mobile tap-to-place announces the pending device through a status live region
- Checks every mobile bottom navigation button meets the minimum touch-target size

### Impact
`✅ Fewer keyboard navigation dead ends`
`✅ Clearer screen reader feedback on mobile placement`
`✅ Fewer missed taps on mobile navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
