### PR TITLE
feat: floating object verb bars for devices and racks (#2075)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -656,6 +656,7 @@
                 onrackrename={handleRackContextRename}
                 onrackduplicate={handleRackContextDuplicate}
                 onrackdelete={handleRackContextDelete}
+                ondelete={handleDelete}
               />
 
               <CanvasViewControls
@@ -685,6 +686,7 @@
           onrackrename={handleRackContextRename}
           onrackduplicate={handleRackContextDuplicate}
           onrackdelete={handleRackContextDelete}
+          ondelete={handleDelete}
         />
       {/if}
     </main>

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -47,6 +47,9 @@ export type ActionId =
   | "toggle-sidebar"
   | "move-device-up"
   | "move-device-down"
+  | "flip-device-face"
+  | "focus-rack"
+  | "export-rack"
   | "cycle-rack-prev"
   | "cycle-rack-next"
   | "escape"
@@ -243,6 +246,30 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     ],
     enabledWhen: (ctx) => ctx.isDeviceSelected || ctx.isRackSelected,
     keywords: ["copy", "clone"],
+  },
+  {
+    id: "flip-device-face",
+    label: "Flip face",
+    scope: "selection",
+    bindings: [],
+    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    keywords: ["rotate", "front", "rear", "face"],
+  },
+  {
+    id: "focus-rack",
+    label: "Focus",
+    scope: "selection",
+    bindings: [],
+    enabledWhen: (ctx) => ctx.isRackSelected,
+    keywords: ["zoom", "centre", "center"],
+  },
+  {
+    id: "export-rack",
+    label: "Export",
+    scope: "selection",
+    bindings: [],
+    enabledWhen: (ctx) => ctx.isRackSelected,
+    keywords: ["download", "svg", "pdf", "png"],
   },
 
   // --- File -----------------------------------------------------------------

--- a/src/lib/actions/selection-actions.ts
+++ b/src/lib/actions/selection-actions.ts
@@ -10,7 +10,7 @@ import { getLayoutStore } from "$lib/stores/layout.svelte";
 import { getSelectionStore } from "$lib/stores/selection.svelte";
 import { getToastStore } from "$lib/stores/toast.svelte";
 import { findNextValidPosition } from "$lib/utils/device-movement";
-import { isContainerChild } from "$lib/utils/collision";
+import { canPlaceDevice, isContainerChild } from "$lib/utils/collision";
 import { toHumanUnits } from "$lib/utils/position";
 import type { DeviceFace } from "$lib/types";
 
