### PR TITLE
feat: backup nudge and restore-from-file confirm flow (#2038)

### DIFF
--- a/src/lib/components/ConfirmReplaceDialog.svelte
+++ b/src/lib/components/ConfirmReplaceDialog.svelte
@@ -1,7 +1,11 @@
 <!--
   ConfirmReplaceDialog Component
-  Confirmation dialog for replacing unsaved rack data.
+  Confirmation dialog for replacing unsaved data: cancel / save-first / replace.
   Built on the unified Dialog primitive (#2092).
+
+  The default copy describes replacing the current rack on a new-rack action.
+  Callers that replace something else (e.g. restore-from-file) override title,
+  message, and the save-first label.
 -->
 <script lang="ts">
   import Dialog from "./Dialog.svelte";
@@ -12,29 +16,35 @@
     onSaveFirst: () => void;
     onReplace: () => void;
     onCancel: () => void;
+    title?: string;
+    message?: string;
+    saveFirstLabel?: string;
   }
 
-  let { open, onSaveFirst, onReplace, onCancel }: Props = $props();
+  let {
+    open,
+    onSaveFirst,
+    onReplace,
+    onCancel,
+    title = "Replace Current Rack?",
+    message,
+    saveFirstLabel = "Save First",
+  }: Props = $props();
 
   const layoutStore = getLayoutStore();
 
   const rackName = $derived(layoutStore.rack?.name || "Untitled Rack");
   const deviceCount = $derived(layoutStore.rack?.devices.length ?? 0);
   const deviceWord = $derived(deviceCount === 1 ? "device" : "devices");
-  const message = $derived(
+  const defaultMessage = $derived(
     `"${rackName}" has ${deviceCount} ${deviceWord} placed. Save your layout first?`,
   );
+  const resolvedMessage = $derived(message ?? defaultMessage);
 </script>
 
-<Dialog
-  {open}
-  title="Replace Current Rack?"
-  size="S"
-  showClose={false}
-  onclose={onCancel}
->
+<Dialog {open} {title} size="S" showClose={false} onclose={onCancel}>
   <div class="confirm-replace-dialog">
-    <p class="message">{message}</p>
+    <p class="message">{resolvedMessage}</p>
 
     <div class="actions">
       <button
@@ -51,7 +61,7 @@
         data-testid="btn-save-first"
         onclick={onSaveFirst}
       >
-        Save First
+        {saveFirstLabel}
       </button>
       <button
         type="button"

--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -10,19 +10,27 @@
 <script lang="ts">
   import { Popover } from "bits-ui";
   import { IconCheck, IconClock, IconWarningTriangle } from "./icons";
+  import ConfirmReplaceDialog from "./ConfirmReplaceDialog.svelte";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
+  import { getToastStore } from "$lib/stores/toast.svelte";
   import {
     getLayoutDurability,
     loadFromFile,
     getStorageMode,
     getServerInstanceLabel,
     handleExportAll,
+    handleSaveAsArchive,
   } from "$lib/storage";
   import { maybeSaveAs } from "$lib/utils/app-actions";
+  import { evaluateBackupNudge, NUDGE_MESSAGE } from "$lib/utils/backup-nudge";
   import "$lib/styles/menu.css";
 
-  const durability = getLayoutDurability(getLayoutStore());
+  const layoutStore = getLayoutStore();
+  const workspaceStore = getWorkspaceStore();
+  const durability = getLayoutDurability(layoutStore);
+  const toastStore = getToastStore();
 
   // Storage mode is fixed for the session (read once from runtime config), so
   // the export-all framing is computed up front rather than tracked reactively.
@@ -36,6 +44,29 @@
 
   let open = $state(false);
   let exportingAll = $state(false);
+  let restoreConfirmOpen = $state(false);
+
+  // Backup nudge: browser mode only, per the epic signal budget (#2071). Server
+  // mode persists to the server, so an export reminder would be noise. The nudge
+  // tracks changesSinceExport and fires a factual toast when a new checkpoint is
+  // crossed; evaluateBackupNudge owns the cadence and snooze persistence.
+  if (!isServerMode) {
+    $effect(() => {
+      // Keyed per layout: each tab owns its own changesSinceExport, so a shared
+      // checkpoint would let one tab suppress or re-fire another tab's nudge.
+      const layoutId = workspaceStore.activeId;
+      const changes = layoutStore.changesSinceExport;
+      const exported = layoutStore.hasEverExported;
+      evaluateBackupNudge(layoutId, changes, exported, () => {
+        toastStore.showToast(NUDGE_MESSAGE, "info", 8000, {
+          label: "Export",
+          onClick: () => {
+            maybeSaveAs();
+          },
+        });
+      });
+    });
+  }
 
   // Announced only after the status settles. The save->saved debounce cascade
   // produces several intermediate statuses in quick succession; announcing every
@@ -71,9 +102,35 @@
     }
   }
 
