### PR TITLE
feat: snapshot list and restore in LoadDialog (#2042)

### DIFF
--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -6,8 +6,9 @@
  * GET    /layouts/:uuid           - Get layout by UUID
  * PUT    /layouts/:uuid           - Create or update layout
  * DELETE /layouts/:uuid           - Delete layout
- * GET    /layouts/:uuid/snapshots - List pre-overwrite snapshots
- * POST   /layouts/:uuid/snapshots - Upload a losing local copy as a snapshot
+ * GET    /layouts/:uuid/snapshots           - List pre-overwrite snapshots
+ * GET    /layouts/:uuid/snapshots/:filename - Get a snapshot's YAML content
+ * POST   /layouts/:uuid/snapshots           - Upload a losing local copy as a snapshot
  *
  * When accessed through nginx proxy (recommended), the same routes are
  * available under /api/layouts (nginx strips /api before forwarding).
@@ -25,7 +26,9 @@ import {
   saveLayout,
   deleteLayout,
   listSnapshots,
+  getSnapshot,
   saveSnapshot,
+  SNAPSHOT_NAME_PATTERN,
 } from "../storage/filesystem";
 import { deleteLayoutAssets } from "../storage/assets";
 import { logger } from "../logger";
@@ -215,6 +218,36 @@ layouts.get("/:uuid/snapshots", async (c) => {
       `Failed to list snapshots for layout ${uuidResult.data}`,
     );
     return c.json({ error: "Failed to list snapshots" }, 500);
+  }
+});
+
+// Get a single snapshot's YAML content
+layouts.get("/:uuid/snapshots/:filename", async (c) => {
+  const uuid = c.req.param("uuid");
+  const filename = c.req.param("filename");
+
+  const uuidResult = UuidSchema.safeParse(uuid);
+  if (!uuidResult.success) {
+    return c.json({ error: "Invalid layout UUID format" }, 400);
+  }
+
+  if (filename.includes("/") || !SNAPSHOT_NAME_PATTERN.test(filename)) {
+    return c.json({ error: "Invalid snapshot filename" }, 400);
+  }
+
+  try {
+    const content = await getSnapshot(uuidResult.data, filename);
+    if (content === null) {
+      return c.json({ error: "Snapshot not found" }, 404);
+    }
+
+    return c.text(content, 200, { "Content-Type": "text/yaml" });
+  } catch (error) {
+    logger.error(
+      { err: error },
+      `Failed to get snapshot ${filename} for layout ${uuidResult.data}`,
+    );
+    return c.json({ error: "Failed to get snapshot" }, 500);
   }
 });
 

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -36,6 +36,27 @@ import { logger } from "../logger";
 /** Header carrying the layout's updatedAt for echo-based conflict detection. */
 export const UPDATED_AT_HEADER = "X-Rackula-Updated-At";
 
+/** Matches a control character (C0 range plus DEL) anywhere in a string. */
+// eslint-disable-next-line no-control-regex -- intentionally rejecting control chars in filenames
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001f\u007f]/;
+
+/**
+ * A snapshot filename param must be a bare {base}~YYYYMMDD-HHMMSS[-N].yaml with
+ * no path separators or control characters. Rejecting control chars closes the
+ * trailing-newline edge that SNAPSHOT_NAME_PATTERN's unanchored end would
+ * otherwise tolerate.
+ */
+function isValidSnapshotFilenameParam(filename: string): boolean {
+  if (
+    filename.includes("/") ||
+    filename.includes("\\") ||
+    CONTROL_CHAR_PATTERN.test(filename)
+  ) {
+    return false;
+  }
+  return SNAPSHOT_NAME_PATTERN.test(filename);
+}
+
 const layouts = new Hono();
 
 // List all layouts
@@ -231,7 +252,7 @@ layouts.get("/:uuid/snapshots/:filename", async (c) => {
     return c.json({ error: "Invalid layout UUID format" }, 400);
   }
 
-  if (filename.includes("/") || !SNAPSHOT_NAME_PATTERN.test(filename)) {
+  if (!isValidSnapshotFilenameParam(filename)) {
     return c.json({ error: "Invalid snapshot filename" }, 400);
   }
 

--- a/api/src/snapshots.test.ts
+++ b/api/src/snapshots.test.ts
@@ -374,6 +374,66 @@ describe("GET /layouts/:uuid/snapshots", () => {
   });
 });
 
