### PR TITLE
fix: make husky pre-commit hook POSIX sh compatible (#2288)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Verify package-lock.json is in sync with package.json
 if git diff --cached --name-only | grep -q 'package.json'; then
   echo "Checking package-lock.json is in sync..."
@@ -21,12 +21,15 @@ if [ -n "$STAGED" ]; then
 fi
 
 # Run tests only for files related to staged changes
-# Skip on Windows UNC paths (\\server\share) — vite cannot resolve plugins from file://server/...
+# Skip on Windows UNC paths (\\server\share): vite cannot resolve plugins from file://server/...
 REPO_PATH="$(pwd)"
-mapfile -d '' CHANGED < <(git diff --cached --name-only --diff-filter=ACMR -z -- '*.ts' '*.svelte')
-if [ "${#CHANGED[@]}" -gt 0 ]; then
+CHANGED=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.svelte' || true)
+if [ -n "$CHANGED" ]; then
   case "$REPO_PATH" in
     //*) ;; # Skip on UNC paths
-    *) NODE_OPTIONS=--max-old-space-size=8192 npx --no-install vitest related "${CHANGED[@]}" --run --passWithNoTests --reporter=dot ;;
+    *)
+      echo "$CHANGED" | tr '\n' '\0' |
+        NODE_OPTIONS=--max-old-space-size=8192 xargs -0 npx --no-install vitest related --run --passWithNoTests --reporter=dot
+      ;;
   esac
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -28,7 +28,9 @@ if [ -n "$CHANGED" ]; then
   case "$REPO_PATH" in
     //*) ;; # Skip on UNC paths
     *)
-      echo "$CHANGED" | tr '\n' '\0' |
+      # Prefix each path with ./ so a filename starting with '-' is read as a
+      # path, not a vitest CLI option (a '--' separator makes related find no tests).
+      echo "$CHANGED" | sed 's,^,./,' | tr '\n' '\0' |
         NODE_OPTIONS=--max-old-space-size=8192 xargs -0 npx --no-install vitest related --run --passWithNoTests --reporter=dot
       ;;
   esac


### PR DESCRIPTION
## **User description**
## Summary

The husky pre-commit hook crashed for everyone with `syntax error near unexpected token \`<'`, forcing `--no-verify` on every commit.

Root cause (confirmed by reading `.husky/_/h`): husky v9 runs user hooks via `sh -e "$s"`, so the `#!/usr/bin/env bash` shebang is ignored and the hook always runs under POSIX `sh`. Line 26 used two bashisms:

- `< <(...)` process substitution: syntax error under dash/posix sh
- `mapfile -d`: needs bash 4.4+; macOS ships bash 3.2.57 (no `mapfile` at all)

## Changes

- `.husky/pre-commit`: rewrote the staged-file collection in POSIX sh using the file's existing `tr '\n' '\0' | xargs -0` idiom (already used for the prettier step above). Shebang set to `#!/usr/bin/env sh` to match how husky actually invokes it.
- `pre-push` was already POSIX clean; no change needed.

Behaviour preserved: vitest `related` still runs only on staged `.ts`/`.svelte` files, the UNC-path skip is intact, and a vitest failure still blocks the commit (`sh -e`).

## Test Plan

- [x] `sh -n .husky/pre-commit` parses cleanly (bash 3.2 posix on macOS)
- [x] `dash -n .husky/pre-commit` parses cleanly (strict POSIX)
- [x] Full hook runs under `sh -e` (exactly how husky invokes it), exit 0
- [x] End-to-end: a staged `.ts` file is captured and passed to `vitest related` as a trailing arg (incl. paths with spaces)
- [x] This very commit was made WITHOUT `--no-verify` (hook ran live and passed)
- [x] No bashisms remain (`mapfile`, `< <()`, `${arr[@]}`)

Closes #2288


___

## **CodeAnt-AI Description**
Fix the pre-commit hook so commits run normally and staged file names are handled safely

### What Changed
- The pre-commit hook now runs with the shell Husky actually uses, so commits no longer fail because of shell compatibility issues
- Staged TypeScript and Svelte files still trigger the related test check before commit
- Files whose names start with `-` are now treated as file paths instead of command options, preventing hook crashes

### Impact
`✅ Fewer blocked commits`
`✅ Fewer pre-commit hook failures`
`✅ Safer commits for dash-prefixed file names`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
