### PR TITLE
ci: automated accessibility checks with axe-core (#2099)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,3 +127,43 @@ jobs:
             test-results/
             playwright-report/
           retention-days: 7
+
+  a11y:
+    name: a11y (axe-core)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-chromium-
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run axe-core accessibility scans
+        run: npm run test:e2e:a11y
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: playwright-report-a11y
+          path: playwright-report/
+          retention-days: 7

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -320,6 +320,51 @@ The `e2e/android-chrome.spec.ts` tests Android Chrome functionality:
 
 **Note:** Playwright Chromium is a desktop build. For real Android device testing, use BrowserStack.
 
+### Accessibility Scans (axe-core)
+
+`e2e/axe.spec.ts` runs axe-core (via `@axe-core/playwright`) against the key
+surfaces and fails CI on any WCAG 2.2 AA violation. It is a guard rail for the UX
+overhaul (epic #2017): the shell rework touches keyboard navigation extensively,
+and these scans catch static, machine-detectable regressions (contrast, names,
+roles, attributes) that manual review would miss.
+
+This is the automated-scan layer. Behavioural a11y (keyboard paths, focus
+trapping, landmark naming) lives in `e2e/accessibility.spec.ts`; axe cannot
+observe those, so the two suites are complementary.
+
+The scans run on their own config (`e2e/playwright.a11y.config.ts`, Chromium
+only, no retries) and their own CI job (`a11y (axe-core)` in `test.yml`):
+
+```bash
+npm run test:e2e:a11y
+```
+
+Current scans: populated canvas with a selected device, the sidebar's Devices
+and Racks tabs, and the Export and Share dialogs.
+
+Adding a scan when a new surface lands:
+
+1. Open the surface in a test (reuse the shared `e2e/helpers`), then scope a scan
+   to it:
+
+   ```typescript
+   import { expectNoA11yViolations } from "./helpers/a11y";
+
+   test("side panel has no WCAG 2.2 AA violations", async ({ page }) => {
+     await gotoWithRack(page);
+     const panel = page.getByTestId("side-panel");
+     await expect(panel).toBeVisible();
+     await expectNoA11yViolations(page, panel); // omit the locator to scan the whole page
+   });
+   ```
+
+2. Run `npm run test:e2e:a11y` and fix any violation it reports.
+3. If a violation genuinely cannot be fixed in the same slice, baseline the rule
+   in `e2e/helpers/a11y.ts` (`BASELINED_RULES`) with a tracking issue link, and
+   open that issue. A baseline disables that rule for every scan, so a fresh
+   violation of a baselined rule will not be caught until the rule is re-enabled:
+   keep the list short and remove each entry as soon as its issue closes.
+
 ### Real Device Testing (BrowserStack)
 
 For comprehensive mobile testing on real iOS and Android devices, use BrowserStack integration.

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -352,9 +352,11 @@ Adding a scan when a new surface lands:
 
    test("side panel has no WCAG 2.2 AA violations", async ({ page }) => {
      await gotoWithRack(page);
-     const panel = page.getByTestId("side-panel");
-     await expect(panel).toBeVisible();
-     await expectNoA11yViolations(page, panel); // omit the locator to scan the whole page
+     const selector = '[data-testid="side-panel"]';
+     await expect(page.locator(selector)).toBeVisible();
+     // expectNoA11yViolations takes a CSS selector string, not a Locator;
+     // omit the second argument to scan the whole page.
+     await expectNoA11yViolations(page, selector);
    });
    ```
 

--- a/e2e/axe.spec.ts
+++ b/e2e/axe.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * axe-core accessibility scans (issue #2099).
+ *
+ * A guard rail for the UX overhaul (epic #2017): each test renders a key surface
+ * and runs axe-core against it, failing CI on any WCAG 2.2 AA violation. The
+ * design spec treats accessibility as part of the design, not a retrofit, and
+ * the shell rework touches keyboard navigation extensively, so these scans catch
+ * regressions that manual review would miss.
+ *
+ * Scope: the surfaces that exist today (populated canvas with a selection, the
+ * sidebar's Devices and Racks tabs, and the Export and Share dialogs). As the
+ * M14 shell lands new surfaces (side panel, layout tabs), add a scan per the
+ * pattern in docs/guides/TESTING.md.
+ *
+ * Behavioural a11y (keyboard paths, focus trapping, landmark naming) lives in
+ * accessibility.spec.ts; this file covers the static, machine-detectable issues
+ * axe can see across a whole surface.
+ *
+ * @see docs/guides/TESTING.md
+ * @see docs/guides/ACCESSIBILITY.md
+ * @see https://github.com/RackulaLives/Rackula/issues/2099
+ */
+import { test } from "./helpers/base-test";
+import { expect } from "@playwright/test";
+import {
+  createTestLayout,
+  gotoWithRack,
+  selectDevice,
+  clickExport,
+  locators,
+} from "./helpers";
+import { expectNoA11yViolations } from "./helpers/a11y";
+
+// A small, deterministic rack so the canvas and sidebar render real content for
+// the scan. Category codes are the single-char share abbreviations:
+// n=network, s=server, w=power.
+const POPULATED_RACK = createTestLayout({
+  name: "A11y Test Layout",
+  rackName: "Rack A",
+  rackHeight: 12,
+  devices: [
+    { type: "a11y-switch", position: 1, face: "front", name: "Switch" },
+    { type: "a11y-server", position: 3, face: "front", name: "Server" },
+    { type: "a11y-pdu", position: 10, face: "rear", name: "PDU" },
+  ],
+  customTypes: [
+    { slug: "a11y-switch", height: 1, colour: "#4A90A4", category: "n" },
+    { slug: "a11y-server", height: 2, colour: "#7B6FA3", category: "s" },
+    { slug: "a11y-pdu", height: 2, colour: "#A4705A", category: "w" },
+  ],
+});
+
+test.describe("axe accessibility scans", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoWithRack(page, POPULATED_RACK);
+  });
+
+  test("canvas with a selected device has no WCAG 2.2 AA violations", async ({
+    page,
+  }) => {
+    // Selecting a device opens the edit drawer and applies the selected state,
+    // so the scan covers the canvas, the device chrome, and the edit panel at
+    // once: the states a user is most often in.
+    await selectDevice(page, 0);
+    await expectNoA11yViolations(page);
+  });
+
+  test("sidebar Devices tab has no WCAG 2.2 AA violations", async ({ page }) => {
+    await page.getByTestId("sidebar-tab-devices").click();
+    await expect(page.getByTestId("drawer-left")).toBeVisible();
+    await expectNoA11yViolations(page, locators.sidebar.pane);
+  });
+
+  test("sidebar Racks tab has no WCAG 2.2 AA violations", async ({ page }) => {
+    await page.getByTestId("sidebar-tab-racks").click();
+    await expect(page.getByTestId("drawer-left")).toBeVisible();
+    await expectNoA11yViolations(page, locators.sidebar.pane);
+  });
+
+  test("Export dialog has no WCAG 2.2 AA violations", async ({ page }) => {
+    await clickExport(page);
+    await expect(page.getByRole("dialog", { name: "Export" })).toBeVisible();
+    await expectNoA11yViolations(page, locators.dialog.root);
+  });
+
+  test("Share dialog has no WCAG 2.2 AA violations", async ({ page }) => {
+    // The toolbar has a tooltip-trigger button and the action button both named
+    // "Share", so target the action button by its testid.
+    await page.getByTestId("btn-share").click();
+    // Assert by accessible name so the scan runs against the Share dialog, not
+    // whatever dialog happens to match the generic selector.
+    await expect(
+      page.getByRole("dialog", { name: "Share Layout" }),
+    ).toBeVisible();
+    await expectNoA11yViolations(page, locators.dialog.root);
+  });
+});

--- a/e2e/helpers/a11y.ts
+++ b/e2e/helpers/a11y.ts
@@ -1,0 +1,115 @@
+/**
+ * Helpers for the axe-core accessibility scan suite (axe.spec.ts, issue #2099).
+ *
+ * A guard rail: each scan runs axe-core against a rendered surface and fails the
+ * test on any violation under the WCAG 2.2 AA rule set. It complements the
+ * behavioural checks in accessibility.spec.ts (keyboard paths, focus trapping,
+ * landmarks) rather than replacing them: axe catches the static, machine-
+ * detectable failures (contrast, names, roles, attributes) across whole
+ * surfaces, while the behavioural suite covers what axe cannot observe.
+ *
+ * Adding a scan when a new surface lands: open the surface in a test, then call
+ * `expectNoA11yViolations(page, locator)` scoped to it. See the documented
+ * pattern in docs/guides/TESTING.md.
+ */
+import AxeBuilder from "@axe-core/playwright";
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * axe rule tags that map to WCAG 2.2 Level AA. axe groups rules by the standard
+ * they enforce; scanning with exactly these tags fails CI on AA-level issues
+ * without flagging AAA rules (which the project does not commit to) or best-
+ * practice heuristics (which are advisory, not conformance failures).
+ */
+export const WCAG_22_AA_TAGS = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22a",
+  "wcag22aa",
+] as const;
+
+/**
+ * Build an axe scanner pinned to the WCAG 2.2 AA rule set. Callers add
+ * `.include(...)` / `.exclude(...)` / `.disableRules(...)` before `.analyze()`.
+ */
+export function axeBuilder(page: Page): AxeBuilder {
+  return new AxeBuilder({ page }).withTags([...WCAG_22_AA_TAGS]);
+}
+
+/**
+ * Rules baselined as known, pre-existing violations. Each entry MUST cite a
+ * tracking issue so the debt is visible and time-bound, not silently ignored.
+ *
+ * Keep this list empty unless a surface genuinely cannot pass yet. A baseline is
+ * a deferral, not a fix: prefer fixing the violation. When you add an entry, the
+ * scan stops failing on that rule everywhere, so scope it as narrowly as
+ * possible and remove it as soon as the linked issue closes.
+ *
+ * @example
+ *   // export const BASELINED_RULES = {
+ *   //   "color-contrast": "https://github.com/RackulaLives/Rackula/issues/NNNN",
+ *   // } as const;
+ */
+export const BASELINED_RULES: Record<string, string> = {
+  // Pre-existing violations found when the guard rail was first wired (#2099).
+  // A baselined rule is disabled for ALL scans, so the guard rail still fails on
+  // any non-baselined rule but will NOT catch a fresh violation of a baselined
+  // rule (even on a new surface). That is the accepted cost of the baseline:
+  // narrow the list, and remove each entry as soon as its issue closes so the
+  // rule is enforced again everywhere.
+  "aria-required-parent": "https://github.com/RackulaLives/Rackula/issues/2253",
+  "aria-required-children":
+    "https://github.com/RackulaLives/Rackula/issues/2254",
+  "nested-interactive": "https://github.com/RackulaLives/Rackula/issues/2255",
+  "color-contrast": "https://github.com/RackulaLives/Rackula/issues/2256",
+};
+
+/**
+ * Run an axe scan on `selector` (a whole page or a single surface) and assert it
+ * has no WCAG 2.2 AA violations. Baselined rules (see BASELINED_RULES) are
+ * disabled so the guard rail enforces "no new violations" while known debt is
+ * tracked separately.
+ *
+ * @param page     The Playwright page.
+ * @param selector Optional CSS selector to scope the scan to one surface (a
+ *   dialog, the sidebar). Omit to scan the full page. Scoping keeps a
+ *   per-surface failure from masking the rest and makes the report point at the
+ *   right component. axe's `.include()` takes a CSS selector, not a Playwright
+ *   Locator, so pass the selector string (e.g. a `[data-testid="..."]` from the
+ *   `locators` registry).
+ */
+export async function expectNoA11yViolations(
+  page: Page,
+  selector?: string,
+): Promise<void> {
+  let builder = axeBuilder(page);
+
+  if (selector) {
+    builder = builder.include(selector);
+  }
+
+  const baselined = Object.keys(BASELINED_RULES);
+  if (baselined.length > 0) {
+    builder = builder.disableRules(baselined);
+  }
+
+  const results = await builder.analyze();
+
+  // Surface a readable summary in the failure message: which rule, how many
+  // nodes, and a link to the axe rule docs. The raw results object is large and
+  // unhelpful when a test fails in CI.
+  const summary = results.violations.map((v) => ({
+    rule: v.id,
+    impact: v.impact,
+    help: v.helpUrl,
+    nodes: v.nodes.length,
+    targets: v.nodes.flatMap((n) => n.target),
+  }));
+
+  expect(
+    results.violations,
+    `axe found ${results.violations.length} WCAG 2.2 AA violation(s):\n${JSON.stringify(summary, null, 2)}`,
+  ).toEqual([]);
+}

--- a/e2e/playwright.a11y.config.ts
+++ b/e2e/playwright.a11y.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright configuration for the axe-core accessibility suite (issue #2099).
+ *
+ * A guard rail for epic #2017: runs axe-core against the key surfaces and fails
+ * CI on any WCAG 2.2 AA violation. Kept separate from the main E2E config so the
+ * scans can be run and gated on their own, and so a layout regression in the
+ * functional suite does not hide an accessibility regression (or vice versa).
+ *
+ * Chromium only: axe-core results do not vary by browser engine (the rules
+ * inspect the DOM and computed styles, not engine quirks), so one browser is
+ * enough and keeps the job fast. No retries: an axe violation is deterministic,
+ * so a retry would only mask real flake elsewhere in the harness.
+ */
+export default defineConfig({
+  testDir: ".",
+  testMatch: ["axe.spec.ts"],
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "on-first-retry",
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run build && npm run preview",
+    port: 4173,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+    cwd: "..",
+  },
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -28,11 +28,13 @@ export default defineConfig({
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
-      // visual-regression.spec.ts has its own config (playwright.visual.config.ts).
+      // visual-regression.spec.ts and axe.spec.ts have their own configs
+      // (playwright.visual.config.ts, playwright.a11y.config.ts).
       testIgnore: [
         "**/ios-safari.spec.ts",
         "**/android-chrome.spec.ts",
         "**/visual-regression.spec.ts",
+        "**/axe.spec.ts",
       ],
     },
     {
@@ -42,6 +44,7 @@ export default defineConfig({
         "**/ios-safari.spec.ts",
         "**/android-chrome.spec.ts",
         "**/visual-regression.spec.ts",
+        "**/axe.spec.ts",
       ],
     },
     // iOS Safari tests

--- a/e2e/playwright.dev.config.ts
+++ b/e2e/playwright.dev.config.ts
@@ -22,8 +22,9 @@ export default defineConfig({
     cwd: "..",
   },
   testDir: ".",
-  // visual-regression.spec.ts has its own config (playwright.visual.config.ts).
-  testIgnore: ["**/visual-regression.spec.ts"],
+  // visual-regression.spec.ts and axe.spec.ts have their own configs
+  // (playwright.visual.config.ts, playwright.a11y.config.ts).
+  testIgnore: ["**/visual-regression.spec.ts", "**/axe.spec.ts"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.60.0",
@@ -122,6 +123,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2899,6 +2913,16 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:e2e:smoke": "playwright test --config e2e/playwright.smoke.config.ts",
     "test:e2e:visual": "playwright test --config e2e/playwright.visual.config.ts",
     "test:e2e:visual:update": "playwright test --config e2e/playwright.visual.config.ts --update-snapshots",
+    "test:e2e:a11y": "playwright test --config e2e/playwright.a11y.config.ts",
     "test:coverage": "NODE_OPTIONS=--max-old-space-size=8192 vitest run --coverage",
     "check:compose-parity": "bash scripts/check-compose-persist-parity.sh",
     "lint": "eslint .",
@@ -38,6 +39,7 @@
     "deps:status": "npm outdated || true"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.60.0",


### PR DESCRIPTION
## **User description**
## Summary

Wires automated WCAG 2.2 AA accessibility scans into CI as a guard rail for the UX overhaul (epic #2017). Each scan runs axe-core (`@axe-core/playwright`) against a key surface and fails CI on any AA violation, so accessibility regressions are caught automatically rather than only by manual review.

This is the automated-scan layer. It complements the behavioural a11y tests added in #1231 (`e2e/accessibility.spec.ts`: keyboard paths, focus trapping, landmarks), which cover what axe cannot observe.

## What changed

- `e2e/helpers/a11y.ts`: `expectNoA11yViolations(page, selector?)` pinned to the WCAG 2.2 AA tag set, plus a `BASELINED_RULES` map (each entry cites a tracking issue) for pre-existing debt.
- `e2e/axe.spec.ts`: scans the populated canvas with a selected device, the sidebar Devices and Racks tabs, and the Export and Share dialogs.
- `e2e/playwright.a11y.config.ts`: dedicated Chromium-only config, no retries (axe results are deterministic and engine-independent).
- `.github/workflows/test.yml`: new `a11y (axe-core)` job, runs on every PR.
- `e2e/playwright.config.ts` / `playwright.dev.config.ts`: ignore `axe.spec.ts` (it runs on its own config).
- `docs/guides/TESTING.md`: documented pattern for adding a scan when a new surface lands.

## Baselined pre-existing violations

The current app has pre-existing AA violations. Per the issue's acceptance criteria, each is baselined with its own tracking issue; the guard rail still fails on any non-baselined rule:

- `aria-required-parent` -> #2253
- `aria-required-children` -> #2254
- `nested-interactive` -> #2255
- `color-contrast` -> #2256

## Acceptance criteria

- [x] axe scans wired into the Playwright E2E CI (new `a11y` job on PRs)
- [x] Scans cover canvas, sidebar, and dialogs (new shell surfaces added as they land)
- [x] CI fails on WCAG 2.2 AA violations; existing violations baselined with an issue each
- [x] Documented pattern for adding a scan when a new surface lands

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:run` (2211 unit tests pass)
- [x] `npm run build` succeeds
- [x] `npm run test:e2e:a11y` passes (5/5 scans green with baselines applied; verified it fails on real violations before baselining)

This is a milestone guard rail: once merged it gates all M14 feature merges.

Closes #2099


___

## **CodeAnt-AI Description**
Add automated accessibility scans to CI for key screens

### What Changed
- CI now runs axe-based accessibility checks on the main canvas, sidebar tabs, and Export and Share dialogs
- Known pre-existing accessibility issues are tracked separately so the new scans still block fresh problems
- Added a dedicated accessibility test setup and command so these scans run on their own
- Documented how to add new accessibility scans when new screens are introduced

### Impact
`✅ Fewer accessibility regressions`
`✅ Earlier WCAG 2.2 AA checks in pull requests`
`✅ Clearer accessibility failure reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
