### PR TITLE
fix: resolve container sibling types globally in canPlaceInContainer (#2131)

### DIFF
--- a/src/lib/data/brandPacks/index.ts
+++ b/src/lib/data/brandPacks/index.ts
@@ -396,43 +396,50 @@ export function getBrandDevices(brandId: string): DeviceType[] {
   }
 }
 
+// Cached merged array of all brand devices (built once on first access)
+let cachedBrandDevices: DeviceType[] | null = null;
+
 /**
  * Get all devices from all brand packs as a single array
- * Used by findBrandDevice and getBrandSlugs to avoid duplication
+ * Used by findBrandDevice and getBrandSlugs to avoid duplication.
+ * Brand packs are static data, so the merged array is built once and cached.
  */
 export function getAllBrandDevices(): DeviceType[] {
-  return [
-    ...ubiquitiDevices,
-    ...mikrotikDevices,
-    ...tplinkDevices,
-    ...synologyDevices,
-    ...apcDevices,
-    ...dellDevices,
-    ...supermicroDevices,
-    ...hpeDevices,
-    ...fortinetDevices,
-    ...eatonDevices,
-    ...netgearDevices,
-    ...paloaltoDevices,
-    ...qnapDevices,
-    ...lenovoDevices,
-    ...cyberpowerDevices,
-    ...netgateDevices,
-    ...blackmagicdesignDevices,
-    ...deskpiDevices,
-    ...kwsDevices,
-    ...acInfinityDevices,
-    ...appleDevices,
-    ...ciscoDevices,
-    ...aristaDevices,
-    ...juniperDevices,
-    ...vertivDevices,
-    ...fsDevices,
-    ...intelDevices,
-    ...beelinkDevices,
-    ...raspberryPiDevices,
-    ...zimaDevices,
-  ];
+  if (!cachedBrandDevices) {
+    cachedBrandDevices = [
+      ...ubiquitiDevices,
+      ...mikrotikDevices,
+      ...tplinkDevices,
+      ...synologyDevices,
+      ...apcDevices,
+      ...dellDevices,
+      ...supermicroDevices,
+      ...hpeDevices,
+      ...fortinetDevices,
+      ...eatonDevices,
+      ...netgearDevices,
+      ...paloaltoDevices,
+      ...qnapDevices,
+      ...lenovoDevices,
+      ...cyberpowerDevices,
+      ...netgateDevices,
+      ...blackmagicdesignDevices,
+      ...deskpiDevices,
+      ...kwsDevices,
+      ...acInfinityDevices,
+      ...appleDevices,
+      ...ciscoDevices,
+      ...aristaDevices,
+      ...juniperDevices,
+      ...vertivDevices,
+      ...fsDevices,
+      ...intelDevices,
+      ...beelinkDevices,
+      ...raspberryPiDevices,
+      ...zimaDevices,
+    ];
+  }
+  return cachedBrandDevices;
 }
 
 /**

--- a/src/lib/utils/collision.ts
+++ b/src/lib/utils/collision.ts
@@ -18,6 +18,7 @@ import type {
   Slot,
 } from "$lib/types";
 import { UNITS_PER_U, heightToInternalUnits } from "$lib/utils/position";
+import { findDeviceType } from "$lib/utils/device-lookup";
 
 // Re-export SlotPosition for test imports
 export type { SlotPosition } from "$lib/types";
@@ -462,7 +463,8 @@ export function canPlaceInSlot(childType: DeviceType, slot: Slot): boolean {
  * - Inherit face from parent container
  *
  * @param rack - The rack containing the container
- * @param deviceLibrary - The device library
+ * @param deviceLibrary - The layout's device types; sibling types are resolved
+ *   through the global lookup path (layout, starter pack, brand packs)
  * @param container - The parent container PlacedDevice
  * @param containerType - The DeviceType of the container
  * @param childType - The DeviceType of the child device to place
@@ -523,12 +525,13 @@ export function canPlaceInContainer(
       continue;
     }
 
-    // Get the sibling's device type for height
-    const siblingType = deviceLibrary.find(
-      (dt) => dt.slug === device.device_type,
-    );
+    // Get the sibling's device type for height. Resolve through the global
+    // lookup path so siblings whose types live only in the starter pack or
+    // brand packs (for example a loaded layout without embedded types) are
+    // still checked. Fail closed if the type cannot be resolved at all.
+    const siblingType = findDeviceType(device.device_type, deviceLibrary);
     if (!siblingType) {
-      continue;
+      return false;
     }
 
     // Container children use 0-indexed positions, not internal units

--- a/src/tests/container-collision.test.ts
+++ b/src/tests/container-collision.test.ts
@@ -22,6 +22,7 @@ import {
   createTestContainerChild,
 } from "./factories";
 import { toInternalUnits } from "$lib/utils/position";
+import { findStarterDevice } from "$lib/data/starterLibrary";
 import type { PlacedDevice, DeviceType, Rack } from "$lib/types";
 
 // =============================================================================
@@ -711,5 +712,144 @@ describe("Container collision edge cases", () => {
         1,
       ),
     ).toBe(true);
+  });
+});
+
+// =============================================================================
+// Sibling Types Resolvable Only Outside the Layout Library (Issue #2131)
+// =============================================================================
+
+describe("Sibling collision when sibling type is not in the passed library", () => {
+  it("detects overlap with a sibling whose type is only resolvable globally", () => {
+    // Sibling references a starter-pack slug that is NOT embedded in the
+    // device library passed to canPlaceInContainer. This mirrors a loaded
+    // layout whose children reference starter/brand-pack types by slug only.
+    const starterSlug = "2u-server";
+    const starterDevice = findStarterDevice(starterSlug);
+    // Guard the scenario premise: starter device exists and is 2U.
+    expect(starterDevice?.u_height).toBe(2);
+
+    const containerType = createTestContainerType({
+      slug: "blade-chassis",
+      u_height: 4,
+    });
+    const childType = createTestDeviceType({
+      slug: "blade-server",
+      u_height: 1,
+      slot_width: 1,
+    });
+
+    const container = createTestDevice({
+      id: "container-1",
+      device_type: "blade-chassis",
+      position: 5,
+    });
+    // Existing sibling occupies positions 0-1 (2U starter device).
+    const existingChild = createTestContainerChild({
+      container_id: "container-1",
+      slot_id: "slot-left",
+      position: 0,
+      device_type: starterSlug,
+    });
+    const rack = createTestRack({ devices: [container, existingChild] });
+
+    // Library deliberately omits the sibling's starter type, leaving only
+    // the container type and the new child type.
+    const deviceLibrary = [containerType, childType];
+
+    // Placing a 1U child at position 1 overlaps the sibling's 0-1 range.
+    expect(
+      canPlaceInContainer(
+        rack,
+        deviceLibrary,
+        container,
+        containerType,
+        childType,
+        "slot-left",
+        1,
+      ),
+    ).toBe(false);
+  });
+
+  it("allows non-overlapping placement next to a globally-resolved sibling", () => {
+    const starterSlug = "2u-server";
+    const containerType = createTestContainerType({
+      slug: "blade-chassis",
+      u_height: 4,
+    });
+    const childType = createTestDeviceType({
+      slug: "blade-server",
+      u_height: 1,
+      slot_width: 1,
+    });
+
+    const container = createTestDevice({
+      id: "container-1",
+      device_type: "blade-chassis",
+      position: 5,
+    });
+    // Sibling occupies positions 0-1.
+    const existingChild = createTestContainerChild({
+      container_id: "container-1",
+      slot_id: "slot-left",
+      position: 0,
+      device_type: starterSlug,
+    });
+    const rack = createTestRack({ devices: [container, existingChild] });
+
+    const deviceLibrary = [containerType, childType];
+
+    // Position 2 is clear of the sibling's 0-1 range and within the 4U container.
+    expect(
+      canPlaceInContainer(
+        rack,
+        deviceLibrary,
+        container,
+        containerType,
+        childType,
+        "slot-left",
+        2,
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks placement when a sibling type cannot be resolved anywhere", () => {
+    // Fail-closed: an unresolvable sibling type must not silently allow overlap.
+    const containerType = createTestContainerType({
+      slug: "blade-chassis",
+      u_height: 4,
+    });
+    const childType = createTestDeviceType({
+      slug: "blade-server",
+      u_height: 1,
+      slot_width: 1,
+    });
+
+    const container = createTestDevice({
+      id: "container-1",
+      device_type: "blade-chassis",
+      position: 5,
+    });
+    const existingChild = createTestContainerChild({
+      container_id: "container-1",
+      slot_id: "slot-left",
+      position: 0,
+      device_type: "totally-unknown-type",
+    });
+    const rack = createTestRack({ devices: [container, existingChild] });
+
+    const deviceLibrary = [containerType, childType];
+
+    expect(
+      canPlaceInContainer(
+        rack,
+        deviceLibrary,
+        container,
+        containerType,
+        childType,
+        "slot-left",
+        0,
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Fixes a fail-open gap in container-child collision validation. `canPlaceInContainer` resolved each sibling child's device type via `deviceLibrary.find(...)`, where `deviceLibrary` is `layout.device_types`. When a sibling's type was resolvable only from the starter library or brand packs (for example a loaded layout whose children reference built-in types by slug without embedding the full definitions), the lookup returned `undefined` and the loop did `continue`, silently skipping the overlap check for that sibling. Overlapping children in the same slot could then be accepted.

## Fix

- Resolve sibling types through the global `findDeviceType` path (layout types, then starter pack, then brand packs), the same lookup used elsewhere in the store.
- Fail closed (`return false`) when a sibling type cannot be resolved anywhere, so an unknown sibling height never permits a silent overlap.

## Reachability

Not introduced by #2127: child types were already globally resolvable before that fix, and interactive placement auto-imports child types. This is only reachable via loaded layouts with unembedded types.

## Tests

Added three TDD-driven cases to `container-collision.test.ts` (collision behaviour, the project's tested complex-logic category):

- detects overlap with a sibling whose type is only resolvable globally (starter pack), with that type deliberately omitted from the passed library
- allows a non-overlapping placement next to a globally-resolved sibling
- blocks placement when a sibling type cannot be resolved anywhere (fail-closed)

Full unit suite green (2214 tests). Lint clean on changed files. The two pre-existing `svelte-check` errors (`Rack.svelte`, `qrcode.ts`) are unrelated to this change.

Closes #2131

Related: #2127, #2128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent hidden child overlaps in container placement**

### What Changed
- Container child placement now checks sibling sizes using the full device lookup path, so children from starter packs or brand packs still block overlapping placements.
- If an existing sibling cannot be identified at all, placement is now rejected instead of silently allowed.
- Added coverage for overlapping, non-overlapping, and unresolved sibling cases.

### Impact
`✅ Fewer invalid container placements`
`✅ Clearer protection for loaded layouts with shared device types`
`✅ Fewer silent overlap errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