@@ -114,14 +114,63 @@ export function duplicateSelection(): void {
 }
 
 /**
- * Toggle the selected device's mounting face between "front" and "rear".
- * Only "rear" flips to "front"; every other value (a missing face, "front",
- * or "both") flips to "rear". No-op if no device is selected.
+ * Toggle a placed device's mounting face between "front" and "rear". Only
+ * "rear" flips to "front"; every other value (a missing face, "front", or
+ * "both") flips to "rear".
+ *
+ * Validates the target face is clear (matching the edit panel's face change)
+ * and leaves container children untouched, since their face is inherited from
+ * the parent container. Shared by the verb bar (selection) and the device
+ * context menu (right-clicked target), so all flip surfaces behave the same.
+ */
+export function flipDeviceFaceAt(
+  layoutStore: ReturnType<typeof getLayoutStore>,
+  toastStore: ReturnType<typeof getToastStore>,
+  rackId: string,
+  deviceIndex: number,
+): void {
+  const rack = layoutStore.getRackById(rackId);
+  if (!rack) return;
+
+  const placedDevice = rack.devices[deviceIndex];
+  if (!placedDevice) return;
+  if (isContainerChild(placedDevice)) return;
+
+  const deviceType = layoutStore.device_types.find(
+    (d) => d.slug === placedDevice.device_type,
+  );
+  if (!deviceType) return;
+
+  const currentFace = placedDevice.face ?? "front";
+  const newFace: DeviceFace = currentFace === "rear" ? "front" : "rear";
+
+  if (
+    !canPlaceDevice(
+      rack,
+      layoutStore.device_types,
+      deviceType.u_height,
+      placedDevice.position,
+      deviceIndex,
+      newFace,
+    )
+  ) {
+    toastStore.showToast(
+      `Cannot flip to ${newFace}: the face is blocked`,
+      "error",
+    );
+    return;
+  }
+
+  layoutStore.updateDeviceFace(rackId, deviceIndex, newFace);
+  toastStore.showToast(`Flipped to ${newFace}`, "success");
+}
+
+/**
+ * Flip the currently selected device's face. No-op if no device is selected.
  */
 export function flipSelectedDeviceFace(): void {
   const selectionStore = getSelectionStore();
   const layoutStore = getLayoutStore();
-  const toastStore = getToastStore();
 
   if (!selectionStore.isDeviceSelected) return;
   if (
@@ -136,17 +185,10 @@ export function flipSelectedDeviceFace(): void {
   const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
   if (deviceIndex === null) return;
 
-  const placedDevice = rack.devices[deviceIndex];
-  if (!placedDevice) return;
-
-  const currentFace = placedDevice.face ?? "front";
-  const newFace: DeviceFace = currentFace === "rear" ? "front" : "rear";
-
-  layoutStore.updateDeviceFace(
-    selectionStore.selectedRackId!,
+  flipDeviceFaceAt(
+    layoutStore,
+    getToastStore(),
+    selectionStore.selectedRackId,
     deviceIndex,
-    newFace,
   );
-
-  toastStore.showToast(`Flipped to ${newFace}`, "success");
 }

--- a/src/lib/actions/selection-actions.ts
+++ b/src/lib/actions/selection-actions.ts
@@ -115,8 +115,8 @@ export function duplicateSelection(): void {
 
 /**
  * Toggle the selected device's mounting face between "front" and "rear".
- * Treats a missing or "both" face as "front" and flips to "rear".
- * No-op if no device is selected.
+ * Only "rear" flips to "front"; every other value (a missing face, "front",
+ * or "both") flips to "rear". No-op if no device is selected.
  */
 export function flipSelectedDeviceFace(): void {
   const selectionStore = getSelectionStore();

--- a/src/lib/actions/selection-actions.ts
+++ b/src/lib/actions/selection-actions.ts
@@ -1,0 +1,152 @@
+/**
+ * Centralized selection-aware verb handlers.
+ *
+ * Each function reads live selection state from the stores and acts on it.
+ * They are shared by the keyboard handler, floating verb bars, and context
+ * menus so all surfaces use one implementation.
+ */
+
+import { getLayoutStore } from "$lib/stores/layout.svelte";
+import { getSelectionStore } from "$lib/stores/selection.svelte";
+import { getToastStore } from "$lib/stores/toast.svelte";
+import { findNextValidPosition } from "$lib/utils/device-movement";
+import { isContainerChild } from "$lib/utils/collision";
+import { toHumanUnits } from "$lib/utils/position";
+import type { DeviceFace } from "$lib/types";
+
+/**
+ * Move the selected device up one valid position in the rack.
+ * No-op if no device is selected or if the device is a container child.
+ */
+export function moveSelectedDeviceUp(): void {
+  _moveSelectedDevice(1);
+}
+
+/**
+ * Move the selected device down one valid position in the rack.
+ * No-op if no device is selected or if the device is a container child.
+ */
+export function moveSelectedDeviceDown(): void {
+  _moveSelectedDevice(-1);
+}
+
+function _moveSelectedDevice(direction: 1 | -1): void {
+  const selectionStore = getSelectionStore();
+  const layoutStore = getLayoutStore();
+
+  if (!selectionStore.isDeviceSelected) return;
+  if (
+    selectionStore.selectedRackId === null ||
+    selectionStore.selectedDeviceId === null
+  )
+    return;
+
+  const rack = layoutStore.getRackById(selectionStore.selectedRackId);
+  if (!rack) return;
+
+  const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
+  if (deviceIndex === null) return;
+
+  const placedDevice = rack.devices[deviceIndex];
+  if (placedDevice && isContainerChild(placedDevice)) return;
+
+  const result = findNextValidPosition(
+    rack,
+    layoutStore.device_types,
+    deviceIndex,
+    direction,
+  );
+
+  if (result.success && result.newPosition !== null) {
+    const humanPosition = toHumanUnits(result.newPosition);
+    layoutStore.moveDevice(
+      selectionStore.selectedRackId!,
+      deviceIndex,
+      humanPosition,
+    );
+  }
+}
+
+/**
+ * Duplicate the currently selected item (device takes priority over rack).
+ * No-op if nothing is selected.
+ */
+export function duplicateSelection(): void {
+  const selectionStore = getSelectionStore();
+  const layoutStore = getLayoutStore();
+  const toastStore = getToastStore();
+
+  if (
+    selectionStore.isDeviceSelected &&
+    selectionStore.selectedRackId &&
+    selectionStore.selectedDeviceId
+  ) {
+    const rack = layoutStore.getRackById(selectionStore.selectedRackId);
+    if (!rack) return;
+
+    const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
+    if (deviceIndex === null) return;
+
+    const result = layoutStore.duplicateDevice(
+      selectionStore.selectedRackId,
+      deviceIndex,
+    );
+    if (result.error) {
+      toastStore.showToast(result.error, "error");
+    } else if (result.device) {
+      selectionStore.selectDevice(
+        selectionStore.selectedRackId,
+        result.device.id,
+      );
+      toastStore.showToast("Device duplicated", "success");
+    }
+    return;
+  }
+
+  if (selectionStore.isRackSelected && selectionStore.selectedRackId) {
+    const result = layoutStore.duplicateRack(selectionStore.selectedRackId);
+    if (result.error) {
+      toastStore.showToast(result.error, "error");
+    } else if (result.rack) {
+      toastStore.showToast("Rack duplicated", "success");
+    }
+  }
+}
+
+/**
+ * Toggle the selected device's mounting face between "front" and "rear".
+ * Treats a missing or "both" face as "front" and flips to "rear".
+ * No-op if no device is selected.
+ */
+export function flipSelectedDeviceFace(): void {
+  const selectionStore = getSelectionStore();
+  const layoutStore = getLayoutStore();
+  const toastStore = getToastStore();
+
+  if (!selectionStore.isDeviceSelected) return;
+  if (
+    selectionStore.selectedRackId === null ||
+    selectionStore.selectedDeviceId === null
+  )
+    return;
+
+  const rack = layoutStore.getRackById(selectionStore.selectedRackId);
+  if (!rack) return;
+
+  const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
+  if (deviceIndex === null) return;
+
+  const placedDevice = rack.devices[deviceIndex];
+  if (!placedDevice) return;
+
+  const currentFace = placedDevice.face ?? "front";
+  const newFace: DeviceFace = currentFace === "rear" ? "front" : "rear";
+
+  layoutStore.updateDeviceFace(
+    selectionStore.selectedRackId!,
+    deviceIndex,
+    newFace,
+  );
+
+  toastStore.showToast(`Flipped to ${newFace}`, "success");
+}

--- a/src/lib/actions/verb-bars.ts
+++ b/src/lib/actions/verb-bars.ts
@@ -1,0 +1,61 @@
+/**
+ * Verb-bar projection: maps the action registry onto the floating verb bars
+ * shown when a device or rack is selected. Consumers render these lists
+ * directly; dispatch is wired at the call site.
+ *
+ * Priority: when isDeviceSelected is true, the device list is used regardless
+ * of isRackSelected (device selection takes precedence).
+ */
+
+import {
+  getActionById,
+  type ActionDefinition,
+  type ActionEnabledContext,
+  type ActionId,
+} from "$lib/actions/registry";
+
+/** Ordered verb ids shown when a device is selected. */
+export const DEVICE_VERB_IDS: ActionId[] = [
+  "move-device-up",
+  "move-device-down",
+  "flip-device-face",
+  "duplicate-selection",
+  "delete-selection",
+];
+
+/** Ordered verb ids shown when a rack is selected. */
+export const RACK_VERB_IDS: ActionId[] = [
+  "duplicate-selection",
+  "focus-rack",
+  "export-rack",
+  "delete-selection",
+];
+
+/**
+ * Return the verb bar actions appropriate for the current selection, filtered
+ * by each action's enabledWhen predicate. Returns an empty array when nothing
+ * is selected. Preserves list order.
+ */
+export function getVerbsForSelection(
+  ctx: ActionEnabledContext,
+): ActionDefinition[] {
+  let ids: ActionId[];
+
+  if (ctx.isDeviceSelected) {
+    ids = DEVICE_VERB_IDS;
+  } else if (ctx.isRackSelected) {
+    ids = RACK_VERB_IDS;
+  } else {
+    return [];
+  }
+
+  const result: ActionDefinition[] = [];
+  for (const id of ids) {
+    const action = getActionById(id);
+    if (!action) continue;
+    if (action.enabledWhen === undefined || action.enabledWhen(ctx)) {
+      result.push(action);
+    }
+  }
+  return result;
+}

--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -414,6 +414,7 @@
       >
         <div
           class="bay-container"
+          data-rack-id={rack.id}
           class:active={isActive}
           class:selected={isSelected}
           role="presentation"
@@ -491,6 +492,7 @@
         >
           <div
             class="bay-container"
+            data-rack-id={rack.id}
             class:active={isActive}
             class:selected={isSelected}
             role="presentation"

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -30,6 +30,7 @@
   import RackCanvasView from "./RackCanvasView.svelte";
   import WelcomeScreen from "./WelcomeScreen.svelte";
   import CanvasContextMenu from "./CanvasContextMenu.svelte";
+  import VerbBarOverlay from "./VerbBarOverlay.svelte";
 
   const ONBOARDING_HINT_KEY = "Rackula_onboarding_hint_dismissed";
 
@@ -87,6 +88,8 @@
     onrackduplicate?: (rackId: string) => void;
     /** Rack context menu: delete rack callback */
     onrackdelete?: (rackId: string) => void;
+    /** Delete the current selection (device or rack), for the floating verb bar. */
+    ondelete?: () => void;
   }
 
   let {
@@ -110,6 +113,7 @@
     onrackrename,
     onrackduplicate,
     onrackdelete,
+    ondelete,
   }: Props = $props();
 
   const layoutStore = getLayoutStore();
@@ -391,6 +395,12 @@
           {onrackdelete}
         />
       </div>
+      <VerbBarOverlay
+        canvasEl={canvasContainer}
+        {ondelete}
+        {onrackfocus}
+        {onrackexport}
+      />
     {:else}
       <WelcomeScreen
         templates={starterTemplates}

--- a/src/lib/components/DeviceContextMenu.svelte
+++ b/src/lib/components/DeviceContextMenu.svelte
@@ -25,6 +25,8 @@
     onmoveup?: () => void;
     /** Move device down callback */
     onmovedown?: () => void;
+    /** Flip device face callback */
+    onflip?: () => void;
     /** Delete device callback */
     ondelete?: () => void;
     /** Whether move up is available */
@@ -55,6 +57,7 @@
     onduplicate,
     onmoveup,
     onmovedown,
+    onflip,
     ondelete,
     canMoveUp = true,
     canMoveDown = true,
@@ -145,6 +148,14 @@
       >
         <span class="context-menu-label">Move Down</span>
         <span class="context-menu-shortcut">&darr;</span>
+      </ContextMenu.Item>
+
+      <ContextMenu.Item
+        class="context-menu-item"
+        data-testid="ctx-menu-item"
+        onSelect={handleSelect(onflip)}
+      >
+        <span class="context-menu-label">Flip face</span>
       </ContextMenu.Item>
 
       <ContextMenu.Separator class="context-menu-separator" />

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -11,9 +11,11 @@
   import { getUIStore } from "$lib/stores/ui.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
-  import { findNextValidPosition } from "$lib/utils/device-movement";
-  import { isContainerChild } from "$lib/utils/collision";
-  import { toHumanUnits } from "$lib/utils/position";
+  import {
+    moveSelectedDeviceUp,
+    moveSelectedDeviceDown,
+    duplicateSelection,
+  } from "$lib/actions/selection-actions";
 
   interface Props {
     onsave?: () => void;
@@ -94,11 +96,14 @@
    * Dispatch map from registry action id to its runtime handler. The actions
    * registry owns command metadata and keybindings; this map binds each
    * command id to the closure that runs it in this app context.
+   *
+   * Typed as Partial so that action ids added to the registry without a
+   * keyboard binding (e.g. verb-bar-only commands) don't require an entry here.
    */
-  const dispatch: Record<ActionId, () => void> = {
+  const dispatch: Partial<Record<ActionId, () => void>> = {
     escape: handleEscape,
-    "move-device-up": () => moveSelectedDevice(1),
-    "move-device-down": () => moveSelectedDevice(-1),
+    "move-device-up": moveSelectedDeviceUp,
+    "move-device-down": moveSelectedDeviceDown,
     "delete-selection": () => ondelete?.(),
     "fit-all": () => onfitall?.(),
     "toggle-sidebar": () => uiStore.toggleLeftDrawer(),
@@ -112,57 +117,10 @@
     load: () => onload?.(),
     export: () => onexport?.(),
     share: () => onshare?.(),
-    "duplicate-selection": () => duplicateSelected(),
+    "duplicate-selection": duplicateSelection,
     "show-help": () => onhelp?.(),
     "toggle-display-mode": () => ontoggledisplaymode?.(),
   };
-
-  /**
-   * Move the selected device up or down, using shared movement utility.
-   * Leapfrogs over blocking devices to find valid positions.
-   * @param direction - 1 for up (higher U), -1 for down (lower U)
-   */
-  function moveSelectedDevice(direction: 1 | -1) {
-    if (!selectionStore.isDeviceSelected) return;
-    if (
-      selectionStore.selectedRackId === null ||
-      selectionStore.selectedDeviceId === null
-    )
-      return;
-
-    // Get the rack containing the selected device
-    const rack = layoutStore.getRackById(selectionStore.selectedRackId);
-    if (!rack) return;
-
-    // Get device index from ID (UUID-based tracking)
-    const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
-    if (deviceIndex === null) return;
-
-    // Contained children use container-relative positions; nudging them with
-    // arrow keys would compute a rack-level U and eject them from the
-    // container. Block this at the keyboard entry point only — the store-level
-    // moveDevice path (used by drag-out) intentionally detaches.
-    const placedDevice = rack.devices[deviceIndex];
-    if (placedDevice && isContainerChild(placedDevice)) return;
-
-    // Use shared utility to find next valid position
-    const result = findNextValidPosition(
-      rack,
-      layoutStore.device_types,
-      deviceIndex,
-      direction,
-    );
-
-    if (result.success && result.newPosition !== null) {
-      // Convert internal units back to human units for the store API
-      const humanPosition = toHumanUnits(result.newPosition);
-      layoutStore.moveDevice(
-        selectionStore.selectedRackId!,
-        deviceIndex,
-        humanPosition,
-      );
-    }
-  }
 
   /**
    * Cycle to the next or previous rack
@@ -195,74 +153,6 @@
     layoutStore.setActiveRack(newRack.id);
     selectionStore.selectRack(newRack.id);
     toastStore.showToast(`Active: ${newRack.name}`, "info");
-  }
-
-  /**
-   * Duplicate the currently selected item (device or rack)
-   * If a device is selected, duplicates the device
-   * If only a rack is selected, duplicates the rack
-   */
-  function duplicateSelected() {
-    // Priority 1: Duplicate selected device
-    if (
-      selectionStore.isDeviceSelected &&
-      selectionStore.selectedRackId &&
-      selectionStore.selectedDeviceId
-    ) {
-      duplicateSelectedDevice();
-      return;
-    }
-
-    // Priority 2: Duplicate selected rack
-    if (selectionStore.isRackSelected && selectionStore.selectedRackId) {
-      duplicateSelectedRack();
-      return;
-    }
-  }
-
-  /**
-   * Duplicate the selected device
-   */
-  function duplicateSelectedDevice() {
-    if (!selectionStore.selectedRackId || !selectionStore.selectedDeviceId)
-      return;
-
-    // Get the rack containing the selected device
-    const rack = layoutStore.getRackById(selectionStore.selectedRackId);
-    if (!rack) return;
-
-    // Get device index from ID (UUID-based tracking)
-    const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
-    if (deviceIndex === null) return;
-
-    const result = layoutStore.duplicateDevice(
-      selectionStore.selectedRackId,
-      deviceIndex,
-    );
-    if (result.error) {
-      toastStore.showToast(result.error, "error");
-    } else if (result.device) {
-      // Select the newly duplicated device
-      selectionStore.selectDevice(
-        selectionStore.selectedRackId,
-        result.device.id,
-      );
-      toastStore.showToast("Device duplicated", "success");
-    }
-  }
-
-  /**
-   * Duplicate the selected rack
-   */
-  function duplicateSelectedRack() {
-    if (!selectionStore.selectedRackId) return;
-
-    const result = layoutStore.duplicateRack(selectionStore.selectedRackId);
-    if (result.error) {
-      toastStore.showToast(result.error, "error");
-    } else if (result.rack) {
-      toastStore.showToast("Rack duplicated", "success");
-    }
   }
 
   /**
@@ -299,7 +189,7 @@
     if (!action) return;
 
     event.preventDefault();
-    dispatch[action.id]();
+    dispatch[action.id]?.();
   }
 </script>
 

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -552,6 +552,7 @@
     onduplicate={() => ctxMenu.handleDuplicate(rack)}
     onmoveup={() => ctxMenu.handleMoveUp(rack, deviceLibrary)}
     onmovedown={() => ctxMenu.handleMoveDown(rack)}
+    onflip={() => ctxMenu.handleFlip(rack)}
     ondelete={() => ctxMenu.handleDelete()}
     canMoveUp={contextActions.getCanMoveUp(
       rack,

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -534,6 +534,7 @@
 <g
   bind:this={groupElement}
   data-device-id={device.slug}
+  data-device-uuid={placedDeviceId}
   data-device-position={position}
   data-testid="rack-device"
   transform="translate({RAIL_WIDTH + slotXOffset}, {yPosition})"

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -262,6 +262,7 @@
   <div
     bind:this={containerElement}
     class="rack-dual-view"
+    data-rack-id={rack.id}
     class:selected
     class:active={isActive}
     class:long-press-active={longPressActive}

--- a/src/lib/components/VerbBar.svelte
+++ b/src/lib/components/VerbBar.svelte
@@ -1,0 +1,165 @@
+<!--
+  VerbBar Component (#2075)
+
+  A presentation-only floating toolbar that renders a row of icon verb buttons
+  for the current selection. It does not position itself, read stores, or own
+  layering: the overlay measures geometry, positions a container, and passes the
+  ordered, already-enabled verbs plus a dispatch callback in as props.
+
+  Accessibility: the toolbar uses a roving tabindex (one button in the tab order
+  at a time) with ArrowLeft/ArrowRight wrapping and Home/End jumps. Each button
+  is icon-only with an aria-label and title. Activation (click, Enter, Space) is
+  handled natively by the buttons and forwarded through ondispatch.
+-->
+<script lang="ts">
+  import type { ActionId } from "$lib/actions/registry";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+  import { nextRovingIndex } from "$lib/utils/roving-index";
+  import type { Component } from "svelte";
+  import {
+    IconChevronUp,
+    IconChevronDown,
+    IconCopy,
+    IconDownloadBold,
+    IconFitAllBold,
+    IconFlip,
+    IconTrash,
+  } from "./icons";
+
+  export interface VerbItem {
+    id: ActionId;
+    label: string;
+  }
+
+  interface Props {
+    verbs: VerbItem[];
+    ariaLabel: string;
+    ondispatch: (id: ActionId) => void;
+  }
+
+  let { verbs, ariaLabel, ondispatch }: Props = $props();
+
+  const iconForVerb: Partial<Record<ActionId, Component<{ size?: number }>>> = {
+    "move-device-up": IconChevronUp,
+    "move-device-down": IconChevronDown,
+    "flip-device-face": IconFlip,
+    "duplicate-selection": IconCopy,
+    "delete-selection": IconTrash,
+    "focus-rack": IconFitAllBold,
+    "export-rack": IconDownloadBold,
+  };
+
+  // The active button is the only one in the tab order. It defaults to the
+  // first button. Keydown moves it; the verb list changing can leave it stale,
+  // so the rendered tabindex reads from a clamped derived value rather than
+  // mutating state in an effect.
+  let activeIndex = $state(0);
+  let buttons = $state<HTMLButtonElement[]>([]);
+
+  const clampedActiveIndex = $derived(
+    verbs.length > 0 ? Math.min(activeIndex, verbs.length - 1) : 0,
+  );
+
+  function isDestructive(id: ActionId): boolean {
+    return id === "delete-selection";
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    const next = nextRovingIndex(clampedActiveIndex, event.key, verbs.length);
+    if (next === clampedActiveIndex) return;
+    event.preventDefault();
+    activeIndex = next;
+    buttons[next]?.focus();
+  }
+</script>
+
+{#if verbs.length > 0}
+  <div
+    class="verb-bar"
+    role="toolbar"
+    aria-label={ariaLabel}
+    aria-orientation="horizontal"
+    tabindex="-1"
+    onkeydown={handleKeydown}
+  >
+    {#each verbs as verb, index (verb.id)}
+      {@const Icon = iconForVerb[verb.id]}
+      <button
+        bind:this={buttons[index]}
+        class="verb-button"
+        class:destructive={isDestructive(verb.id)}
+        type="button"
+        aria-label={verb.label}
+        title={verb.label}
+        tabindex={index === clampedActiveIndex ? 0 : -1}
+        onclick={() => ondispatch(verb.id)}
+      >
+        {#if Icon}
+          <Icon size={ICON_SIZE.md} />
+        {/if}
+      </button>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .verb-bar {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    border-radius: var(--radius-full);
+    border: 1px solid var(--bottom-nav-border);
+    background: var(--bottom-nav-bg);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .verb-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--touch-target-min);
+    min-height: var(--touch-target-min);
+    width: var(--touch-target-min);
+    height: var(--touch-target-min);
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-full);
+    background: transparent;
+    color: var(--colour-text);
+    cursor: pointer;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .verb-button:hover {
+    background: var(--colour-overlay-hover);
+    color: var(--colour-primary);
+  }
+
+  .verb-button:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring-glow);
+    color: var(--colour-primary);
+  }
+
+  .verb-button.destructive:hover,
+  .verb-button.destructive:focus-visible {
+    color: var(--colour-button-destructive);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .verb-button {
+      transition:
+        background-color var(--duration-fast) var(--ease-out),
+        color var(--duration-fast) var(--ease-out),
+        transform var(--duration-fast) var(--ease-out);
+    }
+
+    .verb-button:active {
+      transform: scale(0.97);
+    }
+  }
+</style>

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -1,0 +1,214 @@
+<!--
+  VerbBarOverlay (#2075)
+
+  The canvas-side host for the floating verb bar. It owns everything VerbBar
+  deliberately does not: reading the selection, building the action context,
+  measuring the selected object's screen geometry, positioning the bar in
+  screen space, and dispatching verbs to the shared selection-action handlers.
+
+  It mounts as a screen-space sibling of the panzoom-transformed container so
+  its coordinates are viewport pixels (position: fixed), unaffected by the
+  canvas transform. VerbBar stays presentation-only.
+-->
+<script lang="ts">
+  import VerbBar from "./VerbBar.svelte";
+  import { getVerbsForSelection } from "$lib/actions/verb-bars";
+  import {
+    computeVerbBarPosition,
+    type VerbBarPosition,
+  } from "$lib/utils/verb-bar-position";
+  import type { ActionEnabledContext, ActionId } from "$lib/actions/registry";
+  import {
+    moveSelectedDeviceUp,
+    moveSelectedDeviceDown,
+    flipSelectedDeviceFace,
+    duplicateSelection,
+  } from "$lib/actions/selection-actions";
+  import { getSelectionStore } from "$lib/stores/selection.svelte";
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getCanvasStore } from "$lib/stores/canvas.svelte";
+  import { getStorageMode } from "$lib/storage";
+
+  interface Props {
+    /** Screen-space canvas container the overlay measures and positions within. */
+    canvasEl: HTMLElement | null;
+    /** Delete the current selection (device or rack). */
+    ondelete?: () => void;
+    /** Focus the given racks (rack verb). */
+    onrackfocus?: (rackIds: string[]) => void;
+    /** Export the given racks (rack verb). */
+    onrackexport?: (rackIds: string[]) => void;
+  }
+
+  let { canvasEl, ondelete, onrackfocus, onrackexport }: Props = $props();
+
+  const selection = getSelectionStore();
+  const layout = getLayoutStore();
+  const canvas = getCanvasStore();
+
+  const ctx = $derived<ActionEnabledContext>({
+    hasSelection: selection.hasSelection,
+    isDeviceSelected: selection.isDeviceSelected,
+    isRackSelected: selection.isRackSelected,
+    canUndo: layout.canUndo,
+    canRedo: layout.canRedo,
+    hasRacks: layout.rackCount > 0,
+    mode: getStorageMode(),
+  });
+
+  const verbs = $derived(
+    getVerbsForSelection(ctx).map((a) => ({ id: a.id, label: a.label })),
+  );
+
+  const ariaLabel = $derived(
+    selection.isDeviceSelected ? "Device actions" : "Rack actions",
+  );
+
+  let barEl = $state<HTMLDivElement | null>(null);
+  let pos = $state<VerbBarPosition>({
+    visible: false,
+    left: 0,
+    top: 0,
+    placement: "above",
+  });
+
+  function dispatch(id: ActionId): void {
+    switch (id) {
+      case "move-device-up":
+        moveSelectedDeviceUp();
+        break;
+      case "move-device-down":
+        moveSelectedDeviceDown();
+        break;
+      case "flip-device-face":
+        flipSelectedDeviceFace();
+        break;
+      case "duplicate-selection":
+        duplicateSelection();
+        break;
+      case "delete-selection":
+        ondelete?.();
+        break;
+      case "focus-rack":
+        if (selection.selectedRackId) onrackfocus?.([selection.selectedRackId]);
+        break;
+      case "export-rack":
+        if (selection.selectedRackId)
+          onrackexport?.([selection.selectedRackId]);
+        break;
+    }
+  }
+
+  /** Resolve the DOM node to point at, plus the rack name to avoid (device bars). */
+  function findTarget(): { target: Element | null; rackName: Element | null } {
+    if (!canvasEl) return { target: null, rackName: null };
+
+    if (selection.isDeviceSelected && selection.selectedDeviceId) {
+      const target = canvasEl.querySelector(
+        `[data-device-uuid="${CSS.escape(selection.selectedDeviceId)}"]`,
+      );
+      let rackName: Element | null = null;
+      if (selection.selectedRackId) {
+        const rackEl = canvasEl.querySelector(
+          `[data-rack-id="${CSS.escape(selection.selectedRackId)}"]`,
+        );
+        rackName = rackEl?.querySelector(".rack-dual-view-name") ?? null;
+      }
+      return { target, rackName };
+    }
+
+    if (selection.isRackSelected && selection.selectedRackId) {
+      return {
+        target: canvasEl.querySelector(
+          `[data-rack-id="${CSS.escape(selection.selectedRackId)}"]`,
+        ),
+        rackName: null,
+      };
+    }
+
+    return { target: null, rackName: null };
+  }
+
+  function hide(): void {
+    if (pos.visible) pos = { ...pos, visible: false };
+  }
+
+  function measure(): void {
+    if (!barEl || verbs.length === 0) return hide();
+
+    const { target, rackName } = findTarget();
+    if (!target) return hide();
+
+    const barRect = barEl.getBoundingClientRect();
+    const next = computeVerbBarPosition({
+      target: target.getBoundingClientRect(),
+      rackName: rackName ? rackName.getBoundingClientRect() : null,
+      bar: { width: barRect.width, height: barRect.height },
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      scale: canvas.zoom,
+    });
+
+    if (
+      next.visible !== pos.visible ||
+      next.left !== pos.left ||
+      next.top !== pos.top ||
+      next.placement !== pos.placement
+    ) {
+      pos = next;
+    }
+  }
+
+  // Keep the bar pinned to the selected object. Pan has no reactive signal in
+  // the canvas store, so a requestAnimationFrame loop (running only while a bar
+  // is shown) tracks pan and zoom; a target or verb-set change re-runs this
+  // effect. measure() skips state writes when nothing moved, so an idle
+  // selection costs only a couple of getBoundingClientRect reads per frame and
+  // triggers no re-render.
+  $effect(() => {
+    void selection.selectedDeviceId;
+    void selection.selectedRackId;
+    void verbs;
+    if (verbs.length === 0) return;
+
+    let raf = 0;
+    const tick = () => {
+      measure();
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    const onReflow = () => measure();
+    window.addEventListener("resize", onReflow);
+    window.addEventListener("scroll", onReflow, true);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", onReflow);
+      window.removeEventListener("scroll", onReflow, true);
+    };
+  });
+</script>
+
+{#if verbs.length > 0}
+  <div
+    bind:this={barEl}
+    class="verb-bar-overlay"
+    class:hidden={!pos.visible}
+    style:left="{pos.left}px"
+    style:top="{pos.top}px"
+  >
+    <VerbBar {verbs} {ariaLabel} ondispatch={dispatch} />
+  </div>
+{/if}
+
+<style>
+  .verb-bar-overlay {
+    position: fixed;
+    z-index: var(--z-verb-bar, 50);
+  }
+
+  .verb-bar-overlay.hidden {
+    visibility: hidden;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -15,6 +15,7 @@
   import { getVerbsForSelection } from "$lib/actions/verb-bars";
   import {
     computeVerbBarPosition,
+    VERB_BAR_LOW_ZOOM_THRESHOLD,
     type VerbBarPosition,
   } from "$lib/utils/verb-bar-position";
   import type { ActionEnabledContext, ActionId } from "$lib/actions/registry";
@@ -135,6 +136,9 @@
 
   function measure(): void {
     if (!barEl || verbs.length === 0) return hide();
+    // The bar is hidden below this zoom anyway; skip the selector and layout
+    // reads while zoomed out (the rAF loop calls this every frame).
+    if (canvas.zoom < VERB_BAR_LOW_ZOOM_THRESHOLD) return hide();
 
     const { target, rackName } = findTarget();
     if (!target) return hide();

--- a/src/lib/components/icons/IconFlip.svelte
+++ b/src/lib/components/icons/IconFlip.svelte
@@ -1,0 +1,32 @@
+<!--
+  Flip icon (Iconoir)
+
+  Sizing: Uses size prop (default 20px).
+  Override by passing a different size value.
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <path d="M9.5 20H2L9.5 4V20Z" />
+  <path d="M20.125 20H22L21.0625 18" />
+  <path d="M16.375 20H14.5V18" />
+  <path d="M14.5 12V14" />
+  <path d="M18.25 12L19.1875 14" />
+  <path d="M16.375 8L14.5 4V8" />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -43,6 +43,9 @@ export { default as IconChevronDown } from "./IconChevronDown.svelte";
 export { default as IconChevronLeft } from "./IconChevronLeft.svelte";
 export { default as IconChevronRight } from "./IconChevronRight.svelte";
 
+// Transform icons
+export { default as IconFlip } from "./IconFlip.svelte";
+
 // Undo/Redo icons
 export { default as IconUndo } from "./IconUndo.svelte";
 export { default as IconRedo } from "./IconRedo.svelte";

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -343,6 +343,7 @@
   --z-toolbar: 20;
   --z-sidebar: 10;
   --z-placement-indicator: 50;
+  --z-verb-bar: 50;
   --z-drawer-backdrop: 99;
   --z-drawer: 100;
   --z-fab: 100;

--- a/src/lib/utils/rack-context-actions.ts
+++ b/src/lib/utils/rack-context-actions.ts
@@ -3,7 +3,7 @@
  * Factory for context menu handlers, extracted from Rack.svelte.
  */
 
-import type { Rack as RackType, DeviceType } from "$lib/types";
+import type { Rack as RackType, DeviceType, DeviceFace } from "$lib/types";
 import type { getLayoutStore } from "$lib/stores/layout.svelte";
 import type { getSelectionStore } from "$lib/stores/selection.svelte";
 import type { getToastStore } from "$lib/stores/toast.svelte";
@@ -34,6 +34,8 @@ export interface RackContextActions {
   ): void;
   /** Move the device one U-position downward. */
   handleMoveDown(rack: RackType, target: ContextMenuTarget): void;
+  /** Toggle the device's mounting face between front and rear. */
+  handleFlip(rack: RackType, target: ContextMenuTarget): void;
   /** Remove the device from the rack. */
   handleDelete(target: ContextMenuTarget): void;
   /** Whether the device can move up (checks bounds and collisions). */
@@ -104,6 +106,15 @@ export function createContextMenuActions(
     }
   }
 
+  function handleFlip(rack: RackType, target: ContextMenuTarget): void {
+    const device = rack.devices[target.deviceIndex];
+    if (!device) return;
+    const currentFace = device.face ?? "front";
+    const newFace: DeviceFace = currentFace === "rear" ? "front" : "rear";
+    layoutStore.updateDeviceFace(rack.id, target.deviceIndex, newFace);
+    toastStore.showToast(`Flipped to ${newFace}`, "success");
+  }
+
   function handleDelete(target: ContextMenuTarget): void {
     layoutStore.removeDeviceFromRack(target.rackId, target.deviceIndex);
     selectionStore.clearSelection();
@@ -156,6 +167,7 @@ export function createContextMenuActions(
     handleDuplicate,
     handleMoveUp,
     handleMoveDown,
+    handleFlip,
     handleDelete,
     getCanMoveUp,
     getCanMoveDown,

--- a/src/lib/utils/rack-context-actions.ts
+++ b/src/lib/utils/rack-context-actions.ts
@@ -3,12 +3,13 @@
  * Factory for context menu handlers, extracted from Rack.svelte.
  */
 
-import type { Rack as RackType, DeviceType, DeviceFace } from "$lib/types";
+import type { Rack as RackType, DeviceType } from "$lib/types";
 import type { getLayoutStore } from "$lib/stores/layout.svelte";
 import type { getSelectionStore } from "$lib/stores/selection.svelte";
 import type { getToastStore } from "$lib/stores/toast.svelte";
 import { toHumanUnits, toInternalUnits } from "$lib/utils/position";
 import { canPlaceDevice } from "$lib/utils/collision";
+import { flipDeviceFaceAt } from "$lib/actions/selection-actions";
 
 /** Identifies a right-clicked device and the screen position for the context menu. */
 export interface ContextMenuTarget {
@@ -107,12 +108,7 @@ export function createContextMenuActions(
   }
 
   function handleFlip(rack: RackType, target: ContextMenuTarget): void {
-    const device = rack.devices[target.deviceIndex];
-    if (!device) return;
-    const currentFace = device.face ?? "front";
-    const newFace: DeviceFace = currentFace === "rear" ? "front" : "rear";
-    layoutStore.updateDeviceFace(rack.id, target.deviceIndex, newFace);
-    toastStore.showToast(`Flipped to ${newFace}`, "success");
+    flipDeviceFaceAt(layoutStore, toastStore, rack.id, target.deviceIndex);
   }
 
   function handleDelete(target: ContextMenuTarget): void {

--- a/src/lib/utils/rack-context-menu-handlers.ts
+++ b/src/lib/utils/rack-context-menu-handlers.ts
@@ -5,7 +5,10 @@
  */
 
 import type { Rack, DeviceType } from "$lib/types";
-import type { RackContextActions, ContextMenuTarget } from "$lib/utils/rack-context-actions";
+import type {
+  RackContextActions,
+  ContextMenuTarget,
+} from "$lib/utils/rack-context-actions";
 
 export interface ContextMenuState {
   open: boolean;
@@ -13,12 +16,20 @@ export interface ContextMenuState {
 }
 
 export interface ContextMenuHandlers {
-  handleOpen(event: CustomEvent<{ rackId: string; deviceIndex: number; x: number; y: number }>): void;
+  handleOpen(
+    event: CustomEvent<{
+      rackId: string;
+      deviceIndex: number;
+      x: number;
+      y: number;
+    }>,
+  ): void;
   close(): void;
   handleEdit(rack: Rack): void;
   handleDuplicate(rack: Rack): void;
   handleMoveUp(rack: Rack, deviceLibrary: DeviceType[]): void;
   handleMoveDown(rack: Rack): void;
+  handleFlip(rack: Rack): void;
   handleDelete(): void;
 }
 
@@ -61,6 +72,12 @@ export function createContextMenuHandlers(
       const { target } = getState();
       if (!target) return;
       actions.handleMoveDown(rack, target);
+      close();
+    },
+    handleFlip(rack) {
+      const { target } = getState();
+      if (!target) return;
+      actions.handleFlip(rack, target);
       close();
     },
     handleDelete() {

--- a/src/lib/utils/roving-index.ts
+++ b/src/lib/utils/roving-index.ts
@@ -1,0 +1,35 @@
+/**
+ * Roving-tabindex index math for horizontal toolbars (#2075).
+ *
+ * A roving toolbar keeps exactly one button in the tab order (tabindex 0) and
+ * moves that active index with the arrow keys, wrapping at the ends, while
+ * Home/End jump to the first/last button. This is the pure index calculation;
+ * the component is responsible for applying focus to the resulting index.
+ *
+ * `count` is the number of focusable items. The returned index is always in
+ * `[0, count)` for a non-empty toolbar, or `0` when the toolbar is empty.
+ */
+export function nextRovingIndex(
+  current: number,
+  key: string,
+  count: number,
+): number {
+  if (count <= 0) return 0;
+
+  // Clamp a possibly stale current index into range so arrow math wraps
+  // predictably even if the caller passes an out-of-range value.
+  const index = Math.min(Math.max(current, 0), count - 1);
+
+  switch (key) {
+    case "ArrowRight":
+      return (index + 1) % count;
+    case "ArrowLeft":
+      return (index - 1 + count) % count;
+    case "Home":
+      return 0;
+    case "End":
+      return count - 1;
+    default:
+      return index;
+  }
+}

--- a/src/lib/utils/verb-bar-position.ts
+++ b/src/lib/utils/verb-bar-position.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure verb bar positioning math (#2075)
+ *
+ * Computes where to render a floating verb bar relative to a selected object.
+ * No DOM access, no globals - all inputs are plain numeric rects so the
+ * function is deterministic and unit-testable in isolation.
+ *
+ * Rules:
+ * 1. LOW ZOOM: hidden when scale < VERB_BAR_LOW_ZOOM_THRESHOLD.
+ * 2. HORIZONTAL: centred over the target, clamped within viewport margins.
+ * 3. VERTICAL: placed above by default; flipped below when the above placement
+ *    would run off the top of the viewport (aboveTop < VERB_BAR_MARGIN) OR
+ *    would cover the rack name label (aboveTop < rackName.bottom).
+ */
+
+/** Viewport-space bounding rectangle using plain numbers (no DOM dependency). */
+export interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  bottom: number;
+  right: number;
+}
+
+/** A width/height pair in pixels. */
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface VerbBarPositionInput {
+  /** Viewport-space rect of the selected object the bar points at (device row, or rack name). */
+  target: Rect;
+  /** Viewport-space rect of the rack name to avoid overlapping, if relevant (device bars). Optional. */
+  rackName?: Rect | null;
+  /** Measured size of the bar. */
+  bar: Size;
+  /** Viewport dimensions, for horizontal clamping. */
+  viewport: Size;
+  /** Current canvas zoom scale (1 = 100%). */
+  scale: number;
+}
+
+export type VerbBarPlacement = "above" | "below";
+
+export interface VerbBarPosition {
+  visible: boolean;
+  left: number;
+  top: number;
+  placement: VerbBarPlacement;
+}
+
+/** Gap in px between the bar and the target edge. */
+export const VERB_BAR_MARGIN = 8;
+
+/** Bar is hidden when zoom is below this scale to keep the UI uncluttered. */
+export const VERB_BAR_LOW_ZOOM_THRESHOLD = 0.5;
+
+/**
+ * Compute viewport coordinates for a floating verb bar.
+ *
+ * Returns visible:false when zoomed out below the threshold. Otherwise
+ * returns the clamped horizontal position and the above/below vertical
+ * position based on available space and rack-name collision avoidance.
+ */
+export function computeVerbBarPosition(
+  input: VerbBarPositionInput,
+): VerbBarPosition {
+  const { target, rackName, bar, viewport, scale } = input;
+
+  if (scale < VERB_BAR_LOW_ZOOM_THRESHOLD) {
+    return { visible: false, left: 0, top: 0, placement: "above" };
+  }
+
+  // Horizontal: centre over the target, clamped within viewport margins.
+  const rawLeft = target.left + target.width / 2 - bar.width / 2;
+  const maxLeft = viewport.width - bar.width - VERB_BAR_MARGIN;
+  const left = Math.max(VERB_BAR_MARGIN, Math.min(rawLeft, maxLeft));
+
+  // Vertical: prefer above, flip below on viewport-top or rack-name collision.
+  const aboveTop = target.top - VERB_BAR_MARGIN - bar.height;
+  const tooCloseToTop = aboveTop < VERB_BAR_MARGIN;
+  const coversRackName = rackName != null && aboveTop < rackName.bottom;
+  const flip = tooCloseToTop || coversRackName;
+
+  const placement: VerbBarPlacement = flip ? "below" : "above";
+  const top =
+    placement === "above" ? aboveTop : target.bottom + VERB_BAR_MARGIN;
+
+  return { visible: true, left, top, placement };
+}

--- a/src/tests/roving-index.test.ts
+++ b/src/tests/roving-index.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the roving-tabindex helper used by the floating verb bar (#2075).
+ *
+ * nextRovingIndex is the pure index math behind ArrowRight/ArrowLeft/Home/End
+ * navigation of a horizontal toolbar. The component owns the DOM focus; this
+ * helper only computes which index should become active next.
+ */
+import { describe, it, expect } from "vitest";
+import { nextRovingIndex } from "$lib/utils/roving-index";
+
+describe("nextRovingIndex", () => {
+  it("ArrowRight advances to the next index", () => {
+    expect(nextRovingIndex(0, "ArrowRight", 4)).toBe(1);
+    expect(nextRovingIndex(2, "ArrowRight", 4)).toBe(3);
+  });
+
+  it("ArrowRight wraps from the last index back to the first", () => {
+    expect(nextRovingIndex(3, "ArrowRight", 4)).toBe(0);
+  });
+
+  it("ArrowLeft moves to the previous index", () => {
+    expect(nextRovingIndex(2, "ArrowLeft", 4)).toBe(1);
+    expect(nextRovingIndex(1, "ArrowLeft", 4)).toBe(0);
+  });
+
+  it("ArrowLeft wraps from the first index to the last", () => {
+    expect(nextRovingIndex(0, "ArrowLeft", 4)).toBe(3);
+  });
+
+  it("Home jumps to the first index", () => {
+    expect(nextRovingIndex(3, "Home", 4)).toBe(0);
+    expect(nextRovingIndex(0, "Home", 4)).toBe(0);
+  });
+
+  it("End jumps to the last index", () => {
+    expect(nextRovingIndex(0, "End", 4)).toBe(3);
+    expect(nextRovingIndex(3, "End", 4)).toBe(3);
+  });
+
+  it("returns the current index for unrelated keys", () => {
+    expect(nextRovingIndex(2, "Enter", 4)).toBe(2);
+    expect(nextRovingIndex(2, " ", 4)).toBe(2);
+    expect(nextRovingIndex(2, "Tab", 4)).toBe(2);
+    expect(nextRovingIndex(2, "ArrowUp", 4)).toBe(2);
+  });
+
+  it("handles a single-item toolbar without moving", () => {
+    expect(nextRovingIndex(0, "ArrowRight", 1)).toBe(0);
+    expect(nextRovingIndex(0, "ArrowLeft", 1)).toBe(0);
+    expect(nextRovingIndex(0, "Home", 1)).toBe(0);
+    expect(nextRovingIndex(0, "End", 1)).toBe(0);
+  });
+
+  it("clamps a too-large current index into range before moving", () => {
+    expect(nextRovingIndex(9, "ArrowRight", 4)).toBe(0);
+    expect(nextRovingIndex(9, "ArrowLeft", 4)).toBe(2);
+    expect(nextRovingIndex(9, "Home", 4)).toBe(0);
+    expect(nextRovingIndex(9, "End", 4)).toBe(3);
+  });
+
+  it("returns 0 when the toolbar is empty", () => {
+    expect(nextRovingIndex(0, "ArrowRight", 0)).toBe(0);
+    expect(nextRovingIndex(3, "ArrowLeft", 0)).toBe(0);
+    expect(nextRovingIndex(0, "Home", 0)).toBe(0);
+    expect(nextRovingIndex(0, "End", 0)).toBe(0);
+  });
+});

--- a/src/tests/selection-actions.test.ts
+++ b/src/tests/selection-actions.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getSelectionStore,
+  resetSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
+import {
+  moveSelectedDeviceUp,
+  moveSelectedDeviceDown,
+  duplicateSelection,
+  flipSelectedDeviceFace,
+} from "$lib/actions/selection-actions";
+import {
+  createTestDeviceType,
+  createTestDeviceTypeInput,
+} from "./factories";
+import type { DeviceFace } from "$lib/types";
+
+function resetAll() {
+  resetLayoutStore();
+  resetSelectionStore();
+  resetToastStore();
+}
+
+/**
+ * Set up a rack with a single half-depth device placed on the given face.
+ * Returns the layout store, rack id, device id, and initial position.
+ */
+function setupHalfDepthDevice(face: DeviceFace = "front") {
+  const layout = getLayoutStore();
+  const rack = layout.addRack("Test Rack", 42);
+  if (!rack) throw new Error("addRack returned null");
+
+  const dt = createTestDeviceType({
+    slug: "half-depth-switch",
+    u_height: 1,
+    is_full_depth: false,
+  });
+  layout.addDeviceTypeRaw(dt);
+
+  const ok = layout.placeDevice(rack.id, dt.slug, 10, face);
+  if (!ok) throw new Error("placeDevice failed");
+
+  const placed = layout.getRackById(rack.id)!.devices[0]!;
+  return { layout, rackId: rack.id, deviceId: placed.id };
+}
+
+describe("selection-actions", () => {
+  beforeEach(resetAll);
+
+  // ---------------------------------------------------------------------------
+  // moveSelectedDeviceUp
+  // ---------------------------------------------------------------------------
+
+  describe("moveSelectedDeviceUp", () => {
+    it("moves selected device to a higher U position", () => {
+      const { layout, rackId, deviceId } = setupHalfDepthDevice();
+      getSelectionStore().selectDevice(rackId, deviceId);
+
+      const posBefore = layout.getRackById(rackId)!.devices[0]!.position;
+      moveSelectedDeviceUp();
+      const posAfter = layout.getRackById(rackId)!.devices[0]!.position;
+
+      expect(posAfter).toBeGreaterThan(posBefore);
+    });
+
+    it("is a no-op when no device is selected", () => {
+      const { layout, rackId } = setupHalfDepthDevice();
+      const posBefore = layout.getRackById(rackId)!.devices[0]!.position;
+
+      moveSelectedDeviceUp();
+
+      expect(layout.getRackById(rackId)!.devices[0]!.position).toBe(posBefore);
+    });
+
+    it("is a no-op for a container child (carrier guard)", () => {
+      const layout = getLayoutStore();
+      const rack = layout.addRack("Test Rack", 42);
+      if (!rack) throw new Error("addRack returned null");
+
+      const containerType = layout.addDeviceType(
+        createTestDeviceTypeInput({
+          name: "Test Shelf",
+          u_height: 2,
+          category: "server",
+          colour: "#8B4513",
+          slots: [
+            {
+              id: "slot-left",
+              position: { row: 0, col: 0 },
+              width_fraction: 0.5,
+            },
+          ],
+        }),
+      );
+      const childType = layout.addDeviceType(
+        createTestDeviceTypeInput({
+          name: "Mini PC",
+          u_height: 1,
+          category: "server",
+          colour: "#4A90D9",
+          slot_width: 1,
+          is_full_depth: false,
+        }),
+      );
+
+      layout.placeDevice(rack.id, containerType.slug, 10);
+      const container = layout.activeRack!.devices[0]!;
+
+      layout.placeInContainer(
+        rack.id,
+        childType.slug,
+        container.id,
+        "slot-left",
+        0,
+      );
+      const child = layout.activeRack!.devices[1]!;
+
+      getSelectionStore().selectDevice(rack.id, child.id);
+
+      const posBefore = child.position;
+      moveSelectedDeviceUp();
+      const posAfter = layout
+        .getRackById(rack.id)!
+        .devices.find((d) => d.id === child.id)!.position;
+
+      expect(posAfter).toBe(posBefore);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // moveSelectedDeviceDown
+  // ---------------------------------------------------------------------------
+
+  describe("moveSelectedDeviceDown", () => {
+    it("moves selected device to a lower U position", () => {
+      const layout = getLayoutStore();
+      const rack = layout.addRack("Test Rack", 42);
+      if (!rack) throw new Error("addRack returned null");
+
+      const dt = createTestDeviceType({
+        slug: "switch-down",
+        u_height: 1,
+        is_full_depth: false,
+      });
+      layout.addDeviceTypeRaw(dt);
+
+      layout.placeDevice(rack.id, dt.slug, 20);
+      const placed = layout.getRackById(rack.id)!.devices[0]!;
+
+      getSelectionStore().selectDevice(rack.id, placed.id);
+
+      const posBefore = placed.position;
+      moveSelectedDeviceDown();
+      const posAfter = layout.getRackById(rack.id)!.devices[0]!.position;
+
+      expect(posAfter).toBeLessThan(posBefore);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // duplicateSelection
+  // ---------------------------------------------------------------------------
+
+  describe("duplicateSelection", () => {
+    it("duplicates selected device and selects the new copy", () => {
+      const { layout, rackId, deviceId } = setupHalfDepthDevice();
+      const selection = getSelectionStore();
+      selection.selectDevice(rackId, deviceId);
+
+      const countBefore = layout.getRackById(rackId)!.devices.length;
+      duplicateSelection();
+      const countAfter = layout.getRackById(rackId)!.devices.length;
+
+      expect(countAfter).toBe(countBefore + 1);
+      expect(selection.selectedDeviceId).not.toBe(deviceId);
+      expect(selection.selectedDeviceId).not.toBeNull();
+    });
+
+    it("shows a success toast after duplicating a device", () => {
+      const { rackId, deviceId } = setupHalfDepthDevice();
+      getSelectionStore().selectDevice(rackId, deviceId);
+
+      duplicateSelection();
+
+      expect(getToastStore().toasts.some((t) => t.type === "success")).toBe(
+        true,
+      );
+    });
+
+    it("duplicates selected rack when a rack is selected", () => {
+      const { layout, rackId } = setupHalfDepthDevice();
+      getSelectionStore().selectRack(rackId);
+
+      const rackCountBefore = layout.racks.length;
+      duplicateSelection();
+      const rackCountAfter = layout.racks.length;
+
+      expect(rackCountAfter).toBe(rackCountBefore + 1);
+    });
+
+    it("is a no-op when nothing is selected", () => {
+      const { layout, rackId } = setupHalfDepthDevice();
+      const rackCountBefore = layout.racks.length;
+      const deviceCountBefore = layout.getRackById(rackId)!.devices.length;
+
+      duplicateSelection();
+
+      expect(layout.racks.length).toBe(rackCountBefore);
+      expect(layout.getRackById(rackId)!.devices.length).toBe(deviceCountBefore);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // flipSelectedDeviceFace
+  // ---------------------------------------------------------------------------
+
+  describe("flipSelectedDeviceFace", () => {
+    it("flips front to rear", () => {
+      const { layout, rackId, deviceId } = setupHalfDepthDevice("front");
+      getSelectionStore().selectDevice(rackId, deviceId);
+
+      flipSelectedDeviceFace();
+
+      const updated = layout
+        .getRackById(rackId)!
+        .devices.find((d) => d.id === deviceId)!;
+      expect(updated.face).toBe("rear");
+    });
+
+    it("flips rear to front", () => {
+      const { layout, rackId, deviceId } = setupHalfDepthDevice("rear");
+      getSelectionStore().selectDevice(rackId, deviceId);
+
+      flipSelectedDeviceFace();
+
+      const updated = layout
+        .getRackById(rackId)!
+        .devices.find((d) => d.id === deviceId)!;
+      expect(updated.face).toBe("front");
+    });
+
+    it("is a no-op when no device is selected", () => {
+      const { layout, rackId } = setupHalfDepthDevice("front");
+      const faceBefore = layout.getRackById(rackId)!.devices[0]!.face;
+
+      flipSelectedDeviceFace();
+
+      expect(layout.getRackById(rackId)!.devices[0]!.face).toBe(faceBefore);
+    });
+
+    it("shows a success toast after flipping", () => {
+      const { rackId, deviceId } = setupHalfDepthDevice("front");
+      getSelectionStore().selectDevice(rackId, deviceId);
+
+      flipSelectedDeviceFace();
+
+      expect(getToastStore().toasts.some((t) => t.type === "success")).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/src/tests/selection-actions.test.ts
+++ b/src/tests/selection-actions.test.ts
@@ -11,10 +11,7 @@ import {
   duplicateSelection,
   flipSelectedDeviceFace,
 } from "$lib/actions/selection-actions";
-import {
-  createTestDeviceType,
-  createTestDeviceTypeInput,
-} from "./factories";
+import { createTestDeviceType, createTestDeviceTypeInput } from "./factories";
 import type { DeviceFace } from "$lib/types";
 
 function resetAll() {
@@ -208,7 +205,9 @@ describe("selection-actions", () => {
       duplicateSelection();
 
       expect(layout.racks.length).toBe(rackCountBefore);
-      expect(layout.getRackById(rackId)!.devices.length).toBe(deviceCountBefore);
+      expect(layout.getRackById(rackId)!.devices.length).toBe(
+        deviceCountBefore,
+      );
     });
   });
 
@@ -239,6 +238,18 @@ describe("selection-actions", () => {
         .getRackById(rackId)!
         .devices.find((d) => d.id === deviceId)!;
       expect(updated.face).toBe("front");
+    });
+
+    it("flips a both-face device to rear", () => {
+      const { layout, rackId, deviceId } = setupHalfDepthDevice("both");
+      getSelectionStore().selectDevice(rackId, deviceId);
+
+      flipSelectedDeviceFace();
+
+      const updated = layout
+        .getRackById(rackId)!
+        .devices.find((d) => d.id === deviceId)!;
+      expect(updated.face).toBe("rear");
     });
 
     it("is a no-op when no device is selected", () => {

--- a/src/tests/verb-bar-overlay.test.ts
+++ b/src/tests/verb-bar-overlay.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, cleanup, fireEvent, screen } from "@testing-library/svelte";
+import VerbBarOverlay from "$lib/components/VerbBarOverlay.svelte";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getSelectionStore,
+  resetSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+import { resetCanvasStore } from "$lib/stores/canvas.svelte";
+import { createTestDeviceType } from "./factories";
+import type { DeviceFace } from "$lib/types";
+
+function resetAll() {
+  resetLayoutStore();
+  resetSelectionStore();
+  resetToastStore();
+  resetCanvasStore();
+}
+
+function setupRackWithDevice(face: DeviceFace = "front") {
+  const layout = getLayoutStore();
+  const rack = layout.addRack("Test Rack", 42);
+  if (!rack) throw new Error("addRack returned null");
+
+  const dt = createTestDeviceType({
+    slug: "test-switch",
+    u_height: 1,
+    is_full_depth: false,
+  });
+  layout.addDeviceTypeRaw(dt);
+
+  if (!layout.placeDevice(rack.id, dt.slug, 10, face)) {
+    throw new Error("placeDevice failed");
+  }
+  const placed = layout.getRackById(rack.id)!.devices[0]!;
+  return { layout, rackId: rack.id, deviceId: placed.id };
+}
+
+// In jsdom there is no layout to measure, so the overlay cannot position
+// itself and keeps the bar in a visibility:hidden wrapper. The buttons are
+// still in the DOM and dispatchable; query with hidden:true and assert the
+// click-to-action wiring, which is what this integration test covers. Pixel
+// positioning is verified separately by verb-bar-position.test.ts.
+function clickVerb(name: string) {
+  return fireEvent.click(screen.getByRole("button", { name, hidden: true }));
+}
+
+describe("VerbBarOverlay", () => {
+  beforeEach(resetAll);
+  afterEach(cleanup);
+
+  describe("device selection", () => {
+    it("moves the selected device when the move-up verb is clicked", async () => {
+      const { layout, rackId, deviceId } = setupRackWithDevice();
+      getSelectionStore().selectDevice(rackId, deviceId);
+      render(VerbBarOverlay, { props: { canvasEl: null } });
+
+      const before = layout.getRackById(rackId)!.devices[0]!.position;
+      await clickVerb("Move device up");
+      const after = layout.getRackById(rackId)!.devices[0]!.position;
+
+      expect(after).toBeGreaterThan(before);
+    });
+
+    it("flips the selected device's face when the flip verb is clicked", async () => {
+      const { layout, rackId, deviceId } = setupRackWithDevice("front");
+      getSelectionStore().selectDevice(rackId, deviceId);
+      render(VerbBarOverlay, { props: { canvasEl: null } });
+
+      await clickVerb("Flip face");
+
+      expect(
+        layout.getRackById(rackId)!.devices.find((d) => d.id === deviceId)!
+          .face,
+      ).toBe("rear");
+    });
+  });
+
+  describe("rack selection", () => {
+    it("routes rack verbs to the callbacks with the selected rack id", async () => {
+      const { rackId } = setupRackWithDevice();
+      getSelectionStore().selectRack(rackId);
+
+      const onrackfocus = vi.fn();
+      const onrackexport = vi.fn();
+      const ondelete = vi.fn();
+      render(VerbBarOverlay, {
+        props: { canvasEl: null, onrackfocus, onrackexport, ondelete },
+      });
+
+      await clickVerb("Focus");
+      expect(onrackfocus).toHaveBeenCalledWith([rackId]);
+
+      await clickVerb("Export");
+      expect(onrackexport).toHaveBeenCalledWith([rackId]);
+
+      await clickVerb("Delete selected");
+      expect(ondelete).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/tests/verb-bar-position.test.ts
+++ b/src/tests/verb-bar-position.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the floating verb bar positioning math (#2075)
+ *
+ * Covers the pure computeVerbBarPosition function: above/below placement,
+ * rack-name overlap flip, viewport-top flip, low-zoom hide, and horizontal
+ * clamping. All inputs are plain numeric rects with no DOM dependency.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeVerbBarPosition,
+  VERB_BAR_LOW_ZOOM_THRESHOLD,
+  VERB_BAR_MARGIN,
+  type Rect,
+  type Size,
+  type VerbBarPositionInput,
+} from "$lib/utils/verb-bar-position";
+
+function makeRect(
+  top: number,
+  left: number,
+  width: number,
+  height: number,
+): Rect {
+  return {
+    top,
+    left,
+    width,
+    height,
+    bottom: top + height,
+    right: left + width,
+  };
+}
+
+function input(overrides: Partial<VerbBarPositionInput>): VerbBarPositionInput {
+  return {
+    target: makeRect(300, 200, 120, 24),
+    bar: { width: 180, height: 36 },
+    viewport: { width: 1280, height: 800 },
+    scale: 1,
+    rackName: null,
+    ...overrides,
+  };
+}
+
+describe("computeVerbBarPosition - above placement", () => {
+  it("places above and is visible when there is ample room", () => {
+    const result = computeVerbBarPosition(input({}));
+    expect(result.visible).toBe(true);
+    expect(result.placement).toBe("above");
+  });
+
+  it("centres the bar horizontally over the target", () => {
+    const target = makeRect(300, 200, 120, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, bar }));
+    const expectedLeft = target.left + target.width / 2 - bar.width / 2;
+    expect(result.left).toBe(expectedLeft);
+  });
+
+  it("sets top to aboveTop when placing above", () => {
+    const target = makeRect(300, 200, 120, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, bar }));
+    const expectedTop = target.top - VERB_BAR_MARGIN - bar.height;
+    expect(result.top).toBe(expectedTop);
+  });
+});
+
+describe("computeVerbBarPosition - flip below due to rack name overlap", () => {
+  it("flips below when rack name bottom is below the above placement top", () => {
+    // target at y=300; bar height=36; aboveTop = 300 - 8 - 36 = 256
+    // rackName bottom at 270: 256 < 270, so flip
+    const target = makeRect(300, 200, 120, 24);
+    const rackName = makeRect(240, 100, 200, 30); // bottom = 270
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, rackName, bar }));
+    expect(result.placement).toBe("below");
+    expect(result.visible).toBe(true);
+  });
+
+  it("sets top to target.bottom + VERB_BAR_MARGIN when flipped below", () => {
+    const target = makeRect(300, 200, 120, 24);
+    const rackName = makeRect(240, 100, 200, 30); // bottom = 270
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, rackName, bar }));
+    expect(result.top).toBe(target.bottom + VERB_BAR_MARGIN);
+  });
+
+  it("does not flip when rack name bottom is at or below the above placement top", () => {
+    // target at y=300; bar height=36; aboveTop = 256
+    // rackName bottom at 256: NOT less than 256, so no flip
+    const target = makeRect(300, 200, 120, 24);
+    const rackName = makeRect(226, 100, 200, 30); // bottom = 256
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, rackName, bar }));
+    expect(result.placement).toBe("above");
+  });
+});
+
+describe("computeVerbBarPosition - flip below due to viewport top", () => {
+  it("flips below when target is near the top of the viewport", () => {
+    // target at y=20; bar height=36; aboveTop = 20 - 8 - 36 = -24 < 8 (MARGIN)
+    const target = makeRect(20, 200, 120, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, bar }));
+    expect(result.placement).toBe("below");
+    expect(result.visible).toBe(true);
+  });
+
+  it("does not flip when aboveTop exactly equals VERB_BAR_MARGIN", () => {
+    // aboveTop = target.top - 8 - 36 = target.top - 44
+    // aboveTop === 8 when target.top === 52
+    const target = makeRect(52, 200, 120, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, bar }));
+    // aboveTop === VERB_BAR_MARGIN (not less than), so stays above
+    expect(result.placement).toBe("above");
+  });
+});
+
+describe("computeVerbBarPosition - low zoom hide", () => {
+  it("is hidden when scale is just below the threshold", () => {
+    const result = computeVerbBarPosition(
+      input({ scale: VERB_BAR_LOW_ZOOM_THRESHOLD - 0.01 }),
+    );
+    expect(result.visible).toBe(false);
+  });
+
+  it("is visible at exactly the threshold", () => {
+    const result = computeVerbBarPosition(
+      input({ scale: VERB_BAR_LOW_ZOOM_THRESHOLD }),
+    );
+    expect(result.visible).toBe(true);
+  });
+
+  it("is visible above the threshold", () => {
+    const result = computeVerbBarPosition(
+      input({ scale: VERB_BAR_LOW_ZOOM_THRESHOLD + 0.1 }),
+    );
+    expect(result.visible).toBe(true);
+  });
+
+  it("returns zero coordinates when hidden", () => {
+    const result = computeVerbBarPosition(
+      input({ scale: VERB_BAR_LOW_ZOOM_THRESHOLD - 0.01 }),
+    );
+    expect(result.left).toBe(0);
+    expect(result.top).toBe(0);
+    expect(result.placement).toBe("above");
+  });
+});
+
+describe("computeVerbBarPosition - horizontal clamping", () => {
+  it("clamps left when target is near the right edge", () => {
+    // target right-aligned: left=1200, width=120 -> centre at 1260
+    // bar width=180: unclamped left = 1260 - 90 = 1170
+    // max left = 1280 - 180 - 8 = 1092
+    const target = makeRect(300, 1200, 120, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const viewport: Size = { width: 1280, height: 800 };
+    const result = computeVerbBarPosition(input({ target, bar, viewport }));
+    expect(result.left).toBeLessThanOrEqual(
+      viewport.width - bar.width - VERB_BAR_MARGIN,
+    );
+  });
+
+  it("clamps left when target is near the left edge", () => {
+    // target at left=0, width=120 -> centre at 60
+    // bar width=180: unclamped left = 60 - 90 = -30
+    // min left = VERB_BAR_MARGIN = 8
+    const target = makeRect(300, 0, 120, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const viewport: Size = { width: 1280, height: 800 };
+    const result = computeVerbBarPosition(input({ target, bar, viewport }));
+    expect(result.left).toBeGreaterThanOrEqual(VERB_BAR_MARGIN);
+  });
+
+  it("does not clamp when target is centred in the viewport", () => {
+    // target centred: left=550, width=180 -> centre at 640
+    // bar width=180: unclamped left = 640 - 90 = 550 (well inside viewport)
+    const target = makeRect(300, 550, 180, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const viewport: Size = { width: 1280, height: 800 };
+    const result = computeVerbBarPosition(input({ target, bar, viewport }));
+    const expectedLeft = target.left + target.width / 2 - bar.width / 2;
+    expect(result.left).toBe(expectedLeft);
+  });
+});

--- a/src/tests/verb-bars.test.ts
+++ b/src/tests/verb-bars.test.ts
@@ -107,6 +107,18 @@ describe("verb-bars projection", () => {
     });
   });
 
+  describe("getVerbsForSelection - device takes precedence", () => {
+    it("returns device verbs when both device and rack are flagged selected", () => {
+      const bothCtx: ActionEnabledContext = {
+        ...deviceCtx,
+        isRackSelected: true,
+      };
+      expect(getVerbsForSelection(bothCtx).map((a) => a.id)).toEqual(
+        DEVICE_VERB_IDS,
+      );
+    });
+  });
+
   describe("getVerbsForSelection - no selection", () => {
     it("returns an empty array when nothing is selected", () => {
       expect(getVerbsForSelection(emptyCtx)).toEqual([]);

--- a/src/tests/verb-bars.test.ts
+++ b/src/tests/verb-bars.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEVICE_VERB_IDS,
+  RACK_VERB_IDS,
+  getVerbsForSelection,
+} from "$lib/actions/verb-bars";
+import { getActionById } from "$lib/actions/registry";
+import type { ActionEnabledContext } from "$lib/actions/registry";
+
+/**
+ * Tests for the verb-bar projection module. These cover the filtering and
+ * ordering logic in getVerbsForSelection, not the registry data itself
+ * (which TypeScript validates).
+ */
+
+/** A fully-capable context with device selected. */
+const deviceCtx: ActionEnabledContext = {
+  hasSelection: true,
+  isDeviceSelected: true,
+  isRackSelected: false,
+  canUndo: true,
+  canRedo: false,
+  hasRacks: true,
+  mode: "browser",
+};
+
+/** A fully-capable context with rack selected. */
+const rackCtx: ActionEnabledContext = {
+  hasSelection: true,
+  isDeviceSelected: false,
+  isRackSelected: true,
+  canUndo: true,
+  canRedo: false,
+  hasRacks: true,
+  mode: "browser",
+};
+
+/** No selection. */
+const emptyCtx: ActionEnabledContext = {
+  hasSelection: false,
+  isDeviceSelected: false,
+  isRackSelected: false,
+  canUndo: false,
+  canRedo: false,
+  hasRacks: true,
+  mode: "browser",
+};
+
+describe("verb-bars projection", () => {
+  describe("DEVICE_VERB_IDS ordering", () => {
+    it("contains the expected ids in the declared order", () => {
+      expect(DEVICE_VERB_IDS).toEqual([
+        "move-device-up",
+        "move-device-down",
+        "flip-device-face",
+        "duplicate-selection",
+        "delete-selection",
+      ]);
+    });
+  });
+
+  describe("RACK_VERB_IDS ordering", () => {
+    it("contains the expected ids in the declared order", () => {
+      expect(RACK_VERB_IDS).toEqual([
+        "duplicate-selection",
+        "focus-rack",
+        "export-rack",
+        "delete-selection",
+      ]);
+    });
+  });
+
+  describe("getVerbsForSelection - device context", () => {
+    it("returns device verbs in order when a device is selected", () => {
+      const result = getVerbsForSelection(deviceCtx);
+      expect(result.map((a) => a.id)).toEqual(DEVICE_VERB_IDS);
+    });
+
+    it("excludes rack-only verbs (focus-rack, export-rack) from device results", () => {
+      const ids = getVerbsForSelection(deviceCtx).map((a) => a.id);
+      expect(ids).not.toContain("focus-rack");
+      expect(ids).not.toContain("export-rack");
+    });
+
+    it("includes delete-selection for a device selection", () => {
+      const ids = getVerbsForSelection(deviceCtx).map((a) => a.id);
+      expect(ids).toContain("delete-selection");
+    });
+  });
+
+  describe("getVerbsForSelection - rack context", () => {
+    it("returns rack verbs in order when a rack is selected", () => {
+      const result = getVerbsForSelection(rackCtx);
+      expect(result.map((a) => a.id)).toEqual(RACK_VERB_IDS);
+    });
+
+    it("excludes device-only verbs (move-device-up, move-device-down, flip-device-face) from rack results", () => {
+      const ids = getVerbsForSelection(rackCtx).map((a) => a.id);
+      expect(ids).not.toContain("move-device-up");
+      expect(ids).not.toContain("move-device-down");
+      expect(ids).not.toContain("flip-device-face");
+    });
+
+    it("includes delete-selection for a rack selection", () => {
+      const ids = getVerbsForSelection(rackCtx).map((a) => a.id);
+      expect(ids).toContain("delete-selection");
+    });
+  });
+
+  describe("getVerbsForSelection - no selection", () => {
+    it("returns an empty array when nothing is selected", () => {
+      expect(getVerbsForSelection(emptyCtx)).toEqual([]);
+    });
+  });
+
+  describe("getVerbsForSelection - enabledWhen filtering", () => {
+    it("excludes device verbs whose enabledWhen returns false in rack context", () => {
+      // In rack context isDeviceSelected=false, so move-device-up and
+      // flip-device-face would be filtered out - rack list is used, not device.
+      // This is covered by the rack order test above.
+      // Additional check: device list used only when isDeviceSelected is true.
+      const partialCtx: ActionEnabledContext = {
+        ...rackCtx,
+        isDeviceSelected: false,
+      };
+      const ids = getVerbsForSelection(partialCtx).map((a) => a.id);
+      expect(ids).not.toContain("move-device-up");
+    });
+  });
+
+  describe("registry additions", () => {
+    it("flip-device-face is registered with the correct label and scope", () => {
+      const action = getActionById("flip-device-face");
+      expect(action?.label).toBe("Flip face");
+      expect(action?.scope).toBe("selection");
+    });
+
+    it("focus-rack is registered with the correct label and scope", () => {
+      const action = getActionById("focus-rack");
+      expect(action?.label).toBe("Focus");
+      expect(action?.scope).toBe("selection");
+    });
+
+    it("export-rack is registered with the correct label and scope", () => {
+      const action = getActionById("export-rack");
+      expect(action?.label).toBe("Export");
+      expect(action?.scope).toBe("selection");
+    });
+
+    it("flip-device-face enabledWhen passes for device selection", () => {
+      const action = getActionById("flip-device-face");
+      expect(action?.enabledWhen?.(deviceCtx)).toBe(true);
+    });
+
+    it("flip-device-face enabledWhen fails for rack selection", () => {
+      const action = getActionById("flip-device-face");
+      expect(action?.enabledWhen?.(rackCtx)).toBe(false);
+    });
+
+    it("focus-rack enabledWhen passes for rack selection", () => {
+      const action = getActionById("focus-rack");
+      expect(action?.enabledWhen?.(rackCtx)).toBe(true);
+    });
+
+    it("export-rack enabledWhen passes for rack selection", () => {
+      const action = getActionById("export-rack");
+      expect(action?.enabledWhen?.(rackCtx)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Floating verb bars now appear above the selected device or rack on the canvas, and right-click mirrors the same actions.

- `VerbBarOverlay` hosts the presentation-only `VerbBar`: it reads the selection, builds the action context, measures the target via `data-device-uuid` / `data-rack-id` attributes, positions the bar (above by default, flips below to clear the rack name, hidden below 0.5 zoom), and dispatches verbs to the shared selection-action handlers.
- Device bar: move up, move down, flip face, duplicate, delete. Rack bar: duplicate, focus, export, delete.
- Right-click mirrors the verbs. The rack context menu was already a superset; the device menu gains a Flip face item.
- Keyboard accessible via `VerbBar`'s roving tabindex.

## Notes

- Slot control for half-width devices (an AC item) is deferred to #2322. It depends on the #2158 carrier model and is its own chunk of work.
- The overlay tracks pan with a requestAnimationFrame loop because the canvas store exposes no reactive pan signal. It runs only while a bar is shown and skips state writes when nothing moved. Exposing a pan/transform event from the canvas store is a possible future cleanup.
- Right-click is the desktop affordance; the floating bar is the primary affordance on touch (per mobile spike #2097).

## Test plan

- Unit: verb projection, positioning math (above/below flip, low-zoom hide, clamp), roving index, selection actions.
- Integration: `verb-bar-overlay.test.ts` covers the dispatch wiring (move moves the device, flip toggles the face, rack Focus/Export route to callbacks with the rack id, Delete invokes the callback).
- Full suite: 2560 passing. Lint clean. `npm run build` clean.

Closes #2075

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add floating action bars for selected devices and racks**

### What Changed
- A floating toolbar now appears for the current selection and shows the relevant actions for devices or racks
- Device selection now includes Flip face alongside move, duplicate, and delete
- Rack selection now includes Focus and Export alongside duplicate and delete
- The same device actions are also available from the device right-click menu, including the new Flip face option
- Device and rack actions now share the same behavior across keyboard shortcuts, context menus, and the floating toolbar
- The toolbar supports arrow-key navigation with Home and End, and stays hidden when zoomed too far out

### Impact
`✅ Faster access to common device and rack actions`
`✅ Fewer missed actions on touch devices`
`✅ Clearer face-flip and rack-action controls`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
