### PR TITLE
fix: keep container-child devices in their container on position move (#2224)

### DIFF
--- a/src/lib/components/EditPanelPosition.svelte
+++ b/src/lib/components/EditPanelPosition.svelte
@@ -6,7 +6,11 @@
 <script lang="ts">
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
-  import { canPlaceDevice, isSlotOccupied } from "$lib/utils/collision";
+  import {
+    canPlaceDevice,
+    isContainerChild,
+    isSlotOccupied,
+  } from "$lib/utils/collision";
   import {
     toHumanUnits,
     toInternalUnits,
@@ -22,6 +26,14 @@
 
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
+
+  // Container children use container-relative positions; a rack-level move
+  // (what layoutStore.moveDevice does) would detach them from their container.
+  // The vertical Position controls are inert for children, matching the
+  // keyboard nudge path. Deliberate detachment happens via drag-out.
+  const isChildDevice = $derived(
+    isContainerChild(selectedDeviceInfo.placedDevice),
+  );
 
   // Format an internal-unit position for display, honouring the rack's U
   // numbering direction (desc_units flips the whole-U part, keeps the fraction).
@@ -40,6 +52,9 @@
    * @param step - Step size in U (default 1, use 0.5 for fine movement)
    */
   function moveDevice(direction: number, step: number = 1) {
+    // A rack-level move would eject a container child from its container.
+    if (isChildDevice) return;
+
     const { device, placedDevice, rack, deviceIndex } = selectedDeviceInfo;
 
     // Convert internal units to human U for calculations
@@ -77,6 +92,7 @@
 
   // Check if device can move up
   const canMoveUp = $derived.by(() => {
+    if (isChildDevice) return false;
     const { device, placedDevice, rack, deviceIndex } = selectedDeviceInfo;
     // Convert to human U and add 1
     const newPositionU = toHumanUnits(placedDevice.position) + 1;
@@ -94,6 +110,7 @@
 
   // Check if device can move down
   const canMoveDown = $derived.by(() => {
+    if (isChildDevice) return false;
     const { device, placedDevice, rack, deviceIndex } = selectedDeviceInfo;
     // Convert to human U and subtract 1
     const newPositionU = toHumanUnits(placedDevice.position) - 1;
@@ -301,6 +318,7 @@
           type="button"
           class="position-btn position-btn-fine"
           onclick={() => moveDevice(-1, 1 / 3)}
+          disabled={isChildDevice}
           aria-label="Move device down by one-third rack unit"
           title="Move down ⅓U (fine)"
         >
@@ -310,6 +328,7 @@
           type="button"
           class="position-btn position-btn-fine"
           onclick={() => moveDevice(1, 1 / 3)}
+          disabled={isChildDevice}
           aria-label="Move device up by one-third rack unit"
           title="Move up ⅓U (fine)"
         >

--- a/src/lib/utils/device-movement.ts
+++ b/src/lib/utils/device-movement.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Rack, DeviceType, PlacedDevice } from "$lib/types";
-import { canPlaceDevice } from "./collision";
+import { canPlaceDevice, isContainerChild } from "./collision";
 import {
   UNITS_PER_U,
   toInternalUnits,
@@ -51,6 +51,15 @@ export function findNextValidPosition(
 ): MoveResult {
   const placedDevice = rack.devices[deviceIndex];
   if (!placedDevice) {
+    return { success: false, newPosition: null, reason: "no_valid_position" };
+  }
+
+  // Container children use container-relative positions and are excluded from
+  // rack-level collision. A rack-level move would compute a rack U and shed the
+  // container linkage (see moveDeviceRecorded), ejecting the child from its
+  // container. Vertical position nudging must not do that, so report no valid
+  // position. Deliberate detachment happens via drag-out, not nudge controls.
+  if (isContainerChild(placedDevice)) {
     return { success: false, newPosition: null, reason: "no_valid_position" };
   }
 

--- a/src/tests/device-movement.test.ts
+++ b/src/tests/device-movement.test.ts
@@ -413,6 +413,16 @@ describe("Device Movement Utility", () => {
 
       expect(canMoveUp(rack, deviceTypes, 0)).toBe(false);
     });
+
+    it("returns false for a container child (rack-level move would detach it)", () => {
+      const child = pd("1u-server", 10, "front");
+      child.container_id = "container-1";
+      child.slot_id = "slot-left";
+      const rack = createTestRack(42, [child]);
+      const deviceTypes = createDeviceTypes();
+
+      expect(canMoveUp(rack, deviceTypes, 0)).toBe(false);
+    });
   });
 
   describe("canMoveDown", () => {
@@ -438,6 +448,16 @@ describe("Device Movement Utility", () => {
         pd("1u-server", 2, "front"),
         pd("1u-server", 1, "front"),
       ]);
+      const deviceTypes = createDeviceTypes();
+
+      expect(canMoveDown(rack, deviceTypes, 0)).toBe(false);
+    });
+
+    it("returns false for a container child (rack-level move would detach it)", () => {
+      const child = pd("1u-server", 10, "front");
+      child.container_id = "container-1";
+      child.slot_id = "slot-left";
+      const rack = createTestRack(42, [child]);
       const deviceTypes = createDeviceTypes();
 
       expect(canMoveDown(rack, deviceTypes, 0)).toBe(false);


### PR DESCRIPTION
## **User description**
## Summary

The EditPanel Position up/down/fine move buttons silently detached a container-child device from its container.

For a device placed inside a container slot (`container_id` set), the Position controls called `layoutStore.moveDevice(...)`, which performs a rack-level move. Rack-level moves deliberately shed container linkage (`moveDeviceRecorded` appends a `DetachContainerCommand`) because dragging a child out of its container should detach it. The Position buttons fired that same path unconditionally, so nudging a child's position popped it out of its container.

Flagged during the EditPanel decomposition review (#2216, CodeAnt). Pre-existing behaviour, not introduced by the refactor.

## Decision (AC: intended behaviour)

Match the established keyboard nudge precedent (`KeyboardHandler.svelte` already blocks arrow-key nudges for container children): the vertical Position controls are inert for container children. The existing "Inside Container" context card above the controls explains the device's placement. Deliberate detachment still happens via drag-out.

## Changes

- `EditPanelPosition.svelte`: derive `isChildDevice`, short-circuit the `moveDevice` handler, force `canMoveUp`/`canMoveDown` to `false`, and disable the fine (1/3U) buttons for container children. This is the fix for the bug.
- `device-movement.ts`: `findNextValidPosition` returns no-valid-position for container children. This is deliberate defence-in-depth on the shared movement utility (guarding its invariant for any caller) and is the seam covered by the regression tests below. The component does not consume this utility today (it has its own inline derivations), so this guard is not the load-bearing fix; the component changes are.

## Store contract unchanged

The store's detach-on-move is intentional and remains untouched (covered by `dnd-between-racks.test.ts` "detaches a contained device moved via the direct moveDevice path"). The fix gates the UI entry point, not the store.

## Testing

- New: `device-movement.test.ts` asserts `canMoveUp`/`canMoveDown` return `false` for a container child (regression coverage).
- Full unit suite: 2213 passed (120 files). Lint clean. Svelte autofixer clean. Pre-existing svelte-check errors in `Rack.svelte` and `qrcode.ts` are unrelated (tracked under M04 TS burndown).

Closes #2224

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep container child devices from being detached by position nudges**

### What Changed
- Position up/down and fine-move controls no longer act on devices that are placed inside a container slot
- Container child devices now show the position controls as unavailable, matching the keyboard nudge behavior
- Shared movement checks now treat container children as non-movable at rack level, and tests cover this case

### Impact
`✅ Fewer accidental container detachments`
`✅ Safer position nudges for mounted devices`
`✅ Clearer move controls for container children`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
