### PR TITLE
fix: pin in-progress device name edit to its device (#2223)

### DIFF
--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -39,9 +39,16 @@
     findDeviceType(selectedDeviceInfo.device.slug) ?? selectedDeviceInfo.device,
   );
 
-  // State for device name editing
-  let editingDeviceName = $state(false);
+  // State for device name editing. editingDeviceId pins the edit to the device
+  // it started on; the editor is only open while the current selection still
+  // matches it, so a pending edit never lands on a different placement when the
+  // selection changes mid-edit (#2223).
+  let editingDeviceId = $state<string | null>(null);
   let deviceNameInput = $state("");
+  const editingDeviceName = $derived(
+    editingDeviceId !== null &&
+      selectedDeviceInfo.placedDevice.id === editingDeviceId,
+  );
 
   // Notes and IP mirror the placement and are edited via bind:value.
   // Writable derived: resets to the placement value when the selection changes.
@@ -83,11 +90,18 @@
     const deviceName =
       selectedDeviceInfo.device.model ?? selectedDeviceInfo.device.slug;
     deviceNameInput = selectedDeviceInfo.placedDevice.name ?? deviceName;
-    editingDeviceName = true;
+    editingDeviceId = selectedDeviceInfo.placedDevice.id;
   }
 
   // Save device name
   function saveDeviceName() {
+    // Guard against a selection switch landing the edit on the wrong device.
+    // A blur can fire after the selection (and thus selectedDeviceInfo) has
+    // already advanced to another placement (#2223).
+    if (selectedDeviceInfo.placedDevice.id !== editingDeviceId) {
+      editingDeviceId = null;
+      return;
+    }
     const newName = deviceNameInput.trim();
     const deviceName =
       selectedDeviceInfo.device.model ?? selectedDeviceInfo.device.slug;
@@ -99,7 +113,7 @@
       selectedDeviceInfo.deviceIndex,
       nameToSave,
     );
-    editingDeviceName = false;
+    editingDeviceId = null;
   }
 
   // Handle device name input keydown
@@ -107,7 +121,7 @@
     if (event.key === "Enter") {
       saveDeviceName();
     } else if (event.key === "Escape") {
-      editingDeviceName = false;
+      editingDeviceId = null;
     }
   }
 

