### PR TITLE
feat: actions registry as single source for shortcuts and help (#2096)

### DIFF
--- a/e2e/keyboard.spec.ts
+++ b/e2e/keyboard.spec.ts
@@ -66,8 +66,10 @@ test.describe("Keyboard Shortcuts", () => {
   });
 
   test("? key opens help dialog", async ({ page }) => {
-    // Press ? using keyboard.type which handles shift automatically
-    await page.keyboard.type("?");
+    // Press the physical "?" combo (Shift + /). This dispatches a keydown with
+    // key "?" AND shiftKey=true, matching a real keyboard - keyboard.type("?")
+    // would synthesise a shift-less event and mask shift-handling regressions.
+    await page.keyboard.press("Shift+Slash");
 
     // Help dialog should open (HelpPanel uses Dialog component). Its sr-only
     // Dialog.Title "About Rackula" provides the accessible name, so the

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -1,0 +1,451 @@
+/**
+ * Actions registry: the single source of truth for command metadata across the
+ * app. The keyboard handler, the help overlay, and (later) the app menu (#2073)
+ * and floating verb bars (#2075) all read from this one list so they cannot
+ * drift apart.
+ *
+ * This module is data plus pure functions only. It declares each command's
+ * identity, label, scope, keybindings, and help placement. The runnable
+ * behaviour (the `run` closures over stores and app callbacks) is bound by the
+ * consumer at the call site, keyed by action id - see KeyboardHandler.svelte.
+ *
+ * Named "actions" (not "commands") deliberately: `src/lib/stores/commands/` is
+ * the undo/redo Command Pattern and is a different concept.
+ */
+
+import { matchesShortcut, type ShortcutHandler } from "$lib/utils/keyboard";
+import { formatShortcut } from "$lib/utils/platform";
+
+/**
+ * Where a command applies. Consumers use this to place a command on the right
+ * surface: global commands live on the app menu, layout commands on view
+ * controls, selection commands on the floating verb bars.
+ */
+export type ActionScope = "global" | "layout" | "selection";
+
+/** Stable identifiers for every registered action. */
+export type ActionId =
+  | "save"
+  | "save-as"
+  | "load"
+  | "export"
+  | "share"
+  | "undo"
+  | "redo"
+  | "duplicate-selection"
+  | "delete-selection"
+  | "fit-all"
+  | "toggle-display-mode"
+  | "toggle-annotations"
+  | "toggle-sidebar"
+  | "move-device-up"
+  | "move-device-down"
+  | "move-device-up-fine"
+  | "move-device-down-fine"
+  | "move-device-left"
+  | "move-device-right"
+  | "cycle-rack-prev"
+  | "cycle-rack-next"
+  | "escape"
+  | "show-help";
+
+/**
+ * A single keyboard binding. Mirrors the modifier shape of ShortcutHandler so
+ * the existing matchesShortcut logic resolves events identically.
+ */
+export interface KeyBinding {
+  key: string;
+  ctrl?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+}
+
+/** Named groups for the help overlay, rendered in this declared order. */
+export type HelpGroup = "Navigation" | "General" | "Editing" | "File";
+
+export interface ActionDefinition {
+  /** Stable identifier; the dispatch map and consumers key off this. */
+  id: ActionId;
+  /** Human-readable label for menus, verb bars, and the help overlay. */
+  label: string;
+  /** Where the command applies. */
+  scope: ActionScope;
+  /**
+   * Keyboard bindings. A command may have several (e.g. Ctrl and Cmd variants,
+   * or Delete and Backspace). May be empty for commands with no shortcut.
+   */
+  bindings: KeyBinding[];
+  /**
+   * Optional predicate deciding whether the command is currently runnable,
+   * given a selection/history snapshot. Consumers (verb bars, palette) call
+   * this to enable or hide the command. Selection-scoped commands typically
+   * define it; global commands typically do not.
+   */
+  enabledWhen?: (ctx: ActionEnabledContext) => boolean;
+  /** The help overlay group this command appears under, if any. */
+  helpGroup?: HelpGroup;
+  /**
+   * Display label for the help overlay key cell, used only when the command has
+   * no keyboard binding (e.g. mouse gestures documented in help). When omitted,
+   * the key is formatted from the primary binding.
+   */
+  helpKeyLabel?: string;
+  /** Fuzzy-search synonyms for the future command palette (#2020). */
+  keywords?: string[];
+}
+
+/** Snapshot consumed by enabledWhen predicates. */
+export interface ActionEnabledContext {
+  hasSelection: boolean;
+  isDeviceSelected: boolean;
+  isRackSelected: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
+/**
+ * The registry. Order within a help group is the order rows appear in the help
+ * overlay. Cross-platform Ctrl/Cmd commands list both bindings so the keyboard
+ * handler resolves either modifier.
+ */
+export const ACTION_REGISTRY: ActionDefinition[] = [
+  // --- Navigation -----------------------------------------------------------
+  {
+    id: "fit-all",
+    label: "Fit all (zoom to fit)",
+    scope: "layout",
+    bindings: [{ key: "f" }],
+    helpGroup: "Navigation",
+    keywords: ["zoom", "fit", "reset view"],
+  },
+  {
+    id: "cycle-rack-prev",
+    label: "Previous rack",
+    scope: "layout",
+    bindings: [{ key: "[" }],
+    helpGroup: "Navigation",
+    keywords: ["previous rack", "cycle"],
+  },
+  {
+    id: "cycle-rack-next",
+    label: "Next rack",
+    scope: "layout",
+    bindings: [{ key: "]" }],
+    helpGroup: "Navigation",
+    keywords: ["next rack", "cycle"],
+  },
+
+  // --- General --------------------------------------------------------------
+  {
+    id: "escape",
+    label: "Clear selection / close dialog",
+    scope: "global",
+    bindings: [{ key: "Escape" }],
+    helpGroup: "General",
+    keywords: ["cancel", "deselect", "close"],
+  },
+  {
+    id: "toggle-display-mode",
+    label: "Toggle display mode",
+    scope: "layout",
+    bindings: [{ key: "i" }],
+    helpGroup: "General",
+    keywords: ["image", "label", "view"],
+  },
+  {
+    id: "toggle-annotations",
+    label: "Toggle annotations",
+    scope: "layout",
+    bindings: [{ key: "a" }, { key: "n" }],
+    keywords: ["annotation", "notes", "column"],
+  },
+  {
+    id: "toggle-sidebar",
+    label: "Toggle device sidebar",
+    scope: "global",
+    bindings: [{ key: "d" }],
+    keywords: ["devices", "palette", "drawer"],
+  },
+  {
+    id: "show-help",
+    label: "Show help",
+    scope: "global",
+    bindings: [{ key: "?" }],
+    keywords: ["shortcuts", "about", "keyboard"],
+  },
+
+  // --- Editing --------------------------------------------------------------
+  {
+    id: "delete-selection",
+    label: "Delete selected",
+    scope: "selection",
+    bindings: [{ key: "Delete" }, { key: "Backspace" }],
+    enabledWhen: (ctx) => ctx.hasSelection,
+    helpGroup: "Editing",
+    keywords: ["remove"],
+  },
+  {
+    id: "move-device-up",
+    label: "Move device up",
+    scope: "selection",
+    bindings: [{ key: "ArrowUp" }],
+    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    helpGroup: "Editing",
+    helpKeyLabel: "↑ / ↓",
+    keywords: ["nudge", "up"],
+  },
+  {
+    id: "move-device-down",
+    label: "Move device down",
+    scope: "selection",
+    bindings: [{ key: "ArrowDown" }],
+    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    keywords: ["nudge", "down"],
+  },
+  {
+    id: "move-device-up-fine",
+    label: "Move device ⅓U (fine)",
+    scope: "selection",
+    bindings: [{ key: "ArrowUp", shift: true }],
+    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    helpGroup: "Editing",
+    helpKeyLabel: "Shift + ↑ / ↓",
+    keywords: ["nudge", "fine", "align"],
+  },
+  {
+    id: "move-device-down-fine",
+    label: "Move device ⅓U down (fine)",
+    scope: "selection",
+    bindings: [{ key: "ArrowDown", shift: true }],
+    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    keywords: ["nudge", "fine", "align"],
+  },
+  {
+    id: "move-device-left",
+    label: "Move device to left slot",
+    scope: "selection",
+    bindings: [{ key: "ArrowLeft" }],
+    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    keywords: ["slot", "half-width"],
+  },
+  {
+    id: "move-device-right",
+    label: "Move device to right slot",
+    scope: "selection",
+    bindings: [{ key: "ArrowRight" }],
+    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    keywords: ["slot", "half-width"],
+  },
+  {
+    id: "duplicate-selection",
+    label: "Duplicate selection",
+    scope: "selection",
+    bindings: [
+      { key: "d", ctrl: true },
+      { key: "d", meta: true },
+    ],
+    enabledWhen: (ctx) => ctx.isDeviceSelected || ctx.isRackSelected,
+    keywords: ["copy", "clone"],
+  },
+
+  // --- File -----------------------------------------------------------------
+  {
+    id: "save",
+    label: "Save layout",
+    scope: "global",
+    bindings: [
+      { key: "s", ctrl: true },
+      { key: "s", meta: true },
+    ],
+    helpGroup: "File",
+    keywords: ["store", "persist"],
+  },
+  {
+    id: "save-as",
+    label: "Save As (ZIP)",
+    scope: "global",
+    bindings: [
+      { key: "s", ctrl: true, shift: true },
+      { key: "s", meta: true, shift: true },
+    ],
+    helpGroup: "File",
+    keywords: ["download", "backup", "zip"],
+  },
+  {
+    id: "load",
+    label: "Load layout",
+    scope: "global",
+    bindings: [
+      { key: "o", ctrl: true },
+      { key: "o", meta: true },
+    ],
+    helpGroup: "File",
+    keywords: ["open", "import"],
+  },
+  {
+    id: "export",
+    label: "Export image",
+    scope: "global",
+    bindings: [
+      { key: "e", ctrl: true },
+      { key: "e", meta: true },
+    ],
+    helpGroup: "File",
+    keywords: ["png", "svg", "pdf", "image"],
+  },
+  {
+    id: "share",
+    label: "Share",
+    scope: "global",
+    bindings: [
+      { key: "h", ctrl: true },
+      { key: "h", meta: true },
+    ],
+    helpGroup: "File",
+    keywords: ["link", "url", "qr"],
+  },
+  {
+    id: "undo",
+    label: "Undo",
+    scope: "global",
+    bindings: [
+      { key: "z", ctrl: true },
+      { key: "z", meta: true },
+    ],
+    enabledWhen: (ctx) => ctx.canUndo,
+    helpGroup: "File",
+    keywords: ["revert", "back"],
+  },
+  {
+    id: "redo",
+    label: "Redo",
+    scope: "global",
+    bindings: [
+      { key: "z", ctrl: true, shift: true },
+      { key: "z", meta: true, shift: true },
+      { key: "y", ctrl: true },
+      { key: "y", meta: true },
+    ],
+    enabledWhen: (ctx) => ctx.canRedo,
+    helpGroup: "File",
+    keywords: ["forward", "repeat"],
+  },
+];
+
+/** The order help groups appear in the overlay. */
+const HELP_GROUP_ORDER: HelpGroup[] = [
+  "Navigation",
+  "General",
+  "Editing",
+  "File",
+];
+
+/**
+ * Display-only help rows that document mouse gestures rather than keyboard
+ * shortcuts. They live in the help overlay but are not dispatchable commands,
+ * so they are not registry actions.
+ */
+const HELP_GESTURE_ROWS: { group: HelpGroup; key: string; action: string }[] = [
+  { group: "Navigation", key: "Scroll Wheel", action: "Zoom in/out (at cursor)" },
+  { group: "Navigation", key: "Shift + Scroll", action: "Pan horizontally" },
+  { group: "Navigation", key: "Click + Drag", action: "Pan canvas" },
+];
+
+/** Look up an action definition by its id. */
+export function getActionById(id: ActionId): ActionDefinition | undefined {
+  return ACTION_REGISTRY.find((action) => action.id === id);
+}
+
+/**
+ * Resolve a keyboard event to the action it should trigger. Returns the first
+ * action whose any binding matches, or undefined if none do. Uses the same
+ * matchesShortcut logic the keyboard handler has always used, so resolution is
+ * identical to the prior hand-wired list.
+ */
+export function findActionForEvent(
+  event: KeyboardEvent,
+): ActionDefinition | undefined {
+  for (const action of ACTION_REGISTRY) {
+    for (const binding of action.bindings) {
+      const shortcut: ShortcutHandler = {
+        key: binding.key,
+        ctrl: binding.ctrl,
+        meta: binding.meta,
+        shift: binding.shift,
+        action: () => {},
+      };
+      if (matchesShortcut(event, shortcut)) {
+        return action;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** A single row in the help overlay. */
+export interface HelpRow {
+  key: string;
+  action: string;
+}
+
+/** A named group of help rows. */
+export interface HelpGroupSection {
+  name: HelpGroup;
+  rows: HelpRow[];
+}
+
+/**
+ * Format the help-overlay key cell for an action. Prefers an explicit
+ * helpKeyLabel; otherwise renders the primary (first) binding with
+ * platform-correct modifier labels.
+ */
+function formatHelpKey(action: ActionDefinition): string {
+  if (action.helpKeyLabel) return action.helpKeyLabel;
+  const binding = action.bindings[0];
+  if (!binding) return "";
+  const parts: string[] = [];
+  if (binding.ctrl || binding.meta) parts.push("mod");
+  if (binding.shift) parts.push("shift");
+  parts.push(formatBindingKey(binding.key));
+  return formatShortcut(...parts);
+}
+
+/** Render a raw binding key into a display glyph. */
+function formatBindingKey(key: string): string {
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+}
+
+/**
+ * Build the help overlay's grouped shortcut list from the registry. Only
+ * actions that opt into a help group are shown, plus the documented mouse
+ * gestures. Groups appear in HELP_GROUP_ORDER; rows follow registry order.
+ */
+export function getHelpGroups(): HelpGroupSection[] {
+  const sections: HelpGroupSection[] = [];
+
+  for (const groupName of HELP_GROUP_ORDER) {
+    const rows: HelpRow[] = [];
+
+    // Documented mouse gestures first (Navigation only, in practice).
+    for (const gesture of HELP_GESTURE_ROWS) {
+      if (gesture.group === groupName) {
+        rows.push({ key: gesture.key, action: gesture.action });
+      }
+    }
+
+    // Registry actions flagged for this help group.
+    for (const action of ACTION_REGISTRY) {
+      if (action.helpGroup !== groupName) continue;
+      const key = formatHelpKey(action);
+      if (!key) continue;
+      rows.push({ key, action: action.label });
+    }
+
+    if (rows.length > 0) {
+      sections.push({ name: groupName, rows });
+    }
+  }
+
+  return sections;
+}

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -170,7 +170,10 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     id: "show-help",
     label: "Show help",
     scope: "global",
-    bindings: [{ key: "?" }],
+    // Producing "?" requires Shift on most layouts, so the real keydown event
+    // carries shiftKey=true. Bind both states so the shortcut fires whether or
+    // not Shift is reported.
+    bindings: [{ key: "?" }, { key: "?", shift: true }],
     keywords: ["shortcuts", "about", "keyboard"],
   },
 

--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -10,7 +10,7 @@
   import { IconGitHub, IconBug, IconChat, IconCheck, IconCopy } from "./icons";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
-  import { formatShortcut } from "$lib/utils/platform";
+  import { getHelpGroups } from "$lib/actions/registry";
   import {
     formatRelativeTime,
     formatFullTimestamp,
@@ -141,47 +141,9 @@
     }
   }
 
-  // Keyboard shortcuts grouped by category
-  const shortcutGroups = [
-    {
-      name: "Navigation",
-      shortcuts: [
-        { key: "Scroll Wheel", action: "Zoom in/out (at cursor)" },
-        { key: "Shift + Scroll", action: "Pan horizontally" },
-        { key: "Click + Drag", action: "Pan canvas" },
-        { key: "F", action: "Fit all (zoom to fit)" },
-      ],
-    },
-    {
-      name: "General",
-      shortcuts: [
-        { key: "Escape", action: "Clear selection / Close dialog" },
-        { key: "I", action: "Toggle display mode" },
-        { key: "[", action: "Shrink sidebar" },
-        { key: "]", action: "Widen sidebar" },
-      ],
-    },
-    {
-      name: "Editing",
-      shortcuts: [
-        { key: "Delete", action: "Delete selected" },
-        { key: "↑ / ↓", action: "Move device up/down" },
-        { key: "Shift + ↑ / ↓", action: "Move device ⅓U (fine)" },
-      ],
-    },
-    {
-      name: "File",
-      shortcuts: [
-        { key: formatShortcut("mod", "S"), action: "Save layout" },
-        { key: formatShortcut("mod", "shift", "S"), action: "Save As (ZIP)" },
-        { key: formatShortcut("mod", "O"), action: "Load layout" },
-        { key: formatShortcut("mod", "E"), action: "Export image" },
-        { key: formatShortcut("mod", "H"), action: "Share" },
-        { key: formatShortcut("mod", "Z"), action: "Undo" },
-        { key: formatShortcut("mod", "shift", "Z"), action: "Redo" },
-      ],
-    },
-  ];
+  // Keyboard shortcuts, generated from the actions registry so this overlay and
+  // the keyboard handler can never drift apart.
+  const shortcutGroups = getHelpGroups();
 
   const GITHUB_URL = "https://github.com/RackulaLives/Rackula";
 
@@ -220,7 +182,7 @@
             <section class="shortcut-group">
               <h4>{group.name}</h4>
               <div class="shortcuts-list">
-                {#each group.shortcuts as { key, action } (key)}
+                {#each group.rows as { key, action } (key)}
                   <div class="shortcut-row">
                     <kbd class="key-cell">{key}</kbd>
                     <span class="action">{action}</span>

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -3,11 +3,8 @@
   Handles global keyboard shortcuts for the application
 -->
 <script lang="ts">
-  import {
-    shouldIgnoreKeyboard,
-    matchesShortcut,
-    type ShortcutHandler,
-  } from "$lib/utils/keyboard";
+  import { shouldIgnoreKeyboard } from "$lib/utils/keyboard";
+  import { findActionForEvent, type ActionId } from "$lib/actions/registry";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
@@ -75,229 +72,54 @@
     toastStore.showToast(`Redid: ${desc}`, "info");
   }
 
-  // Define all shortcuts
-  function getShortcuts(): ShortcutHandler[] {
-    return [
-      // Escape - cancel placement mode, or clear selection and close drawers
-      {
-        key: "Escape",
-        action: () => {
-          // Priority: cancel placement mode first
-          if (placementStore.isPlacing) {
-            placementStore.cancelPlacement();
-            // Reset view to show full rack after placement is cancelled
-            onfitall?.();
-            return;
-          }
-          // Otherwise clear selection, active rack, and close drawers
-          selectionStore.clearSelection();
-          layoutStore.setActiveRack(null);
-          uiStore.closeLeftDrawer();
-          uiStore.closeRightDrawer();
-        },
-      },
-
-      // Arrow keys - move selected device (without modifiers)
-      {
-        key: "ArrowUp",
-        action: () => moveSelectedDevice(1),
-      },
-      {
-        key: "ArrowDown",
-        action: () => moveSelectedDevice(-1),
-      },
-      // Shift+Arrow keys - move by 1/3U (fine movement to align with rack holes)
-      {
-        key: "ArrowUp",
-        shift: true,
-        action: () => moveSelectedDevice(1, 1 / 3),
-      },
-      {
-        key: "ArrowDown",
-        shift: true,
-        action: () => moveSelectedDevice(-1, 1 / 3),
-      },
-      // Left/Right arrows - move half-width device between slots
-      {
-        key: "ArrowLeft",
-        action: () => moveDeviceSlot("left"),
-      },
-      {
-        key: "ArrowRight",
-        action: () => moveDeviceSlot("right"),
-      },
-
-      // Delete/Backspace - delete selection
-      {
-        key: "Delete",
-        action: () => ondelete?.(),
-      },
-      {
-        key: "Backspace",
-        action: () => ondelete?.(),
-      },
-
-      // F - fit all
-      {
-        key: "f",
-        action: () => onfitall?.(),
-      },
-
-      // D - toggle sidebar (device palette)
-      {
-        key: "d",
-        action: () => uiStore.toggleLeftDrawer(),
-      },
-
-      // A - toggle annotations
-      {
-        key: "a",
-        action: () => ontoggleannotations?.(),
-      },
-
-      // [ - cycle to previous rack
-      {
-        key: "[",
-        action: () => cycleActiveRack(-1),
-      },
-
-      // Ctrl/Cmd+Z - undo
-      {
-        key: "z",
-        ctrl: true,
-        action: performUndo,
-      },
-      {
-        key: "z",
-        meta: true,
-        action: performUndo,
-      },
-
-      // Ctrl/Cmd+Shift+Z - redo
-      {
-        key: "z",
-        ctrl: true,
-        shift: true,
-        action: performRedo,
-      },
-      {
-        key: "z",
-        meta: true,
-        shift: true,
-        action: performRedo,
-      },
-
-      // Ctrl/Cmd+Y - redo (alternative)
-      {
-        key: "y",
-        ctrl: true,
-        action: performRedo,
-      },
-      {
-        key: "y",
-        meta: true,
-        action: performRedo,
-      },
-
-      // Ctrl/Cmd+S - save
-      {
-        key: "s",
-        ctrl: true,
-        action: () => onsave?.(),
-      },
-      {
-        key: "s",
-        meta: true,
-        action: () => onsave?.(),
-      },
-
-      // Ctrl/Cmd+Shift+S - save as (download ZIP)
-      {
-        key: "s",
-        ctrl: true,
-        shift: true,
-        action: () => onsaveas?.(),
-      },
-      {
-        key: "s",
-        meta: true,
-        shift: true,
-        action: () => onsaveas?.(),
-      },
-
-      // Ctrl/Cmd+O - load
-      {
-        key: "o",
-        ctrl: true,
-        action: () => onload?.(),
-      },
-      {
-        key: "o",
-        meta: true,
-        action: () => onload?.(),
-      },
-
-      // Ctrl/Cmd+E - export
-      {
-        key: "e",
-        ctrl: true,
-        action: () => onexport?.(),
-      },
-      {
-        key: "e",
-        meta: true,
-        action: () => onexport?.(),
-      },
-
-      // Ctrl/Cmd+H - share
-      {
-        key: "h",
-        ctrl: true,
-        action: () => onshare?.(),
-      },
-      {
-        key: "h",
-        meta: true,
-        action: () => onshare?.(),
-      },
-
-      // Ctrl/Cmd+D - duplicate selected (device or rack)
-      {
-        key: "d",
-        ctrl: true,
-        action: () => duplicateSelected(),
-      },
-      {
-        key: "d",
-        meta: true,
-        action: () => duplicateSelected(),
-      },
-
-      // ? - show help
-      {
-        key: "?",
-        action: () => onhelp?.(),
-      },
-
-      // I - toggle display mode (label/image)
-      {
-        key: "i",
-        action: () => ontoggledisplaymode?.(),
-      },
-
-      // N - toggle annotation column
-      {
-        key: "n",
-        action: () => ontoggleannotations?.(),
-      },
-
-      // ] - cycle to next rack
-      {
-        key: "]",
-        action: () => cycleActiveRack(1),
-      },
-    ];
+  /**
+   * Escape - cancel placement mode, or clear selection and close drawers.
+   */
+  function handleEscape() {
+    // Priority: cancel placement mode first
+    if (placementStore.isPlacing) {
+      placementStore.cancelPlacement();
+      // Reset view to show full rack after placement is cancelled
+      onfitall?.();
+      return;
+    }
+    // Otherwise clear selection, active rack, and close drawers
+    selectionStore.clearSelection();
+    layoutStore.setActiveRack(null);
+    uiStore.closeLeftDrawer();
+    uiStore.closeRightDrawer();
   }
+
+  /**
+   * Dispatch map from registry action id to its runtime handler. The actions
+   * registry owns command metadata and keybindings; this map binds each
+   * command id to the closure that runs it in this app context.
+   */
+  const dispatch: Record<ActionId, () => void> = {
+    escape: handleEscape,
+    "move-device-up": () => moveSelectedDevice(1),
+    "move-device-down": () => moveSelectedDevice(-1),
+    "move-device-up-fine": () => moveSelectedDevice(1, 1 / 3),
+    "move-device-down-fine": () => moveSelectedDevice(-1, 1 / 3),
+    "move-device-left": () => moveDeviceSlot("left"),
+    "move-device-right": () => moveDeviceSlot("right"),
+    "delete-selection": () => ondelete?.(),
+    "fit-all": () => onfitall?.(),
+    "toggle-sidebar": () => uiStore.toggleLeftDrawer(),
+    "toggle-annotations": () => ontoggleannotations?.(),
+    "cycle-rack-prev": () => cycleActiveRack(-1),
+    "cycle-rack-next": () => cycleActiveRack(1),
+    undo: performUndo,
+    redo: performRedo,
+    save: () => onsave?.(),
+    "save-as": () => onsaveas?.(),
+    load: () => onload?.(),
+    export: () => onexport?.(),
+    share: () => onshare?.(),
+    "duplicate-selection": () => duplicateSelected(),
+    "show-help": () => onhelp?.(),
+    "toggle-display-mode": () => ontoggledisplaymode?.(),
+  };
 
   /**
    * Move the selected device up or down, using shared movement utility.
@@ -506,16 +328,11 @@
     // Ignore if in input field
     if (shouldIgnoreKeyboard(event)) return;
 
-    const shortcuts = getShortcuts();
+    const action = findActionForEvent(event);
+    if (!action) return;
 
-    for (const shortcut of shortcuts) {
-      if (matchesShortcut(event, shortcut)) {
-        event.preventDefault();
-        shortcut.action();
-
-        return;
-      }
-    }
+    event.preventDefault();
+    dispatch[action.id]();
   }
 </script>
 

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -4,7 +4,6 @@ import {
   getActionById,
   findActionForEvent,
   getHelpGroups,
-  type ActionDefinition,
 } from "$lib/actions/registry";
 
 /**
@@ -133,14 +132,37 @@ describe("actions registry", () => {
       }
     });
 
-    it("only selection-scoped actions declare an enabledWhen predicate dependency", () => {
-      // enabledWhen is optional metadata; when present it must be a function so
-      // consumers (verb bars, palette) can gate without special-casing.
-      for (const action of ACTION_REGISTRY) {
-        if (action.enabledWhen !== undefined) {
-          expect(typeof action.enabledWhen).toBe("function");
-        }
-      }
+    it("gates an enabled-when action by the live selection/history context", () => {
+      // The predicate is what consumers (verb bars, palette) call to enable or
+      // hide a command. Test the gating behaviour, not the field's presence.
+      const dup = getActionById("duplicate-selection");
+      expect(dup?.enabledWhen).toBeDefined();
+      const enabledCtx = {
+        hasSelection: true,
+        isDeviceSelected: true,
+        isRackSelected: false,
+        canUndo: false,
+        canRedo: false,
+      };
+      const disabledCtx = { ...enabledCtx, isDeviceSelected: false };
+      expect(dup?.enabledWhen?.(enabledCtx)).toBe(true);
+      expect(dup?.enabledWhen?.(disabledCtx)).toBe(false);
+    });
+
+    it("gates undo/redo by history availability", () => {
+      const undo = getActionById("undo");
+      const redo = getActionById("redo");
+      const base = {
+        hasSelection: false,
+        isDeviceSelected: false,
+        isRackSelected: false,
+        canUndo: false,
+        canRedo: false,
+      };
+      expect(undo?.enabledWhen?.({ ...base, canUndo: true })).toBe(true);
+      expect(undo?.enabledWhen?.(base)).toBe(false);
+      expect(redo?.enabledWhen?.({ ...base, canRedo: true })).toBe(true);
+      expect(redo?.enabledWhen?.(base)).toBe(false);
     });
   });
 
@@ -203,13 +225,15 @@ describe("actions registry", () => {
     });
 
     it("exposes save as a global-scope action", () => {
-      const save = getActionById("save") as ActionDefinition;
-      expect(save.scope).toBe("global");
+      const save = getActionById("save");
+      expect(save).toBeDefined();
+      expect(save?.scope).toBe("global");
     });
 
     it("exposes duplicate as a selection-scope action", () => {
-      const dup = getActionById("duplicate-selection") as ActionDefinition;
-      expect(dup.scope).toBe("selection");
+      const dup = getActionById("duplicate-selection");
+      expect(dup).toBeDefined();
+      expect(dup?.scope).toBe("selection");
     });
   });
 });

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import {
+  ACTION_REGISTRY,
+  getActionById,
+  findActionForEvent,
+  getHelpGroups,
+  type ActionDefinition,
+} from "$lib/actions/registry";
+
+/**
+ * The actions registry is the single source of truth for command metadata:
+ * keyboard shortcuts, the help overlay, and (later) the app menu and verb bars.
+ * These tests cover the registry's behaviour - keybinding resolution and
+ * help-group generation - not its data contents (which TypeScript validates).
+ */
+
+describe("actions registry", () => {
+  describe("getActionById", () => {
+    it("returns the matching action definition", () => {
+      const action = getActionById("undo");
+      expect(action?.id).toBe("undo");
+    });
+
+    it("returns undefined for an unknown id", () => {
+      expect(getActionById("not-a-real-command" as never)).toBeUndefined();
+    });
+
+    it("never returns two definitions sharing the same id", () => {
+      const ids = ACTION_REGISTRY.map((a) => a.id);
+      const unique = new Set(ids);
+      expect(unique.size).toBe(ids.length);
+    });
+  });
+
+  describe("findActionForEvent (keybinding resolution)", () => {
+    it("resolves Ctrl+S to the save action", () => {
+      const event = new KeyboardEvent("keydown", { key: "s", ctrlKey: true });
+      expect(findActionForEvent(event)?.id).toBe("save");
+    });
+
+    it("resolves Cmd+S to the save action (cross-platform)", () => {
+      const event = new KeyboardEvent("keydown", { key: "s", metaKey: true });
+      expect(findActionForEvent(event)?.id).toBe("save");
+    });
+
+    it("resolves Ctrl+Shift+Z to redo, not undo", () => {
+      const event = new KeyboardEvent("keydown", {
+        key: "z",
+        ctrlKey: true,
+        shiftKey: true,
+      });
+      expect(findActionForEvent(event)?.id).toBe("redo");
+    });
+
+    it("resolves Ctrl+Z (no shift) to undo, not redo", () => {
+      const event = new KeyboardEvent("keydown", { key: "z", ctrlKey: true });
+      expect(findActionForEvent(event)?.id).toBe("undo");
+    });
+
+    it("resolves bare letter keys without modifiers", () => {
+      const event = new KeyboardEvent("keydown", { key: "f" });
+      expect(findActionForEvent(event)?.id).toBe("fit-all");
+    });
+
+    it("is case-insensitive for letter keys", () => {
+      const event = new KeyboardEvent("keydown", { key: "F" });
+      expect(findActionForEvent(event)?.id).toBe("fit-all");
+    });
+
+    it("does not resolve a bare letter when a modifier is held", () => {
+      // Ctrl+F should not trigger the bare 'f' (fit-all) action
+      const event = new KeyboardEvent("keydown", { key: "f", ctrlKey: true });
+      expect(findActionForEvent(event)).toBeUndefined();
+    });
+
+    it("returns undefined when no action matches", () => {
+      const event = new KeyboardEvent("keydown", { key: "q", altKey: true });
+      expect(findActionForEvent(event)).toBeUndefined();
+    });
+
+    it("resolves Escape", () => {
+      const event = new KeyboardEvent("keydown", { key: "Escape" });
+      expect(findActionForEvent(event)?.id).toBe("escape");
+    });
+
+    it("resolves the help key (?)", () => {
+      const event = new KeyboardEvent("keydown", { key: "?" });
+      expect(findActionForEvent(event)?.id).toBe("show-help");
+    });
+
+    it("resolves arrow keys to device movement", () => {
+      const up = new KeyboardEvent("keydown", { key: "ArrowUp" });
+      expect(findActionForEvent(up)?.id).toBe("move-device-up");
+      const down = new KeyboardEvent("keydown", { key: "ArrowDown" });
+      expect(findActionForEvent(down)?.id).toBe("move-device-down");
+    });
+
+    it("distinguishes Shift+Arrow (fine move) from bare Arrow", () => {
+      const fine = new KeyboardEvent("keydown", {
+        key: "ArrowUp",
+        shiftKey: true,
+      });
+      expect(findActionForEvent(fine)?.id).toBe("move-device-up-fine");
+    });
+  });
+
+  describe("registry integrity", () => {
+    it("every binding's key shape is reproducible by findActionForEvent", () => {
+      // For each action that declares a keybinding, an event built from that
+      // binding must resolve back to the same action. This guards against a
+      // binding being shadowed by an earlier, more permissive one.
+      for (const action of ACTION_REGISTRY) {
+        for (const binding of action.bindings) {
+          const event = new KeyboardEvent("keydown", {
+            key: binding.key,
+            ctrlKey: binding.ctrl ?? false,
+            metaKey: binding.meta ?? false,
+            shiftKey: binding.shift ?? false,
+          });
+          const resolved = findActionForEvent(event);
+          expect(
+            resolved?.id,
+            `binding ${JSON.stringify(binding)} on "${action.id}" resolved to "${resolved?.id}"`,
+          ).toBe(action.id);
+        }
+      }
+    });
+
+    it("only selection-scoped actions declare an enabledWhen predicate dependency", () => {
+      // enabledWhen is optional metadata; when present it must be a function so
+      // consumers (verb bars, palette) can gate without special-casing.
+      for (const action of ACTION_REGISTRY) {
+        if (action.enabledWhen !== undefined) {
+          expect(typeof action.enabledWhen).toBe("function");
+        }
+      }
+    });
+  });
+
+  describe("getHelpGroups (help overlay generation)", () => {
+    it("groups actions by their help group, preserving group order", () => {
+      const groups = getHelpGroups();
+      const names = groups.map((g) => g.name);
+      // Groups must appear in a stable, declared order.
+      expect(names).toEqual([...new Set(names)]);
+      expect(groups.length).toBeGreaterThan(0);
+    });
+
+    it("only includes registry actions flagged for the help overlay", () => {
+      const groups = getHelpGroups();
+      const shownLabels = new Set(
+        groups.flatMap((g) => g.rows.map((r) => r.action)),
+      );
+      // Every help-flagged registry action with a renderable key appears.
+      const helpActions = ACTION_REGISTRY.filter(
+        (a) => a.helpGroup && (a.bindings.length > 0 || a.helpKeyLabel),
+      );
+      for (const action of helpActions) {
+        expect(shownLabels.has(action.label)).toBe(true);
+      }
+      // Actions without a help group must NOT appear (e.g. toggle-sidebar).
+      const hiddenAction = ACTION_REGISTRY.find((a) => !a.helpGroup);
+      expect(hiddenAction).toBeDefined();
+      expect(shownLabels.has(hiddenAction!.label)).toBe(false);
+    });
+
+    it("formats the displayed key from the action's primary binding", () => {
+      const groups = getHelpGroups();
+      const saveRow = groups
+        .flatMap((g) => g.rows)
+        .find((r) => r.action.toLowerCase().includes("save layout"));
+      expect(saveRow).toBeDefined();
+      // The mod key formats to Ctrl or Cmd; we just assert it includes "S".
+      expect(saveRow?.key).toContain("S");
+    });
+
+    it("supports display-only help rows that have no real keybinding", () => {
+      // e.g. "Scroll Wheel" -> "Zoom" is documented in help but is not a
+      // keydown shortcut, so it carries a helpKeyLabel instead of bindings.
+      const groups = getHelpGroups();
+      const allRows = groups.flatMap((g) => g.rows);
+      const scrollRow = allRows.find((r) =>
+        r.action.toLowerCase().includes("zoom"),
+      );
+      expect(scrollRow).toBeDefined();
+      expect(scrollRow?.key).toBeTruthy();
+    });
+  });
+
+  describe("scope classification", () => {
+    it("classifies every action into a known scope", () => {
+      const scopes = new Set(ACTION_REGISTRY.map((a) => a.scope));
+      for (const scope of scopes) {
+        expect(["global", "layout", "selection"]).toContain(scope);
+      }
+    });
+
+    it("exposes save as a global-scope action", () => {
+      const save = getActionById("save") as ActionDefinition;
+      expect(save.scope).toBe("global");
+    });
+
+    it("exposes duplicate as a selection-scope action", () => {
+      const dup = getActionById("duplicate-selection") as ActionDefinition;
+      expect(dup.scope).toBe("selection");
+    });
+  });
+});

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -83,7 +83,14 @@ describe("actions registry", () => {
       expect(findActionForEvent(event)?.id).toBe("escape");
     });
 
-    it("resolves the help key (?)", () => {
+    it("resolves the help key (?) when Shift is held (real keyboard)", () => {
+      // On most layouts "?" is Shift+/, so the real keydown reports
+      // shiftKey=true. The shortcut must still fire.
+      const event = new KeyboardEvent("keydown", { key: "?", shiftKey: true });
+      expect(findActionForEvent(event)?.id).toBe("show-help");
+    });
+
+    it("resolves the help key (?) without a reported Shift modifier", () => {
       const event = new KeyboardEvent("keydown", { key: "?" });
       expect(findActionForEvent(event)?.id).toBe("show-help");
     });


### PR DESCRIPTION
## **User description**
## Summary

Foundational M14 shell slice: a typed actions registry that is the single source of truth for command metadata, so the keyboard handler and the help overlay can no longer drift apart.

- New `src/lib/actions/registry.ts`: each command declares `id`, `label`, `scope` (global / layout / selection), keyboard `bindings`, an optional `enabledWhen` predicate, help-overlay grouping, and palette `keywords`. Pure data plus pure functions (`getActionById`, `findActionForEvent`, `getHelpGroups`) - no framework coupling, fully unit-tested.
- `KeyboardHandler.svelte` now resolves events via `findActionForEvent` and dispatches through an id-keyed handler map, replacing the hand-wired shortcut list. Behavior is identical: every prior key combination (Ctrl/Cmd+S/O/E/H/D, Ctrl+Z / Shift+Z / Y, I, F, A/N, Delete, Backspace, arrows, Shift+arrows, `[`/`]`, Escape, `?`) resolves to the same action.
- `HelpPanel.svelte` generates its grouped shortcut list from `getHelpGroups()` instead of a hand-maintained array.
- Corrects the stale `[` / `]` help labels: they cycle racks (Previous / Next rack), they never resized the sidebar.

Named "actions" to avoid colliding with `src/lib/stores/commands/` (the undo/redo Command Pattern), per the issue note.

The `run` closures stay at the call site (they need component-scoped stores and props); the registry owns the metadata and bindings. This is the intentional split that lets the app menu (#2073), verb bars (#2075), and the command palette (#2020) all become thin projections of one registry.

## Test plan

- [x] `npm run lint` - clean
- [x] `npm run test:run` - 2257 passed (124 files), incl. new `actions-registry.test.ts` (24) and the unchanged `keyboard.test.ts` (51) exercising the refactored handler
- [x] `npm run build` - clean
- [x] e2e `keyboard.spec.ts` (chromium) - 7 passed (Delete/Backspace remove rack, Escape clears selection, `?` opens help, Ctrl+S saves, arrows move device, Escape closes dialogs)
- [x] Svelte `svelte-autofixer` on both modified components - no issues from the changes
- [x] Local `/code-review` (recall mode) - one finding (mislabelled `[`/`]` keys) found and fixed; clean sweep otherwise

## Unblocks

- #2073 (app menu renders from registry entries)
- #2075 (floating verb bars render selection-scoped entries)
- #2020 command palette chain (thin UI over the same registry)

Closes #2096


___

## **CodeAnt-AI Description**
**Use one shared source for keyboard shortcuts and help text**

### What Changed
- Keyboard shortcuts now come from one shared list, so the help panel and shortcut handling stay in sync
- The help panel now shows the updated shortcut names, including correct rack cycling labels for `[` and `]`
- Shortcut actions are grouped by context, so global, layout, and selection actions are easier to present consistently
- Mouse gesture rows in the help panel are kept visible, while commands without help entries stay hidden
- Tests were added to verify shortcut matching, help grouping, and correct action lookup

### Impact
`✅ Fewer shortcut/help mismatches`
`✅ Clearer keyboard shortcut help`
`✅ Correct rack navigation labels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
