### PR TITLE
feat: twin-tab guard for the shared working copy (#2044)

### DIFF
--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -14,6 +14,8 @@
     getStorageMode,
     shouldWarnBeforeUnload,
     persistBrowserWorkspace,
+    getTwinTabGuard,
+    setForeignWriteNotifier,
     type PersistTab,
   } from "$lib/storage";
   import { getImageStore } from "$lib/stores/images.svelte";
@@ -21,6 +23,7 @@
   import { getUIStore } from "$lib/stores/ui.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
+  import { getToastStore } from "$lib/stores/toast.svelte";
   import { setupKeyboardViewportAdaptation } from "$lib/utils/keyboard-viewport";
 
   const imageStore = getImageStore();
@@ -28,6 +31,29 @@
   const uiStore = getUIStore();
   const layoutStore = getLayoutStore();
   const workspaceStore = getWorkspaceStore();
+  const toastStore = getToastStore();
+
+  // Twin-tab guard (#2044): one shared instance for this page. The persist path
+  // skips paused layouts; a foreign write to a layout body pauses that layout
+  // and raises an "Open in another tab" toast offering a Reload.
+  const twinTabGuard = getTwinTabGuard();
+  let foreignWriteToastId: string | undefined;
+  setForeignWriteNotifier(() => {
+    // One toast for the page: any paused layout is recovered by the same Reload.
+    // A spurious signal leaves the tab paused until that manual Reload by design.
+    if (foreignWriteToastId) return;
+    foreignWriteToastId = toastStore.showToast(
+      "This layout is open in another tab. Edits here are paused to avoid overwriting it. Reload to continue editing.",
+      "warning",
+      0,
+      {
+        label: "Reload",
+        onClick: () => {
+          if (typeof window !== "undefined") window.location.reload();
+        },
+      },
+    );
+  });
 
   // Register all persistence $effects (localStorage autosave, server autosave, health check)
   initPersistenceEffects();
@@ -76,6 +102,23 @@
     );
   }
 
+  // Persist the workspace, honouring the twin-tab guard: paused layouts are
+  // skipped, and the active layout's body write runs through its per-layout Web
+  // Lock where available (the tab-id stamp is the real ping-pong guard; the lock
+  // only serialises concurrent writers when it can be taken).
+  function persistWorkspaceGuarded(snapshot: {
+    tabs: PersistTab[];
+    activeLayoutId: string | null;
+  }): Promise<void> {
+    const isPaused = (layoutId: string) => twinTabGuard.isPaused(layoutId);
+    const run = () => persistBrowserWorkspace({ ...snapshot, isPaused });
+    if (snapshot.activeLayoutId && !isPaused(snapshot.activeLayoutId)) {
+      return twinTabGuard.withLayoutLock(snapshot.activeLayoutId, run);
+    }
+    run();
+    return Promise.resolve();
+  }
+
   $effect(() => {
     if (getStorageMode() === "server") return;
     // Track the reactive surface: tab set, active id, and the active tab's
@@ -86,7 +129,7 @@
 
     if (workspaceSaveTimer) clearTimeout(workspaceSaveTimer);
     workspaceSaveTimer = setTimeout(() => {
-      persistBrowserWorkspace(snapshot);
+      void persistWorkspaceGuarded(snapshot);
       workspaceSaveTimer = null;
     }, 1000);
 
@@ -109,7 +152,12 @@
     }
     const snapshot = snapshotWorkspaceTabs();
     if (snapshot.tabs.length > 0 && hasPersistableContent()) {
-      persistBrowserWorkspace(snapshot);
+      // Synchronous last-chance write: skip paused layouts but do not await the
+      // Web Lock (pagehide cannot wait on async work).
+      persistBrowserWorkspace({
+        ...snapshot,
+        isPaused: (layoutId) => twinTabGuard.isPaused(layoutId),
+      });
     }
   }
 
@@ -131,6 +179,19 @@
       flushWorkspaceSave();
     }
     window.addEventListener("pagehide", handlePageHide);
+
+    // Twin-tab guard (#2044): a `storage` event fires in every OTHER same-origin
+    // tab when localStorage changes. A foreign write to a layout body pauses this
+    // tab's autosave for that layout id (browser mode only; server mode owns its
+    // own working copy).
+    function handleStorageEvent(event: StorageEvent) {
+      if (getStorageMode() === "server") return;
+      twinTabGuard.handleStorageEvent({
+        key: event.key,
+        newValue: event.newValue,
+      });
+    }
+    window.addEventListener("storage", handleStorageEvent);
 
     // Load bundled images for starter library devices
     imageStore.loadBundledImages();
@@ -155,6 +216,7 @@
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("pagehide", handlePageHide);
+      window.removeEventListener("storage", handleStorageEvent);
     };
   });
 

