### PR TITLE
feat: carrier device types + auto_created placement flag (C1) (#2289)

### DIFF
--- a/src/lib/data/starterLibrary.ts
+++ b/src/lib/data/starterLibrary.ts
@@ -2,11 +2,11 @@
  * Starter Device Type Library
  * Generic rack devices for quick prototyping and universal fallbacks
  *
- * Total devices: 62 generic devices
- * - 43 full-width devices
- * - 8 half-width devices (slot_width: 1)
- * - 4 shelf containers with slots
- * - 7 mini devices for shelf placement
+ * Includes:
+ * - Full-width and half-width (slot_width: 1) devices
+ * - Shelf containers with slots and mini devices for shelf placement
+ * - Carriers (carrier-1u-2col, carrier-1u-2x2, K-79, AV joining tray) that hold
+ *   sub-U / half-width gear; the two carrier-* slugs are stable synthesis targets
  * All branded devices have been moved to brandPacks/
  */
 
@@ -306,6 +306,131 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
         position: { row: 0, col: 2 },
         width_fraction: 0.33,
         height_units: 2,
+      },
+    ],
+  },
+
+  // Carriers - generic 1U mounts for sub-U / half-width gear.
+  // The two synthesized-carrier slugs below (carrier-1u-2col, carrier-1u-2x2)
+  // are STABLE: the import adapter and drag/drop synthesize these exact slugs.
+  // Slots omit `accepts` so fit is dimensional, not category-based.
+  {
+    slug: "carrier-1u-2col",
+    model: "Carrier (1U, 2 Column)",
+    u_height: 1,
+    category: "shelf",
+    subdevice_role: "parent",
+    slots: [
+      {
+        id: "col-1",
+        name: "Column 1",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.5,
+        height_units: 1,
+      },
+      {
+        id: "col-2",
+        name: "Column 2",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.5,
+        height_units: 1,
+      },
+    ],
+  },
+  {
+    slug: "carrier-1u-2x2",
+    model: "Carrier (1U, 2x2)",
+    u_height: 1,
+    category: "shelf",
+    subdevice_role: "parent",
+    slots: [
+      {
+        id: "r0-c0",
+        name: "Top Left",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.5,
+        height_units: 0.5,
+      },
+      {
+        id: "r0-c1",
+        name: "Top Right",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.5,
+        height_units: 0.5,
+      },
+      {
+        id: "r1-c0",
+        name: "Bottom Left",
+        position: { row: 1, col: 0 },
+        width_fraction: 0.5,
+        height_units: 0.5,
+      },
+      {
+        id: "r1-c1",
+        name: "Bottom Right",
+        position: { row: 1, col: 1 },
+        width_fraction: 0.5,
+        height_units: 0.5,
+      },
+    ],
+  },
+  {
+    slug: "carrier-k79-2x2",
+    model: "K-79 Mounting Kit",
+    u_height: 1,
+    category: "shelf",
+    subdevice_role: "parent",
+    slots: [
+      {
+        id: "r0-c0",
+        name: "Top Left",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.5,
+        height_units: 0.5,
+      },
+      {
+        id: "r0-c1",
+        name: "Top Right",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.5,
+        height_units: 0.5,
+      },
+      {
+        id: "r1-c0",
+        name: "Bottom Left",
+        position: { row: 1, col: 0 },
+        width_fraction: 0.5,
+        height_units: 0.5,
+      },
+      {
+        id: "r1-c1",
+        name: "Bottom Right",
+        position: { row: 1, col: 1 },
+        width_fraction: 0.5,
+        height_units: 0.5,
+      },
+    ],
+  },
+  {
+    slug: "carrier-av-tray-2col",
+    model: "AV Joining Tray (2 Column)",
+    u_height: 1,
+    category: "shelf",
+    subdevice_role: "parent",
+    slots: [
+      // Width-only: slots omit height_units so the tray never has a height
+      // grid (the MikroTik 2x2 grid is not assumed universal).
+      {
+        id: "col-1",
+        name: "Left",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.5,
+      },
+      {
+        id: "col-2",
+        name: "Right",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.5,
       },
     ],
   },

--- a/src/lib/data/starterLibrary.ts
+++ b/src/lib/data/starterLibrary.ts
@@ -343,31 +343,32 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
     u_height: 1,
     category: "shelf",
     subdevice_role: "parent",
