### PR TITLE
docs: carrier-first sub-U design spec + epic decomposition (#2158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ You might ask, why should I make an imaginary rack like some sort of IT cosplay?
 - **Document existing layouts** so you know what is where.
 - **Because you can**
 
+## How Racks Work
+
+Racks are measured in rack units, written U. One U is 1.75 inches of vertical space, and a common full-height rack is 42U. Rackula models racks in whole U: a device occupies a whole number of units and mounts at a whole-U boundary, the same way real rails register equipment under the EIA-310 standard. If something sits at U5, it is really at U5, not floating part of a unit above it.
+
+Gear smaller than 1U, like half-height brackets or side-by-side half-width pairs, does not bolt to the rails on its own. It rides inside a 1U carrier (a bracket, tray, or shelf) that takes up one whole U and holds the smaller devices. The carrier registers to the rails, and the small devices register to the carrier.
+
 ## Get Started
 
 ### Use it right now

--- a/docs/plans/2026-06-14-carrier-first-sub-u-decomposition.md
+++ b/docs/plans/2026-06-14-carrier-first-sub-u-decomposition.md
@@ -55,8 +55,8 @@ Verified in code, not hypothetical:
 4. Deleting dead fractional code (C5) comes after C3 + C4.
 5. C5 and C6 BOTH edit `KeyboardHandler.svelte` -> serialize them (no parallel).
 
-**This run (critical path to unblock M14):** C1 -> {C2, C3} -> C4 -> C5.
-**Deferred to their own issues:** C6 (lifecycle), C8 (NetBox), C9 (docs #2165).
+**This run (critical path to unblock M14):** C1 (#2289) -> {C2 (#2290), C3 (#2291)} -> C4 (#2292) -> C5 (#2294).
+**Deferred to their own issues:** C6 (#2295, lifecycle), C8 (#2296, NetBox), C9 (#2165, docs).
 
 ---
 

--- a/docs/plans/2026-06-14-carrier-first-sub-u-decomposition.md
+++ b/docs/plans/2026-06-14-carrier-first-sub-u-decomposition.md
@@ -1,0 +1,220 @@
+# Carrier-First Sub-U Devices: Epic Decomposition Plan (v2)
+
+> **For agentic workers:** This is the EPIC-level decomposition for #2158, not a single
+> bite-sized task plan. Each child below is a coherent, independently mergeable slice. When a
+> child is executed, write its own detailed step plan (via `/dev-issue <n>` or a per-child
+> `superpowers:writing-plans` pass) before touching code. v2 folds in an architect's adversarial
+> pass (see "What changed in v2").
+
+**Goal:** Replace fractional rail positioning (1/3U, 1/2U offsets) with a carrier-first model:
+rails register equipment at whole-U boundaries only; sub-U / half-width gear mounts inside a
+container device that registers to the rails.
+
+**Architecture:** The container/slot infrastructure already exists (`DeviceType.slots[]`,
+`PlacedDevice.container_id`/`slot_id`, `ContainerSlots.svelte`, `placeInContainer()`, cross-rack
+moves with children, child exclusion from rack collision). So this epic ENFORCES the carrier-first
+rule (schema + store + drag/drop), DELETES the fractional rail machinery and the `slot_position`
+left/right pathway, and ADAPTS legacy data on load. Frozen design record:
+`docs/superpowers/specs/2026-06-12-carrier-first-sub-u-design.md`.
+
+**Tech stack:** Svelte 5 runes, TypeScript strict, Zod (`src/lib/schemas/index.ts`),
+Vitest + Playwright. `UNITS_PER_U = 6` is kept (device heights still use 0.5U = 3 units).
+
+---
+
+## What changed in v2 (architect adversarial pass)
+
+Verified in code, not hypothetical:
+
+1. The legacy adapter must live at the SINGLE STORE INGRESS (`loadLayout`/`clearThenLoad`), NOT at
+   `load-pipeline.ts:65`. The M14 browser-workspace lazy-restore path (`browser-launch.ts` ->
+   `loadLayoutBody()`) and the share decode (`share.ts:356`, returns `fromMinimalLayoutV2` without a
+   full-schema pass) both BYPASS `load-pipeline`. One chokepoint at the store ingress covers file,
+   API, archive, share, and browser-restore.
+2. Share links cannot encode carrier children today: `MinimalDeviceSchema` (share.ts:72) has no
+   `container_id`/`slot_id`. C2 must add container fields to the minimal schema + the v1/v2 expanders
+   + carrier-type inclusion, not just bump a version string.
+3. The "stop creating invalid placements" deletions (keyboard fine-move, `moveDeviceSlot`, EditPanel
+   half-width/fine UI) move from C5 INTO C3, so enforcement (C4) never faces a live create-path that
+   can still produce invalid data. C5 shrinks to dead-code removal.
+4. The migration is irreversible (first load adapts -> autosave overwrites the original). C2 gains a
+   one-time pre-migration backup AND a golden-corpus round-trip regression test.
+5. `recoverSlotPositions` removal moves into C2 (the adapter supersedes it).
+6. C1 defines the synthesized-carrier FAMILY (1x2 and 2x2) plus the auto-created placement flag, so
+   the schema field lands once before C2/C3 consume it.
+
+---
+
+## Hard sequencing constraints
+
+1. The legacy adapter (C2, at store ingress) MUST be on main before schema enforcement (C4), or
+   existing layouts with sub-U / fractional / half-width placements fail validation on load.
+2. The adapter (C2) and drag/drop (C3) both synthesize a generic carrier, so the carrier family (C1)
+   lands first.
+3. C3 deletes every live create-path for fractional/half-width placements, so C4 enforcement is safe.
+4. Deleting dead fractional code (C5) comes after C3 + C4.
+5. C5 and C6 BOTH edit `KeyboardHandler.svelte` -> serialize them (no parallel).
+
+**This run (critical path to unblock M14):** C1 -> {C2, C3} -> C4 -> C5.
+**Deferred to their own issues:** C6 (lifecycle), C8 (NetBox), C9 (docs #2165).
+
+---
+
+## CRITICAL PATH (this run) - sub-issues of #2158
+
+### C1 - Carrier device types + auto-created placement flag  [Feature, size:M]
+
+**Files:** `src/lib/data/starterLibrary.ts` (existing shelves ~209-426 are the pattern);
+`src/lib/types/index.ts` + `src/lib/schemas/index.ts` (add the placement flag).
+
+**Scope:**
+- Synthesized-carrier FAMILY (stable slugs the adapter/drag-drop reuse): a 1-row x 2-col carrier
+  (half-width full-height) and a 2x2 carrier (half-width + half-height). Plus the K-79 branded 2x2
+  (RB5009, L009) and the AV joining tray (1 row x 2 cols, full-height). Existing 2-slot/3-slot
+  shelves stay; `accepts` empty (dimensional fit only).
+- Add an "auto-created" boolean to `PlacedDevice` (type + Zod, default false, serialized + share-
+  encoded) so C6 can self-remove auto-synthesized carriers while user-placed carriers persist.
+
+**Acceptance:** the carrier family + branded types pass `DeviceTypeSchema`; the auto-created flag
+round-trips through save/load/share.
+
+**Tests:** schema validation already covers library data (Zero-Change Rule); one round-trip test for
+the auto-created flag.
+
+**Deps:** none. **Risk:** low.
+
+---
+
+### C2 - Legacy adapter at the store ingress + share container-encoding + migration safety  [Feature, size:L]
+
+**Files:**
+- New `adaptLegacyLayout(raw)` module under `src/lib/storage/` (pattern: `migrate-layout.ts:55-78`).
+- Wire it at the SINGLE store ingress (`loadLayout`/`clearThenLoad` in `src/lib/stores/...workspace`),
+  so file/api/archive (`load-pipeline.ts`), share (`share.ts`), AND browser-restore
+  (`browser-workspace.ts:loadLayoutBody`) all pass through it.
+- Share encoding: add `container_id`/`slot_id` + auto-created flag to `MinimalDeviceSchema`
+  (`schemas/share.ts:72`) and to `fromMinimalLayoutV1`/`fromMinimalLayoutV2`/`toMinimalLayout`
+  (`utils/share.ts`); ensure synthesized carrier DeviceTypes are included in `dt`. Bump the format.
+- Remove `recoverSlotPositions` (`schemas/index.ts:898-961, 1019-1041`); the adapter supersedes it.
+
+**Scope:** on ingress, snap fractional rail positions to nearest whole U; wrap any sub-U or paired
+half-width (legacy `slot_position` left/right) placement in a synthesized carrier (C1), marked
+auto-created. Reads raw input BEFORE Zod enforcement. Before the first carrier-first write, save a
+one-time pre-migration backup to a dedicated `Rackula:pre-carrier-backup` localStorage key (decision
+D3), with a restore affordance.
+
+Decisions locked: D1 adapter at store ingress; D2 full carrier support in share links; D3 dedicated
+backup key; D4 explicit `auto_created` schema field; D5 block-live enforcement; D6 create-paths
+deleted in C3.
+
+**Acceptance:** a legacy 1/3U placement snaps to whole U; two co-located half-width devices become a
+1x2 carrier with two children; a share link with carrier children round-trips; a pre-migration
+backup exists after first adaptation.
+
+**Tests (high-value):** GOLDEN-CORPUS round trip - representative legacy fixtures (fractional rail,
+half-width pair, legacy `slot_position`) -> adapt -> save -> reload -> assert stable, no data loss
+(factories from `src/tests/factories.ts`).
+
+**Deps:** C1. **Risk:** medium-high (read-path correctness on live data; covers ALL ingress paths).
+
+---
+
+### C3 - Drag/drop carrier-first + remove all live create-paths  [Feature, size:M]
+
+**Files:**
+- `src/lib/utils/dragdrop.ts`: remove `snapHalfU` (~75-86); extend `detectContainerDropTarget`
+  (~314-353) to not require pre-selection + scan a free cell; synthesize a generic carrier (marked
+  auto-created) when a sub-U device drops on bare rack.
+- `src/lib/stores/layout/device-actions.ts:placeInContainer` (~152-236): auto-place in next free
+  cell; add `findNextFreeChildPosition` (collision.ts).
+- DELETE the live create-paths (moved here from C5): keyboard fine-move handlers + `moveDeviceSlot`
+  (`KeyboardHandler.svelte` ~102-107, 180-220), their action-registry entries
+  (`actions/registry.ts` ~244-256), and the EditPanel half-width + fine-step UI
+  (`EditPanelPosition.svelte`).
+
+**Scope:** sub-U devices get no rail drop zones; drop prefers an existing carrier free cell at the
+target U, else synthesizes a carrier sized to the device. After this slice, NO interactive path can
+create a sub-U rail or half-width-pair placement.
+
+**Acceptance:** palette drop on bare rack synthesizes a carrier; drop near a carrier with a free cell
+fills it; full carrier rejects; no keyboard/edit-panel path creates a fractional rail placement.
+
+**Tests (high-value):** palette drop synthesizes a carrier; drop near a free cell fills it; one child
+per cell; oversized child rejected.
+
+**Deps:** C1. **Risk:** medium.
+
+---
+
+### C4 - Schema + store enforcement (keystone)  [Feature, size:M]
+
+**Files:** `src/lib/schemas/index.ts` (`PlacedDeviceSchema` ~572-642; `LayoutSchema.superRefine`
+~1140-1208); `src/lib/stores/layout/device-actions.ts` (`placeDevice`).
+
+**Scope (3-layer):** Zod requires `container_id`+`slot_id` for sub-U / non-integer-height / half-
+width placement; integer-U position for rail placements; `slot_id` exists in parent
+`DeviceType.slots`; one child per slot; child fits cell (`u_height <= height_units`, width `<=
+width_fraction`). Store `placeDevice` rejects sub-U rail placement. Save-rejection UX: enforcement
+blocks the bad operation LIVE (store/drag layer); it must never leave a user unable to SAVE a layout
+they already have on screen.
+
+**Acceptance:** sub-U rail placement is rejected at the store and schema layers; missing-slot,
+occupied-slot, and oversized-child placements are rejected; saving a valid carrier-first layout
+always succeeds.
+
+**Tests (high-value):** sub-U rail placement rejected; one child per cell; oversized child rejected.
+
+**Deps:** C2 (adapter on main first), C3 (no live create-paths). **Risk:** high.
+
+---
+
+### C5 - Delete dead fractional code + whole-U / slot-ref labelling  [Task, size:M]
+
+**Files (delete/simplify; create-paths already gone in C3):**
+- `src/lib/utils/position.ts:formatPosition` (~67-83): drop fraction glyphs -> whole-U + slot refs
+  ("U5, slot 1/2"); update callers `export/data.ts`, `EditPanelPosition.svelte`, `DeviceDetails.svelte`.
+- `src/lib/utils/device-movement.ts`: drop `stepOverride` + `isHalfU` factor-2/3 logic (~82-87).
+- `src/lib/utils/collision.ts`: delete `isSlotOccupied` (~144-162); drop rack-level half-width
+  `doSlotsOverlap` usage.
+- `src/lib/types/index.ts`: delete `PlacedDevice.slot_position` (~575) and tidy its schema field.
+- Update `UNITS_PER_U` comment (keep value 6). Delete obsolete tests `half-u-stacking.test.ts`,
+  `slot-position-recovery.test.ts`; update `dragdrop.test.ts` for whole-U.
+
+**Acceptance:** no fraction glyphs anywhere; child placements label as slot references; build + suite
+green with the machinery gone.
+
+**Deps:** C3, C4. **Risk:** medium (smaller now that create-paths left in C3). Folds in labelling.
+
+> When C5 merges, the M14 palette chain parked behind #2158 reopens: #2075 -> #2212/#2213/#2214.
+
+---
+
+## DEFERRED - each gets its own dedicated issue (NOT this run)
+
+### C6 - Container lifecycle: cascade delete + undo, deep duplicate, child cell movement  [Feature, size:M]
+
+Cascade delete container -> children with confirm; undo restores the subtree (children-snapshot
+pattern, `commands/device.ts` ~349-520); deep-copy container duplication; child duplicate fills next
+free cell (toast if full); arrow keys move a container whole-U with children and a child between cells
+in its container only; auto-created carriers self-remove on last-child removal (Decision 3).
+SERIALIZE with C5 (both touch `KeyboardHandler.svelte`). Deferred: doesn't gate the M14 unblock.
+
+### C8 - NetBox interop: subdevice_role import + device_bays export  [Feature, size:L]
+
+NetBox import maps `subdevice_role` children to container children and snaps fractional positions
+(reuse C2); export maps a carrier to a parent device with `device_bays` and children to
+`subdevice_role`. Files: `netbox-import.ts`, likely a new `netbox-elevation-import.ts`, `yaml.ts`
+(~126-127, 169-176). Independent of C5/C6. Deferred: large, gates nothing.
+
+### C9 - User documentation (existing sub-issue #2165)  [already filed]
+
+Document the carrier-first model (whole-U rails, carriers for sub-U gear). Spec says docs land with
+implementation. Use `/technical-writing`. Deferred to after the critical path.
+
+---
+
+## Out of scope (per spec)
+
+Cross-container keyboard movement; category-based accepts whitelists; 1.5U rail mounting; stacking
+multiple devices in one cell. The narrow #2152 patch already shipped in M02 (commit 6e5d69a7), and C5
+deletes the machinery it restored.

--- a/docs/superpowers/specs/2026-06-12-carrier-first-sub-u-design.md
+++ b/docs/superpowers/specs/2026-06-12-carrier-first-sub-u-design.md
@@ -1,0 +1,158 @@
+# Carrier-First Sub-U Devices
+
+Date: 2026-06-12
+Status: Approved direction, pending plan
+Related: #2152 (regression), #1248, #1602 (prior slot_position regressions), M03 Data Format & Interop
+
+## Problem
+
+Rackula currently allows devices to mount at 1/3U and 1/2U rail offsets (UNITS_PER_U = 6
+internal units). Per EIA-310, rails register equipment only at whole-U boundaries; the
+three holes per U locate boundaries, they are not alternative mounting positions. The
+fractional offset machinery models a physical fiction and produced the #2152 scatter
+(two RB5009 placed at "U5 1/3" and "U4 2/3").
+
+Real sub-U devices (MikroTik RB5009 at roughly 0.5U half-width, AV half-rack units at
+full-U half-width) mount via a carrier: a bracket, tray, or shelf that registers to the
+rails at a whole U, while the devices register to the carrier. Examples: MikroTik K-79
+(2x2 grid in 1U), AV joining trays (width-only pairs).
+
+## Core rule
+
+A device with u_height less than 1, a non-integer u_height, or less than full width
+cannot mount directly to rails. It must be a child of a container device. Rail
+positions are whole-U only.
+
+## Decisions
+
+1. Existing layouts and share links: import-time adaptation. On load, snap fractional
+   rail positions to the nearest whole U and synthesize a generic carrier for any sub-U
+   or paired half-width placements. One-time read-path adapter, not an ongoing
+   compatibility layer.
+2. The slot_position left/right placement pathway is deleted, including the pair
+   recovery logic (source of #1248 and #1602). A half-width pair becomes a 1-row,
+   2-col carrier. slot_width survives only as a device size descriptor used for
+   cell-fit checks.
+3. Auto-created carriers self-remove when their last child is removed. User-placed
+   carriers persist when empty.
+4. Rail-mountable devices must have integer u_height. Fractional heights of any size,
+   including 1.5U and above, require a carrier. Revisit if real 1.5U rail gear is
+   requested; the starter library contains none.
+5. Sequencing: a narrow #2152 patch ships first on the existing slot machinery
+   (restores pair-keeping, fits M02 stability). Carrier-first lands in M03 and deletes
+   that machinery.
+
+## Data model
+
+Existing pieces that carry the design (already implemented):
+
+- DeviceType.slots[] with Slot { id, position: {row, col}, width_fraction,
+  height_units, accepts }
+- PlacedDevice.container_id + slot_id for children
+- ContainerSlots.svelte, placeInContainer(), detectContainerDropTarget(), child
+  exclusion from rack-level collision, atomic cross-rack moves with children
+
+Changes:
+
+- Rail positions become integer U. The factor-3 and factor-2 position offsets are
+  removed: fraction glyphs in formatPosition, 1/3-step fine movement in
+  device-movement.ts, fractional rail collision math.
+- PlacedDevice.slot_position is removed. Children are located by slot_id alone.
+- u_height keeps 0.5 steps as a device size; it no longer affects rail position math.
+- Schema version bump; share-link format revision.
+
+## Enforcement points
+
+The core rule is enforced in three layers so it cannot leak:
+
+1. Zod schema: sub-U or non-integer-height placement requires container_id and
+   slot_id; rail placements require integer-U position; slot_id must exist in the
+   parent DeviceType.slots; one child per slot; child must fit cell dimensions
+   (u_height <= height_units, width <= width_fraction).
+2. Store actions: placeDevice rejects rail placement of sub-U devices.
+3. Drag and drop: sub-U devices get no valid rail drop zones; drop targeting prefers
+   an existing carrier with a free cell at the target U, else synthesizes a generic
+   carrier sized to the device (1U; 2-col for half-width; 2x2 for half-width plus
+   half-height).
+
+## Lifecycle rules
+
+- Deleting a container cascades to children, with confirm. Undo restores the whole
+  subtree using the children-snapshot pattern already used by cross-rack move
+  (device-actions.ts).
+- Duplicating a container deep-copies children. Duplicating a child targets the next
+  free cell in the same container; if full, toast and do nothing.
+- Dragging a child out of a container onto bare rack follows the same synthesize rule
+  as palette drops.
+- Arrow keys on a container move it whole-U with children. Arrow keys on a child move
+  between cells within its container only.
+- Children inherit the container face. Rear-mounted carriers work without special
+  casing because a carrier is a normal device with a face.
+
+## Library
+
+- K-79 as a branded 2x2 container (RB5009, L009).
+- Generic 1U carrier, 2x2.
+- AV joining tray: 1 row, 2 cols, full-height cells. The AV case never sees a height
+  grid; the MikroTik grid is not assumed universal.
+- Existing 2-slot and 3-slot shelf containers remain.
+- accepts stays empty by default; fit is dimensional, not category-based.
+
+## Import and interop
+
+- Legacy Rackula JSON and share links: snap rail positions to whole U; wrap sub-U and
+  paired half-width placements in synthesized generic carriers.
+- NetBox import: NetBox permits half-U mounting positions. Imported elevations with
+  fractional positions get the same snap-and-synthesize treatment. NetBox child
+  devices (subdevice_role) map to container children; this completes the currently
+  unmapped import path.
+- NetBox export: a carrier maps to a parent device with device_bays; children map to
+  subdevice_role child.
+
+## Labelling
+
+Child placements display as container slot references (for example "U5, slot 1/2"),
+which matches the labelling requested in #2152. Position fraction glyphs are removed.
+
+## Testing
+
+High-value behavioural tests only, per testing policy:
+
+- Sub-U rail placement is rejected.
+- Palette drop on bare rack synthesizes a carrier; drop near a carrier with a free
+  cell fills the cell.
+- One child per cell; oversized child rejected.
+- Cascade delete then undo restores container and children.
+- Deep duplicate copies children; child duplicate fills next free cell.
+- Import adapter snaps fractional positions and synthesizes carriers.
+
+No count assertions, no schema re-testing, factories from src/tests/factories.ts.
+
+## Sequencing
+
+1. M02: narrow #2152 patch restoring pair-keeping on existing slot machinery.
+2. M03: carrier-first as specified here, deleting the slot_position pathway and the
+   fractional rail position machinery.
+
+## Future consumers
+
+Drive bay mapping (discussion #1678: Storinator and JBOD chassis with interior
+drive grids) will reuse the same slot primitives: a parent device with an N x M
+grid of cells holding child items, child metadata via notes, serial, and
+custom_fields, and the same NetBox device_bays mapping. It is out of scope for
+this design, but two constraints here exist so it is not foreclosed:
+
+1. Slot rendering is keyed off the slot definition (face-visible vs interior),
+   not assumed. Carriers use the face-visible case only; interior grids (drive
+   bays behind covers or top-loading) will render in a detail view instead of
+   the rack elevation.
+2. The grid model assumes no maximum dimensions. Carriers are 2x2; a drive
+   chassis grid may be 4x15 or larger. Slot naming stays free-form so cell
+   labels like "Bay A7" work the same way as "slot 1/2".
+
+## Out of scope
+
+- Cross-container keyboard movement.
+- Category-based accepts whitelists.
+- 1.5U rail mounting (revisit on demand).
+- Stacking multiple devices within a single cell.


### PR DESCRIPTION
## **User description**
Lands the frozen design spec, the whole-U README note, and the epic decomposition plan (v2, post architect adversarial pass) for #2158. Docs only - no code.

Decomposition (sub-issues of #2158):
- Critical path (unblocks M14 palette chain): C1 #2289 -> {C2 #2290, C3 #2291} -> C4 #2292 -> C5 #2294
- Deferred: C6 #2295 (lifecycle), C8 #2296 (NetBox), C9 #2165 (docs)

Locked decisions: D1 adapter at store ingress; D2 full carrier support in share links; D3 dedicated pre-migration backup key; D4 explicit auto_created schema field; D5 block-live enforcement; D6 create-paths deleted in C3.

Plan: docs/plans/2026-06-14-carrier-first-sub-u-decomposition.md
Spec: docs/superpowers/specs/2026-06-12-carrier-first-sub-u-design.md

Refs #2158

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the carrier-first rack model and rollout plan**

### What Changed
- Adds a README section explaining that racks use whole-U spacing and that smaller gear must sit in a 1U carrier instead of mounting directly to rails
- Adds the approved design spec for carrier-first sub-U devices, including the core rules, data model, import/export behavior, and testing goals
- Adds the epic decomposition plan that breaks the rollout into ordered child issues, with the critical path and deferred follow-ups clearly listed

### Impact
`✅ Clearer rack layout rules`
`✅ Fewer ambiguous sub-U mounting assumptions`
`✅ Easier handoff for carrier-first implementation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
