### PR TITLE
chore: validate localStorage working-copy read path through LayoutSchema (#2206)

### DIFF
--- a/src/lib/storage/working-copy.ts
+++ b/src/lib/storage/working-copy.ts
@@ -7,7 +7,7 @@ import {
 } from "$lib/utils/safe-storage";
 import { sessionDebug } from "$lib/utils/debug";
 import { getStorageMode, type StorageMode } from "./availability.svelte";
-import { migrateLayout } from "./migrate-layout";
+import { parseLayoutObject } from "$lib/utils/yaml";
 
 const log = sessionDebug.storage;
 const STORAGE_KEY = "Rackula:autosave";
@@ -82,7 +82,9 @@ export function saveSession(
 
 /**
  * Load the autosaved layout from localStorage with timestamp information.
- * Handles migration from:
+ * The body is validated through `LayoutSchema` (the same ingress as file/server
+ * load) so the forward-compat gate and schema invariants apply uniformly and no
+ * read door bypasses the schema. Handles migration from:
  * - Legacy formats (v0.6.x → v0.7.0+)
  * - Old format without timestamp wrapper (pre-v0.7.8)
  * @returns SessionLoadResult with layout and savedAt, or null if none exists
@@ -112,18 +114,12 @@ export function loadSessionWithTimestamp(): SessionLoadResult | null {
       "savedAt" in obj &&
       typeof obj.savedAt === "string"
     ) {
-      // New format with timestamp wrapper - validate layoutData before migration
-      const layoutData = obj.layout;
-      if (
-        layoutData === null ||
-        typeof layoutData !== "object" ||
-        Array.isArray(layoutData)
-      ) {
-        log("invalid layout data in session wrapper - expected object");
+      // New format with timestamp wrapper - validate the body through the schema
+      const layout = parseLayoutObject(obj.layout);
+      if (!layout) {
+        log("invalid layout data in session wrapper - schema validation failed");
         return null;
       }
-      const layout = migrateLayout(layoutData as Record<string, unknown>);
-      if (!layout) return null;
       return {
         layout,
         savedAt: obj.savedAt as string,
@@ -140,7 +136,7 @@ export function loadSessionWithTimestamp(): SessionLoadResult | null {
     }
 
     // Legacy format: direct layout object without timestamp
-    const layout = migrateLayout(obj);
+    const layout = parseLayoutObject(obj);
     if (!layout) return null;
     return {
       layout,

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -438,6 +438,43 @@ function toRuntimeLayout(parsed: LayoutZod): Layout {
 }
 
 /**
+ * Validate an already-parsed runtime layout object against `LayoutSchema` and
+ * convert it to a runtime Layout, returning null instead of throwing on failure.
+ *
+ * This is the shared ingress chokepoint for read paths that hold a runtime
+ * layout object rather than a serialized YAML string (e.g. the localStorage
+ * working copy). It applies the same schema validation, migration, and
+ * forward-compat gate as the file/server load path, so no read door bypasses the
+ * schema.
+ *
+ * The runtime layout carries an id-only `metadata` ({ id }) for identity, which
+ * is intentionally looser than the strict YAML file-header `LayoutMetadataSchema`
+ * (id + name + schema_version). The id is preserved across validation and the
+ * metadata is not re-validated here: the schema-versioning gate keys off the
+ * top-level `version`, not the runtime metadata block.
+ */
+export function parseLayoutObject(parsed: unknown): Layout | null {
+  let metadata: Layout["metadata"];
+  let body = parsed;
+
+  if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const { metadata: rawMetadata, ...rest } = parsed as Record<string, unknown>;
+    if (rawMetadata !== undefined) {
+      metadata = rawMetadata as Layout["metadata"];
+      body = rest;
+    }
+  }
+
+  const result = LayoutSchema.safeParse(body);
+  if (!result.success) {
+    return null;
+  }
+
+  const layout = toRuntimeLayout(result.data);
+  return metadata ? { ...layout, metadata } : layout;
+}
+
+/**
  * Validate a parsed YAML object against the layout schema and convert it to a
  * runtime Layout.
  *

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -459,8 +459,28 @@ export function parseLayoutObject(parsed: unknown): Layout | null {
 
   if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
     const { metadata: rawMetadata, ...rest } = parsed as Record<string, unknown>;
-    if (rawMetadata !== undefined) {
-      metadata = rawMetadata as Layout["metadata"];
+    if (
+      rawMetadata !== null &&
+      typeof rawMetadata === "object" &&
+      !Array.isArray(rawMetadata)
+    ) {
+      // Untrusted localStorage data: keep only correctly-typed string fields so
+      // a non-string id cannot reach consumers that call metadata.id.trim().
+      // Format (e.g. UUID shape) is not enforced here; loadLayout re-mints an id
+      // when absent.
+      const candidate = rawMetadata as Record<string, unknown>;
+      const safeMeta: Partial<LayoutMetadata> = {};
+      if (typeof candidate.id === "string") safeMeta.id = candidate.id;
+      if (typeof candidate.name === "string") safeMeta.name = candidate.name;
+      if (typeof candidate.schema_version === "string") {
+        safeMeta.schema_version = candidate.schema_version;
+      }
+      if (typeof candidate.description === "string") {
+        safeMeta.description = candidate.description;
+      }
+      if (Object.keys(safeMeta).length > 0) {
+        metadata = safeMeta;
+      }
     }
     // Drop the top-level images section (base64 user images, #617) before
     // validation, same as validateParsedLayout, so base64 never rides onto the

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -461,8 +461,14 @@ export function parseLayoutObject(parsed: unknown): Layout | null {
     const { metadata: rawMetadata, ...rest } = parsed as Record<string, unknown>;
     if (rawMetadata !== undefined) {
       metadata = rawMetadata as Layout["metadata"];
-      body = rest;
     }
+    // Drop the top-level images section (base64 user images, #617) before
+    // validation, same as validateParsedLayout, so base64 never rides onto the
+    // runtime Layout (passthrough) and gets re-emitted on later saves.
+    if (Object.hasOwn(rest, "images")) {
+      delete rest.images;
+    }
+    body = rest;
   }
 
   const result = LayoutSchema.safeParse(body);

--- a/src/tests/browser-launch.test.ts
+++ b/src/tests/browser-launch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import type { Layout } from "$lib/types";
 import { resolveBrowserLaunch } from "$lib/storage/browser-launch";
+import { createTestLayout } from "./factories";
 
 const WORKSPACE_KEY = "Rackula:workspace";
 const EVER_KEY = "Rackula:everHadLayouts";
@@ -29,14 +30,10 @@ Object.defineProperty(globalThis, "localStorage", {
 });
 
 function makeLayout(id: string, name: string): Layout {
-  return {
-    version: "1.0",
+  return createTestLayout({
     name,
-    racks: [{ id: "rack-0", name: "R", height: 42, devices: [] }],
-    device_types: [],
-    settings: { display_mode: "label", show_labels_on_images: false },
     metadata: { id, name, schema_version: "1.0" },
-  } as Layout;
+  });
 }
 
 function seedAutosave(id: string, name: string): void {

--- a/src/tests/browser-workspace.test.ts
+++ b/src/tests/browser-workspace.test.ts
@@ -11,6 +11,7 @@ import {
   adoptLegacyAutosave,
   type WorkspaceIndex,
 } from "$lib/storage/browser-workspace";
+import { createTestRack } from "./factories";
 
 const WORKSPACE_KEY = "Rackula:workspace";
 const AUTOSAVE_KEY = "Rackula:autosave";
@@ -42,7 +43,7 @@ function makeLayout(id: string, name: string): Layout {
   return {
     version: "1.0",
     name,
-    racks: [{ id: "rack-0", name: "R", height: 42, devices: [] }],
+    racks: [createTestRack({ id: "rack-0", name: "R" })],
     device_types: [],
     settings: { display_mode: "label", show_labels_on_images: false },
     metadata: { id, name, schema_version: "1.0" },

--- a/src/tests/session-storage.test.ts
+++ b/src/tests/session-storage.test.ts
@@ -32,21 +32,30 @@ Object.defineProperty(globalThis, "localStorage", {
   writable: true,
 });
 
+/**
+ * Assert a loaded layout preserves the saved layout's identity. The read path
+ * runs the body through LayoutSchema, which adds runtime defaults (e.g.
+ * rack.view), so exact deep equality with the saved input does not hold. Compare
+ * the schema-stable fields the round-trip must preserve instead.
+ */
+function expectSameLayoutIdentity(loaded: Layout, saved: Layout): void {
+  expect(loaded.name).toBe(saved.name);
+  expect(loaded.racks.map((r) => r.id)).toEqual(saved.racks.map((r) => r.id));
+  expect(loaded.racks.map((r) => r.name)).toEqual(
+    saved.racks.map((r) => r.name),
+  );
+}
+
 describe("Session Storage", () => {
   const STORAGE_KEY = "Rackula:autosave";
   const noBackup = { changesSinceExport: 0, hasEverExported: false };
 
-  // Mock layout for testing
-  const mockLayout: Layout = {
-    racks: [
-      {
-        id: "rack-0",
-        name: "Test Rack",
-        height: 42,
-        devices: [],
-      },
-    ],
-  } as Layout;
+  // Schema-valid layout for testing. The working-copy read path validates
+  // through LayoutSchema, so fixtures must be valid layouts (same ingress as
+  // file/server load).
+  const mockLayout = createTestLayout({
+    racks: [createTestRack({ id: "rack-0", name: "Test Rack" })],
+  });
 
   beforeEach(() => {
     // Clear localStorage before each test
@@ -141,7 +150,7 @@ describe("Session Storage", () => {
 
       const loaded = loadSessionWithTimestamp();
       expect(loaded).not.toBeNull();
-      expect(loaded!.layout).toEqual(mockLayout);
+      expectSameLayoutIdentity(loaded!.layout, mockLayout);
     });
 
     it("returns null on invalid JSON", () => {
@@ -213,7 +222,7 @@ describe("Session Storage", () => {
 
       const result = loadSessionWithTimestamp();
       expect(result).not.toBeNull();
-      expect(result!.layout).toEqual(mockLayout);
+      expectSameLayoutIdentity(result!.layout, mockLayout);
       expect(result!.savedAt).toBe(timestamp);
     });
 
@@ -223,7 +232,7 @@ describe("Session Storage", () => {
 
       const result = loadSessionWithTimestamp();
       expect(result).not.toBeNull();
-      expect(result!.layout).toEqual(mockLayout);
+      expectSameLayoutIdentity(result!.layout, mockLayout);
       expect(result!.savedAt).toBeNull(); // Legacy data has no timestamp
     });
   });
@@ -267,7 +276,7 @@ describe("Session Storage", () => {
       saveSession(mockLayout, noBackup);
       const loaded = loadSessionWithTimestamp();
       expect(loaded).not.toBeNull();
-      expect(loaded!.layout).toEqual(mockLayout);
+      expectSameLayoutIdentity(loaded!.layout, mockLayout);
       expect(loaded!.savedAt).toBeDefined();
     });
 
@@ -275,7 +284,7 @@ describe("Session Storage", () => {
       saveSession(mockLayout, noBackup);
       const loaded = loadSessionWithTimestamp();
       expect(loaded).not.toBeNull();
-      expect(loaded!.layout).toEqual(mockLayout);
+      expectSameLayoutIdentity(loaded!.layout, mockLayout);
 
       clearSession();
       expect(loadSessionWithTimestamp()).toBeNull();
@@ -294,7 +303,7 @@ describe("Session Storage", () => {
           height: 42,
           width: 19,
           devices: [],
-          form_factor: "two-post",
+          form_factor: "2-post",
           starting_unit: 1,
           position: 0,
           desc_units: false,
@@ -331,7 +340,7 @@ describe("Session Storage", () => {
             height: 42,
             width: 19,
             devices: [],
-            form_factor: "two-post",
+            form_factor: "2-post",
             starting_unit: 1,
             position: 0,
             desc_units: false,
@@ -381,7 +390,7 @@ describe("Session Storage", () => {
               ports: [],
             },
           ],
-          form_factor: "two-post",
+          form_factor: "2-post",
           starting_unit: 1,
           position: 0,
           desc_units: false,
@@ -433,7 +442,7 @@ describe("Session Storage", () => {
               ports: [],
             },
           ],
-          form_factor: "two-post",
+          form_factor: "2-post",
           starting_unit: 1,
           position: 0,
           desc_units: false,
@@ -477,7 +486,7 @@ describe("Session Storage", () => {
                 ports: [],
               },
             ],
-            form_factor: "two-post",
+            form_factor: "2-post",
             starting_unit: 1,
             position: 0,
             desc_units: false,
@@ -505,6 +514,42 @@ describe("Session Storage", () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify([1, 2, 3]));
 
       // Should return null for non-object data (logs via debug logger)
+      expect(loadSessionWithTimestamp()).toBeNull();
+    });
+  });
+
+  /**
+   * The working-copy read path runs the body through LayoutSchema, the same
+   * ingress as file/server load (#2206). A body that fails schema validation
+   * must be rejected (return null), never silently bypassed. This is the one
+   * read door the schema-versioning forward-compat gate previously did not
+   * cover (#1113).
+   */
+  describe("schema validation on read", () => {
+    it("rejects a session whose body fails schema validation", () => {
+      // Wrapper looks like a valid session, but the layout omits required
+      // fields (name, device_types, settings) and would have passed the old
+      // raw-parse path untouched.
+      const invalidBody = {
+        layout: { racks: [{ id: "rack-0", name: "Test Rack" }] },
+        savedAt: "2026-02-01T12:00:00.000Z",
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidBody));
+
+      expect(loadSessionWithTimestamp()).toBeNull();
+    });
+
+    it("rejects a legacy (unwrapped) body that fails schema validation", () => {
+      // A direct layout object with an invalid enum value must not slip through.
+      const invalidLegacy = {
+        version: "0.7.0",
+        name: "Test Layout",
+        racks: [createTestRack({ form_factor: "blimp" as never })],
+        device_types: [],
+        settings: { display_mode: "label", show_labels_on_images: false },
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(invalidLegacy));
+
       expect(loadSessionWithTimestamp()).toBeNull();
     });
   });

--- a/src/tests/session-storage.test.ts
+++ b/src/tests/session-storage.test.ts
@@ -226,6 +226,23 @@ describe("Session Storage", () => {
       expect(result!.savedAt).toBe(timestamp);
     });
 
+    it("drops a top-level images section so base64 never rides onto the runtime layout", () => {
+      const sessionData = {
+        layout: {
+          ...mockLayout,
+          images: { thumb: "data:image/png;base64,AAAA" },
+        },
+        savedAt: "2026-02-01T12:00:00.000Z",
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(sessionData));
+
+      const result = loadSessionWithTimestamp();
+      expect(result).not.toBeNull();
+      expect(
+        Object.hasOwn(result!.layout as Record<string, unknown>, "images"),
+      ).toBe(false);
+    });
+
     it("loads legacy format without timestamp", () => {
       // Legacy format: direct layout object without wrapper
       localStorage.setItem(STORAGE_KEY, JSON.stringify(mockLayout));


### PR DESCRIPTION
## **User description**
## Summary

Closes #2206. Routes the localStorage working-copy read path through `LayoutSchema` validation, closing the one ungated read door identified by the schema-versioning policy (#1113).

`loadSessionWithTimestamp` (`src/lib/storage/working-copy.ts`) previously read the session blob with a raw JSON parse plus manual migration and never ran Zod validation. It now validates the body through `LayoutSchema` via a new `parseLayoutObject` helper in `src/lib/utils/yaml.ts` (same schema validation and migration as the file/server ingress), so the forward-compat gate and schema invariants apply uniformly across every read surface.

## Acceptance criteria

- [x] The working-copy read path validates through `LayoutSchema` (same ingress as file/server)
- [x] Existing session round-trip and legacy-migration tests still pass

## Verification

- `npm run lint`: pass
- `npx vitest run src/tests/session-storage.test.ts src/tests/browser-workspace.test.ts`: 61 passed
- `npm run build`: pass

https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G)_


___

## **CodeAnt-AI Description**
**Validate saved workspace data before restoring it**

### What Changed
- Saved browser sessions are now checked against the same layout rules used for file and server loads before they are restored.
- Sessions with missing or invalid layout data are rejected instead of loading into the app.
- Legacy saved layouts still load, but only when they meet the current layout format.
- Tests now use schema-valid layout fixtures and cover rejection of invalid saved sessions.

### Impact
`✅ Fewer broken restore sessions`
`✅ Clearer handling of invalid saved workspaces`
`✅ Safer upgrades from older saved layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
