### PR TITLE
chore: reorder sidebar tabs to Layouts, Racks, Devices (#2326)

### DIFF
--- a/src/lib/components/SidebarTabs.svelte
+++ b/src/lib/components/SidebarTabs.svelte
@@ -1,6 +1,6 @@
 <!--
   SidebarTabs Component
-  Tab bar for sidebar navigation: Hide | Devices | Racks
+  Tab bar for sidebar navigation: Layouts | Racks | Devices
   Uses bits-ui Tabs for accessibility and keyboard navigation
 -->
 <script lang="ts">
@@ -15,9 +15,9 @@
   let { activeTab, onchange }: Props = $props();
 
   const tabs: { id: SidebarTab; label: string; icon: string }[] = [
-    { id: "devices", label: "Devices", icon: "⬡" },
-    { id: "racks", label: "Racks", icon: "▤" },
     { id: "layouts", label: "Layouts", icon: "▦" },
+    { id: "racks", label: "Racks", icon: "▤" },
+    { id: "devices", label: "Devices", icon: "⬡" },
   ];
 
   function handleValueChange(value: string | undefined) {


### PR DESCRIPTION
## **User description**
## Summary

Reverses the sidebar tab order so tabs render left to right as Layouts, Racks, Devices instead of Devices, Racks, Layouts.

## What changed

- Reordered the single `tabs` array in `src/lib/components/SidebarTabs.svelte` to layouts, racks, devices.
- Updated the stale header comment to match the new visual order.

Keyboard navigation order follows array order via bits-ui Tabs, so it matches the new visual order automatically.

## First-run default unchanged

The first-run default active tab stays Devices. The default is set explicitly in `loadSidebarTabFromStorage()` (`ui.svelte.ts`), which returns the literal `"devices"` and validates stored values against an order-independent membership check. It is not derived from `tabs[0]`, so reordering the array does not change the default. The existing `ui-store.test.ts` assertion "initial sidebarTab is devices" still passes.

## Tests

- npm run lint: ESLint, no issues found
- npm run test:run: 153 files passed, 2586 tests passed
- npm run build: built successfully

No new tests added: this is a visual/structural reorder covered by visual regression (#2098) and axe (#2099). E2E and unit tests reference tabs by `data-testid`, which is order-independent, so no test files needed updating.

## Accessibility (self-cert, #2100)

Keyboard navigation order matches the new visual order. No new colours or motion introduced.

closes #2326
part of epic #2017


___

## **CodeAnt-AI Description**
Reorder the sidebar tabs to match the left-to-right layout view

### What Changed
- The sidebar now shows tabs in this order: Layouts, Racks, Devices
- The sidebar header text was updated to match the new visible order

### Impact
`✅ Matches the visible tab order`
`✅ Easier sidebar navigation`
`✅ Clearer tab labels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
