### PR TITLE
feat: tab strip for open layouts (#2079)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-tab-strip-open-layouts.md
+++ b/docs/superpowers/plans/2026-06-14-tab-strip-open-layouts.md
@@ -1,0 +1,121 @@
+# Tab Strip for Open Layouts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to
+> implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a tab strip showing open layouts with switch, close, and drag-reorder,
+backed by a workspace store that holds one layout-store instance per open tab and
+exposes the active tab's store as the live store, with per-instance undo history.
+
+**Architecture:** A new `workspace` store owns an ordered list of open tabs, each tab
+holding its own `LayoutStore` instance (its own history). The existing
+`getLayoutStore()` singleton becomes the workspace's first/active tab. To repoint the
+388 existing `getLayoutStore()` call sites at the active tab without a sweeping edit,
+`getLayoutStore()` returns a stable proxy whose getters/methods delegate to the
+workspace's current active instance. Switching a tab is a pure focus change (no history
+mutation). Content swaps into a tab go through one clear-then-load primitive that clears
+that tab's history first, which also fixes the latent `loadLayout` history bug.
+
+**Tech Stack:** Svelte 5 runes, TypeScript strict, bits-ui Tabs, Vitest, Playwright.
+
+**Scope boundary (read first):** The spike #2179 storage module (`Rackula:workspace`
+index + `Rackula:layout:<id>` bodies, `setOpenSet`, `getDurability`, lazy restore) is
+design-only; it is NOT in the codebase. This slice keeps tabs as in-memory session
+state and does NOT build that persistence layer. It establishes the workspace-store seam
+and tab UI so #2080 (lazy restore) and #2082 (sidebar) can layer persistence on top.
+Deferred and flagged: persisted open-set, the #2018 overflow/chevron/orphan/rename
+interaction model, and full cross-tab device-id/image-key namespacing (C6).
+
+---
+
+## File Structure
+
+- Create `src/lib/stores/workspace.svelte.ts` - the workspace store: ordered open tabs,
+  each an `{ id, store }`; `activeId`; `activeStore` derived getter; `openTab`,
+  `closeTab`, `switchTo`, `reorderTabs`, `clearThenLoad` (the shared primitive).
+- Modify `src/lib/stores/layout.svelte.ts` - `getLayoutStore()` returns a stable proxy
+  that delegates to the workspace active store; add `clearHistoryThenLoad` usage; keep
+  `createLayoutStore`/`resetLayoutStore` semantics intact.
+- Modify `src/lib/stores/layout/layout-lifecycle.ts` - `loadLayout` clears history
+  (the latent-bug fix) via the state-access history handle.
+- Modify `src/lib/stores/layout/types.ts` - expose `getHistory()` already present; no
+  change expected, verify.
+- Create `src/lib/components/LayoutTabs.svelte` - the tab strip UI (ARIA tablist, roving
+  tabindex, 44px targets, reduced motion, close affordance, unbacked-changes dot,
+  drag-reorder).
+- Modify `src/App.svelte` - mount `LayoutTabs` above the canvas; wire Alt+1-9 nav.
+- Modify `src/lib/components/KeyboardHandler.svelte` - Alt+1-9 jump to tab N.
+- Create `src/tests/workspace-store.test.ts` - behaviour tests for the workspace store.
+- Modify `src/tests/layout-undo-redo.test.ts` (or new) - assert `loadLayout` clears
+  history.
+
+---
+
+## Task 1: Fix latent `loadLayout` history bug (clear-then-load)
+
+**Files:**
+- Modify: `src/lib/stores/layout/layout-lifecycle.ts`
+- Test: `src/tests/layout-undo-redo.test.ts`
+
+- [ ] Step 1: Write failing test asserting history is cleared after `loadLayout`.
+- [ ] Step 2: Run it, expect FAIL (history survives load today).
+- [ ] Step 3: In `loadLayout`, after `ctx.setLayout(...)`, call `ctx.getHistory().clear()`.
+- [ ] Step 4: Run test, expect PASS. Run full suite, expect green.
+- [ ] Step 5: Commit.
+
+## Task 2: Workspace store (per-instance history, focus-only switch)
+
+**Files:**
+- Create: `src/lib/stores/workspace.svelte.ts`
+- Test: `src/tests/workspace-store.test.ts`
+
+Behaviour to test (high-value):
+- `openTab(layout)` creates a new tab with its own store + history; becomes active.
+- `switchTo(id)` changes active without mutating any tab's undo/redo stacks
+  (inactive tab's redo stack survives a round trip).
+- `closeTab(id)` removes the tab; active falls back to a neighbour; closing the last
+  tab is handled.
+- `reorderTabs(from, to)` reorders the open list.
+- `clearThenLoad(id, layout)` clears that tab's history then loads (no cross-tab leak).
+- `activeStore` reflects the active tab's store.
+
+- [ ] Steps: TDD each behaviour, commit per green group.
+
+## Task 3: Repoint `getLayoutStore()` at the active tab via stable proxy
+
+**Files:**
+- Modify: `src/lib/stores/layout.svelte.ts`
+
+- [ ] Make the workspace's first tab wrap the existing `activeInstance`.
+- [ ] `getLayoutStore()` returns a stable proxy delegating reads/methods to
+  `workspace.activeStore`. Preserve `resetLayoutStore()` semantics (resets active tab).
+- [ ] Run full suite (388 call sites, 30+ tests). Expect green.
+- [ ] Commit.
+
+## Task 4: Tab strip UI
+
+**Files:**
+- Create: `src/lib/components/LayoutTabs.svelte`
+- Modify: `src/App.svelte`
+
+- [ ] ARIA tablist with roving tabindex, `aria-selected`, 44px targets, reduced-motion,
+  hover/focus close (x) with accessible label, unbacked-changes dot with accessible
+  text from durability, drag-reorder via existing dragdrop precedent.
+- [ ] Validate with svelte-autofixer.
+- [ ] Mount above canvas in App.svelte.
+- [ ] Commit.
+
+## Task 5: Alt+1-9 tab navigation
+
+**Files:**
+- Modify: `src/lib/components/KeyboardHandler.svelte`
+
+- [ ] Add Alt+1..9 shortcuts to switch to tab N (interceptability noted; bare digits
+  unaffected).
+- [ ] Commit.
+
+## Task 6: Verify, code-review, PR
+
+- [ ] `npm run lint`, `npm run test:run`, `npm run build`, a11y e2e if feasible.
+- [ ] Local `/code-review`, fix findings.
+- [ ] PR `Closes #2079`.

--- a/docs/superpowers/plans/2026-06-14-tab-strip-open-layouts.md
+++ b/docs/superpowers/plans/2026-06-14-tab-strip-open-layouts.md
@@ -24,7 +24,19 @@ design-only; it is NOT in the codebase. This slice keeps tabs as in-memory sessi
 state and does NOT build that persistence layer. It establishes the workspace-store seam
 and tab UI so #2080 (lazy restore) and #2082 (sidebar) can layer persistence on top.
 Deferred and flagged: persisted open-set, the #2018 overflow/chevron/orphan/rename
-interaction model, and full cross-tab device-id/image-key namespacing (C6).
+interaction model, and cross-tab device-id/image-key namespacing (C6).
+
+**C6 deferral (device-id uniqueness across tabs):** Placement images live in the global
+singleton image store keyed `placement-<placedDeviceId>` (see
+`src/lib/stores/commands/device.ts`, `EditPanelImage.svelte`, export/archive paths). Two
+open tabs whose layouts contain a placed device with the same UUID (for example, the same
+file opened in two tabs) collide on that key, so a placement photo set in one tab can
+surface in the other. Full enforcement means namespacing every `placement-<id>` key by
+layout id across ~15 call sites (editor, export, archive, undo commands) and is entangled
+with the #2179 persistence schema and #2080 lazy restore. Regenerating ids on open is not
+a safe minimum here: it would break the undo image-remap commands and the round-trip
+identity #2080 relies on. So C6 is deferred to the persistence slice where image keying is
+reworked; it does not affect the common one-file-per-tab case.
 
 ---
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,7 @@
   import MobileHistoryControls from "$lib/components/mobile/MobileHistoryControls.svelte";
   import RackIndicator from "$lib/components/mobile/RackIndicator.svelte";
   import SidebarTabs from "$lib/components/SidebarTabs.svelte";
+  import LayoutTabs from "$lib/components/LayoutTabs.svelte";
   import RackList from "$lib/components/RackList.svelte";
   import PersistenceEffects from "$lib/components/PersistenceEffects.svelte";
   import DialogOrchestrator from "$lib/components/DialogOrchestrator.svelte";
@@ -587,6 +588,8 @@
     />
 
     <RackIndicator />
+
+    <LayoutTabs />
 
     <main class="app-main" class:mobile={viewportStore.isMobile}>
       <MobileHistoryControls />

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -333,7 +333,9 @@
    * event was a tab-jump so the caller can stop processing.
    */
   function handleTabJump(event: KeyboardEvent): boolean {
-    if (!event.altKey || event.ctrlKey || event.metaKey) return false;
+    if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+      return false;
+    }
     const match = /^Digit([1-9])$/.exec(event.code);
     if (!match) return false;
 

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -6,6 +6,7 @@
   import { shouldIgnoreKeyboard } from "$lib/utils/keyboard";
   import { findActionForEvent, type ActionId } from "$lib/actions/registry";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
@@ -43,6 +44,7 @@
   }: Props = $props();
 
   const layoutStore = getLayoutStore();