--- a/src/tests/edit-panel-name-edit-selection-switch.test.ts
+++ b/src/tests/edit-panel-name-edit-selection-switch.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for Issue #2223: In-progress device name edit can be applied to the
+ * wrong device when selection changes.
+ *
+ * The edit panel stays mounted across device selection changes. If you start
+ * editing device A's display name and then select device B before committing,
+ * the pending edit must NOT land on device B.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import EditPanel from "$lib/components/EditPanel.svelte";
+import { resetLayoutStore, getLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  resetSelectionStore,
+  getSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { resetUIStore } from "$lib/stores/ui.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+
+describe("EditPanel name edit + selection switch (#2223)", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetUIStore();
+    resetToastStore();
+  });
+
+  it("does not apply an in-progress name edit to a newly selected device", async () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const rack = layoutStore.addRack("Test Rack", 42);
+    const rackId = rack!.id;
+
+    const deviceType = layoutStore.addDeviceType({
+      name: "Server Type",
+      u_height: 1,
+      category: "server",
+      colour: "#4A90D9",
+    });
+
+    // Two placements of the same device type at different positions.
+    layoutStore.placeDevice(rackId, deviceType.slug, 1, "front");
+    layoutStore.placeDevice(rackId, deviceType.slug, 2, "front");
+
+    const deviceA = layoutStore.rack!.devices[0]!;
+    const deviceB = layoutStore.rack!.devices[1]!;
+
+    // Select device A and render the panel.
+    selectionStore.selectDevice(rackId, deviceA.id);
+    render(EditPanel);
+
+    // Enter edit mode for device A's name.
+    const editButton = screen.getByRole("button", {
+      name: /edit display name/i,
+    });
+    await fireEvent.click(editButton);
+
+    // Type a new name for device A (do not commit yet).
+    const nameInput = screen.getByLabelText(/^name$/i) as HTMLInputElement;
+    await fireEvent.input(nameInput, { target: { value: "Name For A" } });
+
+    // Switch selection to device B before committing.
+    selectionStore.selectDevice(rackId, deviceB.id);
+    await waitFor(() => {
+      expect(selectionStore.selectedDeviceId).toBe(deviceB.id);
+    });
+
+    // Commit the in-progress edit (e.g. blur fires).
+    await fireEvent.blur(nameInput);
+
+    // Device B must NOT receive device A's in-progress name.
+    const deviceBAfter = layoutStore.rack!.devices.find(
+      (d) => d.id === deviceB.id,
+    );
+    expect(deviceBAfter?.name).not.toBe("Name For A");
+  });
+
+  it("still commits a name edit to the device being edited (no switch)", async () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const rack = layoutStore.addRack("Test Rack", 42);
+    const rackId = rack!.id;
+
+    const deviceType = layoutStore.addDeviceType({
+      name: "Server Type",
+      u_height: 1,
+      category: "server",
+      colour: "#4A90D9",
+    });
+
+    layoutStore.placeDevice(rackId, deviceType.slug, 1, "front");
+    const deviceA = layoutStore.rack!.devices[0]!;
+
+    selectionStore.selectDevice(rackId, deviceA.id);
+    render(EditPanel);
+
+    const editButton = screen.getByRole("button", {
+      name: /edit display name/i,
+    });
+    await fireEvent.click(editButton);
+
+    const nameInput = screen.getByLabelText(/^name$/i) as HTMLInputElement;
+    await fireEvent.input(nameInput, { target: { value: "Renamed A" } });
+    await fireEvent.blur(nameInput);
+
+    const deviceAAfter = layoutStore.rack!.devices.find(
+      (d) => d.id === deviceA.id,
+    );
+    expect(deviceAAfter?.name).toBe("Renamed A");
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

While inline-editing a device's display name in the edit panel, switching the selection to a different device before committing could apply the in-progress edit to the newly selected device instead of the one being edited.

Root cause: the edit panel stays mounted across selection changes (the `selectedDeviceInfo` prop updates in place). The name editor's edit-mode flag was plain `$state` that never reset on selection change, and `saveDeviceName` wrote to whatever placement was currently selected. By contrast, the notes and IP fields were already writable `$derived` keyed off the placement, so they reset correctly.

## Fix

- Capture the placement id (`editingDeviceId`) when editing starts.
- Derive the open/closed editor state: `editingDeviceName` is now `$derived` and is true only while the current selection still matches `editingDeviceId`. Switching selection mid-edit therefore closes the editor automatically.
- Guard `saveDeviceName` against the blur race: a blur can fire after the selection has already advanced, so the save aborts when the current placement id no longer matches the one being edited.

The edit is keyed to the stable `PlacedDevice.id` UUID, so two placements of the same device type are distinguished correctly and the guard is safe against reordering or deletion.

## Test Plan

- [x] New regression test `src/tests/edit-panel-name-edit-selection-switch.test.ts`: start editing device A, switch selection to device B, commit, assert device B does not receive A's in-progress name. (Confirmed failing before the fix, passing after.)
- [x] Happy-path test: editing without a switch still commits to the edited device.
- [x] `npm run lint` clean
- [x] `npm run test:run` (2213 tests) pass
- [x] `npm run build` succeeds
- [x] svelte-autofixer clean on the changed component

Closes #2223


___

## **CodeAnt-AI Description**
**Keep device name edits tied to the device being edited**

### What Changed
- A device name edit now stays attached to the original device, even if the selection changes before the edit is saved.
- If you switch to another device while editing, the pending name change is discarded instead of being applied to the newly selected device.
- Pressing Enter or blurring still saves the name when you remain on the same device, and Escape still cancels the edit.
- Added tests that cover both the selection-switch case and the normal save flow.

### Impact
`✅ Fewer wrong-device renames`
`✅ Safer device switching during inline edits`
`✅ Clearer edit behavior while changing selections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
