### PR TITLE
fix: revert rack height input when a bayed rack rejects the resize (#2222)

### DIFF
--- a/src/lib/components/EditPanelRack.svelte
+++ b/src/lib/components/EditPanelRack.svelte
@@ -86,6 +86,18 @@
 
   // Validate and apply height change
   function attemptHeightChange(newHeight: number): boolean {
+    // Bayed racks must all share a height, so the store rejects per-rack
+    // height changes. Detect that here and revert the optimistic value,
+    // otherwise the input keeps showing a height the rack never adopted
+    // (#2222). getRackGroupForRack is authoritative regardless of whether
+    // the group or an individual bay was selected.
+    const group = layoutStore.getRackGroupForRack(selectedRack.id);
+    if (group?.layout_preset === "bayed") {
+      resizeError = "Bayed racks must share the same height.";
+      rackHeight = selectedRack.height;
+      return false;
+    }
+
     const result = canResizeRackTo(
       selectedRack,
       newHeight,

--- a/src/lib/components/EditPanelRack.svelte
+++ b/src/lib/components/EditPanelRack.svelte
@@ -86,6 +86,14 @@
 
   // Validate and apply height change
   function attemptHeightChange(newHeight: number): boolean {
+    // Re-submitting the current height (re-entering the value, clicking the
+    // already-active preset) is a no-op, not a resize attempt, so it must not
+    // surface a rejection error (#2222).
+    if (newHeight === selectedRack.height) {
+      resizeError = null;
+      return true;
+    }
+
     // Bayed racks must all share a height, so the store rejects per-rack
     // height changes. Detect that here and revert the optimistic value,
     // otherwise the input keeps showing a height the rack never adopted

--- a/src/tests/layout-rack-actions.test.ts
+++ b/src/tests/layout-rack-actions.test.ts
@@ -231,6 +231,21 @@ describe("Layout Store", () => {
       }
     });
 
+    it("rejects a height change for a bayed-group member (#2222)", () => {
+      const store = getLayoutStore();
+      const result = store.addBayedRackGroup("Bayed", 2, 12);
+      expect(result).not.toBeNull();
+      const bay = result!.racks[0];
+      expect(bay.height).toBe(12);
+
+      // Bayed racks must stay the same height. The store silently rejects the
+      // resize so the edit panel can revert its optimistic value (#2222).
+      store.updateRack(bay.id, { height: 24 });
+
+      const after = store.layout.racks.find((r) => r.id === bay.id)!;
+      expect(after.height).toBe(12);
+    });
+
     it("does not propagate non-numbering settings across a bayed group", () => {
       const store = getLayoutStore();
       const result = store.addBayedRackGroup("Bayed", 2, 12);


### PR DESCRIPTION
## **User description**
## Summary

Fixes the rack height preset/input showing a new value even when a bayed rack rejects the resize.

When changing a rack's height via the number input or a preset button, the edit panel optimistically updates the displayed height (`rackHeight` local `$state`, two-way `bind:value`) before the store applies it. For racks in a bayed group, the store's `updateRack` silently rejects per-rack height changes (bays must share a height). The component never reconciled, so the input and preset buttons kept showing a value the rack never adopted, leaving the UI and the model in disagreement.

## Root cause

- `EditPanelRack.attemptHeightChange` only guarded against device-collision conflicts via `canResizeRackTo`. That validator returns `allowed: true` for a bayed rack with no overlapping devices, so the optimistic value was kept and `layoutStore.updateRack({ height })` was called.
- The store rejects the height change for `layout_preset === "bayed"` and returns early (`src/lib/stores/layout/rack-actions.ts`).
- Because `selectedRack.height` never changed, the panel's sync `$effect` did not re-run, so the optimistic `rackHeight` was never reverted.

## Fix

Detect the bayed-group case in `attemptHeightChange` before calling the store, set an error message, and revert `rackHeight` to the rack's actual height. This mirrors the existing device-conflict revert path in the same function.

`getRackGroupForRack(selectedRack.id)` is used rather than the `selectedGroup` prop because that prop is only populated when a group is selected; selecting a bay from the rack list sidebar selects it as a plain rack (`selectedGroup` is `null`) while the store still rejects the resize.

## Acceptance criteria

- [x] Confirm bayed-rack height-resize behaviour in the store (store silently rejects; locked by regression test)
- [x] On a rejected/no-op resize, the height input reflects the actual rack height (revert + error in `attemptHeightChange`)
- [x] Add a regression test for the rejected-resize path (`layout-rack-actions.test.ts`)

## Testing

- Full unit suite: 2212 passed (120 files)
- New regression test passes
- ESLint clean, prettier clean, Svelte autofixer clean on the changed component

Closes #2222

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep rack height input in sync when a bayed rack rejects resizing**

### What Changed
- If you try to change the height of a rack inside a bayed group, the edit panel now shows an error and snaps the height input back to the rack's real height
- Height changes for bayed racks are no longer left visible in the UI when the store rejects them
- Added a regression test to confirm bayed rack height changes are ignored

### Impact
`✅ Fewer mismatched rack height values`
`✅ Clearer resize feedback for bayed racks`
`✅ Fewer silent no-op edits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
