### PR TITLE
feat: lazy tab restore on launch (#2080)

### DIFF
--- a/e2e/multi-context.spec.ts
+++ b/e2e/multi-context.spec.ts
@@ -18,23 +18,28 @@ import {
   readStorageJson,
   collectStorageEvents,
   snapshotStorage,
+  locators,
 } from "./helpers";
 
-const AUTOSAVE_KEY = "Rackula:autosave";
+// The browser multi-layout workspace index (#2080/#2179). The open-set lives
+// here; layout bodies live under Rackula:layout:<id>.
+const WORKSPACE_KEY = "Rackula:workspace";
 
 test.describe("multi-context harness", () => {
-  test("two tabs in one context share the autosave slot", async ({ page }) => {
-    // Tab A loads a rack; the app autosaves it to localStorage.
+  test("two tabs in one context share the workspace index", async ({
+    page,
+  }) => {
+    // Tab A loads a rack; the app autosaves the workspace to localStorage.
     await gotoWithRack(page);
     await expect
-      .poll(() => readStorageJson(page, AUTOSAVE_KEY))
+      .poll(() => readStorageJson(page, WORKSPACE_KEY))
       .not.toBeNull();
 
-    // Tab B opens in the same context and reads the same slot without loading
+    // Tab B opens in the same context and reads the same index without loading
     // a layout of its own, the shared-origin fact #2044's editor election needs.
     const tabB = await openSecondTab(page);
     await tabB.goto("/");
-    const sharedFromB = await readStorageJson(tabB, AUTOSAVE_KEY);
+    const sharedFromB = await readStorageJson(tabB, WORKSPACE_KEY);
     expect(sharedFromB).not.toBeNull();
   });
 
@@ -64,7 +69,7 @@ test.describe("multi-context harness", () => {
     // shape lazy restore (#2080) reads its open-tab set from at startup.
     await gotoWithRack(page);
     await expect
-      .poll(() => readStorageJson(page, AUTOSAVE_KEY))
+      .poll(() => readStorageJson(page, WORKSPACE_KEY))
       .not.toBeNull();
 
     const state = await snapshotStorage(page.context());
@@ -72,8 +77,35 @@ test.describe("multi-context harness", () => {
     try {
       const relaunched = await restoredContext.newPage();
       await relaunched.goto("/");
-      const restored = await readStorageJson(relaunched, AUTOSAVE_KEY);
+      const restored = await readStorageJson(relaunched, WORKSPACE_KEY);
       expect(restored).not.toBeNull();
+    } finally {
+      await restoredContext.close();
+    }
+  });
+
+  test("a cold relaunch restores the open layout to the canvas (#2080)", async ({
+    page,
+    browser,
+  }) => {
+    // Seed a workspace with an open rack, wait for the debounced workspace save
+    // to land its body, then snapshot.
+    await gotoWithRack(page);
+    await expect
+      .poll(() => readStorageJson(page, WORKSPACE_KEY))
+      .not.toBeNull();
+
+    const state = await snapshotStorage(page.context());
+    const restoredContext = await browser.newContext({ storageState: state });
+    try {
+      // A cold relaunch (new context, no live in-memory workspace) must restore
+      // the open tab from the index and hydrate it onto the canvas, not show the
+      // empty state.
+      const relaunched = await restoredContext.newPage();
+      await relaunched.goto("/");
+      await expect(
+        relaunched.locator(locators.rack.container).first(),
+      ).toBeVisible({ timeout: 15000 });
     } finally {
       await restoredContext.close();
     }

--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -97,18 +97,26 @@ test.describe("Persistence", () => {
       timeout: 5000,
     });
 
-    // Wait for the debounced session save (1s) to flush the placed device
-    // to localStorage, instead of sleeping for a fixed duration
+    // Wait for the debounced workspace save (1s) to flush the placed device to
+    // the browser multi-layout schema (#2080): the active layout body lives at
+    // Rackula:layout:<id>, the open set at Rackula:workspace. Poll for a body
+    // that has the placed device, instead of sleeping for a fixed duration.
     await page.waitForFunction(
       () => {
-        const raw = localStorage.getItem("Rackula:autosave");
-        if (!raw) return false;
+        const indexRaw = localStorage.getItem("Rackula:workspace");
+        if (!indexRaw) return false;
         try {
-          const session = JSON.parse(raw) as {
+          const index = JSON.parse(indexRaw) as { activeId?: string | null };
+          if (!index.activeId) return false;
+          const bodyRaw = localStorage.getItem(
+            `Rackula:layout:${index.activeId}`,
+          );
+          if (!bodyRaw) return false;
+          const body = JSON.parse(bodyRaw) as {
             layout?: { racks?: { devices?: unknown[] }[] };
           };
           return (
-            session.layout?.racks?.some(
+            body.layout?.racks?.some(
               (rack) => (rack.devices?.length ?? 0) > 0,
             ) ?? false
           );

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -306,7 +306,12 @@
       const launch = resolveBrowserLaunch();
       if (launch.action === "empty") {
         layoutStore.resetLayout();
-        maybeShowFirstRunNotice();
+        // First-run notice is for genuine fresh installs. A returning user whose
+        // workspace is empty (data lost or wiped) must not be told this is their
+        // first time here. #2095/#2018 own the lost-data recovery state.
+        if (!launch.everHadLayouts) {
+          maybeShowFirstRunNotice();
+        }
         return;
       }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -326,12 +326,12 @@
         maybeShowFirstRunNotice();
       }
 
+      // restoreWorkspace hydrates the active tab and restores its durability
+      // (dirty by autosave convention, not explicitly saved).
       workspaceStore.restoreWorkspace({
         index: launch.index,
         loadBody: launch.loadBody,
       });
-      // The active tab is dirty by autosave convention (not explicitly saved).
-      layoutStore.markDirty();
       requestAnimationFrame(() => {
         if (!canvasStore.restoreViewport()) {
           canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -43,6 +43,7 @@
     applyReconcile,
     uploadSnapshot,
     setServerBaseUpdatedAt,
+    resolveBrowserLaunch,
   } from "$lib/storage";
   import { serializeLayoutToYaml } from "$lib/utils/yaml";
   import {
@@ -294,21 +295,28 @@
       }
     }
 
-    // Get localStorage session data (with timestamp and stored mode if available)
-    const localSession = loadSessionWithTimestamp();
-
-    // Browser mode: no server compare. Restore the working copy if present,
-    // otherwise open straight to the canvas empty state. Surface a server->browser
-    // flip notice when the saved copy came from a server deployment (never silently
-    // degrade), else a one-time first-run notice. No offline toasts ever in browser
-    // mode. Entry actions (new/open/import) live in the sidebar and app menu.
+    // Browser mode: no server compare. Lazily restore the previously open tab
+    // set from the multi-layout workspace (#2080), hydrating the active tab now
+    // and the rest on first focus. With no persisted workspace, open straight to
+    // the canvas empty state. Surface a server->browser flip notice when the
+    // restored copy came from a server deployment (never silently degrade), else
+    // a one-time first-run notice. No offline toasts ever in browser mode. Entry
+    // actions (new/open/import) live in the sidebar and app menu.
     if (!serverMode) {
-      if (!localSession) {
+      const launch = resolveBrowserLaunch();
+      if (launch.action === "empty") {
         layoutStore.resetLayout();
         maybeShowFirstRunNotice();
         return;
       }
-      if (detectModeFlip(localSession.storageMode) === "server-to-browser") {
+
+      const activeEntry = launch.index.activeId
+        ? launch.index.library[launch.index.activeId]
+        : undefined;
+      if (
+        activeEntry &&
+        detectModeFlip(activeEntry.storageMode) === "server-to-browser"
+      ) {
         showStorageToast(
           "This deployment now stores layouts in your browser; your previous server library is not loaded here.",
           "warning",
@@ -317,11 +325,25 @@
       } else {
         maybeShowFirstRunNotice();
       }
-      restoreLocalSession(localSession);
+
+      workspaceStore.restoreWorkspace({
+        index: launch.index,
+        loadBody: launch.loadBody,
+      });
+      // The active tab is dirty by autosave convention (not explicitly saved).
+      layoutStore.markDirty();
+      requestAnimationFrame(() => {
+        if (!canvasStore.restoreViewport()) {
+          canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups);
+        }
+      });
       return;
     }
 
     // Server mode below.
+
+    // Get localStorage session data (with timestamp and stored mode if available)
+    const localSession = loadSessionWithTimestamp();
 
     // No local session: open straight to the canvas empty state. The server
     // library is reachable through the sidebar Layouts tab and the app menu;

--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -13,20 +13,93 @@
     getApiAvailableState,
     getStorageMode,
     shouldWarnBeforeUnload,
+    persistBrowserWorkspace,
+    type PersistTab,
   } from "$lib/storage";
   import { getImageStore } from "$lib/stores/images.svelte";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getUIStore } from "$lib/stores/ui.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
   import { setupKeyboardViewportAdaptation } from "$lib/utils/keyboard-viewport";
 
   const imageStore = getImageStore();
   const viewportStore = getViewportStore();
   const uiStore = getUIStore();
   const layoutStore = getLayoutStore();
+  const workspaceStore = getWorkspaceStore();
 
   // Register all persistence $effects (localStorage autosave, server autosave, health check)
   initPersistenceEffects();
+
+  // Browser-mode multi-layout persistence (#2080): debounced autosave of the
+  // open tab set and the active tab's body into the workspace schema (#2179).
+  // Server mode keeps its own working-copy + server autosave path untouched.
+  let workspaceSaveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function snapshotWorkspaceTabs(): {
+    tabs: PersistTab[];
+    activeLayoutId: string | null;
+  } {
+    const tabs: PersistTab[] = [];
+    let activeLayoutId: string | null = null;
+    for (const tab of workspaceStore.tabs) {
+      const layoutId = tab.layoutId ?? tab.store.layout.metadata?.id;
+      if (!layoutId) continue;
+      if (tab.id === workspaceStore.activeId) activeLayoutId = layoutId;
+      if (tab.hydrated) {
+        tabs.push({
+          layoutId,
+          hydrated: true,
+          layout: $state.snapshot(tab.store.layout),
+          changesSinceExport: tab.store.changesSinceExport,
+          hasEverExported: tab.store.hasEverExported,
+        });
+      } else {
+        tabs.push({
+          layoutId,
+          hydrated: false,
+          name: tab.store.layout.name,
+        });
+      }
+    }
+    return { tabs, activeLayoutId };
+  }
+
+  $effect(() => {
+    if (getStorageMode() === "server") return;
+    // Track the reactive surface: tab set, active id, and the active tab's
+    // layout (so edits to the focused layout trigger a save). Only the active
+    // tab is hydrated-and-editable; inactive bodies do not change in place.
+    const snapshot = snapshotWorkspaceTabs();
+    if (snapshot.tabs.length === 0) return;
+
+    if (workspaceSaveTimer) clearTimeout(workspaceSaveTimer);
+    workspaceSaveTimer = setTimeout(() => {
+      persistBrowserWorkspace(snapshot);
+      workspaceSaveTimer = null;
+    }, 1000);
+
+    return () => {
+      if (workspaceSaveTimer) {
+        clearTimeout(workspaceSaveTimer);
+        workspaceSaveTimer = null;
+      }
+    };
+  });
+
+  // Last-chance synchronous persist of the workspace on page hide, so an edit
+  // still inside the 1s debounce window survives a fast tab close. Browser mode
+  // only; server mode flushes through flushSessionSave.
+  function flushWorkspaceSave(): void {
+    if (getStorageMode() === "server") return;
+    if (workspaceSaveTimer) {
+      clearTimeout(workspaceSaveTimer);
+      workspaceSaveTimer = null;
+    }
+    const snapshot = snapshotWorkspaceTabs();
+    if (snapshot.tabs.length > 0) persistBrowserWorkspace(snapshot);
+  }
 
   onMount(() => {
     // Flush pending session save when page becomes hidden (tab close, navigate away)
@@ -34,6 +107,7 @@
     function handleVisibilityChange() {
       if (document.visibilityState === "hidden") {
         flushSessionSave();
+        flushWorkspaceSave();
       }
     }
     document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -42,6 +116,7 @@
     // (pagehide is bfcache-safe to keep attached, unlike beforeunload)
     function handlePageHide() {
       flushSessionSave();
+      flushWorkspaceSave();
     }
     window.addEventListener("pagehide", handlePageHide);
 

--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -66,13 +66,23 @@
     return { tabs, activeLayoutId };
   }
 
+  // Whether any open tab holds real content worth persisting. A pristine
+  // cold-start blank tab (no rack, never started) is skipped so a fresh install
+  // that never created anything does not leave a phantom workspace + a
+  // returning-user marker behind. A restored or edited layout has started.
+  function hasPersistableContent(): boolean {
+    return workspaceStore.tabs.some(
+      (tab) => !tab.hydrated || tab.store.hasStarted,
+    );
+  }
+
   $effect(() => {
     if (getStorageMode() === "server") return;
     // Track the reactive surface: tab set, active id, and the active tab's
     // layout (so edits to the focused layout trigger a save). Only the active
     // tab is hydrated-and-editable; inactive bodies do not change in place.
     const snapshot = snapshotWorkspaceTabs();
-    if (snapshot.tabs.length === 0) return;
+    if (snapshot.tabs.length === 0 || !hasPersistableContent()) return;
 
     if (workspaceSaveTimer) clearTimeout(workspaceSaveTimer);
     workspaceSaveTimer = setTimeout(() => {
@@ -98,7 +108,9 @@
       workspaceSaveTimer = null;
     }
     const snapshot = snapshotWorkspaceTabs();
-    if (snapshot.tabs.length > 0) persistBrowserWorkspace(snapshot);
+    if (snapshot.tabs.length > 0 && hasPersistableContent()) {
+      persistBrowserWorkspace(snapshot);
+    }
   }
 
   onMount(() => {

--- a/src/lib/storage/browser-launch.ts
+++ b/src/lib/storage/browser-launch.ts
@@ -1,0 +1,56 @@
+/**
+ * Browser-mode launch resolution (#2080).
+ *
+ * Decides what the app does on launch in browser mode by reading the persisted
+ * multi-layout workspace (#2179): adopt a legacy single autosave once, then
+ * either restore the open tab set lazily or open the empty state. The decision
+ * is a pure read over storage so it can be unit tested without mounting the app.
+ */
+
+import {
+  loadWorkspaceIndex,
+  adoptLegacyAutosave,
+  loadLayoutBody,
+  hasEverHadLayouts,
+  type WorkspaceIndex,
+  type LayoutBodyResult,
+} from "./browser-workspace";
+
+/**
+ * Restore the persisted open tab set. `index` is read synchronously to paint
+ * tab shells; `loadBody` is the lazy body reader handed to the workspace store.
+ */
+export interface RestoreLaunch {
+  action: "restore";
+  index: WorkspaceIndex;
+  loadBody: (id: string) => LayoutBodyResult;
+}
+
+/**
+ * Open the canvas empty state. `everHadLayouts` distinguishes a returning user
+ * whose data is gone (lost-data-empty) from a genuine fresh install
+ * (fresh-install-empty); the empty-state UI (#2095/#2018) reads this.
+ */
+export interface EmptyLaunch {
+  action: "empty";
+  everHadLayouts: boolean;
+}
+
+export type BrowserLaunch = RestoreLaunch | EmptyLaunch;
+
+/**
+ * Resolve the browser-mode launch action. Adopts a legacy autosave once when no
+ * workspace exists, then restores when there are open tabs, else opens empty.
+ */
+export function resolveBrowserLaunch(): BrowserLaunch {
+  // One-time migration off the legacy single slot. No-op when a workspace index
+  // already exists or there is nothing to adopt.
+  adoptLegacyAutosave();
+
+  const index = loadWorkspaceIndex();
+  if (index && index.openTabs.length > 0) {
+    return { action: "restore", index, loadBody: loadLayoutBody };
+  }
+
+  return { action: "empty", everHadLayouts: hasEverHadLayouts() };
+}

--- a/src/lib/storage/browser-workspace-persist.ts
+++ b/src/lib/storage/browser-workspace-persist.ts
@@ -1,0 +1,93 @@
+/**
+ * Browser-mode workspace persistence (#2080).
+ *
+ * Writes the current open tab set and the active tab's body into the
+ * multi-layout schema (#2179): the `Rackula:workspace` index records the
+ * ordered open set, the active id, and a per-layout library entry; each
+ * hydrated tab's body is written to `Rackula:layout:<id>`.
+ *
+ * Closing a tab is non-destructive: an id that leaves the open set keeps its
+ * library entry and body so it can be reopened from the sidebar (spike #2179).
+ * The library is the durable list, so entries are retained across persists, not
+ * pruned when a tab closes.
+ */
+
+import type { Layout } from "$lib/types";
+import {
+  loadWorkspaceIndex,
+  saveWorkspaceIndex,
+  saveLayoutBody,
+  markEverHadLayouts,
+  type LibraryEntry,
+} from "./browser-workspace";
+
+/** A tab snapshot for persistence. A shell has no layout body to write. */
+export type PersistTab =
+  | {
+      layoutId: string;
+      hydrated: true;
+      layout: Layout;
+      changesSinceExport: number;
+      hasEverExported: boolean;
+    }
+  | {
+      layoutId: string;
+      hydrated: false;
+      /** The shell's display name, kept in the library entry. */
+      name: string;
+    };
+
+export interface PersistWorkspaceArgs {
+  tabs: PersistTab[];
+  activeLayoutId: string | null;
+}
+
+/**
+ * Persist the current workspace. Idempotent: safe to call on every change.
+ */
+export function persistBrowserWorkspace(args: PersistWorkspaceArgs): void {
+  const { tabs, activeLayoutId } = args;
+
+  // Write each hydrated body first. saveLayoutBody also refreshes that layout's
+  // library entry in the index (updatedAt, durability); it returns false on
+  // quota, leaving the in-memory copy intact and surfacing the flag via the
+  // index. Shells have no body to write.
+  for (const tab of tabs) {
+    if (tab.hydrated) {
+      saveLayoutBody(tab.layoutId, tab.layout, {
+        changesSinceExport: tab.changesSinceExport,
+        hasEverExported: tab.hasEverExported,
+      });
+    }
+  }
+
+  // Re-read the index after the body writes so hydrated entries are current,
+  // then layer in shell entries (carrying the shell name so the tab still
+  // renders next launch) and the final open set.
+  const current = loadWorkspaceIndex();
+  const library: Record<string, LibraryEntry> = current
+    ? { ...current.library }
+    : {};
+
+  for (const tab of tabs) {
+    if (tab.hydrated) continue;
+    const previous = library[tab.layoutId];
+    library[tab.layoutId] = {
+      name: tab.name,
+      updatedAt: previous?.updatedAt ?? "",
+      changesSinceExport: previous?.changesSinceExport ?? 0,
+      hasEverExported: previous?.hasEverExported ?? false,
+      writeFailed: previous?.writeFailed ?? false,
+      storageMode: previous?.storageMode ?? "browser",
+    };
+  }
+
+  saveWorkspaceIndex({
+    schemaVersion: 2,
+    activeId: activeLayoutId,
+    openTabs: tabs.map((tab) => tab.layoutId),
+    library,
+  });
+
+  if (tabs.length > 0) markEverHadLayouts();
+}

--- a/src/lib/storage/browser-workspace.ts
+++ b/src/lib/storage/browser-workspace.ts
@@ -77,6 +77,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+/**
+ * Reject prototype-polluting layout ids. Stored ids are untrusted; using
+ * `__proto__`/`constructor`/`prototype` as an object key would corrupt
+ * Object.prototype, so they are never accepted as a layout id.
+ */
+function isSafeLayoutId(id: string): boolean {
+  return (
+    id !== "__proto__" && id !== "constructor" && id !== "prototype"
+  );
+}
+
 function coerceStorageMode(value: unknown): StorageMode {
   return value === "server" ? "server" : "browser";
 }
@@ -125,15 +136,20 @@ export function loadWorkspaceIndex(): WorkspaceIndex | null {
     return null;
   }
 
+  // Null-prototype map so a hostile stored key cannot reach Object.prototype.
   const rawLibrary = isRecord(parsed.library) ? parsed.library : {};
-  const library: Record<string, LibraryEntry> = {};
+  const library: Record<string, LibraryEntry> = Object.create(null);
   for (const [id, entry] of Object.entries(rawLibrary)) {
+    if (!isSafeLayoutId(id)) continue;
     library[id] = coerceLibraryEntry(entry, id);
   }
 
-  // Only open ids that resolve to a library entry; drop dangling references.
+  // Only open ids that resolve to a library entry; drop dangling/unsafe refs.
   const openTabs = parsed.openTabs.filter(
-    (id): id is string => typeof id === "string" && id in library,
+    (id): id is string =>
+      typeof id === "string" &&
+      isSafeLayoutId(id) &&
+      Object.prototype.hasOwnProperty.call(library, id),
   );
 
   let activeId =
@@ -200,6 +216,11 @@ export function saveLayoutBody(
   layout: Layout,
   durability: DurabilityInput,
 ): boolean {
+  // Reject a prototype-polluting id before it is used as an index key.
+  if (!isSafeLayoutId(id)) {
+    log("refusing to save layout body for unsafe id %s", id);
+    return false;
+  }
   const savedAt = new Date().toISOString();
   let serialized: string;
   try {
@@ -218,7 +239,7 @@ export function saveLayoutBody(
     schemaVersion: SCHEMA_VERSION,
     activeId: id,
     openTabs: [id],
-    library: {},
+    library: Object.create(null) as Record<string, LibraryEntry>,
   };
   const previous = index.library[id];
   index.library[id] = {
@@ -271,7 +292,9 @@ export function adoptLegacyAutosave(): WorkspaceIndex | null {
   const session = loadSessionWithTimestamp();
   if (!session) return null;
 
-  const id = session.layout.metadata?.id?.trim() || generateId();
+  const candidateId = session.layout.metadata?.id?.trim();
+  const id =
+    candidateId && isSafeLayoutId(candidateId) ? candidateId : generateId();
   const layout: Layout = {
     ...session.layout,
     metadata: { ...session.layout.metadata, id, name: session.layout.name },

--- a/src/lib/storage/browser-workspace.ts
+++ b/src/lib/storage/browser-workspace.ts
@@ -1,0 +1,309 @@
+/**
+ * Browser multi-layout storage (spike #2179).
+ *
+ * The browser-mode persistence schema for the workspace of open layout tabs:
+ *
+ * - `Rackula:workspace` - a small index read synchronously at launch to paint
+ *   tab shells before any body is parsed. Holds the ordered open set, the active
+ *   id, and a per-layout library map (name, durability) for the whole library.
+ * - `Rackula:layout:<id>` - one key per layout, holding the full Layout body
+ *   (the large part: base64 device images). Read lazily on tab focus.
+ * - `Rackula:everHadLayouts` - a standalone returning-user marker kept separate
+ *   so it survives a wipe of the index and can distinguish lost-data-empty from
+ *   fresh-install-empty.
+ *
+ * Everything read out of localStorage here is untrusted: the index and bodies
+ * are parsed defensively (malformed JSON, wrong shapes, and out-of-range values
+ * resolve to safe defaults or an unreadable marker rather than throwing). A bad
+ * body can never block startup; it surfaces on focus as the orphan/error state
+ * (#2018).
+ */
+
+import type { Layout } from "$lib/types";
+import {
+  safeGetItem,
+  safeSetItem,
+  safeRemoveItem,
+} from "$lib/utils/safe-storage";
+import { generateId } from "$lib/utils/device";
+import { sessionDebug } from "$lib/utils/debug";
+import { migrateLayout } from "./migrate-layout";
+import { loadSessionWithTimestamp } from "./working-copy";
+import { type StorageMode } from "./availability.svelte";
+
+const log = sessionDebug.storage;
+
+const WORKSPACE_KEY = "Rackula:workspace";
+const EVER_KEY = "Rackula:everHadLayouts";
+const AUTOSAVE_KEY = "Rackula:autosave";
+const SCHEMA_VERSION = 2;
+
+const layoutBodyKey = (id: string) => `Rackula:layout:${id}`;
+
+/** Per-layout durability and naming, stored in the index (no body). */
+export interface LibraryEntry {
+  name: string;
+  updatedAt: string;
+  changesSinceExport: number;
+  hasEverExported: boolean;
+  writeFailed: boolean;
+  storageMode: StorageMode;
+}
+
+/** The workspace index: open set plus the durable library map. */
+export interface WorkspaceIndex {
+  schemaVersion: number;
+  /** Active tab's layout id, or null for an empty workspace. */
+  activeId: string | null;
+  /** Ordered open set (the session working set); a subset of library. */
+  openTabs: string[];
+  /** Every layout that exists, keyed by id. */
+  library: Record<string, LibraryEntry>;
+}
+
+/** Result of reading a layout body: the migrated layout, or unreadable. */
+export type LayoutBodyResult =
+  | { ok: true; layout: Layout }
+  | { ok: false };
+
+/** Durability fields a caller can update without rewriting the body. */
+export interface DurabilityInput {
+  changesSinceExport: number;
+  hasEverExported?: boolean;
+  writeFailed?: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function coerceStorageMode(value: unknown): StorageMode {
+  return value === "server" ? "server" : "browser";
+}
+
+/** Coerce an untrusted library entry into a complete, safe LibraryEntry. */
+function coerceLibraryEntry(value: unknown, fallbackName: string): LibraryEntry {
+  const obj = isRecord(value) ? value : {};
+  const changes = obj.changesSinceExport;
+  return {
+    name: typeof obj.name === "string" ? obj.name : fallbackName,
+    updatedAt: typeof obj.updatedAt === "string" ? obj.updatedAt : "",
+    changesSinceExport:
+      typeof changes === "number" && Number.isFinite(changes) && changes >= 0
+        ? changes
+        : 0,
+    hasEverExported: obj.hasEverExported === true,
+    writeFailed: obj.writeFailed === true,
+    storageMode: coerceStorageMode(obj.storageMode),
+  };
+}
+
+/**
+ * Read and validate the workspace index. Returns null when absent, unparseable,
+ * or structurally invalid (a wrong shape is treated as no workspace rather than
+ * crashing launch). openTabs is filtered to ids that have a library entry, and
+ * activeId is repaired to an open tab so a stale pointer cannot dangle.
+ */
+export function loadWorkspaceIndex(): WorkspaceIndex | null {
+  const serialized = safeGetItem(WORKSPACE_KEY);
+  if (!serialized) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch (error) {
+    log("invalid workspace index JSON: %O", error);
+    return null;
+  }
+
+  if (!isRecord(parsed)) {
+    log("workspace index is not an object");
+    return null;
+  }
+  if (!Array.isArray(parsed.openTabs)) {
+    log("workspace index openTabs is not an array");
+    return null;
+  }
+
+  const rawLibrary = isRecord(parsed.library) ? parsed.library : {};
+  const library: Record<string, LibraryEntry> = {};
+  for (const [id, entry] of Object.entries(rawLibrary)) {
+    library[id] = coerceLibraryEntry(entry, id);
+  }
+
+  // Only open ids that resolve to a library entry; drop dangling references.
+  const openTabs = parsed.openTabs.filter(
+    (id): id is string => typeof id === "string" && id in library,
+  );
+
+  let activeId =
+    typeof parsed.activeId === "string" ? parsed.activeId : null;
+  if (activeId === null || !openTabs.includes(activeId)) {
+    activeId = openTabs[0] ?? null;
+  }
+
+  return {
+    schemaVersion:
+      typeof parsed.schemaVersion === "number"
+        ? parsed.schemaVersion
+        : SCHEMA_VERSION,
+    activeId,
+    openTabs,
+    library,
+  };
+}
+
+/** Persist the workspace index. Returns false on quota or storage failure. */
+export function saveWorkspaceIndex(index: WorkspaceIndex): boolean {
+  try {
+    return safeSetItem(WORKSPACE_KEY, JSON.stringify(index));
+  } catch (error) {
+    log("failed to serialize workspace index: %O", error);
+    return false;
+  }
+}
+
+/**
+ * Read a layout body lazily by id, running the shared migrateLayout. A missing
+ * or unreadable body returns { ok: false } (the #2018 on-focus orphan state)
+ * rather than throwing, so one bad layout cannot take down the workspace.
+ */
+export function loadLayoutBody(id: string): LayoutBodyResult {
+  const serialized = safeGetItem(layoutBodyKey(id));
+  if (!serialized) return { ok: false };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch (error) {
+    log("invalid layout body JSON for %s: %O", id, error);
+    return { ok: false };
+  }
+
+  if (!isRecord(parsed) || !isRecord(parsed.layout)) {
+    log("layout body for %s has no layout object", id);
+    return { ok: false };
+  }
+
+  const layout = migrateLayout(parsed.layout as Record<string, unknown>);
+  if (!layout) return { ok: false };
+  return { ok: true, layout };
+}
+
+/**
+ * Write a layout body and update its index entry (updatedAt, durability).
+ * Returns false when the body write fails (quota or storage unavailable); the
+ * caller keeps the in-memory copy and surfaces the failure (quota strategy).
+ */
+export function saveLayoutBody(
+  id: string,
+  layout: Layout,
+  durability: DurabilityInput,
+): boolean {
+  const savedAt = new Date().toISOString();
+  let serialized: string;
+  try {
+    serialized = JSON.stringify({
+      schemaVersion: SCHEMA_VERSION,
+      layout,
+      savedAt,
+    });
+  } catch (error) {
+    log("failed to serialize layout body for %s: %O", id, error);
+    return false;
+  }
+
+  const wrote = safeSetItem(layoutBodyKey(id), serialized);
+  const index = loadWorkspaceIndex() ?? {
+    schemaVersion: SCHEMA_VERSION,
+    activeId: id,
+    openTabs: [id],
+    library: {},
+  };
+  const previous = index.library[id];
+  index.library[id] = {
+    name: layout.name,
+    updatedAt: savedAt,
+    changesSinceExport: durability.changesSinceExport,
+    hasEverExported:
+      durability.hasEverExported ?? previous?.hasEverExported ?? false,
+    writeFailed: durability.writeFailed ?? !wrote,
+    storageMode: previous?.storageMode ?? "browser",
+  };
+  if (!index.openTabs.includes(id)) index.openTabs.push(id);
+  saveWorkspaceIndex(index);
+
+  return wrote;
+}
+
+/** Remove a layout body and drop its library entry. Open set is left to the caller. */
+export function deleteLayoutBody(id: string): void {
+  safeRemoveItem(layoutBodyKey(id));
+  const index = loadWorkspaceIndex();
+  if (!index) return;
+  delete index.library[id];
+  saveWorkspaceIndex(index);
+}
+
+/** Whether any layout has ever existed in this browser (returning-user marker). */
+export function hasEverHadLayouts(): boolean {
+  return safeGetItem(EVER_KEY) === "1";
+}
+
+/** Set the returning-user marker. Never cleared once set. */
+export function markEverHadLayouts(): void {
+  safeSetItem(EVER_KEY, "1");
+}
+
+/**
+ * One-time adoption of the legacy single `Rackula:autosave` slot into the
+ * multi-layout schema. Runs only when no workspace index exists yet and an
+ * autosave is present. The legacy slot is removed only after both the body and
+ * the index writes land; a failed write keeps the durable fallback so the only
+ * copy is never lost, and the next launch retries cleanly.
+ *
+ * @returns the adopted index, or null when there was nothing to adopt or the
+ *   migration could not complete.
+ */
+export function adoptLegacyAutosave(): WorkspaceIndex | null {
+  if (loadWorkspaceIndex() !== null) return null;
+
+  const session = loadSessionWithTimestamp();
+  if (!session) return null;
+
+  const id = session.layout.metadata?.id?.trim() || generateId();
+  const layout: Layout = {
+    ...session.layout,
+    metadata: { ...session.layout.metadata, id, name: session.layout.name },
+  };
+
+  const wroteBody = saveLayoutBody(id, layout, {
+    changesSinceExport: session.changesSinceExport,
+    hasEverExported: session.hasEverExported,
+  });
+  if (!wroteBody) {
+    // Never delete the only copy on a failed migration; leave the autosave and
+    // any partial index for a clean retry next launch.
+    safeRemoveItem(WORKSPACE_KEY);
+    safeRemoveItem(layoutBodyKey(id));
+    return null;
+  }
+
+  const index = loadWorkspaceIndex();
+  if (!index) return null;
+  index.activeId = id;
+  index.openTabs = [id];
+  index.library[id] = {
+    name: layout.name,
+    updatedAt: session.savedAt ?? new Date().toISOString(),
+    changesSinceExport: session.changesSinceExport,
+    hasEverExported: session.hasEverExported,
+    writeFailed: false,
+    storageMode: session.storageMode,
+  };
+  if (!saveWorkspaceIndex(index)) return null;
+
+  markEverHadLayouts();
+  safeRemoveItem(AUTOSAVE_KEY);
+  return index;
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -65,3 +65,24 @@ export {
   type DurabilityStatus,
   type LayoutDurability,
 } from "./durability.svelte";
+export {
+  loadWorkspaceIndex,
+  saveWorkspaceIndex,
+  loadLayoutBody,
+  saveLayoutBody,
+  deleteLayoutBody,
+  hasEverHadLayouts,
+  markEverHadLayouts,
+  adoptLegacyAutosave,
+  type WorkspaceIndex,
+  type LibraryEntry,
+  type LayoutBodyResult,
+} from "./browser-workspace";
+export {
+  resolveBrowserLaunch,
+  type BrowserLaunch,
+} from "./browser-launch";
+export {
+  persistBrowserWorkspace,
+  type PersistTab,
+} from "./browser-workspace-persist";

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -521,11 +521,16 @@ export function flushSessionSave(): void {
 export function initPersistenceEffects(): void {
   const layoutStore = getLayoutStore();
 
-  // Effect 1: Auto-save layout to localStorage with debouncing
+  // Effect 1: Auto-save layout to the legacy single-slot working copy
+  // (Rackula:autosave) with debouncing. This is the server-mode offline
+  // continuity copy. In browser mode the multi-layout workspace schema (#2179,
+  // wired in PersistenceEffects) owns persistence, and the legacy slot is
+  // consumed once by adoption (#2080), so this effect is server-mode only.
   // Guard: skip clearing on initial run to avoid wiping saved session
   // before App.onMount can restore it (race condition fix)
   let hasEverHadRack = false;
   $effect(() => {
+    if (getStorageMode() === "browser") return;
     const currentLayout = layoutStore.layout;
     if (layoutStore.hasRack) {
       hasEverHadRack = true;

--- a/src/lib/storage/migrate-layout.ts
+++ b/src/lib/storage/migrate-layout.ts
@@ -1,0 +1,82 @@
+import type { Layout } from "$lib/types";
+import { UNITS_PER_U } from "$lib/types/constants";
+import { sessionDebug } from "$lib/utils/debug";
+
+const log = sessionDebug.storage;
+
+/**
+ * Compare semver versions (simplified).
+ * Handles pre-release suffixes like -dev, -alpha.1, etc.
+ * @returns -1 if a < b, 0 if a === b, 1 if a > b
+ */
+function compareVersions(a: string, b: string): number {
+  // Strip pre-release (-dev, -alpha.1, etc.) and build metadata (+build)
+  const stripSuffix = (v: string) => v.split(/[-+]/)[0] ?? v;
+  const cleanA = stripSuffix(a.trim());
+  const cleanB = stripSuffix(b.trim());
+
+  const partsA = cleanA.split(".").map((p) => parseInt(p) || 0);
+  const partsB = cleanB.split(".").map((p) => parseInt(p) || 0);
+
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const partA = partsA[i] ?? 0;
+    const partB = partsB[i] ?? 0;
+    if (partA < partB) return -1;
+    if (partA > partB) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Migrate legacy layout formats to current schema.
+ * Handles:
+ * - v0.6.x: rack (single) → racks[] (array)
+ * - v0.6.x: position in U-values → internal units (×UNITS_PER_U)
+ *
+ * Shared by the legacy single-slot working copy and the multi-layout browser
+ * store so every persisted body is normalised through one code path.
+ *
+ * @param raw - Raw parsed JSON object from localStorage
+ * @returns Migrated Layout object, or null if migration fails
+ */
+export function migrateLayout(raw: Record<string, unknown>): Layout | null {
+  try {
+    // Migration 1: rack → racks
+    if ("rack" in raw && !("racks" in raw)) {
+      const rack = raw.rack;
+      // Validate rack is a proper object before migrating
+      if (rack !== null && typeof rack === "object" && !Array.isArray(rack)) {
+        raw.racks = [rack as Record<string, unknown>];
+        delete raw.rack;
+      }
+    }
+
+    // Migration 2: Position units (U-values → internal units)
+    // Layouts before 0.7.0 used U-values (1, 2, 3...)
+    // New format uses internal units (6, 12, 18...) where 1U = UNITS_PER_U units
+    const version = (raw.version as string) || "0.0.0";
+    const needsPositionMigration = compareVersions(version, "0.7.0") < 0;
+
+    if (needsPositionMigration && Array.isArray(raw.racks)) {
+      for (const rack of raw.racks as Record<string, unknown>[]) {
+        if (Array.isArray(rack.devices)) {
+          for (const device of rack.devices as Record<string, unknown>[]) {
+            // Only migrate rack-level devices (not container children)
+            // Container children have container_id set and use 0-indexed positions
+            if (
+              device.container_id === undefined &&
+              typeof device.position === "number"
+            ) {
+              device.position = Math.round(device.position * UNITS_PER_U);
+            }
+          }
+        }
+      }
+    }
+
+    return raw as unknown as Layout;
+  } catch (error) {
+    log("migration failed: %O", error);
+    return null;
+  }
+}

--- a/src/lib/storage/migrate-layout.ts
+++ b/src/lib/storage/migrate-layout.ts
@@ -1,5 +1,6 @@
 import type { Layout } from "$lib/types";
 import { UNITS_PER_U } from "$lib/types/constants";
+import { VERSION } from "$lib/version";
 import { sessionDebug } from "$lib/utils/debug";
 
 const log = sessionDebug.storage;
@@ -57,6 +58,7 @@ export function migrateLayout(raw: Record<string, unknown>): Layout | null {
     const version = (raw.version as string) || "0.0.0";
     const needsPositionMigration = compareVersions(version, "0.7.0") < 0;
 
+    let migratedAnyPosition = false;
     if (needsPositionMigration && Array.isArray(raw.racks)) {
       for (const rack of raw.racks as Record<string, unknown>[]) {
         if (Array.isArray(rack.devices)) {
@@ -68,10 +70,20 @@ export function migrateLayout(raw: Record<string, unknown>): Layout | null {
               typeof device.position === "number"
             ) {
               device.position = Math.round(device.position * UNITS_PER_U);
+              migratedAnyPosition = true;
             }
           }
         }
       }
+    }
+
+    // Stamp the current version once a position migration actually rescaled a
+    // device, so re-running migrateLayout is idempotent. The multi-layout store
+    // re-reads and re-migrates a body on every lazy load, so without this a
+    // pre-0.7.0 position migration would re-apply each time and inflate
+    // positions repeatedly. Layouts with nothing to rescale are left untouched.
+    if (migratedAnyPosition) {
+      raw.version = VERSION;
     }
 
     return raw as unknown as Layout;

--- a/src/lib/storage/working-copy.ts
+++ b/src/lib/storage/working-copy.ts
@@ -1,6 +1,5 @@
 import type { Layout } from "$lib/types";
 import type { BackupState } from "$lib/stores/layout.svelte";
-import { UNITS_PER_U } from "$lib/types/constants";
 import {
   safeGetItem,
   safeSetItem,
@@ -8,6 +7,7 @@ import {
 } from "$lib/utils/safe-storage";
 import { sessionDebug } from "$lib/utils/debug";
 import { getStorageMode, type StorageMode } from "./availability.svelte";
+import { migrateLayout } from "./migrate-layout";
 
 const log = sessionDebug.storage;
 const STORAGE_KEY = "Rackula:autosave";
@@ -36,80 +36,6 @@ export interface SessionLoadResult {
   hasEverExported: boolean;
   /** Storage mode the copy was saved under (defaults to "browser" if missing) */
   storageMode: StorageMode;
-}
-
-/**
- * Compare semver versions (simplified).
- * Handles pre-release suffixes like -dev, -alpha.1, etc.
- * @returns -1 if a < b, 0 if a === b, 1 if a > b
- */
-function compareVersions(a: string, b: string): number {
-  // Strip pre-release (-dev, -alpha.1, etc.) and build metadata (+build)
-  const stripSuffix = (v: string) => v.split(/[-+]/)[0] ?? v;
-  const cleanA = stripSuffix(a.trim());
-  const cleanB = stripSuffix(b.trim());
-
-  const partsA = cleanA.split(".").map((p) => parseInt(p) || 0);
-  const partsB = cleanB.split(".").map((p) => parseInt(p) || 0);
-
-  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-    const partA = partsA[i] ?? 0;
-    const partB = partsB[i] ?? 0;
-    if (partA < partB) return -1;
-    if (partA > partB) return 1;
-  }
-  return 0;
-}
-
-/**
- * Migrate legacy layout formats to current schema.
- * Handles:
- * - v0.6.x: rack (single) → racks[] (array)
- * - v0.6.x: position in U-values → internal units (×UNITS_PER_U)
- *
- * @param raw - Raw parsed JSON object from localStorage
- * @returns Migrated Layout object, or null if migration fails
- */
-function migrateLayout(raw: Record<string, unknown>): Layout | null {
-  try {
-    // Migration 1: rack → racks
-    if ("rack" in raw && !("racks" in raw)) {
-      const rack = raw.rack;
-      // Validate rack is a proper object before migrating
-      if (rack !== null && typeof rack === "object" && !Array.isArray(rack)) {
-        raw.racks = [rack as Record<string, unknown>];
-        delete raw.rack;
-      }
-    }
-
-    // Migration 2: Position units (U-values → internal units)
-    // Layouts before 0.7.0 used U-values (1, 2, 3...)
-    // New format uses internal units (6, 12, 18...) where 1U = UNITS_PER_U units
-    const version = (raw.version as string) || "0.0.0";
-    const needsPositionMigration = compareVersions(version, "0.7.0") < 0;
-
-    if (needsPositionMigration && Array.isArray(raw.racks)) {
-      for (const rack of raw.racks as Record<string, unknown>[]) {
-        if (Array.isArray(rack.devices)) {
-          for (const device of rack.devices as Record<string, unknown>[]) {
-            // Only migrate rack-level devices (not container children)
-            // Container children have container_id set and use 0-indexed positions
-            if (
-              device.container_id === undefined &&
-              typeof device.position === "number"
-            ) {
-              device.position = Math.round(device.position * UNITS_PER_U);
-            }
-          }
-        }
-      }
-    }
-
-    return raw as unknown as Layout;
-  } catch (error) {
-    log("migration failed: %O", error);
-    return null;
-  }
 }
 
 /**

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -411,8 +411,11 @@ export function createLayoutStore(
     createNewLayoutImpl(stateAccess, name);
   }
 
-  function loadLayout(layoutData: Layout): void {
-    loadLayoutImpl(stateAccess, layoutData);
+  function loadLayout(
+    layoutData: Layout,
+    reservedDeviceIds?: ReadonlySet<string>,
+  ): void {
+    loadLayoutImpl(stateAccess, layoutData, reservedDeviceIds);
   }
 
   // =============================================================================

--- a/src/lib/stores/layout/layout-lifecycle.ts
+++ b/src/lib/stores/layout/layout-lifecycle.ts
@@ -26,8 +26,16 @@ export function createNewLayout(ctx: LayoutStateAccess, name: string): void {
  * Preserves all racks in the layout (multi-rack support)
  * Defensively assigns IDs and positions to support older layouts
  * @param layoutData - Layout to load
+ * @param reservedDeviceIds - Device ids already live in other open tabs. The
+ *   per-rack dedup is seeded with these so a restored layout reusing an id live
+ *   elsewhere is regenerated, never aliasing the global image store's
+ *   placement-<deviceId> keys across tabs (spike #2182).
  */
-export function loadLayout(ctx: LayoutStateAccess, layoutData: Layout): void {
+export function loadLayout(
+  ctx: LayoutStateAccess,
+  layoutData: Layout,
+  reservedDeviceIds?: ReadonlySet<string>,
+): void {
   // Ensures metadata with UUID exists for persistence
   const metadata = layoutData.metadata
     ? { ...layoutData.metadata }
@@ -42,6 +50,11 @@ export function loadLayout(ctx: LayoutStateAccess, layoutData: Layout): void {
   // per-rack, matching the existing behaviour (#1363).
   const seenRackIds = new Set<string>();
   const rackIdRemap = new Map<string, string>();
+
+  // Cross-tab reservation: ids live in other open tabs. Minted ids are added
+  // here so a multi-rack restore stays unique against both the rest of the
+  // layout and every other open tab (#2182).
+  const reserved = new Set<string>(reservedDeviceIds ?? []);
 
   const racksFirstPass = layoutData.racks.map((r, index) => {
     const originalRackId = r.id;
@@ -66,14 +79,17 @@ export function loadLayout(ctx: LayoutStateAccess, layoutData: Layout): void {
     const devices = r.devices.map((d) => {
       const originalId = d.id;
       let nextId = originalId;
-      if (!nextId || seenDeviceIds.has(nextId)) {
-        nextId = generateUniqueDeviceId(seenDeviceIds);
+      // A collision is a duplicate within this rack OR an id reserved by another
+      // open tab. Regenerate against both sets so the new id is globally unique.
+      if (!nextId || seenDeviceIds.has(nextId) || reserved.has(nextId)) {
+        nextId = generateUniqueDeviceId(seenDeviceIds, reserved);
         if (originalId) {
           deviceIdRemap.set(originalId, nextId);
         }
       } else {
         seenDeviceIds.add(nextId);
       }
+      reserved.add(nextId);
       return nextId === originalId ? d : { ...d, id: nextId };
     });
 

--- a/src/lib/stores/layout/mutators.ts
+++ b/src/lib/stores/layout/mutators.ts
@@ -29,11 +29,16 @@ import { getTargetRack } from "./rack-actions";
 // =============================================================================
 
 /**
- * Generate a unique device ID that doesn't collide with the given set (#1363)
+ * Generate a unique device ID that collides with neither the given set (#1363)
+ * nor an optional reserved set (ids live in other open tabs, #2182). The new id
+ * is added to `seen`; the caller owns adding it to `reserved` if needed.
  */
-export function generateUniqueDeviceId(seen: Set<string>): string {
+export function generateUniqueDeviceId(
+  seen: Set<string>,
+  reserved?: ReadonlySet<string>,
+): string {
   let id = generateId();
-  while (seen.has(id)) id = generateId();
+  while (seen.has(id) || reserved?.has(id)) id = generateId();
   seen.add(id);
   return id;
 }

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -61,11 +61,18 @@ export type RestoreBodyResult =
   | { ok: true; layout: Layout }
   | { ok: false };
 
+/** Per-layout fields lazy restore reads from the index library. */
+export interface RestoreLibraryEntry {
+  name: string;
+  changesSinceExport: number;
+  hasEverExported: boolean;
+}
+
 /** The minimal index shape lazy restore needs (from spike #2179). */
 export interface RestoreIndex {
   activeId: string | null;
   openTabs: string[];
-  library: Record<string, { name: string }>;
+  library: Record<string, RestoreLibraryEntry>;
 }
 
 /** Inputs for restoring a workspace from the persisted browser index. */
@@ -126,6 +133,10 @@ export function createWorkspaceStore() {
   // The body loader injected by restoreWorkspace, used for lazy hydration on
   // first focus of a restored shell tab. Null until a restore has run.
   let loadBodyFn: ((id: string) => RestoreBodyResult) | null = null;
+  // Per-layout durability from the restored index, applied on hydration so the
+  // chip and tab dots reflect true backup state (not reset to zero by the body
+  // load). Keyed by persisted layout id.
+  let restoreLibrary: Record<string, RestoreLibraryEntry> = {};
 
   const activeTab = $derived(
     tabs.find((t) => t.id === activeId) ?? tabs[0]!,
@@ -176,6 +187,19 @@ export function createWorkspaceStore() {
       return;
     }
     tab.store.loadLayout(result.layout, deviceIdsInOtherTabs(tab.id));
+    // loadLayout resets backup tracking. An autosaved restore is not explicitly
+    // saved, so it is dirty; restore the persisted durability so the chip and tab
+    // dot reflect true backup state. markDirty first (sets isDirty and bumps the
+    // counter), then restoreBackupState overwrites the counter with the persisted
+    // value, matching the single-session restore path.
+    const entry = tab.layoutId ? restoreLibrary[tab.layoutId] : undefined;
+    if (entry) {
+      tab.store.markDirty();
+      tab.store.restoreBackupState({
+        changesSinceExport: entry.changesSinceExport,
+        hasEverExported: entry.hasEverExported,
+      });
+    }
     tab.hydrated = true;
     tab.unreadable = false;
   }
@@ -273,6 +297,7 @@ export function createWorkspaceStore() {
     if (openIds.length === 0) return;
 
     loadBodyFn = loadBody;
+    restoreLibrary = index.library;
 
     // A placeholder layout carries the persisted name so the tab shell renders
     // before its body is read. metadata.id holds the persisted id so a later

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -29,6 +29,7 @@ import {
   createHistoryStore,
   getHistoryStore,
 } from "./history.svelte";
+import { createLayout } from "$lib/utils/serialization";
 
 /** A single open tab: a stable id plus the layout store backing it. */
 export interface WorkspaceTab {
@@ -36,6 +37,42 @@ export interface WorkspaceTab {
   id: string;
   /** The layout store instance backing this tab (owns its own history). */
   store: LayoutStore;
+  /**
+   * The persisted layout id this tab restores from, when it came from the
+   * browser-mode workspace index. Undefined for tabs created in-session.
+   */
+  layoutId?: string;
+  /**
+   * Whether the tab's real body has been loaded. A lazily-restored tab starts
+   * false (a named placeholder shell) and flips true on first focus. Tabs
+   * created in-session are hydrated from the start.
+   */
+  hydrated: boolean;
+  /**
+   * Set when a restore tab's persisted body could not be read on focus. The tab
+   * stays in place (never silently vanishes); the interaction layer renders the
+   * orphan/error state with Retry/Remove (#2018).
+   */
+  unreadable: boolean;
+}
+
+/** Result of reading a persisted layout body during lazy restore. */
+export type RestoreBodyResult =
+  | { ok: true; layout: Layout }
+  | { ok: false };
+
+/** The minimal index shape lazy restore needs (from spike #2179). */
+export interface RestoreIndex {
+  activeId: string | null;
+  openTabs: string[];
+  library: Record<string, { name: string }>;
+}
+
+/** Inputs for restoring a workspace from the persisted browser index. */
+export interface RestoreWorkspaceArgs {
+  index: RestoreIndex;
+  /** Reads a persisted layout body by id (lazy, injected for testability). */
+  loadBody: (id: string) => RestoreBodyResult;
 }
 
 let tabIdCounter = 0;
@@ -60,12 +97,35 @@ export function createWorkspaceStore() {
     // state_unsafe_mutation. Cold start has empty history anyway. The paths that
     // REPLACE an existing tab with a fresh one (closeLastTab, reset) clear the
     // singleton explicitly, outside any reactive context.
-    return { id: nextTabId(), store: createLayoutStore(getHistoryStore()) };
+    return {
+      id: nextTabId(),
+      store: createLayoutStore(getHistoryStore()),
+      hydrated: true,
+      unreadable: false,
+    };
+  }
+
+  /** Collect device ids live in every tab except the one being hydrated. */
+  function deviceIdsInOtherTabs(exceptTabId: string): Set<string> {
+    // Transient local, built and consumed synchronously; never reactive state.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const ids = new Set<string>();
+    for (const tab of tabs) {
+      if (tab.id === exceptTabId || !tab.hydrated) continue;
+      for (const rack of tab.store.racks) {
+        for (const device of rack.devices) ids.add(device.id);
+      }
+    }
+    return ids;
   }
 
   const firstTab = createInitialTab();
   let tabs = $state<WorkspaceTab[]>([firstTab]);
   let activeId = $state<string>(firstTab.id);
+
+  // The body loader injected by restoreWorkspace, used for lazy hydration on
+  // first focus of a restored shell tab. Null until a restore has run.
+  let loadBodyFn: ((id: string) => RestoreBodyResult) | null = null;
 
   const activeTab = $derived(
     tabs.find((t) => t.id === activeId) ?? tabs[0]!,
@@ -86,22 +146,49 @@ export function createWorkspaceStore() {
     const tab: WorkspaceTab = {
       id: nextTabId(),
       store: createLayoutStore(createHistoryStore()),
+      hydrated: true,
+      unreadable: false,
     };
     tabs = [...tabs, tab];
     activeId = tab.id;
     if (layout) {
       // loadLayout already clears this instance's history (clear-then-load).
-      tab.store.loadLayout(layout);
+      // Reserve ids live in other open tabs so an opened copy never aliases the
+      // global image store's placement-<deviceId> keys (#2182).
+      tab.store.loadLayout(layout, deviceIdsInOtherTabs(tab.id));
     }
     return tab.id;
   }
 
   /**
-   * Focus a tab. Pure focus change: no history mutation on either the outgoing
-   * or incoming tab, so each tab's undo/redo stacks survive a round trip.
+   * Hydrate a lazily-restored tab from its persisted body, once. Routes through
+   * the same clear-then-load primitive as file open (empty history), and
+   * regenerates device ids against the live cross-tab set so a restored copy of
+   * an already-open layout cannot collide (#2182). An unreadable body leaves the
+   * tab in place flagged `unreadable` for the #2018 orphan/error state.
+   */
+  function hydrateTab(tab: WorkspaceTab): void {
+    if (tab.hydrated || !tab.layoutId || !loadBodyFn) return;
+    const result = loadBodyFn(tab.layoutId);
+    if (!result.ok) {
+      tab.unreadable = true;
+      tab.hydrated = true; // Resolved (to an error); do not retry on every focus.
+      return;
+    }
+    tab.store.loadLayout(result.layout, deviceIdsInOtherTabs(tab.id));
+    tab.hydrated = true;
+    tab.unreadable = false;
+  }
+
+  /**
+   * Focus a tab. Pure focus change for the outgoing tab (no history mutation).
+   * If the incoming tab is an unhydrated restore shell, its body is loaded lazily
+   * on this first focus.
    */
   function switchTo(id: string): void {
-    if (!getTab(id)) return;
+    const tab = getTab(id);
+    if (!tab) return;
+    if (!tab.hydrated) hydrateTab(tab);
     activeId = id;
   }
 
@@ -167,7 +254,49 @@ export function createWorkspaceStore() {
     const tab = getTab(id);
     if (!tab) return;
     // loadLayout clears history as part of the content swap (#2079).
-    tab.store.loadLayout(layout);
+    tab.store.loadLayout(layout, deviceIdsInOtherTabs(id));
+  }
+
+  /**
+   * Restore the workspace from the persisted browser-mode index (#2080). Builds
+   * one tab per open id in order, each carrying its persisted name as a shell.
+   * The active tab is hydrated eagerly (its body loaded now); the rest stay
+   * shells and hydrate lazily on first focus. Replaces the cold-start single
+   * blank tab. No-op when there are no open tabs.
+   */
+  function restoreWorkspace(args: RestoreWorkspaceArgs): void {
+    const { index, loadBody } = args;
+    const openIds = index.openTabs.filter((id) => id in index.library);
+    if (openIds.length === 0) return;
+
+    loadBodyFn = loadBody;
+
+    // A placeholder layout carries the persisted name so the tab shell renders
+    // before its body is read. metadata.id holds the persisted id so a later
+    // body load keeps the same identity.
+    const restored: WorkspaceTab[] = openIds.map((layoutId) => {
+      const name = index.library[layoutId]!.name;
+      const placeholder: Layout = {
+        ...createLayout(name),
+        metadata: { id: layoutId, name },
+      };
+      const store = createLayoutStore(createHistoryStore());
+      store.loadLayout(placeholder);
+      return { id: nextTabId(), store, layoutId, hydrated: false, unreadable: false };
+    });
+
+    tabs = restored;
+    const activeLayoutId =
+      index.activeId && openIds.includes(index.activeId)
+        ? index.activeId
+        : openIds[0]!;
+    const activeTabEntry = restored.find((t) => t.layoutId === activeLayoutId)!;
+    activeId = activeTabEntry.id;
+
+    // Eager hydration of the active tab only: its body loads now, the others on
+    // focus. Done after the active id is set so cross-tab reservation sees the
+    // (still-shell) siblings excluded.
+    hydrateTab(activeTabEntry);
   }
 
   return {
@@ -185,6 +314,7 @@ export function createWorkspaceStore() {
     closeTab,
     reorderTabs,
     clearThenLoad,
+    restoreWorkspace,
   };
 }
 

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -221,6 +221,9 @@ export function createWorkspaceStore() {
     if (wasActive) {
       // Prefer the tab that took the closed tab's slot; otherwise the new last.
       const fallback = remaining[index] ?? remaining[remaining.length - 1]!;
+      // The new active tab may be an unhydrated restore shell; load its body
+      // now so closing onto it shows the real layout, not the placeholder.
+      if (!fallback.hydrated) hydrateTab(fallback);
       activeId = fallback.id;
     }
   }

--- a/src/tests/browser-launch.test.ts
+++ b/src/tests/browser-launch.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Layout } from "$lib/types";
+import { resolveBrowserLaunch } from "$lib/storage/browser-launch";
+
+const WORKSPACE_KEY = "Rackula:workspace";
+const EVER_KEY = "Rackula:everHadLayouts";
+const AUTOSAVE_KEY = "Rackula:autosave";
+const bodyKey = (id: string) => `Rackula:layout:${id}`;
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+function makeLayout(id: string, name: string): Layout {
+  return {
+    version: "1.0",
+    name,
+    racks: [{ id: "rack-0", name: "R", height: 42, devices: [] }],
+    device_types: [],
+    settings: { display_mode: "label", show_labels_on_images: false },
+    metadata: { id, name, schema_version: "1.0" },
+  } as Layout;
+}
+
+function seedAutosave(id: string, name: string): void {
+  localStorageMock.setItem(
+    AUTOSAVE_KEY,
+    JSON.stringify({
+      layout: makeLayout(id, name),
+      savedAt: "2026-06-14T09:00:00.000Z",
+      changesSinceExport: 0,
+      hasEverExported: false,
+      storageMode: "browser",
+    }),
+  );
+}
+
+describe("resolveBrowserLaunch", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("routes to the fresh-install empty state when nothing is stored", () => {
+    const result = resolveBrowserLaunch();
+    expect(result.action).toBe("empty");
+    expect(result.everHadLayouts).toBe(false);
+  });
+
+  it("adopts a legacy autosave and routes to restore", () => {
+    seedAutosave("uuid-old", "Migrated");
+
+    const result = resolveBrowserLaunch();
+
+    expect(result.action).toBe("restore");
+    if (result.action === "restore") {
+      expect(result.index.openTabs).toEqual(["uuid-old"]);
+      expect(result.index.activeId).toBe("uuid-old");
+      // loadBody resolves the adopted body.
+      const body = result.loadBody("uuid-old");
+      expect(body.ok).toBe(true);
+      if (body.ok) expect(body.layout.name).toBe("Migrated");
+    }
+    // Legacy slot consumed.
+    expect(localStorageMock.getItem(AUTOSAVE_KEY)).toBeNull();
+  });
+
+  it("restores an existing multi-layout workspace without adoption", () => {
+    localStorageMock.setItem(
+      WORKSPACE_KEY,
+      JSON.stringify({
+        schemaVersion: 2,
+        activeId: "a",
+        openTabs: ["a", "b"],
+        library: {
+          a: { name: "Alpha", changesSinceExport: 0, storageMode: "browser" },
+          b: { name: "Beta", changesSinceExport: 0, storageMode: "browser" },
+        },
+      }),
+    );
+    localStorageMock.setItem(
+      bodyKey("a"),
+      JSON.stringify({ schemaVersion: 2, layout: makeLayout("a", "Alpha") }),
+    );
+
+    const result = resolveBrowserLaunch();
+    expect(result.action).toBe("restore");
+    if (result.action === "restore") {
+      expect(result.index.openTabs).toEqual(["a", "b"]);
+    }
+  });
+
+  it("routes to empty when a returning user's workspace has no open tabs (lost data)", () => {
+    localStorageMock.setItem(EVER_KEY, "1");
+    localStorageMock.setItem(
+      WORKSPACE_KEY,
+      JSON.stringify({
+        schemaVersion: 2,
+        activeId: null,
+        openTabs: [],
+        library: {},
+      }),
+    );
+
+    const result = resolveBrowserLaunch();
+    expect(result.action).toBe("empty");
+    expect(result.everHadLayouts).toBe(true);
+  });
+
+  it("does not adopt when a workspace already exists", () => {
+    seedAutosave("uuid-old", "Should not migrate");
+    localStorageMock.setItem(
+      WORKSPACE_KEY,
+      JSON.stringify({
+        schemaVersion: 2,
+        activeId: "a",
+        openTabs: ["a"],
+        library: {
+          a: { name: "Existing", changesSinceExport: 0, storageMode: "browser" },
+        },
+      }),
+    );
+
+    const result = resolveBrowserLaunch();
+    expect(result.action).toBe("restore");
+    // Autosave untouched because adoption did not run.
+    expect(localStorageMock.getItem(AUTOSAVE_KEY)).not.toBeNull();
+  });
+});

--- a/src/tests/browser-workspace-persist.test.ts
+++ b/src/tests/browser-workspace-persist.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Layout } from "$lib/types";
+import {
+  persistBrowserWorkspace,
+  type PersistTab,
+} from "$lib/storage/browser-workspace-persist";
+import {
+  loadWorkspaceIndex,
+  loadLayoutBody,
+} from "$lib/storage/browser-workspace";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+function makeLayout(id: string, name: string): Layout {
+  return {
+    version: "1.0",
+    name,
+    racks: [{ id: "rack-0", name: "R", height: 42, devices: [] }],
+    device_types: [],
+    settings: { display_mode: "label", show_labels_on_images: false },
+    metadata: { id, name, schema_version: "1.0" },
+  } as Layout;
+}
+
+function tab(over: Partial<PersistTab> & { layoutId: string }): PersistTab {
+  return {
+    hydrated: true,
+    layout: makeLayout(over.layoutId, "Layout " + over.layoutId),
+    changesSinceExport: 0,
+    hasEverExported: false,
+    ...over,
+  };
+}
+
+describe("persistBrowserWorkspace", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("writes the ordered open set and active id to the index", () => {
+    persistBrowserWorkspace({
+      tabs: [tab({ layoutId: "a" }), tab({ layoutId: "b" })],
+      activeLayoutId: "b",
+    });
+
+    const index = loadWorkspaceIndex();
+    expect(index).not.toBeNull();
+    expect(index!.openTabs).toEqual(["a", "b"]);
+    expect(index!.activeId).toBe("b");
+  });
+
+  it("writes each hydrated tab's body so a later launch can restore it", () => {
+    persistBrowserWorkspace({
+      tabs: [tab({ layoutId: "a" })],
+      activeLayoutId: "a",
+    });
+    const body = loadLayoutBody("a");
+    expect(body.ok).toBe(true);
+    if (body.ok) expect(body.layout.name).toBe("Layout a");
+  });
+
+  it("carries per-tab durability into the library entries", () => {
+    persistBrowserWorkspace({
+      tabs: [
+        tab({ layoutId: "a", changesSinceExport: 4, hasEverExported: true }),
+      ],
+      activeLayoutId: "a",
+    });
+    const entry = loadWorkspaceIndex()!.library.a;
+    expect(entry.changesSinceExport).toBe(4);
+    expect(entry.hasEverExported).toBe(true);
+  });
+
+  it("keeps an unhydrated shell in the open set without rewriting its body", () => {
+    // Pre-seed a body for the shell so we can prove it is left untouched.
+    persistBrowserWorkspace({
+      tabs: [tab({ layoutId: "a" })],
+      activeLayoutId: "a",
+    });
+
+    // Now persist with the shell present but unhydrated (no layout to write).
+    persistBrowserWorkspace({
+      tabs: [
+        tab({ layoutId: "a" }),
+        { layoutId: "shell", hydrated: false, name: "Shell" },
+      ],
+      activeLayoutId: "a",
+    });
+
+    const index = loadWorkspaceIndex();
+    expect(index!.openTabs).toEqual(["a", "shell"]);
+    // The shell keeps a library entry carrying its name (so the tab shell can
+    // still render on the next launch) but no body was written for it.
+    expect(index!.library.shell.name).toBe("Shell");
+    expect(loadLayoutBody("shell").ok).toBe(false);
+  });
+
+  it("keeps a closed layout's durable copy when it leaves the open set", () => {
+    persistBrowserWorkspace({
+      tabs: [tab({ layoutId: "a" }), tab({ layoutId: "b" })],
+      activeLayoutId: "a",
+    });
+    expect(loadLayoutBody("b").ok).toBe(true);
+
+    // b is closed: persist without it. Closing keeps the durable copy (spike
+    // #2179: only openTabs loses the id; the library entry and body survive so
+    // the layout can be reopened from the sidebar).
+    persistBrowserWorkspace({
+      tabs: [tab({ layoutId: "a" })],
+      activeLayoutId: "a",
+    });
+
+    const index = loadWorkspaceIndex();
+    expect(index!.openTabs).toEqual(["a"]);
+    expect(index!.library.b).toBeDefined();
+    expect(loadLayoutBody("b").ok).toBe(true);
+  });
+});

--- a/src/tests/browser-workspace.test.ts
+++ b/src/tests/browser-workspace.test.ts
@@ -119,6 +119,27 @@ describe("browser-workspace storage", () => {
       expect(index!.activeId).toBe("a");
     });
 
+    it("ignores a prototype-polluting library key without corrupting Object.prototype", () => {
+      localStorage.setItem(
+        WORKSPACE_KEY,
+        JSON.stringify({
+          schemaVersion: 2,
+          activeId: "a",
+          openTabs: ["a", "__proto__"],
+          library: {
+            a: { name: "Safe", changesSinceExport: 0, storageMode: "browser" },
+            __proto__: { name: "evil", polluted: true },
+          },
+        }),
+      );
+      const index = loadWorkspaceIndex();
+      expect(index).not.toBeNull();
+      // The hostile key is dropped from both library and openTabs.
+      expect(index!.openTabs).toEqual(["a"]);
+      // Object.prototype is untouched.
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
     it("coerces a malformed library entry into safe defaults", () => {
       localStorage.setItem(
         WORKSPACE_KEY,
@@ -185,6 +206,48 @@ describe("browser-workspace storage", () => {
           (result.layout as Record<string, unknown>).rack,
         ).toBeUndefined();
       }
+    });
+
+    it("does not re-migrate positions when a legacy body is loaded twice", () => {
+      // A pre-0.7.0 body: positions are U-values (1, 10) that migrate to
+      // internal units (x6). Loading the body twice must not multiply twice;
+      // migrateLayout stamps the current version so it is idempotent.
+      localStorage.setItem(
+        bodyKey("a"),
+        JSON.stringify({
+          schemaVersion: 2,
+          layout: {
+            version: "0.6.16",
+            name: "Legacy",
+            racks: [
+              {
+                id: "rack-1",
+                name: "Main",
+                height: 42,
+                devices: [
+                  { id: "d1", device_type: "server", position: 1, face: "front" },
+                ],
+              },
+            ],
+            device_types: [],
+            settings: { display_mode: "label", show_labels_on_images: false },
+          },
+          savedAt: "2026-06-14T09:00:00.000Z",
+        }),
+      );
+
+      const first = loadLayoutBody("a");
+      expect(first.ok).toBe(true);
+      if (!first.ok) return;
+      const firstPos = first.layout.racks[0]!.devices[0]!.position;
+
+      // Persist the (now migrated) body back, then load it again. The second
+      // load must yield the same position, not a doubly-migrated one.
+      saveLayoutBody("a", first.layout, { changesSinceExport: 0 });
+      const second = loadLayoutBody("a");
+      expect(second.ok).toBe(true);
+      if (!second.ok) return;
+      expect(second.layout.racks[0]!.devices[0]!.position).toBe(firstPos);
     });
 
     it("propagates a quota failure from saveLayoutBody", () => {
@@ -311,11 +374,11 @@ describe("browser-workspace storage", () => {
       );
       const index = adoptLegacyAutosave();
       expect(index).not.toBeNull();
-      // eslint-disable-next-line no-restricted-syntax -- adoption of a single autosave produces exactly one open tab
-      expect(index!.openTabs).toHaveLength(1);
-      const id = index!.openTabs[0]!;
-      expect(id.length).toBeGreaterThan(0);
-      expect(loadLayoutBody(id).ok).toBe(true);
+      const id = index!.activeId;
+      expect(id).toBeTruthy();
+      expect(id!.length).toBeGreaterThan(0);
+      expect(index!.openTabs).toEqual([id]);
+      expect(loadLayoutBody(id!).ok).toBe(true);
     });
   });
 });

--- a/src/tests/browser-workspace.test.ts
+++ b/src/tests/browser-workspace.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Layout } from "$lib/types";
+import {
+  loadWorkspaceIndex,
+  saveWorkspaceIndex,
+  loadLayoutBody,
+  saveLayoutBody,
+  deleteLayoutBody,
+  hasEverHadLayouts,
+  markEverHadLayouts,
+  adoptLegacyAutosave,
+  type WorkspaceIndex,
+} from "$lib/storage/browser-workspace";
+
+const WORKSPACE_KEY = "Rackula:workspace";
+const AUTOSAVE_KEY = "Rackula:autosave";
+const bodyKey = (id: string) => `Rackula:layout:${id}`;
+
+// In-memory localStorage stand-in.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+function makeLayout(id: string, name: string): Layout {
+  return {
+    version: "1.0",
+    name,
+    racks: [{ id: "rack-0", name: "R", height: 42, devices: [] }],
+    device_types: [],
+    settings: { display_mode: "label", show_labels_on_images: false },
+    metadata: { id, name, schema_version: "1.0" },
+  } as Layout;
+}
+
+function makeIndex(over: Partial<WorkspaceIndex> = {}): WorkspaceIndex {
+  return {
+    schemaVersion: 2,
+    activeId: "a",
+    openTabs: ["a"],
+    library: {
+      a: {
+        name: "Homelab",
+        updatedAt: "2026-06-14T09:00:00.000Z",
+        changesSinceExport: 0,
+        hasEverExported: true,
+        writeFailed: false,
+        storageMode: "browser",
+      },
+    },
+    ...over,
+  };
+}
+
+describe("browser-workspace storage", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  describe("index round-trip", () => {
+    it("saves and loads the workspace index", () => {
+      const index = makeIndex();
+      expect(saveWorkspaceIndex(index)).toBe(true);
+      expect(loadWorkspaceIndex()).toEqual(index);
+    });
+
+    it("returns null when no index exists", () => {
+      expect(loadWorkspaceIndex()).toBeNull();
+    });
+  });
+
+  describe("defensive index parsing (untrusted localStorage)", () => {
+    it("returns null on invalid JSON", () => {
+      localStorage.setItem(WORKSPACE_KEY, "{not json");
+      expect(loadWorkspaceIndex()).toBeNull();
+    });
+
+    it("returns null when the parsed value is not an object", () => {
+      localStorage.setItem(WORKSPACE_KEY, JSON.stringify([1, 2, 3]));
+      expect(loadWorkspaceIndex()).toBeNull();
+    });
+
+    it("returns null when openTabs is not an array", () => {
+      localStorage.setItem(
+        WORKSPACE_KEY,
+        JSON.stringify({ ...makeIndex(), openTabs: "a" }),
+      );
+      expect(loadWorkspaceIndex()).toBeNull();
+    });
+
+    it("drops openTabs ids that have no library entry", () => {
+      const loaded = saveWorkspaceIndex(
+        makeIndex({ openTabs: ["a", "ghost"], activeId: "a" }),
+      );
+      expect(loaded).toBe(true);
+      const index = loadWorkspaceIndex();
+      expect(index!.openTabs).toEqual(["a"]);
+    });
+
+    it("falls back activeId to the first open tab when it is not open", () => {
+      saveWorkspaceIndex(makeIndex({ activeId: "ghost", openTabs: ["a"] }));
+      const index = loadWorkspaceIndex();
+      expect(index!.activeId).toBe("a");
+    });
+
+    it("coerces a malformed library entry into safe defaults", () => {
+      localStorage.setItem(
+        WORKSPACE_KEY,
+        JSON.stringify({
+          schemaVersion: 2,
+          activeId: "a",
+          openTabs: ["a"],
+          library: { a: { name: 123, changesSinceExport: "lots" } },
+        }),
+      );
+      const index = loadWorkspaceIndex();
+      expect(index).not.toBeNull();
+      const entry = index!.library.a;
+      expect(typeof entry.name).toBe("string");
+      expect(entry.changesSinceExport).toBe(0);
+      expect(entry.hasEverExported).toBe(false);
+      expect(entry.storageMode).toBe("browser");
+    });
+  });
+
+  describe("body round-trip", () => {
+    it("saves a body and updates the index entry", () => {
+      saveWorkspaceIndex(makeIndex());
+      const layout = makeLayout("a", "Homelab");
+      expect(saveLayoutBody("a", layout, { changesSinceExport: 3 })).toBe(true);
+
+      const result = loadLayoutBody("a");
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.layout.name).toBe("Homelab");
+
+      const index = loadWorkspaceIndex();
+      expect(index!.library.a.changesSinceExport).toBe(3);
+    });
+
+    it("returns unreadable for a missing body", () => {
+      expect(loadLayoutBody("nope").ok).toBe(false);
+    });
+
+    it("returns unreadable for a corrupt body", () => {
+      localStorage.setItem(bodyKey("a"), "garbage{");
+      expect(loadLayoutBody("a").ok).toBe(false);
+    });
+
+    it("runs migrateLayout on the loaded body (legacy rack -> racks)", () => {
+      localStorage.setItem(
+        bodyKey("a"),
+        JSON.stringify({
+          schemaVersion: 2,
+          layout: {
+            version: "0.6.16",
+            name: "Legacy",
+            rack: { id: "rack-1", name: "Main", height: 42, devices: [] },
+            device_types: [],
+            settings: { display_mode: "label", show_labels_on_images: false },
+          },
+          savedAt: "2026-06-14T09:00:00.000Z",
+        }),
+      );
+      const result = loadLayoutBody("a");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.layout.racks).toBeDefined();
+        expect(
+          (result.layout as Record<string, unknown>).rack,
+        ).toBeUndefined();
+      }
+    });
+
+    it("propagates a quota failure from saveLayoutBody", () => {
+      saveWorkspaceIndex(makeIndex());
+      const original = localStorage.setItem;
+      // Fail only the body write, not the index write.
+      localStorage.setItem = vi.fn((key: string, value: string) => {
+        if (key === bodyKey("a")) {
+          const err = new Error("QuotaExceededError");
+          err.name = "QuotaExceededError";
+          throw err;
+        }
+        original.call(localStorage, key, value);
+      });
+      expect(
+        saveLayoutBody("a", makeLayout("a", "Homelab"), {
+          changesSinceExport: 0,
+        }),
+      ).toBe(false);
+      localStorage.setItem = original;
+    });
+
+    it("deletes a body key and its library entry", () => {
+      saveWorkspaceIndex(makeIndex());
+      saveLayoutBody("a", makeLayout("a", "Homelab"), { changesSinceExport: 0 });
+      deleteLayoutBody("a");
+      expect(loadLayoutBody("a").ok).toBe(false);
+      expect(loadWorkspaceIndex()!.library.a).toBeUndefined();
+    });
+  });
+
+  describe("everHadLayouts marker", () => {
+    it("is false before any layout exists", () => {
+      expect(hasEverHadLayouts()).toBe(false);
+    });
+
+    it("is true after marking and survives an index wipe", () => {
+      markEverHadLayouts();
+      expect(hasEverHadLayouts()).toBe(true);
+      localStorage.removeItem(WORKSPACE_KEY);
+      expect(hasEverHadLayouts()).toBe(true);
+    });
+  });
+
+  describe("one-time adoption off Rackula:autosave", () => {
+    it("returns null when there is neither a workspace nor an autosave", () => {
+      expect(adoptLegacyAutosave()).toBeNull();
+    });
+
+    it("does not run when a workspace index already exists", () => {
+      saveWorkspaceIndex(makeIndex());
+      localStorage.setItem(
+        AUTOSAVE_KEY,
+        JSON.stringify({ layout: makeLayout("a", "Old"), savedAt: "x" }),
+      );
+      // Adoption is a no-op: it returns null and leaves the autosave in place
+      // (the existing index is authoritative).
+      expect(adoptLegacyAutosave()).toBeNull();
+      expect(localStorage.getItem(AUTOSAVE_KEY)).not.toBeNull();
+    });
+
+    it("adopts an autosave into a single-tab workspace and removes the legacy slot", () => {
+      const layout = makeLayout("uuid-old", "Migrated");
+      localStorage.setItem(
+        AUTOSAVE_KEY,
+        JSON.stringify({
+          layout,
+          savedAt: "2026-06-14T09:00:00.000Z",
+          changesSinceExport: 2,
+          hasEverExported: true,
+          storageMode: "browser",
+        }),
+      );
+
+      const index = adoptLegacyAutosave();
+      expect(index).not.toBeNull();
+      expect(index!.openTabs).toEqual(["uuid-old"]);
+      expect(index!.activeId).toBe("uuid-old");
+      expect(index!.library["uuid-old"].name).toBe("Migrated");
+      expect(index!.library["uuid-old"].changesSinceExport).toBe(2);
+      expect(index!.library["uuid-old"].hasEverExported).toBe(true);
+
+      // Index and body landed.
+      expect(loadWorkspaceIndex()).not.toBeNull();
+      const body = loadLayoutBody("uuid-old");
+      expect(body.ok).toBe(true);
+
+      // Legacy slot removed after both writes succeeded.
+      expect(localStorage.getItem(AUTOSAVE_KEY)).toBeNull();
+      // Returning-user marker set.
+      expect(hasEverHadLayouts()).toBe(true);
+    });
+
+    it("keeps the legacy slot intact when the body write fails (never delete the only copy)", () => {
+      const layout = makeLayout("uuid-old", "Migrated");
+      localStorage.setItem(
+        AUTOSAVE_KEY,
+        JSON.stringify({ layout, savedAt: "2026-06-14T09:00:00.000Z" }),
+      );
+      const original = localStorage.setItem;
+      localStorage.setItem = vi.fn((key: string, value: string) => {
+        if (key.startsWith("Rackula:layout:")) {
+          const err = new Error("QuotaExceededError");
+          err.name = "QuotaExceededError";
+          throw err;
+        }
+        original.call(localStorage, key, value);
+      });
+
+      expect(adoptLegacyAutosave()).toBeNull();
+      localStorage.setItem = original;
+
+      // The durable fallback survives; nothing was migrated.
+      expect(localStorage.getItem(AUTOSAVE_KEY)).not.toBeNull();
+      expect(loadWorkspaceIndex()).toBeNull();
+    });
+
+    it("mints an id when the autosaved layout has no metadata id", () => {
+      const layout = makeLayout("", "NoId");
+      delete (layout as { metadata?: unknown }).metadata;
+      localStorage.setItem(
+        AUTOSAVE_KEY,
+        JSON.stringify({ layout, savedAt: "2026-06-14T09:00:00.000Z" }),
+      );
+      const index = adoptLegacyAutosave();
+      expect(index).not.toBeNull();
+      // eslint-disable-next-line no-restricted-syntax -- adoption of a single autosave produces exactly one open tab
+      expect(index!.openTabs).toHaveLength(1);
+      const id = index!.openTabs[0]!;
+      expect(id.length).toBeGreaterThan(0);
+      expect(loadLayoutBody(id).ok).toBe(true);
+    });
+  });
+});

--- a/src/tests/workspace-store.test.ts
+++ b/src/tests/workspace-store.test.ts
@@ -217,6 +217,21 @@ describe("Workspace Store", () => {
       expect(loaded).toEqual(["id-a"]);
     });
 
+    it("restores the active tab's durability from its library entry", () => {
+      const ws = getWorkspaceStore();
+      const index = makeIndex();
+      index.library["id-a"].changesSinceExport = 5;
+      index.library["id-a"].hasEverExported = true;
+      ws.restoreWorkspace({
+        index,
+        loadBody: (id) => ({ ok: true, layout: bodyFor(id, "Body") }),
+      });
+      // The active tab's durability comes from the persisted library entry, not
+      // reset to zero by the body load, so the chip/tab dot reflect true state.
+      expect(ws.activeStore.changesSinceExport).toBe(5);
+      expect(ws.activeStore.hasEverExported).toBe(true);
+    });
+
     it("shows the persisted name on an unhydrated tab before its body loads", () => {
       const ws = getWorkspaceStore();
       ws.restoreWorkspace({

--- a/src/tests/workspace-store.test.ts
+++ b/src/tests/workspace-store.test.ts
@@ -324,6 +324,26 @@ describe("Workspace Store", () => {
       expect(ws.activeId).toBe(betaTabId);
       expect(ws.tabs[1]!.unreadable).toBe(true);
     });
+
+    it("hydrates the fallback tab when closing the active tab onto a shell", () => {
+      const ws = getWorkspaceStore();
+      const loaded: string[] = [];
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) => {
+          loaded.push(id);
+          return { ok: true, layout: bodyFor(id, "Body-" + id) };
+        },
+      });
+      // Active tab (id-a) is hydrated; id-b is still an unhydrated shell.
+      expect(loaded).toEqual(["id-a"]);
+
+      // Close the active tab: focus falls back to the id-b shell, which must be
+      // hydrated so the canvas shows the real layout, not the placeholder.
+      ws.closeTab(ws.tabs[0]!.id);
+      expect(loaded).toEqual(["id-a", "id-b"]);
+      expect(ws.activeStore.layout.name).toBe("Body-id-b");
+    });
   });
 
   describe("clearThenLoad", () => {

--- a/src/tests/workspace-store.test.ts
+++ b/src/tests/workspace-store.test.ts
@@ -5,7 +5,9 @@ import {
 } from "$lib/stores/workspace.svelte";
 import { resetHistoryStore } from "$lib/stores/history.svelte";
 import { createLayout } from "$lib/utils/serialization";
-import { createTestDeviceTypeInput } from "./factories";
+import { createTestDeviceTypeInput, createTestRack } from "./factories";
+import type { WorkspaceIndex } from "$lib/storage/browser-workspace";
+import type { Layout } from "$lib/types";
 
 describe("Workspace Store", () => {
   beforeEach(() => {
@@ -164,6 +166,163 @@ describe("Workspace Store", () => {
 
       ws.reorderTabs(0, 5);
       expect(ws.tabs.map((t) => t.id)).toEqual(order);
+    });
+  });
+
+  describe("restoreWorkspace (lazy tab restore)", () => {
+    function bodyFor(id: string, name: string): Layout {
+      return { ...createLayout(name), metadata: { id, name } };
+    }
+
+    function makeIndex(): WorkspaceIndex {
+      return {
+        schemaVersion: 2,
+        activeId: "id-a",
+        openTabs: ["id-a", "id-b"],
+        library: {
+          "id-a": {
+            name: "Alpha",
+            updatedAt: "",
+            changesSinceExport: 0,
+            hasEverExported: false,
+            writeFailed: false,
+            storageMode: "browser",
+          },
+          "id-b": {
+            name: "Beta",
+            updatedAt: "",
+            changesSinceExport: 0,
+            hasEverExported: false,
+            writeFailed: false,
+            storageMode: "browser",
+          },
+        },
+      };
+    }
+
+    it("restores one tab per open id, ordered, with the active id focused", () => {
+      const ws = getWorkspaceStore();
+      const loaded: string[] = [];
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) => {
+          loaded.push(id);
+          return { ok: true, layout: bodyFor(id, id === "id-a" ? "Alpha" : "Beta") };
+        },
+      });
+
+      expect(ws.tabs.length).toBe(2);
+      expect(ws.activeId).toBe(ws.tabs[0]!.id);
+      // The active layout loaded eagerly; the inactive one did not.
+      expect(loaded).toEqual(["id-a"]);
+    });
+
+    it("shows the persisted name on an unhydrated tab before its body loads", () => {
+      const ws = getWorkspaceStore();
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) => ({ ok: true, layout: bodyFor(id, "Body") }),
+      });
+      // Second (inactive) tab is a shell carrying the index name, no body read.
+      expect(ws.tabs[1]!.store.layout.name).toBe("Beta");
+    });
+
+    it("hydrates an inactive tab lazily on first focus, then not again", () => {
+      const ws = getWorkspaceStore();
+      const loaded: string[] = [];
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) => {
+          loaded.push(id);
+          return { ok: true, layout: bodyFor(id, "Body-" + id) };
+        },
+      });
+      expect(loaded).toEqual(["id-a"]);
+
+      const betaTabId = ws.tabs[1]!.id;
+      ws.switchTo(betaTabId);
+      expect(loaded).toEqual(["id-a", "id-b"]);
+      expect(ws.activeStore.layout.name).toBe("Body-id-b");
+
+      // Switching away and back does not re-read the body.
+      ws.switchTo(ws.tabs[0]!.id);
+      ws.switchTo(betaTabId);
+      expect(loaded).toEqual(["id-a", "id-b"]);
+    });
+
+    it("hydrates a restored tab with empty undo history", () => {
+      const ws = getWorkspaceStore();
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) => ({ ok: true, layout: bodyFor(id, "Body") }),
+      });
+      const betaTabId = ws.tabs[1]!.id;
+      ws.switchTo(betaTabId);
+      expect(ws.activeStore.canUndo).toBe(false);
+      expect(ws.activeStore.canRedo).toBe(false);
+    });
+
+    it("regenerates a restored device id that collides with a live id in another tab", () => {
+      const ws = getWorkspaceStore();
+
+      // Tab A is hydrated eagerly and holds a device with a fixed id.
+      const sharedId = "shared-device-id";
+      const aRack = createTestRack({
+        id: "rack-a",
+        devices: [
+          {
+            id: sharedId,
+            device_type: "server",
+            position: 0,
+            face: "front",
+          },
+        ],
+      });
+      const bRack = createTestRack({
+        id: "rack-b",
+        devices: [
+          {
+            id: sharedId,
+            device_type: "server",
+            position: 0,
+            face: "front",
+          },
+        ],
+      });
+
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) =>
+          id === "id-a"
+            ? { ok: true, layout: { ...bodyFor("id-a", "Alpha"), racks: [aRack] } }
+            : { ok: true, layout: { ...bodyFor("id-b", "Beta"), racks: [bRack] } },
+      });
+
+      // Tab A keeps the shared id.
+      expect(ws.tabs[0]!.store.racks[0]!.devices[0]!.id).toBe(sharedId);
+
+      // Focus tab B: its colliding device id must be regenerated so the global
+      // image store (keyed placement-<deviceId>) cannot alias across tabs.
+      ws.switchTo(ws.tabs[1]!.id);
+      const bId = ws.activeStore.racks[0]!.devices[0]!.id;
+      expect(bId).not.toBe(sharedId);
+    });
+
+    it("leaves a tab as a recoverable shell when its body is unreadable on focus", () => {
+      const ws = getWorkspaceStore();
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) =>
+          id === "id-a"
+            ? { ok: true, layout: bodyFor("id-a", "Alpha") }
+            : { ok: false },
+      });
+      const betaTabId = ws.tabs[1]!.id;
+      ws.switchTo(betaTabId);
+      // Focus still moves to the tab (never silently vanishes); it is flagged
+      // unreadable so the interaction layer can offer Retry/Remove (#2018).
+      expect(ws.activeId).toBe(betaTabId);
+      expect(ws.tabs[1]!.unreadable).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

On launch in browser mode, restore the previously open layout tabs from a persisted multi-layout workspace, hydrating the active tab eagerly and the rest lazily on first focus. Replaces the single `Rackula:autosave` slot (browser mode) with the `Rackula:workspace` index + `Rackula:layout:<id>` bodies schema (spike #2179), with one-time adoption from the legacy autosave slot. With no persisted workspace, the canvas opens to the existing empty state (WelcomeScreen); #2095 owns the empty-state redesign and is untouched here.

## Storage schema built (spike #2179)

- `Rackula:workspace` (`src/lib/storage/browser-workspace.ts`): the index (schemaVersion, activeId, ordered openTabs, per-layout library map of name/updatedAt/durability), read synchronously at launch to paint tab shells.
- `Rackula:layout:<id>`: one body per layout (full Layout incl. base64 images), read lazily on focus through the shared `migrateLayout`.
- `Rackula:everHadLayouts`: returning-user marker, separate key so it survives an index wipe (distinguishes lost-data-empty from fresh-install-empty).

All reads are treated as untrusted: defensive JSON parsing, shape validation, malformed library entries coerced to safe defaults, dangling openTabs/activeId repaired, quota failures propagated, and a bad body resolved on focus as a recoverable shell rather than blocking startup.

## Adoption path from the old autosave

`adoptLegacyAutosave()` runs once when no workspace index exists: reads the legacy `Rackula:autosave`, writes a body + a single-tab index under the layout's id, then removes the legacy slot only after both writes land. A failed write keeps the legacy slot intact (never deletes the only copy) and retries cleanly next launch. The legacy single-slot autosave effect is now gated to server mode.

## Undo/redo and cross-tab id safety (spike #2182)

- History is in-memory only and never persisted; the open-set metadata carries no history. Lazy restore hydrates a tab with empty history via the existing clear-then-load primitive.
- Device-id uniqueness across open tabs is enforced at hydration: `loadLayout` now regenerates device ids against ids live in other open tabs, so a restored layout cannot alias the global image store's `placement-<deviceId>` keys.

## #2270 (C6) left open

This slice implements the minimum correctness change for restore (cross-tab id regeneration at hydration). The full per-layout namespacing of placement image keys that #2270 owns is a larger change touching every image read/write site, so #2270 stays open.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:run` -- 2436 unit tests pass (new: browser-workspace, browser-launch, browser-workspace-persist, workspace lazy-restore + cross-tab dedup + close-onto-shell)
- [x] `npm run build` succeeds; `npm run check` clean for changed files (2 pre-existing errors in Rack.svelte / KeyboardHandler.svelte are on main, untouched here)
- [x] a11y e2e (`test:e2e:a11y`) -- 9 pass (M14 guard rail green)
- [x] visual regression -- 12 pass, no baseline changes
- [x] full chromium e2e -- 131 pass / 6 pre-existing skips; multi-context + persistence specs updated to the new schema, plus a new cold-relaunch restore test

Closes #2080

🤖 Generated with [Claude Code](https://claude.com/claude-code)