### PR TITLE
feat: side panel View tab layout toggles (#2078)

### DIFF
--- a/src/lib/components/SegmentedControl.svelte
+++ b/src/lib/components/SegmentedControl.svelte
@@ -21,6 +21,8 @@
     ariaLabel?: string;
     /** Size variant */
     size?: ControlSize;
+    /** Whether the whole control is disabled */
+    disabled?: boolean;
   }
 
   let {
@@ -29,9 +31,11 @@
     onchange,
     ariaLabel,
     size = "default",
+    disabled = false,
   }: Props = $props();
 
   function handleClick(optionValue: T) {
+    if (disabled) return;
     onchange?.(optionValue);
   }
 </script>
@@ -50,6 +54,7 @@
       class:first={i === 0}
       class:last={i === options.length - 1}
       aria-pressed={option.value === value}
+      {disabled}
       onclick={() => handleClick(option.value)}
     >
       {option.label}
@@ -122,5 +127,15 @@
     outline: 2px solid var(--colour-selection);
     outline-offset: 2px;
     z-index: 2;
+  }
+
+  .segment:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .segment:disabled:hover {
+    background: transparent;
+    color: var(--colour-text-muted);
   }
 </style>

--- a/src/lib/components/SidePanelContent.svelte
+++ b/src/lib/components/SidePanelContent.svelte
@@ -7,8 +7,8 @@
   empty-state orchestration and selection resolution; it does not know about the
   collapse-to-rail chrome.
 
