### PR TITLE
feat: verify LXC release tarball checksum after upload (#2065)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,10 +312,13 @@ jobs:
             | jq -r 'first(.assets[] | select(.name | test("^rackula-lxc-.*\\.tar\\.gz$")) | .name) // empty')"
           tarball_url="$(echo "$release_json" \
             | jq -r 'first(.assets[] | select(.name | test("^rackula-lxc-.*\\.tar\\.gz$")) | .url) // empty')"
-          checksum_url="$(echo "$release_json" \
-            | jq -r 'first(.assets[] | select(.name | test("^rackula-lxc-.*\\.tar\\.gz\\.sha256$")) | .url) // empty')"
           [ -n "$tarball_name" ] && [ -n "$tarball_url" ] || { echo "::error::no rackula-lxc-*.tar.gz asset on release ${TAG}"; exit 1; }
-          [ -n "$checksum_url" ] || { echo "::error::no rackula-lxc-*.tar.gz.sha256 asset on release ${TAG}"; exit 1; }
+          # Select the .sha256 that matches the chosen tarball by exact name, so the
+          # checksum always belongs to the tarball we downloaded.
+          checksum_name="${tarball_name}.sha256"
+          checksum_url="$(echo "$release_json" \
+            | jq -r --arg checksum_name "$checksum_name" 'first(.assets[] | select(.name == $checksum_name) | .url) // empty')"
+          [ -n "$checksum_url" ] || { echo "::error::no ${checksum_name} asset on release ${TAG}"; exit 1; }
 
           curl -fsSL \
             -H "Authorization: Bearer ${GH_TOKEN}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,26 +289,52 @@ jobs:
             deploy/lxc/community-scripts
           sparse-checkout-cone-mode: false
 
-      - name: Download staged tarball
+      - name: Download staged tarball and verify checksum
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          # Resolve the rackula-lxc tarball asset on the (pre)release for $TAG, then
-          # download it by asset API URL. Uses curl + jq only: the self-hosted runner
-          # has no gh CLI (and does not need one).
-          asset_url="$(curl -fsSL \
+          # Resolve and download the rackula-lxc tarball and its .sha256 from the
+          # (pre)release for $TAG by asset API URL, then verify integrity end to end:
+          # this is the post-upload checksum check (the asset is fetched from the
+          # release, not from the build artifact). Uses curl + jq only: the
+          # self-hosted runner has no gh CLI (and does not need one).
+          release_json="$(curl -fsSL \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${GH_REPO}/releases/tags/${TAG}" \
+            "https://api.github.com/repos/${GH_REPO}/releases/tags/${TAG}")"
+
+          # The tarball asset name (e.g. rackula-lxc-v26.6.3.tar.gz) is the bare
+          # filename recorded inside the .sha256 file, so download to that exact
+          # name to keep sha256sum -c satisfied.
+          tarball_name="$(echo "$release_json" \
+            | jq -r 'first(.assets[] | select(.name | test("^rackula-lxc-.*\\.tar\\.gz$")) | .name) // empty')"
+          tarball_url="$(echo "$release_json" \
             | jq -r 'first(.assets[] | select(.name | test("^rackula-lxc-.*\\.tar\\.gz$")) | .url) // empty')"
-          [ -n "$asset_url" ] || { echo "::error::no rackula-lxc-*.tar.gz asset on release ${TAG}"; exit 1; }
+          checksum_url="$(echo "$release_json" \
+            | jq -r 'first(.assets[] | select(.name | test("^rackula-lxc-.*\\.tar\\.gz\\.sha256$")) | .url) // empty')"
+          [ -n "$tarball_name" ] && [ -n "$tarball_url" ] || { echo "::error::no rackula-lxc-*.tar.gz asset on release ${TAG}"; exit 1; }
+          [ -n "$checksum_url" ] || { echo "::error::no rackula-lxc-*.tar.gz.sha256 asset on release ${TAG}"; exit 1; }
+
           curl -fsSL \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/octet-stream" \
-            -o "rackula-lxc-${TAG}.tar.gz" "$asset_url"
-          [ -s "rackula-lxc-${TAG}.tar.gz" ] || { echo "::error::downloaded tarball is empty"; exit 1; }
+            -o "$tarball_name" "$tarball_url"
+          curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/octet-stream" \
+            -o "${tarball_name}.sha256" "$checksum_url"
+          [ -s "$tarball_name" ] || { echo "::error::downloaded tarball is empty"; exit 1; }
+
+          if ! sha256sum -c "${tarball_name}.sha256"; then
+            echo "::error::SHA256 verification failed for ${tarball_name} downloaded from release ${TAG}"
+            exit 1
+          fi
+          echo "Checksum verified for ${tarball_name} (downloaded from release ${TAG})"
+
+          # The smoke gate step globs rackula-lxc-*.tar.gz; the asset name already
+          # matches that glob, so no rename is needed.
 
       - name: LXC smoke gate (deploy-only bootstrap for v26.6.3)
         run: |

--- a/docs/deployment/RELEASE-PIPELINE.md
+++ b/docs/deployment/RELEASE-PIPELINE.md
@@ -17,14 +17,18 @@ before anyone noticed. The gated pipeline validates the actual artifacts before 
 1. Stage (automatic on tag push `v*`)
    - `gh release create <tag> --prerelease`. Prereleases are excluded from `/releases/latest`, so
      LXC `fetch_and_deploy latest` does not pick them up yet.
