### PR TITLE
feat: device palette favourites, virtualization, and image toggle (#2094)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -628,7 +628,10 @@
               onchange={(tab) => uiStore.setSidebarTab(tab)}
             />
             {#if uiStore.sidebarTab === "devices"}
-              <DevicePalette oncreatedevice={handleAddDevice} />
+              <DevicePalette
+                oncreatedevice={handleAddDevice}
+                ontoggledisplaymode={handleToggleDisplayMode}
+              />
             {:else if uiStore.sidebarTab === "racks"}
               <RackList
                 onnewrack={handleNewRack}

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -23,24 +23,49 @@
     saveGroupingModeToStorage,
     type DeviceGroupingMode,
   } from "$lib/utils/deviceGrouping";
+  import {
+    loadFavouritesFromStorage,
+    saveFavouritesToStorage,
+    toggleFavourite,
+  } from "$lib/utils/deviceFavourites";
   import { getUIStore } from "$lib/stores/ui.svelte";
   import { debounce } from "$lib/utils/debounce";
   import { truncateWithEllipsis } from "$lib/utils/searchHighlight";
   import { getBrandPacks, getBrandSlugs } from "$lib/data/brandPacks";
   import { getStarterLibrary, getStarterSlugs } from "$lib/data/starterLibrary";
   import DevicePaletteItem from "./DevicePaletteItem.svelte";
+  import VirtualList from "./VirtualList.svelte";
   import BrandIcon from "./BrandIcon.svelte";
   import SegmentedControl from "./SegmentedControl.svelte";
   import Tooltip from "./Tooltip.svelte";
+  import IconTextBold from "./icons/IconTextBold.svelte";
+  import IconImageBold from "./icons/IconImageBold.svelte";
+  import IconImageLabel from "./icons/IconImageLabel.svelte";
+  import IconPin from "./icons/IconPin.svelte";
   import { ICON_SIZE } from "$lib/constants/sizing";
-  import type { DeviceType } from "$lib/types";
+  import type { DeviceType, DisplayMode } from "$lib/types";
 
   interface Props {
     ondeviceselect?: (event: CustomEvent<{ device: DeviceType }>) => void;
     oncreatedevice?: () => void;
+    /** Cycle the canvas display mode (label -> image -> image-label). The
+     *  palette toggle mirrors the canonical lens; it does not own the state. */
+    ontoggledisplaymode?: () => void;
   }
 
-  let { ondeviceselect, oncreatedevice }: Props = $props();
+  let { ondeviceselect, oncreatedevice, ontoggledisplaymode }: Props = $props();
+
+  // Estimated palette row height in pixels, used by the virtualized lists.
+  // Rows are a flex line with var(--touch-target-min) min-height (48px) plus
+  // vertical padding; 48 keeps the windowing math close enough for overscan.
+  const ROW_HEIGHT = 48;
+  // Below this row count a section renders as plain DOM so the accordion's
+  // height animation and the generic section's category sub-grouping stay
+  // intact. Long lists (big brand packs, A-Z mode) switch to windowing.
+  const VIRTUALIZE_THRESHOLD = 30;
+  // Cap the windowed viewport so a long section scrolls within itself rather
+  // than stretching the whole palette to thousands of pixels.
+  const VIRTUAL_VIEWPORT_MAX = 480;
 
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
@@ -65,6 +90,27 @@
     groupingMode = newMode;
     saveGroupingModeToStorage(newMode);
   }
+
+  // Favourites (pinned device slugs) with localStorage persistence.
+  // Insertion order drives the pinned section order.
+  let favouriteSlugs = $state<Set<string>>(loadFavouritesFromStorage());
+
+  function isFavourite(slug: string): boolean {
+    return favouriteSlugs.has(slug);
+  }
+
+  function handleToggleFavourite(event: CustomEvent<{ device: DeviceType }>) {
+    favouriteSlugs = toggleFavourite(favouriteSlugs, event.detail.device.slug);
+    saveFavouritesToStorage(favouriteSlugs);
+  }
+
+  // Display mode mirrors the canonical canvas lens (uiStore.displayMode); the
+  // palette only reflects and forwards toggle requests, it never owns the state.
+  const displayModeLabels: Record<DisplayMode, string> = {
+    label: "Labels",
+    image: "Images",
+    "image-label": "Both",
+  };
 
   // Accordion mode and state tracking
   let accordionMode = $state<"single" | "multiple">("single");
@@ -313,6 +359,24 @@
     searchDevices(allDevicesCombined, searchQuery),
   );
 
