### PR TITLE
chore: add /orchestrate-issues command for issue-to-PR orchestration

### DIFF
--- a/.claude/commands/orchestrate-issues.md
+++ b/.claude/commands/orchestrate-issues.md
@@ -1,0 +1,71 @@
+---
+description: Orchestrate Rackula GitHub issues through to merged PRs via parallel per-issue subagents (worktree-isolated, skill-gated, auto-merge after both bots approve)
+argument-hint: <issue numbers, e.g. 2295 2296 2165>
+---
+
+# Rackula Issue Orchestrator
+
+Act as an orchestrator. Work these GitHub issues through to a merged PR, one subagent
+per issue, running concurrently:
+
+ISSUES: $ARGUMENTS
+
+If no issue numbers were provided, ask which issues to work before doing anything else.
+
+## Per-issue pipeline (each subagent does this for its own issue)
+
+1. **Set up** — Use `/gh-dev` to pick up the issue and create an isolated worktree
+   (`.worktree/Rackula-issue-<N>`, branch `fix/<N>-desc` or `feat/<N>-desc`, cut from
+   LOCAL `main`). Read the issue's Acceptance Criteria, Technical Notes, Test Requirements.
+2. **Triage type** — Classify the issue so you know which skills apply:
+   - UI / component / styling  → frontend work
+   - auth / API / input / data / serialization → security-sensitive
+   - docs / chore / refactor → neither domain skill needed
+3. **Implement** — Invoke skills by type (process skills first):
+   - ALWAYS: superpowers routing (brainstorming / systematic-debugging / TDD as the task fits)
+   - IF security-sensitive: `/secure-coding`
+   - IF frontend: `/frontend-design:frontend-design`
+   Follow the project TDD protocol (test only high-value behaviour; skip low-value tests).
+4. **Self-review** — Run `/code-review` on the diff BEFORE opening the PR. Fix what it finds.
+5. **Open PR** — Verify local gates first (`npm run lint`, `npm run test:run`, `npm run build`),
+   then push and `gh pr create`. Include `Co-Authored-By`.
+
+## Review-feedback loop (mandatory)
+
+When CodeRabbit, CodeAnt, or `/code-review` returns feedback on the PR, invoke
+`/superpowers:receiving-code-review` to process it. Do NOT performatively agree or blindly
+apply suggestions — verify each one technically, push back in-thread on false positives with
+reasoning, and only commit genuine fixes. Re-request review after pushing changes.
+
+## Merge gate (auto-merge when ALL are true)
+
+- CI fully green AND `mergeStateStatus` is CLEAN (a DIRTY/conflicted PR silently skips CI —
+  check `gh pr view <N> --json mergeable,mergeStateStatus` before trusting green checks).
+- CodeRabbit has approved with zero open findings — OR is genuinely unavailable (credits
+  exhausted / rate-limited), in which case a clean local `/code-review` is the fallback gate.
+- CodeAnt has approved — OR is not configured as a check on this repo (then skip it).
+- Every review item is resolved or rebutted via `/superpowers:receiving-code-review`.
+
+When the gate passes: `gh pr merge` (squash), then
+`gh issue close <N> --comment "Implemented in <commit>"`. Never merge on green CI alone.
+
+## Orchestration rules
+
+- Dispatch all issues in parallel as independent subagents — each in its OWN worktree, with
+  its OWN `blockers-<N>.md`. No shared state between them.
+- NEVER edit files in the main working directory; all work happens in per-issue worktrees.
+- Git over HTTPS, not SSH (the 1Password SSH agent can't sign here). Verify branch HEAD against
+  remote with `gh api repos/RackulaLives/Rackula/commits/main` rather than trusting local refs.
+- Don't routinely `--no-verify`; the husky pre-commit hook is fixed. Only bypass for a verified
+  reason, and say why.
+
+## Stop conditions (per issue)
+
+Stop and record in `blockers-<N>.md` if: a test fails twice with no resolution, the issue is
+genuinely ambiguous and needs a human decision, or a merge conflict you can't cleanly resolve.
+Otherwise proceed autonomously to merge.
+
+## Final report
+
+Per issue: status (MERGED / blocked / needs-decision), PR link, merge commit, and any
+follow-up issues filed.


### PR DESCRIPTION
## **User description**
Adds a reusable `/orchestrate-issues` slash command to `.claude/commands/`.

## What it does
Pass arbitrary issue numbers (`/orchestrate-issues 2295 2296 2165`) and it acts as an orchestrator, fanning out one worktree-isolated subagent per issue and driving each to a merged PR.

Per-issue pipeline:
- `/gh-dev` worktree setup, then triage the issue type
- always: superpowers routing + `/code-review` before PR
- conditional: `/secure-coding` (auth/API/input/data), `/frontend-design` (UI/component)
- `/superpowers:receiving-code-review` to process CodeRabbit / CodeAnt / code-review feedback
- auto-merge once both bots clear and CI is CLEAN

Mirrors the global copy at `~/.claude/commands/orchestrate-issues.md` so cloud sessions get it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add a reusable command for turning multiple GitHub issues into merged PRs in parallel**

### What Changed
- Added a new `/orchestrate-issues` command that can take multiple issue numbers and run them at the same time, each in its own isolated worktree
- Each issue now follows the same path: pick up the issue, classify it by type, apply the right review and design checks, run a pre-PR self-review, then open the PR
- Security-sensitive and frontend issues now trigger the extra skills they need, while docs, chores, and refactors skip those extra steps
- PRs now wait for review feedback to be handled before merging, with a clear process for verifying feedback, pushing back on false positives, and re-requesting review
- Merging now requires green CI plus clean merge status, approved reviews, and resolved feedback before the issue is closed automatically

### Impact
`✅ Faster issue-to-PR turnaround`
`✅ Fewer missed review comments before merge`
`✅ Safer handling of security-sensitive and UI changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
