### PR TITLE
fix: remove stale clearDraggingIndex no-op in Rack.svelte

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -349,7 +349,6 @@
       setContainerHoverInfo: (i) => {
         containerHoverInfo = i;
       },
-      clearDraggingIndex: () => {},
       onDragFinished: setDragFinished,
       layoutStore,
       toastStore,


### PR DESCRIPTION
## **User description**
## Summary

Removes a stale `clearDraggingIndex: () => {}` no-op from the object literal passed to `attachPointerDragListeners` in `Rack.svelte`. `svelte-check` flagged it as an unknown property of `PointerDragContext` (`Rack.svelte:352`).

## Investigation (systematic-debugging)

Traced the drag-index lifecycle across `src/`:

- `clearDraggingIndex` appears only once in the whole codebase: the deleted line.
- The `PointerDragContext` interface (`src/lib/utils/rack-pointer-drag.ts:25-38`) does not declare `clearDraggingIndex`.
- `attachPointerDragListeners` never calls `ctx.clearDraggingIndex()`.
- There is no `draggingIndex` or `setDraggingIndex` state anywhere in `src/`, so the no-op cleared nothing.

It is orphaned dead code from an earlier refactor. The correct fix is to remove it (adding it to the type would only enshrine a no-op for state that does not exist). Drag behaviour is unchanged.

## Verification

- `npx svelte-check`: the `clearDraggingIndex`/`Rack.svelte` error is gone.
- `svelte-autofixer`: zero issues on the edited component.
- `npm run lint`: clean.
- `npm run test:run`: 149 files / 2560 tests pass.
- `npm run build`: succeeds.

Type-only correctness fix, no new user-facing behaviour, so no new unit test (the type checker is the test).

Closes #2275

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove an unused drag cleanup hook from Rack**

### What Changed
- Removed a stale drag cleanup entry from the Rack drag setup
- Drag behavior stays the same; this only removes an unused no-op that was causing a check error

### Impact
`✅ Fewer build-check failures`
`✅ Cleaner Rack drag setup`
`✅ No change to dragging behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