+    // Row 0 is the bottom row (SlotPosition2D: row is 0-indexed from bottom).
     slots: [
       {
         id: "r0-c0",
-        name: "Top Left",
+        name: "Bottom Left",
         position: { row: 0, col: 0 },
         width_fraction: 0.5,
         height_units: 0.5,
       },
       {
         id: "r0-c1",
-        name: "Top Right",
+        name: "Bottom Right",
         position: { row: 0, col: 1 },
         width_fraction: 0.5,
         height_units: 0.5,
       },
       {
         id: "r1-c0",
-        name: "Bottom Left",
+        name: "Top Left",
         position: { row: 1, col: 0 },
         width_fraction: 0.5,
         height_units: 0.5,
       },
       {
         id: "r1-c1",
-        name: "Bottom Right",
+        name: "Top Right",
         position: { row: 1, col: 1 },
         width_fraction: 0.5,
         height_units: 0.5,
@@ -380,31 +381,32 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
     u_height: 1,
     category: "shelf",
     subdevice_role: "parent",
+    // Row 0 is the bottom row (SlotPosition2D: row is 0-indexed from bottom).
     slots: [
       {
         id: "r0-c0",
-        name: "Top Left",
+        name: "Bottom Left",
         position: { row: 0, col: 0 },
         width_fraction: 0.5,
         height_units: 0.5,
       },
       {
         id: "r0-c1",
-        name: "Top Right",
+        name: "Bottom Right",
         position: { row: 0, col: 1 },
         width_fraction: 0.5,
         height_units: 0.5,
       },
       {
         id: "r1-c0",
-        name: "Bottom Left",
+        name: "Top Left",
         position: { row: 1, col: 0 },
         width_fraction: 0.5,
         height_units: 0.5,
       },
       {
         id: "r1-c1",
-        name: "Bottom Right",
+        name: "Top Right",
         position: { row: 1, col: 1 },
         width_fraction: 0.5,
         height_units: 0.5,

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -607,6 +607,10 @@ export const PlacedDeviceSchema = z
     /** Which slot in parent container (references Slot.id) */
     slot_id: z.string().optional(),
 
+    // --- Auto-Created Placement ---
+    /** True when synthesized automatically (e.g. a carrier for a sub-U device) */
+    auto_created: z.boolean().default(false),
+
     // --- Extension Fields ---
     notes: z.string().max(1000).optional(),
     custom_fields: z.record(z.string(), z.any()).optional(),

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -613,6 +613,15 @@ export interface PlacedDevice {
    */
   slot_id?: string;
 
+  // --- Auto-Created Placement ---
+  /**
+   * True when this placement was synthesized automatically (e.g. a carrier
+   * created to hold a sub-U device) rather than placed by the user. Lets a
+   * later slice self-remove auto-synthesized carriers when their last child is
+   * removed, while user-placed carriers persist. Default: false.
+   */
+  auto_created?: boolean;
+
   // --- Extension Fields ---
   /** Notes for this placement */
   notes?: string;

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -144,7 +144,7 @@ function orderDeviceTypeFields(dt: DeviceType): Record<string, unknown> {
 /**
  * Order PlacedDevice fields according to schema v1.0.0
  * Field order: id, device_type, name, position, face, slot_position, front_image, rear_image,
- *              parent_device, device_bay, container_id, slot_id, notes, custom_fields
+ *              parent_device, device_bay, container_id, slot_id, auto_created, notes, custom_fields
  */
 function orderPlacedDeviceFields(
   device: PlacedDevice,
@@ -174,6 +174,10 @@ function orderPlacedDeviceFields(
   if (device.container_id !== undefined)
     ordered.container_id = device.container_id;
   if (device.slot_id !== undefined) ordered.slot_id = device.slot_id;
+
+  // --- Auto-Created Placement ---
+  // Only written when true; the schema defaults it to false on load.
+  if (device.auto_created) ordered.auto_created = true;
 
   // --- Extension Fields ---
   if (device.notes !== undefined) ordered.notes = device.notes;

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -53,6 +53,48 @@ describe("YAML layout round-trip", () => {
     expect(restored.racks[0]?.devices[1]?.slot_position).toBe("right");
   });
 
+  it("preserves auto_created for an auto-synthesized carrier placement", async () => {
+    const carrierType = createTestDeviceType({
+      slug: "carrier-device",
+      u_height: 1,
+    });
+
+    const layout = createTestLayout({
+      racks: [
+        createTestRack({
+          id: "rack-1",
+          devices: [
+            createTestDevice({
+              id: "auto-carrier",
+              device_type: carrierType.slug,
+              position: 10,
+              auto_created: true,
+            }),
+            createTestDevice({
+              id: "user-carrier",
+              device_type: carrierType.slug,
+              position: 14,
+            }),
+          ],
+        }),
+      ],
+      device_types: [carrierType],
+    });
+
+    const yaml = await serializeLayoutToYaml(layout);
+
+    // auto_created must be serialised so a later slice can self-remove
+    // auto-synthesized carriers while user-placed carriers persist.
+    expect(yaml).toContain("auto_created");
+
+    const restored = await parseLayoutYaml(yaml);
+    const auto = restored.racks[0]?.devices.find((d) => d.id === "auto-carrier");
+    const user = restored.racks[0]?.devices.find((d) => d.id === "user-carrier");
+    expect(auto?.auto_created).toBe(true);
+    // A placement that never set the flag round-trips as the default (false).
+    expect(user?.auto_created).toBe(false);
+  });
+
   it("preserves container_id and slot_id for contained child devices", async () => {
     const containerType: DeviceType = {
       ...createTestDeviceType({


### PR DESCRIPTION
## **User description**
## Summary

First slice (C1) of epic #2158 (carrier-first sub-U devices). Adds the carrier
DeviceTypes that the import adapter (C2/#2290) and drag/drop (C3/#2291) will
synthesize, plus the explicit `auto_created` placement flag (decision D4) so a
later slice can self-remove auto-synthesized carriers while user-placed carriers
persist.

## Stable carrier slugs (synthesis targets for C2/C3)

These two slugs are STABLE. C2 (adapter) and C3 (drag/drop) synthesize these
exact slugs as carrier targets, so do not rename them:

| Slug | Shape | Cells |
|------|-------|-------|
| `carrier-1u-2col` | 1U, 1 row x 2 cols | two half-width, full-height cells |
| `carrier-1u-2x2` | 1U, 2 rows x 2 cols | four half-width, half-height cells |

Plus two more carrier types (part of the family):

| Slug | Notes |
|------|-------|
| `carrier-k79-2x2` | K-79 branded 2x2 container (for RB5009, L009) |
| `carrier-av-tray-2col` | AV joining tray, 1 row x 2 cols, full-height; width-only (slots omit `height_units`, so it never has a height grid) |

All four use `subdevice_role: "parent"` and omit `accepts` on their slots so
fit is dimensional, not category-based. The existing 2-slot / 3-slot shelf
containers are unchanged.

## auto_created flag

- Added `auto_created?: boolean` to `PlacedDevice` (`src/lib/types/index.ts`)
  and `PlacedDeviceSchema` (`src/lib/schemas/index.ts`), default `false`.
- Serialized in the FULL layout save/load: YAML (`src/lib/utils/yaml.ts`,
  written only when `true`; the schema defaults it to `false` on load) and the
  JSON session path (raw runtime serialize + schema default on parse).
- One round-trip test added in `src/tests/yaml-roundtrip.test.ts` (TDD: written
  red first, then implemented).

## Scope note: share-link schema deliberately untouched

#2289's AC mentions "round-tripped through share links". This PR scopes C1's
round-trip to the FULL YAML/JSON save/load only and does NOT touch the share-link
minimal schema (`src/lib/schemas/share.ts`, `src/lib/utils/share.ts`). Encoding
`auto_created` + container fields into share links is C2's (#2290) job, and
carriers are not shareable until then. This matches the v2 decomposition plan
(decision D2: full carrier support in share links lands in C2).

## Testing

The carrier library data is covered by the existing `starterLibrary.test.ts`
`DeviceTypeSchema` validation loop (Zero-Change Rule), so no per-device tests
were added. The only new test is the `auto_created` round-trip.

## Verification (local)

- `npm run lint` -> No issues found
- `npm run test:run` -> 140 files, 2455 tests passed
- `npm run build` -> built in 4.65s

Closes #2289

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add carrier device types and keep auto-created placements through save/load

### What Changed
- Added four carrier device types for sub-U and half-width gear, including two stable carrier types that other flows can create automatically
- Saved placements can now mark whether they were created automatically, so auto-added carriers stay identifiable after reopening a layout
- Fixed the 2x2 carrier slot labels so the bottom row and top row are shown in the correct order

### Impact
`✅ Auto-added carriers survive layout save and reload`
`✅ Fewer lost carrier placements after reopening`
`✅ Clearer slot labels on 2x2 carriers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
