### PR TITLE
chore(ci): skip Test workflow for non-code PRs; fix e2e-trusted doc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,17 @@ name: Test
 on:
   pull_request:
     branches: [main]
+    # Skip the suite for non-code-only PRs. A PR runs CI unless ALL its changed
+    # files match here, so mixed docs+code PRs still run. workflow_dispatch and
+    # workflow_call ignore path filters, so manual/reusable runs are unaffected.
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".editorconfig"
+      - ".gitattributes"
+      - ".vscode/**"
+      - ".github/ISSUE_TEMPLATE/**"
   workflow_dispatch:
   workflow_call:
 

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -312,8 +312,10 @@ This keeps untrusted code off the homelab runner without an explicit human OK.
 
 Maintainer prerequisites (one-time, in repo settings):
 
-- GitHub Environment `e2e-trusted`: no required reviewers, deployment branch
-  policy restricted to `main`.
+- GitHub Environment `e2e-trusted`: no required reviewers and no deployment
+  branch policy. Org PRs run from feature branches (and `pull_request` refs are
+  not branch names), so restricting this environment to `main` would block the
+  trusted tier for every PR.
 - GitHub Environment `e2e-approval`: `ggfevans` as the required reviewer, no
   branch restriction (fork PRs run from arbitrary branches).
 - Self-hosted runner online advertising the `ci-runner` label.


### PR DESCRIPTION
## **User description**
Follow-up to #2003 / PR #2245 (two-tier E2E model).

## What
- Add `paths-ignore` to the Test workflow's `pull_request` trigger so docs-only and other non-code PRs no longer run the full suite (including the ~23-min self-hosted `e2e` job). A PR is skipped only when ALL its changed files match, so mixed docs+code PRs still run. `main` has no required status checks, so skipped runs do not block merges. `workflow_dispatch`/`workflow_call` ignore path filters, so manual/reusable runs are unaffected.
- Fix a footgun in `docs/guides/TESTING.md`: the maintainer prereqs said to restrict the `e2e-trusted` environment's deployment branch policy to `main`. That would block the trusted tier for every PR, since org PRs run from feature branches (and `pull_request` refs are not branch names). Corrected to: no deployment branch policy.

## Notes
- The `e2e-approval` environment (ggfevans required reviewer) and `e2e-trusted` (permissive) are already created.
- This PR touches `test.yml` (a code path), so its own CI runs in full.


___

## **CodeAnt-AI Description**
Skip full CI for docs-only PRs and clarify trusted E2E setup

### What Changed
- Docs-only and other non-code-only pull requests no longer run the full Test workflow, while mixed docs + code PRs still do
- Manual and reusable test runs are unchanged
- The testing guide now says the `e2e-trusted` environment should have no branch restriction, so PRs from feature branches can use it

### Impact
`✅ Faster docs-only reviews`
`✅ Fewer unnecessary full CI runs`
`✅ Clearer E2E setup for PRs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
