### PR TITLE
test: verify query string preservation through nginx API proxy (#1011)

### DIFF
--- a/api/src/deploy-config.test.ts
+++ b/api/src/deploy-config.test.ts
@@ -85,3 +85,68 @@ describe("nginx trust-proxy configuration", () => {
     );
   });
 });
+
+/**
+ * Query string preservation through the nginx API proxy (#1011).
+ *
+ * The /api/ prefix location strips the prefix with "rewrite ... break" and
+ * forwards via a URI-less proxy_pass. nginx forwards the rewritten request URI,
+ * including the original query string, so query params survive without explicit
+ * $args handling. These guards fail if someone appends an explicit URI to that
+ * proxy_pass (e.g. $uri$is_args$args), which would double-apply the path and can
+ * drop or duplicate query parameters.
+ *
+ * docker compose + curl verification (not feasible in CI) is documented in the
+ * issue Test Plan; these config guards cover the structural invariant instead.
+ */
+describe("nginx API proxy query string preservation", () => {
+  const deployDir = join(import.meta.dir, "..", "..", "deploy");
+  const configs = [
+    ["Docker template", "nginx.conf.template"],
+    ["LXC config", "lxc/nginx.conf"],
+  ] as const;
+
+  // Isolate the prefix "location /api/ { ... }" block (not the "= /api/"
+  // exact-match error blocks, which have no proxy_pass). The block runs from
+  // the location line to its error_page fallback; a missing anchor throws here
+  // rather than silently slicing the wrong region.
+  const extractApiPrefixBlock = (config: string): string => {
+    const marker = config.indexOf("location /api/ {");
+    expect(marker, "missing 'location /api/' prefix block").toBeGreaterThan(-1);
+    const blockEnd = config.indexOf("error_page", marker);
+    expect(blockEnd, "missing error_page fallback in /api/ block").toBeGreaterThan(
+      marker,
+    );
+    return config.slice(marker, blockEnd);
+  };
+
+  describe.each(configs)("%s", (_label, file) => {
+    const block = extractApiPrefixBlock(
+      readFileSync(join(deployDir, file), "utf-8"),
+    );
+    const proxyPassLine = block
+      .split("\n")
+      .find((line) => line.trim().startsWith("proxy_pass"));
+
+    it("strips the /api prefix with rewrite ... break", () => {
+      expect(block).toContain("rewrite ^/api(/.*)$ $1 break;");
+    });
+
+    it("uses a URI-less proxy_pass so the rewritten path and query survive", () => {
+      // URI-less form ends at host:port (no path segment). An appended URI here
+      // would re-apply the path on top of the rewrite and risk dropping the
+      // query string, so the proxy_pass must stop at the first ";".
+      expect(proxyPassLine, "missing proxy_pass in /api/ block").toMatch(
+        /proxy_pass\s+http:\/\/[^/]+;/,
+      );
+    });
+
+    it("carries the query string on the explicit /api/health upstream URI", () => {
+      // Exact-match endpoints set an explicit upstream URI, so they must append
+      // $is_args$args to forward the query string (the URI-less rule above does
+      // not apply when proxy_pass includes a path).
+      const config = readFileSync(join(deployDir, file), "utf-8");
+      expect(config).toContain("/health$is_args$args;");
+    });
+  });
+});

