### PR TITLE
docs: reconcile roadmap master plan against live GitHub (2026-06-14)

### DIFF
--- a/docs/plans/2026-06-12-m02-release-stability-plan.md
+++ b/docs/plans/2026-06-12-m02-release-stability-plan.md
@@ -8,7 +8,7 @@ Ship Rackula's distribution channels (Unraid CA, ProxmoxVE community-scripts fol
 
 ## Position in sequence
 
-M02 is the active milestone and runs first in the sequence M02 -> M04 -> M03 -> M14 -> M13. M15 (Storage Model & Data Safety) runs in parallel with M02 right now; its issues gate parts of Stage 2 and the contract-test work in Stage 1. Note: #728 (hero video) has moved out of M02 to M13.
+M02 is the active milestone and runs first in the sequence M02 -> M04 -> M03 -> M14 -> M16. M15 (Storage Model & Data Safety) runs in parallel with M02 right now; its issues gate parts of Stage 2 and the contract-test work in Stage 1. Note: #728 (hero video) has moved out of M02 to M16.
 
 ## Cross-milestone gates in
 

--- a/docs/plans/2026-06-12-m03-data-format-interop-plan.md
+++ b/docs/plans/2026-06-12-m03-data-format-interop-plan.md
@@ -8,7 +8,7 @@ Ship the schema versioning and compatibility policy, replace fractional rail pos
 
 **Position in sequence**
 
-M03 runs after M02 (LXC Release & Stability) and M04 (Type Safety, Decomposition & Stability), and before M14 (UX shell) and M13 (keyboard pass). M15 (storage) runs in parallel and does not gate M03. The working sequence is M02 -> M04 -> M03 -> M14 -> M13.
+M03 runs after M02 (LXC Release & Stability) and M04 (Type Safety, Decomposition & Stability), and before M14 (UX shell) and M16 (keyboard pass). M15 (storage) runs in parallel and does not gate M03. The working sequence is M02 -> M04 -> M03 -> M14 -> M16.
 
 **Cross-milestone gates in**
 

--- a/docs/plans/2026-06-12-m04-type-safety-stability-plan.md
+++ b/docs/plans/2026-06-12-m04-type-safety-stability-plan.md
@@ -8,7 +8,7 @@ Finish the TypeScript suppression burndown, the remaining large-file decompositi
 
 **Position in sequence**
 
-M04 runs now, in parallel with M02 and M15, within the M02 -> M04 -> M03 -> M14 -> M13 sequence. M04 must finish before M03 (Data Format & Interop) and M14 (Canvas UX Overhaul) start building on the decomposed, type-checked code.
+M04 runs now, in parallel with M02 and M15, within the M02 -> M04 -> M03 -> M14 -> M16 sequence. M04 must finish before M03 (Data Format & Interop) and M14 (Canvas UX Overhaul) start building on the decomposed, type-checked code.
 
 **Cross-milestone gates in**
 

--- a/docs/plans/2026-06-12-m14-canvas-ux-overhaul-plan.md
+++ b/docs/plans/2026-06-12-m14-canvas-ux-overhaul-plan.md
@@ -8,7 +8,7 @@ Reframe the canvas shell around one principle: place each control where its scop
 
 ## Position in sequence
 