+  // Pinned devices: resolve favourite slugs against the same width/compat/search
+  // filtered pool the rest of the palette uses, preserving favourite order.
+  // Collect only the matching devices (favourites are few) rather than indexing
+  // the whole pool, so the search hot path stays cheap.
+  const pinnedDevices = $derived.by<DeviceType[]>(() => {
+    if (favouriteSlugs.size === 0) return [];
+    const matches: Record<string, DeviceType> = {};
+    for (const device of filteredAllDevices) {
+      if (favouriteSlugs.has(device.slug)) matches[device.slug] = device;
+    }
+    const result: DeviceType[] = [];
+    for (const slug of favouriteSlugs) {
+      const device = matches[slug];
+      if (device) result.push(device);
+    }
+    return result;
+  });
+
   // Sections for brand mode - filter out empty sections (no compatible devices)
   const brandModeSections = $derived<DeviceSection[]>(
     [
@@ -474,6 +538,29 @@
         aria-label="Search devices"
         data-testid="search-devices"
       />
+      {#if ontoggledisplaymode}
+        <Tooltip
+          text={`Display: ${displayModeLabels[uiStore.displayMode]}`}
+          shortcut="I"
+          position="bottom"
+        >
+          <button
+            type="button"
+            class="palette-header-btn"
+            onclick={ontoggledisplaymode}
+            aria-label="Toggle device display mode"
+            data-testid="btn-palette-display-mode"
+          >
+            {#if uiStore.displayMode === "label"}
+              <IconTextBold size={ICON_SIZE.sm} />
+            {:else if uiStore.displayMode === "image"}
+              <IconImageBold size={ICON_SIZE.sm} />
+            {:else}
+              <IconImageLabel size={ICON_SIZE.md} />
+            {/if}
+          </button>
+        </Tooltip>
+      {/if}
       {#if oncreatedevice}
         <Tooltip text="Create custom device" position="bottom">
           <button
@@ -492,6 +579,51 @@
 
   <!-- Device List -->
   <div class="device-list">
+    {#snippet deviceRow(device: DeviceType)}
+      <DevicePaletteItem
+        {device}
+        searchQuery={isSearchActive ? searchQuery : ""}
+        isCompatible={isCompatible(device)}
+        incompatibilityReason={incompatibilityReason(device)}
+        canDelete={canDeleteDevice(device)}
+        isFavourite={isFavourite(device.slug)}
+        onselect={handleDeviceSelect}
+        ondelete={handleDeviceDelete}
+        ontogglefavourite={handleToggleFavourite}
+      />
+    {/snippet}
+
+    <!-- Flat device list: windowed when long, plain DOM when short, so the
+         accordion height animation survives for small sections. -->
+    {#snippet deviceList(devices: DeviceType[], label: string)}
+      {#if devices.length > VIRTUALIZE_THRESHOLD}
+        <div
+          class="virtual-section"
+          style:height="{Math.min(
+            devices.length * ROW_HEIGHT,
+            VIRTUAL_VIEWPORT_MAX,
+          )}px"
+        >
+          <VirtualList
+            items={devices}
+            itemHeight={ROW_HEIGHT}
+            key={(device) => device.slug}
+            ariaLabel={label}
+          >
+            {#snippet row(device)}
+              {@render deviceRow(device)}
+            {/snippet}
+          </VirtualList>
+        </div>
+      {:else}
+        <div class="section-devices" role="list" aria-label={label}>
+          {#each devices as device (device.slug)}
+            {@render deviceRow(device)}
+          {/each}
+        </div>
+      {/if}
+    {/snippet}
+
     {#if !hasDevices}
       <div class="empty-state">
         <p class="empty-message">No devices in library</p>
@@ -502,6 +634,17 @@
         <p class="empty-message">No devices match your search</p>
       </div>
     {:else}
+      {#if pinnedDevices.length > 0}
+        <section class="pinned-section" aria-label="Pinned devices">
+          <h3 class="pinned-header">
+            <IconPin size={ICON_SIZE.sm} filled />
+            <span>Pinned</span>
+            <span class="section-count">({pinnedDevices.length})</span>
+          </h3>
+          {@render deviceList(pinnedDevices, "Pinned devices")}
+        </section>
+      {/if}
+
       {#snippet accordionSections()}
         {#each sections as section (section.id)}
           <Accordion.Item value={section.id} class="accordion-item">
@@ -547,39 +690,13 @@
                         <h3 class="category-header">
                           {getCategoryDisplayName(category)}
                         </h3>
-                        <div class="category-devices">
-                          {#each devices as device (device.slug)}
-                            <DevicePaletteItem
-                              {device}
-                              searchQuery={isSearchActive ? searchQuery : ""}
-                              isCompatible={isCompatible(device)}
-                              incompatibilityReason={incompatibilityReason(
-                                device,
-                              )}
-                              canDelete={canDeleteDevice(device)}
-                              onselect={handleDeviceSelect}
-                              ondelete={handleDeviceDelete}
-                            />
-                          {/each}
-                        </div>
+                        {@render deviceList(devices, getCategoryDisplayName(category))}
                       </div>
                     {/if}
                   {/each}
                 {:else}
                   <!-- All other sections show devices in a flat list -->
-                  <div class="section-devices">
-                    {#each section.devices as device (device.slug)}
-                      <DevicePaletteItem
-                        {device}
-                        searchQuery={isSearchActive ? searchQuery : ""}
-                        isCompatible={isCompatible(device)}
-                        incompatibilityReason={incompatibilityReason(device)}
-                        canDelete={canDeleteDevice(device)}
-                        onselect={handleDeviceSelect}
-                        ondelete={handleDeviceDelete}
-                      />
-                    {/each}
-                  </div>
+                  {@render deviceList(section.devices, section.title)}
                 {/if}
               </div>
             </Accordion.Content>
@@ -635,7 +752,8 @@
       box-shadow var(--duration-fast) ease;
   }
 
-  .create-device-btn {
+  .create-device-btn,
+  .palette-header-btn {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -650,24 +768,28 @@
     border: 1px solid var(--colour-border);
     border-radius: var(--radius-sm);
     cursor: pointer;
+    flex-shrink: 0;
     transition:
       background-color var(--duration-fast) ease,
       color var(--duration-fast) ease,
       border-color var(--duration-fast) ease;
   }
 
-  .create-device-btn:hover {
+  .create-device-btn:hover,
+  .palette-header-btn:hover {
     color: var(--colour-text);
     background: var(--colour-surface-hover);
     border-color: var(--colour-border-hover);
   }
 
-  .create-device-btn:focus-visible {
+  .create-device-btn:focus-visible,
+  .palette-header-btn:focus-visible {
     outline: 2px solid var(--colour-selection);
     outline-offset: 2px;
   }
 
-  .create-device-btn:active {
+  .create-device-btn:active,
+  .palette-header-btn:active {
     background: var(--colour-surface-active);
   }
 
@@ -806,14 +928,33 @@
     color: var(--colour-text-muted);
   }
 
-  .category-devices {
+  .section-devices {
     display: flex;
     flex-direction: column;
   }
 
-  .section-devices {
+  /* Windowed section: fixed height so VirtualList can scroll within it. */
+  .virtual-section {
+    overflow: hidden;
+  }
+
+  .pinned-section {
+    margin: var(--space-1) var(--space-2) var(--space-3);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--colour-border);
+  }
+
+  .pinned-header {
     display: flex;
-    flex-direction: column;
+    align-items: center;
+    gap: var(--space-2);
+    margin: 0;
+    padding: var(--space-2) var(--space-3) var(--space-1);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--colour-text-muted);
   }
 
   .empty-state {

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -7,6 +7,7 @@
   import type { DeviceType } from "$lib/types";
   import IconGrip from "./icons/IconGrip.svelte";
   import IconTrash from "./icons/IconTrash.svelte";
+  import IconPin from "./icons/IconPin.svelte";
   import CategoryIcon from "./CategoryIcon.svelte";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import ImageIndicator from "./ImageIndicator.svelte";
@@ -36,9 +37,13 @@
     incompatibilityReason?: string | null;
     /** Whether this device type can be deleted (unused custom type) */
     canDelete?: boolean;
+    /** Whether this device is pinned (favourited) to the top of the palette */
+    isFavourite?: boolean;
     onselect?: (event: CustomEvent<{ device: DeviceType }>) => void;
     /** Called when user clicks delete button for unused custom device */
     ondelete?: (event: CustomEvent<{ device: DeviceType }>) => void;
+    /** Called when user pins or unpins the device */
+    ontogglefavourite?: (event: CustomEvent<{ device: DeviceType }>) => void;
   }
 
   let {
@@ -48,8 +53,10 @@
     isCompatible = true,
     incompatibilityReason = null,
     canDelete = false,
+    isFavourite = false,
     onselect,
     ondelete,
+    ontogglefavourite,
   }: Props = $props();
 
   // Device display name: model or slug
@@ -62,10 +69,15 @@
   const ariaDescription = $derived.by(() => {
     const parts = [deviceName, `${device.u_height}U`, device.category];
     if (isHalfWidth) parts.push("half-width");
+    if (isFavourite) parts.push("pinned");
     if (!isCompatible && incompatibilityReason)
       parts.push(`(${incompatibilityReason})`);
     return parts.join(", ");
   });
+
+  const favouriteLabel = $derived(
+    isFavourite ? `Unpin ${deviceName}` : `Pin ${deviceName}`,
+  );
 
   // Highlighted text segments for search matching
   const highlightedSegments = $derived(highlightMatch(deviceName, searchQuery));
@@ -104,10 +116,28 @@
     }
   }
 
+  function emitToggleFavourite() {
+    ontogglefavourite?.(
+      new CustomEvent("togglefavourite", { detail: { device } }),
+    );
+  }
+
+  function handleFavouriteClick(event: MouseEvent) {
+    event.stopPropagation();
+    emitToggleFavourite();
+  }
+
+  function handleFavouriteKeyDown(event: KeyboardEvent) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      event.stopPropagation();
+      emitToggleFavourite();
+    }
+  }
+
   function handleContextMenu(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();
-    if (!canDelete) return;
     contextMenuX = event.clientX;
     contextMenuY = event.clientY;
     contextMenuOpen = true;
@@ -116,6 +146,11 @@
   function handleContextMenuDelete() {
     contextMenuOpen = false;
     showConfirmDelete = true;
+  }
+
+  function handleContextMenuFavourite() {
+    contextMenuOpen = false;
+    emitToggleFavourite();
   }
 
   function handleConfirmDelete() {
@@ -255,6 +290,20 @@
       aria-label="Half-depth device">½D</span
     >
   {/if}
+  <Tooltip text={isFavourite ? "Unpin device" : "Pin device"} position="left">
+    <button
+      type="button"
+      class="favourite-btn"
+      class:active={isFavourite}
+      onclick={handleFavouriteClick}
+      onkeydown={handleFavouriteKeyDown}
+      aria-label={favouriteLabel}
+      aria-pressed={isFavourite}
+      data-testid="favourite-device-btn"
+    >
+      <IconPin size={ICON_SIZE.sm} filled={isFavourite} />
+    </button>
+  </Tooltip>
   {#if canDelete}
     <Tooltip text="Delete unused device type" position="left">
       <button
@@ -271,14 +320,21 @@
   {/if}
 </div>
 
-{#if canDelete}
+<!-- Mounted only once a right-click opens it, so the common case (hundreds of
+     palette rows) does not each carry an idle ContextMenu.Root + Portal. -->
+{#if contextMenuOpen}
   <PaletteDeviceContextMenu
     bind:open={contextMenuOpen}
     x={contextMenuX}
     y={contextMenuY}
+    {isFavourite}
+    {canDelete}
+    ontogglefavourite={handleContextMenuFavourite}
     ondelete={handleContextMenuDelete}
   />
+{/if}
 
+{#if canDelete}
   <ConfirmDialog
     open={showConfirmDelete}
     title="Delete Device Type"
@@ -451,6 +507,48 @@
   }
 
   .delete-btn:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: 1px;
+  }
+
+  .favourite-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-6);
+    height: var(--space-6);
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    color: var(--colour-text-muted);
+    opacity: 0;
+    transition:
+      opacity var(--duration-fast) var(--ease-out),
+      color var(--duration-fast) var(--ease-out),
+      background-color var(--duration-fast) var(--ease-out);
+    flex-shrink: 0;
+  }
+
+  /* Pinned devices keep the pin visible at rest so the state reads at a glance. */
+  .favourite-btn.active {
+    opacity: 1;
+    color: var(--colour-selection);
+  }
+
+  .device-palette-item:hover .favourite-btn,
+  .device-palette-item:focus-within .favourite-btn {
+    opacity: 1;
+  }
+
+  .favourite-btn:hover {
+    color: var(--colour-selection);
+    background-color: var(--colour-surface-active);
+  }
+
+  .favourite-btn:focus-visible {
     opacity: 1;
     outline: 2px solid var(--colour-focus-ring);
     outline-offset: 1px;

--- a/src/lib/components/PaletteDeviceContextMenu.svelte
+++ b/src/lib/components/PaletteDeviceContextMenu.svelte
@@ -1,8 +1,8 @@
 <!--
   PaletteDeviceContextMenu Component
-  Right-click context menu for custom device types in the device palette.
-  Shows a "Delete from Library" action for custom (user-defined) devices.
-  Uses bits-ui ContextMenu in virtual trigger mode.
+  Right-click context menu for device types in the device palette.
+  Always offers a pin/unpin action; custom (user-defined) devices also get a
+  "Delete from Library" action. Uses bits-ui ContextMenu in virtual trigger mode.
 -->
 <script lang="ts">
   import { ContextMenu } from "bits-ui";
@@ -13,6 +13,12 @@
     open?: boolean;
     /** Callback when open state changes */
     onOpenChange?: (open: boolean) => void;
+    /** Whether the device is currently pinned (favourited) */
+    isFavourite?: boolean;
+    /** Whether the delete action should be offered (unused custom devices only) */
+    canDelete?: boolean;
+    /** Pin/unpin device callback */
+    ontogglefavourite?: () => void;
     /** Delete device callback */
     ondelete?: () => void;
     /** X coordinate for the menu anchor (cursor screen position). Required: a
@@ -26,6 +32,9 @@
   let {
     open = $bindable(false),
     onOpenChange,
+    isFavourite = false,
+    canDelete = false,
+    ontogglefavourite,
     ondelete,
     x,
     y,
@@ -57,15 +66,31 @@
       customAnchor={virtualAnchor}
     >
       <ContextMenu.Item
-        class="context-menu-item context-menu-item--destructive"
-        data-testid="ctx-menu-item"
+        class="context-menu-item"
+        data-testid="ctx-menu-favourite"
         onSelect={() => {
-          ondelete?.();
+          ontogglefavourite?.();
           open = false;
         }}
       >
-        <span class="context-menu-label">Delete from Library</span>
+        <span class="context-menu-label"
+          >{isFavourite ? "Unpin from top" : "Pin to top"}</span
+        >
       </ContextMenu.Item>
+
+      {#if canDelete}
+        <ContextMenu.Separator class="context-menu-separator" />
+        <ContextMenu.Item
+          class="context-menu-item context-menu-item--destructive"
+          data-testid="ctx-menu-item"
+          onSelect={() => {
+            ondelete?.();
+            open = false;
+          }}
+        >
+          <span class="context-menu-label">Delete from Library</span>
+        </ContextMenu.Item>
+      {/if}
     </ContextMenu.Content>
   </ContextMenu.Portal>
 </ContextMenu.Root>

--- a/src/lib/components/VirtualList.svelte
+++ b/src/lib/components/VirtualList.svelte
@@ -1,0 +1,104 @@
+<!--
+  VirtualList Component
+  Fixed-height windowed list. Renders only the rows intersecting the scroll
+  viewport (plus an overscan margin) so long device lists stay smooth. The
+  windowing geometry lives in $lib/utils/virtualList; this component owns the
+  scroll element, the spacer, and the rendered slice.
+-->
+<script lang="ts" generics="T">
+  import {
+    computeVisibleWindow,
+    type VisibleWindow,
+  } from "$lib/utils/virtualList";
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    /** Items to render. */
+    items: T[];
+    /** Fixed row height in pixels. */
+    itemHeight: number;
+    /** Rows rendered beyond the viewport on each side. */
+    overscan?: number;
+    /** Renders a single row. Receives the item and its absolute index. */
+    row: Snippet<[T, number]>;
+    /** Stable identity for an item, used as the {#each} key so the same DOM
+     *  node is never reused for a different item when the slice shifts. */
+    key: (item: T) => string | number;
+    /** Optional accessible label for the scroll region. */
+    ariaLabel?: string;
+  }
+
+  let { items, itemHeight, overscan = 4, row, key, ariaLabel }: Props =
+    $props();
+
+  let scrollTop = $state(0);
+  let viewportHeight = $state(0);
+
+  // Before the first layout pass clientHeight reports 0; fall back to a single
+  // viewport's worth of rows so the initial paint is never empty.
+  const effectiveViewportHeight = $derived(
+    viewportHeight > 0 ? viewportHeight : itemHeight * (overscan * 2 + 1),
+  );
+
+  const visibleWindow = $derived<VisibleWindow>(
+    computeVisibleWindow({
+      scrollTop,
+      viewportHeight: effectiveViewportHeight,
+      itemHeight,
+      itemCount: items.length,
+      overscan,
+    }),
+  );
+
+  const visibleItems = $derived(
+    items.slice(visibleWindow.startIndex, visibleWindow.endIndex),
+  );
+
+  function handleScroll(event: Event) {
+    scrollTop = (event.currentTarget as HTMLElement).scrollTop;
+  }
+</script>
+
+<div
+  class="virtual-list"
+  role="list"
+  aria-label={ariaLabel}
+  onscroll={handleScroll}
+  bind:clientHeight={viewportHeight}
+>
+  <div
+    class="virtual-list-spacer"
+    style:height="{visibleWindow.totalHeight}px"
+  >
+    <div
+      class="virtual-list-window"
+      style:transform="translateY({visibleWindow.offsetY}px)"
+    >
+      {#each visibleItems as item, i (key(item))}
+        {@render row(item, visibleWindow.startIndex + i)}
+      {/each}
+    </div>
+  </div>
+</div>
+
+<style>
+  .virtual-list {
+    overflow-y: auto;
+    /* Cap the windowed viewport so the spacer can scroll within it. */
+    max-height: 100%;
+  }
+
+  .virtual-list-spacer {
+    position: relative;
+    width: 100%;
+  }
+
+  .virtual-list-window {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/src/lib/components/icons/IconPin.svelte
+++ b/src/lib/components/icons/IconPin.svelte
@@ -1,0 +1,30 @@
+<!--
+  Pin icon for favourite (pinned) device types in the palette.
+  `filled` draws the solid pinned state; otherwise the outline (unpinned) state.
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+    filled?: boolean;
+  }
+
+  let { size = 16, filled = false }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill={filled ? "currentColor" : "none"}
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+  data-icon="pin"
+>
+  <path d="M12 17v5" />
+  <path
+    d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"
+  />
+</svg>

--- a/src/lib/utils/deviceFavourites.ts
+++ b/src/lib/utils/deviceFavourites.ts
@@ -1,0 +1,52 @@
+/**
+ * Device Favourites Utilities
+ * Handles localStorage persistence for pinned (favourited) device slugs in the
+ * device palette. Mirrors the deviceGrouping persistence pattern.
+ */
+
+import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
+
+export const FAVOURITES_STORAGE_KEY = "Rackula-device-favourites";
+
+/**
+ * Load the saved favourite device slugs from localStorage.
+ * Insertion order is preserved so the pinned section is stable across sessions.
+ * @returns A set of slugs, empty when nothing valid is stored.
+ */
+export function loadFavouritesFromStorage(): Set<string> {
+  const stored = safeGetItem(FAVOURITES_STORAGE_KEY);
+  if (!stored) return new Set();
+
+  try {
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((s): s is string => typeof s === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Persist the favourite device slugs to localStorage.
+ * @param slugs Any iterable of slugs; insertion order is retained.
+ */
+export function saveFavouritesToStorage(slugs: Iterable<string>): void {
+  safeSetItem(FAVOURITES_STORAGE_KEY, JSON.stringify([...slugs]));
+}
+
+/**
+ * Return a new set with the slug toggled: removed if present, appended if absent.
+ * The input set is never mutated.
+ */
+export function toggleFavourite(
+  favourites: Set<string>,
+  slug: string,
+): Set<string> {
+  const next = new Set(favourites);
+  if (next.has(slug)) {
+    next.delete(slug);
+  } else {
+    next.add(slug);
+  }
+  return next;
+}

--- a/src/lib/utils/virtualList.ts
+++ b/src/lib/utils/virtualList.ts
@@ -1,0 +1,79 @@
+/**
+ * Virtual List Windowing
+ *
+ * Pure geometry for fixed-height list virtualization. Given the current scroll
+ * offset and viewport size, work out which contiguous slice of rows needs to be
+ * rendered and where the rendered block sits inside a full-height spacer. The
+ * palette uses this to keep long device lists (500+ rows) scrolling smoothly
+ * without mounting every row.
+ */
+
+export interface VisibleWindowInput {
+  /** Current scroll offset of the viewport, in pixels. */
+  scrollTop: number;
+  /** Visible height of the scroll viewport, in pixels. */
+  viewportHeight: number;
+  /** Fixed height of each row, in pixels. */
+  itemHeight: number;
+  /** Total number of rows in the list. */
+  itemCount: number;
+  /** Extra rows rendered above and below the viewport to mask fast scrolling. */
+  overscan: number;
+}
+
+export interface VisibleWindow {
+  /** Index of the first rendered row (inclusive). */
+  startIndex: number;
+  /** Index just past the last rendered row (exclusive). */
+  endIndex: number;
+  /** Top offset of the rendered block within the full list, in pixels. */
+  offsetY: number;
+  /** Full scroll height of the list, in pixels. */
+  totalHeight: number;
+}
+
+/**
+ * Compute the slice of rows to render for the given scroll state.
+ *
+ * A non-positive `itemHeight` is treated as "unmeasured" and renders every row
+ * in one batch, which keeps the component correct before the first layout pass.
+ */
+export function computeVisibleWindow({
+  scrollTop,
+  viewportHeight,
+  itemHeight,
+  itemCount,
+  overscan,
+}: VisibleWindowInput): VisibleWindow {
+  if (itemCount <= 0) {
+    return { startIndex: 0, endIndex: 0, offsetY: 0, totalHeight: 0 };
+  }
+
+  if (itemHeight <= 0) {
+    return {
+      startIndex: 0,
+      endIndex: itemCount,
+      offsetY: 0,
+      totalHeight: 0,
+    };
+  }
+
+  const totalHeight = itemCount * itemHeight;
+  const safeScrollTop = Math.max(0, scrollTop);
+
+  const firstVisible = Math.floor(safeScrollTop / itemHeight);
+  // +1 covers the row straddled by the viewport's bottom edge when scrollTop
+  // is not an exact multiple of itemHeight, so the last visible row is never
+  // left unrendered.
+  const visibleCount = Math.ceil(viewportHeight / itemHeight) + 1;
+
+  const startIndex = Math.max(0, firstVisible - overscan);
+  const endIndex = Math.min(itemCount, firstVisible + visibleCount + overscan);
+
+  return {
+    startIndex,
+    endIndex,
+    offsetY: startIndex * itemHeight,
+    totalHeight,
+  };
+}

--- a/src/lib/utils/virtualList.ts
+++ b/src/lib/utils/virtualList.ts
@@ -59,13 +59,20 @@ export function computeVisibleWindow({
   }
 
   const totalHeight = itemCount * itemHeight;
-  const safeScrollTop = Math.max(0, scrollTop);
 
-  const firstVisible = Math.floor(safeScrollTop / itemHeight);
   // +1 covers the row straddled by the viewport's bottom edge when scrollTop
   // is not an exact multiple of itemHeight, so the last visible row is never
   // left unrendered.
   const visibleCount = Math.ceil(viewportHeight / itemHeight) + 1;
+
+  // Clamp the scroll offset to the current content's max scroll. When a long
+  // list shrinks (e.g. search filtering) the scroll container can still report
+  // a stale, oversized scrollTop; without this clamp firstVisible would exceed
+  // itemCount and produce startIndex > endIndex, rendering a blank list.
+  const maxScrollTop = Math.max(0, totalHeight - viewportHeight);
+  const safeScrollTop = Math.min(Math.max(0, scrollTop), maxScrollTop);
+
+  const firstVisible = Math.floor(safeScrollTop / itemHeight);
 
   const startIndex = Math.max(0, firstVisible - overscan);
   const endIndex = Math.min(itemCount, firstVisible + visibleCount + overscan);

--- a/src/tests/device-favourites.test.ts
+++ b/src/tests/device-favourites.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Device Favourites Tests
+ *
+ * Covers the localStorage-backed favourites set used by the device palette:
+ * load/save round-trips, toggle behaviour, and resilience to malformed storage.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  loadFavouritesFromStorage,
+  saveFavouritesToStorage,
+  toggleFavourite,
+  FAVOURITES_STORAGE_KEY,
+} from "$lib/utils/deviceFavourites";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("deviceFavourites", () => {
+  describe("loadFavouritesFromStorage", () => {
+    it("returns an empty set when nothing is stored", () => {
+      expect(loadFavouritesFromStorage().size).toBe(0);
+    });
+
+    it("round-trips saved slugs preserving order", () => {
+      saveFavouritesToStorage(["server-a", "switch-b"]);
+      const loaded = loadFavouritesFromStorage();
+      expect([...loaded]).toEqual(["server-a", "switch-b"]);
+    });
+
+    it("returns an empty set when stored JSON is malformed", () => {
+      localStorage.setItem(FAVOURITES_STORAGE_KEY, "not-json{");
+      expect(loadFavouritesFromStorage().size).toBe(0);
+    });
+
+    it("ignores non-string entries in stored JSON", () => {
+      localStorage.setItem(
+        FAVOURITES_STORAGE_KEY,
+        JSON.stringify(["valid", 42, null, "also-valid"]),
+      );
+      expect([...loadFavouritesFromStorage()]).toEqual(["valid", "also-valid"]);
+    });
+
+    it("returns an empty set when stored JSON is not an array", () => {
+      localStorage.setItem(
+        FAVOURITES_STORAGE_KEY,
+        JSON.stringify({ slug: "server-a" }),
+      );
+      expect(loadFavouritesFromStorage().size).toBe(0);
+    });
+  });
+
+  describe("toggleFavourite", () => {
+    it("adds a slug that is absent", () => {
+      const next = toggleFavourite(new Set(["a"]), "b");
+      expect([...next]).toEqual(["a", "b"]);
+    });
+
+    it("removes a slug that is present", () => {
+      const next = toggleFavourite(new Set(["a", "b"]), "a");
+      expect([...next]).toEqual(["b"]);
+    });
+
+    it("does not mutate the input set", () => {
+      const original = new Set(["a"]);
+      toggleFavourite(original, "b");
+      expect([...original]).toEqual(["a"]);
+    });
+
+    it("preserves insertion order when re-adding after removal", () => {
+      let set = new Set(["a", "b"]);
+      set = toggleFavourite(set, "a"); // -> ["b"]
+      set = toggleFavourite(set, "a"); // -> ["b", "a"]
+      expect([...set]).toEqual(["b", "a"]);
+    });
+  });
+
+  describe("saveFavouritesToStorage", () => {
+    it("persists an iterable so a later load reflects the change", () => {
+      saveFavouritesToStorage(new Set(["x", "y"]));
+      expect([...loadFavouritesFromStorage()]).toEqual(["x", "y"]);
+    });
+
+    it("clears storage to an empty set", () => {
+      saveFavouritesToStorage(["x"]);
+      saveFavouritesToStorage([]);
+      expect(loadFavouritesFromStorage().size).toBe(0);
+    });
+  });
+});

--- a/src/tests/virtual-list.test.ts
+++ b/src/tests/virtual-list.test.ts
@@ -116,6 +116,24 @@ describe("computeVisibleWindow", () => {
     expect(w.offsetY).toBe(0);
   });
 
+  it("renders a valid bottom slice when scrollTop is stale after the list shrinks", () => {
+    // A long list was scrolled near the bottom (scrollTop for ~1000 rows),
+    // then a filter shrank it to 10 rows without a new scroll event firing.
+    const w = computeVisibleWindow({
+      scrollTop: 39600,
+      viewportHeight: 200,
+      itemHeight,
+      itemCount: 10,
+      overscan: 4,
+    });
+    // The window must stay within bounds and render the items that exist,
+    // not collapse to an empty slice translated past the content.
+    expect(w.startIndex).toBeLessThanOrEqual(w.endIndex);
+    expect(w.endIndex).toBe(10);
+    expect(w.endIndex - w.startIndex).toBeGreaterThan(0);
+    expect(w.offsetY).toBeLessThanOrEqual(w.totalHeight);
+  });
+
   it("treats a non-positive itemHeight as a single rendered batch", () => {
     const w = computeVisibleWindow({
       scrollTop: 0,

--- a/src/tests/virtual-list.test.ts
+++ b/src/tests/virtual-list.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Virtual List Windowing Tests
+ *
+ * Covers the pure windowing math that drives the device palette's virtualized
+ * row rendering: which slice of a fixed-height list is visible for a given
+ * scroll offset, plus the spacer geometry that keeps the scrollbar honest.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeVisibleWindow } from "$lib/utils/virtualList";
+
+describe("computeVisibleWindow", () => {
+  const itemHeight = 40;
+
+  it("reports full content height regardless of scroll", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 0,
+      viewportHeight: 200,
+      itemHeight,
+      itemCount: 100,
+      overscan: 0,
+    });
+    expect(w.totalHeight).toBe(4000);
+  });
+
+  it("returns the top slice at scrollTop 0 (no overscan)", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 0,
+      viewportHeight: 200,
+      itemHeight,
+      itemCount: 100,
+      overscan: 0,
+    });
+    // 200 / 40 = 5 fully-visible rows, +1 for a straddled bottom row -> 0..5,
+    // endIndex is exclusive
+    expect(w.startIndex).toBe(0);
+    expect(w.endIndex).toBe(6);
+    expect(w.offsetY).toBe(0);
+  });
+
+  it("advances the window when scrolled and offsets the spacer", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 400,
+      viewportHeight: 200,
+      itemHeight,
+      itemCount: 100,
+      overscan: 0,
+    });
+    // 400 / 40 = row 10 at the top, 5 visible + 1 straddled -> [10, 16)
+    expect(w.startIndex).toBe(10);
+    expect(w.endIndex).toBe(16);
+    expect(w.offsetY).toBe(400);
+  });
+
+  it("expands the window by the overscan on both sides", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 400,
+      viewportHeight: 200,
+      itemHeight,
+      itemCount: 100,
+      overscan: 3,
+    });
+    expect(w.startIndex).toBe(7); // 10 - 3
+    expect(w.endIndex).toBe(19); // 16 + 3
+    expect(w.offsetY).toBe(7 * itemHeight);
+  });
+
+  it("clamps the start index at zero when overscanning past the top", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 0,
+      viewportHeight: 200,
+      itemHeight,
+      itemCount: 100,
+      overscan: 5,
+    });
+    expect(w.startIndex).toBe(0);
+    expect(w.offsetY).toBe(0);
+  });
+
+  it("clamps the end index at the item count near the bottom", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 3900, // near the very bottom of a 100-item, 4000px list
+      viewportHeight: 200,
+      itemHeight,
+      itemCount: 100,
+      overscan: 2,
+    });
+    expect(w.endIndex).toBe(100);
+    expect(w.endIndex).toBeLessThanOrEqual(100);
+  });
+
+  it("renders the whole list when it fits in the viewport", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 0,
+      viewportHeight: 1000,
+      itemHeight,
+      itemCount: 5,
+      overscan: 0,
+    });
+    expect(w.startIndex).toBe(0);
+    expect(w.endIndex).toBe(5);
+    expect(w.totalHeight).toBe(200);
+  });
+
+  it("returns an empty window for an empty list", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 0,
+      viewportHeight: 200,
+      itemHeight,
+      itemCount: 0,
+      overscan: 2,
+    });
+    expect(w.startIndex).toBe(0);
+    expect(w.endIndex).toBe(0);
+    expect(w.totalHeight).toBe(0);
+    expect(w.offsetY).toBe(0);
+  });
+
+  it("treats a non-positive itemHeight as a single rendered batch", () => {
+    const w = computeVisibleWindow({
+      scrollTop: 0,
+      viewportHeight: 200,
+      itemHeight: 0,
+      itemCount: 10,
+      overscan: 0,
+    });
+    expect(w.startIndex).toBe(0);
+    expect(w.endIndex).toBe(10);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Lands issue #2094, an M14 (epic #2017) shell slice for the device library palette. Three capabilities:

- Favourites: pin/unpin a device from the row hover action or the right-click context menu. Pinned devices appear in a new section at the top of the palette and persist per browser via localStorage (`Rackula-device-favourites`), following the existing grouping-preference pattern.
- Virtualization: device lists longer than 30 rows render through a fixed-height windowed list (`VirtualList.svelte` + pure windowing math in `virtualList.ts`), so only visible rows mount. Short sections stay plain DOM so the accordion height animation and the generic section's category sub-grouping are untouched. Search and grouping keep working over the windowed lists.
- Display mode toggle: a pointer-reachable header button cycles the canvas display mode (Labels / Images / Both). It mirrors the canonical `uiStore.displayMode` lens and routes through App's existing `handleToggleDisplayMode`, so it does not introduce a competing source of truth (per #2074).

Subsumes the scheduling of #114 (virtualization) and the toggle half of #1540; both stay open and linked for cross-reference.

## Design notes

- Windowing geometry (`computeVisibleWindow`) and favourites persistence (`deviceFavourites`) are pure modules built test-first.
- No new dependency: virtualization is a small self-contained util + component (greenfield simplicity).
- 44px touch targets preserved (rows keep `--touch-target-min`, 48px); reduced-motion behaviour inherited from existing accordion styles.
- The context menu now offers pin/unpin for every device (delete stays gated to unused custom types) and is lazily mounted on open, so hundreds of rows do not each carry an idle menu.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run test:run` (126 files, 2256 tests pass, includes 20 new unit tests for windowing + favourites)
- [x] `npm run build` succeeds
- [x] Svelte MCP autofixer clean on all touched/new components
- [ ] CI `a11y (axe-core)` guard rail green (sidebar Devices scan covers the new toggle, pin buttons, and pinned section)
- [ ] CI visual-regression green

## Acceptance criteria

- [x] Pin/unpin from palette item hover and context menu; pinned section above groups
- [x] Pins persist across sessions
- [x] List virtualized; smooth scrolling with 500+ device types
- [x] Search and grouping modes work unchanged over the virtualized list
- [x] Display mode toggle reachable by pointer in the palette header
- [x] Keyboard navigation and screen reader announcements preserved (aria-pressed pin/toggle, role=list + labels, pinned section heading)

Closes #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Let users pin devices, scroll long lists smoothly, and switch palette display mode from the device panel**

### What Changed
- Devices can now be pinned to the top of the palette and stay pinned across sessions in the same browser
- Pinned devices show a pin button and a dedicated "Pinned" section, and can also be pinned or unpinned from the right-click menu
- Long device lists now load only the visible rows, which keeps large palettes responsive while preserving search and grouping
- The palette header now includes a display mode button that switches the canvas between labels, images, and both

### Impact
`✅ Faster scrolling in large device libraries`
`✅ Quicker access to frequently used devices`
`✅ Easier switching between label and image views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