--- a/deploy/lxc/nginx.conf
+++ b/deploy/lxc/nginx.conf
@@ -68,7 +68,8 @@ server {
 
     # API health check — used by frontend to detect persistence API availability
     location = /api/health {
-        proxy_pass http://127.0.0.1:3001/health;
+        # Preserve query parameters for potential diagnostics/verbosity flags.
+        proxy_pass http://127.0.0.1:3001/health$is_args$args;
         proxy_http_version 1.1;
         proxy_connect_timeout 3s;
         proxy_read_timeout 3s;
@@ -89,6 +90,13 @@ server {
         # Strip /api prefix: /api/layouts -> /layouts
         rewrite ^/api(/.*)$ $1 break;
 
+        # Query strings are preserved automatically. proxy_pass has no URI part
+        # (it ends at the port), so nginx forwards the request URI set by the
+        # rewrite above, which keeps the original query string. For example,
+        # GET /api/layouts?filter=foo forwards to /layouts?filter=foo.
+        # Do not append $uri$is_args$args here: mixing an explicit URI in
+        # proxy_pass with "rewrite ... break" double-applies the path and can
+        # drop or duplicate query parameters.
         proxy_pass http://127.0.0.1:3001;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -113,7 +113,10 @@ server {
 
     # API proxy (when sidecar is running)
     # Use variable to defer DNS resolution to request time (allows nginx to start without API)
-    # Using $uri$is_args$args for normalized path+query (safer than $request_uri)
+    # Exact-match endpoints below set an explicit upstream URI and use
+    # $is_args$args to carry the query string. The prefix /api/ location uses a
+    # URI-less proxy_pass instead, which forwards the rewritten path and query
+    # string automatically (see that block for details).
     # Configure via environment variables: API_HOST (default: rackula-api), API_PORT (default: 3001), API_WRITE_TOKEN (optional)
     # Note: NGINX_ENVSUBST_FILTER in Dockerfile restricts substitution to runtime variables only
     
@@ -203,6 +206,13 @@ server {
         # Using rewrite to capture path after /api and forward without prefix
         rewrite ^/api(/.*)$ $1 break;
 
+        # Query strings are preserved automatically. proxy_pass has no URI part
+        # (it ends at the port), so nginx forwards the request URI set by the
+        # rewrite above, which keeps the original query string. For example,
+        # GET /api/layouts?filter=foo forwards to /layouts?filter=foo.
+        # Do not append $uri$is_args$args here: mixing an explicit URI in
+        # proxy_pass with "rewrite ... break" double-applies the path and can
+        # drop or duplicate query parameters.
         proxy_pass http://$api_upstream:${API_PORT};
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## **User description**
## Summary

Verifies and documents that the nginx API proxy preserves query strings, and adds regression guards.

- The `/api/` prefix location strips the prefix with `rewrite ^/api(/.*)$ $1 break;` and forwards via a URI-less `proxy_pass`. nginx forwards the rewritten request URI, including the original query string, so query params survive without explicit `$args` handling. Confirmed this is correct behavior, so no change to the prefix `proxy_pass` was needed.
- Documented the behavior in both `deploy/nginx.conf.template` and `deploy/lxc/nginx.conf`, with a warning against the fragile `proxy_pass ...$uri$is_args$args` form (mixing an explicit URI with `rewrite ... break` double-applies the path and can drop or duplicate query parameters). This is the form CodeAnt flagged in the original review.
- Fixed a real divergence found during review: the LXC `/api/health` endpoint used `proxy_pass .../health;` with no `$is_args$args`, dropping query strings, while the Docker template used `/health$is_args$args`. The issue Test Plan exercises `/api/health?verbose=true`, so LXC now matches Docker.

## Tests

Added config guards to `api/src/deploy-config.test.ts` (the existing nginx config regression suite, run via `bun test`). They cover both deploy targets and fail on the two real regressions:

- the prefix `proxy_pass` gaining an explicit URI (`$uri$is_args$args`), which would drop or duplicate the query string
- an exact-match endpoint dropping `$is_args$args`

Both failure modes were verified by temporary mutation. The literal `docker compose` + `curl` checks in the issue Test Plan are not feasible in CI, so these structural guards stand in for them.

## Acceptance criteria

- [x] Test coverage for query param preservation (`GET /api/...?filter=foo`, exact-match endpoints) via config guards, since live HTTP testing needs docker compose and is not CI-feasible
- [x] Document expected behavior in nginx config comments
- [x] Considered making query handling explicit in `proxy_pass`: rejected for the prefix location (the URI-less form is correct and the explicit form is fragile); applied `$is_args$args` to the LXC health endpoint where an explicit URI is used

## Verification

- `npm run lint`: pass
- `npm run build`: pass
- `bun test src/deploy-config.test.ts` (api): 19 pass, 0 fail

Closes #1011

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G)_


___

## **CodeAnt-AI Description**
**Preserve query strings in API proxy requests**

### What Changed
- API requests sent through `/api/` now keep their query strings when forwarded, so filtered or diagnostic requests reach the backend intact
- The `/api/health` endpoint in the LXC setup now also passes query strings through, matching the Docker setup
- Added regression checks that cover both deploy setups and prevent future changes from dropping or duplicating query parameters
- Updated the config notes to explain which API paths preserve query strings automatically and which ones must pass them through explicitly

### Impact
`✅ Fewer missing filter parameters on API requests`
`✅ Consistent health checks across Docker and LXC`
`✅ Lower risk of query string regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
