### PR TITLE
feat: snap zoom in/out to round ladder rungs (#2336)

### DIFF
--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -30,7 +30,24 @@ import {
 // Panzoom constants
 export const ZOOM_MIN = 0.25; // 25% - allows fitting 6+ large racks
 export const ZOOM_MAX = 2; // 200%
-export const ZOOM_STEP = 0.25; // 25%
+
+// Round zoom levels the in/out buttons snap to, ascending from ZOOM_MIN to ZOOM_MAX
+const ZOOM_LADDER = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+
+/**
+ * Snap a zoom level to the next rung on the ladder in the given direction.
+ * Stepping "in" returns the smallest rung strictly greater than current;
+ * stepping "out" returns the largest rung strictly less than current.
+ * On-rung values advance one rung. The result is clamped to ZOOM_MIN/ZOOM_MAX.
+ */
+export function snapZoom(current: number, direction: "in" | "out"): number {
+  if (direction === "in") {
+    const next = ZOOM_LADDER.find((rung) => rung > current);
+    return next ?? ZOOM_MAX;
+  }
+  const prev = [...ZOOM_LADDER].reverse().find((rung) => rung < current);
+  return prev ?? ZOOM_MIN;
+}
 
 const VIEWPORT_KEY = "Rackula:viewport";
 
@@ -220,12 +237,12 @@ function disposePanzoom(): void {
 }
 
 /**
- * Zoom in by one step
+ * Zoom in to the next ladder rung
  */
 function zoomIn(): void {
   if (!panzoomInstance || currentZoom >= ZOOM_MAX) return;
 
-  const newZoom = Math.min(currentZoom + ZOOM_STEP, ZOOM_MAX);
+  const newZoom = snapZoom(currentZoom, "in");
   const transform = panzoomInstance.getTransform();
 
   // Zoom centered on current view
@@ -233,12 +250,12 @@ function zoomIn(): void {
 }
 
 /**
- * Zoom out by one step
+ * Zoom out to the next ladder rung
  */
 function zoomOut(): void {
   if (!panzoomInstance || currentZoom <= ZOOM_MIN) return;
 
-  const newZoom = Math.max(currentZoom - ZOOM_STEP, ZOOM_MIN);
+  const newZoom = snapZoom(currentZoom, "out");
   const transform = panzoomInstance.getTransform();
 
   panzoomInstance.zoomAbs(transform.x, transform.y, newZoom);

--- a/src/tests/canvas-store.test.ts
+++ b/src/tests/canvas-store.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
 	getCanvasStore,
 	resetCanvasStore,
+	snapZoom,
 	ZOOM_MIN,
-	ZOOM_MAX,
-	ZOOM_STEP
+	ZOOM_MAX
 } from '$lib/stores/canvas.svelte';
 import { createMockPanzoom } from './mocks/panzoom';
 
@@ -83,6 +83,48 @@ describe('Canvas Store', () => {
 		});
 	});
 
+	describe('snapZoom', () => {
+		it('snaps out from an off-ladder value to the rung below', () => {
+			expect(snapZoom(1.18, 'out')).toBe(1.0);
+		});
+
+		it('snaps in from an off-ladder value to the rung above', () => {
+			expect(snapZoom(1.18, 'in')).toBe(1.25);
+		});
+
+		it('advances one rung when out from a value on the ladder', () => {
+			expect(snapZoom(1.0, 'out')).toBe(0.75);
+		});
+
+		it('advances one rung when in from a value on the ladder', () => {
+			expect(snapZoom(1.0, 'in')).toBe(1.25);
+		});
+
+		it('stays at ZOOM_MIN when stepping out from the minimum', () => {
+			expect(snapZoom(ZOOM_MIN, 'out')).toBe(ZOOM_MIN);
+		});
+
+		it('stays at ZOOM_MAX when stepping in from the maximum', () => {
+			expect(snapZoom(ZOOM_MAX, 'in')).toBe(ZOOM_MAX);
+		});
+
+		it('clamps a below-minimum value to ZOOM_MIN when stepping out', () => {
+			expect(snapZoom(ZOOM_MIN - 0.1, 'out')).toBe(ZOOM_MIN);
+		});
+
+		it('clamps an above-maximum value to ZOOM_MAX when stepping in', () => {
+			expect(snapZoom(ZOOM_MAX + 0.1, 'in')).toBe(ZOOM_MAX);
+		});
+
+		it('steps in toward the maximum from just below it', () => {
+			expect(snapZoom(1.9, 'in')).toBe(ZOOM_MAX);
+		});
+
+		it('steps out toward the minimum from just above it', () => {
+			expect(snapZoom(0.3, 'out')).toBe(ZOOM_MIN);
+		});
+	});
+
 	describe('zoomIn', () => {
 		it('does nothing without panzoom instance', () => {
 			const store = getCanvasStore();
@@ -93,14 +135,24 @@ describe('Canvas Store', () => {
 			expect(store.zoom).toBe(initialZoom);
 		});
 
-		it('increases zoom by ZOOM_STEP', () => {
+		it('snaps up to the next ladder rung', () => {
 			const store = getCanvasStore();
 			const mockPanzoom = createMockPanzoom(1);
 
 			store.setPanzoomInstance(mockPanzoom as ReturnType<typeof import('panzoom').default>);
 			store.zoomIn();
 
-			expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(0, 0, 1 + ZOOM_STEP);
+			expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(0, 0, 1.25);
+		});
+
+		it('snaps up to the nearest ladder rung from an off-ladder value', () => {
+			const store = getCanvasStore();
+			const mockPanzoom = createMockPanzoom(1.18);
+
+			store.setPanzoomInstance(mockPanzoom as ReturnType<typeof import('panzoom').default>);
+			store.zoomIn();
+
+			expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(0, 0, 1.25);
 		});
 
 		it('does not exceed ZOOM_MAX', () => {
@@ -134,14 +186,24 @@ describe('Canvas Store', () => {
 			expect(store.zoom).toBe(initialZoom);
 		});
 
-		it('decreases zoom by ZOOM_STEP', () => {
+		it('snaps down to the next ladder rung', () => {
 			const store = getCanvasStore();
 			const mockPanzoom = createMockPanzoom(1);
 
 			store.setPanzoomInstance(mockPanzoom as ReturnType<typeof import('panzoom').default>);
 			store.zoomOut();
 
-			expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(0, 0, 1 - ZOOM_STEP);
+			expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(0, 0, 0.75);
+		});
+
+		it('snaps down to the nearest ladder rung from an off-ladder value', () => {
+			const store = getCanvasStore();
+			const mockPanzoom = createMockPanzoom(1.18);
+
+			store.setPanzoomInstance(mockPanzoom as ReturnType<typeof import('panzoom').default>);
+			store.zoomOut();
+
+			expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(0, 0, 1.0);
 		});
 
 		it('does not go below ZOOM_MIN', () => {


### PR DESCRIPTION
## **User description**
Closes #2336

## Problem

The zoom in/out buttons applied a fixed 0.25 step. From an off-boundary zoom (e.g. 118%), stepping out landed on 93% instead of stopping at 100% first.

## Change

Replaces the fixed `ZOOM_STEP` with a snap-to-ladder helper in `canvas.svelte.ts`:

- `snapZoom(current, "out")` returns the largest ladder rung strictly less than current.
- `snapZoom(current, "in")` returns the smallest ladder rung strictly greater than current.
- Ladder: `[0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]`. Results clamp to `ZOOM_MIN` (25%) and `ZOOM_MAX` (200%).
- On-rung values advance one rung (strict inequality), preserving the prior on-boundary stepping.

Zoom OUT: 118% -> 100% -> 75% -> 50% -> 25%. Zoom IN is symmetrical.

`snapZoom` is a small pure helper, exported so it is unit-testable without the panzoom store.

## Tests

- `snapZoom` covered directly: off-ladder snap down (1.18 -> 1.0) and up (1.18 -> 1.25), on-rung advance, and the min/max clamp edges.
- `zoomIn`/`zoomOut` store tests updated to assert ladder rungs.
- Behaviour-focused only; no DOM/structure/class/color assertions.

Local gates: `npm run lint` clean, `canvas-store`/`ui-store` suites green, `npm run build` passes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Zoom buttons now move between rounded zoom levels instead of fixed 25% jumps**

### What Changed
- Zoom in and zoom out now snap to the next round level, so off-step zoom values land on a clean rung instead of skipping past it.
- Zoom out now goes to the next lower rung first, and zoom in goes to the next higher rung first, while still stopping at the minimum and maximum zoom levels.
- The zoom buttons keep their previous behavior when starting from an exact ladder level.

### Impact
`✅ Cleaner zoom steps`
`✅ Fewer skipped zoom levels`
`✅ Predictable zoom at min and max`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
