### PR TITLE
feat: move canvas view and history controls to bottom-left (#2074)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,6 +7,7 @@
   import AnimationDefs from "$lib/components/AnimationDefs.svelte";
   import Toolbar from "$lib/components/Toolbar.svelte";
   import Canvas from "$lib/components/Canvas.svelte";
+  import CanvasViewControls from "$lib/components/canvas/CanvasViewControls.svelte";
   import { PaneGroup, Pane, PaneResizer } from "paneforge";
   import DevicePalette from "$lib/components/DevicePalette.svelte";
   import SidePanel from "$lib/components/SidePanel.svelte";
@@ -651,6 +652,12 @@
                 onrackduplicate={handleRackContextDuplicate}
                 onrackdelete={handleRackContextDelete}
               />
+
+              <CanvasViewControls
+                displayMode={uiStore.displayMode}
+                onfitall={handleFitAll}
+                ontoggledisplaymode={handleToggleDisplayMode}
+              />
             </div>
 
             <SidePanel />
@@ -783,6 +790,8 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    /* Anchor the bottom-left CanvasViewControls to the canvas region. */
+    position: relative;
   }
 
   /* Note: Mobile overscroll prevention should be in global styles (index.html or app.css) */

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -1,0 +1,256 @@
+<!--
+  CanvasViewControls Component
+  Bottom-left canvas cluster holding the view and history controls in two
+  visually separated groups: History (undo, redo) and View (zoom out, zoom
+  readout, zoom in, fit, display-mode lens).
+
+  This surfaces existing handlers; it does not own view or history logic. The
+  display-mode lens here is the canonical layout-scoped control; the side panel
+  View tab and the palette toggle mirror the same state.
+-->
+<script lang="ts">
+  import { ICON_SIZE } from "$lib/constants/sizing";
+  import { getCanvasStore } from "$lib/stores/canvas.svelte";
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getToastStore } from "$lib/stores/toast.svelte";
+  import type { DisplayMode } from "$lib/types";
+  import Tooltip from "../Tooltip.svelte";
+  import {
+    IconFitAllBold,
+    IconImageBold,
+    IconImageLabel,
+    IconMinusBold,
+    IconPlusBold,
+    IconRedoBold,
+    IconTextBold,
+    IconUndoBold,
+  } from "../icons";
+
+  interface Props {
+    displayMode: DisplayMode;
+    onfitall?: () => void;
+    ontoggledisplaymode?: () => void;
+  }
+
+  let { displayMode, onfitall, ontoggledisplaymode }: Props = $props();
+
+  const canvasStore = getCanvasStore();
+  const layoutStore = getLayoutStore();
+  const toastStore = getToastStore();
+
+  const displayModeLabels: Record<DisplayMode, string> = {
+    label: "Labels",
+    image: "Images",
+    "image-label": "Both",
+  };
+
+  function handleUndo() {
+    if (!layoutStore.canUndo) return;
+    const desc = layoutStore.undoDescription?.replace("Undo: ", "") ?? "action";
+    layoutStore.undo();
+    toastStore.showToast(`Undid: ${desc}`, "info");
+  }
+
+  function handleRedo() {
+    if (!layoutStore.canRedo) return;
+    const desc = layoutStore.redoDescription?.replace("Redo: ", "") ?? "action";
+    layoutStore.redo();
+    toastStore.showToast(`Redid: ${desc}`, "info");
+  }
+
+</script>
+
+<div class="canvas-view-controls">
+  <div class="control-group" role="group" aria-label="History actions">
+    <Tooltip
+      text={layoutStore.undoDescription ?? "Undo"}
+      shortcut="Ctrl+Z"
+      position="top"
+    >
+      <button
+        class="control-button"
+        type="button"
+        aria-label={layoutStore.undoDescription ?? "Undo"}
+        disabled={!layoutStore.canUndo}
+        onclick={handleUndo}
+        data-testid="btn-undo"
+      >
+        <IconUndoBold size={ICON_SIZE.md} />
+      </button>
+    </Tooltip>
+
+    <Tooltip
+      text={layoutStore.redoDescription ?? "Redo"}
+      shortcut="Ctrl+Shift+Z"
+      position="top"
+    >
+      <button
+        class="control-button"
+        type="button"
+        aria-label={layoutStore.redoDescription ?? "Redo"}
+        disabled={!layoutStore.canRedo}
+        onclick={handleRedo}
+        data-testid="btn-redo"
+      >
+        <IconRedoBold size={ICON_SIZE.md} />
+      </button>
+    </Tooltip>
+  </div>
+
+  <div class="control-group" role="group" aria-label="View actions">
+    <Tooltip text="Zoom out" position="top">
+      <button
+        class="control-button"
+        type="button"
+        aria-label="Zoom out"
+        disabled={!canvasStore.canZoomOut}
+        onclick={() => canvasStore.zoomOut()}
+        data-testid="btn-zoom-out"
+      >
+        <IconMinusBold size={ICON_SIZE.md} />
+      </button>
+    </Tooltip>
+
+    <span
+      class="zoom-readout"
+      role="status"
+      aria-live="polite"
+      aria-label={`Zoom level ${canvasStore.zoomPercentage} percent`}
+      data-testid="zoom-readout"
+    >
+      {canvasStore.zoomPercentage}%
+    </span>
+
+    <Tooltip text="Zoom in" position="top">
+      <button
+        class="control-button"
+        type="button"
+        aria-label="Zoom in"
+        disabled={!canvasStore.canZoomIn}
+        onclick={() => canvasStore.zoomIn()}
+        data-testid="btn-zoom-in"
+      >
+        <IconPlusBold size={ICON_SIZE.md} />
+      </button>
+    </Tooltip>
+
+    <Tooltip text="Fit all" shortcut="F" position="top">
+      <button
+        class="control-button"
+        type="button"
+        aria-label="Fit all"
+        onclick={() => onfitall?.()}
+        data-testid="btn-fit-all"
+      >
+        <IconFitAllBold size={ICON_SIZE.md} />
+      </button>
+    </Tooltip>
+
+    <Tooltip
+      text={`Display: ${displayModeLabels[displayMode]}`}
+      shortcut="I"
+      position="top"
+    >
+      <button
+        class="control-button"
+        type="button"
+        aria-label="Toggle display mode"
+        onclick={() => ontoggledisplaymode?.()}
+        data-testid="btn-display-mode"
+      >
+        {#if displayMode === "label"}
+          <IconTextBold size={ICON_SIZE.md} />
+        {:else if displayMode === "image"}
+          <IconImageBold size={ICON_SIZE.md} />
+        {:else}
+          <IconImageLabel size={ICON_SIZE.lg} />
+        {/if}
+      </button>
+    </Tooltip>
+  </div>
+</div>
+
+<style>
+  .canvas-view-controls {
+    position: absolute;
+    bottom: max(var(--space-3), env(safe-area-inset-bottom, 0px));
+    left: max(var(--space-3), env(safe-area-inset-left, 0px));
+    z-index: calc(var(--z-toolbar) + 1);
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    pointer-events: none;
+  }
+
+  .control-group {
+    pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    border-radius: var(--radius-full);
+    border: 1px solid var(--bottom-nav-border);
+    background: var(--bottom-nav-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .control-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--touch-target-min);
+    min-height: var(--touch-target-min);
+    width: var(--touch-target-min);
+    height: var(--touch-target-min);
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-full);
+    background: transparent;
+    color: var(--colour-text);
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      color var(--duration-fast) var(--ease-out),
+      transform var(--duration-fast) var(--ease-out);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .control-button:hover:not(:disabled) {
+    background: var(--colour-overlay-hover);
+    color: var(--colour-primary);
+  }
+
+  .control-button:active:not(:disabled) {
+    transform: scale(0.97);
+  }
+
+  .control-button:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring-glow);
+    color: var(--colour-primary);
+  }
+
+  .control-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  .zoom-readout {
+    min-width: 3.5ch;
+    padding: 0 var(--space-1);
+    color: var(--colour-text);
+    font-size: var(--font-size-sm);
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+    user-select: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .control-button {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/components/icons/IconMinusBold.svelte
+++ b/src/lib/components/icons/IconMinusBold.svelte
@@ -1,0 +1,20 @@
+<!--
+  Minus icon (Phosphor Bold)
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 256 256"
+  fill="currentColor"
+  aria-hidden="true"
+>
+  <path d="M228,128a12,12,0,0,1-12,12H40a12,12,0,0,1,0-24H216A12,12,0,0,1,228,128Z" />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -76,6 +76,7 @@ export { default as IconWarningTriangle } from "./IconWarningTriangle.svelte";
 // =============================================================================
 
 export { default as IconPlusBold } from "./IconPlusBold.svelte";
+export { default as IconMinusBold } from "./IconMinusBold.svelte";
 export { default as IconUndoBold } from "./IconUndoBold.svelte";
 export { default as IconRedoBold } from "./IconRedoBold.svelte";
 export { default as IconTextBold } from "./IconTextBold.svelte";


### PR DESCRIPTION
## Summary

Relocates the view and history controls to a canvas bottom-left cluster in two visually separated groups, per the M14 canvas-controls spec:

- History: undo, redo
- View: zoom out, zoom readout, zoom in, fit, display-mode lens

The new `CanvasViewControls.svelte` surfaces existing handlers; it does not own view or history logic:

- Undo/redo route through the layout store (same toast feedback as the old toolbar)
- Zoom in/out call the canvas store directly (which clamps to ZOOM_MIN/MAX); buttons disable at the bounds
- Fit and display-mode toggle reuse the `handleFitAll` / `handleToggleDisplayMode` handlers passed from `App.svelte`

The display-mode lens here is the canonical layout-scoped control; the side panel View tab (#2078) and palette toggle (#2094) mirror the same state via the same shared `handleToggleDisplayMode` handler (not forked). The cluster is mounted desktop-only inside the `.canvas-region` wrapper (from #2076), which is given `position: relative` to anchor it. Mobile keeps its existing `MobileHistoryControls`.

Builds on #2072 (removed these from the top bar, handlers left live) and #2076 (side panel + canvas-region). Scope is limited to the new cluster and its mount; no underlying handlers changed.

## Accessibility

- All controls keyboard accessible with ARIA labels and `type="button"`; two `role="group"` containers labelled History and View
- 48px touch targets (`--touch-target-min`), `:focus-visible` rings, `prefers-reduced-motion` support
- Zoom readout announced via an `aria-live="polite"` `role="status"` region
- Adds a matching `IconMinusBold` so zoom-out pairs visually with `IconPlusBold`

## Verification

- `npm run lint` clean
- `npm run test:run` (2394 passed)
- `npm run build` succeeds
- `npm run test:e2e:a11y` (9/9 axe-core scans pass, including the canvas scan covering the new cluster: no new WCAG 2.2 AA violations)
- CI `a11y (axe-core)` and `visual regression` both green

## Visual baselines

Ran the Update Visual Snapshots workflow against this branch. The cluster plus the (already-clean) top bar change less than 1 percent of the frame, which is under the visual tripwire's `maxDiffPixelRatio: 0.01` threshold, so Playwright reported no diff and rewrote nothing. The `visual regression` gate passes as-is; there are no baseline changes to commit.

Note: `main`'s committed canvas baselines still depict the pre-#2072 top-bar controls (a pre-existing staleness from when #2072 landed without a baseline refresh). That delta is also within tolerance, so it does not block this PR; refreshing main's baselines is out of scope for this slice.

Closes #2074