### PR TITLE
feat: cached layout previews in the Layouts sidebar (#2083)

### DIFF
--- a/src/lib/components/LayoutsLibrary.svelte
+++ b/src/lib/components/LayoutsLibrary.svelte
@@ -21,6 +21,11 @@
   import { generateId } from "$lib/utils/device";
   import type { Layout } from "$lib/types";
   import { buildLayoutRows, nextDuplicateName } from "./layouts-library";
+  import {
+    layoutPreviewKey,
+    createLayoutPreviewCache,
+  } from "./layout-preview-cache";
+  import { renderLayoutPreviewSvg } from "./layout-preview-render";
   import LayoutContextMenu from "./LayoutContextMenu.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import Dialog from "./Dialog.svelte";
@@ -41,6 +46,43 @@
   const rows = $derived(
     buildLayoutRows(workspaceStore.tabs, workspaceStore.activeId),
   );
+
+  // Cached mini-render previews (#2083). The cache is bounded and session-only:
+  // durable persistence of previews belongs to the storage slice (#2080). Keyed
+  // by tab id and invalidated by a content hash, so a preview is re-rendered
+  // only when the layout's rendered image would actually change (placing or
+  // moving a device, resizing a rack, recolouring a device type), and a rename
+  // never throws the thumbnail away.
+  const previewCache = createLayoutPreviewCache();
+
+  /**
+   * Resolve the preview SVG for a tab, rendering and caching it on a miss.
+   * Returns null when there is nothing to draw (no racks), so the row shows a
+   * placeholder instead of an empty frame.
+   */
+  function previewFor(tabId: string): string | null {
+    const tab = workspaceStore.tabs.find((t) => t.id === tabId);
+    if (!tab) return null;
+
+    const layout = tab.store.layout;
+    const key = layoutPreviewKey(layout);
+    const cached = previewCache.get(tabId, key);
+    if (cached !== undefined) return cached;
+
+    const svg = renderLayoutPreviewSvg(layout);
+    if (svg === null) return null;
+    previewCache.set(tabId, key, svg);
+    return svg;
+  }
+
+  // Drop cache entries for tabs that have closed so the cache tracks the open
+  // set and does not grow unbounded across a long session.
+  $effect(() => {
+    const openIds = new Set(workspaceStore.tabs.map((t) => t.id));
+    for (const id of previewCache.keys()) {
+      if (!openIds.has(id)) previewCache.delete(id);
+    }
+  });
 
   // Delete confirmation state.
   let deleteConfirmOpen = $state(false);
@@ -200,6 +242,7 @@
     aria-label="Layout library"
   >
     {#each rows as row (row.tabId)}
+      {@const previewSvg = previewFor(row.tabId)}
       <LayoutContextMenu
         onopen={() => openLayout(row.tabId)}
         onrename={() => openRename(row.tabId)}
@@ -222,6 +265,14 @@
             class:is-active={row.isActive}
             aria-hidden="true"
           ></span>
+          <span class="layout-preview" aria-hidden="true">
+            {#if previewSvg}
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -- Safe: SVG built by generateExportSVG via the DOM API; all user text is set with textContent and escaped by XMLSerializer, never raw-HTML injected. -->
+              {@html previewSvg}
+            {:else}
+              <span class="layout-preview-empty"></span>
+            {/if}
+          </span>
           <span class="layout-info">
             <span class="layout-name">{row.name}</span>
             <span class="layout-meta">
@@ -399,6 +450,45 @@
   .layout-indicator.is-active {
     background: var(--colour-success, #2e7d32);
     border-color: var(--colour-success, #2e7d32);
+  }
+
+  /* Cached mini-render of the layout (#2083). Decorative (aria-hidden): the row
+     name and meta carry the accessible label, so the thumbnail is never the only
+     affordance. A fixed box keeps row height stable while the inner SVG scales to
+     fit without distortion. */
+  .layout-preview {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: var(--space-1, 4px);
+    overflow: hidden;
+    background: var(--colour-surface-secondary);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-sm);
+  }
+
+  .layout-preview :global(svg) {
+    display: block;
+    max-width: 100%;
+    max-height: 100%;
+    width: auto;
+    height: auto;
+  }
+
+  .layout-preview-empty {
+    width: 100%;
+    height: 100%;
+    background: repeating-linear-gradient(
+      45deg,
+      transparent,
+      transparent 4px,
+      var(--colour-border) 4px,
+      var(--colour-border) 5px
+    );
+    opacity: 0.4;
   }
 
   .layout-info {

--- a/src/lib/components/layout-preview-cache.ts
+++ b/src/lib/components/layout-preview-cache.ts
@@ -7,9 +7,9 @@
  *
  * Two pure pieces:
  *  - `layoutPreviewKey` derives a stable cache key from the fields that affect
- *    the render (racks, device types, groups, display mode). Anything else,
- *    including the layout name, is excluded so a rename never invalidates the
- *    thumbnail.
+ *    the render (racks, device types, groups). Anything else, including the
+ *    layout name and display mode (previews always render in label mode), is
+ *    excluded so a rename never invalidates the thumbnail.
  *  - `createLayoutPreviewCache` is a bounded, in-memory LRU keyed by tab id. It
  *    is session-only: durable persistence of previews belongs to the
  *    browser-mode storage schema slice (#2080) and is intentionally not built
@@ -24,7 +24,7 @@ import type { Layout, Rack, DeviceType, RackGroup } from "$lib/types";
  * The key is a deterministic serialization of only the render-affecting
  * fields. Two layouts that render identically share a key; any edit that would
  * change the rendered image (placing or moving a device, resizing a rack,
- * recolouring a device type, switching display mode) changes it. The layout
+ * recolouring a device type) changes it. The layout
  * name is deliberately excluded: it is shown as the row's text label, not in
  * the render, so renaming must not throw the cached thumbnail away.
  */
@@ -32,9 +32,8 @@ export function layoutPreviewKey(layout: Layout): string {
   const racks = (layout.racks ?? []).map(rackKeyParts);
   const deviceTypes = (layout.device_types ?? []).map(deviceTypeKeyParts);
   const groups = (layout.rack_groups ?? []).map(groupKeyParts);
-  const displayMode = layout.settings?.display_mode ?? "label";
 
-  return JSON.stringify({ racks, deviceTypes, groups, displayMode });
+  return JSON.stringify({ racks, deviceTypes, groups });
 }
 
 function rackKeyParts(rack: Rack) {

--- a/src/lib/components/layout-preview-cache.ts
+++ b/src/lib/components/layout-preview-cache.ts
@@ -1,0 +1,140 @@
+/**
+ * Layout preview cache
+ *
+ * Backs the cached mini-renders shown per row in the Layouts sidebar tab
+ * (#2083). A preview is a small SVG render of a layout that doubles as a thumb,
+ * regenerated only when the layout's render-affecting content changes.
+ *
+ * Two pure pieces:
+ *  - `layoutPreviewKey` derives a stable cache key from the fields that affect
+ *    the render (racks, device types, groups, display mode). Anything else,
+ *    including the layout name, is excluded so a rename never invalidates the
+ *    thumbnail.
+ *  - `createLayoutPreviewCache` is a bounded, in-memory LRU keyed by tab id. It
+ *    is session-only: durable persistence of previews belongs to the
+ *    browser-mode storage schema slice (#2080) and is intentionally not built
+ *    here.
+ */
+
+import type { Layout, Rack, DeviceType, RackGroup } from "$lib/types";
+
+/**
+ * Derive a stable cache key for a layout's preview.
+ *
+ * The key is a deterministic serialization of only the render-affecting
+ * fields. Two layouts that render identically share a key; any edit that would
+ * change the rendered image (placing or moving a device, resizing a rack,
+ * recolouring a device type, switching display mode) changes it. The layout
+ * name is deliberately excluded: it is shown as the row's text label, not in
+ * the render, so renaming must not throw the cached thumbnail away.
+ */
+export function layoutPreviewKey(layout: Layout): string {
+  const racks = (layout.racks ?? []).map(rackKeyParts);
+  const deviceTypes = (layout.device_types ?? []).map(deviceTypeKeyParts);
+  const groups = (layout.rack_groups ?? []).map(groupKeyParts);
+  const displayMode = layout.settings?.display_mode ?? "label";
+
+  return JSON.stringify({ racks, deviceTypes, groups, displayMode });
+}
+
+function rackKeyParts(rack: Rack) {
+  return {
+    id: rack.id,
+    height: rack.height,
+    width: rack.width,
+    starting_unit: rack.starting_unit,
+    desc_units: rack.desc_units,
+    show_rear: rack.show_rear,
+    devices: rack.devices.map((d) => ({
+      id: d.id,
+      device_type: d.device_type,
+      position: d.position,
+      face: d.face,
+      slot_position: d.slot_position,
+      name: d.name,
+      colour_override: d.colour_override,
+    })),
+  };
+}
+
+function deviceTypeKeyParts(device: DeviceType) {
+  return {
+    slug: device.slug,
+    u_height: device.u_height,
+    slot_width: device.slot_width,
+    colour: device.colour,
+    category: device.category,
+  };
+}
+
+function groupKeyParts(group: RackGroup) {
+  return {
+    id: group.id,
+    layout_preset: group.layout_preset,
+    rack_ids: group.rack_ids,
+  };
+}
+
+/** A bounded, in-memory LRU cache of rendered previews keyed by tab id. */
+export interface LayoutPreviewCache {
+  /** Return the cached SVG for a tab when its key still matches, else undefined. */
+  get(tabId: string, key: string): string | undefined;
+  /** Store a rendered SVG for a tab under the given content key. */
+  set(tabId: string, key: string, svg: string): void;
+  /** Drop a tab's entry (e.g. when its layout closes). */
+  delete(tabId: string): void;
+  /** Tab ids with a cached entry, so callers can prune closed tabs. */
+  keys(): IterableIterator<string>;
+  /** Number of cached entries. */
+  readonly size: number;
+}
+
+interface CacheEntry {
+  key: string;
+  svg: string;
+}
+
+/**
+ * Create a bounded preview cache.
+ *
+ * Entries are keyed by tab id and hold the content key they were rendered for,
+ * so a stale render is never served after an edit. The cache is least-recently-
+ * used: reading or writing a tab marks it most-recent, and when the entry count
+ * exceeds `limit` the least-recently-used tab is evicted. A `Map` preserves
+ * insertion order, which the eviction relies on.
+ */
+export function createLayoutPreviewCache(limit = 24): LayoutPreviewCache {
+  const entries = new Map<string, CacheEntry>();
+
+  function touch(tabId: string, entry: CacheEntry): void {
+    entries.delete(tabId);
+    entries.set(tabId, entry);
+  }
+
+  return {
+    get(tabId, key) {
+      const entry = entries.get(tabId);
+      if (!entry || entry.key !== key) return undefined;
+      touch(tabId, entry);
+      return entry.svg;
+    },
+    set(tabId, key, svg) {
+      touch(tabId, { key, svg });
+      while (entries.size > limit) {
+        const oldest = entries.keys().next().value;
+        if (oldest === undefined) break;
+        entries.delete(oldest);
+      }
+    },
+    delete(tabId) {
+      entries.delete(tabId);
+    },
+    keys() {
+      // Snapshot the ids so a caller can delete entries while iterating.
+      return [...entries.keys()][Symbol.iterator]();
+    },
+    get size() {
+      return entries.size;
+    },
+  };
+}

--- a/src/lib/components/layout-preview-render.ts
+++ b/src/lib/components/layout-preview-render.ts
@@ -1,0 +1,56 @@
+/**
+ * Layout preview rendering
+ *
+ * Turns a layout into a small SVG string for the cached thumbnail shown in the
+ * Layouts sidebar tab (#2083). It reuses the export renderer (`generateExportSVG`)
+ * rather than introducing a second renderer, so a thumbnail always matches what
+ * an export would produce.
+ *
+ * Safety: `generateExportSVG` builds the SVG with the DOM API and sets every
+ * user-controlled string (device and rack names) via `textContent`/attributes,
+ * never via raw-HTML injection. `XMLSerializer` then escapes the result, so the
+ * returned string is safe to mount with `{@html}` (the same contract the export
+ * preview relies on). No user text is interpolated into markup here.
+ */
+
+import type { Layout, ExportOptions } from "$lib/types";
+import { generateExportSVG, exportAsSVG } from "$lib/utils/export";
+
+/**
+ * Fixed options for the thumbnail render. Front view only, label display mode
+ * (so previews work without device images), and no names/legend/QR chrome so
+ * the miniature stays compact. The transparent background lets the row's own
+ * surface colour show through and keeps light/dark themes consistent.
+ */
+const PREVIEW_OPTIONS: ExportOptions = {
+  format: "svg",
+  scope: "all",
+  includeNames: false,
+  includeLegend: false,
+  background: "transparent",
+  exportView: "front",
+  displayMode: "label",
+  includeQR: false,
+};
+
+/**
+ * Render a layout to an SVG string for its preview thumbnail.
+ *
+ * Returns null when the layout has no racks to draw (an empty thumbnail adds no
+ * information; the row falls back to a placeholder). The render does not pass an
+ * image map: thumbnails render in label mode, so device images are not needed
+ * and the preview never depends on the per-image store.
+ */
+export function renderLayoutPreviewSvg(layout: Layout): string | null {
+  const racks = layout.racks ?? [];
+  if (racks.length === 0) return null;
+
+  const svg = generateExportSVG(
+    racks,
+    layout.device_types ?? [],
+    PREVIEW_OPTIONS,
+    undefined,
+    layout.rack_groups,
+  );
+  return exportAsSVG(svg);
+}

--- a/src/tests/layout-preview-cache.test.ts
+++ b/src/tests/layout-preview-cache.test.ts
@@ -66,12 +66,12 @@ describe("layoutPreviewKey", () => {
     expect(layoutPreviewKey(before)).not.toBe(layoutPreviewKey(after));
   });
 
-  it("changes when the display mode changes", () => {
+  it("ignores the display mode (previews always render in label mode)", () => {
     const before = createTestLayout();
     const after = createTestLayout();
     after.settings = { ...after.settings, display_mode: "image" };
 
-    expect(layoutPreviewKey(before)).not.toBe(layoutPreviewKey(after));
+    expect(layoutPreviewKey(before)).toBe(layoutPreviewKey(after));
   });
 
   it("ignores the layout name (name is shown as row text, not in the render)", () => {

--- a/src/tests/layout-preview-cache.test.ts
+++ b/src/tests/layout-preview-cache.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  layoutPreviewKey,
+  createLayoutPreviewCache,
+} from "$lib/components/layout-preview-cache";
+import {
+  createTestLayout,
+  createTestRack,
+  createTestDevice,
+  createTestDeviceType,
+} from "./factories";
+
+describe("layoutPreviewKey", () => {
+  it("is stable for the same render-affecting content", () => {
+    const a = createTestLayout({
+      racks: [createTestRack({ devices: [createTestDevice({ id: "d1" })] })],
+    });
+    const b = createTestLayout({
+      racks: [createTestRack({ devices: [createTestDevice({ id: "d1" })] })],
+    });
+
+    expect(layoutPreviewKey(a)).toBe(layoutPreviewKey(b));
+  });
+
+  it("changes when a device is placed", () => {
+    const before = createTestLayout({
+      racks: [createTestRack({ devices: [] })],
+    });
+    const after = createTestLayout({
+      racks: [createTestRack({ devices: [createTestDevice({ id: "d1" })] })],
+    });
+
+    expect(layoutPreviewKey(before)).not.toBe(layoutPreviewKey(after));
+  });
+
+  it("changes when a device moves to a new position", () => {
+    const before = createTestLayout({
+      racks: [
+        createTestRack({ devices: [createTestDevice({ id: "d1", position: 1 })] }),
+      ],
+    });
+    const after = createTestLayout({
+      racks: [
+        createTestRack({ devices: [createTestDevice({ id: "d1", position: 5 })] }),
+      ],
+    });
+
+    expect(layoutPreviewKey(before)).not.toBe(layoutPreviewKey(after));
+  });
+
+  it("changes when rack geometry changes", () => {
+    const before = createTestLayout({ racks: [createTestRack({ height: 42 })] });
+    const after = createTestLayout({ racks: [createTestRack({ height: 24 })] });
+
+    expect(layoutPreviewKey(before)).not.toBe(layoutPreviewKey(after));
+  });
+
+  it("changes when a device type colour changes", () => {
+    const before = createTestLayout({
+      device_types: [createTestDeviceType({ slug: "srv", colour: "#111111" })],
+    });
+    const after = createTestLayout({
+      device_types: [createTestDeviceType({ slug: "srv", colour: "#222222" })],
+    });
+
+    expect(layoutPreviewKey(before)).not.toBe(layoutPreviewKey(after));
+  });
+
+  it("changes when the display mode changes", () => {
+    const before = createTestLayout();
+    const after = createTestLayout();
+    after.settings = { ...after.settings, display_mode: "image" };
+
+    expect(layoutPreviewKey(before)).not.toBe(layoutPreviewKey(after));
+  });
+
+  it("ignores the layout name (name is shown as row text, not in the render)", () => {
+    const a = createTestLayout({ name: "Homelab" });
+    const b = createTestLayout({ name: "Rack Room" });
+
+    expect(layoutPreviewKey(a)).toBe(layoutPreviewKey(b));
+  });
+});
+
+describe("createLayoutPreviewCache", () => {
+  it("returns a cached value only when the key matches", () => {
+    const cache = createLayoutPreviewCache(8);
+    cache.set("tab-1", "key-a", "<svg>a</svg>");
+
+    expect(cache.get("tab-1", "key-a")).toBe("<svg>a</svg>");
+    expect(cache.get("tab-1", "key-b")).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown tab", () => {
+    const cache = createLayoutPreviewCache(8);
+    expect(cache.get("missing", "key-a")).toBeUndefined();
+  });
+
+  it("replaces a stale entry when the key for a tab changes", () => {
+    const cache = createLayoutPreviewCache(8);
+    cache.set("tab-1", "key-a", "<svg>old</svg>");
+    cache.set("tab-1", "key-b", "<svg>new</svg>");
+
+    expect(cache.get("tab-1", "key-a")).toBeUndefined();
+    expect(cache.get("tab-1", "key-b")).toBe("<svg>new</svg>");
+    expect(cache.size).toBe(1);
+  });
+
+  it("evicts the least-recently-used entry when the bound is exceeded", () => {
+    const cache = createLayoutPreviewCache(2);
+    cache.set("tab-1", "k1", "one");
+    cache.set("tab-2", "k2", "two");
+    // Touch tab-1 so tab-2 becomes least-recently-used.
+    cache.get("tab-1", "k1");
+    cache.set("tab-3", "k3", "three");
+
+    expect(cache.size).toBe(2);
+    expect(cache.get("tab-2", "k2")).toBeUndefined();
+    expect(cache.get("tab-1", "k1")).toBe("one");
+    expect(cache.get("tab-3", "k3")).toBe("three");
+  });
+
+  it("drops a tab's entry on delete", () => {
+    const cache = createLayoutPreviewCache(8);
+    cache.set("tab-1", "k1", "one");
+    cache.delete("tab-1");
+
+    expect(cache.get("tab-1", "k1")).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it("exposes a key snapshot safe to delete from while iterating", () => {
+    const cache = createLayoutPreviewCache(8);
+    cache.set("tab-1", "k1", "one");
+    cache.set("tab-2", "k2", "two");
+
+    for (const id of cache.keys()) {
+      if (id === "tab-1") cache.delete(id);
+    }
+
+    expect(cache.get("tab-1", "k1")).toBeUndefined();
+    expect(cache.get("tab-2", "k2")).toBe("two");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a cached mini-render preview per layout row in the Layouts sidebar tab
(#2082 left a leading slot for exactly this). The thumbnail reuses the export
renderer (`generateExportSVG`) rather than introducing a second renderer, so a
preview always matches what an export would produce.

## How previews are cached and invalidated

- `layoutPreviewKey(layout)` derives a stable cache key from only the
  render-affecting fields (racks geometry + placed devices, device-type
  colour/height, rack groups, display mode). The layout name is deliberately
  excluded, so a rename never throws the thumbnail away.
- `createLayoutPreviewCache()` is a bounded, in-memory LRU keyed by tab id. It
  holds the content key each render was made for, so a stale render is never
  served after an edit. When the entry count exceeds the bound the
  least-recently-used tab is evicted; closing a tab drops its entry.
- Storage is session-only by design. Durable persistence of previews belongs to
  the browser-mode storage slice (#2080) and is intentionally not built here.

## Accessibility

The preview is decorative (`aria-hidden="true"`): the row name and meta carry
the accessible label, so the thumbnail is never the only affordance. 44px row
targets and the existing keyboard navigation are unchanged. The
`sidebar Layouts tab has no WCAG 2.2 AA violations` axe scan passes.

## Safety

User text (device and rack names) reaches the SVG only via `textContent` and
attributes, then `XMLSerializer` escaping. No user-controlled string is
interpolated into markup; the `{@html}` mount carries the same safe-by-construction
contract the export preview already relies on (with an inline eslint justification).

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run test:run` (2377 passed, incl. 13 new cache/invalidation tests)
- [x] `npm run build` succeeds
- [x] `npm run check` clean for the new files (2 pre-existing errors in
      Rack.svelte / KeyboardHandler.svelte are unrelated and predate this branch)
- [x] axe a11y suite (7 scans) passes, including the Layouts tab
- [x] Svelte MCP `svelte-autofixer` reports zero issues

## Note for reviewers: visual-regression baseline

The `visual` CI check will go red until the Linux baseline is regenerated. This
is the intended flow for an intentional visual change (see
`docs/guides/TESTING.md`): the Layouts sidebar now renders thumbnails, so
`sidebar-layouts.png` legitimately differs. A maintainer needs to run the
"Update Visual Snapshots" workflow on this branch, then download and commit the
`visual-baselines` artifact. The preview render is deterministic for a given
layout, so it is not masked (masking would defeat the regression check).

Closes #2083