+  const workspace = getWorkspaceStore();
   const selectionStore = getSelectionStore();
   const uiStore = getUIStore();
   const toastStore = getToastStore();
@@ -324,9 +326,33 @@
     }
   }
 
+  /**
+   * Alt+1-9 jumps to the Nth open layout tab. Keyed off event.code (Digit1..9)
+   * rather than event.key because macOS remaps Alt+digit to a symbol (Alt+1
+   * yields the character produced by that key, not "1"). Returns true when the
+   * event was a tab-jump so the caller can stop processing.
+   */
+  function handleTabJump(event: KeyboardEvent): boolean {
+    if (!event.altKey || event.ctrlKey || event.metaKey) return false;
+    const match = /^Digit([1-9])$/.exec(event.code);
+    if (!match) return false;
+
+    event.preventDefault();
+    const index = Number(match[1]) - 1;
+    const tab = workspace.tabs[index];
+    if (tab) {
+      workspace.switchTo(tab.id);
+    }
+    return true;
+  }
+
   function handleKeyDown(event: KeyboardEvent) {
     // Ignore if in input field
     if (shouldIgnoreKeyboard(event)) return;
+
+    // Workspace tab jumps (Alt+1-9) are dynamic, not fixed registry actions, so
+    // they take precedence over the action registry.
+    if (handleTabJump(event)) return;
 
     const action = findActionForEvent(event);
     if (!action) return;

--- a/src/lib/components/LayoutTabs.svelte
+++ b/src/lib/components/LayoutTabs.svelte
@@ -1,0 +1,292 @@
+<!--
+  LayoutTabs Component
+  Tab strip for the open layouts in the workspace. Each tab switches the active
+  layout; a per-tab close affordance removes it from the open set (the layout
+  itself is not deleted). Tabs can be dragged to reorder.
+
+  Accessibility:
+  - role="tablist" / role="tab" with aria-selected on the active tab.
+  - Roving tabindex: only the active tab is in the tab order; ArrowLeft/Right
+    move focus between tabs (Home/End jump to first/last).
+  - The unbacked-changes dot carries accessible text (never colour alone,
+    WCAG 1.4.1); the close control has an accessible name.
+  - The close button is a sibling of the tab button, not nested inside it
+    (no button-in-button), so each tab exposes two distinct controls.
+-->
+<script lang="ts">
+  import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
+  import { getLayoutDurability } from "$lib/storage";
+  import { IconClose } from "./icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+
+  const workspace = getWorkspaceStore();
+
+  // The label and durability dot read live from each tab's own store.
+  const tabViews = $derived(
+    workspace.tabs.map((tab) => {
+      const durability = getLayoutDurability(tab.store);
+      return {
+        id: tab.id,
+        get name() {
+          return tab.store.layout.name;
+        },
+        // "Backed" means durable (saved/exported with no changes since). An
+        // unbacked tab shows the changes dot.
+        get unbacked() {
+          return durability.status !== "saved";
+        },
+        get statusLabel() {
+          return durability.label;
+        },
+      };
+    }),
+  );
+
+  let dragIndex = $state<number | null>(null);
+  let dragOverIndex = $state<number | null>(null);
+
+  function focusTabAt(index: number): void {
+    const tab = workspace.tabs[index];
+    if (!tab) return;
+    const el = document.getElementById(`layout-tab-${tab.id}`);
+    el?.focus();
+  }
+
+  function handleTabKeydown(event: KeyboardEvent, index: number): void {
+    const count = workspace.tabs.length;
+    if (count === 0) return;
+
+    switch (event.key) {
+      case "ArrowRight": {
+        event.preventDefault();
+        focusTabAt((index + 1) % count);
+        break;
+      }
+      case "ArrowLeft": {
+        event.preventDefault();
+        focusTabAt((index - 1 + count) % count);
+        break;
+      }
+      case "Home": {
+        event.preventDefault();
+        focusTabAt(0);
+        break;
+      }
+      case "End": {
+        event.preventDefault();
+        focusTabAt(count - 1);
+        break;
+      }
+    }
+  }
+
+  function handleDragStart(event: DragEvent, index: number): void {
+    dragIndex = index;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = "move";
+      // Some browsers require data to be set for a drag to start.
+      event.dataTransfer.setData("text/plain", String(index));
+    }
+  }
+
+  function handleDragOver(event: DragEvent, index: number): void {
+    if (dragIndex === null) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    dragOverIndex = index;
+  }
+
+  function handleDrop(event: DragEvent, index: number): void {
+    event.preventDefault();
+    if (dragIndex !== null && dragIndex !== index) {
+      workspace.reorderTabs(dragIndex, index);
+    }
+    dragIndex = null;
+    dragOverIndex = null;
+  }
+
+  function handleDragEnd(): void {
+    dragIndex = null;
+    dragOverIndex = null;
+  }
+
+  function handleClose(event: MouseEvent, id: string): void {
+    // Keep the click from also selecting the tab.
+    event.stopPropagation();
+    workspace.closeTab(id);
+  }
+</script>
+
+{#if tabViews.length > 1}
+  <div class="layout-tabs" role="tablist" aria-label="Open layouts">
+    {#each tabViews as view, index (view.id)}
+      {@const selected = view.id === workspace.activeId}
+      <div
+        class="layout-tab"
+        class:active={selected}
+        class:drag-over={dragOverIndex === index && dragIndex !== index}
+        draggable="true"
+        ondragstart={(e) => handleDragStart(e, index)}
+        ondragover={(e) => handleDragOver(e, index)}
+        ondrop={(e) => handleDrop(e, index)}
+        ondragend={handleDragEnd}
+        role="presentation"
+      >
+        <button
+          type="button"
+          id="layout-tab-{view.id}"
+          class="layout-tab-button"
+          role="tab"
+          aria-selected={selected}
+          tabindex={selected ? 0 : -1}
+          data-testid="layout-tab-{view.id}"
+          onclick={() => workspace.switchTo(view.id)}
+          onkeydown={(e) => handleTabKeydown(e, index)}
+        >
+          {#if view.unbacked}
+            <span class="layout-tab-dot" aria-hidden="true"></span>
+            <span class="sr-only">{view.statusLabel}.</span>
+          {/if}
+          <span class="layout-tab-label">{view.name}</span>
+        </button>
+        <button
+          type="button"
+          class="layout-tab-close"
+          aria-label={`Close ${view.name}`}
+          data-testid="layout-tab-close-{view.id}"
+          onclick={(e) => handleClose(e, view.id)}
+        >
+          <IconClose size={ICON_SIZE.sm} />
+        </button>
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .layout-tabs {
+    display: flex;
+    align-items: stretch;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2);
+    background: var(--colour-sidebar-bg);
+    border-bottom: 1px solid var(--colour-border);
+    overflow: hidden;
+  }
+
+  .layout-tab {
+    display: flex;
+    align-items: center;
+    /* Comfortable minimum near 120px; the active tab keeps room for its label
+       and close button. The hard floor / chevron overflow is a follow-up. */
+    min-width: 120px;
+    max-width: 220px;
+    min-height: 44px;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--colour-text-muted);
+    transition:
+      background var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+  }
+
+  .layout-tab:hover {
+    background: var(--colour-surface-hover);
+    color: var(--colour-text);
+  }
+
+  .layout-tab.active {
+    background: var(--colour-surface-active);
+    border-color: var(--colour-border);
+    color: var(--colour-text);
+  }
+
+  .layout-tab.drag-over {
+    border-color: var(--colour-selection);
+  }
+
+  .layout-tab-button {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    min-width: 0;
+    /* 44px row height comes from the parent; pad horizontally. */
+    padding: 0 var(--space-2);
+    height: 100%;
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .layout-tab-button:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: -2px;
+    border-radius: var(--radius-sm);
+  }
+
+  .layout-tab-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .layout-tab-dot {
+    flex: 0 0 auto;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--colour-warning, var(--colour-selection));
+  }
+
+  .layout-tab-close {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    margin-right: var(--space-1);
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--colour-text-muted);
+    cursor: pointer;
+    transition: background var(--duration-fast) var(--ease-out);
+  }
+
+  .layout-tab-close:hover {
+    background: var(--colour-surface-hover);
+    color: var(--colour-text);
+  }
+
+  .layout-tab-close:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: -2px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .layout-tab,
+    .layout-tab-close {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/components/LayoutTabs.svelte
+++ b/src/lib/components/LayoutTabs.svelte
@@ -57,6 +57,11 @@
     index: number,
     id: string,
   ): void {
+    // Only handle keys aimed at the tab itself. When focus is on the nested
+    // close button, let Enter/Space reach it so keyboard close still works
+    // instead of being swallowed as tab activation.
+    if (event.target !== event.currentTarget) return;
+
     const count = workspace.tabs.length;
     if (count === 0) return;
 

--- a/src/lib/components/LayoutTabs.svelte
+++ b/src/lib/components/LayoutTabs.svelte
@@ -52,7 +52,11 @@
     el?.focus();
   }
 
