### PR TITLE
feat: generate layout JSON Schema from Zod 4 (#2226)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "process-images": "npx tsx scripts/process-images.ts",
     "generate-bundled-images": "npx tsx scripts/generate-bundled-images.ts",
     "generate-brand-assets": "npx tsx scripts/generate-brand-assets.ts",
+    "generate-schema": "npx tsx scripts/generate-schema.ts",
     "update-contributors": "npx tsx scripts/update-contributors.ts",
     "refresh-lockfile": "rm -rf node_modules package-lock.json && npm install",
     "deps:status": "npm outdated || true"

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -1,0 +1,96 @@
+/**
+ * Generate the layout JSON Schema from the Zod source (issue #2226).
+ *
+ * Emits static/schemas/layout-v1.json from LayoutSchema using Zod 4's native
+ * z.toJSONSchema(). The JSON Schema is the published, language-agnostic contract
+ * for the saved-layout format; the Zod schema in src/lib/schemas/index.ts stays
+ * the single source of truth and this script is its deterministic projection.
+ *
+ * Why io: "input": validators run against the file as written to disk, which is
+ * the schema's input shape (before the migration transform that snaps legacy
+ * positions and fills rack IDs). The output shape only exists in memory after a
+ * successful parse.
+ *
+ * Why unrepresentable: "any": LayoutSchema carries .transform()/.superRefine()
+ * cross-field rules that JSON Schema cannot express. Those are emitted as
+ * permissive ("any") rather than throwing, so the artifact covers the structural
+ * ~80% of validation. The $description records this limitation.
+ *
+ * Usage:
+ *   npm run generate-schema
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SCRIPT_DIR, "..");
+const OUTPUT_FILE = join(ROOT, "static", "schemas", "layout-v1.json");
+
+/** Canonical published location of this schema (static/ serves at site root). */
+const SCHEMA_ID = "https://count.racku.la/schemas/layout-v1.json";
+
+const SCHEMA_DESCRIPTION =
+  "Beta. Generated from the Rackula Zod layout schema. Covers the structural " +
+  "shape of a saved layout but not cross-field rules expressed in Zod " +
+  "(.refine/.superRefine: referential integrity, carrier-first rail placement, " +
+  "slot fit) or the load-time .transform (legacy position migration, rack id " +
+  "generation, unknown-field preservation). Expect roughly 80 percent " +
+  "validation coverage; the Zod schema in src/lib/schemas/index.ts is " +
+  "authoritative.";
+
+/**
+ * Recursively sort object keys so the output is byte-stable across runs.
+ * Arrays keep their order (it is semantic in JSON Schema, e.g. required lists).
+ */
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  if (value && typeof value === "object") {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  // version.ts reads the Vite-injected __APP_VERSION__ global, which only exists
+  // in a build. Provide it from package.json before importing the schema graph.
+  const pkg = JSON.parse(
+    readFileSync(join(ROOT, "package.json"), "utf8"),
+  ) as { version: string };
+  (globalThis as Record<string, unknown>).__APP_VERSION__ = pkg.version;
+
+  const { z } = await import("$lib/zod.ts");
+  const { LayoutSchema } = await import("$lib/schemas/index.ts");
+
+  const generated = z.toJSONSchema(LayoutSchema, {
+    io: "input",
+    unrepresentable: "any",
+  }) as Record<string, unknown>;
+
+  const { $schema, ...rest } = generated;
+
+  const schema = {
+    $schema,
+    $id: SCHEMA_ID,
+    $description: SCHEMA_DESCRIPTION,
+    title: "Rackula Layout",
+    ...rest,
+  };
+
+  mkdirSync(dirname(OUTPUT_FILE), { recursive: true });
+  writeFileSync(OUTPUT_FILE, JSON.stringify(sortKeys(schema), null, 2) + "\n");
+
+  console.log(`Wrote ${OUTPUT_FILE}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -24,14 +24,22 @@ import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { z as Zod } from "$lib/zod.ts";
+import type { LayoutSchema as LayoutSchemaType } from "$lib/schemas/index.ts";
+
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
 const OUTPUT_FILE = join(ROOT, "static", "schemas", "layout-v1.json");
 
-/** Canonical published location of this schema (static/ serves at site root). */
-const SCHEMA_ID = "https://count.racku.la/schemas/layout-v1.json";
+/** JSON Schema dialect this artifact targets; pinned so the published contract
+ * does not silently follow Zod's default. */
+export const JSON_SCHEMA_DIALECT =
+  "https://json-schema.org/draft/2020-12/schema";
 
-const SCHEMA_DESCRIPTION =
+/** Canonical published location of this schema (static/ serves at site root). */
+export const SCHEMA_ID = "https://count.racku.la/schemas/layout-v1.json";
+
+export const SCHEMA_DESCRIPTION =
   "Beta. Generated from the Rackula Zod layout schema. Covers the structural " +
   "shape of a saved layout but not cross-field rules expressed in Zod " +
   "(.refine/.superRefine: referential integrity, carrier-first rail placement, " +
@@ -58,6 +66,35 @@ function sortKeys(value: unknown): unknown {
   return value;
 }
 
+/**
+ * Project the Zod layout schema to the full, sorted, published JSON Schema
+ * object. Takes the Zod namespace and LayoutSchema as parameters so the script
+ * and its drift-guard test produce byte-identical output from one code path.
+ */
+export function assembleSchema(
+  z: typeof Zod,
+  layoutSchema: typeof LayoutSchemaType,
+): Record<string, unknown> {
+  const generated = z.toJSONSchema(layoutSchema, {
+    io: "input",
+    unrepresentable: "any",
+  }) as Record<string, unknown>;
+
+  // Discard Zod's emitted dialect and pin our own below, so the published
+  // contract does not couple to Zod's default.
+  const { $schema: _generatedDialect, ...rest } = generated;
+  void _generatedDialect;
+
+  return sortKeys({
+    $schema: JSON_SCHEMA_DIALECT,
+    $id: SCHEMA_ID,
+    $description: SCHEMA_DESCRIPTION,
+    title: "Rackula Layout",
+    ...rest,
+  }) as Record<string, unknown>;
+}
+
+/** Generate the artifact from the live Zod schema and write it to disk. */
 async function main(): Promise<void> {
   // version.ts reads the Vite-injected __APP_VERSION__ global, which only exists
   // in a build. Provide it from package.json before importing the schema graph.
@@ -69,28 +106,22 @@ async function main(): Promise<void> {
   const { z } = await import("$lib/zod.ts");
   const { LayoutSchema } = await import("$lib/schemas/index.ts");
 
-  const generated = z.toJSONSchema(LayoutSchema, {
-    io: "input",
-    unrepresentable: "any",
-  }) as Record<string, unknown>;
-
-  const { $schema, ...rest } = generated;
-
-  const schema = {
-    $schema,
-    $id: SCHEMA_ID,
-    $description: SCHEMA_DESCRIPTION,
-    title: "Rackula Layout",
-    ...rest,
-  };
+  const schema = assembleSchema(z, LayoutSchema);
 
   mkdirSync(dirname(OUTPUT_FILE), { recursive: true });
-  writeFileSync(OUTPUT_FILE, JSON.stringify(sortKeys(schema), null, 2) + "\n");
+  writeFileSync(OUTPUT_FILE, JSON.stringify(schema, null, 2) + "\n");
 
   console.log(`Wrote ${OUTPUT_FILE}`);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+// Run only when executed directly, not when imported (e.g. by the drift test),
+// so importing this module never triggers the file write.
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/tests/layout-json-schema.test.ts
+++ b/src/tests/layout-json-schema.test.ts
@@ -3,15 +3,21 @@ import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import { z } from "$lib/zod";
 import { LayoutSchema } from "$lib/schemas";
+import {
+  assembleSchema,
+  SCHEMA_ID,
+  SCHEMA_DESCRIPTION,
+  JSON_SCHEMA_DIALECT,
+} from "../../scripts/generate-schema";
 
 /**
  * Guards the generated JSON Schema artifact (issue #2226).
  *
  * The real failure mode is a stale artifact: someone changes the Zod schema in
  * src/lib/schemas and forgets to re-run `npm run generate-schema`, so the
- * published contract drifts from the source of truth. These tests fail when that
- * happens. They mirror the generator's options exactly; if the generator changes
- * its options, update both.
+ * published contract drifts from the source of truth. These tests reuse the
+ * generator's own assembleSchema(), so the comparison covers the full schema
+ * including the envelope, with no duplicated projection to drift out of sync.
  */
 const ARTIFACT_PATH = join(
   process.cwd(),
@@ -20,20 +26,6 @@ const ARTIFACT_PATH = join(
   "layout-v1.json",
 );
 
-function generate(): Record<string, unknown> {
-  const generated = z.toJSONSchema(LayoutSchema, {
-    io: "input",
-    unrepresentable: "any",
-  }) as Record<string, unknown>;
-  const { $schema, ...rest } = generated;
-  return {
-    $schema,
-    $id: "https://count.racku.la/schemas/layout-v1.json",
-    title: "Rackula Layout",
-    ...rest,
-  };
-}
-
 describe("layout JSON Schema artifact", () => {
   const artifact = JSON.parse(readFileSync(ARTIFACT_PATH, "utf8")) as Record<
     string,
@@ -41,26 +33,12 @@ describe("layout JSON Schema artifact", () => {
   >;
 
   it("is in sync with the Zod source schema", () => {
-    const fresh = generate();
-    // Compare structural content (drop the envelope fields the generator adds
-    // around the Zod output) so this asserts the generated body, not the prose.
-    const strip = (s: Record<string, unknown>) => {
-      const { $id, $description, title, $schema, ...body } = s;
-      void $id;
-      void $description;
-      void title;
-      void $schema;
-      return body;
-    };
-    expect(strip(artifact)).toEqual(strip(fresh));
+    expect(artifact).toEqual(assembleSchema(z, LayoutSchema));
   });
 
   it("carries the published schema envelope", () => {
-    expect(artifact.$schema).toBe(
-      "https://json-schema.org/draft/2020-12/schema",
-    );
-    expect(artifact.$id).toBe("https://count.racku.la/schemas/layout-v1.json");
-    expect(typeof artifact.$description).toBe("string");
-    expect(artifact.$description as string).toMatch(/beta/i);
+    expect(artifact.$schema).toBe(JSON_SCHEMA_DIALECT);
+    expect(artifact.$id).toBe(SCHEMA_ID);
+    expect(artifact.$description).toBe(SCHEMA_DESCRIPTION);
   });
 });

--- a/src/tests/layout-json-schema.test.ts
+++ b/src/tests/layout-json-schema.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import { z } from "$lib/zod";
+import { LayoutSchema } from "$lib/schemas";
+
+/**
+ * Guards the generated JSON Schema artifact (issue #2226).
+ *
+ * The real failure mode is a stale artifact: someone changes the Zod schema in
+ * src/lib/schemas and forgets to re-run `npm run generate-schema`, so the
+ * published contract drifts from the source of truth. These tests fail when that
+ * happens. They mirror the generator's options exactly; if the generator changes
+ * its options, update both.
+ */
+const ARTIFACT_PATH = join(
+  process.cwd(),
+  "static",
+  "schemas",
+  "layout-v1.json",
+);
+
+function generate(): Record<string, unknown> {
+  const generated = z.toJSONSchema(LayoutSchema, {
+    io: "input",
+    unrepresentable: "any",
+  }) as Record<string, unknown>;
+  const { $schema, ...rest } = generated;
+  return {
+    $schema,
+    $id: "https://count.racku.la/schemas/layout-v1.json",
+    title: "Rackula Layout",
+    ...rest,
+  };
+}
+
+describe("layout JSON Schema artifact", () => {
+  const artifact = JSON.parse(readFileSync(ARTIFACT_PATH, "utf8")) as Record<
+    string,
+    unknown
+  >;
+
+  it("is in sync with the Zod source schema", () => {
+    const fresh = generate();
+    // Compare structural content (drop the envelope fields the generator adds
+    // around the Zod output) so this asserts the generated body, not the prose.
+    const strip = (s: Record<string, unknown>) => {
+      const { $id, $description, title, $schema, ...body } = s;
+      void $id;
+      void $description;
+      void title;
+      void $schema;
+      return body;
+    };
+    expect(strip(artifact)).toEqual(strip(fresh));
+  });
+
+  it("carries the published schema envelope", () => {
+    expect(artifact.$schema).toBe(
+      "https://json-schema.org/draft/2020-12/schema",
+    );
+    expect(artifact.$id).toBe("https://count.racku.la/schemas/layout-v1.json");
+    expect(typeof artifact.$description).toBe("string");
+    expect(artifact.$description as string).toMatch(/beta/i);
+  });
+});

--- a/static/schemas/layout-v1.json
+++ b/static/schemas/layout-v1.json
@@ -1,0 +1,1110 @@
+{
+  "$description": "Beta. Generated from the Rackula Zod layout schema. Covers the structural shape of a saved layout but not cross-field rules expressed in Zod (.refine/.superRefine: referential integrity, carrier-first rail placement, slot fit) or the load-time .transform (legacy position migration, rack id generation, unknown-field preservation). Expect roughly 80 percent validation coverage; the Zod schema in src/lib/schemas/index.ts is authoritative.",
+  "$id": "https://count.racku.la/schemas/layout-v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": {},
+  "properties": {
+    "cables": {
+      "items": {
+        "additionalProperties": {},
+        "properties": {
+          "a_device_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "a_interface": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "b_device_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "b_interface": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "color": {
+            "pattern": "^#[0-9a-fA-F]{6}$",
+            "type": "string"
+          },
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "label": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "length": {
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "length_unit": {
+            "enum": [
+              "m",
+              "cm",
+              "ft",
+              "in"
+            ],
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "connected",
+              "planned",
+              "decommissioning"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "cat5e",
+              "cat6",
+              "cat6a",
+              "cat7",
+              "cat8",
+              "dac-passive",
+              "dac-active",
+              "mmf-om3",
+              "mmf-om4",
+              "smf-os2",
+              "aoc",
+              "power",
+              "serial"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "a_device_id",
+          "a_interface",
+          "b_device_id",
+          "b_interface"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "connections": {
+      "items": {
+        "additionalProperties": {},
+        "properties": {
+          "a_port_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "b_port_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "color": {
+            "pattern": "^#[0-9a-fA-F]{6}$",
+            "type": "string"
+          },
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "label": {
+            "maxLength": 100,
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "a_port_id",
+          "b_port_id"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "device_types": {
+      "items": {
+        "additionalProperties": {},
+        "properties": {
+          "airflow": {
+            "enum": [
+              "passive",
+              "front-to-rear",
+              "rear-to-front",
+              "left-to-right",
+              "right-to-left",
+              "side-to-rear",
+              "mixed"
+            ],
+            "type": "string"
+          },
+          "asset_tag": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "category": {
+            "enum": [
+              "server",
+              "network",
+              "firewall",
+              "patch-panel",
+              "power",
+              "storage",
+              "kvm",
+              "av-media",
+              "cooling",
+              "shelf",
+              "blank",
+              "cable-management",
+              "chassis",
+              "other"
+            ],
+            "type": "string"
+          },
+          "colour": {
+            "pattern": "^#[0-9a-fA-F]{6}$",
+            "type": "string"
+          },
+          "custom_fields": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "device_bays": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "position": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "front_image": {
+            "type": "boolean"
+          },
+          "interfaces": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "label": {
+                  "maxLength": 64,
+                  "type": "string"
+                },
+                "mgmt_only": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "poe_mode": {
+                  "enum": [
+                    "pd",
+                    "pse"
+                  ],
+                  "type": "string"
+                },
+                "poe_type": {
+                  "enum": [
+                    "type1-ieee802.3af",
+                    "type2-ieee802.3at",
+                    "type3-ieee802.3bt",
+                    "type4-ieee802.3bt",
+                    "passive-24v-1pair",
+                    "passive-24v-2pair",
+                    "passive-48v-1pair",
+                    "passive-48v-2pair",
+                    "passive-56v-4pair"
+                  ],
+                  "type": "string"
+                },
+                "position": {
+                  "enum": [
+                    "front",
+                    "rear"
+                  ],
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "100base-tx",
+                    "1000base-t",
+                    "2.5gbase-t",
+                    "5gbase-t",
+                    "10gbase-t",
+                    "1000base-x-sfp",
+                    "10gbase-x-sfpp",
+                    "25gbase-x-sfp28",
+                    "40gbase-x-qsfpp",
+                    "100gbase-x-qsfp28",
+                    "100gbase-x-qsfpdd",
+                    "200gbase-x-qsfp56",
+                    "200gbase-x-qsfpdd",
+                    "400gbase-x-qsfpdd",
+                    "console",
+                    "usb-a",
+                    "usb-b",
+                    "usb-c",
+                    "usb-mini-b",
+                    "usb-micro-b",
+                    "virtual",
+                    "lag",
+                    "other"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "type"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "inventory_items": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "asset_tag": {
+                  "type": "string"
+                },
+                "manufacturer": {
+                  "type": "string"
+                },
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "part_id": {
+                  "type": "string"
+                },
+                "serial": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "is_full_depth": {
+            "type": "boolean"
+          },
+          "is_powered": {
+            "type": "boolean"
+          },
+          "links": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "label": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "url": {
+                  "format": "uri",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "url"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "manufacturer": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "model": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "notes": {
+            "maxLength": 1000,
+            "type": "string"
+          },
+          "part_number": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "power_outlets": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "feed_leg": {
+                  "enum": [
+                    "A",
+                    "B",
+                    "C"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "power_port": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "power_ports": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "allocated_draw": {
+                  "exclusiveMinimum": 0,
+                  "type": "number"
+                },
+                "maximum_draw": {
+                  "exclusiveMinimum": 0,
+                  "type": "number"
+                },
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "rack_widths": {
+            "items": {
+              "anyOf": [
+                {
+                  "const": 10,
+                  "type": "number"
+                },
+                {
+                  "const": 19,
+                  "type": "number"
+                },
+                {
+                  "const": 23,
+                  "type": "number"
+                }
+              ]
+            },
+            "type": "array"
+          },
+          "rear_image": {
+            "type": "boolean"
+          },
+          "serial_number": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "slot_width": {
+            "anyOf": [
+              {
+                "const": 1,
+                "type": "number"
+              },
+              {
+                "const": 2,
+                "type": "number"
+              }
+            ]
+          },
+          "slots": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "accepts": {
+                  "items": {
+                    "enum": [
+                      "server",
+                      "network",
+                      "firewall",
+                      "patch-panel",
+                      "power",
+                      "storage",
+                      "kvm",
+                      "av-media",
+                      "cooling",
+                      "shelf",
+                      "blank",
+                      "cable-management",
+                      "chassis",
+                      "other"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "height_units": {
+                  "exclusiveMinimum": 0,
+                  "maximum": 50,
+                  "type": "number"
+                },
+                "id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "maxLength": 100,
+                  "type": "string"
+                },
+                "position": {
+                  "properties": {
+                    "col": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "row": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "row",
+                    "col"
+                  ],
+                  "type": "object"
+                },
+                "width_fraction": {
+                  "exclusiveMinimum": 0,
+                  "maximum": 1,
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "position"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "slug": {
+            "maxLength": 100,
+            "minLength": 1,
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+            "type": "string"
+          },
+          "subdevice_role": {
+            "enum": [
+              "parent",
+              "child"
+            ],
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "u_height": {
+            "maximum": 50,
+            "minimum": 0.5,
+            "type": "number"
+          },
+          "va_rating": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "weight": {
+            "exclusiveMinimum": 0,
+            "type": "number"
+          },
+          "weight_unit": {
+            "enum": [
+              "kg",
+              "lb"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "slug",
+          "u_height",
+          "colour",
+          "category"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "metadata": {
+      "additionalProperties": {},
+      "properties": {
+        "description": {
+          "maxLength": 1000,
+          "type": "string"
+        },
+        "id": {
+          "minLength": 1,
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "schema_version": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "schema_version"
+      ],
+      "type": "object"
+    },
+    "name": {
+      "maxLength": 100,
+      "minLength": 1,
+      "type": "string"
+    },
+    "rack": {
+      "additionalProperties": {},
+      "properties": {
+        "desc_units": {
+          "type": "boolean"
+        },
+        "devices": {
+          "items": {
+            "additionalProperties": {},
+            "properties": {
+              "auto_created": {
+                "default": false,
+                "type": "boolean"
+              },
+              "colour_override": {
+                "pattern": "^#[0-9A-Fa-f]{6}$",
+                "type": "string"
+              },
+              "container_id": {
+                "type": "string"
+              },
+              "custom_fields": {
+                "additionalProperties": {},
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "device_bay": {
+                "type": "string"
+              },
+              "device_type": {
+                "maxLength": 100,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+                "type": "string"
+              },
+              "face": {
+                "enum": [
+                  "front",
+                  "rear",
+                  "both"
+                ],
+                "type": "string"
+              },
+              "front_image": {
+                "type": "string"
+              },
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "name": {
+                "maxLength": 100,
+                "type": "string"
+              },
+              "notes": {
+                "maxLength": 1000,
+                "type": "string"
+              },
+              "parent_device": {
+                "type": "string"
+              },
+              "ports": {
+                "default": [],
+                "items": {
+                  "additionalProperties": {},
+                  "properties": {
+                    "id": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "label": {
+                      "maxLength": 64,
+                      "type": "string"
+                    },
+                    "template_index": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "template_name": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "100base-tx",
+                        "1000base-t",
+                        "2.5gbase-t",
+                        "5gbase-t",
+                        "10gbase-t",
+                        "1000base-x-sfp",
+                        "10gbase-x-sfpp",
+                        "25gbase-x-sfp28",
+                        "40gbase-x-qsfpp",
+                        "100gbase-x-qsfp28",
+                        "100gbase-x-qsfpdd",
+                        "200gbase-x-qsfp56",
+                        "200gbase-x-qsfpdd",
+                        "400gbase-x-qsfpdd",
+                        "console",
+                        "usb-a",
+                        "usb-b",
+                        "usb-c",
+                        "usb-mini-b",
+                        "usb-micro-b",
+                        "virtual",
+                        "lag",
+                        "other"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "template_name",
+                    "template_index",
+                    "type"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "position": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "rear_image": {
+                "type": "string"
+              },
+              "slot_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "device_type",
+              "position",
+              "face"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "form_factor": {
+          "enum": [
+            "2-post",
+            "4-post",
+            "4-post-cabinet",
+            "wall-mount",
+            "open-frame"
+          ],
+          "type": "string"
+        },
+        "height": {
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "notes": {
+          "maxLength": 1000,
+          "type": "string"
+        },
+        "position": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "show_rear": {
+          "default": true,
+          "type": "boolean"
+        },
+        "starting_unit": {
+          "maximum": 9007199254740991,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "const": 10,
+              "type": "number"
+            },
+            {
+              "const": 19,
+              "type": "number"
+            },
+            {
+              "const": 21,
+              "type": "number"
+            },
+            {
+              "const": 23,
+              "type": "number"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "height",
+        "width",
+        "desc_units",
+        "form_factor",
+        "starting_unit",
+        "position",
+        "devices"
+      ],
+      "type": "object"
+    },
+    "rack_groups": {
+      "items": {
+        "additionalProperties": {},
+        "properties": {
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "layout_preset": {
+            "enum": [
+              "bayed",
+              "row"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "rack_ids": {
+            "items": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "rack_ids"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "racks": {
+      "items": {
+        "additionalProperties": {},
+        "properties": {
+          "desc_units": {
+            "type": "boolean"
+          },
+          "devices": {
+            "items": {
+              "additionalProperties": {},
+              "properties": {
+                "auto_created": {
+                  "default": false,
+                  "type": "boolean"
+                },
+                "colour_override": {
+                  "pattern": "^#[0-9A-Fa-f]{6}$",
+                  "type": "string"
+                },
+                "container_id": {
+                  "type": "string"
+                },
+                "custom_fields": {
+                  "additionalProperties": {},
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "device_bay": {
+                  "type": "string"
+                },
+                "device_type": {
+                  "maxLength": 100,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+                  "type": "string"
+                },
+                "face": {
+                  "enum": [
+                    "front",
+                    "rear",
+                    "both"
+                  ],
+                  "type": "string"
+                },
+                "front_image": {
+                  "type": "string"
+                },
+                "id": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "maxLength": 100,
+                  "type": "string"
+                },
+                "notes": {
+                  "maxLength": 1000,
+                  "type": "string"
+                },
+                "parent_device": {
+                  "type": "string"
+                },
+                "ports": {
+                  "default": [],
+                  "items": {
+                    "additionalProperties": {},
+                    "properties": {
+                      "id": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "label": {
+                        "maxLength": 64,
+                        "type": "string"
+                      },
+                      "template_index": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "template_name": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "type": {
+                        "enum": [
+                          "100base-tx",
+                          "1000base-t",
+                          "2.5gbase-t",
+                          "5gbase-t",
+                          "10gbase-t",
+                          "1000base-x-sfp",
+                          "10gbase-x-sfpp",
+                          "25gbase-x-sfp28",
+                          "40gbase-x-qsfpp",
+                          "100gbase-x-qsfp28",
+                          "100gbase-x-qsfpdd",
+                          "200gbase-x-qsfp56",
+                          "200gbase-x-qsfpdd",
+                          "400gbase-x-qsfpdd",
+                          "console",
+                          "usb-a",
+                          "usb-b",
+                          "usb-c",
+                          "usb-mini-b",
+                          "usb-micro-b",
+                          "virtual",
+                          "lag",
+                          "other"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "template_name",
+                      "template_index",
+                      "type"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "position": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "rear_image": {
+                  "type": "string"
+                },
+                "slot_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "device_type",
+                "position",
+                "face"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "form_factor": {
+            "enum": [
+              "2-post",
+              "4-post",
+              "4-post-cabinet",
+              "wall-mount",
+              "open-frame"
+            ],
+            "type": "string"
+          },
+          "height": {
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 100,
+            "minLength": 1,
+            "type": "string"
+          },
+          "notes": {
+            "maxLength": 1000,
+            "type": "string"
+          },
+          "position": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "show_rear": {
+            "default": true,
+            "type": "boolean"
+          },
+          "starting_unit": {
+            "maximum": 9007199254740991,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "width": {
+            "anyOf": [
+              {
+                "const": 10,
+                "type": "number"
+              },
+              {
+                "const": 19,
+                "type": "number"
+              },
+              {
+                "const": 21,
+                "type": "number"
+              },
+              {
+                "const": 23,
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "height",
+          "width",
+          "desc_units",
+          "form_factor",
+          "starting_unit",
+          "position",
+          "devices"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "settings": {
+      "additionalProperties": {},
+      "properties": {
+        "display_mode": {
+          "enum": [
+            "label",
+            "image",
+            "image-label"
+          ],
+          "type": "string"
+        },
+        "show_labels_on_images": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "display_mode",
+        "show_labels_on_images"
+      ],
+      "type": "object"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "device_types",
+    "settings"
+  ],
+  "title": "Rackula Layout",
+  "type": "object"
+}


### PR DESCRIPTION
## **User description**
Closes #2226

## What

- Add `scripts/generate-schema.ts`, which projects `LayoutSchema` (`src/lib/schemas/index.ts`) to a JSON Schema artifact at `static/schemas/layout-v1.json` using Zod 4's native `z.toJSONSchema()`. No new dependency.
- Wire it in as the `generate-schema` npm script.
- Commit the generated artifact. It carries `$schema` (draft 2020-12), a canonical `$id` (`https://count.racku.la/schemas/layout-v1.json`), a `title`, and a `$description` noting beta status and the coverage limitation.
- Add `src/tests/layout-json-schema.test.ts`, a sync guard that fails if the committed artifact drifts from the live Zod source.

## Why

Spike #571 confirmed the project pins `zod@^4.4.3`, which ships a native JSON Schema converter. This publishes a language-agnostic contract for the saved-layout format while the Zod schema stays the single source of truth.

Generation uses `io: "input"` (validators run against the on-disk file shape, before the migration transform) and `unrepresentable: "any"` so the cross-field `.refine`/`.superRefine`/`.transform` rules degrade to permissive rather than throwing. Those rules (referential integrity, carrier-first rail placement, slot fit, position migration, unknown-field preservation) cannot be expressed in JSON Schema, so the artifact covers the structural shape only. The `$description` records this. Output is sorted by key, so generation is byte-stable across runs.

## Verification

- `npm run lint`: clean
- `npm run test:run`: 143 files, 2495 tests passing
- `npm run build`: succeeds
- `npm run generate-schema`: regenerates identical output (deterministic)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnkWoUexSXCRStNmJRux5G)_


___

## **CodeAnt-AI Description**
**Generate and keep the saved layout JSON Schema in sync with the source schema**

### What Changed
- Added a command that creates and updates the published layout JSON Schema from the app’s layout rules
- Committed the generated schema file so other tools can use the layout format as a stable contract
- Added a test that fails when the committed schema drifts from the source schema
- The generated schema now includes a clear public schema ID and a note that it covers the structural shape, not every Zod-only rule

### Impact
`✅ Easier integration with external tools`
`✅ Fewer stale schema updates`
`✅ Clearer layout format contract`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
