### PR TITLE
chore: block CSS class selectors in E2E tests (#1423)

### DIFF
--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -354,20 +354,44 @@ npx browserstack-node-sdk playwright test
 
 ### Selector Strategy
 
-Use `data-testid` attributes for reliable element selection:
+Locate elements by what the user perceives (role, label, text), not by how they
+are styled. CSS class selectors are brittle: a styling rename silently breaks the
+test. Prefer, in this order:
+
+1. `getByRole()` with an accessible name, e.g.
+   `page.getByRole("dialog", { name: "About Rackula" })`. This doubles as an
+   accessibility check.
+2. `getByLabel()` / `getByText()` for form fields and visible copy.
+3. `getByTestId()` (`data-testid`) for structural anchors that have no natural
+   role or label, e.g. the rack canvas or a toast container.
 
 ```typescript
-// Good - stable selector
-await page.click('[data-testid="btn-new-rack"]');
+// Good - role/label/testid
+await page.getByRole("button", { name: "New Rack" }).click();
+await page.getByLabel("IP Address/Hostname").fill("192.168.1.1");
+await page.getByTestId("btn-new-rack").click();
 
-// Avoid - fragile selectors
-await page.click('.toolbar-action-btn[aria-label="New Rack"]');
+// Avoid - CSS class selector (breaks on styling changes)
+await page.locator(".toolbar-action-btn").click();
 ```
 
-Available data-testid attributes:
+Reusable selector strings (structural anchors and the few intentional class
+selectors that have no role) live in `e2e/helpers/locators.ts`. Reference that
+registry rather than hard-coding `data-testid` lists here, which drift as the UI
+changes. Interactive controls are not listed there: reach them with
+`getByRole`/`getByLabel` at the call site.
 
-- Toolbar: `btn-new-rack`, `btn-save`, `btn-load-layout`, `btn-export`, `btn-undo`, `btn-redo`, `btn-delete`, `btn-reset-view`, `btn-help`, `btn-toggle-theme`, `btn-toggle-display-mode`, `btn-toggle-airflow`, `btn-hamburger-menu`
-- DevicePalette: `search-devices`, `btn-import-devices`, `btn-add-device`
+`label:has-text("...")` is a Playwright text-engine locator, not a CSS class
+selector, and is fine to use.
+
+#### Lint enforcement
+
+ESLint blocks new CSS class selectors in `e2e/**/*.ts`. A string literal passed
+to `.locator()` that starts with `.` (e.g. `page.locator(".rack-header")`) fails
+lint. The rule does not flag the `locators` registry, `getByRole`/`getByTestId`/
+`getByLabel`/`getByText`, attribute/id/tag selectors, or `:has-text()`. To fix a
+violation, switch to a role/label/testid locator, or add the selector to
+`e2e/helpers/locators.ts` if it is a genuine structural anchor.
 
 ### E2E Test Structure
 
@@ -382,14 +406,14 @@ test.describe("Feature", () => {
 
   test("user can complete workflow", async ({ page }) => {
     // Arrange
-    await page.click('[data-testid="btn-new-rack"]');
+    await page.getByTestId("btn-new-rack").click();
 
     // Act
-    await page.fill('[data-testid="input-rack-name"]', "Test Rack");
-    await page.click('[data-testid="btn-create-rack"]');
+    await page.getByLabel("Rack Name", { exact: true }).fill("Test Rack");
+    await page.getByTestId("btn-create-rack").click();
 
     // Assert
-    await expect(page.locator(".rack-name")).toHaveText("Test Rack");
+    await expect(page.getByText("Test Rack")).toBeVisible();
   });
 });
 ```
@@ -617,7 +641,7 @@ describe.each(ALL_BRAND_PACKS)("$name brand pack", ({ devices }) => {
 - Follow AAA pattern (Arrange-Act-Assert)
 - Test edge cases and error states
 - Keep tests focused and independent
-- Use `data-testid` for E2E selectors
+- Prefer role/label/text locators for E2E, with `data-testid` for structural anchors
 - Trust schema validation for data correctness
 - Use parameterized tests for similar cases
 

--- a/e2e/archive-format.spec.ts
+++ b/e2e/archive-format.spec.ts
@@ -117,7 +117,7 @@ test.describe("Archive Format", () => {
     await loadFileFromDiskViaMenu(page, legacyJsonPath);
 
     // Should show error toast - legacy format no longer supported
-    const toast = page.locator('.toast-error, .toast.error, [role="alert"]');
+    const toast = page.getByRole("alert");
     await expect(toast.first()).toBeVisible({ timeout: 5000 });
   });
 
@@ -129,7 +129,7 @@ test.describe("Archive Format", () => {
     await loadFileFromDiskViaMenu(page, corruptedPath);
 
     // Should show error toast
-    const toast = page.locator('.toast-error, .toast.error, [role="alert"]');
+    const toast = page.getByRole("alert");
     await expect(toast.first()).toBeVisible({ timeout: 5000 });
   });
 });

--- a/e2e/device-metadata.spec.ts
+++ b/e2e/device-metadata.spec.ts
@@ -43,13 +43,9 @@ const TEST_METADATA_2 = {
  * Helper to wait for the saved indicator after a blur
  */
 async function waitForSaved(page: Page, fieldType: "ip" | "notes") {
-  // The saved indicator appears as a checkmark next to the label
-  const labelSelector =
-    fieldType === "ip"
-      ? 'label:has-text("IP Address")'
-      : 'label:has-text("Notes")';
-  // Wait for the saved indicator to appear (confirms save completed)
-  await expect(page.locator(`${labelSelector} .saved-indicator`)).toBeVisible({
+  // The saved indicator appears as a checkmark next to the field's label.
+  // Wait for it to appear (confirms the save completed).
+  await expect(page.getByTestId(`saved-indicator-${fieldType}`)).toBeVisible({
     timeout: 3000,
   });
 }

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -111,4 +111,14 @@ export const locators = {
     content: '[data-testid="ctx-menu"]',
     item: '[data-testid="ctx-menu-item"]',
   },
+
+  /**
+   * Regions whose text changes between builds or over time. Used as
+   * toHaveScreenshot() masks in the visual-regression suite. These are leaf
+   * spans with no role of their own, so they stay as class selectors here.
+   */
+  dynamic: {
+    version: ".version",
+    layoutMeta: ".layout-meta",
+  },
 } as const;

--- a/e2e/helpers/visual.ts
+++ b/e2e/helpers/visual.ts
@@ -22,8 +22,8 @@ export const VISUAL_VIEWPORT = { width: 1280, height: 720 } as const;
  */
 export function dynamicMasks(page: Page): Locator[] {
   return [
-    page.locator(".version"), // app version, e.g. start-screen footer
-    page.locator(".layout-meta"), // "last saved" timestamps in layout lists
+    page.locator(locators.dynamic.version), // app version, e.g. start-screen footer
+    page.locator(locators.dynamic.layoutMeta), // "last saved" timestamps in layout lists
   ];
 }
 

--- a/e2e/keyboard.spec.ts
+++ b/e2e/keyboard.spec.ts
@@ -69,11 +69,12 @@ test.describe("Keyboard Shortcuts", () => {
     // Press ? using keyboard.type which handles shift automatically
     await page.keyboard.type("?");
 
-    // Help dialog should open (HelpPanel uses Dialog component)
-    // The Dialog.Title is sr-only with text "About Rackula" — check dialog is visible
-    await expect(page.locator(locators.dialog.root)).toBeVisible({ timeout: 2000 });
-    // Verify it's the help dialog by checking for the logo or keyboard shortcuts content
-    await expect(page.locator(".help-dialog")).toBeVisible();
+    // Help dialog should open (HelpPanel uses Dialog component). Its sr-only
+    // Dialog.Title "About Rackula" provides the accessible name, so the
+    // role/name locator both finds the dialog and confirms it is the help one.
+    await expect(
+      page.getByRole("dialog", { name: "About Rackula" }),
+    ).toBeVisible({ timeout: 2000 });
   });
 
   test("Ctrl+S triggers save", async ({ page }) => {

--- a/e2e/mobile-placement-mouse.spec.ts
+++ b/e2e/mobile-placement-mouse.spec.ts
@@ -53,10 +53,13 @@ test.describe("Mobile tap-to-place with a mouse (#1757)", () => {
     await expect(firstDevice).toBeVisible();
     await firstDevice.click();
 
-    // Placement mode is active: the "Tap to place" header appears and the
-    // bottom sheet has closed. Dual-view renders the header in both the front
-    // and rear SVGs, so scope to the first to avoid a strict-mode violation.
-    const placementHeader = page.locator(".placement-header").first();
+    // Placement mode is active: the "Tap to place" status header appears and
+    // the bottom sheet has closed. The header is a role="status" region; scope
+    // by its text since dual-view renders it in both the front and rear SVGs.
+    const placementHeader = page
+      .getByRole("status")
+      .filter({ hasText: "Tap to place" })
+      .first();
     await expect(placementHeader).toBeVisible();
     await expect(placementHeader).toContainText("Tap to place");
     await expect(page.locator(locators.mobile.bottomSheet)).not.toBeVisible();

--- a/e2e/undo-redo.spec.ts
+++ b/e2e/undo-redo.spec.ts
@@ -102,9 +102,7 @@ test.describe("Undo/Redo", () => {
     const ipInput = page.locator("#device-ip");
     await ipInput.fill("192.168.1.50");
     await ipInput.blur();
-    await expect(
-      page.locator('label:has-text("IP Address") .saved-indicator'),
-    ).toBeVisible();
+    await expect(page.getByTestId("saved-indicator-ip")).toBeVisible();
     await expect(ipInput).toHaveValue("192.168.1.50");
 
     // Deselect so Ctrl+Z is not swallowed by the focused input.

--- a/e2e/view-reset.spec.ts
+++ b/e2e/view-reset.spec.ts
@@ -83,9 +83,11 @@ test.describe("View Reset on Rack Changes", () => {
     expect(transformBefore).toBeTruthy();
     expect(transformBefore?.x).toBe(-300);
 
-    // Click on a different height preset (e.g., 42U)
+    // Click on a different height preset (e.g., 42U). Scope to the right edit
+    // drawer so the desktop preset wins over the mobile RackEditSheet variant.
     await page
-      .locator('.drawer-right [data-testid="btn-preset-height-42"]')
+      .getByTestId("drawer-device-edit")
+      .getByTestId("btn-preset-height-42")
       .click();
 
     // Wait for the view to reset (transform should change from panned position)

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -140,7 +140,7 @@ test.describe("visual regression", () => {
   test("menu - file", async ({ page }) => {
     await gotoVisual(page, POPULATED_URL, { theme: "light" });
     await page.getByRole("button", { name: "File menu" }).click();
-    const menu = page.locator(".menu-content");
+    const menu = page.getByRole("menu");
     await expect(menu).toBeVisible();
     await settle(page);
     await expect(menu).toHaveScreenshot("menu-file.png");
@@ -149,7 +149,7 @@ test.describe("visual regression", () => {
   test("menu - settings", async ({ page }) => {
     await gotoVisual(page, POPULATED_URL, { theme: "light" });
     await page.getByRole("button", { name: "Settings menu" }).click();
-    const menu = page.locator(".menu-content");
+    const menu = page.getByRole("menu");
     await expect(menu).toBeVisible();
     await settle(page);
     await expect(menu).toHaveScreenshot("menu-settings.png");

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,36 @@ import svelteConfig from "./svelte.config.js";
 
 const gitignorePath = fileURLToPath(new URL("./.gitignore", import.meta.url));
 
+// Shared no-restricted-syntax entries for all test files (unit + E2E).
+// Defined once so the E2E block can extend rather than replace them: in flat
+// config a later block that re-declares a rule overrides the earlier value
+// entirely, so the E2E block must re-list these to keep them in force.
+const testRestrictedSyntax = [
+  {
+    selector:
+      'CallExpression[callee.property.name="toHaveLength"][arguments.0.type="Literal"]',
+    message:
+      "Avoid exact length assertions on data arrays (breaks on additions). Use .length > 0 for existence checks. For behavioral invariants (deduplication, pagination), use eslint-disable-next-line with justification.",
+  },
+  {
+    selector:
+      'CallExpression[callee.property.name="toBe"][arguments.0.value=/^#/]',
+    message:
+      "Avoid hardcoded color assertions - breaks on design token changes. Test user-visible behavior instead.",
+  },
+  {
+    selector: 'CallExpression[callee.property.name="toHaveClass"]',
+    message:
+      "Avoid CSS class assertions - tests implementation details. Use testing-library queries instead.",
+  },
+  {
+    selector:
+      'BinaryExpression[operator="==="][left.operator="typeof"][right.value="function"]',
+    message:
+      "Avoid function existence checks - TypeScript already validates this. Test behavior instead.",
+  },
+];
+
 export default defineConfig(
   includeIgnoreFile(gitignorePath),
   js.configs.recommended,
@@ -86,30 +116,28 @@ export default defineConfig(
       "testing-library/no-node-access": "error",
 
       // Block patterns via no-restricted-syntax
+      "no-restricted-syntax": ["error", ...testRestrictedSyntax],
+    },
+  },
+  {
+    // E2E (Playwright) selector convention: prefer role/testid/label locators
+    // over brittle CSS class selectors. Flags inline string literals passed to
+    // .locator() that start with a class (`.`), e.g. page.locator(".rack-header").
+    // It does NOT flag the centralised `locators` registry (member expressions),
+    // getByRole/getByTestId/getByLabel/getByText, attribute/id/tag selectors, or
+    // Playwright text-engine locators such as `label:has-text("...")`.
+    // Re-lists the shared test restrictions because a re-declared rule in a later
+    // flat-config block replaces, rather than merges with, the earlier value.
+    files: ["e2e/**/*.ts"],
+    rules: {
       "no-restricted-syntax": [
         "error",
+        ...testRestrictedSyntax,
         {
           selector:
-            'CallExpression[callee.property.name="toHaveLength"][arguments.0.type="Literal"]',
+            'CallExpression[callee.property.name="locator"] > Literal:first-child[value=/^\\s*\\./]',
           message:
-            "Avoid exact length assertions on data arrays (breaks on additions). Use .length > 0 for existence checks. For behavioral invariants (deduplication, pagination), use eslint-disable-next-line with justification.",
-        },
-        {
-          selector:
-            'CallExpression[callee.property.name="toBe"][arguments.0.value=/^#/]',
-          message:
-            "Avoid hardcoded color assertions - breaks on design token changes. Test user-visible behavior instead.",
-        },
-        {
-          selector: 'CallExpression[callee.property.name="toHaveClass"]',
-          message:
-            "Avoid CSS class assertions - tests implementation details. Use testing-library queries instead.",
-        },
-        {
-          selector:
-            'BinaryExpression[operator="==="][left.operator="typeof"][right.value="function"]',
-          message:
-            "Avoid function existence checks - TypeScript already validates this. Test behavior instead.",
+            "Avoid CSS class selectors in E2E locators - they break on styling changes. Prefer getByRole()/getByTestId()/getByLabel(), or add the selector to e2e/helpers/locators.ts. See docs/guides/TESTING.md.",
         },
       ],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -135,7 +135,7 @@ export default defineConfig(
         ...testRestrictedSyntax,
         {
           selector:
-            'CallExpression[callee.property.name="locator"] > Literal:first-child[value=/^\\s*\\./]',
+            'CallExpression[callee.property.name="locator"][arguments.0.type="Literal"][arguments.0.value=/^\\s*\\./]',
           message:
             "Avoid CSS class selectors in E2E locators - they break on styling changes. Prefer getByRole()/getByTestId()/getByLabel(), or add the selector to e2e/helpers/locators.ts. See docs/guides/TESTING.md.",
         },

--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -369,7 +369,7 @@
     IP Address/Hostname
     {#if ipSaved}
       <Tooltip text="Saved">
-        <span class="saved-indicator">✓</span>
+        <span class="saved-indicator" data-testid="saved-indicator-ip">✓</span>
       </Tooltip>
     {/if}
   </label>
@@ -389,7 +389,9 @@
     Notes
     {#if notesSaved}
       <Tooltip text="Saved">
-        <span class="saved-indicator">✓</span>
+        <span class="saved-indicator" data-testid="saved-indicator-notes"
+          >✓</span
+        >
       </Tooltip>
     {/if}
   </label>


### PR DESCRIPTION
## **User description**
## Summary

Adds an ESLint `no-restricted-syntax` rule scoped to `e2e/**/*.ts` that blocks brittle CSS class selectors in Playwright locators, enforcing the role/testid/label convention established by #1420. Also sweeps the suite so lint is green.

The rule flags inline string-literal class selectors passed to `.locator()`, e.g. `page.locator(".rack-header")`. It deliberately does NOT flag:

- the centralised `locators` registry (member expressions like `locators.rack.container`)
- `getByRole` / `getByTestId` / `getByLabel` / `getByText`
- attribute, id, and tag selectors
- Playwright text-engine locators such as `label:has-text("...")`

The shared test `no-restricted-syntax` entries are extracted into a `testRestrictedSyntax` const so the E2E block extends rather than replaces them. In flat config a re-declared rule in a later block overrides the earlier value entirely, so the E2E block must re-list the shared selectors to keep them in force.

### Sweep (migrations to role/testid/label)

- `archive-format.spec.ts`: error toast -> `getByRole("alert")` (the `.toast-error`/`.toast.error` classes never existed; error toasts use `role="alert"`)
- `keyboard.spec.ts`: help dialog -> `getByRole("dialog", { name: "About Rackula" })`
- `mobile-placement-mouse.spec.ts`: placement header -> `getByRole("status").filter({ hasText: "Tap to place" })`
- `view-reset.spec.ts`: preset button -> scoped `getByTestId("drawer-device-edit").getByTestId("btn-preset-height-42")`
- `device-metadata.spec.ts` + `undo-redo.spec.ts`: saved indicator -> `getByTestId("saved-indicator-ip|notes")` (added the `data-testid` to the indicator spans in `EditPanelMetadata.svelte`)

### Docs

Updated `docs/guides/TESTING.md` with the selector convention and the new lint rule, and removed the stale hand-maintained `data-testid` list (several entries like `btn-save`, `btn-help`, `btn-delete` no longer exist) in favour of pointing readers at `e2e/helpers/locators.ts`.

## Test Plan

- [x] `npm run lint` is green
- [x] `npm run build` succeeds
- [x] The rule fires on a `.locator(".class")` literal and does NOT fire on the registry, `getByRole`/`getByText`, `:has-text()`, attribute/id/tag selectors (verified by local probe)
- [x] All migrated specs pass on chromium and webkit (`keyboard`, `device-metadata`, `undo-redo`, `archive-format`, `view-reset`, `mobile-placement-mouse`)

Closes #1423


___

## **CodeAnt-AI Description**
**Use user-facing selectors in E2E tests and expose saved states for IP and notes**

### What Changed
- E2E tests now rely on roles, labels, test IDs, or visible text instead of CSS class selectors, making them less likely to break when styling changes
- The saved checkmark beside IP address and notes now has its own test ID, so tests can confirm edits were saved without depending on label layout
- Lint now blocks new CSS class selectors in `e2e/**/*.ts`, and the testing guide now explains the preferred selector style and where to find reusable selectors

### Impact
`✅ Fewer broken E2E tests after UI styling changes`
`✅ Clearer save-state checks for device edits`
`✅ Easier-to-follow testing rules for new E2E coverage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