-M14 runs after M03 in the working sequence M02 -> M04 -> M03 -> M14 -> M13, with M15 (Storage Model & Data Safety) running in parallel now. M04's decomposition and M03's carrier-first data model (#2158) are the floor this milestone builds on. M13 follows M14; #2094 absorbed M13's virtualization tracker (#114).
+M14 runs after M03 in the working sequence M02 -> M04 -> M03 -> M14 -> M16, with M15 (Storage Model & Data Safety) running in parallel now. M04's decomposition and M03's carrier-first data model (#2158) are the floor this milestone builds on. M16 follows M14; #2094 absorbed M16's virtualization tracker (#114).
 
 ## Cross-milestone gates in
 

--- a/docs/plans/2026-06-12-m15-storage-data-safety-plan.md
+++ b/docs/plans/2026-06-12-m15-storage-data-safety-plan.md
@@ -8,7 +8,7 @@ Make storage explicit and data loss hard. The app runs in one of two explicit mo
 
 **Position in sequence**
 
-The milestone sequence is M02 -> M04 -> M03 -> M14 -> M13. M15 runs now, in parallel with M02 and M04 (the milestone number is an ID, not an order). M15's #2037 is on the critical path for both M14 (entry chain) and the M02 dev cutover (#2134), so Stage 2 should not lag.
+The milestone sequence is M02 -> M04 -> M03 -> M14 -> M16. M15 runs now, in parallel with M02 and M04 (the milestone number is an ID, not an order). M15's #2037 is on the critical path for both M14 (entry chain) and the M02 dev cutover (#2134), so Stage 2 should not lag.
 
 **Cross-milestone gates in**
 

--- a/docs/plans/2026-06-12-m16-post-shell-pass-plan.md
+++ b/docs/plans/2026-06-12-m16-post-shell-pass-plan.md
@@ -1,16 +1,16 @@
-# M13 -- Post-Shell Keyboard, Help & Content Pass Execution Plan
+# M16 -- Post-Shell Keyboard, Help & Content Pass Execution Plan
 
-Note: GitHub milestone 35 was retitled "M13 -- Post-Shell Keyboard, Help & Content Pass" on 2026-06-13 to match this recharter.
+Note: this plan covers GitHub milestone 35, titled "M16 -- Post-Shell Keyboard, Help & Content Pass" as of 2026-06-14. The milestone was rechartered 2026-06-12, first labelled M13, briefly retitled M13 on GitHub on 2026-06-13, then renamed to M16; the M13 label is retired and not reused.
 
 > For agentic workers: execute one task per session via /dev-issue <number>. The GitHub issue body is the source of truth (each carries an Alignment audit 2026-06-12 section with binding ACs). Do not start a task whose listed blockers are open. Follow repo TDD policy (CLAUDE.md): tests only where behaviour warrants them.
 
 **Goal**
 
-Land the three issues of the rechartered M13 (milestone 35) against the new M14 shell: a keyboard-only device placement flow on the virtualized palette (#106), contextual tooltips rendered from the command registry (#117), and a hero recording of the finished shell (#728). M13 was rechartered 2026-06-12; its former contents were superseded by M14 or closed stale (see Verification).
+Land the three issues of the rechartered M16 (milestone 35) against the new M14 shell: a keyboard-only device placement flow on the virtualized palette (#106), contextual tooltips rendered from the command registry (#117), and a hero recording of the finished shell (#728). M16 was rechartered 2026-06-12; its former contents were superseded by M14 or closed stale (see Verification).
 
 **Position in sequence**
 
-Working order is M02 -> M04 -> M03 -> M14 -> M13, with M15 (storage) running in parallel now. M13 is the last milestone in the chain. It deliberately runs after the M14 Canvas UX Overhaul so every task here targets the new shell, not surfaces M14 deletes.
+Working order is M02 -> M04 -> M03 -> M14 -> M16, with M15 (storage) running in parallel now. M16 is the last milestone in the chain. It deliberately runs after the M14 Canvas UX Overhaul so every task here targets the new shell, not surfaces M14 deletes.
 
 **Cross-milestone gates in**
 
@@ -20,7 +20,7 @@ Working order is M02 -> M04 -> M03 -> M14 -> M13, with M15 (storage) running in 
 
 **Cross-milestone gates out**
 
-None. Nothing downstream waits on M13; it closes the post-shell polish chain. The in-app coffin-mark rebrand (#2048) is already closed and does not block #728.
+None. Nothing downstream waits on M16; it closes the post-shell polish chain. The in-app coffin-mark rebrand (#2048) is already closed and does not block #728.
 
 ## Stage 1: Keyboard placement on the new palette
 
@@ -105,10 +105,10 @@ Verify:
 
 Milestone close-out checklist:
 
-- [ ] #106, #117, #728 all closed (gh issue list -R RackulaLives/Rackula --milestone "M13 -- Post-Shell Keyboard, Help & Content Pass" --state open returns nothing)
-- [ ] Former M13 contents confirmed superseded, no orphans: #114 -> #2094, #115 -> #2095, #951 -> #2082/#2073, #767 -> #2158, #946 closed stale (all five verified closed as of 2026-06-12)
+- [ ] #106, #117, #728 all closed (gh issue list -R RackulaLives/Rackula --milestone "M16 -- Post-Shell Keyboard, Help & Content Pass" --state open returns nothing)
+- [ ] Former M16 contents confirmed superseded, no orphans: #114 -> #2094, #115 -> #2095, #951 -> #2082/#2073, #767 -> #2158, #946 closed stale (all five verified closed as of 2026-06-12)
 - [ ] Smoke: keyboard-only placement flow works on a production build (npm run build, then preview)
 - [ ] Smoke: tooltips and HelpPanel show identical shortcuts for the same commands (single registry source)
 - [ ] Smoke: README hero renders the new shell recording
 - [ ] npm run test:run, npm run lint, and npm run build green on main after the final merge
-- [ ] Close milestone M13 on GitHub
+- [ ] Close milestone M16 on GitHub

--- a/docs/plans/2026-06-12-roadmap-execution-master-plan.md
+++ b/docs/plans/2026-06-12-roadmap-execution-master-plan.md
@@ -7,49 +7,59 @@
 > acceptance criteria. If a plan file and an issue disagree, the issue wins; fix the plan
 > in a docs PR.
 
-Goal: take Rackula from the current state (M02/M15 in progress) to the post-overhaul
-shell (M14) with no rework, in the order that respects every cross-milestone dependency
-found by the 2026-06-12 alignment audit (29 verified findings).
+Goal: finish the post-burndown roadmap. The M14 canvas shell has shipped and M04 is
+complete; M15 is trailing. The remaining work splits into three tracks that respect every
+verified cross-milestone dependency: finish M15, close M02 (prod cutover, then a 7-day
+soak, then VPS decommission), and drive M03 carrier-first (#2158), the one live gate still
+blocking the M14 placement tail and the JSON Schema publish (#571).
 
-Status date: 2026-06-12. Sequencing authority: docs/planning/ROADMAP.md.
+Status date: 2026-06-14 (live-GitHub reconciliation applied; supersedes the 2026-06-12
+snapshot). Sequencing authority: docs/planning/ROADMAP.md.
 
 ## Execution order
 
-M15 runs now, in parallel with M02 and M04. Then strictly: M03, M14, M13. M07 and later
-follow per ROADMAP.
+The post-burndown roadmap is three independent tracks, not a linear chain. M04 is complete
+and the M14 shell has shipped, so the old "then strictly M03, M14" ordering no longer
+applies. Run in parallel: Track A finishes M15 (all remaining issues are unblocked);
+Track B closes M02 (#2029 prod cutover, 7-day soak, #1986 VPS decommission); Track C lands
+M03 #2158 (carrier-first), the single live cross-track gate, which then unblocks the M14
+placement tail (#2075, then palette #2212/#2213/#2214) and the JSON Schema publish (#571).
+M16 (post-shell pass) and M07 and later follow per ROADMAP.
 
-| Order | Milestone | Plan file | State |
+| Track | Milestone | Plan file | State |
 | --- | --- | --- | --- |
-| now | M15 Storage Model & Data Safety | 2026-06-12-m15-storage-data-safety-plan.md | in progress |
-| now | M02 LXC Release & Stability | 2026-06-12-m02-release-stability-plan.md | in progress |
-| now | M04 Type Safety, Decomposition & Stability | 2026-06-12-m04-type-safety-stability-plan.md | in progress |
-| next | M03 Data Format & Interop | 2026-06-12-m03-data-format-interop-plan.md | planned |
-| then | M14 Canvas UX Overhaul | 2026-06-12-m14-canvas-ux-overhaul-plan.md | planned |
-| then | M13 Post-Shell Keyboard, Help & Content | 2026-06-12-m13-post-shell-pass-plan.md | planned |
+| done | M04 Type Safety, Decomposition & Stability | 2026-06-12-m04-type-safety-stability-plan.md | complete (98% closed); last issue #2103 closing via PR #2301 |
+| A (now) | M15 Storage Model & Data Safety | 2026-06-12-m15-storage-data-safety-plan.md | trailing; 4 features + 1 chore left, all unblocked (75% closed) |
+| B (now) | M02 LXC Release & Stability | 2026-06-12-m02-release-stability-plan.md | closure path #2029 then soak then #1986 (69% closed) |
+| C (now) | M03 Data Format & Interop | 2026-06-12-m03-data-format-interop-plan.md | active frontier; #2158 carrier-first in progress (12% closed) |
+| tail | M14 Canvas UX Overhaul | 2026-06-12-m14-canvas-ux-overhaul-plan.md | shell complete (83%); placement tail #2075/#2212/#2213/#2214 parked behind M03 #2158 |
+| after tail | M16 Post-Shell Keyboard, Help & Content | 2026-06-12-m16-post-shell-pass-plan.md | planned (3 issues) |
 
 ## Cross-milestone gates
 
 These are the dependencies that cross plan files. A task whose gate is open must not
 start. Each gate is also recorded on the issues themselves.
 
-1. #2180 (M04) lands before #2037 (M15) rewrites src/lib/storage/manager.svelte.ts,
-   or rides the #2037 PR as its first commit.
-2. #2091 (M15) blocks #2041 and #2042 (M15) and defines the storage-contract test that
-   #2133 (M02) must pass.
-3. #2037 (M15), ideally with #2041, lands before the dev cutover #2134 (M02);
-   otherwise #2134 carries its forward-compat AC.
-4. #2037 (M15) gates #2187 (M14 mode-aware menu items). The rest of the M14 entry
-   chain (#2073 shell, #2081, #2080, #2095) depends only on #2073's shell slice.
-5. #617 (M15) lands before a tagged release ships the chip (#2035) and nudge (#2038)
-   to users; until then both carry the custom-image guard AC.
-6. #2158 (M03) lands before M14 placement, drag, or verb-bar work (#2075) and before
-   #571 publishes the JSON Schema; #2095 templates are authored after the bump.
-7. Guard rails #2098/#2099/#2100 plus wave-0 designs (#2179, #2182, #2183, #2184,
-   #2185) are green before any M14 shell slice merges.
-8. #2029 (M02 prod cutover) plus the 7-day soak gate #1986 (VPS decommission), which
-   closes M02. The user-data disposition AC on #2029 runs before the flip.
-9. Waiting-external issues (#2142, #2053, #2013) never gate anything; they form a
-   background track.
+1. SATISFIED (2026-06-13): #2180 (M04) landed before #2037 (M15) rewrote
+   src/lib/storage/manager.svelte.ts. The ride-along fallback was not needed.
+2. SATISFIED for M15, ACTIVE for M02: #2091 (M15) is closed, so #2041 (closed) and #2042
+   (M15, unblocked) can proceed. The storage-contract test it defines is still the bar
+   that #2133 (M02) must pass.
+3. SATISFIED: #2037 (M15) landed, so the dev cutover #2134 (M02) can proceed; the
+   forward-compat fallback is no longer required.
+4. SATISFIED: #2037 (M15) and #2187 (M14 mode-aware menu) are both closed. The rest of
+   the M14 entry chain (#2073 shell, #2081, #2080, #2095) has shipped.
+5. SATISFIED (2026-06-14): #617 (M15) landed, so the chip (#2035, closed) and nudge
+   (#2038, ready) can ship without the custom-image guard.
+6. ACTIVE (the live cross-track gate): #2158 (M03) lands before M14 placement, drag, or
+   verb-bar work (#2075) and before #571 publishes the JSON Schema; #2095 templates are
+   authored after the bump. #2158 is at design stage (PR #2297); the slot_position
+   deletion is C5 (#2294), several blocked steps down the C1-C6 chain.
+7. SATISFIED: guard rails #2098/#2099/#2100 and wave-0 designs (#2179, #2182, #2183,
+   #2184, #2185) are all closed; the M14 shell slices shipped.
+8. ACTIVE (M02 closure): #2029 (M02 prod cutover) plus the 7-day soak gate #1986 (VPS
+   decommission) close M02. The user-data disposition AC on #2029 runs before the flip.
+9. Background: waiting-external issues (#2142, #2053, #2013) never gate anything.
 
 ## Conventions for executing agents
 
@@ -71,5 +81,12 @@ start. Each gate is also recorded on the issues themselves.
 
 Produced by the 2026-06-12 milestone alignment audit (multi-agent, 29 verified
 findings). Restructuring applied the same day: 16 closures, 9 moves, 37 issue-body
-amendments, 9 new issues (#2179-#2187), M13 recharter, M02 closure definition,
-ROADMAP and canvas-UX spec updates.
+amendments, 9 new issues (#2179-#2187), the M13 recharter (the milestone is now M16 on
+GitHub), M02 closure definition, ROADMAP and canvas-UX spec updates.
+
+Reconciled 2026-06-14 against live GitHub (multi-agent, per-milestone verification): M04
+burned down to one closing straggler (#2103, PR #2301), M15 to four unblocked features,
+the M14 shell shipped (placement tail parked behind M03 #2158), and M03 confirmed as just
+starting rather than "burned down" (12% closed). Gates 1-5 and 7 are satisfied; gates 6
+and 8 remain live. The execution order above was rewritten from a linear chain into three
+parallel tracks.


### PR DESCRIPTION
## **User description**
## What

Reconciles `docs/plans/2026-06-12-roadmap-execution-master-plan.md` (and sibling plan files) against live GitHub state. Every milestone in the plan's scope was verified by a per-milestone agent querying `gh`, not trusted from the stale snapshot.

## Why

Overnight burndown moved the ground truth. The plan still described a 2026-06-12 picture and a linear execution chain that no longer holds.

## Key corrections

- M04: complete (98% closed). Only #2103 remains, closing via PR #2301. Was "in progress".
- M15: trailing (75% closed); all remaining issues unblocked. Every linchpin (#2037, #2091, #2041, #617, #2035) is closed.
- M14: shell shipped (83% closed). Only the M03-gated placement tail (#2075, palette #2212/#2213/#2214) remains. Was "planned, after M03".
- M03: confirmed just starting (12% closed), not "burned down". #2158 is at design stage; the slot_position deletion (C5/#2294) is several blocked steps away.
- Execution order rewritten from a linear chain into three parallel tracks (A: finish M15, B: close M02, C: land M03 #2158).
- Cross-milestone gates: 1-5 and 7 marked SATISFIED with dates; gates 6 (#2158) and 8 (M02 closure) flagged as the only live blockers.
- Milestone rename M13 -> M16 throughout (the post-shell milestone churned M13 then M16 on GitHub; live title is M16). Renamed the companion plan file and the sibling sequence references; kept M13 only in the two history notes.

## Not in this PR (GitHub state changes, for maintainer)

- Closing milestone M04 once #2301 merges.
- Re-syncing the stale epic checklists on #2071 (M15) and #2017 (M14), whose boxes show closed issues as unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Reconcile roadmap plans with the latest GitHub milestone state

### What Changed
- Updated the roadmap master plan to match current progress: M04 is complete, M14 has shipped, M15 is still in progress, and M03 is now the main blocker for the remaining tail work
- Rewrote the execution order from a single chain into three parallel tracks for finishing M15, closing M02, and landing M03, with M16 shown as the final post-shell milestone
- Changed all related plan files to use M16 instead of M13 and refreshed milestone notes, sequence references, and close-out checklists to match the renamed milestone

### Impact
`✅ Clearer roadmap status`
`✅ Fewer stale milestone references`
`✅ Less confusion about what still blocks the next release work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
