### PR TITLE
test: E2E strategy for the M14 shell (#2183)

### DIFF
--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -431,6 +431,38 @@ changes. Interactive controls are not listed there: reach them with
 `label:has-text("...")` is a Playwright text-engine locator, not a CSS class
 selector, and is fine to use.
 
+#### Selecting palette devices by name
+
+The Devices palette is virtualized (#2094): lists over 30 rows window their
+content, so off-screen rows unmount, and a pinned device renders twice (once in
+the favourites section, once in its category). Positional indexing
+(`.nth(index)`) is therefore unreliable. Select a palette device by its visible
+name instead:
+
+```typescript
+import { dragDeviceToRack, paletteItemByName } from "./helpers";
+
+// Drag a specific device by name (preferred over deviceIndex)
+await dragDeviceToRack(page, { deviceName: "Test Server" });
+
+// Locate a palette item by name (scope to favourites first if pinned)
+await expect(paletteItemByName(page, "Test Server")).toBeVisible();
+```
+
+#### Multi-context tests (twin-tab, restore)
+
+The M14 shell adds layout tabs (#2079), so some flows need more than one page on
+the same origin: the twin-tab guard (#2044) and lazy tab restore (#2080). The
+`e2e/helpers/multi-context.ts` helpers wrap that: `openSecondTab` opens a second
+page in the same browser context (shared localStorage and `storage` events),
+`collectStorageEvents` records the cross-tab events the guard reacts to, and
+`snapshotStorage` captures `storageState` so a relaunch can be modelled with a
+fresh context. See `e2e/multi-context.spec.ts` for worked examples.
+
+The full carry-over audit, naming convention for new testids, the multi-context
+harness design, and the per-slice rewrite-or-delete decisions live in
+[`docs/research/spike-2183-e2e-shell-strategy.md`](../research/spike-2183-e2e-shell-strategy.md).
+
 #### Lint enforcement
 
 ESLint blocks new CSS class selectors in `e2e/**/*.ts`. A string literal passed

--- a/docs/research/spike-2183-e2e-shell-strategy.md
+++ b/docs/research/spike-2183-e2e-shell-strategy.md
@@ -1,0 +1,208 @@
+# Spike #2183: E2E Strategy for the M14 Shell
+
+Date: 2026-06-14
+Parent epic: #2017 (Canvas UX Overhaul, milestone M14)
+Sequencing: M14 wave 0, alongside guard rails #2098 (visual), #2099 (axe), #2100 (UX standards)
+
+---
+
+## Problem
+
+M04 spent real effort on E2E: data-testids on structural components (#1419), helper
+migration to role and testid locators (#1420), the lint rule that blocks CSS class
+selectors (#1423), stale-selector cleanup (#1264), and coverage (#1227, #1231). Some of
+that effort is written against surfaces the M14 shell deletes. #2072 reframes the top bar
+and #2081 removes the StartScreen, so any spec that asserts on the toolbar or the start
+screen needs a decision: rewrite or delete. Nothing today says which.
+
+Two shell features also need a test capability the suite does not have. The twin-tab guard
+(#2044) and lazy tab restore (#2080) involve more than one page on the same origin, and no
+existing E2E issue plans the multi-context harness they need.
+
+This document is the strategy: which selectors and helpers carry over, the naming
+convention M14 slices follow as they add testids, the multi-context harness design, and the
+per-slice rewrite-or-delete call for the affected specs.
+
+## Selector posture (unchanged)
+
+The project already has a sound selector strategy, documented in
+`docs/guides/TESTING.md` (Selector Strategy) and enforced by the lint rule from #1423. M14
+does not change it. The order of preference stays:
+
+1. `getByRole()` with an accessible name. Doubles as an accessibility check.
+2. `getByLabel()` or `getByText()` for form fields and visible copy.
+3. `getByTestId()` for structural anchors with no natural role or label.
+
+CSS class selectors are reserved for the few intentional anchors in
+`e2e/helpers/locators.ts`. A new `.locator(".foo")` fails lint. This holds through the
+overhaul: a shell that rebuilds the DOM is exactly the situation role and testid locators
+are meant to survive.
+
+## Carry-over audit
+
+The shell reframe touches the top bar, the entry flow, the palette, and adds the tab strip.
+The audit below classifies the #1419 testids and #1420 helpers against those changes.
+
+### Testids: carry, rename, or retire
+
+| Testid (or family)                          | Owner today                | M14 fate                                              |
+| ------------------------------------------- | -------------------------- | ---------------------------------------------------- |
+| `rack-canvas`, `rack-front`, `rack-rear`    | Canvas                     | Carry. The canvas survives; verbs float over it.     |
+| `rack-device`, `rack-drop-zone`             | RackView                   | Carry. Device chrome is unchanged by the shell.      |
+| `device-palette-item`                       | DevicePaletteItem          | Carry, but stop indexing by position (see below).    |
+| `sidebar-tab-devices`, `sidebar-tab-racks`  | SidebarTabs                | Carry. A third tab, Layouts, joins them (#2082).     |
+| `drawer-left`                               | Sidebar                    | Carry. The left drawer stays the sidebar host.       |
+| `drawer-device-edit`                        | EditPanel                  | Carry. Becomes the side panel Edit tab (#2077).      |
+| `btn-export`, `btn-share`                   | Toolbar                    | Carry the action, expect a new home. Reach by role.  |
+| `menu-save`, `menu-load`                    | FileMenu                   | Reframed into the app menu (#2073). Reach by role.   |
+| `btn-new-rack`                              | SidebarTabs (Racks)        | Carry. Creation moves toward place-first but the     |
+|                                             |                            | button persists for the keyboard and explicit path.  |
+| `start-screen`                              | StartScreen                | Retire with #2081. Specs that assert it are deleted  |
+|                                             |                            | or rewritten to the WelcomeScreen empty state.       |
+| `toast-message`, `ctx-menu`, `ctx-menu-item`| Toast, ContextMenu         | Carry. Both survive the shell.                       |
+| `mobile-bottom-nav`, `nav-tab-*`            | mobile nav                 | Carry. Mobile shell adaptation is deferred (M12).    |
+| `layout-tab-{id}`, `layout-tab-close-{id}`  | LayoutTabs (#2079, landed) | Carry. Already follows the parametrized convention.  |
+
+The toolbar class anchors in `locators.ts` (`toolbar.root`, `toolbar.brand`,
+`toolbar.center`) belong to the surface #2072 reframes. They are not testids and not the
+preferred locator; the specs that use them are listed in the per-slice table and move to
+role or testid locators when #2072 lands.
+
+### Helpers: carry, adjust, or retire
+
+| Helper file               | M14 fate                                                            |
+| ------------------------- | ------------------------------------------------------------------ |
+| `a11y.ts`                 | Carry. The axe guard rail (#2099) grows a scan per new surface.    |
+| `base-test.ts`            | Carry. The File System Access shim is shell-agnostic.              |
+| `device-actions.ts`       | Adjust. Add name-based palette selection (done here, see below).   |
+| `index.ts`, `locators.ts` | Carry. Registry grows; the toolbar entries retire with #2072.      |
+| `mobile-navigation.ts`    | Carry. Mobile shell work is deferred.                              |
+| `rack-setup.ts`           | Carry. The wizard path survives for explicit creation.            |
+| `test-layouts.ts`         | Carry. Share-link fixtures are independent of the shell chrome.    |
+| `toolbar-actions.ts`      | Adjust on #2073. `clickSave`/`clickLoad` move to the app menu;     |
+|                           | the functions stay, their internals change. Already role-based.    |
+| `visual.ts`               | Carry. The visual guard rail (#2098) re-baselines per slice.       |
+| `multi-context.ts`        | New (this issue). Twin-tab and restore primitive for #2044/#2080.  |
+
+## Naming convention for new testids
+
+M14 slices add surfaces. To keep the registry coherent and avoid the drift #1264 cleaned up,
+new testids follow the existing house style:
+
+- Kebab-case, lowercase, scope-prefixed by surface: `side-panel`, `app-menu`,
+  `storage-chip`, `layout-tab-{id}`.
+- One stable id per structural anchor, parametrized by entity id where a set repeats
+  (`layout-tab-{id}`, `layout-tab-close-{id}` is the precedent from #2079).
+- Add a testid only when no role or accessible name reaches the element. Buttons, dialogs,
+  and inputs are reached by role or label at the call site, never given a testid for its own
+  sake. The registry comment in `locators.ts` states this; it stays true.
+- Register a structural anchor in `e2e/helpers/locators.ts` rather than hard-coding the
+  string in a spec, so a rename is a one-line registry edit.
+- Every new surface gets an axe scan (#2099) and, where it is visually load-bearing, a visual
+  baseline (#2098), per the patterns in `docs/guides/TESTING.md`.
+
+## Palette selection: stop indexing by position
+
+`dragDeviceToRack` indexed palette items by position
+(`querySelectorAll(...)[deviceIndex]`). Two M14-era facts break that:
+
+- Virtualization (#2094, landed): the palette windows lists over 30 rows. Off-screen rows
+  unmount, so a positional index does not map to a stable device.
+- Favourites (#2094): a pinned device renders twice, once in the favourites section and once
+  in its category, so an index can land on either copy.
+
+There was already a skipped spec waiting on this: `custom-device.spec.ts` notes that custom
+devices sort into the brand list rather than appending, so `deviceIndex: count - 1` drags the
+wrong device, and asks for a `dragDeviceByName()` helper.
+
+The fix, implemented in this issue:
+
+- `dragDeviceToRack(page, { deviceName })` selects the palette item whose visible
+  `.device-name` text matches, inside the drag `page.evaluate`. The `deviceIndex` path stays
+  as a fallback so existing call sites are unchanged.
+- `paletteItemByName(page, name)` returns the palette item locator by name, the same
+  `getByTestId("device-palette-item").filter({ hasText })` pattern the skipped spec already
+  uses inline. When a name is ambiguous because the device is pinned, scope to the favourites
+  section first, then take `.first()`.
+
+Name-based selection is the convention for the palette from here on. Positional indexing is
+the fallback only, and only where order is genuinely fixed.
+
+## Multi-context harness (#2044, #2080)
+
+Both features turn on one fact: pages in the same Playwright `BrowserContext` share an origin,
+so they share localStorage and receive each other's `storage` events. Pages in different
+contexts are isolated and share state only through an explicit `storageState` snapshot.
+
+The harness wraps the same-context case, which is what the two features need:
+
+- `openSecondTab(page)`: opens a second page in the same context. The two pages share the
+  workspace index and layout bodies (`Rackula:workspace`, `Rackula:layout:<id>` per spike
+  #2179). This is the arrangement the twin-tab guard (#2044) elects an editor across.
+- `readStorageJson(page, key)`: reads and parses a localStorage key, for asserting that a
+  write in one tab is visible to another.
+- `collectStorageEvents(observer, action)`: records the `storage` events `observer` receives
+  while `action` runs in another tab. The twin-tab guard reacts to these events, so its test
+  asserts that a write in tab A fires a `storage` event in tab B.
+- `snapshotStorage(context)`: captures `storageState` so a relaunch can be modelled with a
+  fresh context. Lazy restore (#2080) reads the open-tab set at startup, so its test seeds
+  one context, snapshots it, then launches a new cold context from the snapshot rather than
+  reusing a live in-memory workspace.
+
+The harness is deliberately thin. #2044 and #2080 are not built yet, so it provides the
+primitive without simulating behaviour that does not exist. `multi-context.spec.ts` smoke-tests
+the primitive against the current app (shared autosave slot, cross-tab `storage` event, restore
+from snapshot) so the harness is proven before the features depend on it. When the features
+land, their specs compose these helpers.
+
+The Web Lock the spec describes (a `navigator.locks` lease keyed by layout id) is the editor
+election mechanism #2044 will build. There is no such code today, so the harness does not test
+it. When #2044 adds it, a twin-tab spec uses `openSecondTab` plus `collectStorageEvents` to
+assert that the second tab is paused and the first remains the editor.
+
+## A multi-tab axe scan
+
+`axe.spec.ts` scans single surfaces. A multi-tab axe scan (several layout tabs open, then
+scan the tab strip and the active canvas) is a noted follow-up there. It is not built in this
+issue because the tab strip's a11y is better scanned once the chevron overflow and the
+unbacked-changes dots land (both follow #2079). When that scan is added, it follows the
+existing axe pattern: open the surface with the shared helpers, then
+`expectNoA11yViolations(page, '[role="tablist"]')`.
+
+## Per-slice decision: rewrite or delete
+
+The specs and helpers that assert on a removed or reframed surface, with the call per slice.
+"Rewrite" means the user behaviour still exists and the spec retargets the new locator;
+"delete" means the surface is gone and the assertion has no successor.
+
+| Slice                          | Spec or helper                  | Touches                  | Decision                                                                 |
+| ------------------------------ | ------------------------------- | ------------------------ | ----------------------------------------------------------------------- |
+| #2072 top bar reframe          | `smoke.spec.ts`                 | `toolbar.root` visible   | Rewrite. Assert the workspace frame by role, not the `.toolbar` class.  |
+| #2072 top bar reframe          | `deploy-smoke.spec.ts`          | toolbar + startScreen    | Rewrite the toolbar assertion; delete the start-screen branch (#2081).  |
+| #2072 top bar reframe          | `device-images.spec.ts`         | toolbar visible          | Rewrite. The toolbar visibility check moves to the new frame anchor.    |
+| #2072 top bar reframe          | `responsive.spec.ts`            | `toolbar.center`         | Rewrite. Retarget the responsive check to the reframed top bar.         |
+| #2072 top bar reframe          | `helpers/locators.ts`           | `toolbar.*` entries      | Retire the `toolbar` registry entries once no spec references them.     |
+| #2072 top bar reframe          | `helpers/visual.ts`             | toolbar settle wait      | Adjust the settle selector to the new frame; keep the visual baseline.  |
+| #2081 StartScreen removal      | `helpers/locators.ts`           | `startScreen.root`       | Retire `start-screen` from the registry; the surface is deleted.        |
+| #2081 StartScreen removal      | any spec asserting start screen | `start-screen` testid    | Delete the start-screen assertion; rewrite entry to WelcomeScreen empty |
+|                                |                                 |                          | state where a first-launch test still has value.                        |
+| #2073 app menu                 | `helpers/toolbar-actions.ts`    | File menu internals      | Adjust. `clickSave`/`clickLoad` retarget the app menu; signatures hold. |
+| #2079 tab strip (landed)       | new `multi-context.spec.ts`     | n/a                      | Already role/testid based; no rewrite needed.                           |
+| #2094 palette (landed)         | `device-actions.ts`             | positional index         | Adjusted here: name-based selection added, index kept as fallback.      |
+
+The rule for each slice: when the slice merges, the specs in its row are updated in the same
+PR (the slice owns its test impact), and the visual (#2098) and axe (#2099) baselines are
+refreshed for any surface it changes. No spec is left asserting a deleted surface.
+
+## What this issue delivers
+
+- This strategy document.
+- `device-actions.ts`: `dragDeviceToRack({ deviceName })` and `paletteItemByName`, fixing the
+  positional-index fragility under virtualization and favourites.
+- `multi-context.ts`: the twin-tab and restore harness primitive (`openSecondTab`,
+  `readStorageJson`, `collectStorageEvents`, `snapshotStorage`).
+- `multi-context.spec.ts`: smoke coverage proving the harness against the current app.
+- A pointer from `docs/guides/TESTING.md` to this document.
+
+It does not rewrite the per-slice specs in the table: each is rewritten when its slice merges,
+by the slice's PR, because the new locator does not exist until the slice lands.

--- a/e2e/helpers/device-actions.ts
+++ b/e2e/helpers/device-actions.ts
@@ -7,10 +7,18 @@ import { expect } from "@playwright/test";
 import { locators } from "./locators";
 
 /**
- * Drag a device from palette to rack using manual DragEvent dispatch
+ * Drag a device from palette to rack using manual DragEvent dispatch.
+ *
+ * Prefer `deviceName` over `deviceIndex`: positional indexing is fragile under
+ * the virtualized palette (#2094), where off-screen rows unmount and a pinned
+ * device renders twice (once in the favourites section, once in its category).
+ * `deviceName` matches the visible device name, so it survives reordering,
+ * virtualization, and the favourites duplicate.
+ *
  * @param page - Playwright page
  * @param options.yOffsetPercent - Vertical position in rack (0-100), default 10
- * @param options.deviceIndex - Which palette device to drag (default 0 = first)
+ * @param options.deviceName - Visible name of the palette device to drag (preferred)
+ * @param options.deviceIndex - Positional fallback when no name is given (default 0 = first)
  * @param options.rackIndex - Zero-based index of the target rack in multi-rack layouts (default 0)
  * @returns Number of devices in rack after drag
  */
@@ -18,11 +26,13 @@ export async function dragDeviceToRack(
   page: Page,
   options?: {
     yOffsetPercent?: number;
+    deviceName?: string;
     deviceIndex?: number;
     rackIndex?: number;
   },
 ): Promise<number> {
   const yPercent = options?.yOffsetPercent ?? 10;
+  const deviceName = options?.deviceName ?? null;
   const deviceIndex = options?.deviceIndex ?? 0;
   const rackIndex = options?.rackIndex ?? 0;
 
@@ -31,11 +41,22 @@ export async function dragDeviceToRack(
   const deviceCountBefore = await page.locator(locators.rack.device).count();
 
   await page.evaluate(
-    ({ yPercent, deviceIndex, rackIndex }) => {
-      const deviceItems = document.querySelectorAll(
-        '[data-testid="device-palette-item"]',
+    ({ yPercent, deviceName, deviceIndex, rackIndex }) => {
+      const deviceItems = Array.from(
+        document.querySelectorAll('[data-testid="device-palette-item"]'),
       );
-      const deviceItem = deviceItems[deviceIndex];
+      // Index by name when given: positional indexing breaks under
+      // virtualization and the favourites duplicate (#2094). Check for null
+      // (not truthiness) so an empty name still searches rather than silently
+      // falling back to the index path.
+      const deviceItem =
+        deviceName !== null
+          ? deviceItems.find(
+              (item) =>
+                item.querySelector(".device-name")?.textContent?.trim() ===
+                deviceName,
+            )
+          : deviceItems[deviceIndex];
       // Use front-view SVGs so rackIndex maps directly to rack number
       const rackSvgs = document.querySelectorAll(
         '[data-testid="rack-front"] .rack-svg',
@@ -48,7 +69,11 @@ export async function dragDeviceToRack(
       }
 
       if (!deviceItem) {
-        throw new Error(`Device item at index ${deviceIndex} not found`);
+        throw new Error(
+          deviceName !== null
+            ? `Device named "${deviceName}" not found in palette`
+            : `Device item at index ${deviceIndex} not found`,
+        );
       }
 
       const rackRect = rack.getBoundingClientRect();
@@ -93,7 +118,7 @@ export async function dragDeviceToRack(
         }),
       );
     },
-    { yPercent, deviceIndex, rackIndex },
+    { yPercent, deviceName, deviceIndex, rackIndex },
   );
 
   // Wait for device count to increase
@@ -103,6 +128,24 @@ export async function dragDeviceToRack(
   }).toPass({ timeout: 5000 });
 
   return await page.locator(locators.rack.device).count();
+}
+
+/**
+ * Locate a palette item by its visible device name.
+ *
+ * Use this instead of `.nth(index)` when targeting a specific device: the
+ * palette is virtualized and sorts custom devices into the brand list (#2094),
+ * so positional indices are unstable. Filtering by name survives reordering and
+ * the favourites duplicate.
+ *
+ * A pinned device renders twice (favourites section and category section). When
+ * the name is ambiguous, scope the search first, e.g.
+ * `page.getByTestId("device-palette-favourites")`, then call `.first()`.
+ */
+export function paletteItemByName(page: Page, deviceName: string): Locator {
+  return page
+    .getByTestId("device-palette-item")
+    .filter({ hasText: deviceName });
 }
 
 /**

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -17,6 +17,7 @@ export {
 // Device actions
 export {
   dragDeviceToRack,
+  paletteItemByName,
   selectDevice,
   deselectDevice,
   deleteSelectedDevice,
@@ -42,6 +43,14 @@ export {
 
 // Mobile navigation
 export { openDeviceLibraryFromBottomNav } from "./mobile-navigation";
+
+// Multi-context (twin-tab #2044, lazy tab restore #2080)
+export {
+  openSecondTab,
+  readStorageJson,
+  collectStorageEvents,
+  snapshotStorage,
+} from "./multi-context";
 
 // Centralised CSS selectors
 export { locators } from "./locators";

--- a/e2e/helpers/multi-context.ts
+++ b/e2e/helpers/multi-context.ts
@@ -1,0 +1,123 @@
+/**
+ * Multi-context helpers for the M14 shell (issue #2183).
+ *
+ * The tab strip (#2079) makes Rackula a multi-layout workspace, and two shell
+ * features need more than one page open at once:
+ *
+ * - Twin-tab guard (#2044): two browser tabs on the same origin hold the same
+ *   working copy. The guard elects one editor per layout (a Web Lock keyed by
+ *   layout id) and pauses the others. Testing it needs two pages that share
+ *   localStorage and can observe each other's `storage` events.
+ * - Lazy tab restore (#2080): launch restores the open-tab set from the
+ *   `Rackula:workspace` index, hydrating only the active tab. Testing the
+ *   restore path needs a first page to seed the workspace index, then a second
+ *   page (same origin) that reads it on launch.
+ *
+ * Both rely on a single fact about browser storage: pages in the SAME
+ * Playwright BrowserContext share an origin, so they share localStorage and
+ * receive each other's `storage` events. Pages in DIFFERENT contexts are
+ * isolated and only share state through an explicit `storageState` snapshot.
+ *
+ * These helpers wrap the same-context case, which is what #2044 and #2080 need.
+ * They are deliberately thin: the shell features they support are not built
+ * yet, so this provides the harness primitive without simulating behaviour that
+ * does not exist. When #2044/#2080 land, their specs compose these helpers.
+ */
+import type { BrowserContext, Page } from "@playwright/test";
+
+/**
+ * Open a second page in the same browser context as an existing page.
+ *
+ * The new page shares localStorage and `storage` events with `page`, the
+ * arrangement the twin-tab guard (#2044) elects an editor across. Returns the
+ * new page; the caller navigates it (e.g. with `gotoWithRack`).
+ *
+ * @example
+ *   const tabB = await openSecondTab(page);
+ *   await gotoWithRack(tabB);
+ *   // tabB now shares the workspace index with `page`
+ */
+export async function openSecondTab(page: Page): Promise<Page> {
+  return page.context().newPage();
+}
+
+/**
+ * Read a single localStorage key from a page as a parsed JSON value.
+ *
+ * Returns `null` when the key is absent or does not parse as JSON. Use this to
+ * assert that a write in one tab is visible to another (both must be in the same
+ * context). The workspace index lives at `Rackula:workspace` and layout bodies
+ * at `Rackula:layout:<id>` (spike #2179).
+ */
+export async function readStorageJson<T = unknown>(
+  page: Page,
+  key: string,
+): Promise<T | null> {
+  return page.evaluate((storageKey) => {
+    const raw = window.localStorage.getItem(storageKey);
+    if (raw === null) return null;
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return null;
+    }
+  }, key) as Promise<T | null>;
+}
+
+/**
+ * Capture the `storage` events a page receives while `action` runs.
+ *
+ * The twin-tab guard reacts to cross-tab `storage` events, so a test for it
+ * asserts that writing in one tab fires a `storage` event in the other. This
+ * installs a listener on `observer`, runs `action` (typically a write in a
+ * different tab in the same context), then resolves with the keys that changed.
+ *
+ * @param observer - The page expected to receive the events
+ * @param action - The work that triggers a cross-tab write
+ * @param options.timeout - How long to wait for events, default 2000ms
+ * @returns The localStorage keys reported by `storage` events during `action`
+ */
+export async function collectStorageEvents(
+  observer: Page,
+  action: () => Promise<void>,
+  options?: { timeout?: number },
+): Promise<string[]> {
+  const timeout = options?.timeout ?? 2000;
+
+  await observer.evaluate(() => {
+    const w = window as unknown as { __rackulaStorageKeys?: string[] };
+    w.__rackulaStorageKeys = [];
+    w.addEventListener("storage", (event) => {
+      if (event.key !== null) w.__rackulaStorageKeys?.push(event.key);
+    });
+  });
+
+  await action();
+  await observer.waitForTimeout(timeout);
+
+  return observer.evaluate(() => {
+    const w = window as unknown as { __rackulaStorageKeys?: string[] };
+    return w.__rackulaStorageKeys ?? [];
+  });
+}
+
+/**
+ * Snapshot a context's storage state for cross-context restore tests.
+ *
+ * Lazy restore (#2080) and a fresh launch read the workspace index at startup.
+ * To test "reopen the app and restore the tabs", seed state in one context,
+ * snapshot it here, then create a NEW context with that snapshot. A new context
+ * (rather than a new page) models a genuine relaunch: it starts cold and reads
+ * the restored index, instead of inheriting a live in-memory workspace.
+ *
+ * @example
+ *   const state = await snapshotStorage(page.context());
+ *   const restored = await browser.newContext({ storageState: state });
+ *   const relaunched = await restored.newPage();
+ *   await relaunched.goto("/");
+ */
+export async function snapshotStorage(
+  context: BrowserContext,
+): Promise<Awaited<ReturnType<BrowserContext["storageState"]>>> {
+  return context.storageState();
+}

--- a/e2e/multi-context.spec.ts
+++ b/e2e/multi-context.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * Multi-context harness smoke tests (issue #2183).
+ *
+ * Proves the primitive the twin-tab guard (#2044) and lazy tab restore (#2080)
+ * build on: two pages in the same browser context share localStorage and see
+ * each other's `storage` events, and a fresh context restores from a storage
+ * snapshot. The shell features themselves are not built yet, so these tests
+ * cover the harness, not the guard or the restore flow. When #2044/#2080 land,
+ * their specs compose the same helpers.
+ *
+ * @see docs/research/spike-2183-e2e-shell-strategy.md
+ */
+import { test } from "./helpers/base-test";
+import { expect } from "@playwright/test";
+import {
+  gotoWithRack,
+  openSecondTab,
+  readStorageJson,
+  collectStorageEvents,
+  snapshotStorage,
+} from "./helpers";
+
+const AUTOSAVE_KEY = "Rackula:autosave";
+
+test.describe("multi-context harness", () => {
+  test("two tabs in one context share the autosave slot", async ({ page }) => {
+    // Tab A loads a rack; the app autosaves it to localStorage.
+    await gotoWithRack(page);
+    await expect
+      .poll(() => readStorageJson(page, AUTOSAVE_KEY))
+      .not.toBeNull();
+
+    // Tab B opens in the same context and reads the same slot without loading
+    // a layout of its own, the shared-origin fact #2044's editor election needs.
+    const tabB = await openSecondTab(page);
+    await tabB.goto("/");
+    const sharedFromB = await readStorageJson(tabB, AUTOSAVE_KEY);
+    expect(sharedFromB).not.toBeNull();
+  });
+
+  test("a write in one tab fires a storage event in another", async ({
+    page,
+  }) => {
+    await gotoWithRack(page);
+    const observer = await openSecondTab(page);
+    await observer.goto("/");
+
+    // Writing in `page` must reach `observer` as a `storage` event: this is the
+    // signal the twin-tab guard (#2044) reacts to across tabs.
+    const changedKeys = await collectStorageEvents(observer, async () => {
+      await page.evaluate((key) => {
+        window.localStorage.setItem(key, JSON.stringify({ ping: Date.now() }));
+      }, "Rackula:twin-tab-probe");
+    });
+
+    expect(changedKeys).toContain("Rackula:twin-tab-probe");
+  });
+
+  test("a fresh context restores from a storage snapshot", async ({
+    page,
+    browser,
+  }) => {
+    // Seed state in the first context, then relaunch cold from a snapshot, the
+    // shape lazy restore (#2080) reads its open-tab set from at startup.
+    await gotoWithRack(page);
+    await expect
+      .poll(() => readStorageJson(page, AUTOSAVE_KEY))
+      .not.toBeNull();
+
+    const state = await snapshotStorage(page.context());
+    const restoredContext = await browser.newContext({ storageState: state });
+    try {
+      const relaunched = await restoredContext.newPage();
+      await relaunched.goto("/");
+      const restored = await readStorageJson(relaunched, AUTOSAVE_KEY);
+      expect(restored).not.toBeNull();
+    } finally {
+      await restoredContext.close();
+    }
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Lands the wave-0 E2E strategy for the M14 shell reframe (epic #2017). This is
testing infrastructure (chore), exempt from the M14 feature-merge gate but still
green on the guard-rail jobs.

Three deliverables, matching the issue:

- Carry-over audit, naming convention for new testids, multi-context harness
  design, and per-slice rewrite-or-delete decisions, in
  `docs/research/spike-2183-e2e-shell-strategy.md` (the established wave-0
  `spike-NNNN` precedent alongside #2179/#2182/#2018/#2019/#2020), with a pointer
  added from `docs/guides/TESTING.md`.
- Multi-context Playwright harness (`e2e/helpers/multi-context.ts`) for the
  twin-tab guard (#2044) and lazy tab restore (#2080): `openSecondTab`,
  `readStorageJson`, `collectStorageEvents`, `snapshotStorage`.
  `e2e/multi-context.spec.ts` smoke-tests the primitive against the current app.
- Device-palette selector fix: `dragDeviceToRack({ deviceName })` and
  `paletteItemByName` select by visible name instead of positional index, which
  is fragile under virtualization (#2094, off-screen rows unmount and a pinned
  device renders twice). `deviceIndex` stays as a fallback so existing call sites
  are unchanged. This also unblocks the `dragDeviceByName()` helper the skipped
  `custom-device.spec.ts` tests were waiting on.

No production source touched: only `e2e/` and `docs/`. The guard-rail jobs
(`a11y (axe-core)`, `visual regression`) use `testMatch` restricted to their own
specs, so the new spec does not run there and no rendered surface changed.

## Test Plan

- [x] `npm run lint` -> No issues found
- [x] `multi-context.spec.ts` -> 3 passed on chromium, 3 passed on webkit
- [x] Drag-using specs (basic-workflow, multi-rack, undo-redo) -> 19 passed, 3 pre-existing skips (behaviour-preserving for the `deviceIndex` path)
- [x] `deviceName` drag path + clear-error path verified passing (throwaway specs, removed)
- [x] Local `/code-review` pass (extra-high effort): no defects; one cheap hardening applied (explicit null check so an empty name still searches)

Closes #2183


___

## **CodeAnt-AI Description**
**Add E2E coverage and helpers for M14 shell testing**

### What Changed
- Added a new multi-context test setup that proves two tabs can share autosaved state, react to cross-tab storage changes, and restore state from a saved snapshot
- Added reusable helpers for opening a second tab, reading stored app data, collecting storage events, and restoring browser state for relaunch tests
- Updated device palette interactions to target devices by visible name instead of position, which avoids failures when the palette is virtualized or shows a pinned device twice
- Documented the new testing approach and selector guidance in the testing guide and added a strategy note for the M14 shell

### Impact
`✅ Fewer broken device-drag tests`
`✅ Reliable twin-tab test coverage`
`✅ Safer relaunch and restore checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