-  function handleTabKeydown(event: KeyboardEvent, index: number): void {
+  function handleTabKeydown(
+    event: KeyboardEvent,
+    index: number,
+    id: string,
+  ): void {
     const count = workspace.tabs.length;
     if (count === 0) return;
 
@@ -75,6 +79,13 @@
       case "End": {
         event.preventDefault();
         focusTabAt(count - 1);
+        break;
+      }
+      case "Enter":
+      case " ": {
+        // A div with role="tab" does not activate on Enter/Space natively.
+        event.preventDefault();
+        workspace.switchTo(id);
         break;
       }
     }
@@ -121,34 +132,33 @@
   <div class="layout-tabs" role="tablist" aria-label="Open layouts">
     {#each tabViews as view, index (view.id)}
       {@const selected = view.id === workspace.activeId}
+      <!--
+        The tab is a div with role="tab" (a direct child of the tablist) so the
+        close affordance can be a real nested button without a button-in-button.
+        The div carries roving tabindex, aria-selected, click and key activation.
+      -->
       <div
+        id="layout-tab-{view.id}"
         class="layout-tab"
         class:active={selected}
         class:drag-over={dragOverIndex === index && dragIndex !== index}
+        role="tab"
+        aria-selected={selected}
+        tabindex={selected ? 0 : -1}
+        data-testid="layout-tab-{view.id}"
         draggable="true"
+        onclick={() => workspace.switchTo(view.id)}
+        onkeydown={(e) => handleTabKeydown(e, index, view.id)}
         ondragstart={(e) => handleDragStart(e, index)}
         ondragover={(e) => handleDragOver(e, index)}
         ondrop={(e) => handleDrop(e, index)}
         ondragend={handleDragEnd}
-        role="presentation"
       >
-        <button
-          type="button"
-          id="layout-tab-{view.id}"
-          class="layout-tab-button"
-          role="tab"
-          aria-selected={selected}
-          tabindex={selected ? 0 : -1}
-          data-testid="layout-tab-{view.id}"
-          onclick={() => workspace.switchTo(view.id)}
-          onkeydown={(e) => handleTabKeydown(e, index)}
-        >
-          {#if view.unbacked}
-            <span class="layout-tab-dot" aria-hidden="true"></span>
-            <span class="sr-only">{view.statusLabel}.</span>
-          {/if}
-          <span class="layout-tab-label">{view.name}</span>
-        </button>
+        {#if view.unbacked}
+          <span class="layout-tab-dot" aria-hidden="true"></span>
+          <span class="sr-only">{view.statusLabel}.</span>
+        {/if}
+        <span class="layout-tab-label">{view.name}</span>
         <button
           type="button"
           class="layout-tab-close"
@@ -177,15 +187,20 @@
   .layout-tab {
     display: flex;
     align-items: center;
+    gap: var(--space-1);
     /* Comfortable minimum near 120px; the active tab keeps room for its label
        and close button. The hard floor / chevron overflow is a follow-up. */
     min-width: 120px;
     max-width: 220px;
     min-height: 44px;
+    padding: 0 var(--space-1) 0 var(--space-2);
     border: 1px solid transparent;
     border-radius: var(--radius-sm);
     background: transparent;
     color: var(--colour-text-muted);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
     transition:
       background var(--duration-fast) var(--ease-out),
       border-color var(--duration-fast) var(--ease-out);
@@ -206,31 +221,14 @@
     border-color: var(--colour-selection);
   }
 
-  .layout-tab-button {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    min-width: 0;
-    /* 44px row height comes from the parent; pad horizontally. */
-    padding: 0 var(--space-2);
-    height: 100%;
-    background: transparent;
-    border: none;
-    color: inherit;
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
-    text-align: left;
-    cursor: pointer;
-  }
-
-  .layout-tab-button:focus-visible {
+  .layout-tab:focus-visible {
     outline: 2px solid var(--colour-selection);
     outline-offset: -2px;
-    border-radius: var(--radius-sm);
   }
 
   .layout-tab-label {
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -24,11 +24,8 @@ import { MAX_RACKS } from "$lib/types/constants";
 import { createLayout } from "$lib/utils/serialization";
 import type { CreateDeviceTypeInput } from "$lib/stores/layout-helpers";
 import { debug } from "$lib/utils/debug";
-import {
-  createHistoryStore,
-  getHistoryStore,
-  type HistoryStore,
-} from "./history.svelte";
+import { createHistoryStore, type HistoryStore } from "./history.svelte";
+import { getWorkspaceStore } from "./workspace.svelte";
 import type { LayoutStateAccess } from "./layout/types";
 import {
   type BackupState,
@@ -1211,15 +1208,37 @@ export function createLayoutStore(
  */
 export type LayoutStore = ReturnType<typeof createLayoutStore>;
 
-// Active instance for the app session (one layout open at a time).
-const activeInstance = createLayoutStore(getHistoryStore());
+/**
+ * Stable facade over the active tab's layout store.
+ *
+ * Every consumer reads `getLayoutStore()` once and then accesses reactive
+ * getters/methods off it. The multi-layout workspace swaps which underlying
+ * store is active when the user switches tabs, so this returns a Proxy that
+ * forwards every access to the workspace's current active store. Reading a
+ * reactive getter through the Proxy inside a reactive context tracks both the
+ * active-tab change and the underlying property, so the whole app follows the
+ * active tab without any call-site changes.
+ *
+ * The workspace owns the first tab and binds it to the app-session history
+ * singleton (getHistoryStore()), so getLayoutStore() and getHistoryStore()
+ * stay consistent with one layout open.
+ */
+const layoutStoreFacade = new Proxy({} as LayoutStore, {
+  get(_target, prop) {
+    // Read each property off the live active store. Getters resolve against it
+    // (so reactive getters track correctly); methods are closures that already
+    // bind their own instance, so forwarding the reference is enough.
+    const active = getWorkspaceStore().activeStore;
+    return Reflect.get(active, prop, active);
+  },
+});
 
 /**
  * Get access to the active layout store.
- * @returns Store object with state and actions
+ * @returns Store facade forwarding to the active tab's state and actions
  */
 export function getLayoutStore(): LayoutStore {
-  return activeInstance;
+  return layoutStoreFacade;
 }
 
 /**
@@ -1227,5 +1246,5 @@ export function getLayoutStore(): LayoutStore {
  * @param clearStarted - If true, also clears the hasStarted flag (default: true)
  */
 export function resetLayoutStore(clearStarted: boolean = true): void {
-  activeInstance.resetLayout(clearStarted);
+  getWorkspaceStore().activeStore.resetLayout(clearStarted);
 }

--- a/src/lib/stores/layout/layout-lifecycle.ts
+++ b/src/lib/stores/layout/layout-lifecycle.ts
@@ -122,6 +122,12 @@ export function loadLayout(ctx: LayoutStateAccess, layoutData: Layout): void {
   });
   ctx.resetBackupTracking();
 
+  // Clear undo/redo history: the commands on the stack reference the layout
+  // being replaced. Without this, Ctrl+Z would replay them against the freshly
+  // loaded layout, mutating the wrong document. Each layout owns its own
+  // history, so swapping content into this instance must reset its stacks.
+  ctx.getHistory().clear();
+
   // Set active rack to first rack
   ctx.setActiveRackId(ctx.getLayout().racks[0]?.id ?? null);
 

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -54,6 +54,12 @@ function nextTabId(): string {
  */
 export function createWorkspaceStore() {
   function createInitialTab(): WorkspaceTab {
+    // The first/fresh tab binds to the app-session history singleton. We do NOT
+    // clear here: lazy construction of the workspace can be triggered from
+    // inside a reactive read (a $derived), and clearing $state there throws
+    // state_unsafe_mutation. Cold start has empty history anyway. The paths that
+    // REPLACE an existing tab with a fresh one (closeLastTab, reset) clear the
+    // singleton explicitly, outside any reactive context.
     return { id: nextTabId(), store: createLayoutStore(getHistoryStore()) };
   }
 
@@ -110,6 +116,11 @@ export function createWorkspaceStore() {
     if (index === -1) return;
 
     if (tabs.length === 1) {
+      // Replacing the only tab with a fresh blank one: clear the singleton
+      // history the fresh tab binds to, so it does not inherit the closed
+      // tab's undo/redo stack. Safe to mutate state here (event-handler path,
+      // not a reactive read).
+      getHistoryStore().clear();
       const fresh = createInitialTab();
       tabs = [fresh];
       activeId = fresh.id;
@@ -192,8 +203,10 @@ export function getWorkspaceStore(): WorkspaceStore {
 
 /**
  * Reset the workspace to a single fresh tab (primarily for testing). Recreates
- * the instance so a new session starts clean.
+ * the instance and clears the app-session history singleton the first tab binds
+ * to, so the new session starts with empty undo/redo.
  */
 export function resetWorkspaceStore(): void {
+  getHistoryStore().clear();
   workspaceInstance = createWorkspaceStore();
 }

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -57,8 +57,9 @@ export function createWorkspaceStore() {
     return { id: nextTabId(), store: createLayoutStore(getHistoryStore()) };
   }
 
-  let tabs = $state<WorkspaceTab[]>([createInitialTab()]);
-  let activeId = $state<string>(tabs[0]!.id);
+  const firstTab = createInitialTab();
+  let tabs = $state<WorkspaceTab[]>([firstTab]);
+  let activeId = $state<string>(firstTab.id);
 
   const activeTab = $derived(
     tabs.find((t) => t.id === activeId) ?? tabs[0]!,

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -1,0 +1,198 @@
+/**
+ * Workspace Store
+ *
+ * Owns the set of layouts open as tabs. Each tab holds its own LayoutStore
+ * instance, and therefore its own undo/redo history. The active tab's store is
+ * the one live store the rest of the app reads through getLayoutStore().
+ *
+ * History model (spike #2182):
+ * - History is per layout-store instance. The active tab's history is the only
+ *   live history; there is no global cross-tab undo stack.
+ * - Switching tabs is a PURE focus change: no history-stack mutation. An
+ *   inactive tab's undo and redo stacks freeze exactly as the user left them,
+ *   so returning to a tab resumes its own history, including redo.
+ * - Every content swap into a tab (open, restore) goes through one
+ *   clear-then-load primitive that clears that tab's history first.
+ *
+ * Persistence: tabs are in-memory session state here. The browser-mode
+ * multi-layout storage schema (spike #2179: `Rackula:workspace` index +
+ * `Rackula:layout:<id>` bodies) is a separate slice (#2080) that layers onto
+ * this store; it is intentionally not built here.
+ */
+
+import type { Layout } from "$lib/types";
+import {
+  createLayoutStore,
+  type LayoutStore,
+} from "./layout.svelte";
+import {
+  createHistoryStore,
+  getHistoryStore,
+} from "./history.svelte";
+
+/** A single open tab: a stable id plus the layout store backing it. */
+export interface WorkspaceTab {
+  /** Stable identity for the tab, independent of the layout's metadata id. */
+  id: string;
+  /** The layout store instance backing this tab (owns its own history). */
+  store: LayoutStore;
+}
+
+let tabIdCounter = 0;
+function nextTabId(): string {
+  tabIdCounter += 1;
+  return `tab-${tabIdCounter}`;
+}
+
+/**
+ * Create a workspace store instance.
+ *
+ * The first tab wraps a layout store bound to the app-session history
+ * singleton (getHistoryStore()), so existing call sites that read
+ * getLayoutStore()/getHistoryStore() see the same instance and history they
+ * always have. Tabs opened afterwards get their own fresh history instance.
+ */
+export function createWorkspaceStore() {
+  function createInitialTab(): WorkspaceTab {
+    return { id: nextTabId(), store: createLayoutStore(getHistoryStore()) };
+  }
+
+  let tabs = $state<WorkspaceTab[]>([createInitialTab()]);
+  let activeId = $state<string>(tabs[0]!.id);
+
+  const activeTab = $derived(
+    tabs.find((t) => t.id === activeId) ?? tabs[0]!,
+  );
+  const activeStore = $derived(activeTab.store);
+
+  function getTab(id: string): WorkspaceTab | undefined {
+    return tabs.find((t) => t.id === id);
+  }
+
+  /**
+   * Open a new tab backed by a fresh layout store (its own history) and make
+   * it active. The layout, when provided, is loaded through the shared
+   * clear-then-load path so the new tab starts with empty history.
+   * @returns the new tab's id
+   */
+  function openTab(layout?: Layout): string {
+    const tab: WorkspaceTab = {
+      id: nextTabId(),
+      store: createLayoutStore(createHistoryStore()),
+    };
+    tabs = [...tabs, tab];
+    activeId = tab.id;
+    if (layout) {
+      // loadLayout already clears this instance's history (clear-then-load).
+      tab.store.loadLayout(layout);
+    }
+    return tab.id;
+  }
+
+  /**
+   * Focus a tab. Pure focus change: no history mutation on either the outgoing
+   * or incoming tab, so each tab's undo/redo stacks survive a round trip.
+   */
+  function switchTo(id: string): void {
+    if (!getTab(id)) return;
+    activeId = id;
+  }
+
+  /**
+   * Close a tab. Closing keeps the underlying layout (no body is destroyed
+   * here; persistence is a separate slice). If the closed tab was active,
+   * focus falls back to the nearest neighbour. The workspace never goes empty:
+   * closing the only tab resets it to a fresh blank tab.
+   */
+  function closeTab(id: string): void {
+    const index = tabs.findIndex((t) => t.id === id);
+    if (index === -1) return;
+
+    if (tabs.length === 1) {
+      const fresh = createInitialTab();
+      tabs = [fresh];
+      activeId = fresh.id;
+      return;
+    }
+
+    const wasActive = activeId === id;
+    const remaining = tabs.filter((t) => t.id !== id);
+    tabs = remaining;
+
+    if (wasActive) {
+      // Prefer the tab that took the closed tab's slot; otherwise the new last.
+      const fallback = remaining[index] ?? remaining[remaining.length - 1]!;
+      activeId = fallback.id;
+    }
+  }
+
+  /**
+   * Reorder the open tabs by moving the tab at fromIndex to toIndex. Does not
+   * change which tab is active. Out-of-range indices are ignored.
+   */
+  function reorderTabs(fromIndex: number, toIndex: number): void {
+    if (
+      fromIndex < 0 ||
+      fromIndex >= tabs.length ||
+      toIndex < 0 ||
+      toIndex >= tabs.length ||
+      fromIndex === toIndex
+    ) {
+      return;
+    }
+    const next = [...tabs];
+    const [moved] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, moved!);
+    tabs = next;
+  }
+
+  /**
+   * Swap new content into an existing tab through the shared clear-then-load
+   * primitive: the tab's history is cleared, then the layout is loaded. Used
+   * when a tab's content is replaced (file open into the current tab, restore).
+   */
+  function clearThenLoad(id: string, layout: Layout): void {
+    const tab = getTab(id);
+    if (!tab) return;
+    // loadLayout clears history as part of the content swap (#2079).
+    tab.store.loadLayout(layout);
+  }
+
+  return {
+    get tabs() {
+      return tabs;
+    },
+    get activeId() {
+      return activeId;
+    },
+    get activeStore() {
+      return activeStore;
+    },
+    openTab,
+    switchTo,
+    closeTab,
+    reorderTabs,
+    clearThenLoad,
+  };
+}
+
+/** Public type of a workspace store instance. */
+export type WorkspaceStore = ReturnType<typeof createWorkspaceStore>;
+
+let workspaceInstance: WorkspaceStore | null = null;
+
+/** Get the app-session workspace store (created lazily on first access). */
+export function getWorkspaceStore(): WorkspaceStore {
+  if (!workspaceInstance) {
+    workspaceInstance = createWorkspaceStore();
+  }
+  return workspaceInstance;
+}
+
+/**
+ * Reset the workspace to a single fresh tab (primarily for testing). Recreates
+ * the instance so a new session starts clean.
+ */
+export function resetWorkspaceStore(): void {
+  workspaceInstance = createWorkspaceStore();
+}

--- a/src/tests/keyboard.test.ts
+++ b/src/tests/keyboard.test.ts
@@ -960,7 +960,7 @@ describe("KeyboardHandler Component", () => {
       resetWorkspaceStore();
     });
 
-    it("Alt+2 switches to the second open tab", async () => {
+    it("Alt+1 jumps to the first open tab", async () => {
       const workspace = getWorkspaceStore();
       const firstId = workspace.activeId;
       const secondId = workspace.openTab(createLayout("Second"));
@@ -969,7 +969,7 @@ describe("KeyboardHandler Component", () => {
 
       render(KeyboardHandler);
 
-      // Switch back to the first tab. macOS remaps Alt+digit to a symbol, so the
+      // Alt+1 jumps to the first tab. macOS remaps Alt+digit to a symbol, so the
       // handler keys off event.code (Digit1), not event.key.
       await fireEvent.keyDown(window, {
         key: "1",

--- a/src/tests/keyboard.test.ts
+++ b/src/tests/keyboard.test.ts
@@ -8,6 +8,11 @@ import {
 import KeyboardHandler from "$lib/components/KeyboardHandler.svelte";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import {
+  getWorkspaceStore,
+  resetWorkspaceStore,
+} from "$lib/stores/workspace.svelte";
+import { createLayout } from "$lib/utils/serialization";
+import {
   getSelectionStore,
   resetSelectionStore,
 } from "$lib/stores/selection.svelte";
@@ -947,6 +952,47 @@ describe("KeyboardHandler Component", () => {
 
       // Should leapfrog over the blocking device at 6, land at U7 (internal units = 42)
       expect(layoutStore.rack!.devices[0]!.position).toBe(toInternalUnits(7));
+    });
+  });
+
+  describe("Tab Navigation Shortcuts", () => {
+    beforeEach(() => {
+      resetWorkspaceStore();
+    });
+
+    it("Alt+2 switches to the second open tab", async () => {
+      const workspace = getWorkspaceStore();
+      const firstId = workspace.activeId;
+      const secondId = workspace.openTab(createLayout("Second"));
+      // Focus is on the second tab after opening it.
+      expect(workspace.activeId).toBe(secondId);
+
+      render(KeyboardHandler);
+
+      // Switch back to the first tab. macOS remaps Alt+digit to a symbol, so the
+      // handler keys off event.code (Digit1), not event.key.
+      await fireEvent.keyDown(window, {
+        key: "1",
+        code: "Digit1",
+        altKey: true,
+      });
+
+      expect(workspace.activeId).toBe(firstId);
+    });
+
+    it("Alt+N is a no-op when fewer than N tabs are open", async () => {
+      const workspace = getWorkspaceStore();
+      const onlyId = workspace.activeId;
+
+      render(KeyboardHandler);
+
+      await fireEvent.keyDown(window, {
+        key: "5",
+        code: "Digit5",
+        altKey: true,
+      });
+
+      expect(workspace.activeId).toBe(onlyId);
     });
   });
 });

--- a/src/tests/layout-undo-redo.test.ts
+++ b/src/tests/layout-undo-redo.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { resetHistoryStore } from "$lib/stores/history.svelte";
 import { toInternalUnits } from "$lib/utils/position";
+import { createLayout } from "$lib/utils/serialization";
 import { setupStoreWithRack } from "./factories";
 
 describe("Layout Store - Undo/Redo Integration", () => {
@@ -430,6 +431,45 @@ describe("Layout Store - Undo/Redo Integration", () => {
 
       store.redo(); // Redo move
       expect(store.rack.devices[0]?.position).toBe(toInternalUnits(15));
+    });
+  });
+
+  describe("loadLayout clears history", () => {
+    it("clears the undo stack so Ctrl+Z cannot replay commands against the new layout", () => {
+      const store = getLayoutStore();
+
+      // Build up history against the current layout.
+      store.addDeviceTypeRecorded({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#336699",
+      });
+      expect(store.canUndo).toBe(true);
+
+      // Load a different layout. History from the previous layout must not
+      // survive: undoing would otherwise mutate the wrong layout.
+      store.loadLayout(createLayout("Freshly Loaded"));
+
+      expect(store.canUndo).toBe(false);
+      expect(store.canRedo).toBe(false);
+    });
+
+    it("clears the redo stack on load", () => {
+      const store = getLayoutStore();
+
+      store.addDeviceTypeRecorded({
+        name: "Test Server",
+        u_height: 2,
+        category: "server",
+        colour: "#336699",
+      });
+      store.undo();
+      expect(store.canRedo).toBe(true);
+
+      store.loadLayout(createLayout("Freshly Loaded"));
+
+      expect(store.canRedo).toBe(false);
     });
   });
 });

--- a/src/tests/workspace-store.test.ts
+++ b/src/tests/workspace-store.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getWorkspaceStore,
+  resetWorkspaceStore,
+} from "$lib/stores/workspace.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { createLayout } from "$lib/utils/serialization";
+
+describe("Workspace Store", () => {
+  beforeEach(() => {
+    // The first tab shares the app-session history singleton; reset it so each
+    // test starts with an empty undo/redo stack.
+    resetHistoryStore();
+    resetWorkspaceStore();
+  });
+
+  describe("initial state", () => {
+    it("starts with exactly one open tab that is active", () => {
+      const ws = getWorkspaceStore();
+      expect(ws.tabs.length).toBe(1);
+      expect(ws.activeId).toBe(ws.tabs[0]!.id);
+      expect(ws.activeStore).toBe(ws.tabs[0]!.store);
+    });
+  });
+
+  describe("openTab", () => {
+    it("opens a new tab, makes it active, and loads the given layout", () => {
+      const ws = getWorkspaceStore();
+      const id = ws.openTab(createLayout("Homelab"));
+
+      expect(ws.tabs.length).toBe(2);
+      expect(ws.activeId).toBe(id);
+      expect(ws.activeStore.layout.name).toBe("Homelab");
+    });
+
+    it("gives each tab its own independent history", () => {
+      const ws = getWorkspaceStore();
+      const firstId = ws.activeId;
+
+      // Edit the first tab so it has undo history.
+      ws.activeStore.addDeviceTypeRecorded({
+        name: "Server A",
+        u_height: 1,
+        category: "server",
+        colour: "#336699",
+      });
+      expect(ws.activeStore.canUndo).toBe(true);
+
+      // Open a second tab. Its history is empty and independent.
+      ws.openTab(createLayout("Second"));
+      expect(ws.activeStore.canUndo).toBe(false);
+
+      // The first tab's history is untouched.
+      ws.switchTo(firstId);
+      expect(ws.activeStore.canUndo).toBe(true);
+    });
+  });
+
+  describe("switchTo is a pure focus change", () => {
+    it("does not mutate either tab's undo or redo stacks", () => {
+      const ws = getWorkspaceStore();
+      const firstId = ws.activeId;
+
+      // First tab: one edit, then undo, leaving a populated redo stack.
+      ws.activeStore.addDeviceTypeRecorded({
+        name: "Server A",
+        u_height: 1,
+        category: "server",
+        colour: "#336699",
+      });
+      ws.activeStore.undo();
+      expect(ws.activeStore.canRedo).toBe(true);
+      expect(ws.activeStore.canUndo).toBe(false);
+
+      // Switch away and back. The first tab's redo stack must survive the
+      // round trip (no global cross-tab undo, no stack mutation on switch).
+      const secondId = ws.openTab(createLayout("Second"));
+      ws.switchTo(firstId);
+      expect(ws.activeStore.canRedo).toBe(true);
+
+      ws.switchTo(secondId);
+      ws.switchTo(firstId);
+      expect(ws.activeStore.canRedo).toBe(true);
+    });
+
+    it("ignores a switch to an unknown id", () => {
+      const ws = getWorkspaceStore();
+      const before = ws.activeId;
+      ws.switchTo("does-not-exist");
+      expect(ws.activeId).toBe(before);
+    });
+  });
+
+  describe("closeTab", () => {
+    it("removes the tab and falls back to a neighbour as active", () => {
+      const ws = getWorkspaceStore();
+      const firstId = ws.activeId;
+      const secondId = ws.openTab(createLayout("Second"));
+
+      expect(ws.activeId).toBe(secondId);
+      ws.closeTab(secondId);
+
+      expect(ws.tabs.length).toBe(1);
+      expect(ws.activeId).toBe(firstId);
+    });
+
+    it("keeps an inactive tab active when closing a different tab", () => {
+      const ws = getWorkspaceStore();
+      const firstId = ws.activeId;
+      ws.openTab(createLayout("Second"));
+      const thirdId = ws.openTab(createLayout("Third"));
+
+      // Active is the third tab. Close the first (inactive) tab.
+      ws.closeTab(firstId);
+
+      expect(ws.tabs.length).toBe(2);
+      expect(ws.activeId).toBe(thirdId);
+    });
+
+    it("never leaves the workspace with zero tabs", () => {
+      const ws = getWorkspaceStore();
+      const onlyId = ws.activeId;
+
+      ws.closeTab(onlyId);
+
+      expect(ws.tabs.length).toBe(1);
+      expect(ws.activeId).toBe(ws.tabs[0]!.id);
+    });
+  });
+
+  describe("reorderTabs", () => {
+    it("moves a tab from one index to another", () => {
+      const ws = getWorkspaceStore();
+      const a = ws.activeId;
+      const b = ws.openTab(createLayout("B"));
+      const c = ws.openTab(createLayout("C"));
+
+      // Order is [a, b, c]. Move c (index 2) to the front (index 0).
+      ws.reorderTabs(2, 0);
+
+      expect(ws.tabs.map((t) => t.id)).toEqual([c, a, b]);
+      // Reorder does not change which tab is active.
+      expect(ws.activeId).toBe(c);
+    });
+
+    it("ignores out-of-range indices", () => {
+      const ws = getWorkspaceStore();
+      ws.openTab(createLayout("B"));
+      const order = ws.tabs.map((t) => t.id);
+
+      ws.reorderTabs(0, 5);
+      expect(ws.tabs.map((t) => t.id)).toEqual(order);
+    });
+  });
+
+  describe("clearThenLoad", () => {
+    it("clears the target tab's history then loads, with no cross-tab leak", () => {
+      const ws = getWorkspaceStore();
+      const firstId = ws.activeId;
+
+      // Build history on the first tab.
+      ws.activeStore.addDeviceTypeRecorded({
+        name: "Server A",
+        u_height: 1,
+        category: "server",
+        colour: "#336699",
+      });
+      expect(ws.activeStore.canUndo).toBe(true);
+
+      // Swap new content into the same tab via the shared primitive.
+      ws.clearThenLoad(firstId, createLayout("Reloaded"));
+
+      expect(ws.activeStore.layout.name).toBe("Reloaded");
+      expect(ws.activeStore.canUndo).toBe(false);
+      expect(ws.activeStore.canRedo).toBe(false);
+    });
+  });
+});

--- a/src/tests/workspace-store.test.ts
+++ b/src/tests/workspace-store.test.ts
@@ -126,6 +126,28 @@ describe("Workspace Store", () => {
       expect(ws.tabs.length).toBe(1);
       expect(ws.activeId).toBe(ws.tabs[0]!.id);
     });
+
+    it("starts the replacement tab with a clean history when closing the last tab", () => {
+      const ws = getWorkspaceStore();
+      const onlyId = ws.activeId;
+
+      // Build history on the only tab.
+      ws.activeStore.addDeviceTypeRecorded({
+        name: "Server A",
+        u_height: 1,
+        category: "server",
+        colour: "#336699",
+      });
+      expect(ws.activeStore.canUndo).toBe(true);
+
+      // Closing the last tab replaces it with a fresh blank tab. The fresh tab
+      // must not inherit the closed tab's undo/redo stack (it shares the
+      // app-session history singleton).
+      ws.closeTab(onlyId);
+
+      expect(ws.activeStore.canUndo).toBe(false);
+      expect(ws.activeStore.canRedo).toBe(false);
+    });
   });
 
   describe("reorderTabs", () => {

--- a/src/tests/workspace-store.test.ts
+++ b/src/tests/workspace-store.test.ts
@@ -5,6 +5,7 @@ import {
 } from "$lib/stores/workspace.svelte";
 import { resetHistoryStore } from "$lib/stores/history.svelte";
 import { createLayout } from "$lib/utils/serialization";
+import { createTestDeviceTypeInput } from "./factories";
 
 describe("Workspace Store", () => {
   beforeEach(() => {
@@ -38,12 +39,9 @@ describe("Workspace Store", () => {
       const firstId = ws.activeId;
 
       // Edit the first tab so it has undo history.
-      ws.activeStore.addDeviceTypeRecorded({
-        name: "Server A",
-        u_height: 1,
-        category: "server",
-        colour: "#336699",
-      });
+      ws.activeStore.addDeviceTypeRecorded(
+        createTestDeviceTypeInput({ name: "Server A" }),
+      );
       expect(ws.activeStore.canUndo).toBe(true);
 
       // Open a second tab. Its history is empty and independent.
@@ -62,12 +60,9 @@ describe("Workspace Store", () => {
       const firstId = ws.activeId;
 
       // First tab: one edit, then undo, leaving a populated redo stack.
-      ws.activeStore.addDeviceTypeRecorded({
-        name: "Server A",
-        u_height: 1,
-        category: "server",
-        colour: "#336699",
-      });
+      ws.activeStore.addDeviceTypeRecorded(
+        createTestDeviceTypeInput({ name: "Server A" }),
+      );
       ws.activeStore.undo();
       expect(ws.activeStore.canRedo).toBe(true);
       expect(ws.activeStore.canUndo).toBe(false);
@@ -132,12 +127,9 @@ describe("Workspace Store", () => {
       const onlyId = ws.activeId;
 
       // Build history on the only tab.
-      ws.activeStore.addDeviceTypeRecorded({
-        name: "Server A",
-        u_height: 1,
-        category: "server",
-        colour: "#336699",
-      });
+      ws.activeStore.addDeviceTypeRecorded(
+        createTestDeviceTypeInput({ name: "Server A" }),
+      );
       expect(ws.activeStore.canUndo).toBe(true);
 
       // Closing the last tab replaces it with a fresh blank tab. The fresh tab
@@ -181,12 +173,9 @@ describe("Workspace Store", () => {
       const firstId = ws.activeId;
 
       // Build history on the first tab.
-      ws.activeStore.addDeviceTypeRecorded({
-        name: "Server A",
-        u_height: 1,
-        category: "server",
-        colour: "#336699",
-      });
+      ws.activeStore.addDeviceTypeRecorded(
+        createTestDeviceTypeInput({ name: "Server A" }),
+      );
       expect(ws.activeStore.canUndo).toBe(true);
 
       // Swap new content into the same tab via the shared primitive.


### PR DESCRIPTION
## **User description**
## Summary

Adds a tab strip for the open layouts, backed by a new workspace store that holds one layout-store instance per open tab. Switching tabs is a pure focus change; each tab keeps its own undo/redo history.

This is the foundational M14 shell slice (epic #2017). It establishes the workspace seam and the tab UI that lazy restore (#2080) and the sidebar library (#2082) layer onto. It also fixes a latent history bug on the load path.

### What landed

- Workspace store (`src/lib/stores/workspace.svelte.ts`): ordered open tabs, each its own `LayoutStore` (its own history); `activeStore`; `openTab` / `switchTo` / `closeTab` / `reorderTabs` / `clearThenLoad`.
- `getLayoutStore()` now returns a stable Proxy forwarding to the active tab's store, so the keyboard handler, toolbar, panels, and canvas follow the active tab with no call-site changes (388 call sites unchanged).
- History model per spike #2182: per-instance history, no global cross-tab undo; `switchTo` mutates no stack, so an inactive tab's redo survives a round trip; content swaps go through one clear-then-load primitive.
- Latent bug fix: `loadLayout()` now clears the instance's history. Previously Ctrl+Z after a load replayed commands against the wrong layout.
- `LayoutTabs.svelte`: accessible tab strip. `role=tablist` / `role=tab` (div tabs so the nested close button is not a button-in-button), `aria-selected`, roving tabindex with Arrow/Home/End, Enter/Space activation, 44px targets, reduced motion, focus-visible outlines. The unbacked-changes dot carries `sr-only` status text (never colour alone, WCAG 1.4.1) and reads the same durability source as the storage chip (#2035). Hover/focus close affordance; close keeps the layout. Drag to reorder.
- Alt+1-9 jumps to the Nth tab, keyed off `event.code` (Digit1..9) so it survives the macOS Alt+digit remapping.
- The strip hides itself with a single tab open, so the single-layout experience is unchanged.

### Scope and deferrals

The spike #2179 persistence module (`Rackula:workspace` index + `Rackula:layout:<id>` bodies, `setOpenSet`, lazy restore) is design-only and not yet in the codebase, so tabs are in-memory session state in this slice. Deferred (does not preclude follow-ups): persisted open-set and lazy restore (#2080), the #2018 overflow / chevron / orphan / rename interaction model, and cross-tab device-id / image-key namespacing (C6 - placement images live in a global singleton keyed `placement-<deviceId>`; two tabs sharing a placed-device UUID would collide; full fix is entangled with the persistence rework and ~15 call sites). See `docs/superpowers/plans/2026-06-14-tab-strip-open-layouts.md` for the full C6 note.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run test:run` (2251 passed, +15 new)
- [x] `npm run build` succeeds
- [x] Local `/code-review` pass; a11y findings on the tablist content model and an Alt+Shift guard addressed
- [x] svelte-autofixer clean on all new/changed `.svelte` files
- [x] basic-workflow e2e green in chromium (app boots, single-layout experience intact)
- [ ] CI a11y (axe-core) and visual-regression jobs (a11y scan could not run locally: `@axe-core/playwright` not installed in this environment; CI is authoritative). A new axe scan for the multi-tab strip is a follow-up per the note in `e2e/axe.spec.ts`.

Closes #2079


___

## **CodeAnt-AI Description**
**Add tabbed open layouts with separate history per tab**

### What Changed
- Added an open-layout tab strip where users can switch, close, and drag-reorder layouts.
- Each tab keeps its own undo/redo history, so switching tabs does not affect the current tab’s history and returning to a tab resumes where it was left.
- Opening or replacing a layout now clears that tab’s history first, which prevents undo from affecting the wrong layout after a load.
- Added Alt+1–9 shortcuts to jump to the matching open tab, and the main layout view now follows the active tab automatically.

### Impact
`✅ Faster switching between open layouts`
`✅ Fewer wrong-layout undo actions after loading files`
`✅ Quicker keyboard navigation between tabs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
