### PR TITLE
feat: app menu mode-aware items (#2187)

### DIFF
--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -128,6 +128,10 @@ export interface ActionEnabledContext {
   isRackSelected: boolean;
   canUndo: boolean;
   canRedo: boolean;
+  /** Whether the active layout has at least one rack to act on. */
+  hasRacks: boolean;
+  /** The active storage mode, for mode-aware app-menu items. */
+  mode: StorageMode;
 }
 
 /**
@@ -335,6 +339,8 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
       { key: "h", ctrl: true },
       { key: "h", meta: true },
     ],
+    // Sharing needs a rack to encode in the link; disabled on an empty layout.
+    enabledWhen: (ctx) => ctx.hasRacks,
     helpGroup: "File",
     appMenuGroup: "file",
     keywords: ["link", "url", "qr"],
@@ -344,6 +350,8 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     label: "View YAML",
     scope: "global",
     bindings: [],
+    // The YAML view has nothing to show until a rack exists.
+    enabledWhen: (ctx) => ctx.hasRacks,
     appMenuGroup: "file",
     keywords: ["yaml", "source", "raw", "edit"],
   },
@@ -576,6 +584,13 @@ export interface AppMenuItem {
   label: string;
   /** The platform-formatted keyboard shortcut, if the action has one. */
   shortcut?: string;
+  /**
+   * Whether the item is currently disabled. Computed from the action's
+   * enabledWhen predicate against the supplied context; false when no context
+   * is given or the action declares no predicate. Disabled items stay in the
+   * menu (rendered aria-disabled) rather than being hidden.
+   */
+  disabled?: boolean;
 }
 
 /** A named section of the app menu. */