--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -41,7 +41,15 @@
   setForeignWriteNotifier(() => {
     // One toast for the page: any paused layout is recovered by the same Reload.
     // A spurious signal leaves the tab paused until that manual Reload by design.
-    if (foreignWriteToastId) return;
+    // Suppress only while the previous toast is still on screen; once the user
+    // dismisses it without reloading, a later foreign write must re-raise it
+    // (the tab stays paused, so the Reload prompt has to come back).
+    if (
+      foreignWriteToastId &&
+      toastStore.toasts.some((toast) => toast.id === foreignWriteToastId)
+    ) {
+      return;
+    }
     foreignWriteToastId = toastStore.showToast(
       "This layout is open in another tab. Edits here are paused to avoid overwriting it. Reload to continue editing.",
       "warning",
@@ -103,20 +111,22 @@
   }
 
   // Persist the workspace, honouring the twin-tab guard: paused layouts are
-  // skipped, and the active layout's body write runs through its per-layout Web
-  // Lock where available (the tab-id stamp is the real ping-pong guard; the lock
-  // only serialises concurrent writers when it can be taken).
+  // skipped, and every hydrated body write (not just the active layout's) runs
+  // through its own per-layout Web Lock where available, so a non-active layout
+  // body is still serialised against a peer tab editing that same layout. Each
+  // lock is keyed per layout id, so writing many bodies never nests one lock.
+  // The tab-id stamp remains the real ping-pong guard; the lock only serialises
+  // concurrent writers when it can be taken.
   function persistWorkspaceGuarded(snapshot: {
     tabs: PersistTab[];
     activeLayoutId: string | null;
   }): Promise<void> {
-    const isPaused = (layoutId: string) => twinTabGuard.isPaused(layoutId);
-    const run = () => persistBrowserWorkspace({ ...snapshot, isPaused });
-    if (snapshot.activeLayoutId && !isPaused(snapshot.activeLayoutId)) {
-      return twinTabGuard.withLayoutLock(snapshot.activeLayoutId, run);
-    }
-    run();
-    return Promise.resolve();
+    return persistBrowserWorkspace({
+      ...snapshot,
+      isPaused: (layoutId) => twinTabGuard.isPaused(layoutId),
+      withLayoutLock: (layoutId, write) =>
+        twinTabGuard.withLayoutLock(layoutId, write),
+    });
   }
 
   $effect(() => {

--- a/src/lib/storage/browser-workspace-persist.ts
+++ b/src/lib/storage/browser-workspace-persist.ts
@@ -40,20 +40,28 @@ export type PersistTab =
 export interface PersistWorkspaceArgs {
   tabs: PersistTab[];
   activeLayoutId: string | null;
+  /**
+   * Twin-tab guard predicate (#2044): returns true when a layout's autosave is
+   * paused because a foreign tab wrote its body. A paused layout's body is left
+   * untouched so this tab cannot clobber the peer's copy; its index entry is
+   * still written so the open set and shell names stay current.
+   */
+  isPaused?: (layoutId: string) => boolean;
 }
 
 /**
  * Persist the current workspace. Idempotent: safe to call on every change.
  */
 export function persistBrowserWorkspace(args: PersistWorkspaceArgs): void {
-  const { tabs, activeLayoutId } = args;
+  const { tabs, activeLayoutId, isPaused } = args;
 
   // Write each hydrated body first. saveLayoutBody also refreshes that layout's
   // library entry in the index (updatedAt, durability); it returns false on
   // quota, leaving the in-memory copy intact and surfacing the flag via the
-  // index. Shells have no body to write.
+  // index. Shells have no body to write. A paused layout (twin-tab guard) is
+  // skipped so a foreign peer's copy is never clobbered.
   for (const tab of tabs) {
-    if (tab.hydrated) {
+    if (tab.hydrated && !isPaused?.(tab.layoutId)) {
       saveLayoutBody(tab.layoutId, tab.layout, {
         changesSinceExport: tab.changesSinceExport,
         hasEverExported: tab.hasEverExported,

--- a/src/lib/storage/browser-workspace-persist.ts
+++ b/src/lib/storage/browser-workspace-persist.ts
@@ -47,25 +47,47 @@ export interface PersistWorkspaceArgs {
    * still written so the open set and shell names stay current.
    */
   isPaused?: (layoutId: string) => boolean;
+  /**
+   * Twin-tab guard lock wrapper (#2044): runs a single layout-body write under
+   * that layout's per-layout Web Lock where available. Every hydrated body write
+   * (not just the active one) goes through it, so a non-active layout body is
+   * still serialised against a peer tab editing that same layout. Omitted on the
+   * synchronous pagehide path, where async work cannot be awaited.
+   */
+  withLayoutLock?: <T>(layoutId: string, write: () => T) => Promise<T>;
 }
 
 /**
  * Persist the current workspace. Idempotent: safe to call on every change.
+ *
+ * Returns a promise that resolves once every body write has run. When
+ * `withLayoutLock` is supplied, each hydrated body write is taken under its own
+ * per-layout lock; the index write that follows reflects the completed bodies.
  */
-export function persistBrowserWorkspace(args: PersistWorkspaceArgs): void {
-  const { tabs, activeLayoutId, isPaused } = args;
+export async function persistBrowserWorkspace(
+  args: PersistWorkspaceArgs,
+): Promise<void> {
+  const { tabs, activeLayoutId, isPaused, withLayoutLock } = args;
 
   // Write each hydrated body first. saveLayoutBody also refreshes that layout's
   // library entry in the index (updatedAt, durability); it returns false on
   // quota, leaving the in-memory copy intact and surfacing the flag via the
   // index. Shells have no body to write. A paused layout (twin-tab guard) is
-  // skipped so a foreign peer's copy is never clobbered.
+  // skipped so a foreign peer's copy is never clobbered. Each write runs under
+  // its own per-layout lock when one is supplied; the locks are distinct per
+  // layout id so writing many bodies in this loop cannot nest the same lock.
   for (const tab of tabs) {
     if (tab.hydrated && !isPaused?.(tab.layoutId)) {
-      saveLayoutBody(tab.layoutId, tab.layout, {
-        changesSinceExport: tab.changesSinceExport,
-        hasEverExported: tab.hasEverExported,
-      });
+      const write = () =>
+        saveLayoutBody(tab.layoutId, tab.layout, {
+          changesSinceExport: tab.changesSinceExport,
+          hasEverExported: tab.hasEverExported,
+        });
+      if (withLayoutLock) {
+        await withLayoutLock(tab.layoutId, write);
+      } else {
+        write();
+      }
     }
   }
 

--- a/src/lib/storage/browser-workspace-persist.ts
+++ b/src/lib/storage/browser-workspace-persist.ts
@@ -100,8 +100,26 @@ export async function persistBrowserWorkspace(
     : {};
 
   for (const tab of tabs) {
-    if (tab.hydrated) continue;
     const previous = library[tab.layoutId];
+    if (tab.hydrated) {
+      // A non-paused hydrated tab already wrote its library entry via
+      // saveLayoutBody above, so it is current and left alone. A paused tab
+      // (twin-tab guard) skipped its body write, so it has no fresh entry. Its
+      // id is still in openTabs below; without a library entry loadWorkspaceIndex
+      // would filter it out as dangling and drop the layout even though its body
+      // survives. Carry forward the existing entry (or a default named from the
+      // in-memory layout) so the paused tab survives a persist+reload round-trip.
+      if (!isPaused?.(tab.layoutId) || previous) continue;
+      library[tab.layoutId] = {
+        name: tab.layout.name,
+        updatedAt: "",
+        changesSinceExport: tab.changesSinceExport,
+        hasEverExported: tab.hasEverExported,
+        writeFailed: false,
+        storageMode: "browser",
+      };
+      continue;
+    }
     library[tab.layoutId] = {
       name: tab.name,
       updatedAt: previous?.updatedAt ?? "",

--- a/src/lib/storage/browser-workspace.ts
+++ b/src/lib/storage/browser-workspace.ts
@@ -30,7 +30,7 @@ import { sessionDebug } from "$lib/utils/debug";
 import { migrateLayout } from "./migrate-layout";
 import { loadSessionWithTimestamp } from "./working-copy";
 import { type StorageMode } from "./availability.svelte";
-import { getTabId, stampBodyWrite } from "./twin-tab-guard";
+import { getTabId, WRITER_TAB_ID_FIELD } from "./twin-tab-guard";
 
 const log = sessionDebug.storage;
 
@@ -225,20 +225,21 @@ export function saveLayoutBody(
   const savedAt = new Date().toISOString();
   let serialized: string;
   try {
+    // Serialize the body once, stamping the writing tab's id inline so a peer
+    // tab can tell this write apart from its own and pause its autosave on a
+    // foreign write (twin-tab guard #2044). The field name is single-sourced via
+    // WRITER_TAB_ID_FIELD so the write side cannot drift from the read side
+    // (readWriterTabId), and a large body is not re-serialized to add the stamp.
     serialized = JSON.stringify({
       schemaVersion: SCHEMA_VERSION,
       layout,
       savedAt,
+      [WRITER_TAB_ID_FIELD]: getTabId(),
     });
   } catch (error) {
     log("failed to serialize layout body for %s: %O", id, error);
     return false;
   }
-  // Stamp the writing tab's id so a peer tab can tell this write apart from its
-  // own and pause its autosave on a foreign write (twin-tab guard #2044). The
-  // stamp shape lives in one place (stampBodyWrite) so it cannot drift from the
-  // read side (readWriterTabId).
-  serialized = stampBodyWrite(serialized, getTabId());
 
   const wrote = safeSetItem(layoutBodyKey(id), serialized);
   const index = loadWorkspaceIndex() ?? {

--- a/src/lib/storage/browser-workspace.ts
+++ b/src/lib/storage/browser-workspace.ts
@@ -30,7 +30,7 @@ import { sessionDebug } from "$lib/utils/debug";
 import { migrateLayout } from "./migrate-layout";
 import { loadSessionWithTimestamp } from "./working-copy";
 import { type StorageMode } from "./availability.svelte";
-import { getTabId } from "./twin-tab-guard";
+import { getTabId, stampBodyWrite } from "./twin-tab-guard";
 
 const log = sessionDebug.storage;
 
@@ -225,18 +225,20 @@ export function saveLayoutBody(
   const savedAt = new Date().toISOString();
   let serialized: string;
   try {
-    // Stamp the writing tab's id so a peer tab can tell this write apart from
-    // its own and pause its autosave on a foreign write (twin-tab guard #2044).
     serialized = JSON.stringify({
       schemaVersion: SCHEMA_VERSION,
       layout,
       savedAt,
-      writerTabId: getTabId(),
     });
   } catch (error) {
     log("failed to serialize layout body for %s: %O", id, error);
     return false;
   }
+  // Stamp the writing tab's id so a peer tab can tell this write apart from its
+  // own and pause its autosave on a foreign write (twin-tab guard #2044). The
+  // stamp shape lives in one place (stampBodyWrite) so it cannot drift from the
+  // read side (readWriterTabId).
+  serialized = stampBodyWrite(serialized, getTabId());
 
   const wrote = safeSetItem(layoutBodyKey(id), serialized);
   const index = loadWorkspaceIndex() ?? {

--- a/src/lib/storage/browser-workspace.ts
+++ b/src/lib/storage/browser-workspace.ts
@@ -30,6 +30,7 @@ import { sessionDebug } from "$lib/utils/debug";
 import { migrateLayout } from "./migrate-layout";
 import { loadSessionWithTimestamp } from "./working-copy";
 import { type StorageMode } from "./availability.svelte";
+import { getTabId } from "./twin-tab-guard";
 
 const log = sessionDebug.storage;
 
@@ -224,10 +225,13 @@ export function saveLayoutBody(
   const savedAt = new Date().toISOString();
   let serialized: string;
   try {
+    // Stamp the writing tab's id so a peer tab can tell this write apart from
+    // its own and pause its autosave on a foreign write (twin-tab guard #2044).
     serialized = JSON.stringify({
       schemaVersion: SCHEMA_VERSION,
       layout,
       savedAt,
+      writerTabId: getTabId(),
     });
   } catch (error) {
     log("failed to serialize layout body for %s: %O", id, error);

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -90,6 +90,11 @@ export {
   type PersistTab,
 } from "./browser-workspace-persist";
 export {
+  getTwinTabGuard,
+  setForeignWriteNotifier,
+  type TwinTabGuard,
+} from "./twin-tab-guard";
+export {
   adaptLegacyLayout,
   CARRIER_2COL_SLUG,
   CARRIER_2X2_SLUG,

--- a/src/lib/storage/twin-tab-guard.ts
+++ b/src/lib/storage/twin-tab-guard.ts
@@ -1,0 +1,225 @@
+/**
+ * Twin-tab guard for the shared browser working copy (#2044).
+ *
+ * Two same-origin browser tabs editing the same layout both autosave into the
+ * one localStorage body key (`Rackula:layout:<id>`), so without a guard their
+ * writes silently clobber each other (ping-pong). This module stops that:
+ *
+ * - Every body write is stamped with a per-tab id (`getTabId`). A tab can tell
+ *   its own echoed write from a foreign tab's write.
+ * - The `storage` event fires in every OTHER same-origin tab when a layout body
+ *   key changes. `detectForeignLayoutWrite` reads the stamp; a write whose id is
+ *   not ours pauses THIS tab's autosave for THAT layout id.
+ * - Pause is per layout (keyed by `layout.metadata.id`), never per workspace:
+ *   M14's tabs let two browser tabs hold disjoint open sets, so editing layout A
+ *   in one tab must not pause layout B open elsewhere (spike #2018).
+ * - Web Locks (`rackula:layout:<id>`) serialise the read-modify-write WHERE
+ *   AVAILABLE. Without Web Locks the tab-id check alone still prevents silent
+ *   ping-pong (it is detect-and-pause, not leader election).
+ *
+ * Recovery is by design manual: a paused layout stays paused until the user
+ * Reloads (a spurious foreign-write signal therefore leaves the tab paused, the
+ * documented recovery, not an oversight).
+ */
+
+import { generateId } from "$lib/utils/device";
+import { sessionDebug } from "$lib/utils/debug";
+
+const log = sessionDebug.storage;
+
+const LAYOUT_KEY_PREFIX = "Rackula:layout:";
+const LOCK_PREFIX = "rackula:layout:";
+
+/** The localStorage key holding a layout body. */
+export function layoutBodyStorageKey(layoutId: string): string {
+  return `${LAYOUT_KEY_PREFIX}${layoutId}`;
+}
+
+/** The per-layout Web Lock name. */
+export function layoutLockName(layoutId: string): string {
+  return `${LOCK_PREFIX}${layoutId}`;
+}
+
+/** Extract the layout id from a body key, or null if the key is not a body key. */
+function layoutIdFromKey(key: string | null): string | null {
+  if (!key || !key.startsWith(LAYOUT_KEY_PREFIX)) return null;
+  const id = key.slice(LAYOUT_KEY_PREFIX.length);
+  return id.length > 0 ? id : null;
+}
+
+/**
+ * The stable id for this browser tab, minted once per page. Stamped into every
+ * body write so a peer tab can attribute the write and a tab can ignore its own
+ * echoed `storage` event.
+ */
+let tabId: string | null = null;
+export function getTabId(): string {
+  if (tabId === null) tabId = generateId();
+  return tabId;
+}
+
+/**
+ * Stamp a serialized body with the writer's tab id. The serialized JSON is an
+ * object (the body wrapper); the stamp is merged in so the read path can read it
+ * back without changing the layout payload.
+ */
+export function stampBodyWrite(serialized: string, writerTabId: string): string {
+  try {
+    const parsed = JSON.parse(serialized) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return serialized;
+    }
+    return JSON.stringify({ ...(parsed as object), writerTabId });
+  } catch {
+    // A non-object body cannot carry a stamp; leave it untouched.
+    return serialized;
+  }
+}
+
+/** Read the writer tab id stamped into a serialized body, or null. */
+export function readWriterTabId(serialized: string | null): string | null {
+  if (!serialized) return null;
+  try {
+    const parsed = JSON.parse(serialized) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const writer = (parsed as Record<string, unknown>).writerTabId;
+    return typeof writer === "string" ? writer : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The relevant fields of a `storage` event for foreign-write detection. */
+export interface StorageEventLike {
+  key: string | null;
+  newValue: string | null;
+}
+
+/** Result of inspecting a storage event for a foreign layout-body write. */
+export type ForeignWriteResult =
+  | { foreign: true; layoutId: string }
+  | { foreign: false };
+
+/**
+ * Decide whether a `storage` event is a foreign tab writing a layout body.
+ *
+ * A removal (`newValue === null`) is not a competing write. A write whose stamp
+ * matches this tab is our own echo. A write with no parseable stamp cannot be
+ * proven ours, so it is treated as foreign (safer than ignoring a real twin).
+ */
+export function detectForeignLayoutWrite(
+  event: StorageEventLike,
+  ownTabId: string,
+): ForeignWriteResult {
+  const layoutId = layoutIdFromKey(event.key);
+  if (layoutId === null) return { foreign: false };
+  if (event.newValue === null) return { foreign: false };
+  const writer = readWriterTabId(event.newValue);
+  if (writer === ownTabId) return { foreign: false };
+  return { foreign: true, layoutId };
+}
+
+export interface TwinTabGuardOptions {
+  /** This tab's id. Defaults to the module-stable `getTabId()`. */
+  tabId?: string;
+  /** Called once when a layout is first paused by a foreign write. */
+  onForeignWrite?: (layoutId: string) => void;
+  /**
+   * The Web Locks manager, or undefined where unavailable. Defaults to
+   * `navigator.locks` in a browser. Injected for testing.
+   */
+  locks?: LockManager;
+}
+
+/** The twin-tab guard instance: pause tracking plus the Web-Lock wrapper. */
+export interface TwinTabGuard {
+  /** Whether autosave for this layout is paused by a detected foreign write. */
+  isPaused(layoutId: string): boolean;
+  /** Feed a `storage` event; pauses the targeted layout if the write is foreign. */
+  handleStorageEvent(event: StorageEventLike): void;
+  /**
+   * Run a body write through the per-layout Web Lock where available. The write
+   * runs regardless (the tab-id stamp is the real ping-pong guard); the lock
+   * only serialises concurrent writers when it can be acquired.
+   */
+  withLayoutLock<T>(layoutId: string, write: () => T): Promise<T>;
+}
+
+function resolveLocks(explicit: LockManager | undefined): LockManager | undefined {
+  if (explicit !== undefined) return explicit;
+  if (typeof navigator !== "undefined" && "locks" in navigator) {
+    return navigator.locks;
+  }
+  return undefined;
+}
+
+export function createTwinTabGuard(
+  options: TwinTabGuardOptions = {},
+): TwinTabGuard {
+  const ownTabId = options.tabId ?? getTabId();
+  const locks = resolveLocks(options.locks);
+  // Once a layout is paused it stays paused: recovery is a manual Reload.
+  const paused = new Set<string>();
+
+  function isPaused(layoutId: string): boolean {
+    return paused.has(layoutId);
+  }
+
+  function handleStorageEvent(event: StorageEventLike): void {
+    const result = detectForeignLayoutWrite(event, ownTabId);
+    if (!result.foreign) return;
+    if (paused.has(result.layoutId)) return;
+    paused.add(result.layoutId);
+    log("twin-tab: foreign write detected for layout %s, pausing", result.layoutId);
+    options.onForeignWrite?.(result.layoutId);
+  }
+
+  async function withLayoutLock<T>(
+    layoutId: string,
+    write: () => T,
+  ): Promise<T> {
+    if (!locks) return write();
+    let captured: T;
+    await locks.request(layoutLockName(layoutId), { ifAvailable: true }, () => {
+      captured = write();
+    });
+    // The callback runs synchronously (own write) whether or not the lock was
+    // granted (ifAvailable yields a null lock when held), so captured is set.
+    return captured!;
+  }
+
+  return { isPaused, handleStorageEvent, withLayoutLock };
+}
+
+/**
+ * Process-wide guard for the browser workspace. One instance per page so the
+ * persist path and the `storage`-event listener share the same pause set. The
+ * foreign-write notifier is settable so the UI layer can attach the "Open in
+ * another tab" toast without the storage module importing a store.
+ */
+let singleton: TwinTabGuard | null = null;
+let foreignWriteNotifier: ((layoutId: string) => void) | null = null;
+
+export function getTwinTabGuard(): TwinTabGuard {
+  if (singleton === null) {
+    singleton = createTwinTabGuard({
+      onForeignWrite: (layoutId) => foreignWriteNotifier?.(layoutId),
+    });
+  }
+  return singleton;
+}
+
+/** Attach the UI notifier called once when a layout is first paused. */
+export function setForeignWriteNotifier(
+  notifier: (layoutId: string) => void,
+): void {
+  foreignWriteNotifier = notifier;
+}
+
+/** Reset the singleton and notifier (tests). */
+export function resetTwinTabGuard(): void {
+  singleton = null;
+  foreignWriteNotifier = null;
+}

--- a/src/lib/storage/twin-tab-guard.ts
+++ b/src/lib/storage/twin-tab-guard.ts
@@ -30,6 +30,13 @@ const log = sessionDebug.storage;
 const LAYOUT_KEY_PREFIX = "Rackula:layout:";
 const LOCK_PREFIX = "rackula:layout:";
 
+/**
+ * The single source of truth for the writer-tab-id field name in a serialized
+ * body. The write side (saveLayoutBody) and the read side (readWriterTabId) both
+ * key off this constant so the stamp shape can never drift between them.
+ */
+export const WRITER_TAB_ID_FIELD = "writerTabId";
+
 /** The localStorage key holding a layout body. */
 export function layoutBodyStorageKey(layoutId: string): string {
   return `${LAYOUT_KEY_PREFIX}${layoutId}`;
@@ -53,27 +60,10 @@ function layoutIdFromKey(key: string | null): string | null {
  * echoed `storage` event.
  */
 let tabId: string | null = null;
+/** Return this tab's stable id, minting it on first use. */
 export function getTabId(): string {
   if (tabId === null) tabId = generateId();
   return tabId;
-}
-
-/**
- * Stamp a serialized body with the writer's tab id. The serialized JSON is an
- * object (the body wrapper); the stamp is merged in so the read path can read it
- * back without changing the layout payload.
- */
-export function stampBodyWrite(serialized: string, writerTabId: string): string {
-  try {
-    const parsed = JSON.parse(serialized) as unknown;
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return serialized;
-    }
-    return JSON.stringify({ ...(parsed as object), writerTabId });
-  } catch {
-    // A non-object body cannot carry a stamp; leave it untouched.
-    return serialized;
-  }
 }
 
 /** Read the writer tab id stamped into a serialized body, or null. */
@@ -84,7 +74,7 @@ export function readWriterTabId(serialized: string | null): string | null {
     if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
       return null;
     }
-    const writer = (parsed as Record<string, unknown>).writerTabId;
+    const writer = (parsed as Record<string, unknown>)[WRITER_TAB_ID_FIELD];
     return typeof writer === "string" ? writer : null;
   } catch {
     return null;
@@ -121,6 +111,7 @@ export function detectForeignLayoutWrite(
   return { foreign: true, layoutId };
 }
 
+/** Construction options for {@link createTwinTabGuard}. */
 export interface TwinTabGuardOptions {
   /** This tab's id. Defaults to the module-stable `getTabId()`. */
   tabId?: string;
@@ -155,6 +146,7 @@ function resolveLocks(explicit: LockManager | undefined): LockManager | undefine
   return undefined;
 }
 
+/** Create a twin-tab guard: per-layout pause tracking plus the Web-Lock wrapper. */
 export function createTwinTabGuard(
   options: TwinTabGuardOptions = {},
 ): TwinTabGuard {
@@ -202,6 +194,7 @@ export function createTwinTabGuard(
 let singleton: TwinTabGuard | null = null;
 let foreignWriteNotifier: ((layoutId: string) => void) | null = null;
 
+/** Return the process-wide twin-tab guard, creating it on first use. */
 export function getTwinTabGuard(): TwinTabGuard {
   if (singleton === null) {
     singleton = createTwinTabGuard({

--- a/src/tests/browser-workspace-persist.test.ts
+++ b/src/tests/browser-workspace-persist.test.ts
@@ -135,6 +135,26 @@ describe("persistBrowserWorkspace", () => {
     expect(loadLayoutBody("a").ok).toBe(true);
   });
 
+  it("keeps a paused tab in the library so it survives a persist+reload round-trip", async () => {
+    // A tab that is already paused on its first persist never reaches
+    // saveLayoutBody, which is the only path that writes its library entry. The
+    // index loop must still record it, otherwise its id lands in openTabs with
+    // no library entry and loadWorkspaceIndex drops it as dangling on reload,
+    // losing the tab even though the peer's body is intact in localStorage.
+    await persistBrowserWorkspace({
+      tabs: [tab({ layoutId: "a" }), tab({ layoutId: "paused" })],
+      activeLayoutId: "a",
+      isPaused: (layoutId) => layoutId === "paused",
+    });
+
+    // Reload the index the way the next launch would: openTabs is filtered to
+    // ids that have a library entry, so a surviving paused id proves the entry
+    // was written.
+    const index = loadWorkspaceIndex();
+    expect(index!.openTabs).toContain("paused");
+    expect(index!.library.paused).toBeDefined();
+  });
+
   it("takes the per-layout lock for every hydrated body, not just the active one", async () => {
     const locked: string[] = [];
     const withLayoutLock = async <T>(

--- a/src/tests/browser-workspace-persist.test.ts
+++ b/src/tests/browser-workspace-persist.test.ts
@@ -114,6 +114,54 @@ describe("persistBrowserWorkspace", () => {
     expect(loadLayoutBody("shell").ok).toBe(false);
   });
 
+  it("skips a paused layout's body but still records it in the open set", async () => {
+    // Pre-seed b's body so we can prove the paused write leaves it untouched.
+    await persistBrowserWorkspace({
+      tabs: [tab({ layoutId: "b", changesSinceExport: 9 })],
+      activeLayoutId: "b",
+    });
+
+    await persistBrowserWorkspace({
+      tabs: [tab({ layoutId: "a" }), tab({ layoutId: "b", changesSinceExport: 1 })],
+      activeLayoutId: "a",
+      isPaused: (layoutId) => layoutId === "b",
+    });
+
+    const index = loadWorkspaceIndex();
+    // Both stay in the open set; a was written, b's body was skipped so its
+    // pre-seeded durability survives untouched (no clobber of the peer's copy).
+    expect(index!.openTabs).toEqual(["a", "b"]);
+    expect(index!.library.b.changesSinceExport).toBe(9);
+    expect(loadLayoutBody("a").ok).toBe(true);
+  });
+
+  it("takes the per-layout lock for every hydrated body, not just the active one", async () => {
+    const locked: string[] = [];
+    const withLayoutLock = async <T>(
+      layoutId: string,
+      write: () => T,
+    ): Promise<T> => {
+      locked.push(layoutId);
+      return write();
+    };
+
+    await persistBrowserWorkspace({
+      tabs: [
+        tab({ layoutId: "a" }),
+        tab({ layoutId: "b" }),
+        { layoutId: "shell", hydrated: false, name: "Shell" },
+      ],
+      activeLayoutId: "a",
+      withLayoutLock,
+    });
+
+    // Both hydrated bodies (active a and non-active b) ran under their own lock;
+    // the unhydrated shell has no body so it is never locked.
+    expect(locked).toEqual(["a", "b"]);
+    expect(loadLayoutBody("a").ok).toBe(true);
+    expect(loadLayoutBody("b").ok).toBe(true);
+  });
+
   it("keeps a closed layout's durable copy when it leaves the open set", () => {
     persistBrowserWorkspace({
       tabs: [tab({ layoutId: "a" }), tab({ layoutId: "b" })],

--- a/src/tests/browser-workspace.test.ts
+++ b/src/tests/browser-workspace.test.ts
@@ -11,6 +11,7 @@ import {
   adoptLegacyAutosave,
   type WorkspaceIndex,
 } from "$lib/storage/browser-workspace";
+import { detectForeignLayoutWrite } from "$lib/storage/twin-tab-guard";
 import { createTestRack } from "./factories";
 
 const WORKSPACE_KEY = "Rackula:workspace";
@@ -173,6 +174,26 @@ describe("browser-workspace storage", () => {
 
       const index = loadWorkspaceIndex();
       expect(index!.library.a.changesSinceExport).toBe(3);
+    });
+
+    it("stamps the writer tab id so a peer detects the write as foreign without corrupting the body (#2044)", () => {
+      saveLayoutBody("a", makeLayout("a", "Homelab"), { changesSinceExport: 0 });
+
+      // The peer reads the raw body off localStorage and runs the guard's
+      // detection against a different tab id: this real write must register as a
+      // foreign write for layout "a".
+      const newValue = localStorage.getItem(bodyKey("a"));
+      const result = detectForeignLayoutWrite(
+        { key: bodyKey("a"), newValue },
+        "a-different-tab",
+      );
+      expect(result).toEqual({ foreign: true, layoutId: "a" });
+
+      // The stamp is a sibling of the layout, so loadLayoutBody still returns a
+      // clean layout (the writerTabId never reaches the schema/body).
+      const loaded = loadLayoutBody("a");
+      expect(loaded.ok).toBe(true);
+      if (loaded.ok) expect(loaded.layout.name).toBe("Homelab");
     });
 
     it("returns unreadable for a missing body", () => {

--- a/src/tests/twin-tab-guard.test.ts
+++ b/src/tests/twin-tab-guard.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   getTabId,
-  stampBodyWrite,
   readWriterTabId,
   detectForeignLayoutWrite,
   createTwinTabGuard,
   layoutBodyStorageKey,
+  WRITER_TAB_ID_FIELD,
 } from "$lib/storage/twin-tab-guard";
+
+// Build a foreign-write body the way saveLayoutBody does: the writer tab id is a
+// sibling of the layout payload, keyed by the single-sourced field name.
+function stampBodyWrite(serialized: string, writerTabId: string): string {
+  const parsed = JSON.parse(serialized) as Record<string, unknown>;
+  return JSON.stringify({ ...parsed, [WRITER_TAB_ID_FIELD]: writerTabId });
+}
 
 describe("getTabId", () => {
   it("returns a stable non-empty id for the lifetime of the tab", () => {

--- a/src/tests/twin-tab-guard.test.ts
+++ b/src/tests/twin-tab-guard.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  getTabId,
+  stampBodyWrite,
+  readWriterTabId,
+  detectForeignLayoutWrite,
+  createTwinTabGuard,
+  layoutBodyStorageKey,
+} from "$lib/storage/twin-tab-guard";
+
+describe("getTabId", () => {
+  it("returns a stable non-empty id for the lifetime of the tab", () => {
+    const first = getTabId();
+    const second = getTabId();
+    expect(first.length).toBeGreaterThan(0);
+    expect(second).toBe(first);
+  });
+});
+
+describe("stampBodyWrite / readWriterTabId", () => {
+  it("stamps this tab's id into the serialized body so peers can attribute the write", () => {
+    const serialized = stampBodyWrite('{"layout":{"name":"x"}}', "tab-123");
+    expect(readWriterTabId(serialized)).toBe("tab-123");
+  });
+
+  it("returns null for a body with no writer stamp", () => {
+    expect(readWriterTabId('{"layout":{"name":"x"}}')).toBeNull();
+  });
+
+  it("returns null for malformed JSON rather than throwing", () => {
+    expect(readWriterTabId("not json")).toBeNull();
+    expect(readWriterTabId(null)).toBeNull();
+  });
+});
+
+describe("detectForeignLayoutWrite", () => {
+  const key = layoutBodyStorageKey("layout-a");
+
+  it("flags a write whose writer id differs from this tab", () => {
+    const newValue = stampBodyWrite('{"layout":{}}', "other-tab");
+    const result = detectForeignLayoutWrite(
+      { key, newValue },
+      "this-tab",
+    );
+    expect(result).toEqual({ foreign: true, layoutId: "layout-a" });
+  });
+
+  it("ignores this tab's own echoed write", () => {
+    const newValue = stampBodyWrite('{"layout":{}}', "this-tab");
+    const result = detectForeignLayoutWrite(
+      { key, newValue },
+      "this-tab",
+    );
+    expect(result.foreign).toBe(false);
+  });
+
+  it("ignores storage events for keys outside the layout-body family", () => {
+    const result = detectForeignLayoutWrite(
+      { key: "Rackula:workspace", newValue: stampBodyWrite("{}", "other") },
+      "this-tab",
+    );
+    expect(result.foreign).toBe(false);
+  });
+
+  it("ignores a removal (null newValue) which is not a competing write", () => {
+    const result = detectForeignLayoutWrite(
+      { key, newValue: null },
+      "this-tab",
+    );
+    expect(result.foreign).toBe(false);
+  });
+
+  it("treats a foreign write with no parseable writer id as foreign (cannot prove it is ours)", () => {
+    const result = detectForeignLayoutWrite(
+      { key, newValue: '{"layout":{}}' },
+      "this-tab",
+    );
+    expect(result).toEqual({ foreign: true, layoutId: "layout-a" });
+  });
+});
+
+describe("createTwinTabGuard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("pauses the layout a foreign write targeted and reports it as paused", () => {
+    const guard = createTwinTabGuard({ tabId: "this-tab" });
+    expect(guard.isPaused("layout-a")).toBe(false);
+
+    guard.handleStorageEvent({
+      key: layoutBodyStorageKey("layout-a"),
+      newValue: stampBodyWrite('{"layout":{}}', "other-tab"),
+    });
+
+    expect(guard.isPaused("layout-a")).toBe(true);
+  });
+
+  it("leaves other layouts editable when one layout is paused (per-layout, not per-workspace)", () => {
+    const guard = createTwinTabGuard({ tabId: "this-tab" });
+    guard.handleStorageEvent({
+      key: layoutBodyStorageKey("layout-a"),
+      newValue: stampBodyWrite('{"layout":{}}', "other-tab"),
+    });
+
+    expect(guard.isPaused("layout-a")).toBe(true);
+    expect(guard.isPaused("layout-b")).toBe(false);
+  });
+
+  it("does not pause on this tab's own echoed write", () => {
+    const guard = createTwinTabGuard({ tabId: "this-tab" });
+    guard.handleStorageEvent({
+      key: layoutBodyStorageKey("layout-a"),
+      newValue: stampBodyWrite('{"layout":{}}', "this-tab"),
+    });
+    expect(guard.isPaused("layout-a")).toBe(false);
+  });
+
+  it("notifies once per layout when a foreign write first pauses it", () => {
+    const onForeignWrite = vi.fn();
+    const guard = createTwinTabGuard({ tabId: "this-tab", onForeignWrite });
+    const event = {
+      key: layoutBodyStorageKey("layout-a"),
+      newValue: stampBodyWrite('{"layout":{}}', "other-tab"),
+    };
+
+    guard.handleStorageEvent(event);
+    guard.handleStorageEvent(event);
+
+    expect(onForeignWrite).toHaveBeenCalledTimes(1);
+    expect(onForeignWrite).toHaveBeenCalledWith("layout-a");
+  });
+
+  it("stays paused until reset (manual Reload is the documented recovery)", () => {
+    const guard = createTwinTabGuard({ tabId: "this-tab" });
+    guard.handleStorageEvent({
+      key: layoutBodyStorageKey("layout-a"),
+      newValue: stampBodyWrite('{"layout":{}}', "other-tab"),
+    });
+    // A subsequent own-write does not clear the pause; only a reset does.
+    guard.handleStorageEvent({
+      key: layoutBodyStorageKey("layout-a"),
+      newValue: stampBodyWrite('{"layout":{}}', "this-tab"),
+    });
+    expect(guard.isPaused("layout-a")).toBe(true);
+  });
+});
+
+describe("createTwinTabGuard.withLayoutLock (Web Locks where available)", () => {
+  it("runs the write through navigator.locks when available, keyed per layout", async () => {
+    const request = vi.fn(
+      async (
+        _name: string,
+        _opts: { ifAvailable?: boolean },
+        cb: (lock: object | null) => unknown,
+      ) => cb({}),
+    );
+    const guard = createTwinTabGuard({
+      tabId: "this-tab",
+      locks: { request } as unknown as LockManager,
+    });
+
+    const write = vi.fn(() => true);
+    const result = await guard.withLayoutLock("layout-a", write);
+
+    expect(result).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "rackula:layout:layout-a",
+      { ifAvailable: true },
+      expect.any(Function),
+    );
+  });
+
+  it("still runs the write when Web Locks are unavailable (tab-id fallback)", async () => {
+    const guard = createTwinTabGuard({ tabId: "this-tab", locks: undefined });
+    const write = vi.fn(() => true);
+    const result = await guard.withLayoutLock("layout-a", write);
+    expect(result).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the write when the lock is held by a peer (ifAvailable yields null lock)", async () => {
+    // ifAvailable: a held lock invokes the callback with null rather than
+    // blocking. The write must still proceed; the tab-id stamp is what prevents
+    // silent ping-pong, the lock only serialises where it can be taken.
+    const request = vi.fn(
+      async (
+        _name: string,
+        _opts: { ifAvailable?: boolean },
+        cb: (lock: object | null) => unknown,
+      ) => cb(null),
+    );
+    const guard = createTwinTabGuard({
+      tabId: "this-tab",
+      locks: { request } as unknown as LockManager,
+    });
+    const write = vi.fn(() => true);
+    const result = await guard.withLayoutLock("layout-a", write);
+    expect(result).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Stops two same-origin browser tabs from silently clobbering one localStorage working copy. Detect-and-pause, no leader election.

- Per-tab id stamped into every layout body write (`saveLayoutBody` routes through `stampBodyWrite`).
- `storage`-event detection of foreign writes pauses this tab's autosave, keyed per layout (`layout.metadata.id`), not per autosave slot, so editing layout A never pauses layout B open in another tab (forward-compat for M14 multi-layout tabs, per spike #2018 / #2179).
- "Open in another tab" toast with a Reload action. Recovery is manual by design: a paused layout stays paused until the user reloads (a spurious foreign-write signal therefore leaves the tab paused, the documented recovery).
- Web Locks (`rackula:layout:<id>`) wrap the read-modify-write where available. Without Web Locks the tab-id stamp alone still prevents silent ping-pong.

## Acceptance criteria

- [x] Per-tab id stamped into session writes
- [x] `storage`-event detection of foreign writes pauses this tab's autosave effects
- [x] "Open in another tab" toast with Reload action
- [x] Web Locks wrap the session read-modify-write where available
- [x] Tab-id stamp and Web Lock keyed per layout (not per autosave slot)

## Files changed

- `src/lib/storage/twin-tab-guard.ts` (new): per-tab id, body stamp/read, foreign-write detection, pause-set state machine, per-layout Web Lock wrapper, page singleton.
- `src/lib/storage/browser-workspace.ts`: `saveLayoutBody` stamps the writer tab id (single-sourced via `stampBodyWrite`).
- `src/lib/storage/browser-workspace-persist.ts`: `persistBrowserWorkspace` accepts an `isPaused` predicate; paused layout bodies are skipped (index entry still written).
- `src/lib/components/PersistenceEffects.svelte`: shared guard, `storage`-event listener, paused-aware persist, active-layout Web Lock, foreign-write toast.
- `src/lib/storage/index.ts`: exports.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:run` (144 files, 2544 tests)
- [x] `npm run build`

Unit tests cover the guard logic: per-layout tab-id stamp, own-echo suppression, foreign-write pause (per-layout, not per-workspace), notify-once, manual-recovery semantics, Web-Locks-where-available with the unavailable and held-lock fallbacks, plus a cross-module test proving a real `saveLayoutBody` write is detected as foreign by a peer without corrupting the loaded layout.

Note: the spike #2018 multi-layout BroadcastChannel "Take over" / live banner refinement is out of scope here and remains tracked by #2018.

Closes #2044

https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G)_


___

## **CodeAnt-AI Description**
**Prevent one tab from overwriting a layout that is open in another tab**

### What Changed
- When the same layout is open in two browser tabs, a foreign edit now pauses autosave in the other tab instead of silently overwriting the shared copy
- The paused layout shows a warning with a Reload action so the user can recover manually
- Pausing applies only to the affected layout; other open layouts in the same tab keep saving normally
- Layout saves now carry a hidden tab identifier so the app can tell its own writes from another tab’s writes without changing the saved layout itself

### Impact
`✅ Fewer lost edits between tabs`
`✅ Clearer warning when a layout is already open elsewhere`
`✅ Safer multi-layout editing in separate tabs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
