### PR TITLE
feat: verb bar opacity 0.95 and always above selection (#2334)

### DIFF
--- a/src/lib/components/VerbBar.svelte
+++ b/src/lib/components/VerbBar.svelte
@@ -110,7 +110,7 @@
     padding: var(--space-1);
     border-radius: var(--radius-full);
     border: 1px solid var(--bottom-nav-border);
-    background: var(--bottom-nav-bg);
+    background: var(--verb-bar-bg);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     box-shadow: var(--shadow-lg);

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -100,34 +100,23 @@
     }
   }
 
-  /** Resolve the DOM node to point at, plus the rack name to avoid (device bars). */
-  function findTarget(): { target: Element | null; rackName: Element | null } {
-    if (!canvasEl) return { target: null, rackName: null };
+  /** Resolve the DOM node the bar points at. */
+  function findTarget(): Element | null {
+    if (!canvasEl) return null;
 
     if (selection.isDeviceSelected && selection.selectedDeviceId) {
-      const target = canvasEl.querySelector(
+      return canvasEl.querySelector(
         `[data-device-uuid="${CSS.escape(selection.selectedDeviceId)}"]`,
       );
-      let rackName: Element | null = null;
-      if (selection.selectedRackId) {
-        const rackEl = canvasEl.querySelector(
-          `[data-rack-id="${CSS.escape(selection.selectedRackId)}"]`,
-        );
-        rackName = rackEl?.querySelector(".rack-dual-view-name") ?? null;
-      }
-      return { target, rackName };
     }
 
     if (selection.isRackSelected && selection.selectedRackId) {
-      return {
-        target: canvasEl.querySelector(
-          `[data-rack-id="${CSS.escape(selection.selectedRackId)}"]`,
-        ),
-        rackName: null,
-      };
+      return canvasEl.querySelector(
+        `[data-rack-id="${CSS.escape(selection.selectedRackId)}"]`,
+      );
     }
 
-    return { target: null, rackName: null };
+    return null;
   }
 
   function hide(): void {
@@ -140,13 +129,12 @@
     // reads while zoomed out (the rAF loop calls this every frame).
     if (canvas.zoom < VERB_BAR_LOW_ZOOM_THRESHOLD) return hide();
 
-    const { target, rackName } = findTarget();
+    const target = findTarget();
     if (!target) return hide();
 
     const barRect = barEl.getBoundingClientRect();
     const next = computeVerbBarPosition({
       target: target.getBoundingClientRect(),
-      rackName: rackName ? rackName.getBoundingClientRect() : null,
       bar: { width: barRect.width, height: barRect.height },
       viewport: { width: window.innerWidth, height: window.innerHeight },
       scale: canvas.zoom,
@@ -155,8 +143,7 @@
     if (
       next.visible !== pos.visible ||
       next.left !== pos.left ||
-      next.top !== pos.top ||
-      next.placement !== pos.placement
+      next.top !== pos.top
     ) {
       pos = next;
     }

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -365,6 +365,7 @@
   --bottom-nav-bg: rgba(33, 34, 44, 0.85);
   --bottom-nav-border: rgba(52, 55, 70, 0.6);
   --bottom-nav-blur: 20px;
+  --verb-bar-bg: rgba(33, 34, 44, 0.95);
   --bottom-nav-active-pill-bg: rgba(139, 233, 253, 0.12);
   --bottom-nav-active-colour: var(--colour-primary);
   --bottom-nav-inactive-colour: var(--colour-text-muted);
@@ -600,6 +601,7 @@
   --bottom-nav-bg: rgba(239, 237, 220, 0.85);
   --bottom-nav-border: rgba(222, 220, 207, 0.6);
   --bottom-nav-active-pill-bg: rgba(3, 106, 150, 0.1);
+  --verb-bar-bg: rgba(239, 237, 220, 0.95);
 
   --colour-error-hover: #b33030;
 

--- a/src/lib/utils/verb-bar-position.ts
+++ b/src/lib/utils/verb-bar-position.ts
@@ -8,9 +8,9 @@
  * Rules:
  * 1. LOW ZOOM: hidden when scale < VERB_BAR_LOW_ZOOM_THRESHOLD.
  * 2. HORIZONTAL: centred over the target, clamped within viewport margins.
- * 3. VERTICAL: placed above by default; flipped below when the above placement
- *    would run off the top of the viewport (aboveTop < VERB_BAR_MARGIN) OR
- *    would cover the rack name label (aboveTop < rackName.bottom).
+ * 3. VERTICAL: always placed above the target. When space above is tight the
+ *    bar may overlap the rack name label or sit partly off the top of the
+ *    viewport rather than flipping below.
  */
 
 /** Viewport-space bounding rectangle using plain numbers (no DOM dependency). */
@@ -32,8 +32,6 @@ export interface Size {
 export interface VerbBarPositionInput {
   /** Viewport-space rect of the selected object the bar points at (device row, or rack name). */
   target: Rect;
-  /** Viewport-space rect of the rack name to avoid overlapping, if relevant (device bars). Optional. */
-  rackName?: Rect | null;
   /** Measured size of the bar. */
   bar: Size;
   /** Viewport dimensions, for horizontal clamping. */
@@ -42,7 +40,7 @@ export interface VerbBarPositionInput {
   scale: number;
 }
 
-export type VerbBarPlacement = "above" | "below";
+export type VerbBarPlacement = "above";
 
 export interface VerbBarPosition {
   visible: boolean;
@@ -61,13 +59,14 @@ export const VERB_BAR_LOW_ZOOM_THRESHOLD = 0.5;
  * Compute viewport coordinates for a floating verb bar.
  *
  * Returns visible:false when zoomed out below the threshold. Otherwise
- * returns the clamped horizontal position and the above/below vertical
- * position based on available space and rack-name collision avoidance.
+ * returns the clamped horizontal position and the above vertical position.
+ * The bar always sits above the target; when space is tight it may overlap
+ * the rack name label or sit partly off the top of the viewport.
  */
 export function computeVerbBarPosition(
   input: VerbBarPositionInput,
 ): VerbBarPosition {
-  const { target, rackName, bar, viewport, scale } = input;
+  const { target, bar, viewport, scale } = input;
 
   if (scale < VERB_BAR_LOW_ZOOM_THRESHOLD) {
     return { visible: false, left: 0, top: 0, placement: "above" };
@@ -78,15 +77,8 @@ export function computeVerbBarPosition(
   const maxLeft = viewport.width - bar.width - VERB_BAR_MARGIN;
   const left = Math.max(VERB_BAR_MARGIN, Math.min(rawLeft, maxLeft));
 
-  // Vertical: prefer above, flip below on viewport-top or rack-name collision.
-  const aboveTop = target.top - VERB_BAR_MARGIN - bar.height;
-  const tooCloseToTop = aboveTop < VERB_BAR_MARGIN;
-  const coversRackName = rackName != null && aboveTop < rackName.bottom;
-  const flip = tooCloseToTop || coversRackName;
+  // Vertical: always above the target.
+  const top = target.top - VERB_BAR_MARGIN - bar.height;
 
-  const placement: VerbBarPlacement = flip ? "below" : "above";
-  const top =
-    placement === "above" ? aboveTop : target.bottom + VERB_BAR_MARGIN;
-
-  return { visible: true, left, top, placement };
+  return { visible: true, left, top, placement: "above" };
 }

--- a/src/tests/verb-bar-position.test.ts
+++ b/src/tests/verb-bar-position.test.ts
@@ -1,9 +1,9 @@
 /**
  * Tests for the floating verb bar positioning math (#2075)
  *
- * Covers the pure computeVerbBarPosition function: above/below placement,
- * rack-name overlap flip, viewport-top flip, low-zoom hide, and horizontal
- * clamping. All inputs are plain numeric rects with no DOM dependency.
+ * Covers the pure computeVerbBarPosition function: always-above placement,
+ * low-zoom hide, and horizontal clamping. All inputs are plain numeric rects
+ * with no DOM dependency.
  */
 import { describe, it, expect } from "vitest";
 import {
@@ -37,7 +37,6 @@ function input(overrides: Partial<VerbBarPositionInput>): VerbBarPositionInput {
     bar: { width: 180, height: 36 },
     viewport: { width: 1280, height: 800 },
     scale: 1,
-    rackName: null,
     ...overrides,
   };
 }
@@ -66,55 +65,23 @@ describe("computeVerbBarPosition - above placement", () => {
   });
 });
 
-describe("computeVerbBarPosition - flip below due to rack name overlap", () => {
-  it("flips below when rack name bottom is below the above placement top", () => {
-    // target at y=300; bar height=36; aboveTop = 300 - 8 - 36 = 256
-    // rackName bottom at 270: 256 < 270, so flip
-    const target = makeRect(300, 200, 120, 24);
-    const rackName = makeRect(240, 100, 200, 30); // bottom = 270
-    const bar: Size = { width: 180, height: 36 };
-    const result = computeVerbBarPosition(input({ target, rackName, bar }));
-    expect(result.placement).toBe("below");
-    expect(result.visible).toBe(true);
-  });
-
-  it("sets top to target.bottom + VERB_BAR_MARGIN when flipped below", () => {
-    const target = makeRect(300, 200, 120, 24);
-    const rackName = makeRect(240, 100, 200, 30); // bottom = 270
-    const bar: Size = { width: 180, height: 36 };
-    const result = computeVerbBarPosition(input({ target, rackName, bar }));
-    expect(result.top).toBe(target.bottom + VERB_BAR_MARGIN);
-  });
-
-  it("does not flip when rack name bottom is at or below the above placement top", () => {
-    // target at y=300; bar height=36; aboveTop = 256
-    // rackName bottom at 256: NOT less than 256, so no flip
-    const target = makeRect(300, 200, 120, 24);
-    const rackName = makeRect(226, 100, 200, 30); // bottom = 256
-    const bar: Size = { width: 180, height: 36 };
-    const result = computeVerbBarPosition(input({ target, rackName, bar }));
-    expect(result.placement).toBe("above");
-  });
-});
-
-describe("computeVerbBarPosition - flip below due to viewport top", () => {
-  it("flips below when target is near the top of the viewport", () => {
-    // target at y=20; bar height=36; aboveTop = 20 - 8 - 36 = -24 < 8 (MARGIN)
+describe("computeVerbBarPosition - always above near viewport top", () => {
+  it("stays above for the topmost target near the top of the viewport", () => {
+    // target at y=20; bar height=36; aboveTop = 20 - 8 - 36 = -24.
+    // The bar may sit partly off-screen or overlap the rack name label,
+    // but it never flips below the target.
     const target = makeRect(20, 200, 120, 24);
     const bar: Size = { width: 180, height: 36 };
     const result = computeVerbBarPosition(input({ target, bar }));
-    expect(result.placement).toBe("below");
+    expect(result.placement).toBe("above");
     expect(result.visible).toBe(true);
   });
 
-  it("does not flip when aboveTop exactly equals VERB_BAR_MARGIN", () => {
-    // aboveTop = target.top - 8 - 36 = target.top - 44
-    // aboveTop === 8 when target.top === 52
-    const target = makeRect(52, 200, 120, 24);
+  it("keeps top at aboveTop for the topmost target", () => {
+    const target = makeRect(20, 200, 120, 24);
     const bar: Size = { width: 180, height: 36 };
     const result = computeVerbBarPosition(input({ target, bar }));
-    // aboveTop === VERB_BAR_MARGIN (not less than), so stays above
-    expect(result.placement).toBe("above");
+    expect(result.top).toBe(target.top - VERB_BAR_MARGIN - bar.height);
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

Two changes to the floating selection verb bar (#2334):

1. Background opacity increased from 0.85 to 0.95 alpha so the bar reads cleanly against busy canvas content. Implemented via a new dedicated `--verb-bar-bg` token (dark + light themes). The shared `--bottom-nav-bg` token is left untouched because it is consumed by four other components (CanvasViewControls, MobileHistoryControls, MobileBottomNav, and the verb bar).
2. The verb bar now always renders above the selected device, including the topmost device at the top of a rack. The flip-below behaviour and the rack-name collision avoidance are removed. When space above is tight the bar may overlap the rack name label or sit partly off the top of the viewport rather than flipping below.

## Changes

- `src/lib/styles/tokens.css`: add `--verb-bar-bg` at 0.95 alpha in both the dark and light theme blocks.
- `src/lib/components/VerbBar.svelte`: point the bar background at `--verb-bar-bg`.
- `src/lib/utils/verb-bar-position.ts`: `computeVerbBarPosition()` always places above. Removed the `rackName` input, the `tooCloseToTop || coversRackName` flip, and the `"below"` placement variant as dead code.
- `src/lib/components/VerbBarOverlay.svelte`: drop the now-unused rack-name lookup and the `placement` change-detection (placement is constant).
- `src/tests/verb-bar-position.test.ts`: the topmost-device cases now assert "above"; flip-below tests removed.

## Verification

- `npm run lint`: clean
- `npm run test:run`: verb-bar tests pass
- `npm run build`: succeeds
- Local `/code-review` (high effort): zero findings

Closes #2334

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Keep the verb bar above the selected item and make it stand out more clearly**

### What Changed
- The floating verb bar now always appears above the selected device or rack, even when space is tight at the top of the canvas
- It no longer drops below the selection to avoid the rack label, so it may overlap the label or sit partly off-screen instead
- The bar background is now more opaque in both themes, making it easier to read against busy canvas content

### Impact
`✅ Clearer actions on busy canvases`
`✅ Fewer verb bar position changes near the top of racks`
`✅ Easier-to-read selection controls in dark and light themes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
