### PR TITLE
fix: namespace placement image keys per layout to prevent cross-tab collision (#2270)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -6,6 +6,7 @@
 -->
 <script lang="ts">
   import { NewRackWizard, type CreateRackData } from "$lib/components/wizard";
+  import { placementKey } from "$lib/utils/placement-key";
   import AddDeviceForm from "$lib/components/AddDeviceForm.svelte";
   import ImportFromNetBoxDialog from "$lib/components/ImportFromNetBoxDialog.svelte";
   import ConfirmDialog from "$lib/components/ConfirmDialog.svelte";
@@ -320,9 +321,14 @@
       // getUsedDeviceTypeSlugs returns a fresh set we own, so we extend it in
       // place with per-placement keys rather than allocating another set.
       const usedImageKeys = layoutStore.getUsedDeviceTypeSlugs();
+      const nextLayoutId = nextLayout.metadata?.id;
       for (const rack of nextLayout.racks) {
         for (const device of rack.devices) {
-          usedImageKeys.add(`placement-${device.id}`);
+          usedImageKeys.add(
+            nextLayoutId
+              ? placementKey(nextLayoutId, device.id)
+              : `placement-${device.id}`,
+          );
         }
       }
       imageStore.cleanupOrphanedImages(usedImageKeys);

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -699,6 +699,7 @@
   rackGroups={layoutStore.rack_groups}
   deviceTypes={layoutStore.device_types}
   images={imageStore.getAllImages()}
+  layoutId={layoutStore.layout.metadata?.id}
   displayMode={uiStore.displayMode}
   layoutName={layoutStore.layout.name}
   selectedRackId={selectionStore.isRackSelected

--- a/src/lib/components/EditPanelImage.svelte
+++ b/src/lib/components/EditPanelImage.svelte
@@ -6,6 +6,7 @@
   import ImageUpload from "./ImageUpload.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
+  import { placementKey } from "$lib/utils/placement-key";
   import type { SelectedDeviceInfo } from "$lib/types";
   import type { ImageData } from "$lib/types/images";
 
@@ -18,17 +19,19 @@
   const layoutStore = getLayoutStore();
   const imageStore = getImageStore();
 
+  const layoutId = $derived(layoutStore.layout.metadata!.id);
+
   // Get the current placement images (if any)
   const placementFrontImage = $derived.by(() =>
     imageStore.getDeviceImage(
-      `placement-${selectedDeviceInfo.placedDevice.id}`,
+      placementKey(layoutId, selectedDeviceInfo.placedDevice.id),
       "front",
     ),
   );
 
   const placementRearImage = $derived.by(() =>
     imageStore.getDeviceImage(
-      `placement-${selectedDeviceInfo.placedDevice.id}`,
+      placementKey(layoutId, selectedDeviceInfo.placedDevice.id),
       "rear",
     ),
   );
@@ -36,7 +39,7 @@
   // Handle placement image upload
   function handlePlacementImageUpload(face: "front" | "rear", data: ImageData) {
     const deviceId = selectedDeviceInfo.placedDevice.id;
-    imageStore.setDeviceImage(`placement-${deviceId}`, face, data);
+    imageStore.setDeviceImage(placementKey(layoutId, deviceId), face, data);
     layoutStore.updateDevicePlacementImage(
       selectedDeviceInfo.rack.id,
       selectedDeviceInfo.deviceIndex,
@@ -48,7 +51,7 @@
   // Handle placement image removal
   function handlePlacementImageRemove(face: "front" | "rear") {
     const deviceId = selectedDeviceInfo.placedDevice.id;
-    imageStore.removeDeviceImage(`placement-${deviceId}`, face);
+    imageStore.removeDeviceImage(placementKey(layoutId, deviceId), face);
     layoutStore.updateDevicePlacementImage(
       selectedDeviceInfo.rack.id,
       selectedDeviceInfo.deviceIndex,

--- a/src/lib/components/ExportDialog.svelte
+++ b/src/lib/components/ExportDialog.svelte
@@ -46,6 +46,7 @@
     rackGroups?: RackGroup[];
     deviceTypes: DeviceType[];
     images?: ImageStoreMap;
+    layoutId?: string;
     displayMode?: DisplayMode;
     layoutName?: string;
     selectedRackId: string | null;
@@ -66,6 +67,7 @@
     rackGroups = [],
     deviceTypes,
     images,
+    layoutId,
     displayMode = "label",
     layoutName = "layout",
     selectedRackId: _selectedRackId,
@@ -289,6 +291,7 @@
         previewOptions,
         images,
         rackGroups,
+        layoutId,
       );
       const width = parseInt(svg.getAttribute("width") || "0", 10);
       const height = parseInt(svg.getAttribute("height") || "0", 10);

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -25,6 +25,8 @@
   import CategoryIconSVG from "./CategoryIconSVG.svelte";
   import LabelOverlaySVG from "./LabelOverlaySVG.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { placementKey } from "$lib/utils/placement-key";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { useLongPress } from "$lib/utils/gestures";
   import { hapticTap } from "$lib/utils/haptics";
@@ -138,6 +140,7 @@
   const effectiveColour = $derived(colourOverride ?? device.colour);
 
   const imageStore = getImageStore();
+  const layoutStore = getLayoutStore();
 
   // Check if display mode shows images (either 'image' or 'image-label')
   const isImageMode = $derived(
@@ -152,10 +155,10 @@
 
     // Try placement-specific image first (if placedDeviceId is provided)
     if (placedDeviceId) {
-      const placementUrl = imageStore.getImageUrl(
-        `placement-${placedDeviceId}`,
-        face,
-      );
+      const layoutId = layoutStore.layout.metadata?.id;
+      const placementUrl = layoutId
+        ? imageStore.getImageUrl(placementKey(layoutId, placedDeviceId), face)
+        : undefined;
       if (placementUrl) return placementUrl;
     }
 

--- a/src/lib/stores/commands/device-type.ts
+++ b/src/lib/stores/commands/device-type.ts
@@ -6,6 +6,7 @@ import type { Command } from "./types";
 import type { Cable, DeviceType, PlacedDevice } from "$lib/types";
 import { getImageStore } from "../images.svelte";
 import type { DeviceImageData } from "$lib/types/images";
+import { placementKey } from "$lib/utils/placement-key";
 
 /**
  * Interface for layout store operations needed by device type commands
@@ -100,6 +101,7 @@ export function createDeleteDeviceTypeCommand(
   placedDevices: { rackId: string; device: PlacedDevice }[],
   store: DeviceTypeCommandStore,
   connectedCables: Cable[] = [],
+  layoutId: string = "",
 ): Command {
   const deviceData = placedDevices.map((d) => ({
     rackId: d.rackId,
@@ -122,7 +124,7 @@ export function createDeleteDeviceTypeCommand(
   // Snapshot placement-specific images for each placed device
   const placementSnapshots = new Map<string, DeviceImageData>();
   for (const d of placedDevices) {
-    const key = `placement-${d.device.id}`;
+    const key = placementKey(layoutId, d.device.id);
     const snap = imageStore.getAllImages().get(key);
     if (snap) placementSnapshots.set(key, structuredClone(snap));
   }
@@ -143,10 +145,10 @@ export function createDeleteDeviceTypeCommand(
       // Remove placement images at both the snapshot id and any remapped id
       // left over from a prior undo (otherwise redo leaks an orphan key).
       for (const { device } of deviceData) {
-        imgStore.removeAllDeviceImages(`placement-${device.id}`);
+        imgStore.removeAllDeviceImages(placementKey(layoutId, device.id));
         const remapped = restoredDeviceIdMap.get(device.id);
         if (remapped && remapped !== device.id) {
-          imgStore.removeAllDeviceImages(`placement-${remapped}`);
+          imgStore.removeAllDeviceImages(placementKey(layoutId, remapped));
         }
       }
       store.removeDeviceTypeRaw(deviceTypeCopy.slug);
@@ -164,10 +166,10 @@ export function createDeleteDeviceTypeCommand(
         const actualId = placed?.id ?? device.id;
         restoredDeviceIdMap.set(device.id, actualId);
         // Restore placement images under the (possibly remapped) key
-        const originalKey = `placement-${device.id}`;
+        const originalKey = placementKey(layoutId, device.id);
         const snap = placementSnapshots.get(originalKey);
         if (snap) {
-          const actualKey = `placement-${actualId}`;
+          const actualKey = placementKey(layoutId, actualId);
           if (snap.front)
             imgStore.setDeviceImage(actualKey, "front", snap.front);
           if (snap.rear) imgStore.setDeviceImage(actualKey, "rear", snap.rear);

--- a/src/lib/stores/commands/device.ts
+++ b/src/lib/stores/commands/device.ts
@@ -5,6 +5,7 @@
 import type { Command } from "./types";
 import type { PlacedDevice, DeviceFace } from "$lib/types";
 import { getImageStore } from "../images.svelte";
+import { placementKey } from "$lib/utils/placement-key";
 
 /**
  * Interface for layout store operations needed by device commands
@@ -96,6 +97,7 @@ export function createRemoveDeviceCommand(
   device: PlacedDevice,
   store: DeviceCommandStore,
   deviceName: string = "device",
+  layoutId: string = "",
 ): Command {
   // Store a deep copy of the device for restoration
   // structuredClone handles nested objects like ports and custom_fields
@@ -103,7 +105,7 @@ export function createRemoveDeviceCommand(
 
   // Snapshot placement images before removal for undo restoration
   const imageStore = getImageStore();
-  const imageKey = `placement-${device.id}`;
+  const imageKey = placementKey(layoutId, device.id);
   const imageSnapshot = imageStore.getAllImages().get(imageKey);
   const snapshotCopy = imageSnapshot
     ? structuredClone(imageSnapshot)
@@ -126,7 +128,7 @@ export function createRemoveDeviceCommand(
       // Restore placement images under the (possibly remapped) key
       if (snapshotCopy) {
         const imgStore = getImageStore();
-        const actualKey = `placement-${actualId}`;
+        const actualKey = placementKey(layoutId, actualId);
         if (snapshotCopy.front)
           imgStore.setDeviceImage(actualKey, "front", snapshotCopy.front);
         if (snapshotCopy.rear)
@@ -304,15 +306,15 @@ export function createUpdateDeviceIpCommand(
  * Move placement image from one device ID key to another when placeDeviceRaw remaps the ID.
  * No-op if no image exists under the old key.
  */
-function rekeyPlacementImage(oldId: string, newId: string): void {
+function rekeyPlacementImage(oldId: string, newId: string, layoutId: string = ""): void {
   const imgStore = getImageStore();
-  const data = imgStore.getAllImages().get(`placement-${oldId}`);
+  const data = imgStore.getAllImages().get(placementKey(layoutId, oldId));
   if (!data) return;
   if (data.front)
-    imgStore.setDeviceImage(`placement-${newId}`, "front", data.front);
+    imgStore.setDeviceImage(placementKey(layoutId, newId), "front", data.front);
   if (data.rear)
-    imgStore.setDeviceImage(`placement-${newId}`, "rear", data.rear);
-  imgStore.removeAllDeviceImages(`placement-${oldId}`);
+    imgStore.setDeviceImage(placementKey(layoutId, newId), "rear", data.rear);
+  imgStore.removeAllDeviceImages(placementKey(layoutId, oldId));
 }
 
 /**
@@ -332,6 +334,7 @@ export function createCrossRackMoveCommand(
   children: PlacedDevice[],
   store: CrossRackMoveStore,
   deviceName: string = "device",
+  layoutId: string = "",
 ): Command {
   // Deep-copy all devices at command creation time to isolate from reactive state
   const parentCopy = structuredClone(parentDevice);
@@ -414,7 +417,7 @@ export function createCrossRackMoveCommand(
 
       // Re-key placement image if parent ID was remapped (#1478)
       if (actualParentId !== currentParentImageId) {
-        rekeyPlacementImage(currentParentImageId, actualParentId);
+        rekeyPlacementImage(currentParentImageId, actualParentId, layoutId);
         currentParentImageId = actualParentId;
       }
 
@@ -433,7 +436,7 @@ export function createCrossRackMoveCommand(
         const actualChildId = actualChild?.id ?? childToPlace.id;
         const previousChildImageId = currentChildImageIds[i];
         if (previousChildImageId && actualChildId !== previousChildImageId) {
-          rekeyPlacementImage(previousChildImageId, actualChildId);
+          rekeyPlacementImage(previousChildImageId, actualChildId, layoutId);
           currentChildImageIds[i] = actualChildId;
         }
       });
@@ -463,7 +466,7 @@ export function createCrossRackMoveCommand(
 
       // Re-key placement image and update source ID tracking if remapped (#1478)
       if (undoActualParentId !== currentParentImageId) {
-        rekeyPlacementImage(currentParentImageId, undoActualParentId);
+        rekeyPlacementImage(currentParentImageId, undoActualParentId, layoutId);
         currentParentImageId = undoActualParentId;
       }
       currentSourceDeviceIds[0] = undoActualParentId;
@@ -481,7 +484,7 @@ export function createCrossRackMoveCommand(
         const actualChildId = actualChild?.id ?? childToPlace.id;
         const previousChildImageId = currentChildImageIds[i];
         if (previousChildImageId && actualChildId !== previousChildImageId) {
-          rekeyPlacementImage(previousChildImageId, actualChildId);
+          rekeyPlacementImage(previousChildImageId, actualChildId, layoutId);
           currentChildImageIds[i] = actualChildId;
         }
         currentSourceDeviceIds[i + 1] = actualChildId;

--- a/src/lib/stores/commands/device.ts
+++ b/src/lib/stores/commands/device.ts
@@ -105,8 +105,8 @@ export function createRemoveDeviceCommand(
 
   // Snapshot placement images before removal for undo restoration
   const imageStore = getImageStore();
-  const imageKey = placementKey(layoutId, device.id);
-  const imageSnapshot = imageStore.getAllImages().get(imageKey);
+  let currentImageId = device.id;
+  const imageSnapshot = imageStore.getAllImages().get(placementKey(layoutId, currentImageId));
   const snapshotCopy = imageSnapshot
     ? structuredClone(imageSnapshot)
     : undefined;
@@ -116,8 +116,8 @@ export function createRemoveDeviceCommand(
     description: `Remove ${deviceName}`,
     timestamp: Date.now(),
     execute() {
-      // Clean up placement images (moved from raw mutator)
-      getImageStore().removeAllDeviceImages(imageKey);
+      // Clean up placement images using current ID (may differ from original after undo remap)
+      getImageStore().removeAllDeviceImages(placementKey(layoutId, currentImageId));
       store.removeDeviceAtIndexRaw(index);
     },
     undo() {
@@ -125,6 +125,7 @@ export function createRemoveDeviceCommand(
       // Read back actual device — placeDeviceRaw may remap the ID (#1363 dedup guard)
       const placed = store.getDeviceAtIndex(placedIdx);
       const actualId = placed?.id ?? deviceCopy.id;
+      currentImageId = actualId;
       // Restore placement images under the (possibly remapped) key
       if (snapshotCopy) {
         const imgStore = getImageStore();

--- a/src/lib/stores/layout/device-actions.ts
+++ b/src/lib/stores/layout/device-actions.ts
@@ -493,6 +493,7 @@ export function moveDeviceToRack(
     childrenSnapshots,
     adapter,
     deviceName,
+    layout.metadata?.id ?? "",
   );
 
   history.execute(command);

--- a/src/lib/stores/layout/recorded-device-actions.ts
+++ b/src/lib/stores/layout/recorded-device-actions.ts
@@ -413,6 +413,7 @@ export function removeDeviceRecorded(
     device,
     adapter,
     deviceName,
+    layout.metadata?.id ?? "",
   );
   history.execute(command);
   ctx.markDirty();

--- a/src/lib/stores/layout/recorded-device-type-actions.ts
+++ b/src/lib/stores/layout/recorded-device-type-actions.ts
@@ -114,6 +114,7 @@ export function deleteDeviceTypeRecorded(
     placedDevices,
     adapter,
     connectedCables,
+    layout.metadata?.id ?? "",
   );
   history.execute(command);
   ctx.markDirty();
@@ -167,6 +168,7 @@ export function deleteMultipleDeviceTypesRecorded(
       placedDevices,
       adapter,
       connectedCables,
+      layout.metadata?.id ?? "",
     );
     commands.push(command);
   }

--- a/src/lib/utils/app-actions.ts
+++ b/src/lib/utils/app-actions.ts
@@ -165,6 +165,7 @@ export async function handleExportSubmit(
       exportOptions,
       images,
       layoutStore.rack_groups,
+      layoutStore.layout.metadata?.id,
     );
 
     const exportViewOrDefault = options.exportView ?? "both";

--- a/src/lib/utils/archive.ts
+++ b/src/lib/utils/archive.ts
@@ -37,7 +37,7 @@ import {
   buildYamlFilename,
   extractUuidFromFolderName,
 } from "./folder-structure";
-import { isPlacementKey, deviceIdFromPlacementKey, placementKey } from "./placement-key";
+import { isPlacementKey, deviceIdFromPlacementKey, layoutIdFromPlacementKey, placementKey } from "./placement-key";
 
 /**
  * Lazily load JSZip library
@@ -311,11 +311,8 @@ async function addLayoutFolderToZip(
       // Handle placement-specific images (key format: placement-{layoutId}:{deviceId})
       if (isPlacementKey(imageKey)) {
         // Skip images belonging to a different layout (multi-tab: same device UUID, different layout)
-        const colonIdx = imageKey.indexOf(":");
-        if (colonIdx !== -1) {
-          const keyLayoutId = imageKey.slice("placement-".length, colonIdx);
-          if (keyLayoutId !== layoutMetadata.id) continue;
-        }
+        const keyLayoutId = layoutIdFromPlacementKey(imageKey);
+        if (keyLayoutId !== undefined && keyLayoutId !== layoutMetadata.id) continue;
         const deviceId = deviceIdFromPlacementKey(imageKey);
         // Find the device across all racks to get its device_type slug for the folder path
         const placedDevice = layout.racks

--- a/src/lib/utils/archive.ts
+++ b/src/lib/utils/archive.ts
@@ -37,6 +37,7 @@ import {
   buildYamlFilename,
   extractUuidFromFolderName,
 } from "./folder-structure";
+import { isPlacementKey, deviceIdFromPlacementKey, placementKey } from "./placement-key";
 
 /**
  * Lazily load JSZip library
@@ -306,9 +307,9 @@ async function addLayoutFolderToZip(
     }
 
     for (const [imageKey, deviceImages] of images) {
-      // Handle placement-specific images (key format: placement-{deviceId})
-      if (imageKey.startsWith("placement-")) {
-        const deviceId = imageKey.replace("placement-", "");
+      // Handle placement-specific images (key format: placement-{layoutId}:{deviceId})
+      if (isPlacementKey(imageKey)) {
+        const deviceId = deviceIdFromPlacementKey(imageKey);
         // Find the device across all racks to get its device_type slug for the folder path
         const placedDevice = layout.racks
           .flatMap((rack) => rack.devices)
@@ -483,6 +484,11 @@ async function extractNewFormatZip(
   const yamlContent = new TextDecoder().decode(yamlBytes);
   const layout = await parseLayoutYaml(yamlContent);
 
+  // Derive the layout id from the folder name UUID (canonical persisted identity).
+  const layoutId = (format.folderName && extractUuidFromFolderName(format.folderName))
+    || layout.metadata?.id
+    || "";
+
   // Extract images from assets folder
   const images: ImageStoreMap = new Map();
   const failedImages: string[] = [];
@@ -510,6 +516,7 @@ async function extractNewFormatZip(
         imagePath,
         deviceSlug,
         filename,
+        layoutId,
       );
 
       if (result.error) {
@@ -556,6 +563,8 @@ async function extractOldFormatZip(
   const yamlContent = new TextDecoder().decode(yamlBytes);
   const layout = await parseLayoutYaml(yamlContent);
 
+  const layoutId = layout.metadata?.id ?? "";
+
   // Old format: images at root level or in images/ folder
   const images: ImageStoreMap = new Map();
   const failedImages: string[] = [];
@@ -585,6 +594,7 @@ async function extractOldFormatZip(
         imagePath,
         deviceSlug,
         filename,
+        layoutId,
       );
 
       if (result.error) {
@@ -640,6 +650,7 @@ async function extractImageFromZip(
   imagePath: string,
   deviceSlug: string,
   filename: string,
+  layoutId: string = "",
 ): Promise<{
   imageKey?: string;
   face?: "front" | "rear";
@@ -660,10 +671,10 @@ async function extractImageFromZip(
     imageKey = deviceSlug;
     face = deviceTypeFaceMatch[1] as "front" | "rear";
   } else if (placementFaceMatch) {
-    // Placement-specific image
-    const deviceId = placementFaceMatch[1];
+    // Placement-specific image — namespace by layout id
+    const deviceId = placementFaceMatch[1]!;
     face = placementFaceMatch[2] as "front" | "rear";
-    imageKey = `placement-${deviceId}`;
+    imageKey = placementKey(layoutId, deviceId);
   } else {
     return {}; // Unknown format, skip
   }

--- a/src/lib/utils/archive.ts
+++ b/src/lib/utils/archive.ts
@@ -275,9 +275,10 @@ async function addLayoutFolderToZip(
 ): Promise<void> {
   // Generate or use provided metadata
   const layoutMetadata: LayoutMetadata = metadata ?? {
-    id: generateId(),
-    name: layout.name,
-    schema_version: "1.0",
+    id: layout.metadata?.id ?? generateId(),
+    name: layout.metadata?.name ?? layout.name,
+    schema_version: layout.metadata?.schema_version ?? "1.0",
+    description: layout.metadata?.description,
   };
 
   // Build folder name: "{Layout Name}-{UUID}"

--- a/src/lib/utils/archive.ts
+++ b/src/lib/utils/archive.ts
@@ -309,6 +309,12 @@ async function addLayoutFolderToZip(
     for (const [imageKey, deviceImages] of images) {
       // Handle placement-specific images (key format: placement-{layoutId}:{deviceId})
       if (isPlacementKey(imageKey)) {
+        // Skip images belonging to a different layout (multi-tab: same device UUID, different layout)
+        const colonIdx = imageKey.indexOf(":");
+        if (colonIdx !== -1) {
+          const keyLayoutId = imageKey.slice("placement-".length, colonIdx);
+          if (keyLayoutId !== layoutMetadata.id) continue;
+        }
         const deviceId = deviceIdFromPlacementKey(imageKey);
         // Find the device across all racks to get its device_type slug for the folder path
         const placedDevice = layout.racks

--- a/src/lib/utils/export/multi.ts
+++ b/src/lib/utils/export/multi.ts
@@ -29,6 +29,7 @@ export async function exportAsZip(
   options: ExportOptions,
   images?: ImageStoreMap,
   onProgress?: ExportProgressCallback,
+  layoutId?: string,
 ): Promise<Blob> {
   // Dynamically import JSZip wrapper
   const { createZip, generateRackFilename } = await import("../zip");
@@ -40,7 +41,7 @@ export async function exportAsZip(
     onProgress?.({ current: i + 1, total: racks.length, rackName: rack.name });
 
     // Generate SVG for this rack
-    const svg = generateSingleRackSVG(rack, deviceLibrary, options, images);
+    const svg = generateSingleRackSVG(rack, deviceLibrary, options, images, layoutId);
 
     // Convert to the requested format
     let blob: Blob;
@@ -92,6 +93,7 @@ export async function exportAsMultiPagePDF(
   options: ExportOptions,
   images?: ImageStoreMap,
   onProgress?: ExportProgressCallback,
+  layoutId?: string,
 ): Promise<Blob> {
   // Dynamically import jsPDF to avoid loading it on app startup
   const { jsPDF } = await import("jspdf");
@@ -109,7 +111,7 @@ export async function exportAsMultiPagePDF(
     onProgress?.({ current: i + 1, total: racks.length, rackName: rack.name });
 
     // Generate SVG for this rack
-    const svg = generateSingleRackSVG(rack, deviceLibrary, options, images);
+    const svg = generateSingleRackSVG(rack, deviceLibrary, options, images, layoutId);
 
     // Parse SVG to get dimensions
     const imgWidth = parseInt(svg.getAttribute("width") || "0", 10);

--- a/src/lib/utils/export/svg.ts
+++ b/src/lib/utils/export/svg.ts
@@ -10,6 +10,7 @@ import type {
   DeviceCategory,
 } from "$lib/types";
 import type { ImageStoreMap } from "$lib/types/images";
+import { placementKey } from "$lib/utils/placement-key";
 import { getBlockedSlots } from "../blocked-slots";
 import {
   fitTextToWidth,
@@ -386,6 +387,7 @@ export function generateExportSVG(
   options: ExportOptions,
   images?: ImageStoreMap,
   rackGroups?: RackGroup[],
+  layoutId?: string,
 ): SVGElement {
   const {
     includeNames,
@@ -865,7 +867,9 @@ export function generateExportSVG(
       // Placement image wins per face, else fall back to the device-type image
       // (mirrors RackDevice.svelte). Per-face so a front-only placement still
       // inherits the device-type rear image.
-      const placementImages = images?.get(`placement-${placedDevice.id}`);
+      const placementImages = images?.get(
+        layoutId ? placementKey(layoutId, placedDevice.id) : `placement-${placedDevice.id}`,
+      );
       const slugImages = images?.get(device.slug);
       const deviceImage = placementImages?.[face] ?? slugImages?.[face];
       // Support both URL-based (bundled) and dataUrl-based (user upload) images
@@ -1470,6 +1474,7 @@ export function generateSingleRackSVG(
   deviceLibrary: DeviceType[],
   options: ExportOptions,
   images?: ImageStoreMap,
+  layoutId?: string,
 ): SVGElement {
-  return generateExportSVG([rack], deviceLibrary, options, images);
+  return generateExportSVG([rack], deviceLibrary, options, images, undefined, layoutId);
 }

--- a/src/lib/utils/placement-key.ts
+++ b/src/lib/utils/placement-key.ts
@@ -1,0 +1,30 @@
+/**
+ * Helpers for placement image keys in the global image store.
+ *
+ * Format: `placement-{layoutId}:{deviceId}`
+ * The colon separator is safe because layout and device ids are UUIDs
+ * (hex + hyphens only).
+ */
+
+/** Build a namespaced placement image key. */
+export function placementKey(layoutId: string, deviceId: string): string {
+  return `placement-${layoutId}:${deviceId}`;
+}
+
+/** True for any key that starts with the placement prefix. */
+export function isPlacementKey(key: string): boolean {
+  return key.startsWith("placement-");
+}
+
+/**
+ * Extract the raw device id from a placement key.
+ * Handles both the current namespaced format (`placement-{layoutId}:{deviceId}`)
+ * and the legacy un-namespaced format (`placement-{deviceId}`).
+ */
+export function deviceIdFromPlacementKey(key: string): string {
+  const colonIdx = key.indexOf(":");
+  if (colonIdx !== -1) {
+    return key.slice(colonIdx + 1);
+  }
+  return key.slice("placement-".length);
+}

--- a/src/lib/utils/placement-key.ts
+++ b/src/lib/utils/placement-key.ts
@@ -28,3 +28,13 @@ export function deviceIdFromPlacementKey(key: string): string {
   }
   return key.slice("placement-".length);
 }
+
+/**
+ * Extract the layout id from a namespaced placement key.
+ * Returns undefined for legacy un-namespaced keys (`placement-{deviceId}`).
+ */
+export function layoutIdFromPlacementKey(key: string): string | undefined {
+  const colonIdx = key.indexOf(":");
+  if (colonIdx === -1) return undefined;
+  return key.slice("placement-".length, colonIdx);
+}

--- a/src/lib/utils/placement-key.ts
+++ b/src/lib/utils/placement-key.ts
@@ -6,9 +6,9 @@
  * (hex + hyphens only).
  */
 
-/** Build a namespaced placement image key. */
+/** Build a namespaced placement image key. Falls back to legacy format when layoutId is absent. */
 export function placementKey(layoutId: string, deviceId: string): string {
-  return `placement-${layoutId}:${deviceId}`;
+  return layoutId ? `placement-${layoutId}:${deviceId}` : `placement-${deviceId}`;
 }
 
 /** True for any key that starts with the placement prefix. */

--- a/src/tests/image-undo.test.ts
+++ b/src/tests/image-undo.test.ts
@@ -19,9 +19,12 @@ import type {
   CrossRackMoveStore,
 } from "$lib/stores/commands/device";
 import type { DeviceTypeCommandStore } from "$lib/stores/commands/device-type";
+import { placementKey } from "$lib/utils/placement-key";
 import { createTestDevice, createTestDeviceType } from "./factories";
 import type { PlacedDevice, DeviceType } from "$lib/types";
 import type { ImageData } from "$lib/types/images";
+
+const TEST_LAYOUT_ID = "test-layout-abc";
 
 // Helper to create mock ImageData (user upload)
 function createMockImageData(filename = "test-front.png"): ImageData {
@@ -115,7 +118,7 @@ describe("Image Undo — Device Removal", () => {
     const store = createMockDeviceStore(devices);
 
     // Set up a placement image for this device
-    const imageKey = `placement-${device.id}`;
+    const imageKey = placementKey(TEST_LAYOUT_ID, device.id);
     const frontImage = createMockImageData("dev-1-front.png");
     imageStore.setDeviceImage(imageKey, "front", frontImage);
 
@@ -123,7 +126,7 @@ describe("Image Undo — Device Removal", () => {
     expect(imageStore.hasImage(imageKey, "front")).toBe(true);
 
     // Create the remove command (should snapshot images)
-    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device");
+    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device", TEST_LAYOUT_ID);
 
     // Execute: removes device and cleans up images
     cmd.execute();
@@ -146,7 +149,7 @@ describe("Image Undo — Device Removal", () => {
     const devices = [device];
     const store = createMockDeviceStore(devices);
 
-    const imageKey = `placement-${device.id}`;
+    const imageKey = placementKey(TEST_LAYOUT_ID, device.id);
     imageStore.setDeviceImage(
       imageKey,
       "front",
@@ -158,7 +161,7 @@ describe("Image Undo — Device Removal", () => {
       createMockImageData("dev-2-rear.png"),
     );
 
-    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device");
+    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device", TEST_LAYOUT_ID);
 
     cmd.execute();
     expect(imageStore.hasImage(imageKey, "front")).toBe(false);
@@ -183,7 +186,7 @@ describe("Image Undo — Device Removal", () => {
     const devices = [device];
     const store = createMockDeviceStore(devices);
 
-    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device");
+    const cmd = createRemoveDeviceCommand(0, device, store, "Test Device", TEST_LAYOUT_ID);
 
     cmd.execute();
     // Should not throw
@@ -212,6 +215,9 @@ describe("Image Undo — Device Type Deletion", () => {
     const devices = [device1, device2];
     const store = createMockDeviceTypeStore(deviceTypes, devices);
 
+    const pk1 = placementKey(TEST_LAYOUT_ID, device1.id);
+    const pk2 = placementKey(TEST_LAYOUT_ID, device2.id);
+
     // Set up type-level image
     imageStore.setDeviceImage(
       "my-server",
@@ -221,12 +227,12 @@ describe("Image Undo — Device Type Deletion", () => {
 
     // Set up placement-specific images
     imageStore.setDeviceImage(
-      "placement-placed-1",
+      pk1,
       "front",
       createMockImageData("placed-1-front.png"),
     );
     imageStore.setDeviceImage(
-      "placement-placed-2",
+      pk2,
       "rear",
       createMockImageData("placed-2-rear.png"),
     );
@@ -238,13 +244,15 @@ describe("Image Undo — Device Type Deletion", () => {
         { rackId: "rack-1", device: device2 },
       ],
       store,
+      [],
+      TEST_LAYOUT_ID,
     );
 
     // Execute: deletes type, devices, and images
     cmd.execute();
     expect(imageStore.hasImage("my-server", "front")).toBe(false);
-    expect(imageStore.hasImage("placement-placed-1", "front")).toBe(false);
-    expect(imageStore.hasImage("placement-placed-2", "rear")).toBe(false);
+    expect(imageStore.hasImage(pk1, "front")).toBe(false);
+    expect(imageStore.hasImage(pk2, "rear")).toBe(false);
 
     // Undo: should restore everything
     cmd.undo();
@@ -252,13 +260,13 @@ describe("Image Undo — Device Type Deletion", () => {
     expect(imageStore.getDeviceImage("my-server", "front")?.filename).toBe(
       "my-server-front.png",
     );
-    expect(imageStore.hasImage("placement-placed-1", "front")).toBe(true);
+    expect(imageStore.hasImage(pk1, "front")).toBe(true);
     expect(
-      imageStore.getDeviceImage("placement-placed-1", "front")?.filename,
+      imageStore.getDeviceImage(pk1, "front")?.filename,
     ).toBe("placed-1-front.png");
-    expect(imageStore.hasImage("placement-placed-2", "rear")).toBe(true);
+    expect(imageStore.hasImage(pk2, "rear")).toBe(true);
     expect(
-      imageStore.getDeviceImage("placement-placed-2", "rear")?.filename,
+      imageStore.getDeviceImage(pk2, "rear")?.filename,
     ).toBe("placed-2-rear.png");
   });
 
@@ -268,7 +276,7 @@ describe("Image Undo — Device Type Deletion", () => {
     const devices: PlacedDevice[] = [];
     const store = createMockDeviceTypeStore(deviceTypes, devices);
 
-    const cmd = createDeleteDeviceTypeCommand(deviceType, [], store);
+    const cmd = createDeleteDeviceTypeCommand(deviceType, [], store, [], TEST_LAYOUT_ID);
 
     cmd.execute();
     expect(() => cmd.undo()).not.toThrow();
@@ -338,8 +346,10 @@ describe("Image Undo — Cross-Rack Move (#1478)", () => {
       updateDeviceIpRaw() {},
     };
 
+    const parentKey = placementKey(TEST_LAYOUT_ID, device.id);
+    const remappedKey = placementKey(TEST_LAYOUT_ID, remappedId);
     imageStore.setDeviceImage(
-      "placement-parent-1",
+      parentKey,
       "front",
       createMockImageData("server-front.png"),
     );
@@ -353,19 +363,21 @@ describe("Image Undo — Cross-Rack Move (#1478)", () => {
       device,
       [],
       store,
+      "device",
+      TEST_LAYOUT_ID,
     );
 
     cmd.execute();
     // After execute: device is in target with remapped ID; image must follow
-    expect(imageStore.hasImage("placement-parent-1", "front")).toBe(false);
-    expect(imageStore.hasImage(`placement-${remappedId}`, "front")).toBe(true);
+    expect(imageStore.hasImage(parentKey, "front")).toBe(false);
+    expect(imageStore.hasImage(remappedKey, "front")).toBe(true);
 
     cmd.undo();
     // After undo: device is back in source with original ID; image must follow back
-    expect(imageStore.hasImage(`placement-${remappedId}`, "front")).toBe(false);
-    expect(imageStore.hasImage("placement-parent-1", "front")).toBe(true);
+    expect(imageStore.hasImage(remappedKey, "front")).toBe(false);
+    expect(imageStore.hasImage(parentKey, "front")).toBe(true);
     expect(
-      imageStore.getDeviceImage("placement-parent-1", "front")?.filename,
+      imageStore.getDeviceImage(parentKey, "front")?.filename,
     ).toBe("server-front.png");
   });
 
@@ -437,13 +449,17 @@ describe("Image Undo — Cross-Rack Move (#1478)", () => {
       updateDeviceIpRaw() {},
     };
 
+    const child1Key = placementKey(TEST_LAYOUT_ID, child1.id);
+    const child2Key = placementKey(TEST_LAYOUT_ID, child2.id);
+    const remappedChild1Key = placementKey(TEST_LAYOUT_ID, remappedChild1);
+    const remappedChild2Key = placementKey(TEST_LAYOUT_ID, remappedChild2);
     imageStore.setDeviceImage(
-      "placement-child-1",
+      child1Key,
       "front",
       createMockImageData("child-1-front.png"),
     );
     imageStore.setDeviceImage(
-      "placement-child-2",
+      child2Key,
       "rear",
       createMockImageData("child-2-rear.png"),
     );
@@ -457,28 +473,22 @@ describe("Image Undo — Cross-Rack Move (#1478)", () => {
       parent,
       [child1, child2],
       store,
+      "device",
+      TEST_LAYOUT_ID,
     );
 
     cmd.execute();
     // Child images must follow their remapped IDs
-    expect(imageStore.hasImage("placement-child-1", "front")).toBe(false);
-    expect(imageStore.hasImage(`placement-${remappedChild1}`, "front")).toBe(
-      true,
-    );
-    expect(imageStore.hasImage("placement-child-2", "rear")).toBe(false);
-    expect(imageStore.hasImage(`placement-${remappedChild2}`, "rear")).toBe(
-      true,
-    );
+    expect(imageStore.hasImage(child1Key, "front")).toBe(false);
+    expect(imageStore.hasImage(remappedChild1Key, "front")).toBe(true);
+    expect(imageStore.hasImage(child2Key, "rear")).toBe(false);
+    expect(imageStore.hasImage(remappedChild2Key, "rear")).toBe(true);
 
     cmd.undo();
     // After undo: child images return to original keys
-    expect(imageStore.hasImage(`placement-${remappedChild1}`, "front")).toBe(
-      false,
-    );
-    expect(imageStore.hasImage("placement-child-1", "front")).toBe(true);
-    expect(imageStore.hasImage(`placement-${remappedChild2}`, "rear")).toBe(
-      false,
-    );
-    expect(imageStore.hasImage("placement-child-2", "rear")).toBe(true);
+    expect(imageStore.hasImage(remappedChild1Key, "front")).toBe(false);
+    expect(imageStore.hasImage(child1Key, "front")).toBe(true);
+    expect(imageStore.hasImage(remappedChild2Key, "rear")).toBe(false);
+    expect(imageStore.hasImage(child2Key, "rear")).toBe(true);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

- Adds `src/lib/utils/placement-key.ts` with `placementKey(layoutId, deviceId)` helper
- Changes the global image store key format from `placement-<deviceId>` to `placement-<layoutId>:<deviceId>` across all ~15 call sites
- Colon separator is safe because UUIDs only use hex digits and hyphens
- Archive extraction is backward-compatible: `deviceIdFromPlacementKey` handles both the new namespaced format and the legacy flat format

## Call sites updated

- `EditPanelImage.svelte`: image upload/clear
- `RackDevice.svelte`: image lookup for rendering
- `commands/device.ts`: `createRemoveDeviceCommand`, `createCrossRackMoveCommand` (rekey on ID remap)
- `commands/device-type.ts`: `createDeleteDeviceTypeCommand`
- `layout/recorded-device-actions.ts`, `recorded-device-type-actions.ts`, `device-actions.ts`
- `utils/archive.ts`: ZIP export (`createFolderArchive`) and import (`extractNewFormatZip`, `extractOldFormatZip`)
- `utils/export/svg.ts`: `generateExportSVG`, `generateSingleRackSVG` (with backward-compat fallback when no `layoutId` provided)
- `utils/export/multi.ts`: `exportAsZip`, `exportAsMultiPagePDF`
- `components/ExportDialog.svelte`, `DialogOrchestrator.svelte`, `utils/app-actions.ts`

## Test plan

- [x] `image-undo.test.ts` updated to use namespaced keys and `TEST_LAYOUT_ID` - 47 tests pass
- [x] `commands-device.test.ts`, `commands-device-type.test.ts`, `export-placement-images.test.ts` - all pass
- [x] ESLint clean
- [x] TypeScript strict check clean (pre-existing wizard/index.ts error unrelated)

Closes #2270

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep placement images separate for each layout**

### What Changed
- Placement images now use the current layout’s ID in their storage key, so opening the same device in multiple layouts or tabs no longer causes image mix-ups
- Device removal, cross-rack moves, and device type deletion now remove and restore the correct placement images for the active layout
- Export, preview, and archive import/export now read and write the new layout-scoped placement image format, while still handling older saved files

### Impact
`✅ Fewer image mix-ups between open layouts`
`✅ Correct placement image restore after undo`
`✅ Cleaner exports and imports for saved layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
