### PR TITLE
fix: patch libssl3/libcrypto3 for CVE-2026-45447 (alerts #80-83)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 ARG APK_CACHEBUST=0
 RUN echo "apk-cachebust=${APK_CACHEBUST}" && \
     apk upgrade --no-cache && \
-    apk add --no-cache --upgrade libssl3 libcrypto3
+    apk add --no-cache --upgrade "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0"
 
 # Create non-root user with matching group
 RUN addgroup --system --gid 1001 rackula && \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,12 +13,16 @@ FROM base AS runner
 WORKDIR /app
 
 # Patch system packages to resolve known CVEs (e.g. libssl3/libcrypto3
-# CVE-2026-31789). The oven/bun:1.3.10-alpine base does not ship libxml2, so
-# CVE-2026-6732 does not apply here; this mirrors deploy/Dockerfile's pattern.
-# APK_CACHEBUST is fed a per-build value so the buildcache for this layer is
-# invalidated each build and apk upgrade re-fetches current Alpine secfixes.
+# CVE-2026-31789 and CVE-2026-45447). The oven/bun:1.3.10-alpine base does not
+# ship libxml2, so CVE-2026-6732 does not apply here; this mirrors
+# deploy/Dockerfile's pattern. APK_CACHEBUST is fed a per-build value so the
+# buildcache for this layer is invalidated each build and apk upgrade re-fetches
+# current Alpine secfixes. The openssl libs are named explicitly so the fix for
+# the tracked CVE-2026-45447 alerts is force-applied.
 ARG APK_CACHEBUST=0
-RUN echo "apk-cachebust=${APK_CACHEBUST}" && apk upgrade --no-cache
+RUN echo "apk-cachebust=${APK_CACHEBUST}" && \
+    apk upgrade --no-cache && \
+    apk add --no-cache --upgrade libssl3 libcrypto3
 
 # Create non-root user with matching group
 RUN addgroup --system --gid 1001 rackula && \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -31,7 +31,7 @@ ARG APK_CACHEBUST=0
 USER root
 RUN echo "apk-cachebust=${APK_CACHEBUST}" && \
     apk upgrade --no-cache && \
-    apk add --no-cache --upgrade libssl3 libcrypto3
+    apk add --no-cache --upgrade "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0"
 USER nginx
 
 # OCI labels

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -21,13 +21,17 @@ RUN npm run build
 
 # Production stage - non-root nginx
 FROM nginxinc/nginx-unprivileged:alpine
-# Patch system packages to resolve known CVEs (e.g. libpng, libxml2 CVE-2026-6732).
-# APK_CACHEBUST is fed a per-build value (release version / date) so this layer's
-# buildcache is invalidated each build and apk upgrade re-fetches current Alpine
-# secfixes instead of reusing a stale cached layer.
+# Patch system packages to resolve known CVEs (e.g. libpng, libxml2 CVE-2026-6732,
+# libssl3/libcrypto3 CVE-2026-45447). APK_CACHEBUST is fed a per-build value
+# (release version / date) so this layer's buildcache is invalidated each build
+# and apk upgrade re-fetches current Alpine secfixes instead of reusing a stale
+# cached layer. The openssl libs are named explicitly so the fix for the tracked
+# CVE-2026-45447 alerts is force-applied even if a future base ships them pinned.
 ARG APK_CACHEBUST=0
 USER root
-RUN echo "apk-cachebust=${APK_CACHEBUST}" && apk upgrade --no-cache
+RUN echo "apk-cachebust=${APK_CACHEBUST}" && \
+    apk upgrade --no-cache && \
+    apk add --no-cache --upgrade libssl3 libcrypto3
 USER nginx
 
 # OCI labels


### PR DESCRIPTION
## **User description**
## What

Patches the OpenSSL runtime libraries (`libssl3`, `libcrypto3`) to >=3.5.7-r0 in the runtime stages of **both** container images so the four Trivy HIGH code-scanning alerts for **CVE-2026-45447** resolve on the next published rebuild.

CVE-2026-45447 is an OpenSSL heap use-after-free in `PKCS7_verify()` (severity HIGH). Fixed Alpine version: `3.5.7-r0` (installed: `3.5.6-r0`).

| Alert | Image | Package |
| ----- | ----- | ------- |
| #80 | `rackula-api` | libcrypto3 |
| #81 | `rackula-api` | libssl3 |
| #82 | `rackula` | libcrypto3 |
| #83 | `rackula` | libssl3 |

## Where

- `deploy/Dockerfile` -> image `rackula`. Patched the **nginx final runtime stage** (`nginxinc/nginx-unprivileged:alpine`), inside the existing `USER root` / `USER nginx` block. Trivy scans the runtime image, so the fix must land there.
- `api/Dockerfile` -> image `rackula-api`. Patched the **bun final runtime stage** (`oven/bun:1.3.10-alpine`).

## How

Both runtime stages already ran a broad `apk upgrade --no-cache` gated by `APK_CACHEBUST` (per-build cache-bust so secfixes are always re-fetched). That broad upgrade already pulls the patched openssl libs. This change adds an explicit, named `apk add --no-cache --upgrade libssl3 libcrypto3` so the intent is self-documenting and the fix survives even if the broad upgrade is ever removed. The existing CVE comments now also cite CVE-2026-45447.

Minimal change: no base-image tag bumps. Alpine's repo already serves `libssl3`/`libcrypto3` `3.5.7-r0`.

## Verification

- Docker/Trivy are not available in this environment, so no local image build/scan was run.
- Verified via Alpine package index that `3.5.7-r0` is the current published version of both libs.
- `npm run lint` clean. Local code review clean.

The four Trivy alerts (#80-83) are **code-scanning alerts, not issues** -- they will auto-resolve on the next scan after the rebuilt images are published. They are not manually dismissed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Patch OpenSSL libraries in both container images**

### What Changed
- Both published images now explicitly upgrade `libssl3` and `libcrypto3` in their runtime layers, so the OpenSSL CVE fixes are included in the next rebuild.
- The fix applies to both the app image and the API image.
- The build notes were updated to call out the OpenSSL CVE being addressed.

### Impact
`✅ Fewer vulnerable releases`
`✅ Safer container rebuilds`
`✅ Lower exposure to OpenSSL security issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
