### PR TITLE
feat: side panel Edit tab contextual properties (#2077)

### DIFF
--- a/docs/superpowers/specs/2026-06-14-edit-tab-contextual-properties-design.md
+++ b/docs/superpowers/specs/2026-06-14-edit-tab-contextual-properties-design.md
@@ -1,0 +1,87 @@
+# Edit Tab Contextual Properties (#2077)
+
+Date: 2026-06-14
+Issue: #2077 (feat: side panel Edit tab contextual properties)
+Epic: #2017 (Canvas UX Overhaul, M14)
+Base: #2076 (side panel architecture) merged to main
+
+## Problem
+
+The Edit tab in `SidePanelContent.svelte` should show properties contextual to the
+current selection, with a clear empty state when nothing is selected. The acceptance
+criteria read:
+
+- Properties reflect the current single or multi selection.
+- Clear empty state when nothing is selected.
+
+## Current state (landed by #2076)
+
+`SidePanelContent.svelte` already:
+
+- Resolves a selected rack, a selected device (`SelectedDeviceInfo`), and a selected
+  group (bayed rack) from the shared selection store.
+- Renders `EditPanelRack` for a rack or group, the four device sections for a device,
+  and an empty-state paragraph (`side-panel-edit-empty`) when nothing is selected.
+- `EditPanelRack` already handles the group case fully: group name editing, group-wide
+  rear-view toggle, group-aware height rejection, and a "Delete Bayed Rack" action.
+
+## The multi-select constraint
+
+The shared selection store (`src/lib/stores/selection.svelte.ts`) is strictly
+single-select: one `selectedType` and one id at a time. There is no array of selected
+ids, no marquee, no shift-click, and no other M14 issue currently owns building a
+multi-select selection model. The scope guard for this slice forbids touching the shared
+selection store, canvas interaction, or the View tab.
+
+The only multi-entity selection the live model supports is a **bayed rack group**: a
+single selection that resolves to multiple racks. That is the "multi selection" this
+slice can honestly represent. Per-device marquee multi-select has no backing state, so
+the panel must not fabricate it; it lands when a future issue builds the selection model.
+
+## Decision
+
+Make the Edit tab's contextual properties legible and complete for every selection the
+model supports today, without inventing a multi-select model.
+
+1. **Contextual heading.** Replace the static "Edit" heading with a heading that names
+   the selection kind: "Device", "Rack", "Bayed Rack" (the multi-rack group case), or
+   "Edit" when nothing is selected. This makes "properties reflect the current selection"
+   legible and gives screen-reader users the panel's context. The heading remains the
+   programmatic focus target (`tabindex="-1"`, `editHeadingId`) from #2076.
+
+2. **Empty state stays a paragraph**, unchanged in markup id (`side-panel-edit-empty`),
+   with its copy kept clear and actionable.
+
+3. **No new selection state.** The group (bayed rack) case is the multi-entity case;
+   it is already wired through `selectedGroup` to `EditPanelRack`. No changes to the
+   selection store, canvas, or View tab.
+
+### Selection -> heading resolution
+
+| Selection                     | Heading      | Body                                    |
+| ----------------------------- | ------------ | --------------------------------------- |
+| Device selected               | Device       | metadata / position / image / actions   |
+| Bayed rack group selected     | Bayed Rack   | `EditPanelRack` (group properties)      |
+| Single rack selected          | Rack         | `EditPanelRack` (rack properties)       |
+| Nothing selected              | Edit         | empty-state paragraph                   |
+
+The resolution is pure derived state over the already-resolved `selectedDeviceInfo`,
+`selectedGroup`, and `selectedRack`.
+
+## Out of scope
+
+- A multi-select selection model (selection-store array, shift-click, marquee). No issue
+  owns this yet; it is a milestone-sized change that the scope guard excludes.
+- The View tab (#2078) and the rail chrome (#2076).
+- Per-device group actions ("Bay together" etc.) belong to the verb-bar work (#2075).
+
+## Testing
+
+The selection -> heading/body resolution is real logic worth a test: render
+`SidePanelContent` with `activeTab: "edit"` and assert the contextual heading and that
+the right body renders for each selection kind (device, single rack, bayed group,
+nothing). This complements the existing `edit-panel-name-edit-selection-switch.test.ts`,
+which must stay green.
+
+Thin presentational wrapping (the heading text itself) is covered by the resolution
+test; no separate low-value render test is added.

--- a/src/lib/components/SidePanelContent.svelte
+++ b/src/lib/components/SidePanelContent.svelte
@@ -104,6 +104,17 @@
     selectedRack !== null || selectedDeviceInfo !== null,
   );
 
+  // Contextual heading naming the current selection kind. The branches mirror the
+  // tabpanel's render order (rack/group first, then device) so the heading never
+  // diverges from the body. A bayed rack group is the multi-rack selection the
+  // model supports; it reads as "Bayed Rack". With nothing selected the heading
+  // stays the neutral tab name and the empty state shows.
+  const editHeadingLabel = $derived.by(() => {
+    if (selectedRack) return selectedGroup ? "Bayed Rack" : "Rack";
+    if (selectedDeviceInfo) return "Device";
+    return "Edit";
+  });
+
   // Delete-device-type confirmation lives at the host level (per #1398 contract).
   let showDeleteConfirm = $state(false);
 
@@ -169,7 +180,9 @@
     class="side-panel-tabpanel"
     data-testid="side-panel-panel-edit"
   >
-    <h2 id={editHeadingId} class="side-panel-heading" tabindex="-1">Edit</h2>
+    <h2 id={editHeadingId} class="side-panel-heading" tabindex="-1">
+      {editHeadingLabel}
+    </h2>
     {#if selectedRack}
       <EditPanelRack {selectedRack} {selectedGroup} />
     {:else if selectedDeviceInfo}

--- a/src/tests/side-panel-edit-context.test.ts
+++ b/src/tests/side-panel-edit-context.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for Issue #2077: side panel Edit tab contextual properties.
+ *
+ * The Edit tab in SidePanelContent must reflect the current selection: a device,
+ * a single rack, a bayed rack group (the multi-rack case the selection model
+ * supports), or nothing. The contextual heading names the selection kind and the
+ * matching properties render; with no selection a clear empty state shows instead.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import SidePanelContent from "$lib/components/SidePanelContent.svelte";
+import { resetLayoutStore, getLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  resetSelectionStore,
+  getSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { resetUIStore } from "$lib/stores/ui.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+
+function renderEditTab() {
+  return render(SidePanelContent, {
+    props: { activeTab: "edit", onTabChange: () => {} },
+  });
+}
+
+describe("Edit tab contextual properties (#2077)", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetUIStore();
+    resetToastStore();
+  });
+
+  it("shows the empty state and an Edit heading when nothing is selected", () => {
+    renderEditTab();
+
+    expect(
+      screen.getByTestId("side-panel-edit-empty"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /^edit$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("names a single rack and shows its rack properties", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const rack = layoutStore.addRack("Test Rack", 42);
+    selectionStore.selectRack(rack!.id);
+
+    renderEditTab();
+
+    expect(
+      screen.getByRole("heading", { name: /^rack$/i }),
+    ).toBeInTheDocument();
+    // The rack properties (delete action) render, not the empty state.
+    expect(
+      screen.getByRole("button", { name: /delete rack/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("side-panel-edit-empty"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("names a bayed rack group as the multi-rack selection", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const result = layoutStore.addBayedRackGroup("Bayed Group", 2, 42);
+    const group = result!.group;
+    selectionStore.selectGroup(group.id, group.rack_ids[0]);
+
+    renderEditTab();
+
+    expect(
+      screen.getByRole("heading", { name: /bayed rack/i }),
+    ).toBeInTheDocument();
+    // Group-level delete action proves the group body rendered.
+    expect(
+      screen.getByRole("button", { name: /delete bayed rack/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("side-panel-edit-empty"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("names a selected device and shows its device properties", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const rack = layoutStore.addRack("Test Rack", 42);
+    const rackId = rack!.id;
+    const deviceType = layoutStore.addDeviceType({
+      name: "Server Type",
+      u_height: 1,
+      category: "server",
+      colour: "#4A90D9",
+    });
+    layoutStore.placeDevice(rackId, deviceType.slug, 1, "front");
+    const device = layoutStore.rack!.devices[0]!;
+    selectionStore.selectDevice(rackId, device.id);
+
+    renderEditTab();
+
+    expect(
+      screen.getByRole("heading", { name: /^device$/i }),
+    ).toBeInTheDocument();
+    // The device name editor proves the device body rendered.
+    expect(
+      screen.getByRole("button", { name: /edit display name/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("side-panel-edit-empty"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Makes the side panel Edit tab name the current selection so its properties read in context. The heading resolves to Device, Rack, Bayed Rack (the multi-rack group the selection model supports today), or the neutral Edit when nothing is selected, and the existing empty state still shows on an empty selection.

This sits on top of #2076, which landed the side panel architecture and the Edit tab's single-selection resolution and empty state. This slice adds the contextual heading and locks the resolution with tests.

## Scope

- Confined to the Edit tabpanel content in `SidePanelContent.svelte`. The View tabpanel (#2078) is untouched, and the rail chrome (#2076) is untouched.
- No changes to the shared selection store, canvas interaction, or the EditPanel section components.

## Multi-select note

The shared selection store is single-select; the only multi-entity selection it supports is a bayed rack group (a single selection that resolves to multiple racks), which the Edit tab now names "Bayed Rack" and edits via the group-aware `EditPanelRack`. A per-device marquee multi-select model is not built here (no issue owns it yet, and it is out of this slice's scope). Design note: `docs/superpowers/specs/2026-06-14-edit-tab-contextual-properties-design.md`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:run` 135 files / 2398 tests pass (incl. 4 new resolution tests)
- [x] `npm run build` succeeds
- [x] `npm run test:e2e:a11y` 9/9 pass, no new WCAG 2.2 AA violations (incl. canvas-with-selected-device, which renders the changed heading)
- [x] Visual regression: no baseline captures the side panel heading; with nothing selected the heading stays "Edit" (byte-identical), so no baseline regeneration needed

Closes #2077

🤖 Generated with [Claude Code](https://claude.com/claude-code)