+describe("GET /layouts/:uuid/snapshots/:filename", () => {
+  it("returns the stored snapshot YAML for a listed filename", async () => {
+    const app = await createApp(buildEnv());
+    const v1 = createLayoutYaml("My Layout", "v1");
+    await putLayout(app, TEST_UUID, v1);
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v2"), {
+      [UPDATED_AT_HEADER]: STALE_UPDATED_AT,
+    });
+
+    const list = await app.request(`/layouts/${TEST_UUID}/snapshots`);
+    const { snapshots } = await list.json();
+    const filename = snapshots[0].filename;
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/snapshots/${filename}`,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/yaml");
+    expect(await response.text()).toBe(v1);
+  });
+
+  it("returns 404 for an unknown snapshot filename", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/snapshots/my-layout~20200101-000000.yaml`,
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 for an unknown layout", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await app.request(
+      `/layouts/${UNKNOWN_UUID}/snapshots/my-layout~20200101-000000.yaml`,
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 for an invalid uuid", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await app.request(
+      "/layouts/not-a-uuid/snapshots/my-layout~20200101-000000.yaml",
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a path-traversal filename", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/snapshots/${encodeURIComponent("../../secret.yaml")}`,
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
 describe("POST /layouts/:uuid/snapshots", () => {
   it("stores an uploaded losing copy as a snapshot", async () => {
     const app = await createApp(buildEnv());

--- a/api/src/snapshots.test.ts
+++ b/api/src/snapshots.test.ts
@@ -595,6 +595,45 @@ describe("snapshot route auth gating", () => {
     const response = await app.request(`/layouts/${TEST_UUID}/snapshots`);
     expect(response.status).toBe(401);
   });
+
+  it("serves a single snapshot without a token in write-token mode", async () => {
+    const app = await createApp(
+      buildEnv({ RACKULA_API_WRITE_TOKEN: TEST_TOKEN }),
+    );
+    const authHeader = { Authorization: `Bearer ${TEST_TOKEN}` };
+    const v1 = createLayoutYaml("My Layout", "v1");
+    await putLayout(app, TEST_UUID, v1, authHeader);
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v2"), {
+      ...authHeader,
+      [UPDATED_AT_HEADER]: STALE_UPDATED_AT,
+    });
+
+    const list = await app.request(`/layouts/${TEST_UUID}/snapshots`);
+    const { snapshots } = await list.json();
+    const filename = snapshots[0].filename;
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/snapshots/${filename}`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(v1);
+  });
+
+  it("does not serve a single snapshot without a session when auth is enabled", async () => {
+    const app = await createApp(
+      buildEnv({
+        RACKULA_AUTH_MODE: "oidc",
+        RACKULA_AUTH_SESSION_SECRET:
+          "rackula-auth-session-secret-for-tests-0123456789",
+        CORS_ORIGIN: "https://rack.example.com",
+      }),
+    );
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/snapshots/my-layout~20200101-000000.yaml`,
+    );
+    expect(response.status).toBe(401);
+  });
 });
 
 describe("snapshot folder invisibility", () => {

--- a/api/src/snapshots.test.ts
+++ b/api/src/snapshots.test.ts
@@ -432,6 +432,30 @@ describe("GET /layouts/:uuid/snapshots/:filename", () => {
     );
     expect(response.status).toBe(400);
   });
+
+  it("rejects a backslash-separated filename", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/snapshots/${encodeURIComponent(
+        "..\\..\\secret.yaml",
+      )}`,
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects a filename with a trailing newline", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/snapshots/${encodeURIComponent(
+        "my-layout~20200101-000000.yaml\n",
+      )}`,
+    );
+    expect(response.status).toBe(400);
+  });
 });
 
 describe("POST /layouts/:uuid/snapshots", () => {

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -152,7 +152,7 @@ function formatSnapshotTimestamp(date: Date): string {
   );
 }
 
-const SNAPSHOT_NAME_PATTERN = /~(\d{8}-\d{6})(?:-(\d+))?\.yaml$/;
+export const SNAPSHOT_NAME_PATTERN = /~(\d{8}-\d{6})(?:-(\d+))?\.yaml$/;
 
 /**
  * Compare snapshot filenames newest-first using the embedded timestamp and
@@ -276,6 +276,42 @@ export async function listSnapshots(
       b.timestamp.localeCompare(a.timestamp) ||
       compareSnapshotNamesDesc(a.filename, b.filename),
   );
+}
+
+/** A snapshot filename is a bare {base}~YYYYMMDD-HHMMSS[-N].yaml with no path. */
+function isSafeSnapshotFilename(filename: string): boolean {
+  if (filename.includes("/") || filename.includes("\\")) {
+    return false;
+  }
+  return SNAPSHOT_NAME_PATTERN.test(filename);
+}
+
+/**
+ * Read a single snapshot's YAML content for a layout.
+ * Returns null when the layout, the snapshots folder, or the file is missing,
+ * or when the filename is not a safe snapshot name.
+ */
+export async function getSnapshot(
+  uuid: string,
+  filename: string,
+): Promise<string | null> {
+  if (!isSafeSnapshotFilename(filename)) {
+    return null;
+  }
+
+  const folder = await findFolderByUuid(uuid);
+  if (!folder) {
+    return null;
+  }
+
+  try {
+    return await readFile(join(folder, SNAPSHOTS_DIR, filename), "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
 }
 
 /**

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -154,6 +154,11 @@ function formatSnapshotTimestamp(date: Date): string {
 
 export const SNAPSHOT_NAME_PATTERN = /~(\d{8}-\d{6})(?:-(\d+))?\.yaml$/;
 
+// Control characters (ASCII 0x00-0x1F and 0x7F) are never valid in a snapshot
+// filename and must be rejected before any filesystem access.
+// eslint-disable-next-line no-control-regex -- intentionally matching control chars
+const CONTROL_CHAR_PATTERN = /[\x00-\x1f\x7f]/;
+
 /**
  * Compare snapshot filenames newest-first using the embedded timestamp and
  * numeric collision suffix (no suffix sorts oldest within a timestamp).
@@ -281,6 +286,11 @@ export async function listSnapshots(
 /** A snapshot filename is a bare {base}~YYYYMMDD-HHMMSS[-N].yaml with no path. */
 function isSafeSnapshotFilename(filename: string): boolean {
   if (filename.includes("/") || filename.includes("\\")) {
+    return false;
+  }
+  // Reject control characters (ASCII 0x00-0x1F and 0x7F) so a malformed name
+  // returns null rather than surfacing a thrown readFile error.
+  if (CONTROL_CHAR_PATTERN.test(filename)) {
     return false;
   }
   return SNAPSHOT_NAME_PATTERN.test(filename);

--- a/src/lib/components/LoadDialog.svelte
+++ b/src/lib/components/LoadDialog.svelte
@@ -136,19 +136,27 @@
       return;
     }
 
-    expandedId = item.id;
+    const requestedId = item.id;
+    expandedId = requestedId;
     snapshots = [];
     snapshotsError = null;
     snapshotsLoading = true;
 
     try {
-      snapshots = await listSnapshots(item.id);
+      const result = await listSnapshots(requestedId);
+      // Ignore a stale response if the user expanded a different layout while
+      // this request was in flight.
+      if (expandedId !== requestedId) return;
+      snapshots = result;
     } catch (e) {
+      if (expandedId !== requestedId) return;
       snapshotsError =
         e instanceof PersistenceError ? e.message : "Failed to load snapshots";
       persistenceDebug.api("toggleSnapshots: failed %O", e);
     } finally {
-      snapshotsLoading = false;
+      if (expandedId === requestedId) {
+        snapshotsLoading = false;
+      }
     }
   }
 

--- a/src/lib/components/LoadDialog.svelte
+++ b/src/lib/components/LoadDialog.svelte
@@ -50,7 +50,14 @@
   );
 
   $effect(() => {
-    if (!dialogStore.isOpen("load")) return;
+    if (!dialogStore.isOpen("load")) {
+      // Collapse any open snapshot panel so a reopen never shows a stale list.
+      // The component stays mounted, so this state would otherwise persist.
+      expandedId = null;
+      snapshots = [];
+      snapshotsError = null;
+      return;
+    }
     if (!apiActive) {
       loading = false;
       return;

--- a/src/lib/components/LoadDialog.svelte
+++ b/src/lib/components/LoadDialog.svelte
@@ -6,7 +6,10 @@
   import {
     listSavedLayouts,
     deleteSavedLayout,
+    listSnapshots,
+    restoreFromSnapshot,
     type SavedLayoutItem,
+    type SnapshotItem,
     PersistenceError,
     isApiAvailable,
     loadFromApi,
@@ -15,7 +18,14 @@
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
   import { persistenceDebug } from "$lib/utils/debug";
-  import { IconTrash, IconFolderBold, IconUpload } from "$lib/components/icons";
+  import { formatSnapshotTimestamp } from "$lib/utils/snapshot-timestamp";
+  import {
+    IconTrash,
+    IconFolderBold,
+    IconUpload,
+    IconChevronRight,
+    IconChevronDown,
+  } from "$lib/components/icons";
   import Dialog from "./Dialog.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
 
@@ -27,6 +37,13 @@
   let deletingId = $state<string | null>(null);
   let confirmingDeleteId = $state<string | null>(null);
   let apiActive = $derived(isApiAvailable());
+
+  // Per-layout snapshot expansion state, keyed by layout id.
+  let expandedId = $state<string | null>(null);
+  let snapshots = $state<SnapshotItem[]>([]);
+  let snapshotsLoading = $state(false);
+  let snapshotsError = $state<string | null>(null);
+  let restoringFilename = $state<string | null>(null);
 
   const confirmingDeleteItem = $derived(
     layouts.find((l) => l.id === confirmingDeleteId),
@@ -86,6 +103,9 @@
     try {
       await deleteSavedLayout(item.id);
       layouts = layouts.filter((l) => l.id !== item.id);
+      if (expandedId === item.id) {
+        expandedId = null;
+      }
       toastStore.showToast(`Deleted "${item.name}"`, "info");
     } catch (e) {
       const message =
@@ -100,6 +120,41 @@
     const success = await loadFromFile();
     if (success) {
       dialogStore.close();
+    }
+  }
+
+  async function toggleSnapshots(item: SavedLayoutItem) {
+    if (expandedId === item.id) {
+      expandedId = null;
+      return;
+    }
+
+    expandedId = item.id;
+    snapshots = [];
+    snapshotsError = null;
+    snapshotsLoading = true;
+
+    try {
+      snapshots = await listSnapshots(item.id);
+    } catch (e) {
+      snapshotsError =
+        e instanceof PersistenceError ? e.message : "Failed to load snapshots";
+      persistenceDebug.api("toggleSnapshots: failed %O", e);
+    } finally {
+      snapshotsLoading = false;
+    }
+  }
+
+  async function handleRestoreSnapshot(uuid: string, filename: string) {
+    if (restoringFilename) return;
+    restoringFilename = filename;
+    try {
+      const success = await restoreFromSnapshot(uuid, filename);
+      if (success) {
+        dialogStore.close();
+      }
+    } finally {
+      restoringFilename = null;
     }
   }
 
@@ -167,46 +222,104 @@
                 class:invalid={!item.valid}
                 class:deleting={deletingId === item.id}
               >
-                <div
-                  class="layout-row"
-                  role="button"
-                  tabindex={item.valid ? 0 : -1}
-                  aria-disabled={!item.valid}
-                  onclick={() => handleOpenLayout(item)}
-                  onkeydown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      handleOpenLayout(item);
-                    }
-                  }}
-                >
-                  <div class="layout-info">
-                    <span class="layout-name">
-                      {item.name}
-                      {#if !item.valid}
-                        <span class="error-badge" title="Corrupted file">!</span
-                        >
-                      {/if}
-                    </span>
-                    <span class="layout-meta">
-                      {#if item.valid}
-                        {formatCounts(item)} - {formatDate(item.updatedAt)}
-                      {:else}
-                        <span class="error-text">File corrupted</span> -
-                        {formatDate(item.updatedAt)}
-                      {/if}
-                    </span>
+                <div class="layout-main">
+                  <button
+                    class="expand-btn"
+                    onclick={() => toggleSnapshots(item)}
+                    aria-expanded={expandedId === item.id}
+                    aria-label={`Show snapshots for ${item.name}`}
+                    title="Show snapshots"
+                  >
+                    {#if expandedId === item.id}
+                      <IconChevronDown size={16} />
+                    {:else}
+                      <IconChevronRight size={16} />
+                    {/if}
+                  </button>
+                  <div
+                    class="layout-row"
+                    role="button"
+                    tabindex={item.valid ? 0 : -1}
+                    aria-disabled={!item.valid}
+                    onclick={() => handleOpenLayout(item)}
+                    onkeydown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleOpenLayout(item);
+                      }
+                    }}
+                  >
+                    <div class="layout-info">
+                      <span class="layout-name">
+                        {item.name}
+                        {#if !item.valid}
+                          <span class="error-badge" title="Corrupted file"
+                            >!</span
+                          >
+                        {/if}
+                      </span>
+                      <span class="layout-meta">
+                        {#if item.valid}
+                          {formatCounts(item)} - {formatDate(item.updatedAt)}
+                        {:else}
+                          <span class="error-text">File corrupted</span> -
+                          {formatDate(item.updatedAt)}
+                        {/if}
+                      </span>
+                    </div>
                   </div>
+                  <button
+                    class="delete-btn"
+                    onclick={() => handleDeleteLayout(item)}
+                    disabled={deletingId === item.id}
+                    aria-label={`Delete layout ${item.name}`}
+                    title="Delete layout"
+                  >
+                    <IconTrash size={16} />
+                  </button>
                 </div>
-                <button
-                  class="delete-btn"
-                  onclick={() => handleDeleteLayout(item)}
-                  disabled={deletingId === item.id}
-                  aria-label={`Delete layout ${item.name}`}
-                  title="Delete layout"
-                >
-                  <IconTrash size={16} />
-                </button>
+
+                {#if expandedId === item.id}
+                  <div class="snapshots-panel">
+                    {#if snapshotsLoading}
+                      <div class="snapshots-status">
+                        <div
+                          class="spinner-loader"
+                          data-testid="snapshots-spinner"
+                        ></div>
+                        <span>Loading snapshots...</span>
+                      </div>
+                    {:else if snapshotsError}
+                      <div class="snapshots-status error">
+                        <span>{snapshotsError}</span>
+                      </div>
+                    {:else if snapshots.length === 0}
+                      <div class="snapshots-status empty">
+                        <span>No snapshots for this layout.</span>
+                      </div>
+                    {:else}
+                      <ul class="snapshot-list">
+                        {#each snapshots as snapshot (snapshot.filename)}
+                          <li class="snapshot-item">
+                            <span class="snapshot-time">
+                              {formatSnapshotTimestamp(snapshot.filename)}
+                            </span>
+                            <button
+                              class="restore-btn"
+                              onclick={() =>
+                                handleRestoreSnapshot(item.id, snapshot.filename)}
+                              disabled={restoringFilename !== null}
+                            >
+                              {restoringFilename === snapshot.filename
+                                ? "Restoring..."
+                                : "Restore"}
+                            </button>
+                          </li>
+                        {/each}
+                      </ul>
+                    {/if}
+                  </div>
+                {/if}
               </div>
             {/each}
           </div>
@@ -318,7 +431,7 @@
 
   .layout-item {
     display: flex;
-    align-items: center;
+    flex-direction: column;
     background: var(--colour-surface);
     border: 1px solid var(--colour-border);
     border-radius: var(--radius-md);
@@ -333,11 +446,98 @@
     background: var(--colour-surface-hover);
   }
 
+  .layout-main {
+    display: flex;
+    align-items: center;
+  }
+
+  .expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-2);
+    margin-left: var(--space-1);
+    border: none;
+    background: transparent;
+    color: var(--colour-text-muted);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition:
+      color 0.15s,
+      background-color 0.15s;
+  }
+
+  .expand-btn:hover {
+    color: var(--colour-primary);
+    background: var(--colour-surface-hover);
+  }
+
   .layout-row {
     flex: 1;
     min-width: 0;
     padding: var(--space-4);
     cursor: pointer;
+  }
+
+  .snapshots-panel {
+    border-top: 1px solid var(--colour-border);
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .snapshots-status {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: 0.75rem;
+    color: var(--colour-text-muted);
+  }
+
+  .snapshots-status.error {
+    color: var(--colour-error);
+  }
+
+  .snapshot-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .snapshot-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .snapshot-time {
+    font-size: 0.75rem;
+    color: var(--colour-text-muted);
+  }
+
+  .restore-btn {
+    padding: var(--space-1) var(--space-3);
+    border: 1px solid var(--colour-border);
+    background: var(--colour-surface);
+    color: var(--colour-text);
+    font-size: 0.75rem;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition:
+      border-color 0.15s,
+      background-color 0.15s;
+  }
+
+  .restore-btn:hover:not(:disabled) {
+    border-color: var(--colour-primary);
+    background: var(--colour-surface-hover);
+  }
+
+  .restore-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .layout-item.deleting {

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -80,6 +80,26 @@ const LayoutListResponseSchema = z.object({
 });
 
 /**
+ * Snapshot list entry from the API. The filename carries a UTC
+ * YYYYMMDD-HHMMSS suffix; timestamp is the file mtime (ISO 8601).
+ */
+const SnapshotItemSchema = z.object({
+  filename: z.string().min(1),
+  timestamp: z.string().datetime(),
+  size: z.number().int().nonnegative(),
+});
+
+const SnapshotListResponseSchema = z.object({
+  snapshots: z.array(SnapshotItemSchema),
+});
+
+export interface SnapshotItem {
+  filename: string;
+  timestamp: string;
+  size: number;
+}
+
+/**
  * Save (PUT) response schema. The server echoes the stored updatedAt.
  */
 const SaveLayoutResponseSchema = z.object({
@@ -444,6 +464,106 @@ export async function uploadSnapshot(
   } catch (error) {
     log("uploadSnapshot: error uuid=%s %O", uuid, error);
     return false;
+  }
+}
+
+/**
+ * List pre-overwrite snapshots for a layout, newest first.
+ * @param uuid - The layout's UUID (stable identity)
+ */
+export async function listSnapshots(uuid: string): Promise<SnapshotItem[]> {
+  if (!isApiAvailable()) {
+    log("listSnapshots: API not available");
+    return [];
+  }
+
+  const url = `${API_BASE_URL}/layouts/${encodeURIComponent(uuid)}/snapshots`;
+  log("listSnapshots: fetching %s", url);
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(API_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new PersistenceError("Layout not found", 404);
+    }
+    const error = await safeParseErrorJson(response);
+    throw new PersistenceError(
+      error.error ?? "Failed to list snapshots",
+      response.status,
+    );
+  }
+
+  try {
+    const rawData: unknown = await response.json();
+    const data = SnapshotListResponseSchema.parse(rawData);
+    log("listSnapshots: found %d snapshots", data.snapshots.length);
+    return data.snapshots;
+  } catch (error) {
+    log("listSnapshots: validation failed %O", error);
+    throw new PersistenceError("Invalid response from API server");
+  }
+}
+
+/**
+ * Load a snapshot by layout UUID and filename, routing the YAML through the
+ * same parse/validate/adapt pipeline as a normal layout load (#2042). A
+ * pre-schema-bump snapshot therefore hits the migration or reject path rather
+ * than bypassing it.
+ * @param uuid - The layout's UUID (stable identity)
+ * @param filename - The snapshot filename from {@link listSnapshots}
+ */
+export async function loadSnapshot(
+  uuid: string,
+  filename: string,
+): Promise<{
+  layout: Layout;
+  images: ImageStoreMap;
+  failedImagesCount: number;
+  failedKeys: string[];
+}> {
+  log("loadSnapshot: uuid=%s filename=%s", uuid, filename);
+
+  if (!isApiAvailable()) {
+    throw new PersistenceError("API not available");
+  }
+
+  const url = `${API_BASE_URL}/layouts/${encodeURIComponent(
+    uuid,
+  )}/snapshots/${encodeURIComponent(filename)}`;
+  log("loadSnapshot: fetching %s", url);
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(API_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new PersistenceError("Snapshot not found", 404);
+    }
+    const error = await safeParseErrorJson(response);
+    throw new PersistenceError(
+      error.error ?? "Failed to load snapshot",
+      response.status,
+    );
+  }
+
+  const declared = Number(response.headers.get("Content-Length"));
+  if (Number.isFinite(declared) && declared > MAX_LAYOUT_RESPONSE_BYTES) {
+    throw new PersistenceError("Snapshot data too large");
+  }
+
+  const yamlContent = await response.text();
+  if (new TextEncoder().encode(yamlContent).length > MAX_LAYOUT_RESPONSE_BYTES) {
+    throw new PersistenceError("Snapshot data too large");
+  }
+
+  try {
+    return await parseLayoutYamlWithImages(yamlContent);
+  } catch (error) {
+    log("loadSnapshot: failed to parse uuid=%s %O", uuid, error);
+    throw new PersistenceError("Snapshot data is corrupted - could not parse");
   }
 }
 

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -17,9 +17,11 @@ export {
   listSavedLayouts,
   loadSavedLayout,
   deleteSavedLayout,
+  listSnapshots,
   PersistenceError,
   getServerInstanceLabel,
   type SavedLayoutItem,
+  type SnapshotItem,
 } from "./api";
 export {
   loadSessionWithTimestamp,
@@ -32,6 +34,7 @@ export {
   finalizeLayoutLoad,
   loadFromApi,
   loadFromFile,
+  restoreFromSnapshot,
 } from "./load-pipeline";
 export {
   handleLoad,

--- a/src/lib/storage/load-pipeline.ts
+++ b/src/lib/storage/load-pipeline.ts
@@ -11,7 +11,7 @@ import { clearSession } from "./working-copy";
 import { setServerBaseUpdatedAt } from "./server-base";
 import type { Layout } from "$lib/types";
 import type { ImageStoreMap } from "$lib/types/images";
-import { loadSavedLayout, PersistenceError } from "./api";
+import { loadSavedLayout, loadSnapshot, PersistenceError } from "./api";
 import { extractFolderArchive } from "$lib/utils/archive";
 import { openFilePicker } from "$lib/utils/file";
 import { layoutDebug } from "$lib/utils/debug";
@@ -111,6 +111,48 @@ export async function loadFromApi(uuid: string) {
       }
     } else {
       message = "Failed to open layout — check your connection";
+    }
+    toastStore.showToast(message, "error");
+    return false;
+  }
+}
+
+/**
+ * Restore a pre-overwrite snapshot as the working copy (#2042).
+ *
+ * Restore-as-new-write, not an in-place revert: the snapshot YAML is parsed,
+ * validated, and adapted through the same {@link loadSnapshot} +
+ * {@link finalizeLayoutLoad} pipeline as a normal load, then the server base
+ * updatedAt is cleared so the next save snapshots the diverged server copy
+ * before overwriting it rather than reverting the stored layout in place.
+ */
+export async function restoreFromSnapshot(uuid: string, filename: string) {
+  const toastStore = getToastStore();
+
+  try {
+    const { layout, images, failedImagesCount } = await loadSnapshot(
+      uuid,
+      filename,
+    );
+    // No server base: the next save PUT carries a null last-known timestamp,
+    // so the server snapshots its current copy before this restore overwrites it.
+    setServerBaseUpdatedAt(null);
+    finalizeLayoutLoad(layout, images, failedImagesCount, {
+      successMessage: "Snapshot restored",
+    });
+    return true;
+  } catch (e) {
+    let message: string;
+    if (e instanceof PersistenceError) {
+      if (e.statusCode !== undefined && e.statusCode >= 500) {
+        message = "Server error - please try again later";
+      } else if (e.statusCode === 404) {
+        message = "Snapshot not found - it may have been pruned";
+      } else {
+        message = e.message;
+      }
+    } else {
+      message = "Failed to restore snapshot - check your connection";
     }
     toastStore.showToast(message, "error");
     return false;

--- a/src/lib/utils/snapshot-timestamp.ts
+++ b/src/lib/utils/snapshot-timestamp.ts
@@ -1,0 +1,52 @@
+/**
+ * Snapshot timestamp parsing and localized formatting (#2042).
+ *
+ * Snapshot filenames carry a UTC YYYYMMDD-HHMMSS suffix (Syncthing naming).
+ * The LoadDialog renders these as localized timestamps in the browser's
+ * timezone so users in non-UTC zones do not misread restore points by hours.
+ */
+
+/** Captures the UTC YYYYMMDD-HHMMSS suffix from a snapshot filename. */
+const SNAPSHOT_TIMESTAMP_PATTERN = /~(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})/;
+
+/**
+ * Parse the UTC timestamp suffix from a snapshot filename into a Date.
+ * Returns null when the filename has no parseable suffix.
+ */
+export function parseSnapshotTimestamp(filename: string): Date | null {
+  const match = SNAPSHOT_TIMESTAMP_PATTERN.exec(filename);
+  if (!match) {
+    return null;
+  }
+
+  const [, year, month, day, hour, minute, second] = match;
+  const ms = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+  );
+  const date = new Date(ms);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Format a snapshot filename's UTC suffix as a localized timestamp string.
+ * Falls back to the raw filename when the suffix cannot be parsed.
+ */
+export function formatSnapshotTimestamp(filename: string): string {
+  const date = parseSnapshotTimestamp(filename);
+  if (!date) {
+    return filename;
+  }
+
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/src/lib/utils/snapshot-timestamp.ts
+++ b/src/lib/utils/snapshot-timestamp.ts
@@ -6,8 +6,13 @@
  * timezone so users in non-UTC zones do not misread restore points by hours.
  */
 
-/** Captures the UTC YYYYMMDD-HHMMSS suffix from a snapshot filename. */
-const SNAPSHOT_TIMESTAMP_PATTERN = /~(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})/;
+/**
+ * Captures the UTC YYYYMMDD-HHMMSS suffix from a snapshot filename, anchored to
+ * the backend snapshot shape `...~YYYYMMDD-HHMMSS[-N].yaml`. Anchoring to the
+ * filename tail keeps arbitrary embedded fragments from parsing as valid times.
+ */
+const SNAPSHOT_TIMESTAMP_PATTERN =
+  /~(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-\d+)?\.yaml$/;
 
 /**
  * Parse the UTC timestamp suffix from a snapshot filename into a Date.

--- a/src/lib/utils/snapshot-timestamp.ts
+++ b/src/lib/utils/snapshot-timestamp.ts
@@ -25,16 +25,28 @@ export function parseSnapshotTimestamp(filename: string): Date | null {
   }
 
   const [, year, month, day, hour, minute, second] = match;
-  const ms = Date.UTC(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-    Number(hour),
-    Number(minute),
-    Number(second),
-  );
-  const date = new Date(ms);
-  return Number.isNaN(date.getTime()) ? null : date;
+  const y = Number(year);
+  const mo = Number(month);
+  const d = Number(day);
+  const h = Number(hour);
+  const mi = Number(minute);
+  const s = Number(second);
+
+  // Date.UTC silently normalizes out-of-range components (month 13, day 32, ...)
+  // into a different valid instant, so reject them explicitly rather than render
+  // a misleading restore time.
+  const date = new Date(Date.UTC(y, mo - 1, d, h, mi, s));
+  if (
+    date.getUTCFullYear() !== y ||
+    date.getUTCMonth() !== mo - 1 ||
+    date.getUTCDate() !== d ||
+    date.getUTCHours() !== h ||
+    date.getUTCMinutes() !== mi ||
+    date.getUTCSeconds() !== s
+  ) {
+    return null;
+  }
+  return date;
 }
 
 /**

--- a/src/tests/LoadDialog.test.ts
+++ b/src/tests/LoadDialog.test.ts
@@ -7,6 +7,7 @@ import { resetToastStore } from "$lib/stores/toast.svelte";
 import * as persistenceApi from "$lib/storage/api";
 import * as loadPipeline from "$lib/storage/load-pipeline";
 import * as persistenceStore from "$lib/storage/availability.svelte";
+import { formatSnapshotTimestamp } from "$lib/utils/snapshot-timestamp";
 
 // Mock the dependencies
 vi.mock("$lib/storage/api", () => ({
@@ -212,8 +213,12 @@ describe("LoadDialog", () => {
 
     expect(persistenceApi.listSnapshots).toHaveBeenCalledWith("uuid-1");
     // The raw UTC filename suffix must not surface; a localized time does.
-    const restoreButton = await screen.findByText(/Restore/i);
-    expect(restoreButton).toBeInTheDocument();
+    const expectedLabel = formatSnapshotTimestamp(
+      "test-layout-1~20260615-143005.yaml",
+    );
+    expect(
+      await screen.findByText(expectedLabel),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText(/20260615-143005/),
     ).not.toBeInTheDocument();

--- a/src/tests/LoadDialog.test.ts
+++ b/src/tests/LoadDialog.test.ts
@@ -13,6 +13,7 @@ vi.mock("$lib/storage/api", () => ({
   listSavedLayouts: vi.fn(),
   deleteSavedLayout: vi.fn(),
   loadSavedLayout: vi.fn(),
+  listSnapshots: vi.fn(),
   PersistenceError: class PersistenceError extends Error {
     statusCode?: number;
     constructor(message: string, statusCode?: number) {
@@ -26,6 +27,7 @@ vi.mock("$lib/storage/api", () => ({
 vi.mock("$lib/storage/load-pipeline", () => ({
   loadFromApi: vi.fn(),
   loadFromFile: vi.fn(),
+  restoreFromSnapshot: vi.fn(),
 }));
 
 vi.mock("$lib/storage/availability.svelte", () => ({
@@ -177,5 +179,82 @@ describe("LoadDialog", () => {
 
     expect(await screen.findByText("Server error")).toBeInTheDocument();
     expect(screen.getByText(/Retry/i)).toBeInTheDocument();
+  });
+
+  it("lists snapshots with localized timestamps when expanded", async () => {
+    const mockLayouts: persistenceApi.SavedLayoutItem[] = [
+      {
+        id: "uuid-1",
+        name: "Test Layout 1",
+        version: "1.0",
+        updatedAt: new Date().toISOString(),
+        rackCount: 1,
+        deviceCount: 5,
+        valid: true,
+      },
+    ];
+    vi.mocked(persistenceApi.listSavedLayouts).mockResolvedValue(mockLayouts);
+    vi.mocked(persistenceApi.listSnapshots).mockResolvedValue([
+      {
+        filename: "test-layout-1~20260615-143005.yaml",
+        timestamp: "2026-06-15T14:30:05.000Z",
+        size: 1024,
+      },
+    ]);
+
+    dialogStore.open("load");
+    render(LoadDialog);
+    await screen.findByText("Test Layout 1");
+
+    await fireEvent.click(
+      screen.getByLabelText(/Show snapshots for Test Layout 1/i),
+    );
+
+    expect(persistenceApi.listSnapshots).toHaveBeenCalledWith("uuid-1");
+    // The raw UTC filename suffix must not surface; a localized time does.
+    const restoreButton = await screen.findByText(/Restore/i);
+    expect(restoreButton).toBeInTheDocument();
+    expect(
+      screen.queryByText(/20260615-143005/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("restores a snapshot through the load pipeline and closes the dialog", async () => {
+    const mockLayouts: persistenceApi.SavedLayoutItem[] = [
+      {
+        id: "uuid-1",
+        name: "Test Layout 1",
+        version: "1.0",
+        updatedAt: new Date().toISOString(),
+        rackCount: 1,
+        deviceCount: 5,
+        valid: true,
+      },
+    ];
+    vi.mocked(persistenceApi.listSavedLayouts).mockResolvedValue(mockLayouts);
+    vi.mocked(persistenceApi.listSnapshots).mockResolvedValue([
+      {
+        filename: "test-layout-1~20260615-143005.yaml",
+        timestamp: "2026-06-15T14:30:05.000Z",
+        size: 1024,
+      },
+    ]);
+    vi.mocked(loadPipeline.restoreFromSnapshot).mockResolvedValue(true);
+
+    dialogStore.open("load");
+    render(LoadDialog);
+    await screen.findByText("Test Layout 1");
+
+    await fireEvent.click(
+      screen.getByLabelText(/Show snapshots for Test Layout 1/i),
+    );
+    const restoreButton = await screen.findByText(/Restore/i);
+    await fireEvent.click(restoreButton);
+
+    expect(loadPipeline.restoreFromSnapshot).toHaveBeenCalledWith(
+      "uuid-1",
+      "test-layout-1~20260615-143005.yaml",
+    );
+    expect(dialogStore.isOpen("load")).toBe(false);
   });
 });

--- a/src/tests/load-pipeline.test.ts
+++ b/src/tests/load-pipeline.test.ts
@@ -8,7 +8,10 @@ import {
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
 import * as persistenceApi from "$lib/storage/api";
-import { getServerBaseUpdatedAt } from "$lib/storage/server-base";
+import {
+  getServerBaseUpdatedAt,
+  setServerBaseUpdatedAt,
+} from "$lib/storage/server-base";
 import * as archive from "$lib/utils/archive";
 import * as fileUtils from "$lib/utils/file";
 import { createTestLayout } from "./factories";
@@ -184,6 +187,11 @@ describe("load-pipeline", () => {
     });
 
     it("clears the server base so the next save is a fresh write, not an in-place revert", async () => {
+      // Seed a non-null base so the assertion cannot pass vacuously: the test
+      // must observe restoreFromSnapshot actively clearing it.
+      setServerBaseUpdatedAt("2026-06-15T12:00:00.000Z");
+      expect(getServerBaseUpdatedAt()).not.toBeNull();
+
       const layout = createTestLayout({ name: "Restore As New Write" });
       vi.mocked(persistenceApi.loadSnapshot).mockResolvedValue({
         layout,

--- a/src/tests/load-pipeline.test.ts
+++ b/src/tests/load-pipeline.test.ts
@@ -3,10 +3,12 @@ import {
   finalizeLayoutLoad,
   loadFromApi,
   loadFromFile,
+  restoreFromSnapshot,
 } from "$lib/storage/load-pipeline";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
 import * as persistenceApi from "$lib/storage/api";
+import { getServerBaseUpdatedAt } from "$lib/storage/server-base";
 import * as archive from "$lib/utils/archive";
 import * as fileUtils from "$lib/utils/file";
 import { createTestLayout } from "./factories";
@@ -26,6 +28,7 @@ vi.mock("$lib/stores/images.svelte", () => ({
 
 vi.mock("$lib/storage/api", () => ({
   loadSavedLayout: vi.fn(),
+  loadSnapshot: vi.fn(),
   PersistenceError: class PersistenceError extends Error {
     statusCode?: number;
     constructor(message: string, statusCode?: number) {
@@ -152,6 +155,60 @@ describe("load-pipeline", () => {
       expect(toastStore.toasts).toContainEqual(
         expect.objectContaining({ message: "Not found", type: "error" }),
       );
+    });
+  });
+
+  describe("restoreFromSnapshot", () => {
+    it("loads the snapshot through loadSnapshot and finalizes as the working copy", async () => {
+      const layout = createTestLayout({ name: "Restored Snapshot" });
+      vi.mocked(persistenceApi.loadSnapshot).mockResolvedValue({
+        layout,
+        images: new Map(),
+        failedImagesCount: 0,
+        failedKeys: [],
+      });
+
+      const result = await restoreFromSnapshot(
+        "uuid-1",
+        "restored~20260615-143005.yaml",
+      );
+
+      expect(result).toBe(true);
+      // Restore must go through the same loadSnapshot parse/validate/adapt path
+      // as a normal load, not a bespoke bypass.
+      expect(persistenceApi.loadSnapshot).toHaveBeenCalledWith(
+        "uuid-1",
+        "restored~20260615-143005.yaml",
+      );
+      expect(layoutStore.layout.name).toBe("Restored Snapshot");
+    });
+
+    it("clears the server base so the next save is a fresh write, not an in-place revert", async () => {
+      const layout = createTestLayout({ name: "Restore As New Write" });
+      vi.mocked(persistenceApi.loadSnapshot).mockResolvedValue({
+        layout,
+        images: new Map(),
+        failedImagesCount: 0,
+        failedKeys: [],
+      });
+
+      await restoreFromSnapshot("uuid-1", "x~20260615-143005.yaml");
+
+      expect(getServerBaseUpdatedAt()).toBeNull();
+    });
+
+    it("shows an error toast when the snapshot cannot be loaded", async () => {
+      vi.mocked(persistenceApi.loadSnapshot).mockRejectedValue(
+        new persistenceApi.PersistenceError("Snapshot not found", 404),
+      );
+
+      const result = await restoreFromSnapshot(
+        "uuid-1",
+        "missing~20260615-143005.yaml",
+      );
+
+      expect(result).toBe(false);
+      expect(toastStore.toasts.some((t) => t.type === "error")).toBe(true);
     });
   });
 

--- a/src/tests/persistence-api.test.ts
+++ b/src/tests/persistence-api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkApiHealth,
   loadSavedLayout,
+  loadSnapshot,
   saveLayoutToServer,
   uploadSnapshot,
 } from "$lib/storage/api";
@@ -323,5 +324,60 @@ describe("loadSavedLayout", () => {
       "11111111-1111-4111-8111-111111111111",
     );
     expect(result.updatedAt).toBe("2026-06-14T10:00:00.000Z");
+  });
+});
+
+describe("loadSnapshot", () => {
+  const UUID = "11111111-1111-4111-8111-111111111111";
+  const FILENAME = "my-layout~20260615-143005.yaml";
+
+  beforeEach(() => {
+    setApiAvailable(true);
+    vi.stubGlobal("AbortSignal", {
+      timeout: () => new AbortController().signal,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    setApiAvailable(false);
+  });
+
+  it("parses snapshot YAML through the same validated pipeline as file load", async () => {
+    const yaml = await serializeLayoutToYaml(
+      createTestLayout({ name: "From Snapshot" }),
+      "",
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(yaml, {
+        status: 200,
+        headers: { "Content-Type": "text/yaml" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await loadSnapshot(UUID, FILENAME);
+
+    // A valid snapshot resolves to a parsed Layout: it went through
+    // parseLayoutYamlWithImages (LayoutSchema), not a raw passthrough.
+    expect(result.layout.name).toBe("From Snapshot");
+    expect(fetchMock.mock.calls[0]?.[0]).toContain(
+      `/snapshots/${encodeURIComponent(FILENAME)}`,
+    );
+  });
+
+  it("rejects a snapshot whose YAML fails schema validation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("name: broken\nracks: not-a-list", {
+          status: 200,
+          headers: { "Content-Type": "text/yaml" },
+        }),
+      ),
+    );
+
+    await expect(loadSnapshot(UUID, FILENAME)).rejects.toThrow(/corrupted/i);
   });
 });

--- a/src/tests/snapshot-timestamp.test.ts
+++ b/src/tests/snapshot-timestamp.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSnapshotTimestamp,
+  formatSnapshotTimestamp,
+} from "$lib/utils/snapshot-timestamp";
+
+describe("parseSnapshotTimestamp", () => {
+  it("parses the UTC suffix as a UTC instant, not local time", () => {
+    const date = parseSnapshotTimestamp("my-layout~20260615-143005.yaml");
+    expect(date?.toISOString()).toBe("2026-06-15T14:30:05.000Z");
+  });
+
+  it("parses a collision-suffixed snapshot name", () => {
+    const date = parseSnapshotTimestamp("my-layout~20260615-143005-2.yaml");
+    expect(date?.toISOString()).toBe("2026-06-15T14:30:05.000Z");
+  });
+
+  it("returns null when the filename has no timestamp suffix", () => {
+    expect(parseSnapshotTimestamp("my-layout.yaml")).toBeNull();
+  });
+});
+
+describe("formatSnapshotTimestamp", () => {
+  it("renders the UTC suffix in a non-UTC locale using local time", () => {
+    // 14:30 UTC is 10:30 in America/New_York (EDT, UTC-4 on this date).
+    const formatted = new Intl.DateTimeFormat("en-US", {
+      timeZone: "America/New_York",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(parseSnapshotTimestamp("my-layout~20260615-143005.yaml")!);
+    expect(formatted).toContain("10:30");
+    expect(formatted).not.toContain("14:30");
+  });
+
+  it("falls back to the raw filename when the suffix is unparseable", () => {
+    expect(formatSnapshotTimestamp("weird-name.yaml")).toBe("weird-name.yaml");
+  });
+});

--- a/src/tests/snapshot-timestamp.test.ts
+++ b/src/tests/snapshot-timestamp.test.ts
@@ -43,4 +43,9 @@ describe("formatSnapshotTimestamp", () => {
   it("falls back to the raw filename when the suffix is unparseable", () => {
     expect(formatSnapshotTimestamp("weird-name.yaml")).toBe("weird-name.yaml");
   });
+
+  it("falls back to the raw filename when components are out of range", () => {
+    const filename = "my-layout~20261340-996199.yaml";
+    expect(formatSnapshotTimestamp(filename)).toBe(filename);
+  });
 });

--- a/src/tests/snapshot-timestamp.test.ts
+++ b/src/tests/snapshot-timestamp.test.ts
@@ -21,18 +21,23 @@ describe("parseSnapshotTimestamp", () => {
 });
 
 describe("formatSnapshotTimestamp", () => {
-  it("renders the UTC suffix in a non-UTC locale using local time", () => {
-    // 14:30 UTC is 10:30 in America/New_York (EDT, UTC-4 on this date).
-    const formatted = new Intl.DateTimeFormat("en-US", {
-      timeZone: "America/New_York",
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(parseSnapshotTimestamp("my-layout~20260615-143005.yaml")!);
-    expect(formatted).toContain("10:30");
-    expect(formatted).not.toContain("14:30");
+  it("renders the parsed UTC instant as a localized timestamp", () => {
+    const filename = "my-layout~20260615-143005.yaml";
+    // The real function must render the same localized string the runtime
+    // would produce for the parsed UTC instant, not the raw filename suffix.
+    const expected = parseSnapshotTimestamp(filename)!.toLocaleString(
+      undefined,
+      {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      },
+    );
+    const formatted = formatSnapshotTimestamp(filename);
+    expect(formatted).toBe(expected);
+    expect(formatted).not.toContain("20260615-143005");
   });
 
   it("falls back to the raw filename when the suffix is unparseable", () => {


### PR DESCRIPTION
## **User description**
## Summary

Adds a per-layout snapshots expansion to the server-mode LoadDialog so users can find and restore pre-overwrite snapshots (Phase 4 of spike #2019).

- Each saved layout gets an expand toggle that lists its snapshots, newest first.
- Snapshot entries render the UTC `YYYYMMDD-HHMMSS` filename suffix as a localized timestamp (browser timezone), not the raw suffix, so non-UTC users do not misread restore points.
- A Restore action loads the snapshot as the working copy.

## Restore-as-new-write, through the validated pipeline

Restore is a restore-as-new-write, not an in-place revert. The snapshot YAML is fetched and routed through the same parse/validate/adapt pipeline as a normal load:

- `loadSnapshot` calls `parseLayoutYamlWithImages` (LayoutSchema), so a pre-schema-bump snapshot hits the migration or reject path rather than bypassing it.
- `restoreFromSnapshot` then calls `finalizeLayoutLoad`, which runs the carrier-first read-path adapter at `loadLayout` (the single store ingress landed by C2 #2304).
- It clears the server base updatedAt so the next save snapshots the diverged server copy before overwriting, rather than reverting the stored layout in place.

## API

Adds `GET /layouts/:uuid/snapshots/:filename` to serve a single snapshot's YAML content, with filename validation (path separators and control characters rejected) and 404 for missing snapshots. Client wrappers: `listSnapshots`, `loadSnapshot`, and the `restoreFromSnapshot` pipeline function.

## Files changed

- `api/src/storage/filesystem.ts`: `getSnapshot`, exported `SNAPSHOT_NAME_PATTERN`.
- `api/src/routes/layouts.ts`: GET snapshot-content route with filename guard.
- `src/lib/storage/api.ts`: `listSnapshots`, `loadSnapshot`, `SnapshotItem`.
- `src/lib/storage/load-pipeline.ts`: `restoreFromSnapshot`.
- `src/lib/storage/index.ts`: re-exports.
- `src/lib/utils/snapshot-timestamp.ts`: parse + localized format of the filename suffix.
- `src/lib/components/LoadDialog.svelte`: snapshots expansion UI.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:run` (2490 client tests pass)
- [x] `bun test` in `api/` (291 tests pass, including new snapshot-content route cases)
- [x] `npm run build`
- [x] New unit tests: snapshot restore routes through the validated parse pipeline; restore-as-new-write clears the server base; localized timestamp rendering; server route returns content / 404 / 400, and rejects traversal, backslash, and control-char filenames.

Closes #2042

https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G)_


___

## **CodeAnt-AI Description**
Restore saved snapshots from the Load dialog

### What Changed
- Saved layouts now show an expandable snapshot list in the Load dialog, with each snapshot labeled by a localized time instead of the raw UTC filename stamp
- Users can restore a snapshot directly from the list; the restored snapshot loads as the current working copy and the dialog closes on success
- Snapshot lists reset when the dialog closes so reopening it does not show stale entries
- Snapshot links are now rejected when they contain path separators or control characters, including newline edge cases

### Impact
`✅ Faster rollback to a previous save`
`✅ Clearer snapshot times for non-UTC users`
`✅ Fewer stale snapshot lists after reopening Load dialog`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
