### PR TITLE
ci: bundle-size performance budget and baseline for the M14 shell (#2185)

### DIFF
--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -1,0 +1,37 @@
+name: Performance Budget
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: perf-budget-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  budget:
+    name: bundle budget
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Check bundle budget
+        run: npm run check:bundle-budget

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -575,6 +575,70 @@ Update flow for an intentional visual change:
 Dynamic regions (the app version string and "last saved" timestamps) are masked
 so they never trip the diff.
 
+### Performance Budget
+
+`scripts/check-bundle-budget.ts` is a guard rail for the UX overhaul (epic #2017,
+issue #2185): the shell rework adds UI surface (side panel, tab strip, the
+dialog system, command and app menus), and this gate keeps the initial-load
+bundle from regressing as those slices land. It is the performance counterpart
+to the visual-regression and axe-core guard rails.
+
+It measures the gzipped size of the initial-load graph, the entry script plus
+every modulepreloaded chunk plus the linked stylesheet, read straight from the
+built `dist/index.html` so it stays correct as content hashes and chunk
+boundaries change. Gzip is used because production is served compressed, so
+transfer size is what blocks first paint.
+
+It runs chromium-free as the `bundle budget` job in
+`.github/workflows/performance-budget.yml` on every pull request. Run it locally:
+
+```bash
+npm run build && npm run check:bundle-budget
+```
+
+The budget lives in `performance-budget.json`:
+
+| Field            | Meaning                                                   |
+| ---------------- | --------------------------------------------------------- |
+| `baseline`       | Raw gzipped size of the recorded build, per entry         |
+| `headroom`       | Room each entry may grow over its baseline before failing |
+| `toleranceBytes` | Extra slack absorbing minifier and dependency noise       |
+
+The enforced threshold for an entry is `baseline + headroom`; a build fails only
+when a measurement exceeds that threshold by more than `toleranceBytes`. The
+recorded baseline is the initial-load graph measured before the M14 shell work
+(`initialJs` ~321 KiB, `initialCss` ~23 KiB, `initialTotal` ~345 KiB gzipped).
+Headroom (`initialJs` ~30 KiB, `initialCss` ~8 KiB) is deliberate: it lets the
+shell grow within a known envelope while still catching a runaway regression.
+The decision logic lives in `src/lib/utils/bundle-budget.ts` and is unit tested
+in `src/tests/bundle-budget.test.ts`.
+
+When a shell slice legitimately grows the bundle past budget, justify the growth
+in the PR and rebaseline:
+
+```bash
+npm run build && npm run check:bundle-budget -- --update
+```
+
+`--update` rewrites only `baseline` from the current build; it keeps `headroom`
+and `toleranceBytes`, so an intentional increase is recorded explicitly in the
+diff rather than slipping in silently.
+
+#### Runtime Performance Baseline
+
+The bundle budget is the automated, deterministic gate. Runtime timings (initial
+render, palette scroll with a large library, tab switch, dialog open) are
+recorded as a manual baseline rather than enforced in CI, because frame timings
+on shared CI runners are too noisy to gate on without false failures.
+
+Capture them locally against a production build using the test-data generators
+in `scripts/performance-benchmark.ts` and the Chrome DevTools Performance panel
+(method and current numbers: `docs/research/performance-baseline.md`). Targets:
+initial render under 16 ms (60 fps), pan and zoom under 16 ms per frame, and
+under 50 MB heap for a full rack with ports. Re-measure when a shell slice
+changes rendering or interaction, and update the baseline doc if the envelope
+shifts intentionally.
+
 ## Coverage
 
 Coverage thresholds are configured in `vitest.config.ts`:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:e2e:a11y": "playwright test --config e2e/playwright.a11y.config.ts",
     "test:coverage": "NODE_OPTIONS=--max-old-space-size=8192 vitest run --coverage",
     "check:compose-parity": "bash scripts/check-compose-persist-parity.sh",
+    "check:bundle-budget": "npx tsx scripts/check-bundle-budget.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/performance-budget.json
+++ b/performance-budget.json
@@ -1,0 +1,13 @@
+{
+  "toleranceBytes": 5120,
+  "baseline": {
+    "initialJs": 329099,
+    "initialCss": 23868,
+    "initialTotal": 352967
+  },
+  "headroom": {
+    "initialJs": 30000,
+    "initialCss": 8000,
+    "initialTotal": 38000
+  }
+}

--- a/scripts/check-bundle-budget.ts
+++ b/scripts/check-bundle-budget.ts
@@ -1,0 +1,218 @@
+/**
+ * Bundle budget CI gate (issue #2185).
+ *
+ * Measures the gzipped size of the initial-load graph in a production build and
+ * compares it against the committed budget in performance-budget.json. Exits
+ * non-zero when the build is over budget so shell-slice PRs (epic #2017) cannot
+ * quietly regress the bundle the browser has to fetch on first paint.
+ *
+ * Why gzip: production is served gzip/brotli, so transfer size, not raw size,
+ * is what users wait on. Why the initial-load graph specifically: it is the
+ * critical path that blocks first render, and it is what the M14 shell grows.
+ *
+ * Usage:
+ *   npm run build && npm run check:bundle-budget
+ *   npm run check:bundle-budget -- --update   # rewrite the baseline from dist/
+ *
+ * The decision logic lives in src/lib/utils/bundle-budget.ts and is unit
+ * tested. This script is the I/O shell around it.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { gzipSync } from "node:zlib";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  evaluateBudget,
+  thresholdFor,
+  type BudgetConfig,
+  type BudgetEntry,
+  type Measurements,
+} from "../src/lib/utils/bundle-budget";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SCRIPT_DIR, "..");
+const DIST_DIR = join(ROOT, "dist");
+const INDEX_HTML = join(DIST_DIR, "index.html");
+const BUDGET_FILE = join(ROOT, "performance-budget.json");
+
+/** gzip level 9 to match the static-asset compression production serves. */
+function gzipSize(absPath: string): number {
+  return gzipSync(readFileSync(absPath), { level: 9 }).length;
+}
+
+/** Extract a single HTML attribute value from a tag string, order-independent. */
+function attr(tag: string, name: string): string | undefined {
+  const match = new RegExp(`\\b${name}="([^"]*)"`, "i").exec(tag);
+  return match ? match[1] : undefined;
+}
+
+/**
+ * Only count hashed build output under /assets/. That excludes /config.js,
+ * the per-deployment runtime config the container/LXC entrypoints overwrite,
+ * which is not shell code and varies by environment.
+ */
+function isBundledAsset(href: string): boolean {
+  return href.startsWith("/assets/");
+}
+
+/**
+ * Read the initial-load asset graph straight from the built index.html. The
+ * entry script, every modulepreloaded chunk, and every linked stylesheet are
+ * what the browser fetches before first render. Reading the HTML keeps this
+ * robust to content-hashed filenames and to chunking changes from the bundler.
+ */
+function collectInitialAssets(html: string): { js: string[]; css: string[] } {
+  const js = new Set<string>();
+  const css = new Set<string>();
+
+  // Tokenise each script/link tag and inspect its attributes individually, so
+  // matching does not depend on attribute order (the bundler interleaves
+  // `crossorigin` and may reorder rel/href across versions).
+  const tagRe = /<(script|link)\b[^>]*>/gi;
+  let tag: RegExpExecArray | null;
+  while ((tag = tagRe.exec(html)) !== null) {
+    const raw = tag[0];
+    const isScript = tag[1].toLowerCase() === "script";
+
+    if (isScript) {
+      const src = attr(raw, "src");
+      if (src && src.endsWith(".js") && isBundledAsset(src)) js.add(src);
+      continue;
+    }
+
+    const rel = attr(raw, "rel")?.toLowerCase();
+    const href = attr(raw, "href");
+    if (!href || !isBundledAsset(href)) continue;
+    if (rel === "modulepreload" && href.endsWith(".js")) js.add(href);
+    if (rel === "stylesheet" && href.endsWith(".css")) css.add(href);
+  }
+
+  return { js: [...js], css: [...css] };
+}
+
+/** Map an index.html asset href (e.g. "/assets/main-abc.js") to a dist path. */
+function assetPath(href: string): string {
+  const cleaned = href.replace(/^\//, "").split("?")[0];
+  return join(DIST_DIR, cleaned);
+}
+
+function sumGzip(hrefs: string[]): number {
+  let total = 0;
+  for (const href of hrefs) {
+    const path = assetPath(href);
+    if (!existsSync(path)) {
+      throw new Error(
+        `Asset referenced by index.html is missing from dist/: ${href}`,
+      );
+    }
+    total += gzipSize(path);
+  }
+  return total;
+}
+
+function measureInitialGraph(): Measurements {
+  if (!existsSync(INDEX_HTML)) {
+    throw new Error(
+      `dist/index.html not found. Run "npm run build" before the budget check.`,
+    );
+  }
+
+  const html = readFileSync(INDEX_HTML, "utf-8");
+  const { js, css } = collectInitialAssets(html);
+
+  if (js.length === 0) {
+    throw new Error("No entry JS found in dist/index.html; build looks empty.");
+  }
+
+  const initialJs = sumGzip(js);
+  const initialCss = sumGzip(css);
+
+  return {
+    initialJs,
+    initialCss,
+    initialTotal: initialJs + initialCss,
+  };
+}
+
+function loadBudget(): BudgetConfig {
+  if (!existsSync(BUDGET_FILE)) {
+    throw new Error(`Budget file not found: ${BUDGET_FILE}`);
+  }
+  return JSON.parse(readFileSync(BUDGET_FILE, "utf-8")) as BudgetConfig;
+}
+
+function kib(bytes: number): string {
+  return `${(bytes / 1024).toFixed(1)} KiB`;
+}
+
+const ENTRIES: BudgetEntry[] = ["initialJs", "initialCss", "initialTotal"];
+
+/** Rewrite only the baseline from the current build; keep headroom and tolerance. */
+function updateBaseline(measured: Measurements, current: BudgetConfig): void {
+  const updated: BudgetConfig = {
+    toleranceBytes: current.toleranceBytes,
+    baseline: {
+      initialJs: measured.initialJs,
+      initialCss: measured.initialCss,
+      initialTotal: measured.initialTotal,
+    },
+    headroom: current.headroom,
+  };
+  writeFileSync(BUDGET_FILE, JSON.stringify(updated, null, 2) + "\n");
+  console.log("Updated performance-budget.json baseline from current dist/:");
+  for (const entry of ENTRIES) {
+    console.log(
+      `  ${entry}: baseline ${kib(updated.baseline[entry])}, ` +
+        `budget ${kib(thresholdFor(updated, entry))}`,
+    );
+  }
+}
+
+function main(): void {
+  const shouldUpdate = process.argv.includes("--update");
+  const budget = loadBudget();
+  const measured = measureInitialGraph();
+
+  if (shouldUpdate) {
+    updateBaseline(measured, budget);
+    return;
+  }
+
+  const result = evaluateBudget(measured, budget);
+
+  console.log("\nBundle budget (gzipped initial-load graph)\n");
+  console.log(
+    `  ${"entry".padEnd(14)}${"measured".padStart(12)}${"budget".padStart(12)}${"headroom".padStart(12)}`,
+  );
+  for (const row of result.rows) {
+    const marker = row.breached ? "  OVER" : "";
+    console.log(
+      `  ${row.entry.padEnd(14)}${kib(row.measured).padStart(12)}${kib(
+        row.threshold,
+      ).padStart(12)}${kib(row.headroom).padStart(12)}${marker}`,
+    );
+  }
+  console.log(`\n  tolerance: ${kib(budget.toleranceBytes)}`);
+
+  if (!result.passed) {
+    console.error("\nBundle budget exceeded:");
+    for (const breach of result.breaches) {
+      console.error(
+        `  ${breach.entry} is ${kib(breach.overBy)} over the ${kib(
+          breach.threshold,
+        )} budget (measured ${kib(breach.measured)}).`,
+      );
+    }
+    console.error(
+      "\nIf this growth is intentional, justify it in the PR and rebaseline with:\n" +
+        "  npm run build && npm run check:bundle-budget -- --update\n",
+    );
+    process.exit(1);
+  }
+
+  console.log("\nWithin budget.\n");
+}
+
+main();

--- a/scripts/check-bundle-budget.ts
+++ b/scripts/check-bundle-budget.ts
@@ -20,14 +20,15 @@
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { gzipSync } from "node:zlib";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  ENTRIES,
   evaluateBudget,
+  parseBudgetConfig,
   thresholdFor,
   type BudgetConfig,
-  type BudgetEntry,
   type Measurements,
 } from "../src/lib/utils/bundle-budget";
 
@@ -95,7 +96,13 @@ function collectInitialAssets(html: string): { js: string[]; css: string[] } {
 /** Map an index.html asset href (e.g. "/assets/main-abc.js") to a dist path. */
 function assetPath(href: string): string {
   const cleaned = href.replace(/^\//, "").split("?")[0];
-  return join(DIST_DIR, cleaned);
+  const resolved = resolve(DIST_DIR, cleaned);
+  // index.html is project-built and trusted, but resolve any traversal defensively
+  // so a stray "../" can never make the gate read or measure a file outside dist/.
+  if (resolved !== DIST_DIR && !resolved.startsWith(DIST_DIR + sep)) {
+    throw new Error(`Asset path escapes dist/: ${href}`);
+  }
+  return resolved;
 }
 
 function sumGzip(hrefs: string[]): number {
@@ -140,14 +147,12 @@ function loadBudget(): BudgetConfig {
   if (!existsSync(BUDGET_FILE)) {
     throw new Error(`Budget file not found: ${BUDGET_FILE}`);
   }
-  return JSON.parse(readFileSync(BUDGET_FILE, "utf-8")) as BudgetConfig;
+  return parseBudgetConfig(JSON.parse(readFileSync(BUDGET_FILE, "utf-8")));
 }
 
 function kib(bytes: number): string {
   return `${(bytes / 1024).toFixed(1)} KiB`;
 }
-
-const ENTRIES: BudgetEntry[] = ["initialJs", "initialCss", "initialTotal"];
 
 /** Rewrite only the baseline from the current build; keep headroom and tolerance. */
 function updateBaseline(measured: Measurements, current: BudgetConfig): void {

--- a/src/lib/utils/bundle-budget.ts
+++ b/src/lib/utils/bundle-budget.ts
@@ -1,0 +1,123 @@
+/**
+ * Bundle budget evaluation (issue #2185).
+ *
+ * Pure threshold-comparison logic for the performance-budget CI gate. It takes
+ * measured gzipped sizes of the initial-load graph and a committed budget, and
+ * decides whether the build is within budget. Kept free of I/O so it is unit
+ * testable; the measurement side (reading dist/, gzip) lives in
+ * scripts/check-bundle-budget.ts.
+ *
+ * The gate watches the M14 shell (epic #2017): the side panel, tab strip,
+ * dialog system, and command/app menus add UI surface, and this budget keeps
+ * the initial-load bundle from regressing as those slices land.
+ *
+ * The threshold for an entry is baseline + headroom. The baseline is the raw
+ * measured size of the current build (rewritten with --update); headroom is the
+ * deliberate slack the shell is allowed to grow into. A separate tolerance
+ * absorbs minifier and dependency noise so the gate fails on real regressions,
+ * not rounding.
+ */
+
+/** The budgeted dimensions of the initial-load graph, in gzipped bytes. */
+export interface Measurements {
+  /** Entry JS plus all modulepreloaded JS chunks. */
+  initialJs: number;
+  /** Stylesheets linked from the entry HTML. */
+  initialCss: number;
+  /** initialJs + initialCss. */
+  initialTotal: number;
+}
+
+export type BudgetEntry = keyof Measurements;
+
+export interface BudgetConfig {
+  /**
+   * Slack added to every threshold before a measurement counts as a breach.
+   * Absorbs the few-byte noise of minifier and dependency churn.
+   */
+  toleranceBytes: number;
+  /** Raw measured size of the recorded baseline build, per entry. */
+  baseline: Record<BudgetEntry, number>;
+  /** Deliberate room each entry is allowed to grow over its baseline. */
+  headroom: Record<BudgetEntry, number>;
+}
+
+export interface BudgetRow {
+  entry: BudgetEntry;
+  measured: number;
+  baseline: number;
+  threshold: number;
+  /** threshold + tolerance - measured. Negative means over budget. */
+  headroom: number;
+  breached: boolean;
+}
+
+export interface BudgetBreach {
+  entry: BudgetEntry;
+  measured: number;
+  threshold: number;
+  /** How far the measurement is over the bare threshold (ignoring tolerance). */
+  overBy: number;
+}
+
+export interface BudgetResult {
+  passed: boolean;
+  rows: BudgetRow[];
+  breaches: BudgetBreach[];
+}
+
+const ENTRIES: BudgetEntry[] = ["initialJs", "initialCss", "initialTotal"];
+
+/** The enforced threshold for an entry: its baseline plus its headroom. */
+export function thresholdFor(budget: BudgetConfig, entry: BudgetEntry): number {
+  return budget.baseline[entry] + budget.headroom[entry];
+}
+
+/**
+ * Compare measured sizes against the budget. A measurement breaches only when
+ * it exceeds its threshold (baseline + headroom) by more than the tolerance.
+ */
+export function evaluateBudget(
+  measured: Measurements,
+  budget: BudgetConfig,
+): BudgetResult {
+  const rows: BudgetRow[] = [];
+  const breaches: BudgetBreach[] = [];
+
+  for (const entry of ENTRIES) {
+    const value = measured[entry];
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      throw new Error(
+        `Missing or invalid measurement for budgeted entry "${entry}"`,
+      );
+    }
+
+    const threshold = thresholdFor(budget, entry);
+    const limit = threshold + budget.toleranceBytes;
+    const breached = value > limit;
+
+    rows.push({
+      entry,
+      measured: value,
+      baseline: budget.baseline[entry],
+      threshold,
+      headroom: limit - value,
+      breached,
+    });
+
+    if (breached) {
+      breaches.push({
+        entry,
+        measured: value,
+        threshold,
+        overBy: value - threshold,
+      });
+    }
+  }
+
+  return {
+    passed: breaches.length === 0,
+    rows,
+    breaches,
+  };
+}

--- a/src/lib/utils/bundle-budget.ts
+++ b/src/lib/utils/bundle-budget.ts
@@ -66,7 +66,57 @@ export interface BudgetResult {
   breaches: BudgetBreach[];
 }
 
-const ENTRIES: BudgetEntry[] = ["initialJs", "initialCss", "initialTotal"];
+export const ENTRIES: BudgetEntry[] = [
+  "initialJs",
+  "initialCss",
+  "initialTotal",
+];
+
+// Compile-time guard: a new field on Measurements forces a matching key here,
+// so a budgeted dimension can never be silently dropped from evaluation.
+const _entriesExhaustive: Record<BudgetEntry, true> = {
+  initialJs: true,
+  initialCss: true,
+  initialTotal: true,
+} satisfies Record<keyof Measurements, true>;
+void _entriesExhaustive;
+
+function assertFinite(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Budget field "${label}" must be a finite number`);
+  }
+  return value;
+}
+
+/**
+ * Validate a raw, JSON-parsed budget into a BudgetConfig. The budget backs a
+ * safety gate, so a typo in performance-budget.json (a non-numeric tolerance, a
+ * missing headroom) must fail loudly rather than silently disable breach
+ * detection via NaN or string concatenation.
+ */
+export function parseBudgetConfig(raw: unknown): BudgetConfig {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("Budget must be a JSON object");
+  }
+  const obj = raw as Record<string, unknown>;
+
+  const toleranceBytes = assertFinite(obj.toleranceBytes, "toleranceBytes");
+  if (toleranceBytes < 0) {
+    throw new Error('Budget field "toleranceBytes" must not be negative');
+  }
+
+  const baselineRaw = (obj.baseline ?? {}) as Record<string, unknown>;
+  const headroomRaw = (obj.headroom ?? {}) as Record<string, unknown>;
+
+  const baseline = {} as Record<BudgetEntry, number>;
+  const headroom = {} as Record<BudgetEntry, number>;
+  for (const entry of ENTRIES) {
+    baseline[entry] = assertFinite(baselineRaw[entry], `baseline.${entry}`);
+    headroom[entry] = assertFinite(headroomRaw[entry], `headroom.${entry}`);
+  }
+
+  return { toleranceBytes, baseline, headroom };
+}
 
 /** The enforced threshold for an entry: its baseline plus its headroom. */
 export function thresholdFor(budget: BudgetConfig, entry: BudgetEntry): number {

--- a/src/lib/utils/bundle-budget.ts
+++ b/src/lib/utils/bundle-budget.ts
@@ -66,11 +66,11 @@ export interface BudgetResult {
   breaches: BudgetBreach[];
 }
 
-export const ENTRIES: BudgetEntry[] = [
+export const ENTRIES = [
   "initialJs",
   "initialCss",
   "initialTotal",
-];
+] as const satisfies readonly BudgetEntry[];
 
 // Compile-time guard: a new field on Measurements forces a matching key here,
 // so a budgeted dimension can never be silently dropped from evaluation.

--- a/src/tests/bundle-budget.test.ts
+++ b/src/tests/bundle-budget.test.ts
@@ -11,7 +11,11 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { evaluateBudget, thresholdFor } from "$lib/utils/bundle-budget";
+import {
+  evaluateBudget,
+  parseBudgetConfig,
+  thresholdFor,
+} from "$lib/utils/bundle-budget";
 import type { BudgetConfig, Measurements } from "$lib/utils/bundle-budget";
 
 // initialJs threshold = 190_000 + 10_000 = 200_000
@@ -121,5 +125,51 @@ describe("evaluateBudget", () => {
     } as Measurements;
 
     expect(() => evaluateBudget(incomplete, budget)).toThrow(/initialTotal/);
+  });
+});
+
+describe("parseBudgetConfig", () => {
+  const valid = {
+    toleranceBytes: 5120,
+    baseline: { initialJs: 329099, initialCss: 23868, initialTotal: 352967 },
+    headroom: { initialJs: 30000, initialCss: 8000, initialTotal: 38000 },
+  };
+
+  it("returns a typed config when every field is a finite number", () => {
+    const config = parseBudgetConfig(valid);
+    expect(config.toleranceBytes).toBe(5120);
+    expect(thresholdFor(config, "initialJs")).toBe(329099 + 30000);
+  });
+
+  it("rejects a non-numeric tolerance so a typo cannot disable breach detection", () => {
+    const bad = { ...valid, toleranceBytes: "5120" };
+    expect(() => parseBudgetConfig(bad)).toThrow(/toleranceBytes/);
+  });
+
+  it("rejects a negative tolerance", () => {
+    const bad = { ...valid, toleranceBytes: -1 };
+    expect(() => parseBudgetConfig(bad)).toThrow(/toleranceBytes/);
+  });
+
+  it("rejects a non-numeric baseline value", () => {
+    const bad = {
+      ...valid,
+      baseline: { ...valid.baseline, initialJs: "329099" },
+    };
+    expect(() => parseBudgetConfig(bad)).toThrow(/baseline\.initialJs/);
+  });
+
+  it("rejects a missing headroom entry", () => {
+    const bad = {
+      toleranceBytes: 5120,
+      baseline: valid.baseline,
+      headroom: { initialJs: 30000, initialCss: 8000 }, // initialTotal missing
+    };
+    expect(() => parseBudgetConfig(bad)).toThrow(/headroom\.initialTotal/);
+  });
+
+  it("rejects a non-object budget", () => {
+    expect(() => parseBudgetConfig(null)).toThrow();
+    expect(() => parseBudgetConfig("nope")).toThrow();
   });
 });

--- a/src/tests/bundle-budget.test.ts
+++ b/src/tests/bundle-budget.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Bundle Budget Evaluation Tests
+ *
+ * Tests the pure threshold-comparison and diffing logic that backs the
+ * performance-budget CI gate (issue #2185). The measurement side (gzip, reading
+ * dist/) is I/O and lives in scripts/check-bundle-budget.ts; only the decision
+ * logic is tested here because that is where the behaviour lives.
+ *
+ * The enforced threshold for an entry is baseline + headroom; a measurement
+ * breaches only when it exceeds that threshold by more than the tolerance.
+ */
+
+import { describe, it, expect } from "vitest";
+import { evaluateBudget, thresholdFor } from "$lib/utils/bundle-budget";
+import type { BudgetConfig, Measurements } from "$lib/utils/bundle-budget";
+
+// initialJs threshold = 190_000 + 10_000 = 200_000
+// initialCss threshold = 24_000 + 6_000 = 30_000
+// initialTotal threshold = 214_000 + 16_000 = 230_000
+const budget: BudgetConfig = {
+  toleranceBytes: 1024,
+  baseline: {
+    initialJs: 190_000,
+    initialCss: 24_000,
+    initialTotal: 214_000,
+  },
+  headroom: {
+    initialJs: 10_000,
+    initialCss: 6_000,
+    initialTotal: 16_000,
+  },
+};
+
+describe("evaluateBudget", () => {
+  it("derives the threshold as baseline plus headroom", () => {
+    expect(thresholdFor(budget, "initialJs")).toBe(200_000);
+    expect(thresholdFor(budget, "initialCss")).toBe(30_000);
+    expect(thresholdFor(budget, "initialTotal")).toBe(230_000);
+  });
+
+  it("passes when every measurement is under its threshold", () => {
+    const measured: Measurements = {
+      initialJs: 150_000,
+      initialCss: 24_000,
+      initialTotal: 174_000,
+    };
+
+    const result = evaluateBudget(measured, budget);
+
+    expect(result.passed).toBe(true);
+    expect(result.breaches).toEqual([]);
+  });
+
+  it("fails and reports the breaching entry when a measurement exceeds threshold + tolerance", () => {
+    const measured: Measurements = {
+      initialJs: 250_000, // well over 200_000 + 1024
+      initialCss: 24_000,
+      initialTotal: 274_000, // also over, but we assert on the JS breach
+    };
+
+    const result = evaluateBudget(measured, budget);
+
+    expect(result.passed).toBe(false);
+    const jsBreach = result.breaches.find((b) => b.entry === "initialJs");
+    expect(jsBreach).toBeDefined();
+    expect(jsBreach?.measured).toBe(250_000);
+    expect(jsBreach?.threshold).toBe(200_000);
+    expect(jsBreach?.overBy).toBe(50_000);
+  });
+
+  it("tolerates a measurement that exceeds the threshold but stays within tolerance", () => {
+    const measured: Measurements = {
+      initialJs: 200_500, // 500 over threshold, within 1024 tolerance
+      initialCss: 24_000,
+      initialTotal: 224_500,
+    };
+
+    const result = evaluateBudget(measured, budget);
+
+    expect(result.passed).toBe(true);
+    expect(result.breaches).toEqual([]);
+  });
+
+  it("fails once a measurement exceeds the threshold by more than the tolerance", () => {
+    const measured: Measurements = {
+      initialJs: 201_500, // 1500 over threshold, beyond 1024 tolerance
+      initialCss: 24_000,
+      initialTotal: 225_500,
+    };
+
+    const result = evaluateBudget(measured, budget);
+
+    expect(result.passed).toBe(false);
+    expect(result.breaches.map((b) => b.entry)).toContain("initialJs");
+  });
+
+  it("reports a row for every budget entry regardless of pass or fail", () => {
+    const measured: Measurements = {
+      initialJs: 150_000,
+      initialCss: 24_000,
+      initialTotal: 174_000,
+    };
+
+    const result = evaluateBudget(measured, budget);
+
+    expect(result.rows.map((r) => r.entry).sort()).toEqual(
+      ["initialCss", "initialJs", "initialTotal"].sort(),
+    );
+    for (const row of result.rows) {
+      expect(row.headroom).toBe(
+        row.threshold + budget.toleranceBytes - row.measured,
+      );
+    }
+  });
+
+  it("throws when the measurements are missing a budgeted entry", () => {
+    const incomplete = {
+      initialJs: 150_000,
+      initialCss: 24_000,
+      // initialTotal missing
+    } as Measurements;
+
+    expect(() => evaluateBudget(incomplete, budget)).toThrow(/initialTotal/);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Establishes a deterministic performance guard rail for the canvas UX overhaul (epic #2017). A new CI job measures the gzipped size of the initial-load graph and fails when it exceeds a committed budget, so shell-slice PRs cannot quietly regress the bundle the browser fetches on first paint. This is infrastructure (chore/ci), exempt from the M14 feature-merge gate, and lands independently.

## What it measures

The initial-load graph: the entry script, every modulepreloaded chunk, and every linked stylesheet, read straight from the built `dist/index.html`. Reading the HTML keeps the measurement correct as content hashes and chunk boundaries change. Only hashed output under `/assets/` is counted, so the per-deployment `config.js` (overwritten by the Docker/LXC entrypoints) is excluded. Sizes are gzipped because production is served compressed, so transfer size is what blocks first paint.

## Budget and baseline

`performance-budget.json` records:

| Field            | Value (gzipped)                                              |
| ---------------- | ------------------------------------------------------------ |
| `baseline`       | initialJs ~321 KiB, initialCss ~23 KiB, initialTotal ~345 KiB |
| `headroom`       | initialJs 30 KiB, initialCss 8 KiB, initialTotal 38 KiB      |
| `toleranceBytes` | 5 KiB                                                        |

The enforced threshold for an entry is `baseline + headroom`; a build fails only when a measurement exceeds that by more than `toleranceBytes`. Rationale: the baseline is the current pre-M14-shell build measured by the script itself, so the gate is self-consistent. The headroom is deliberate, not arbitrary: it lets the shell (side panel, tab strip, dialog system, command/app menus) grow within a known envelope (~9% on JS) while still catching a runaway regression. The tolerance absorbs minifier and dependency noise so the gate fails on real growth, not rounding. These numbers are baseline-derived and documented; the maintainer can tighten or loosen them by editing the JSON.

When a slice legitimately grows the bundle, rebaseline with `npm run build && npm run check:bundle-budget -- --update` (rewrites only `baseline`, keeping headroom and tolerance, so the increase shows up explicitly in the diff).

## Runtime timings

The bundle budget is the automated, deterministic gate. Runtime timings (initial render, palette scroll with a large library, tab switch, dialog open) are recorded as a manual baseline (`docs/research/performance-baseline.md` plus `scripts/performance-benchmark.ts`) rather than enforced in CI, because frame timings on shared runners are too noisy to gate on without false failures. Documented in `docs/guides/TESTING.md` alongside the visual-regression and axe-core guard rails.

## Files

- `src/lib/utils/bundle-budget.ts`: pure threshold/diff logic
- `src/tests/bundle-budget.test.ts`: unit tests for the budget evaluation (TDD)
- `scripts/check-bundle-budget.ts`: gzip measurement + budget gate, run via tsx
- `performance-budget.json`: recorded baseline + intentional headroom
- `.github/workflows/performance-budget.yml`: `bundle budget` CI job (build then check)
- `docs/guides/TESTING.md`: budget docs alongside the guard rails
- `package.json`: `check:bundle-budget` script

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run test:run` (2322 tests pass, including 7 new budget tests)
- [x] `npm run build` succeeds
- [x] Fresh `npm run build && npm run check:bundle-budget` passes deterministically (within budget)
- [x] Simulated regression: a too-tight budget makes the gate exit 1 with a clear message
- [x] `--update` rewrites only the baseline, preserving headroom and tolerance

Closes #2185


___

## **CodeAnt-AI Description**
**Add a CI performance budget for the initial-load bundle**

### What Changed
- Added a new CI check that measures the gzipped size of the initial page assets and fails when the bundle grows past the recorded budget
- Added an update flow to rebaseline the budget from a fresh production build when bundle growth is intentional
- Added validation so bad budget values fail fast, and asset paths are checked so only files inside the build output are measured
- Added unit tests for budget limits, tolerance handling, and invalid budget files
- Documented how to run the check locally and when to rebaseline it

### Impact
`✅ Fewer bundle size regressions`
`✅ Earlier warning on oversized deploys`
`✅ Safer intentional bundle growth`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