-   - Build the LXC tarball and attach it to the prerelease.
+   - Build the LXC tarball plus a matching `rackula-lxc-<tag>.tar.gz.sha256` and attach both to the
+     prerelease. The `.sha256` file is `sha256sum -c` compatible (one line: hash, two spaces, bare
+     filename) and is generated from the exact uploaded tarball.
    - Build and push Docker images with immutable tags only: `:X.Y.Z`, `:vX.Y.Z-persist`, and api
      `:X.Y.Z`. No `:latest`. No prod deploy.
 2. Gate (automatic, fail closed)
    - Docker gate (GitHub-hosted): `docker compose up` the `:X.Y.Z` image, check `/` 200, then the
      persist profile (persist frontend + api sidecar) and check `/api/health` 200.
-   - LXC gate (self-hosted `ci-runner` on the non-prod Proxmox host pve-rusty): download the staged
-     tarball and run `scripts/lxc-smoke-test.sh` on a throwaway unprivileged CT.
+   - LXC gate (self-hosted `ci-runner` on the non-prod Proxmox host pve-rusty): download both the
+     staged tarball and its `.sha256` from the release, verify integrity with `sha256sum -c` (the
+     post-upload checksum check), then run `scripts/lxc-smoke-test.sh` on a throwaway unprivileged
+     CT. A checksum mismatch fails the gate.
    - Any gate failure stops the run. Nothing is promoted. Downstream `latest` consumers keep the
      prior good version (automatic rollback, because `latest` is never overwritten until promote).
 3. Promote (only if all gates pass, behind the `prod` Environment)
@@ -44,6 +48,15 @@ CHANGELOG.md, tags, and pushes). After the tag is pushed:
    `latest`.
 3. If a gate fails, the release stays a prerelease. Fix forward (new tag) or investigate. The prior
    `latest` is untouched.
+
+## Consumer fetch path
+
+LXC installs fetch the tarball from the release asset, not from a build artifact. Both
+`deploy/lxc/community-scripts/install/rackula-install.sh` and the `ct/rackula.sh` update flow call
+`fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula"
+"rackula-lxc-*.tar.gz"`, which resolves the matching asset on the latest (promoted) GitHub release.
+Because each release publishes `rackula-lxc-<tag>.tar.gz.sha256` alongside the tarball, the fetch
+helper can verify the download against the published checksum before deploying.
 
 ## The prerelease window
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #2065.

Tagged releases already attach the LXC tarball and its `.sha256` (built and uploaded by `build-lxc.yml`, with a `sha256sum -c` check inside the publish job). This PR completes the issue by adding the post-upload integrity verification in the release pipeline and documenting the consumer fetch path.

- `release.yml` `gate-lxc`: the download step now resolves both the `rackula-lxc-*.tar.gz` asset and its `rackula-lxc-*.tar.gz.sha256` from the (pre)release, downloads the tarball to its exact published name, and runs `sha256sum -c` against it before the LXC smoke gate. A checksum mismatch fails the gate. This is the post-upload check: the asset is fetched from the release, not from the build artifact.
- `RELEASE-PIPELINE.md`: documents the `.sha256` (one line: hash, two spaces, bare filename, generated from the exact uploaded tarball), the gate verification step, and a new "Consumer fetch path" section noting that `rackula-install.sh` and the `ct/rackula.sh` update flow fetch the tarball from the release asset via `fetch_and_deploy_gh_release` and can verify it against the published checksum.

## Acceptance criteria

- [x] Tagged release (v*) assets include the LXC tarball (`build-lxc.yml` publish job)
- [x] Assets include a matching `.sha256` generated from the exact uploaded tarball (`sha256sum` over the built tarball, uploaded together)
- [x] Checksum verified in CI after upload (download asset from release, `sha256sum -c`) - `release.yml` `gate-lxc`
- [x] `rackula-install.sh` fetch path documented to prefer the release asset URL (already fetches via `fetch_and_deploy_gh_release ... rackula-lxc-*.tar.gz`; now documented)

## Test plan

- `npm run lint`: pass
- Both workflow YAML files parse (validated with a YAML parser)
- `sha256sum file > file.sha256` confirmed `sha256sum -c` compatible (single line, hash, two spaces, bare filename)

## Notes

- No TS/JS touched, so `npm run test:run` / `npm run build` were not run; changes are workflow + docs only.
- An unrelated `package-lock.json` diff (stripped `libc` fields from a different npm version in the build env) was reverted to keep this PR scoped.

https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G)_


___

## **CodeAnt-AI Description**
**Verify LXC release downloads before the smoke gate**

### What Changed
- The release pipeline now downloads the LXC tarball and its published checksum from the release, verifies the file before testing, and stops if the checksum does not match.
- The LXC install and update path is documented as fetching the tarball from the release asset, with checksum verification available through the published `.sha256` file.
- Release docs now explain that the uploaded LXC tarball and checksum are paired assets generated from the exact file that was published.

### Impact
`✅ Fewer corrupted release installs`
`✅ Earlier release failures when an uploaded tarball is wrong`
`✅ Safer LXC updates from the latest release`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