-  async function handleRestore() {
-    await loadFromFile();
+  function handleRestore() {
     open = false;
+    // Restoring replaces the working copy. Confirm first only when there are
+    // changes not yet in any exported file; a fully backed-up copy goes straight
+    // to the picker.
+    if (layoutStore.changesSinceExport > 0) {
+      restoreConfirmOpen = true;
+    } else {
+      void loadFromFile();
+    }
+  }
+
+  function handleRestoreCancel() {
+    restoreConfirmOpen = false;
+  }
+
+  function handleRestoreReplace() {
+    restoreConfirmOpen = false;
+    void loadFromFile();
+  }
+
+  async function handleRestoreExportFirst() {
+    restoreConfirmOpen = false;
+    // Turn the dangerous moment into the backup moment: export, then restore
+    // only if the export actually succeeded (not cancelled or failed).
+    const exported = await handleSaveAsArchive();
+    if (exported) {
+      await loadFromFile();
+    }
   }
 </script>
 
@@ -137,6 +194,16 @@
     </Popover.Content>
   </Popover.Portal>
 </Popover.Root>
+
+<ConfirmReplaceDialog
+  open={restoreConfirmOpen}
+  title="Replace this layout?"
+  message="This layout has changes that are not in any exported file. Restoring replaces it with the file you choose."
+  saveFirstLabel="Export first"
+  onSaveFirst={handleRestoreExportFirst}
+  onReplace={handleRestoreReplace}
+  onCancel={handleRestoreCancel}
+/>
 
 <span class="sr-only" role="status" aria-live="polite" aria-atomic="true">
   {announced}

--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -13,7 +13,6 @@
   import ConfirmReplaceDialog from "./ConfirmReplaceDialog.svelte";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
-  import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import {
     getLayoutDurability,
@@ -23,12 +22,14 @@
     handleExportAll,
     handleSaveAsArchive,
   } from "$lib/storage";
-  import { maybeSaveAs } from "$lib/utils/app-actions";
+  import {
+    maybeSaveAs,
+    shouldShowCleanupPrompt,
+  } from "$lib/utils/app-actions";
   import { evaluateBackupNudge, NUDGE_MESSAGE } from "$lib/utils/backup-nudge";
   import "$lib/styles/menu.css";
 
   const layoutStore = getLayoutStore();
-  const workspaceStore = getWorkspaceStore();
   const durability = getLayoutDurability(layoutStore);
   const toastStore = getToastStore();
 
@@ -52,9 +53,13 @@
   // crossed; evaluateBackupNudge owns the cadence and snooze persistence.
   if (!isServerMode) {
     $effect(() => {
-      // Keyed per layout: each tab owns its own changesSinceExport, so a shared
-      // checkpoint would let one tab suppress or re-fire another tab's nudge.
-      const layoutId = workspaceStore.activeId;
+      // Keyed by the stable per-layout id (layout.metadata.id, the UUID that
+      // survives renames and reloads), not the per-tab id which nextTabId()
+      // regenerates on every reload/restore. A per-tab key would let persisted
+      // checkpoints drift across reloads and re-fire or attach to the wrong
+      // layout.
+      const layoutId = layoutStore.layout.metadata?.id;
+      if (!layoutId) return;
       const changes = layoutStore.changesSinceExport;
       const exported = layoutStore.hasEverExported;
       evaluateBackupNudge(layoutId, changes, exported, () => {
@@ -125,6 +130,12 @@
 
   async function handleRestoreExportFirst() {
     restoreConfirmOpen = false;
+    // Route through the same cleanup-prompt contract as the other save-as
+    // paths: when unused custom device types exist, the prompt is shown and the
+    // export is deferred into the cleanup dialog. The restore does not chain in
+    // that case (the user is now in the cleanup flow), matching maybeSaveAs's
+    // fire-and-forget contract.
+    if (shouldShowCleanupPrompt("saveAs")) return;
     // Turn the dangerous moment into the backup moment: export, then restore
     // only if the export actually succeeded (not cancelled or failed).
     const exported = await handleSaveAsArchive();

--- a/src/lib/utils/backup-nudge.ts
+++ b/src/lib/utils/backup-nudge.ts
@@ -1,0 +1,134 @@
+/**
+ * Backup nudge: change-based export reminder for browser mode.
+ *
+ * The storage chip is the always-on honest signal. This nudge is the single
+ * escalation on top of it: a non-modal toast that fires when the user has
+ * accumulated enough unexported changes to risk losing a meaningful editing
+ * session. Tone is factual, not nagging (Excalidraw honest-copy precedent).
+ *
+ * Cadence:
+ * - A never-exported layout fires once on the first edit (cold start). Without
+ *   this, a brand-new session that never exports gets no reminder until 30
+ *   changes, which is too late for a first-time user.
+ * - After that, the nudge re-fires each time changesSinceExport crosses the
+ *   next multiple of 30 (30, 60, 90, ...).
+ *
+ * The last checkpoint the user was nudged at is persisted in localStorage so
+ * reloads do not re-nag for changes they already saw a nudge about. The key is
+ * per layout: each open tab tracks its own changesSinceExport, so a shared key
+ * would let one tab suppress or re-fire another tab's nudge. Exporting resets
+ * the counter, which clears the persisted checkpoint so the cadence restarts.
+ */
+
+import { safeGetItem, safeSetItem, safeRemoveItem } from "./safe-storage";
+
+const NUDGE_THRESHOLD_KEY_PREFIX = "Rackula:backup-nudge-threshold:";
+
+/** Changes between nudges once the user has exported at least once. */
+export const NUDGE_INTERVAL = 30;
+
+/** Factual nudge copy: states the situation and the remedy, no nagging. */
+export const NUDGE_MESSAGE =
+  "This layout lives only in this browser. Export a file to keep a copy.";
+
+function thresholdKey(layoutId: string): string {
+  return NUDGE_THRESHOLD_KEY_PREFIX + layoutId;
+}
+
+/**
+ * The change checkpoint the user has reached, or 0 when below the first
+ * checkpoint. Checkpoints are: 1 (cold start, never exported), then every
+ * multiple of NUDGE_INTERVAL (30, 60, ...).
+ *
+ * Pure: same inputs always yield the same checkpoint.
+ */
+export function currentNudgeCheckpoint(
+  changesSinceExport: number,
+  hasEverExported: boolean,
+): number {
+  if (changesSinceExport <= 0) return 0;
+
+  const intervalCheckpoint =
+    Math.floor(changesSinceExport / NUDGE_INTERVAL) * NUDGE_INTERVAL;
+
+  // A never-exported layout gets a one-time cold-start checkpoint at the first
+  // edit, before it has reached the first interval.
+  if (!hasEverExported && intervalCheckpoint === 0) {
+    return 1;
+  }
+
+  return intervalCheckpoint;
+}
+
+/**
+ * Decide whether to fire the nudge and, if so, the checkpoint to record.
+ * Returns the checkpoint to persist when the nudge should fire, or null when it
+ * should not (below the first checkpoint, or already nudged at this checkpoint).
+ *
+ * Pure: no storage reads. The caller supplies the last persisted checkpoint.
+ */
+export function nudgeCheckpointToFire(
+  changesSinceExport: number,
+  hasEverExported: boolean,
+  lastNudgedCheckpoint: number,
+): number | null {
+  const checkpoint = currentNudgeCheckpoint(changesSinceExport, hasEverExported);
+  if (checkpoint === 0) return null;
+  if (checkpoint <= lastNudgedCheckpoint) return null;
+  return checkpoint;
+}
+
+/** Read the last checkpoint the layout was nudged at (0 when none). */
+export function loadLastNudgedCheckpoint(layoutId: string): number {
+  const raw = safeGetItem(thresholdKey(layoutId));
+  if (raw === null) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+/** Persist the checkpoint the layout was just nudged at. */
+export function saveLastNudgedCheckpoint(
+  layoutId: string,
+  checkpoint: number,
+): void {
+  safeSetItem(thresholdKey(layoutId), String(checkpoint));
+}
+
+/**
+ * Clear the layout's persisted checkpoint so its cadence restarts. Called when
+ * the changes-since-export counter resets to 0 (an export happened).
+ */
+export function clearNudgeCheckpoint(layoutId: string): void {
+  safeRemoveItem(thresholdKey(layoutId));
+}
+
+/**
+ * Evaluate the nudge for the current change state and fire it through the
+ * provided callback when a new checkpoint is crossed. Reads and updates the
+ * layout's persisted checkpoint. When the counter has reset to 0 (an export
+ * happened), clears the persisted checkpoint so the cadence restarts.
+ *
+ * The `fire` callback is injected so this stays free of store/toast imports and
+ * is unit-testable: callers pass a function that shows the toast.
+ */
+export function evaluateBackupNudge(
+  layoutId: string,
+  changesSinceExport: number,
+  hasEverExported: boolean,
+  fire: (checkpoint: number) => void,
+): void {
+  if (changesSinceExport === 0) {
+    clearNudgeCheckpoint(layoutId);
+    return;
+  }
+
+  const checkpoint = nudgeCheckpointToFire(
+    changesSinceExport,
+    hasEverExported,
+    loadLastNudgedCheckpoint(layoutId),
+  );
+  if (checkpoint === null) return;
+
+  saveLastNudgedCheckpoint(layoutId, checkpoint);
+  fire(checkpoint);
+}

--- a/src/tests/backup-nudge.test.ts
+++ b/src/tests/backup-nudge.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  NUDGE_INTERVAL,
+  currentNudgeCheckpoint,
+  nudgeCheckpointToFire,
+  loadLastNudgedCheckpoint,
+  saveLastNudgedCheckpoint,
+  clearNudgeCheckpoint,
+  evaluateBackupNudge,
+} from "$lib/utils/backup-nudge";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+});
+
+describe("currentNudgeCheckpoint", () => {
+  it("is 0 below the first change", () => {
+    expect(currentNudgeCheckpoint(0, false)).toBe(0);
+    expect(currentNudgeCheckpoint(0, true)).toBe(0);
+  });
+
+  it("returns a cold-start checkpoint on the first edit when never exported", () => {
+    expect(currentNudgeCheckpoint(1, false)).toBe(1);
+    expect(currentNudgeCheckpoint(29, false)).toBe(1);
+  });
+
+  it("does not cold-start once the layout has been exported", () => {
+    expect(currentNudgeCheckpoint(1, true)).toBe(0);
+    expect(currentNudgeCheckpoint(29, true)).toBe(0);
+  });
+
+  it("returns the highest crossed multiple of the interval", () => {
+    expect(currentNudgeCheckpoint(NUDGE_INTERVAL, true)).toBe(NUDGE_INTERVAL);
+    expect(currentNudgeCheckpoint(NUDGE_INTERVAL + 5, true)).toBe(NUDGE_INTERVAL);
+    expect(currentNudgeCheckpoint(NUDGE_INTERVAL * 3, false)).toBe(
+      NUDGE_INTERVAL * 3,
+    );
+  });
+});
+
+describe("nudgeCheckpointToFire", () => {
+  it("does not fire below the first checkpoint", () => {
+    expect(nudgeCheckpointToFire(0, true, 0)).toBeNull();
+    expect(nudgeCheckpointToFire(5, true, 0)).toBeNull();
+  });
+
+  it("fires the cold-start nudge once for a never-exported layout", () => {
+    expect(nudgeCheckpointToFire(1, false, 0)).toBe(1);
+    // Already nudged at the cold-start checkpoint: no re-fire while below 30.
+    expect(nudgeCheckpointToFire(10, false, 1)).toBeNull();
+  });
+
+  it("fires at the first interval", () => {
+    expect(nudgeCheckpointToFire(NUDGE_INTERVAL, true, 0)).toBe(NUDGE_INTERVAL);
+  });
+
+  it("re-fires only when a new multiple is crossed", () => {
+    // Sitting at the interval after being nudged for it: no re-fire.
+    expect(
+      nudgeCheckpointToFire(NUDGE_INTERVAL + 10, true, NUDGE_INTERVAL),
+    ).toBeNull();
+    // Crossing the next multiple re-fires.
+    expect(
+      nudgeCheckpointToFire(NUDGE_INTERVAL * 2, true, NUDGE_INTERVAL),
+    ).toBe(NUDGE_INTERVAL * 2);
+  });
+
+  it("escalates from the cold-start checkpoint to the first interval", () => {
+    expect(nudgeCheckpointToFire(NUDGE_INTERVAL, false, 1)).toBe(
+      NUDGE_INTERVAL,
+    );
+  });
+});
+
+describe("nudge checkpoint persistence", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("defaults to 0 when nothing is persisted", () => {
+    expect(loadLastNudgedCheckpoint("layout-a")).toBe(0);
+  });
+
+  it("round-trips a saved checkpoint", () => {
+    saveLastNudgedCheckpoint("layout-a", NUDGE_INTERVAL * 2);
+    expect(loadLastNudgedCheckpoint("layout-a")).toBe(NUDGE_INTERVAL * 2);
+  });
+
+  it("clears the persisted checkpoint", () => {
+    saveLastNudgedCheckpoint("layout-a", NUDGE_INTERVAL);
+    clearNudgeCheckpoint("layout-a");
+    expect(loadLastNudgedCheckpoint("layout-a")).toBe(0);
+  });
+
+  it("keeps checkpoints separate per layout", () => {
+    saveLastNudgedCheckpoint("layout-a", NUDGE_INTERVAL * 2);
+    saveLastNudgedCheckpoint("layout-b", NUDGE_INTERVAL);
+    expect(loadLastNudgedCheckpoint("layout-a")).toBe(NUDGE_INTERVAL * 2);
+    expect(loadLastNudgedCheckpoint("layout-b")).toBe(NUDGE_INTERVAL);
+    clearNudgeCheckpoint("layout-a");
+    expect(loadLastNudgedCheckpoint("layout-a")).toBe(0);
+    expect(loadLastNudgedCheckpoint("layout-b")).toBe(NUDGE_INTERVAL);
+  });
+
+  it("treats corrupt persisted values as no checkpoint", () => {
+    localStorageMock.setItem(
+      "Rackula:backup-nudge-threshold:layout-a",
+      "not-a-number",
+    );
+    expect(loadLastNudgedCheckpoint("layout-a")).toBe(0);
+  });
+});
+
+describe("evaluateBackupNudge", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  const LAYOUT = "layout-a";
+
+  it("fires the cold-start nudge on the first edit when never exported", () => {
+    const fire = vi.fn();
+    evaluateBackupNudge(LAYOUT, 1, false, fire);
+    expect(fire).toHaveBeenCalledWith(1);
+    expect(loadLastNudgedCheckpoint(LAYOUT)).toBe(1);
+  });
+
+  it("does not re-fire while sitting at the same checkpoint", () => {
+    const fire = vi.fn();
+    evaluateBackupNudge(LAYOUT, NUDGE_INTERVAL, true, fire);
+    fire.mockClear();
+    // More edits within the same interval window must not re-fire.
+    evaluateBackupNudge(LAYOUT, NUDGE_INTERVAL + 5, true, fire);
+    expect(fire).not.toHaveBeenCalled();
+  });
+
+  it("re-fires when the next multiple is crossed", () => {
+    const fire = vi.fn();
+    evaluateBackupNudge(LAYOUT, NUDGE_INTERVAL, true, fire);
+    fire.mockClear();
+    evaluateBackupNudge(LAYOUT, NUDGE_INTERVAL * 2, true, fire);
+    expect(fire).toHaveBeenCalledWith(NUDGE_INTERVAL * 2);
+    expect(loadLastNudgedCheckpoint(LAYOUT)).toBe(NUDGE_INTERVAL * 2);
+  });
+
+  it("clears the persisted checkpoint when changes reset to 0 on export", () => {
+    saveLastNudgedCheckpoint(LAYOUT, NUDGE_INTERVAL);
+    const fire = vi.fn();
+    evaluateBackupNudge(LAYOUT, 0, true, fire);
+    expect(fire).not.toHaveBeenCalled();
+    expect(loadLastNudgedCheckpoint(LAYOUT)).toBe(0);
+  });
+
+  it("does not re-nag across a reload at the same checkpoint", () => {
+    const fire = vi.fn();
+    // First session: cross 30 and fire.
+    evaluateBackupNudge(LAYOUT, NUDGE_INTERVAL, true, fire);
+    expect(fire).toHaveBeenCalledTimes(1);
+    fire.mockClear();
+    // Simulated reload: persisted checkpoint survives, same change count.
+    evaluateBackupNudge(LAYOUT, NUDGE_INTERVAL, true, fire);
+    expect(fire).not.toHaveBeenCalled();
+  });
+
+  it("does not let one layout's checkpoint suppress another's nudge", () => {
+    const fire = vi.fn();
+    // Tab A reaches a high checkpoint.
+    evaluateBackupNudge("tab-a", NUDGE_INTERVAL * 2, true, fire);
+    fire.mockClear();
+    // Tab B is a fresh never-exported layout: its cold-start must still fire.
+    evaluateBackupNudge("tab-b", 1, false, fire);
+    expect(fire).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Closes #2038. Adds a change-based export nudge plus a restore-from-file flow in the storage status chip popover (Phase 3 of spike #2019).

- Change-based export nudge: a non-modal toast with an Export action fires at 30 changes since the last export and re-fires only at multiples of 30. Dismissal/snooze is persisted, and the never-exported cold-start case is covered. Browser-mode only, per the epic #2071 signal budget.
- Factual, non-nagging copy (Excalidraw honest-copy precedent).
- Restore-from-file action in the chip popover reusing `loadFromFile()`.
- Confirm dialog offers Export first / Replace / Cancel only when unbacked changes exist (`ConfirmReplaceDialog`, replacing the prior `RestoreConfirmDialog`).

Per the alignment update on #2038, the Export-first nudge no longer needs the image-dropping caveat: the default export embeds custom images, so the Export action certifies an honest backup.

## Verification

- `npm run lint`: pass
- `npx vitest run src/tests/backup-nudge.test.ts`: 20 passed
- `npm run build`: pass

https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G)_


___

## **CodeAnt-AI Description**
Add export reminders and a safer restore-from-file flow

### What Changed
- Shows a non-modal export reminder after the first edit in a never-exported layout, then again every 30 changes
- Remembers when the reminder was last shown so it does not repeat after reload, and clears the reminder state after export
- Restoring from file now asks for confirmation when the current layout has unsaved changes
- The restore dialog now offers Export first, Replace, and Cancel, with Export first saving a copy before opening the file picker
- Added tests covering reminder timing, persistence, and restore confirmation behavior

### Impact
`✅ Fewer lost edits in browser-only sessions`
`✅ Clearer backup reminders`
`✅ Safer file restores`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
