### PR TITLE
ci(test): make self-hosted E2E advisory (non-blocking)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,13 @@ jobs:
     name: e2e (self-hosted full suite)
     needs: validate
     if: github.event_name == 'pull_request'
+    # Advisory, not merge-blocking. Per spike #1994 the self-hosted tier is
+    # *additive* to the GH-hosted chromium smoke (the validate job), which stays
+    # the hard gate. This job runs on a single homelab VM (one runner, one host)
+    # — a SPOF — so a failure here (runner down, unprovisioned, flake) must not
+    # block PRs. continue-on-error keeps the full-suite result visible as signal
+    # while letting the overall Test run conclude green.
+    continue-on-error: true
     runs-on: [self-hosted, ci-runner]
     timeout-minutes: 30
     environment: ${{ github.event.pull_request.head.repo.full_name == 'RackulaLives/Rackula' && 'e2e-trusted' || 'e2e-approval' }}


### PR DESCRIPTION
## **User description**
## What
Marks the `e2e-self-hosted` job in `test.yml` as `continue-on-error: true` — advisory, not merge-blocking.

## Why
The self-hosted full E2E suite runs on a single homelab VM (one runner, one host) — a single point of failure. Per **spike #1994**, this tier is explicitly *additive* to the GH-hosted chromium smoke (the `validate` job), which remains the hard gate. As a blocking job, every PR is held whenever the homelab runner is down, mid-reboot, or unprovisioned — for zero baseline coverage gained.

With `continue-on-error`, a failure (runner offline, flake, host gap) no longer fails the overall **Test** run, but the job's own result stays visible so you still see broader-browser regressions.

## Notes
- `main` currently has no required-status-check rules, so this also future-proofs against the job being marked required later.
- The underlying host gap that caused the original 338/340 failures (`libnspr4.so` missing) is fixed separately in homelab-infra (Playwright system libs added to the `github-runner` role), so the suite should now pass on its own — this just makes sure it can never *block* when the homelab side has a bad day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the self-hosted E2E suite advisory instead of blocking PRs**

### What Changed
- The full self-hosted browser test run no longer fails the overall PR check when the homelab runner is unavailable or a test flakes
- The GH-hosted smoke test remains the required gate before merge
- PRs still show the full self-hosted result, so broader browser issues remain visible without stopping the workflow

### Impact
`✅ Fewer PRs blocked by homelab outages`
`✅ No merge delays from self-hosted E2E flakes`
`✅ Clearer visibility into full-suite browser regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