-  The Edit tab hosts the decomposed EditPanel sections (#1398). The View tab is a
-  placeholder filled by #2078 with the layout-scoped view toggles.
+  The Edit tab hosts the decomposed EditPanel sections (#1398). The View tab hosts
+  the layout-scoped view toggles (ViewControls, #2078).
 -->
 <script lang="ts">
   import { Tabs } from "$lib/components/ui/Tabs";
@@ -17,6 +17,7 @@
   import EditPanelPosition from "./EditPanelPosition.svelte";
   import EditPanelImage from "./EditPanelImage.svelte";
   import EditPanelActions from "./EditPanelActions.svelte";
+  import ViewControls from "./ViewControls.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
@@ -209,9 +210,7 @@
     data-testid="side-panel-panel-view"
   >
     <h2 id={viewHeadingId} class="side-panel-heading" tabindex="-1">View</h2>
-    <p class="side-panel-empty" data-testid="side-panel-view-placeholder">
-      Layout view controls live here. Filled in by issue #2078.
-    </p>
+    <ViewControls />
   </Tabs.Content>
 </Tabs.Root>
 

--- a/src/lib/components/ViewControls.svelte
+++ b/src/lib/components/ViewControls.svelte
@@ -1,0 +1,127 @@
+<!--
+  ViewControls Component
+
+  The body of the side panel's View tab (#2078): the layout-scoped view toggles
+  that are always reachable regardless of selection. Display mode, annotations,
+  and rear view. Theme is an app preference and lives behind the Settings gear,
+  not here.
+
+  These controls mirror existing store state rather than forking a second source
+  of truth. Display mode is the same state as the canvas lens (#2074) and the
+  palette toggle (#2094); rear view is the active rack's per-rack show_rear, the
+  same field the Edit tab's rack section edits.
+-->
+<script lang="ts">
+  import SegmentedControl from "./SegmentedControl.svelte";
+  import Switch from "./Switch.svelte";
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getUIStore } from "$lib/stores/ui.svelte";
+  import type { DisplayMode } from "$lib/types";
+
+  const layoutStore = getLayoutStore();
+  const uiStore = getUIStore();
+
+  const displayModeOptions: Array<{ value: DisplayMode; label: string }> = [
+    { value: "label", label: "Label" },
+    { value: "image", label: "Image" },
+    { value: "image-label", label: "Image + Label" },
+  ];
+
+  // The active rack scopes the per-rack rear-view toggle. With no rack the
+  // control is disabled rather than hidden, so the View tab stays stable.
+  const activeRack = $derived(layoutStore.activeRack);
+
+  function handleDisplayModeChange(mode: DisplayMode) {
+    if (uiStore.displayMode === mode) return;
+    uiStore.setDisplayMode(mode);
+    layoutStore.updateDisplayMode(uiStore.displayMode);
+    layoutStore.updateShowLabelsOnImages(uiStore.showLabelsOnImages);
+  }
+
+  function handleAnnotationsChange(enabled: boolean) {
+    uiStore.setAnnotations(enabled);
+  }
+
+  // Rear view is per-rack. Bayed racks share one physical front/rear view, so a
+  // change fans out to every rack in the bay to keep it consistent. Row groups
+  // are independent racks, so only the active rack changes.
+  function handleRearViewChange(value: string) {
+    const rack = activeRack;
+    if (!rack) return;
+    const showRear = value === "show";
+    const group = layoutStore.getRackGroupForRack(rack.id);
+    if (group?.layout_preset === "bayed") {
+      for (const rackId of group.rack_ids) {
+        layoutStore.updateRack(rackId, { show_rear: showRear });
+      }
+    } else {
+      layoutStore.updateRack(rack.id, { show_rear: showRear });
+    }
+  }
+</script>
+
+<div class="view-controls">
+  <section class="control-group">
+    <h3 class="control-label">Display Mode</h3>
+    <SegmentedControl
+      options={displayModeOptions}
+      value={uiStore.displayMode}
+      onchange={handleDisplayModeChange}
+      ariaLabel="Display mode"
+    />
+  </section>
+
+  <section class="control-group">
+    <Switch
+      id="view-annotations"
+      checked={uiStore.showAnnotations}
+      label="Annotations"
+      helperText="Show the annotation column beside each rack."
+      onchange={handleAnnotationsChange}
+    />
+  </section>
+
+  <section class="control-group">
+    <h3 class="control-label">Rear View</h3>
+    <SegmentedControl
+      options={[
+        { value: "show", label: "Show" },
+        { value: "hide", label: "Hide" },
+      ]}
+      value={activeRack?.show_rear ? "show" : "hide"}
+      onchange={handleRearViewChange}
+      ariaLabel="Show rear view on canvas"
+      disabled={!activeRack}
+    />
+    {#if !activeRack}
+      <p class="control-helper">Add a rack to control its rear view.</p>
+    {/if}
+  </section>
+</div>
+
+<style>
+  .view-controls {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+
+  .control-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .control-label {
+    margin: 0;
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text);
+  }
+
+  .control-helper {
+    margin: 0;
+    font-size: var(--font-size-sm);
+    color: var(--colour-text-muted);
+  }
+</style>

--- a/src/tests/side-panel-view-toggles.test.ts
+++ b/src/tests/side-panel-view-toggles.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for Issue #2078: side panel View tab layout toggles.
+ *
+ * The View tab is always reachable (independent of selection) and holds the
+ * layout-scoped view toggles: display mode, annotations, and rear view. It
+ * mirrors existing store state rather than forking a second source of truth:
+ * display mode is the same state as the canvas lens (#2074), and rear view is
+ * the active rack's per-rack show_rear. Theme is an app preference and must not
+ * appear here.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import SidePanelContent from "$lib/components/SidePanelContent.svelte";
+import { resetLayoutStore, getLayoutStore } from "$lib/stores/layout.svelte";
+import { resetSelectionStore } from "$lib/stores/selection.svelte";
+import { resetUIStore, getUIStore } from "$lib/stores/ui.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+
+function renderViewTab() {
+  return render(SidePanelContent, {
+    props: { activeTab: "view", onTabChange: () => {} },
+  });
+}
+
+describe("View tab layout toggles (#2078)", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetUIStore();
+    resetToastStore();
+  });
+
+  it("is reachable with no selection and shows the view toggles", () => {
+    renderViewTab();
+
+    // The view toggles render regardless of selection (no empty state gate).
+    expect(
+      screen.getByRole("group", { name: /display mode/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: /annotations/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not duplicate the theme control (app preference, lives in Settings)", () => {
+    renderViewTab();
+
+    expect(
+      screen.queryByRole("switch", { name: /theme/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("changing display mode updates the shared store state", async () => {
+    const user = userEvent.setup();
+    const uiStore = getUIStore();
+    expect(uiStore.displayMode).toBe("label");
+
+    renderViewTab();
+
+    await user.click(screen.getByRole("button", { name: /^image$/i }));
+
+    expect(uiStore.displayMode).toBe("image");
+  });
+
+  it("display mode change persists to the layout settings", async () => {
+    const user = userEvent.setup();
+    const layoutStore = getLayoutStore();
+    layoutStore.addRack("Test Rack", 42);
+
+    renderViewTab();
+
+    await user.click(screen.getByRole("button", { name: /^image$/i }));
+
+    expect(layoutStore.layout.settings.display_mode).toBe("image");
+  });
+
+  it("toggling annotations updates the shared store state", async () => {
+    const user = userEvent.setup();
+    const uiStore = getUIStore();
+    expect(uiStore.showAnnotations).toBe(false);
+
+    renderViewTab();
+
+    await user.click(screen.getByRole("switch", { name: /annotations/i }));
+
+    expect(uiStore.showAnnotations).toBe(true);
+  });
+
+  it("rear view reflects and updates the active rack's show_rear", async () => {
+    const user = userEvent.setup();
+    const layoutStore = getLayoutStore();
+    const rack = layoutStore.addRack("Test Rack", 42);
+    layoutStore.setActiveRack(rack!.id);
+
+    renderViewTab();
+
+    // Default for a new rack is show_rear: true, so "Hide" turns it off.
+    await user.click(screen.getByRole("button", { name: /^hide$/i }));
+
+    expect(layoutStore.getRackById(rack!.id)?.show_rear).toBe(false);
+  });
+
+  it("rear view fans out to every rack in a bayed group", async () => {
+    const user = userEvent.setup();
+    const layoutStore = getLayoutStore();
+    const result = layoutStore.addBayedRackGroup("Bayed Group", 2, 42);
+    const group = result!.group;
+    layoutStore.setActiveRack(group.rack_ids[0]!);
+
+    renderViewTab();
+
+    await user.click(screen.getByRole("button", { name: /^hide$/i }));
+
+    for (const rackId of group.rack_ids) {
+      expect(layoutStore.getRackById(rackId)?.show_rear).toBe(false);
+    }
+  });
+
+  it("disables the rear view control when there is no active rack", () => {
+    renderViewTab();
+
+    // No racks exist after reset, so the active-rack-scoped control is disabled.
+    const showButton = screen.getByRole("button", { name: /^show$/i });
+    expect(showButton).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Fills the side panel's View tabpanel (previously a placeholder) with the layout-scoped view toggles. The View tab is always reachable regardless of selection, matching the spec's canonical-home model.

Toggles:
- Display mode (Label / Image / Image + Label)
- Annotations (show the annotation column)
- Rear view (Show / Hide for the active rack)

Theme stays an app preference behind the Settings gear and is deliberately not duplicated here.

## State reuse (no second source of truth)

These controls mirror existing store state rather than forking it:
- Display mode reuses `uiStore.displayMode` and the layout-settings persistence path (`layoutStore.updateDisplayMode` / `updateShowLabelsOnImages`), the same state as the canvas lens (#2074) and the palette toggle (#2094). The same wiring the mobile View sheet already uses (`DialogOrchestrator`).
- Annotations reuse `uiStore.showAnnotations` / `setAnnotations`.
- Rear view edits the active rack's per-rack `show_rear`; for a bayed group it fans out to every rack in the bay (row groups stay independent). When no rack exists the control is disabled.

No store shape changed, so the in-flight #2074 / #2094 work is unaffected.

## Implementation

- New `ViewControls.svelte` (the View tab body), composed by `SidePanelContent.svelte`. Keeps the tab content extractable, matching the EditPanel section pattern.
- `SegmentedControl.svelte` gains a `disabled` prop for the no-rack rear-view state. Default `false`, so existing callers are unchanged.
- Scope is limited to the View tabpanel and the small view-toggle component it composes. The Edit tab (#2077) and the rail chrome (#2076) are untouched. The transitional rear-view/annotation controls still in `EditPanelRack` are left in place for a follow-up; this slice does not remove them.

## Test Plan

- [x] `npm run lint` - clean
- [x] `npm run test:run` - 2406 passed (136 files), incl. 8 new View-tab tests
- [x] `npm run build` - succeeds
- [x] a11y guard rail: `axe.spec.ts` 9/9 pass, including "side panel View tab has no WCAG 2.2 AA violations"
- [x] No visual-regression baseline captures the side panel View tab, so no baselines change
- [x] Svelte MCP `svelte-autofixer` clean on all changed `.svelte` files

Closes #2078