### PR TITLE
fix(export): defer object URL revocation to avoid racing download start (#2201)

### DIFF
--- a/src/lib/utils/export/utils.ts
+++ b/src/lib/utils/export/utils.ts
@@ -11,7 +11,10 @@ export function downloadBlob(blob: Blob, filename: string): void {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  // Defer revocation so the URL stays valid while the browser starts the
+  // download. Revoking synchronously can race the download start and produce
+  // intermittent failed or empty downloads.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 /**

--- a/src/tests/export-utils.test.ts
+++ b/src/tests/export-utils.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { downloadBlob } from "$lib/utils/export/utils";
+
+describe("downloadBlob", () => {
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createObjectURL = vi.fn(() => "blob:mock-url");
+    revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+    // happy-dom anchors throw on click navigation; suppress the no-op click.
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not revoke the object URL synchronously (would race the download)", () => {
+    const blob = new Blob(["data"], { type: "text/plain" });
+
+    downloadBlob(blob, "export.txt");
+
+    // The download may begin asynchronously after click(); revoking now would
+    // invalidate the URL before the browser fetches it.
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("revokes the object URL on a later tick to free memory", () => {
+    const blob = new Blob(["data"], { type: "text/plain" });
+
+    downloadBlob(blob, "export.txt");
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:mock-url");
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

`downloadBlob` revoked the object URL synchronously immediately after `link.click()`. Browsers that begin fetching the blob asynchronously after `click()` could see the URL invalidated before the download started, causing intermittent failed or empty downloads. This affects all export formats (SVG, PNG, JPEG, PDF), CSV export, and ShareDialog YAML downloads, since they all route through `downloadBlob`.

The fix defers revocation with `setTimeout(() => URL.revokeObjectURL(url), 0)` so the URL stays valid long enough for the download to begin. Memory is still freed on the next tick.

## Changes

- `src/lib/utils/export/utils.ts`: defer `URL.revokeObjectURL` to a later tick.
- `src/tests/export-utils.test.ts`: new focused tests asserting revocation is deferred (not synchronous) and still occurs after timers advance. Written TDD-first (red against the old synchronous code, green after the fix).

## Test Plan

- [x] `npm run lint` clean
- [x] New tests fail against the old synchronous implementation, pass after the fix
- [x] Export-related test suites pass, no regressions
- [x] Local /code-review clean

## Provenance

Pre-existing behaviour surfaced by CodeAnt on PR #2199; filed separately to keep that PR a pure structural refactor.

Closes #2201


___

## **CodeAnt-AI Description**
**Prevent exports from failing when the download starts**

### What Changed
- Export files now keep their download link valid long enough for the browser to start the download, which avoids empty or failed downloads.
- The link is still cleaned up on the next tick so browser memory is released after the download begins.
- Added tests to confirm the link is not removed too early and is still cleaned up shortly after.

### Impact
`✅ Fewer failed exports`
`✅ Fewer empty download files`
`✅ Reliable SVG, PNG, JPEG, PDF, CSV, and YAML downloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
