### PR TITLE
feat: app menu in the logo (#2073)

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -89,13 +89,12 @@ test.describe("Accessibility", () => {
         "WebKit skips buttons in Tab order by default (macOS keyboard setting)",
       );
 
-      // Start from a known anchor: the brand/about button leads the toolbar.
-      // It carries a Tooltip wrapper that duplicates the accessible name, so
-      // anchor on the button itself by testid.
-      const about = page.getByTestId("btn-logo-about");
-      await expect(about).toHaveAttribute("aria-label", "About & Shortcuts");
-      await about.focus();
-      await expect(about).toBeFocused();
+      // Start from a known anchor: the logo, which is also the app-menu
+      // trigger, leads the toolbar. Anchor on the button itself by testid.
+      const appMenu = page.getByTestId("btn-app-menu");
+      await expect(appMenu).toHaveAttribute("aria-label", "App menu");
+      await appMenu.focus();
+      await expect(appMenu).toBeFocused();
 
       // Walk forward with Tab and record what each stop is. A keyboard user
       // must be able to reach controls without the focus ring vanishing into a

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -54,8 +54,9 @@ export const locators = {
   toolbar: {
     root: ".toolbar",
     center: ".toolbar-center",
-    brand: ".toolbar-brand",
-    brandLogoMark: ".toolbar-brand .logo-mark",
+    // The logo is also the app-menu trigger.
+    brand: '[data-testid="btn-app-menu"]',
+    brandLogoMark: '[data-testid="btn-app-menu"] .logo-mark',
   },
 
   sidebar: {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -53,6 +53,7 @@
     maybeExport,
     handleShare,
     handleFitAll,
+    resetAndOpenNewRack,
   } from "$lib/utils/app-actions";
   import {
     handleNewRack,
@@ -585,6 +586,7 @@
       ontogglepromptcleanup={() => uiStore.togglePromptCleanupOnSave()}
       onopencleanup={handleOpenCleanupDialog}
       onhelp={handleHelp}
+      onnewlayout={resetAndOpenNewRack}
     />
 
     <RackIndicator />

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -15,6 +15,7 @@
 
 import { matchesShortcut, type ShortcutHandler } from "$lib/utils/keyboard";
 import { formatShortcut } from "$lib/utils/platform";
+import type { StorageMode } from "$lib/storage";
 
 /**
  * Where a command applies. Consumers use this to place a command on the right
@@ -27,7 +28,13 @@ export type ActionScope = "global" | "layout" | "selection";
 export type ActionId =
   | "save"
   | "save-as"
+  | "export-backup"
+  | "new-layout"
   | "load"
+  | "import-devices"
+  | "import-netbox"
+  | "new-custom-device"
+  | "view-yaml"
   | "export"
   | "share"
   | "undo"
@@ -63,6 +70,14 @@ export interface KeyBinding {
 /** Named groups for the help overlay, rendered in this declared order. */
 export type HelpGroup = "Navigation" | "General" | "Editing" | "File";
 
+/**
+ * Sections of the app menu (the menu behind the logo), rendered in this
+ * declared order with separators between them. Actions opt into the menu by
+ * declaring an appMenuGroup; the menu is projected from the registry so it
+ * cannot drift from the keyboard handler or help overlay (#2073).
+ */
+export type AppMenuGroup = "file" | "layout" | "devices" | "help";
+
 export interface ActionDefinition {
   /** Stable identifier; the dispatch map and consumers key off this. */
   id: ActionId;
@@ -84,6 +99,18 @@ export interface ActionDefinition {
   enabledWhen?: (ctx: ActionEnabledContext) => boolean;
   /** The help overlay group this command appears under, if any. */
   helpGroup?: HelpGroup;
+  /**
+   * The app-menu section this command appears under, if any. Actions without
+   * an appMenuGroup are not shown in the menu behind the logo.
+   */
+  appMenuGroup?: AppMenuGroup;
+  /**
+   * Restricts an app-menu action to a single storage mode. "server" shows only
+   * in the server build, "browser" only in the browser build. Mode-agnostic
+   * items (the default) show in both. Full mode-aware enable/disable is #2187;
+   * this field only handles the static server-vs-browser item split (#2073).
+   */
+  storageMode?: StorageMode;
   /**
    * Display label for the help overlay key cell, used only when the command has
    * no keyboard binding (e.g. mouse gestures documented in help). When omitted,
@@ -168,13 +195,14 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
   },
   {
     id: "show-help",
-    label: "Show help",
+    label: "About and shortcuts",
     scope: "global",
     // Producing "?" requires Shift on most layouts, so the real keydown event
     // carries shiftKey=true. Bind both states so the shortcut fires whether or
     // not Shift is reported.
     bindings: [{ key: "?" }, { key: "?", shift: true }],
-    keywords: ["shortcuts", "about", "keyboard"],
+    appMenuGroup: "help",
+    keywords: ["shortcuts", "about", "keyboard", "version"],
   },
 
   // --- Editing --------------------------------------------------------------
@@ -253,6 +281,15 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
 
   // --- File -----------------------------------------------------------------
   {
+    id: "export-backup",
+    label: "Export backup",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "file",
+    storageMode: "browser",
+    keywords: ["download", "backup", "zip", "save"],
+  },
+  {
     id: "save",
     label: "Save layout",
     scope: "global",
@@ -261,6 +298,8 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
       { key: "s", meta: true },
     ],
     helpGroup: "File",
+    appMenuGroup: "file",
+    storageMode: "server",
     keywords: ["store", "persist"],
   },
   {
@@ -272,18 +311,9 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
       { key: "s", meta: true, shift: true },
     ],
     helpGroup: "File",
+    appMenuGroup: "file",
+    storageMode: "server",
     keywords: ["download", "backup", "zip"],
-  },
-  {
-    id: "load",
-    label: "Load layout",
-    scope: "global",
-    bindings: [
-      { key: "o", ctrl: true },
-      { key: "o", meta: true },
-    ],
-    helpGroup: "File",
-    keywords: ["open", "import"],
   },
   {
     id: "export",
@@ -294,6 +324,7 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
       { key: "e", meta: true },
     ],
     helpGroup: "File",
+    appMenuGroup: "file",
     keywords: ["png", "svg", "pdf", "image"],
   },
   {
@@ -305,8 +336,71 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
       { key: "h", meta: true },
     ],
     helpGroup: "File",
+    appMenuGroup: "file",
     keywords: ["link", "url", "qr"],
   },
+  {
+    id: "view-yaml",
+    label: "View YAML",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "file",
+    keywords: ["yaml", "source", "raw", "edit"],
+  },
+
+  // --- Layout (app menu) ----------------------------------------------------
+  {
+    id: "new-layout",
+    label: "New layout",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "layout",
+    keywords: ["new", "rack", "create", "blank"],
+  },
+  {
+    id: "load",
+    label: "Open layout",
+    scope: "global",
+    bindings: [
+      { key: "o", ctrl: true },
+      { key: "o", meta: true },
+    ],
+    helpGroup: "File",
+    appMenuGroup: "layout",
+    keywords: ["open", "load", "import"],
+  },
+
+  // --- Devices (app menu) ---------------------------------------------------
+  {
+    id: "import-devices",
+    label: "Import devices",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "devices",
+    keywords: ["import", "devices", "library"],
+  },
+  {
+    id: "import-netbox",
+    label: "Import from NetBox",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "devices",
+    keywords: ["netbox", "import", "dcim"],
+  },
+  {
+    id: "new-custom-device",
+    label: "New custom device",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "devices",
+    keywords: ["custom", "device", "create"],
+  },
+
+  // --- Help (app menu) ------------------------------------------------------
+  // show-help ("About and shortcuts") is defined in the General group above
+  // with appMenuGroup: "help"; the menu projection places it in this section.
+  // Its dialog (HelpPanel) is the About panel and includes the shortcut list,
+  // so one entry covers both about and shortcuts.
   {
     id: "undo",
     label: "Undo",
@@ -349,7 +443,11 @@ const HELP_GROUP_ORDER: HelpGroup[] = [
  * so they are not registry actions.
  */
 const HELP_GESTURE_ROWS: { group: HelpGroup; key: string; action: string }[] = [
-  { group: "Navigation", key: "Scroll Wheel", action: "Zoom in/out (at cursor)" },
+  {
+    group: "Navigation",
+    key: "Scroll Wheel",
+    action: "Zoom in/out (at cursor)",
+  },
   { group: "Navigation", key: "Shift + Scroll", action: "Pan horizontally" },
   { group: "Navigation", key: "Click + Drag", action: "Pan canvas" },
 ];
@@ -398,6 +496,19 @@ export interface HelpGroupSection {
 }
 
 /**
+ * Render a single binding with platform-correct modifier labels (e.g. "Ctrl+S"
+ * or "Cmd+S"). Shared by the help overlay and the app menu so both surfaces
+ * format keys identically.
+ */
+function formatBinding(binding: KeyBinding): string {
+  const parts: string[] = [];
+  if (binding.ctrl || binding.meta) parts.push("mod");
+  if (binding.shift) parts.push("shift");
+  parts.push(formatBindingKey(binding.key));
+  return formatShortcut(...parts);
+}
+
+/**
  * Format the help-overlay key cell for an action. Prefers an explicit
  * helpKeyLabel; otherwise renders the primary (first) binding with
  * platform-correct modifier labels.
@@ -406,11 +517,7 @@ function formatHelpKey(action: ActionDefinition): string {
   if (action.helpKeyLabel) return action.helpKeyLabel;
   const binding = action.bindings[0];
   if (!binding) return "";
-  const parts: string[] = [];
-  if (binding.ctrl || binding.meta) parts.push("mod");
-  if (binding.shift) parts.push("shift");
-  parts.push(formatBindingKey(binding.key));
-  return formatShortcut(...parts);
+  return formatBinding(binding);
 }
 
 /** Render a raw binding key into a display glyph. */
@@ -447,6 +554,75 @@ export function getHelpGroups(): HelpGroupSection[] {
 
     if (rows.length > 0) {
       sections.push({ name: groupName, rows });
+    }
+  }
+
+  return sections;
+}
+
+/** The order app-menu sections appear in, with separators between them. */
+const APP_MENU_GROUP_ORDER: AppMenuGroup[] = [
+  "layout",
+  "file",
+  "devices",
+  "help",
+];
+
+/** A single projected app-menu item. */
+export interface AppMenuItem {
+  /** The registry action id this item dispatches. */
+  id: ActionId;
+  /** The display label, taken from the registry. */
+  label: string;
+  /** The platform-formatted keyboard shortcut, if the action has one. */
+  shortcut?: string;
+}
+
+/** A named section of the app menu. */
+export interface AppMenuSection {
+  group: AppMenuGroup;
+  items: AppMenuItem[];
+}
+
+/**
+ * Format an action's primary keybinding as a menu shortcut (e.g. "Ctrl+S" or
+ * "Cmd+S"). Returns undefined when the action has no keybinding, so the menu
+ * omits the shortcut chip rather than rendering an empty one.
+ */
+function formatMenuShortcut(action: ActionDefinition): string | undefined {
+  const binding = action.bindings[0];
+  if (!binding) return undefined;
+  return formatBinding(binding);
+}
+
+/**
+ * Project the app menu (the menu behind the logo) from the registry. Items are
+ * every action that declares an appMenuGroup, grouped into sections in
+ * APP_MENU_GROUP_ORDER and following registry order within each section.
+ *
+ * The menu is storage-mode aware in the narrow, static sense this slice owns:
+ * a server-only action (Save, Save As) is dropped in browser mode, and a
+ * browser-only action (Export backup) is dropped in server mode. Full
+ * mode-aware enable/disable logic is #2187; this is only the item-set split.
+ */
+export function getAppMenuSections(mode: StorageMode): AppMenuSection[] {
+  const sections: AppMenuSection[] = [];
+
+  for (const group of APP_MENU_GROUP_ORDER) {
+    const items: AppMenuItem[] = [];
+
+    for (const action of ACTION_REGISTRY) {
+      if (action.appMenuGroup !== group) continue;
+      if (action.storageMode && action.storageMode !== mode) continue;
+      items.push({
+        id: action.id,
+        label: action.label,
+        shortcut: formatMenuShortcut(action),
+      });
+    }
+
+    if (items.length > 0) {
+      sections.push({ group, items });
     }
   }
 

--- a/src/lib/components/AppMenu.svelte
+++ b/src/lib/components/AppMenu.svelte
@@ -1,0 +1,141 @@
+<!--
+  AppMenu Component
+  The menu behind the logo. The logo lockup is the menu trigger; the items are
+  projected from the actions registry (getAppMenuSections), so the menu cannot
+  drift from the keyboard handler or help overlay. Storage-mode aware in the
+  static sense: the item set differs between the browser and server builds.
+  Full mode-aware enable/disable logic is #2187.
+-->
+<script lang="ts">
+  import { DropdownMenu } from "bits-ui";
+  import LogoLockup from "./LogoLockup.svelte";
+  import { getAppMenuSections, type ActionId } from "$lib/actions/registry";
+  import { getStorageMode, type StorageMode } from "$lib/storage";
+  import "$lib/styles/menu.css";
+
+  interface Props {
+    /** Maps each app-menu action id to the closure that runs it. */
+    onaction: (id: ActionId) => void;
+    /** Whether any rack exists; gates share and view-yaml. */
+    hasRacks?: boolean;
+    /** Party mode passes through to the logo lockup. */
+    partyMode?: boolean;
+  }
+
+  let { onaction, hasRacks = false, partyMode = false }: Props = $props();
+
+  let open = $state(false);
+
+  const mode: StorageMode = getStorageMode();
+  const sections = getAppMenuSections(mode);
+
+  // Actions that need a rack to act on. Only share and view-yaml are gated,
+  // matching the existing FileMenu: save, load, and the exports stay available
+  // for an empty-but-named layout. Full mode-aware enable/disable is #2187.
+  const RACK_DEPENDENT: ReadonlySet<ActionId> = new Set<ActionId>([
+    "share",
+    "view-yaml",
+  ]);
+
+  function isDisabled(id: ActionId): boolean {
+    return RACK_DEPENDENT.has(id) && !hasRacks;
+  }
+
+  function handleSelect(id: ActionId) {
+    return () => {
+      onaction(id);
+      open = false;
+    };
+  }
+</script>
+
+<DropdownMenu.Root bind:open>
+  <DropdownMenu.Trigger>
+    {#snippet child({ props })}
+      <button
+        {...props}
+        type="button"
+        class="app-menu-trigger"
+        aria-label="App menu"
+        data-testid="btn-app-menu"
+      >
+        <LogoLockup size={32} {partyMode} />
+      </button>
+    {/snippet}
+  </DropdownMenu.Trigger>
+
+  <DropdownMenu.Portal>
+    <DropdownMenu.Content
+      class="menu-content menu-inline"
+      sideOffset={4}
+      align="start"
+    >
+      {#each sections as section, sectionIndex (section.group)}
+        {#if sectionIndex > 0}
+          <DropdownMenu.Separator class="menu-separator" />
+        {/if}
+        <DropdownMenu.Group>
+          {#each section.items as item (item.id)}
+            <DropdownMenu.Item
+              class="menu-item"
+              disabled={isDisabled(item.id)}
+              data-testid={`app-menu-${item.id}`}
+              onSelect={handleSelect(item.id)}
+            >
+              <span class="menu-label">{item.label}</span>
+              {#if item.shortcut}
+                <span class="menu-shortcut">{item.shortcut}</span>
+              {/if}
+            </DropdownMenu.Item>
+          {/each}
+        </DropdownMenu.Group>
+      {/each}
+    </DropdownMenu.Content>
+  </DropdownMenu.Portal>
+</DropdownMenu.Root>
+
+<style>
+  /* The logo doubles as the menu trigger. Keeps the visual treatment the logo
+     had as a plain toolbar button (transparent, subtle hover and focus ring). */
+  .app-menu-trigger {
+    display: flex;
+    align-items: center;
+    padding: var(--space-1);
+    border: none;
+    border-radius: var(--radius-md);
+    background: transparent;
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      transform var(--duration-fast) var(--ease-out);
+  }
+
+  .app-menu-trigger:hover {
+    background: var(--colour-surface-hover);
+  }
+
+  .app-menu-trigger:active {
+    transform: scale(0.98);
+  }
+
+  .app-menu-trigger:focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--colour-bg),
+      0 0 0 4px var(--colour-focus-ring);
+  }
+
+  .app-menu-trigger[data-state="open"] {
+    background: var(--colour-surface-hover);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .app-menu-trigger {
+      transition: none;
+    }
+
+    .app-menu-trigger:active {
+      transform: none;
+    }
+  }
+</style>

--- a/src/lib/components/LogoLockup.svelte
+++ b/src/lib/components/LogoLockup.svelte
@@ -11,7 +11,10 @@
 <script lang="ts">
   import SantaHat from "./SantaHat.svelte";
   import { isChristmas } from "$lib/utils/christmas";
-  import { LOGO_PATH, LOGO_SQUARE_VIEWBOX } from "$lib/components/logo-geometry";
+  import {
+    LOGO_PATH,
+    LOGO_SQUARE_VIEWBOX,
+  } from "$lib/components/logo-geometry";
 
   interface Props {
     size?: number;
@@ -401,9 +404,8 @@
     }
   }
 
-  /* Always show Rackula text in toolbar hamburger button (mobile) */
-  :global(.toolbar-brand) .logo-title,
-  :global(.toolbar-brand.hamburger-mode) .logo-title {
+  /* Always show Rackula text when the logo is the toolbar app-menu trigger */
+  :global(.app-menu-trigger) .logo-title {
     display: block !important;
   }
 

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -7,10 +7,11 @@
 -->
 <script lang="ts">
   import Tooltip from "./Tooltip.svelte";
+  import AppMenu from "./AppMenu.svelte";
   import FileMenu from "./FileMenu.svelte";
   import SettingsMenu from "./SettingsMenu.svelte";
   import StorageStatusChip from "./StorageStatusChip.svelte";
-  import LogoLockup from "./LogoLockup.svelte";
+  import type { ActionId } from "$lib/actions/registry";
   import {
     IconUndoBold,
     IconRedoBold,
@@ -56,6 +57,7 @@
     ontogglepromptcleanup?: () => void;
     onopencleanup?: () => void;
     onhelp?: () => void;
+    onnewlayout?: () => void;
     onlayouts?: () => void;
   }
 
@@ -88,6 +90,7 @@
     ontogglepromptcleanup,
     onopencleanup,
     onhelp,
+    onnewlayout,
     onlayouts,
   }: Props = $props();
 
@@ -207,8 +210,27 @@
     onopencleanup?.();
   }
 
-  function handleHelp() {
-    onhelp?.();
+  // Dispatch map from app-menu action id to its handler. The menu items
+  // themselves come from the registry (AppMenu projects getAppMenuSections);
+  // this binds each id to the closure that runs it, mirroring how
+  // KeyboardHandler binds the same ids to keyboard shortcuts.
+  const appMenuDispatch: Partial<Record<ActionId, () => void>> = {
+    "new-layout": () => onnewlayout?.(),
+    load: () => onload?.(),
+    save: () => onsave?.(),
+    "save-as": () => onsaveas?.(),
+    "export-backup": () => onsaveas?.(),
+    export: () => onexport?.(),
+    share: () => onshare?.(),
+    "view-yaml": () => onviewyaml?.(),
+    "import-devices": () => onimportdevices?.(),
+    "import-netbox": () => onimportnetbox?.(),
+    "new-custom-device": () => onnewcustomdevice?.(),
+    "show-help": () => onhelp?.(),
+  };
+
+  function handleAppMenuAction(id: ActionId) {
+    appMenuDispatch[id]?.();
   }
 
   function startEditingName() {
@@ -237,19 +259,9 @@
 </script>
 
 <header class="toolbar">
-  <!-- Left: Logo -->
+  <!-- Left: Logo (also the app menu) -->
   <div class="toolbar-section toolbar-left">
-    <Tooltip text="About & Shortcuts" shortcut="?" position="bottom">
-      <button
-        class="toolbar-brand"
-        type="button"
-        aria-label="About & Shortcuts"
-        onclick={handleHelp}
-        data-testid="btn-logo-about"
-      >
-        <LogoLockup size={32} {partyMode} />
-      </button>
-    </Tooltip>
+    <AppMenu onaction={handleAppMenuAction} {hasRacks} {partyMode} />
   </div>
 
   <!-- Layout name (desktop only) -->
@@ -577,35 +589,6 @@
 
   .toolbar-right-mobile {
     gap: var(--space-1);
-  }
-
-  /* Logo button */
-  .toolbar-brand {
-    display: flex;
-    align-items: center;
-    padding: var(--space-1);
-    border: none;
-    border-radius: var(--radius-md);
-    background: transparent;
-    cursor: pointer;
-    transition:
-      background-color var(--duration-fast) var(--ease-out),
-      transform var(--duration-fast) var(--ease-out);
-  }
-
-  .toolbar-brand:hover {
-    background: var(--colour-surface-hover);
-  }
-
-  .toolbar-brand:active {
-    transform: scale(0.98);
-  }
-
-  .toolbar-brand:focus-visible {
-    outline: none;
-    box-shadow:
-      0 0 0 2px var(--colour-bg),
-      0 0 0 4px var(--colour-focus-ring);
   }
 
   /* Icon buttons - shared by toolbar and dropdown triggers */

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -4,6 +4,7 @@ import {
   getActionById,
   findActionForEvent,
   getHelpGroups,
+  getAppMenuSections,
 } from "$lib/actions/registry";
 
 /**
@@ -213,6 +214,101 @@ describe("actions registry", () => {
       );
       expect(scrollRow).toBeDefined();
       expect(scrollRow?.key).toBeTruthy();
+    });
+  });
+
+  describe("getAppMenuSections (app menu projection)", () => {
+    it("projects only registry actions flagged for the app menu", () => {
+      // Every item the menu shows must trace back to a registered action, so
+      // the menu and the keyboard handler cannot drift apart.
+      const sections = getAppMenuSections("browser");
+      const ids = sections.flatMap((s) => s.items.map((i) => i.id));
+      for (const id of ids) {
+        const action = getActionById(id);
+        expect(
+          action,
+          `menu item "${id}" has no registry action`,
+        ).toBeDefined();
+        expect(action?.appMenuGroup).toBeDefined();
+      }
+    });
+
+    it("shows each app-menu action exactly once within a mode", () => {
+      for (const mode of ["browser", "server"] as const) {
+        const ids = getAppMenuSections(mode).flatMap((s) =>
+          s.items.map((i) => i.id),
+        );
+        // No action appears twice in a given mode's menu.
+        expect(ids.length).toBe(new Set(ids).size);
+      }
+    });
+
+    it("covers every app-menu action across the two storage modes", () => {
+      // Mode-exclusive items (browser-only export, server-only save) mean no
+      // single mode is the full superset, but their union must be.
+      const browserIds = getAppMenuSections("browser").flatMap((s) =>
+        s.items.map((i) => i.id),
+      );
+      const serverIds = getAppMenuSections("server").flatMap((s) =>
+        s.items.map((i) => i.id),
+      );
+      const union = new Set([...browserIds, ...serverIds]);
+      const appMenuActionIds = ACTION_REGISTRY.filter(
+        (a) => a.appMenuGroup,
+      ).map((a) => a.id);
+      expect(union).toEqual(new Set(appMenuActionIds));
+    });
+
+    it("omits server-only Save and Save As in browser mode", () => {
+      const ids = getAppMenuSections("browser").flatMap((s) =>
+        s.items.map((i) => i.id),
+      );
+      expect(ids).not.toContain("save");
+      expect(ids).not.toContain("save-as");
+    });
+
+    it("adds Save and Save As in server mode", () => {
+      const ids = getAppMenuSections("server").flatMap((s) =>
+        s.items.map((i) => i.id),
+      );
+      expect(ids).toContain("save");
+      expect(ids).toContain("save-as");
+    });
+
+    it("leads the browser file section with Export backup, not Save", () => {
+      // Spec: the browser build leads with Export backup.
+      const fileSection = getAppMenuSections("browser").find(
+        (s) => s.group === "file",
+      );
+      expect(fileSection).toBeDefined();
+      expect(fileSection?.items[0]?.id).toBe("export-backup");
+    });
+
+    it("carries the registry label and platform shortcut for each item", () => {
+      const sections = getAppMenuSections("server");
+      const save = sections
+        .flatMap((s) => s.items)
+        .find((i) => i.id === "save");
+      expect(save?.label).toBe(getActionById("save")?.label);
+      // mod+S formats to Ctrl+S or Cmd+S; we just assert the key letter shows.
+      expect(save?.shortcut).toContain("S");
+    });
+
+    it("leaves shortcut undefined for actions with no keybinding", () => {
+      const sections = getAppMenuSections("browser");
+      const viewYaml = sections
+        .flatMap((s) => s.items)
+        .find((i) => i.id === "view-yaml");
+      expect(viewYaml).toBeDefined();
+      expect(viewYaml?.shortcut).toBeUndefined();
+    });
+
+    it("groups items into named sections in a stable order", () => {
+      const sections = getAppMenuSections("browser");
+      const groups = sections.map((s) => s.group);
+      // Sections appear once each, in declared order.
+      expect(groups).toEqual([...new Set(groups)]);
+      expect(sections.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Turns the toolbar logo into the app-menu trigger. Menu items are projected from the actions registry (`getAppMenuSections`), so the menu cannot drift from the keyboard handler or help overlay. This is the mode-agnostic shell slice (a) of #2073; mode-aware enable/disable is #2187.

- New `AppMenu.svelte`: the logo (`LogoLockup`) is the bits-ui `DropdownMenu` trigger. Keyboard accessible (role=menu/menuitem, arrow nav, Escape), 44px-friendly menu items via shared `menu.css`, reduced-motion aware.
- Registry now owns the menu: new `appMenuGroup` / `storageMode` fields plus `getAppMenuSections(mode)`. New global actions (`new-layout`, `import-devices`, `import-netbox`, `new-custom-device`, `view-yaml`, `export-backup`) join the existing file actions. Shortcut formatting shares `formatBinding` with the help overlay (no duplication).
- Storage-mode aware item set: server build adds Save and Save As; browser build leads with Export backup.
- `Toolbar` binds each app-menu action id to its handler, mirroring `KeyboardHandler`. New `onnewlayout` prop threaded from `App.svelte`.
- Help section is a single "About and shortcuts" entry: the HelpPanel it opens is the About dialog and already includes the shortcut list, so there is no separate, duplicate About item.

### Scope

Per the M14 plan, this is the logo/menu slice only. The top-bar reframe (removing the existing `FileMenu` and other scattered entry points) is #2072 and is intentionally left untouched here to avoid colliding with that slice. `FileMenu.svelte` is unchanged.

## Test Plan

- [x] `npm run lint` (clean)
- [x] `npm run test:run` (2340 passed)
- [x] `npm run build` (succeeds)
- [x] E2E axe-core a11y guard rail (5/5), responsive + accessibility (22/22), keyboard + smoke (14/14), full chromium suite (127/127)
- [x] TDD: registry -> app-menu projection (`getAppMenuSections`) with storage-mode shaping (`actions-registry.test.ts`)

Unblocks #2187 (mode-aware items) and, with #2082, #2081.

Closes #2073


___

## **CodeAnt-AI Description**
**Turn the toolbar logo into the app menu and project menu items from the shared action list**

### What Changed
- The logo now opens the main app menu instead of a separate About button.
- The menu is split into clear sections for layout, file, devices, and help, with items coming from the shared action list.
- Menu contents now change by build type: browser mode shows Export backup, while server mode includes Save and Save As.
- Menu items keep the same labels and shortcuts as the rest of the app, and some entries are hidden when no rack exists.
- Accessibility checks and registry tests now cover the new logo menu behavior and its keyboard access.

### Impact
`✅ Faster access to core app actions`
`✅ Fewer shortcut and menu mismatches`
`✅ Clearer menu behavior in browser and server builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