@@ -600,12 +615,19 @@ function formatMenuShortcut(action: ActionDefinition): string | undefined {
  * every action that declares an appMenuGroup, grouped into sections in
  * APP_MENU_GROUP_ORDER and following registry order within each section.
  *
- * The menu is storage-mode aware in the narrow, static sense this slice owns:
- * a server-only action (Save, Save As) is dropped in browser mode, and a
- * browser-only action (Export backup) is dropped in server mode. Full
- * mode-aware enable/disable logic is #2187; this is only the item-set split.
+ * The menu is storage-mode aware in two layers. The item set splits by mode: a
+ * server-only action (Save, Save As) is dropped in browser mode and a
+ * browser-only action (Export backup) is dropped in server mode. When a live
+ * context is supplied, each item's `disabled` is also derived from its action's
+ * enabledWhen predicate (e.g. share and view-yaml need a rack), so the menu is
+ * the registry's first runtime consumer of enabledWhen. Disabled items stay in
+ * the menu (rendered aria-disabled) rather than being hidden. Called with the
+ * mode alone, every item is enabled.
  */
-export function getAppMenuSections(mode: StorageMode): AppMenuSection[] {
+export function getAppMenuSections(
+  mode: StorageMode,
+  context?: ActionEnabledContext,
+): AppMenuSection[] {
   const sections: AppMenuSection[] = [];
 
   for (const group of APP_MENU_GROUP_ORDER) {
@@ -618,6 +640,10 @@ export function getAppMenuSections(mode: StorageMode): AppMenuSection[] {
         id: action.id,
         label: action.label,
         shortcut: formatMenuShortcut(action),
+        disabled:
+          context && action.enabledWhen
+            ? !action.enabledWhen(context)
+            : false,
       });
     }
 

--- a/src/lib/components/AppMenu.svelte
+++ b/src/lib/components/AppMenu.svelte
@@ -2,14 +2,20 @@
   AppMenu Component
   The menu behind the logo. The logo lockup is the menu trigger; the items are
   projected from the actions registry (getAppMenuSections), so the menu cannot
-  drift from the keyboard handler or help overlay. Storage-mode aware in the
-  static sense: the item set differs between the browser and server builds.
-  Full mode-aware enable/disable logic is #2187.
+  drift from the keyboard handler or help overlay. Storage-mode aware on two
+  levels: the item set differs between the browser and server builds, and each
+  item's enabled state is derived from its registry enabledWhen predicate
+  against a live context (rack presence, storage mode). Disabled items stay in
+  the menu, rendered aria-disabled by bits-ui, rather than being hidden.
 -->
 <script lang="ts">
   import { DropdownMenu } from "bits-ui";
   import LogoLockup from "./LogoLockup.svelte";
-  import { getAppMenuSections, type ActionId } from "$lib/actions/registry";
+  import {
+    getAppMenuSections,
+    type ActionEnabledContext,
+    type ActionId,
+  } from "$lib/actions/registry";
   import { getStorageMode, type StorageMode } from "$lib/storage";
   import "$lib/styles/menu.css";
 
@@ -27,19 +33,22 @@
   let open = $state(false);
 
   const mode: StorageMode = getStorageMode();
-  const sections = getAppMenuSections(mode);
 
-  // Actions that need a rack to act on. Only share and view-yaml are gated,
-  // matching the existing FileMenu: save, load, and the exports stay available
-  // for an empty-but-named layout. Full mode-aware enable/disable is #2187.
-  const RACK_DEPENDENT: ReadonlySet<ActionId> = new Set<ActionId>([
-    "share",
-    "view-yaml",
-  ]);
+  // Live context for the registry's enabledWhen predicates. Only the app menu's
+  // global-scope items are projected, and the gated ones (share, view-yaml)
+  // read hasRacks; the selection and history fields are not consulted by any
+  // menu item, so they are reported as the neutral, no-target state.
+  const enableContext: ActionEnabledContext = $derived({
+    hasSelection: false,
+    isDeviceSelected: false,
+    isRackSelected: false,
+    canUndo: false,
+    canRedo: false,
+    hasRacks,
+    mode,
+  });
 
-  function isDisabled(id: ActionId): boolean {
-    return RACK_DEPENDENT.has(id) && !hasRacks;
-  }
+  const sections = $derived(getAppMenuSections(mode, enableContext));
 
   function handleSelect(id: ActionId) {
     return () => {
@@ -78,7 +87,7 @@
           {#each section.items as item (item.id)}
             <DropdownMenu.Item
               class="menu-item"
-              disabled={isDisabled(item.id)}
+              disabled={item.disabled ?? false}
               data-testid={`app-menu-${item.id}`}
               onSelect={handleSelect(item.id)}
             >

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -144,6 +144,8 @@ describe("actions registry", () => {
         isRackSelected: false,
         canUndo: false,
         canRedo: false,
+        hasRacks: true,
+        mode: "browser" as const,
       };
       const disabledCtx = { ...enabledCtx, isDeviceSelected: false };
       expect(dup?.enabledWhen?.(enabledCtx)).toBe(true);
@@ -159,6 +161,8 @@ describe("actions registry", () => {
         isRackSelected: false,
         canUndo: false,
         canRedo: false,
+        hasRacks: false,
+        mode: "browser" as const,
       };
       expect(undo?.enabledWhen?.({ ...base, canUndo: true })).toBe(true);
       expect(undo?.enabledWhen?.(base)).toBe(false);
@@ -309,6 +313,107 @@ describe("actions registry", () => {
       // Sections appear once each, in declared order.
       expect(groups).toEqual([...new Set(groups)]);
       expect(sections.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getAppMenuSections (mode-aware item enable/disable)", () => {
+    // The app menu is the first runtime consumer of enabledWhen. It passes a
+    // live context (rack presence, storage mode, selection/history) and the
+    // registry decides which items are runnable. Disabled items stay in the
+    // menu (accessible, greyed) rather than disappearing.
+    const fullContext = {
+      hasSelection: false,
+      isDeviceSelected: false,
+      isRackSelected: false,
+      canUndo: false,
+      canRedo: false,
+      hasRacks: true,
+      mode: "browser" as const,
+    };
+
+    it("leaves items enabled when no enable context is supplied", () => {
+      // The signature stays backwards compatible: called with a mode alone,
+      // every projected item is enabled (no disabled flag set true).
+      const sections = getAppMenuSections("browser");
+      const disabled = sections
+        .flatMap((s) => s.items)
+        .filter((i) => i.disabled);
+      expect(disabled.length).toBe(0);
+    });
+
+    it("disables rack-dependent items when no racks exist", () => {
+      // share and view-yaml need a rack to act on; with no racks they are
+      // present but disabled, matching the prior FileMenu/AppMenu behaviour.
+      const sections = getAppMenuSections("browser", {
+        ...fullContext,
+        hasRacks: false,
+      });
+      const items = sections.flatMap((s) => s.items);
+      const share = items.find((i) => i.id === "share");
+      const viewYaml = items.find((i) => i.id === "view-yaml");
+      expect(share?.disabled).toBe(true);
+      expect(viewYaml?.disabled).toBe(true);
+    });
+
+    it("enables rack-dependent items when at least one rack exists", () => {
+      const sections = getAppMenuSections("browser", {
+        ...fullContext,
+        hasRacks: true,
+      });
+      const items = sections.flatMap((s) => s.items);
+      expect(items.find((i) => i.id === "share")?.disabled).toBe(false);
+      expect(items.find((i) => i.id === "view-yaml")?.disabled).toBe(false);
+    });
+
+    it("never disables items that declare no enable predicate", () => {
+      // new-layout, import-devices, etc. have no enabledWhen, so they stay
+      // enabled regardless of rack presence.
+      const sections = getAppMenuSections("browser", {
+        ...fullContext,
+        hasRacks: false,
+      });
+      const items = sections.flatMap((s) => s.items);
+      const newLayout = items.find((i) => i.id === "new-layout");
+      const importDevices = items.find((i) => i.id === "import-devices");
+      expect(newLayout?.disabled).toBe(false);
+      expect(importDevices?.disabled).toBe(false);
+    });
+
+    it("disables but does not hide rack-dependent items", () => {
+      // Disabled items remain in the projection so the menu stays accessible
+      // (bits-ui renders them aria-disabled), rather than vanishing.
+      const ids = getAppMenuSections("browser", {
+        ...fullContext,
+        hasRacks: false,
+      }).flatMap((s) => s.items.map((i) => i.id));
+      expect(ids).toContain("share");
+      expect(ids).toContain("view-yaml");
+    });
+  });
+
+  describe("rack-dependent enable predicates", () => {
+    const base = {
+      hasSelection: false,
+      isDeviceSelected: false,
+      isRackSelected: false,
+      canUndo: false,
+      canRedo: false,
+      hasRacks: false,
+      mode: "browser" as const,
+    };
+
+    it("gates share on rack presence", () => {
+      const share = getActionById("share");
+      expect(share?.enabledWhen).toBeDefined();
+      expect(share?.enabledWhen?.({ ...base, hasRacks: true })).toBe(true);
+      expect(share?.enabledWhen?.({ ...base, hasRacks: false })).toBe(false);
+    });
+
+    it("gates view-yaml on rack presence", () => {
+      const viewYaml = getActionById("view-yaml");
+      expect(viewYaml?.enabledWhen).toBeDefined();
+      expect(viewYaml?.enabledWhen?.({ ...base, hasRacks: true })).toBe(true);
+      expect(viewYaml?.enabledWhen?.({ ...base, hasRacks: false })).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Folds the app menu's rack-dependent item disabling into the actions registry's declarative `enabledWhen` mechanism, completing the mode-aware item behaviour split out of #2073. The app menu becomes the registry's first runtime consumer of `enabledWhen`.

- Extends `ActionEnabledContext` with `hasRacks` (layout presence) and `mode` (storage mode) so app-menu actions can gate on context.
- Declares `enabledWhen: (ctx) => ctx.hasRacks` on `share` and `view-yaml` (both need a rack to act on), replacing the hardcoded `RACK_DEPENDENT` set inside `AppMenu.svelte`.
- `getAppMenuSections(mode, context?)` now derives each item's `disabled` flag from its action's `enabledWhen` against the supplied context. Called with the mode alone (no context), every item stays enabled, so the signature is backwards compatible.
- Disabled items remain in the menu and are rendered `aria-disabled` by bits-ui rather than being hidden, keeping the menu accessible.

Scope is limited to `registry.ts`, `AppMenu.svelte`, and the registry tests. No changes to the top bar layout (`Toolbar.svelte`), which #2072 owns.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run test:run` (132 files, 2360 tests pass; 42 in `actions-registry.test.ts`, 5 new mode-aware cases written test-first)
- [x] `npm run build` succeeds
- [x] `npm run check` introduces zero new type errors (3 pre-existing on base, unchanged)
- [x] a11y guard rail (`test:e2e:a11y`): 5/5 axe scans pass, no WCAG 2.2 AA violations
- [x] visual regression guard rail (`test:e2e:visual`): 11/11 pass, including the `menu - file` snapshot
- [x] `svelte-autofixer` reports no issues on `AppMenu.svelte`

Closes #2187

🤖 Generated with [Claude Code](https://claude.com/claude-code)