### PR TITLE
feat: merge layout tabs into the toolbar (#2324)

### DIFF
--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -104,10 +104,15 @@ test.describe("Command palette", () => {
   test("Ctrl/Cmd+K opens the palette even when a text field is focused", async ({
     page,
   }) => {
-    // Click the layout name display button to enter rename mode.
-    // This reveals a text input (data-testid="layout-name-input") and focuses it,
-    // simulating a user with keyboard focus inside an editable field.
-    await page.getByTestId("layout-name-display").click();
+    // Double-click the active layout tab to enter inline rename mode. This
+    // reveals a text input (data-testid="layout-name-input") and focuses it,
+    // simulating a user with keyboard focus inside an editable field. Scope to
+    // the layout tablist so the selected tab is unambiguous (the sidebar also
+    // has tabs).
+    await page
+      .getByRole("tablist", { name: "Open layouts" })
+      .getByRole("tab", { selected: true })
+      .dblclick();
     const nameInput = page.getByTestId("layout-name-input");
     await expect(nameInput).toBeFocused();
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,7 +18,6 @@
   import MobileHistoryControls from "$lib/components/mobile/MobileHistoryControls.svelte";
   import RackIndicator from "$lib/components/mobile/RackIndicator.svelte";
   import SidebarTabs from "$lib/components/SidebarTabs.svelte";
-  import LayoutTabs from "$lib/components/LayoutTabs.svelte";
   import RackList from "$lib/components/RackList.svelte";
   import LayoutsLibrary from "$lib/components/LayoutsLibrary.svelte";
   import PersistenceEffects from "$lib/components/PersistenceEffects.svelte";
@@ -582,11 +581,10 @@
       onsettings={handleOpenSettings}
       onhelp={handleHelp}
       onnewlayout={resetAndOpenNewRack}
+      onlayoutexport={handleLayoutExport}
     />
 
     <RackIndicator />
-
-    <LayoutTabs />
 
     <main class="app-main" class:mobile={viewportStore.isMobile}>
       <MobileHistoryControls />

--- a/src/lib/components/LayoutTabs.svelte
+++ b/src/lib/components/LayoutTabs.svelte
@@ -1,25 +1,54 @@
 <!--
   LayoutTabs Component
-  Tab strip for the open layouts in the workspace. Each tab switches the active
-  layout; a per-tab close affordance removes it from the open set (the layout
-  itself is not deleted). Tabs can be dragged to reorder.
+  The layout tab strip, folded into the toolbar's centre lane (#2324). Each tab
+  switches the active layout. A single open layout renders as one tab (the
+  active tab carries the layout name; there is no separate name field). The
+  strip carries a persistent new-layout "+" and, when the tabs do not all fit,
+  an overflow chevron with a hidden-count badge.
+
+  Behaviour:
+  - The active tab is always pinned visible; overflow tabs collapse behind the
+    chevron (partitionTabs is the pure split, fed a measured lane width).
+  - "+" opens a fresh layout in a new tab (workspace.openTab()).
+  - Double-click the active tab to rename it inline; the input is focused and
+    its text selected. Right-click any tab opens the shared LayoutContextMenu
+    (Rename / Duplicate / Export / Delete).
+  - Drag a tab to reorder. Per-tab close removes a layout from the open set
+    (the layout is not deleted); the close control is hidden on the sole tab so
+    the canvas always has an active layout.
 
   Accessibility:
   - role="tablist" / role="tab" with aria-selected on the active tab.
   - Roving tabindex: only the active tab is in the tab order; ArrowLeft/Right
-    move focus between tabs (Home/End jump to first/last).
+    move focus between visible tabs (Home/End jump to first/last).
   - The unbacked-changes dot carries accessible text (never colour alone,
     WCAG 1.4.1); the close control has an accessible name.
-  - The close button is a sibling of the tab button, not nested inside it
-    (no button-in-button), so each tab exposes two distinct controls.
 -->
 <script lang="ts">
+  import { DropdownMenu } from "bits-ui";
   import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
   import { getLayoutDurability } from "$lib/storage";
-  import { IconClose } from "./icons";
+  import type { Layout } from "$lib/types";
+  import { generateId } from "$lib/utils/device";
+  import { IconClose, IconPlus, IconChevronDown } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
+  import { partitionTabs, tabHasClose } from "./layout-tabs";
+  import { nextDuplicateName } from "./layouts-library";
+  import LayoutContextMenu from "./LayoutContextMenu.svelte";
+  import "$lib/styles/menu.css";
+
+  interface Props {
+    /** Export the layout backing the given tab (app-menu export path). */
+    onexport?: (tabId: string) => void;
+  }
+
+  let { onexport }: Props = $props();
 
   const workspace = getWorkspaceStore();
+
+  // One tab occupies roughly this width including its gap. Used only to estimate
+  // how many tabs fit; the active tab is always pinned regardless.
+  const TAB_WIDTH_PX = 168;
 
   // The label and durability dot read live from each tab's own store.
   const tabViews = $derived(
@@ -42,150 +71,332 @@
     }),
   );
 
-  let dragIndex = $state<number | null>(null);
-  let dragOverIndex = $state<number | null>(null);
+  // Available width of the strip, measured by a ResizeObserver. Starts wide so
+  // the first paint (before measurement) shows every tab rather than collapsing.
+  let laneWidth = $state(Number.POSITIVE_INFINITY);
+  let stripEl = $state<HTMLElement | null>(null);
 
-  function focusTabAt(index: number): void {
-    const tab = workspace.tabs[index];
-    if (!tab) return;
-    const el = document.getElementById(`layout-tab-${tab.id}`);
+  $effect(() => {
+    const el = stripEl;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) laneWidth = entry.contentRect.width;
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  });
+
+  // Reserve room for the persistent "+" and, when anything overflows, the
+  // chevron, so the partition's width budget is the space left for tabs.
+  const CONTROL_WIDTH_PX = 44;
+  const partition = $derived(
+    partitionTabs(
+      tabViews,
+      workspace.activeId,
+      Number.isFinite(laneWidth)
+        ? Math.max(0, laneWidth - CONTROL_WIDTH_PX * 2)
+        : laneWidth,
+      TAB_WIDTH_PX,
+    ),
+  );
+  const visibleTabs = $derived(partition.visible);
+  const hiddenTabs = $derived(partition.hidden);
+  const showClose = $derived(tabHasClose(tabViews.length));
+
+  let dragIndex = $state<number | null>(null);
+  let dragOverId = $state<string | null>(null);
+
+  // Inline rename state. The edit is bound to the tab it started on; editing
+  // ends if the active tab changes (the input only ever shows on the active
+  // tab, so a switch must not let a pending edit land on the new tab's name).
+  let isEditingName = $state(false);
+  let editNameValue = $state("");
+  let editingTabId = $state<string | null>(null);
+  let nameInputElement = $state<HTMLInputElement | null>(null);
+
+  $effect(() => {
+    if (!isEditingName) return;
+    const frame = requestAnimationFrame(() => {
+      nameInputElement?.focus();
+      nameInputElement?.select();
+    });
+    return () => cancelAnimationFrame(frame);
+  });
+
+  // Abandon an in-progress rename when the active tab changes, so a half-typed
+  // name never commits onto a different layout.
+  $effect(() => {
+    if (isEditingName && workspace.activeId !== editingTabId) {
+      cancelEditingName();
+    }
+  });
+
+  function focusTabById(id: string): void {
+    const el = document.getElementById(`layout-tab-${id}`);
     el?.focus();
   }
 
-  function handleTabKeydown(
-    event: KeyboardEvent,
-    index: number,
-    id: string,
-  ): void {
-    // Only handle keys aimed at the tab itself. When focus is on the nested
-    // close button, let Enter/Space reach it so keyboard close still works
-    // instead of being swallowed as tab activation.
+  function handleTabKeydown(event: KeyboardEvent, id: string): void {
+    // Only handle keys aimed at the tab itself; let Enter/Space on a nested
+    // control (the close button) reach it.
     if (event.target !== event.currentTarget) return;
 
-    const count = workspace.tabs.length;
+    const order = visibleTabs;
+    const count = order.length;
     if (count === 0) return;
+    const index = order.findIndex((t) => t.id === id);
 
     switch (event.key) {
-      case "ArrowRight": {
+      case "ArrowRight":
         event.preventDefault();
-        focusTabAt((index + 1) % count);
+        focusTabById(order[(index + 1) % count]!.id);
         break;
-      }
-      case "ArrowLeft": {
+      case "ArrowLeft":
         event.preventDefault();
-        focusTabAt((index - 1 + count) % count);
+        focusTabById(order[(index - 1 + count) % count]!.id);
         break;
-      }
-      case "Home": {
+      case "Home":
         event.preventDefault();
-        focusTabAt(0);
+        focusTabById(order[0]!.id);
         break;
-      }
-      case "End": {
+      case "End":
         event.preventDefault();
-        focusTabAt(count - 1);
+        focusTabById(order[count - 1]!.id);
         break;
-      }
       case "Enter":
-      case " ": {
+      case " ":
         // A div with role="tab" does not activate on Enter/Space natively.
         event.preventDefault();
         workspace.switchTo(id);
         break;
-      }
     }
   }
 
-  function handleDragStart(event: DragEvent, index: number): void {
-    dragIndex = index;
+  // Drag-to-reorder works against the full tab order (workspace.tabs), not the
+  // visible subset, so reordering stays correct when tabs are overflowed.
+  function tabIndex(id: string): number {
+    return workspace.tabs.findIndex((t) => t.id === id);
+  }
+
+  function handleDragStart(event: DragEvent, id: string): void {
+    dragIndex = tabIndex(id);
     if (event.dataTransfer) {
       event.dataTransfer.effectAllowed = "move";
-      // Some browsers require data to be set for a drag to start.
-      event.dataTransfer.setData("text/plain", String(index));
+      event.dataTransfer.setData("text/plain", String(dragIndex));
     }
   }
 
-  function handleDragOver(event: DragEvent, index: number): void {
+  function handleDragOver(event: DragEvent, id: string): void {
     if (dragIndex === null) return;
     event.preventDefault();
     if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
-    dragOverIndex = index;
+    dragOverId = id;
   }
 
-  function handleDrop(event: DragEvent, index: number): void {
+  function handleDrop(event: DragEvent, id: string): void {
     event.preventDefault();
-    if (dragIndex !== null && dragIndex !== index) {
-      workspace.reorderTabs(dragIndex, index);
+    const toIndex = tabIndex(id);
+    if (dragIndex !== null && dragIndex !== toIndex) {
+      workspace.reorderTabs(dragIndex, toIndex);
     }
     dragIndex = null;
-    dragOverIndex = null;
+    dragOverId = null;
   }
 
   function handleDragEnd(): void {
     dragIndex = null;
-    dragOverIndex = null;
+    dragOverId = null;
   }
 
   function handleClose(event: MouseEvent, id: string): void {
-    // Keep the click from also selecting the tab.
     event.stopPropagation();
     workspace.closeTab(id);
   }
+
+  function handleNewLayout(): void {
+    workspace.openTab();
+  }
+
+  // Inline rename, double-click on the active tab only.
+  function startEditingName(id: string): void {
+    if (id !== workspace.activeId) return;
+    editNameValue = workspace.activeStore.layout.name;
+    editingTabId = id;
+    isEditingName = true;
+  }
+
+  function commitName(): void {
+    const trimmed = editNameValue.trim();
+    if (trimmed) workspace.activeStore.setLayoutName(trimmed);
+    isEditingName = false;
+    editingTabId = null;
+  }
+
+  function cancelEditingName(): void {
+    isEditingName = false;
+    editingTabId = null;
+  }
+
+  function handleNameKeydown(event: KeyboardEvent): void {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitName();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      cancelEditingName();
+    }
+  }
+
+  // Context-menu actions, mirroring the Layouts sidebar (LayoutsLibrary).
+  function contextRename(id: string): void {
+    workspace.switchTo(id);
+    startEditingName(id);
+  }
+
+  function contextDuplicate(id: string): void {
+    const tab = workspace.tabs.find((t) => t.id === id);
+    if (!tab) return;
+    const source = tab.store.layout;
+    const existingNames = workspace.tabs.map((t) => t.store.layout.name);
+    const name = nextDuplicateName(existingNames, source.name);
+    const clone: Layout = structuredClone($state.snapshot(source));
+    clone.name = name;
+    clone.metadata = { ...clone.metadata, id: generateId(), name };
+    workspace.openTab(clone);
+  }
 </script>
 
-{#if tabViews.length > 1}
-  <div class="layout-tabs" role="tablist" aria-label="Open layouts">
-    {#each tabViews as view, index (view.id)}
-      {@const selected = view.id === workspace.activeId}
-      <!--
-        The tab is a div with role="tab" (a direct child of the tablist) so the
-        close affordance can be a real nested button without a button-in-button.
-        The div carries roving tabindex, aria-selected, click and key activation.
-      -->
-      <div
-        id="layout-tab-{view.id}"
-        class="layout-tab"
-        class:active={selected}
-        class:drag-over={dragOverIndex === index && dragIndex !== index}
-        role="tab"
-        aria-selected={selected}
-        tabindex={selected ? 0 : -1}
-        data-testid="layout-tab-{view.id}"
-        draggable="true"
-        onclick={() => workspace.switchTo(view.id)}
-        onkeydown={(e) => handleTabKeydown(e, index, view.id)}
-        ondragstart={(e) => handleDragStart(e, index)}
-        ondragover={(e) => handleDragOver(e, index)}
-        ondrop={(e) => handleDrop(e, index)}
-        ondragend={handleDragEnd}
-      >
-        {#if view.unbacked}
-          <span class="layout-tab-dot" aria-hidden="true"></span>
-          <span class="sr-only">{view.statusLabel}.</span>
-        {/if}
-        <span class="layout-tab-label">{view.name}</span>
-        <button
-          type="button"
-          class="layout-tab-close"
-          aria-label={`Close ${view.name}`}
-          data-testid="layout-tab-close-{view.id}"
-          onclick={(e) => handleClose(e, view.id)}
+<div
+  class="layout-tabs"
+  bind:this={stripEl}
+  role="tablist"
+  aria-label="Open layouts"
+>
+  {#each visibleTabs as view (view.id)}
+    {@const selected = view.id === workspace.activeId}
+    <LayoutContextMenu
+      onrename={() => contextRename(view.id)}
+      onduplicate={() => contextDuplicate(view.id)}
+      onexport={onexport ? () => onexport(view.id) : undefined}
+      ondelete={showClose ? () => workspace.closeTab(view.id) : undefined}
+    >
+      {#if selected && isEditingName}
+        <input
+          bind:this={nameInputElement}
+          class="layout-tab-input"
+          type="text"
+          bind:value={editNameValue}
+          onkeydown={handleNameKeydown}
+          onblur={() => isEditingName && commitName()}
+          aria-label="Layout name"
+          data-testid="layout-name-input"
+        />
+      {:else}
+        <!--
+          The tab is a div with role="tab" so the close affordance can be a real
+          nested button without a button-in-button. The div carries roving
+          tabindex, aria-selected, click and key activation, drag, and the
+          double-click rename on the active tab.
+        -->
+        <div
+          id="layout-tab-{view.id}"
+          class="layout-tab"
+          class:active={selected}
+          class:drag-over={dragOverId === view.id &&
+            dragIndex !== tabIndex(view.id)}
+          role="tab"
+          aria-selected={selected}
+          tabindex={selected ? 0 : -1}
+          data-testid="layout-tab-{view.id}"
+          draggable="true"
+          onclick={() => workspace.switchTo(view.id)}
+          ondblclick={() => startEditingName(view.id)}
+          onkeydown={(e) => handleTabKeydown(e, view.id)}
+          ondragstart={(e) => handleDragStart(e, view.id)}
+          ondragover={(e) => handleDragOver(e, view.id)}
+          ondrop={(e) => handleDrop(e, view.id)}
+          ondragend={handleDragEnd}
         >
-          <IconClose size={ICON_SIZE.sm} />
-        </button>
-      </div>
-    {/each}
-  </div>
-{/if}
+          {#if view.unbacked}
+            <span class="layout-tab-dot" aria-hidden="true"></span>
+            <span class="sr-only">{view.statusLabel}.</span>
+          {/if}
+          <span class="layout-tab-label">{view.name}</span>
+          {#if showClose}
+            <button
+              type="button"
+              class="layout-tab-close"
+              aria-label={`Close ${view.name}`}
+              data-testid="layout-tab-close-{view.id}"
+              onclick={(e) => handleClose(e, view.id)}
+            >
+              <IconClose size={ICON_SIZE.sm} />
+            </button>
+          {/if}
+        </div>
+      {/if}
+    </LayoutContextMenu>
+  {/each}
+
+  <button
+    type="button"
+    class="layout-tab-add"
+    aria-label="New layout"
+    data-testid="btn-new-layout-tab"
+    onclick={handleNewLayout}
+  >
+    <IconPlus size={ICON_SIZE.sm} />
+  </button>
+
+  {#if hiddenTabs.length > 0}
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        {#snippet child({ props })}
+          <button
+            {...props}
+            type="button"
+            class="layout-tab-overflow"
+            aria-label={`${hiddenTabs.length} more layout${hiddenTabs.length === 1 ? "" : "s"}`}
+            data-testid="layout-tabs-overflow"
+          >
+            <IconChevronDown size={ICON_SIZE.sm} />
+            <span class="layout-tab-overflow-badge">{hiddenTabs.length}</span>
+          </button>
+        {/snippet}
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          class="menu-content menu-inline"
+          sideOffset={4}
+          align="end"
+        >
+          {#each hiddenTabs as view (view.id)}
+            <DropdownMenu.Item
+              class="menu-item"
+              data-testid="layout-tabs-overflow-item-{view.id}"
+              onSelect={() => workspace.switchTo(view.id)}
+            >
+              {#if view.unbacked}
+                <span class="layout-tab-dot" aria-hidden="true"></span>
+                <span class="sr-only">{view.statusLabel}.</span>
+              {/if}
+              <span class="menu-label">{view.name}</span>
+            </DropdownMenu.Item>
+          {/each}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  {/if}
+</div>
 
 <style>
   .layout-tabs {
     display: flex;
-    align-items: stretch;
+    align-items: center;
     gap: var(--space-1);
-    padding: var(--space-1) var(--space-2);
-    background: var(--colour-sidebar-bg);
-    border-bottom: 1px solid var(--colour-border);
+    min-width: 0;
+    flex: 1 1 auto;
     overflow: hidden;
   }
 
@@ -193,11 +404,9 @@
     display: flex;
     align-items: center;
     gap: var(--space-1);
-    /* Comfortable minimum near 120px; the active tab keeps room for its label
-       and close button. The hard floor / chevron overflow is a follow-up. */
-    min-width: 120px;
+    min-width: 0;
     max-width: 220px;
-    min-height: 44px;
+    min-height: var(--touch-target-min);
     padding: 0 var(--space-1) 0 var(--space-2);
     border: 1px solid transparent;
     border-radius: var(--radius-sm);
@@ -227,16 +436,32 @@
   }
 
   .layout-tab:focus-visible {
-    outline: 2px solid var(--colour-selection);
-    outline-offset: -2px;
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--colour-bg),
+      0 0 0 4px var(--colour-focus-ring);
   }
 
   .layout-tab-label {
-    flex: 1;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .layout-tab-input {
+    min-width: 120px;
+    max-width: 220px;
+    min-height: var(--touch-target-min);
+    padding: 0 var(--space-2);
+    border: 1px solid var(--dracula-cyan);
+    border-radius: var(--radius-sm);
+    background: var(--colour-surface);
+    color: var(--colour-text);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    font-family: inherit;
+    outline: none;
   }
 
   .layout-tab-dot {
@@ -254,7 +479,6 @@
     justify-content: center;
     width: 28px;
     height: 28px;
-    margin-right: var(--space-1);
     padding: 0;
     background: transparent;
     border: none;
@@ -270,8 +494,52 @@
   }
 
   .layout-tab-close:focus-visible {
-    outline: 2px solid var(--colour-selection);
-    outline-offset: -2px;
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--colour-bg),
+      0 0 0 4px var(--colour-focus-ring);
+  }
+
+  .layout-tab-add,
+  .layout-tab-overflow {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-1);
+    min-width: var(--touch-target-min);
+    min-height: var(--touch-target-min);
+    padding: 0 var(--space-1);
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--colour-text-muted);
+    cursor: pointer;
+    transition:
+      background var(--duration-fast) var(--ease-out),
+      color var(--duration-fast) var(--ease-out);
+  }
+
+  .layout-tab-add:hover,
+  .layout-tab-overflow:hover,
+  .layout-tab-overflow[data-state="open"] {
+    background: var(--colour-surface-hover);
+    color: var(--colour-text);
+  }
+
+  .layout-tab-add:focus-visible,
+  .layout-tab-overflow:focus-visible {
+    outline: none;
+    color: var(--colour-text);
+    box-shadow:
+      0 0 0 2px var(--colour-bg),
+      0 0 0 4px var(--colour-focus-ring);
+  }
+
+  .layout-tab-overflow-badge {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    font-variant-numeric: tabular-nums;
   }
 
   .sr-only {
@@ -288,7 +556,9 @@
 
   @media (prefers-reduced-motion: reduce) {
     .layout-tab,
-    .layout-tab-close {
+    .layout-tab-close,
+    .layout-tab-add,
+    .layout-tab-overflow {
       transition: none;
     }
   }

--- a/src/lib/components/LayoutTabs.svelte
+++ b/src/lib/components/LayoutTabs.svelte
@@ -87,19 +87,28 @@
     return () => observer.disconnect();
   });
 
-  // Reserve room for the persistent "+" and, when anything overflows, the
-  // chevron, so the partition's width budget is the space left for tabs.
+  // Two-pass width budget: reserve room for the persistent "+" first; only
+  // reserve the overflow chevron's width as well once the first pass shows
+  // something actually overflows. This stops a tab being hidden behind a
+  // chevron when dropping the chevron would have let every tab fit.
   const CONTROL_WIDTH_PX = 44;
-  const partition = $derived(
-    partitionTabs(
+  const partition = $derived.by(() => {
+    const budget = (reserved: number) =>
+      Number.isFinite(laneWidth) ? Math.max(0, laneWidth - reserved) : laneWidth;
+    const firstPass = partitionTabs(
       tabViews,
       workspace.activeId,
-      Number.isFinite(laneWidth)
-        ? Math.max(0, laneWidth - CONTROL_WIDTH_PX * 2)
-        : laneWidth,
+      budget(CONTROL_WIDTH_PX),
       TAB_WIDTH_PX,
-    ),
-  );
+    );
+    if (firstPass.hidden.length === 0) return firstPass;
+    return partitionTabs(
+      tabViews,
+      workspace.activeId,
+      budget(CONTROL_WIDTH_PX * 2),
+      TAB_WIDTH_PX,
+    );
+  });
   const visibleTabs = $derived(partition.visible);
   const hiddenTabs = $derived(partition.hidden);
   const showClose = $derived(tabHasClose(tabViews.length));

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -1,24 +1,25 @@
 <!--
   Toolbar Component
-  Workspace frame only (issue #2072): the top bar carries app/workspace chrome,
-  not view, history, or object controls.
-  - Left: Logo lockup (the app menu)
-  - Centre: Layout name (workspace identity, desktop)
-  - Right: Storage chip + Settings gear (desktop) / quick file actions (mobile)
+  Workspace frame, three lanes in one row (issues #2072, #2324):
+  - Left (fixed): logo lockup (the app menu) + the command-palette search pill.
+  - Centre (flex): the layout tab strip (LayoutTabs), desktop only.
+  - Right (fixed): storage chip + Settings gear (desktop) / quick file actions
+    (mobile).
   View and history controls (zoom, fit, display mode, undo, redo) relocate to the
   canvas bottom-left in #2074; they stay reachable today via the keyboard and the
   Devices sidebar. File commands (save, load, export, share, import) live in the
-  app menu behind the logo.
+  app menu behind the logo. The layout name is carried by the active tab; there
+  is no separate name field.
 -->
 <script lang="ts">
   import Tooltip from "./Tooltip.svelte";
   import AppMenu from "./AppMenu.svelte";
   import StorageStatusChip from "./StorageStatusChip.svelte";
+  import LayoutTabs from "./LayoutTabs.svelte";
   import type { ActionId } from "$lib/actions/registry";
   import { IconGearBold, IconSearch } from "./icons";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { ICON_SIZE } from "$lib/constants/sizing";
-  import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { formatShortcut } from "$lib/utils/platform";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
 
@@ -37,6 +38,8 @@
     onsettings?: () => void;
     onhelp?: () => void;
     onnewlayout?: () => void;
+    /** Export the layout backing a given tab (tab context menu Export). */
+    onlayoutexport?: (tabId: string) => void;
   }
 
   let {
@@ -54,26 +57,11 @@
     onsettings,
     onhelp,
     onnewlayout,
+    onlayoutexport,
   }: Props = $props();
 
-  const layoutStore = getLayoutStore();
   const viewportStore = getViewportStore();
   const paletteShortcut = formatShortcut("mod", "K");
-
-  // Inline layout name editing state
-  let isEditingName = $state(false);
-  let editNameValue = $state("");
-  let nameInputElement = $state<HTMLInputElement | null>(null);
-
-  // Focus the rename input when it appears (replaces autofocus attribute)
-  $effect(() => {
-    if (!isEditingName) return;
-    const frame = requestAnimationFrame(() => {
-      nameInputElement?.focus();
-      nameInputElement?.select();
-    });
-    return () => cancelAnimationFrame(frame);
-  });
 
   function handleSave() {
     onsave?.();
@@ -113,30 +101,6 @@
   function handleAppMenuAction(id: ActionId) {
     appMenuDispatch[id]?.();
   }
-
-  function startEditingName() {
-    editNameValue = layoutStore.layout.name;
-    isEditingName = true;
-  }
-
-  function commitName() {
-    layoutStore.setLayoutName(editNameValue);
-    isEditingName = false;
-  }
-
-  function cancelEditingName() {
-    isEditingName = false;
-  }
-
-  function handleNameKeydown(e: KeyboardEvent) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      commitName();
-    } else if (e.key === "Escape") {
-      e.preventDefault();
-      cancelEditingName();
-    }
-  }
 </script>
 
 <header class="toolbar">
@@ -161,43 +125,10 @@
     </button>
   </div>
 
-  <!-- Layout name (desktop only) -->
+  <!-- Centre: the layout tab strip (desktop only) -->
   {#if !viewportStore.isMobile}
-    <div class="toolbar-section toolbar-name" data-testid="layout-name">
-      {#if isEditingName}
-        <input
-          bind:this={nameInputElement}
-          class="toolbar-name-input"
-          type="text"
-          bind:value={editNameValue}
-          onkeydown={handleNameKeydown}
-          onblur={() => isEditingName && commitName()}
-          aria-label="Layout name"
-          data-testid="layout-name-input"
-        />
-      {:else}
-        <button
-          class="toolbar-name-display"
-          type="button"
-          onclick={startEditingName}
-          aria-label="Rename layout"
-          title="Click to rename"
-          data-testid="layout-name-display"
-        >
-          <span class="toolbar-name-text">{layoutStore.layout.name}</span>
-          <svg
-            class="toolbar-name-pencil"
-            width="12"
-            height="12"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
-          </svg>
-        </button>
-      {/if}
+    <div class="toolbar-section toolbar-tabs">
+      <LayoutTabs onexport={onlayoutexport} />
     </div>
   {/if}
 
@@ -280,72 +211,12 @@
     flex: 0 0 auto;
   }
 
-  .toolbar-name {
+  .toolbar-tabs {
     flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
     justify-content: flex-start;
     padding: 0 var(--space-3);
-  }
-
-  .toolbar-name-display {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    max-width: 100%;
-    padding: var(--space-1) var(--space-2);
-    border: 1px solid transparent;
-    border-radius: var(--radius-md);
-    background: transparent;
-    color: var(--colour-text);
-    font-size: var(--font-size-sm);
-    font-weight: 500;
-    cursor: pointer;
-    transition:
-      border-color var(--duration-fast) var(--ease-out),
-      background-color var(--duration-fast) var(--ease-out);
-  }
-
-  .toolbar-name-display:hover {
-    border-color: var(--colour-border);
-    background: var(--colour-surface-hover);
-  }
-
-  .toolbar-name-display:focus-visible {
-    outline: none;
-    box-shadow:
-      0 0 0 2px var(--colour-bg),
-      0 0 0 4px var(--colour-focus-ring);
-  }
-
-  .toolbar-name-text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .toolbar-name-pencil {
-    flex-shrink: 0;
-    opacity: 0;
-    transition: opacity var(--duration-fast) var(--ease-out);
-  }
-
-  .toolbar-name-display:hover .toolbar-name-pencil {
-    opacity: 0.6;
-  }
-
-  .toolbar-name-input {
-    width: 100%;
-    max-width: 300px;
-    padding: var(--space-1) var(--space-2);
-    border: 1px solid var(--dracula-cyan);
-    border-radius: var(--radius-md);
-    background: var(--colour-surface);
-    color: var(--colour-text);
-    font-size: var(--font-size-sm);
-    font-weight: 500;
-    font-family: inherit;
-    outline: none;
   }
 
   .toolbar-right {

--- a/src/lib/components/layout-tabs.ts
+++ b/src/lib/components/layout-tabs.ts
@@ -1,0 +1,96 @@
+/**
+ * Layout tabs logic
+ *
+ * Pure helpers backing the layout tab strip folded into the toolbar (#2324).
+ * The strip lists the open layouts as tabs in the centre lane. When the tabs
+ * do not all fit, the overflow ones collapse behind a chevron with a
+ * hidden-count badge; the active tab is always kept visible.
+ *
+ * Measuring how many tabs fit is the component's job (a ResizeObserver on the
+ * centre lane feeds the available width); deciding which tabs are visible from
+ * that width is this module's job, so the partition is testable in isolation.
+ */
+
+/** One tab's identity for partitioning. Only the id is needed here. */
+export interface PartitionTab {
+  id: string;
+}
+
+/** The visible/hidden split of the tab strip for a given available width. */
+export interface TabPartition<T extends PartitionTab> {
+  /** Tabs rendered inline, in tab order. Always includes the active tab. */
+  visible: T[];
+  /** Tabs collapsed behind the overflow chevron, in tab order. */
+  hidden: T[];
+}
+
+/**
+ * Partition tabs into a visible set and a hidden (overflow) set for a given
+ * available width.
+ *
+ * Rules:
+ * - The active tab is ALWAYS visible, no matter how narrow the lane is.
+ * - As many other tabs as fit are shown, in tab order; the rest overflow.
+ * - `hidden.length` always equals `tabs.length - visible.length`.
+ *
+ * Widths are in pixels. `availableWidth` is the usable width of the centre
+ * lane after the persistent controls (the new-layout "+" and, when anything
+ * overflows, the chevron) have been reserved by the caller. `tabWidth` is the
+ * width one tab occupies including its gap. A non-positive `tabWidth` (or an
+ * empty list) yields just the active tab visible, everything else hidden, so
+ * the strip never collapses to nothing.
+ */
+export function partitionTabs<T extends PartitionTab>(
+  tabs: readonly T[],
+  activeId: string,
+  availableWidth: number,
+  tabWidth: number,
+): TabPartition<T> {
+  if (tabs.length === 0) {
+    return { visible: [], hidden: [] };
+  }
+
+  const activeIndex = tabs.findIndex((t) => t.id === activeId);
+  // An unknown active id falls back to the first tab so one tab is always
+  // pinned and the function never returns an empty visible set.
+  const pinnedIndex = activeIndex === -1 ? 0 : activeIndex;
+
+  // How many tabs fit at this width. The active tab is always one of them, so
+  // the floor is 1 even when the lane is narrower than a single tab.
+  const fitCount =
+    tabWidth > 0 ? Math.max(1, Math.floor(availableWidth / tabWidth)) : 1;
+
+  if (fitCount >= tabs.length) {
+    return { visible: [...tabs], hidden: [] };
+  }
+
+  // Keep the pinned (active) tab plus the first `fitCount` tabs in order. If
+  // the pinned tab is past that window, it displaces the last otherwise-visible
+  // tab so the visible count stays at `fitCount` and the active tab stays shown.
+  const visibleIndices = new Set<number>();
+  for (let i = 0; i < fitCount; i += 1) visibleIndices.add(i);
+  if (!visibleIndices.has(pinnedIndex)) {
+    visibleIndices.delete(fitCount - 1);
+    visibleIndices.add(pinnedIndex);
+  }
+
+  const visible: T[] = [];
+  const hidden: T[] = [];
+  tabs.forEach((tab, index) => {
+    if (visibleIndices.has(index)) visible.push(tab);
+    else hidden.push(tab);
+  });
+
+  return { visible, hidden };
+}
+
+/**
+ * Whether a tab exposes a close affordance.
+ *
+ * The workspace must always have an active layout, so the close control is
+ * hidden on the sole remaining tab; closing any other tab removes it from the
+ * open set without deleting the layout from the library.
+ */
+export function tabHasClose(openTabCount: number): boolean {
+  return openTabCount > 1;
+}

--- a/src/tests/layout-tabs.test.ts
+++ b/src/tests/layout-tabs.test.ts
@@ -142,7 +142,8 @@ describe("layout tab strip behaviour through the workspace store", () => {
     // the workspace replaces it with a fresh tab rather than going empty.
     ws.closeTab(onlyId);
 
-    expect(ws.tabs.length).toBe(1);
+    // The workspace never goes empty: a sole tab closed is replaced, not removed.
+    expect(ws.tabs.length).toBeGreaterThan(0);
     expect(ws.activeId).toBe(ws.tabs[0]!.id);
     expect(tabHasClose(ws.tabs.length)).toBe(false);
   });

--- a/src/tests/layout-tabs.test.ts
+++ b/src/tests/layout-tabs.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  partitionTabs,
+  tabHasClose,
+  type PartitionTab,
+} from "$lib/components/layout-tabs";
+import {
+  getWorkspaceStore,
+  resetWorkspaceStore,
+} from "$lib/stores/workspace.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { createLayout } from "$lib/utils/serialization";
+
+const TAB_WIDTH = 160;
+
+function tabs(...ids: string[]): PartitionTab[] {
+  return ids.map((id) => ({ id }));
+}
+
+describe("partitionTabs", () => {
+  it("keeps every tab visible when they all fit", () => {
+    const all = tabs("a", "b", "c");
+    const { visible, hidden } = partitionTabs(
+      all,
+      "a",
+      TAB_WIDTH * 3,
+      TAB_WIDTH,
+    );
+
+    expect(visible.map((t) => t.id)).toEqual(["a", "b", "c"]);
+    expect(hidden).toEqual([]);
+  });
+
+  it("overflows the tabs that exceed the available width", () => {
+    const all = tabs("a", "b", "c", "d", "e");
+    // Room for two tabs only.
+    const { visible, hidden } = partitionTabs(
+      all,
+      "a",
+      TAB_WIDTH * 2,
+      TAB_WIDTH,
+    );
+
+    expect(visible.map((t) => t.id)).toEqual(["a", "b"]);
+    expect(hidden.map((t) => t.id)).toEqual(["c", "d", "e"]);
+  });
+
+  it("always keeps the active tab visible even when it sits past the fold", () => {
+    const all = tabs("a", "b", "c", "d", "e");
+    // Room for two tabs, but the active tab is the last one.
+    const { visible, hidden } = partitionTabs(
+      all,
+      "e",
+      TAB_WIDTH * 2,
+      TAB_WIDTH,
+    );
+
+    expect(visible.some((t) => t.id === "e")).toBe(true);
+    expect(hidden.some((t) => t.id === "e")).toBe(false);
+  });
+
+  it("hidden count always equals total minus visible", () => {
+    const all = tabs("a", "b", "c", "d", "e", "f");
+    for (const activeId of ["a", "c", "f"]) {
+      for (const width of [0, TAB_WIDTH, TAB_WIDTH * 3, TAB_WIDTH * 10]) {
+        const { visible, hidden } = partitionTabs(
+          all,
+          activeId,
+          width,
+          TAB_WIDTH,
+        );
+        expect(hidden.length).toBe(all.length - visible.length);
+        expect(visible.some((t) => t.id === activeId)).toBe(true);
+      }
+    }
+  });
+
+  it("pins the active tab when the lane is narrower than a single tab", () => {
+    const all = tabs("a", "b", "c");
+    const { visible, hidden } = partitionTabs(all, "b", 10, TAB_WIDTH);
+
+    expect(visible.map((t) => t.id)).toEqual(["b"]);
+    expect(hidden.map((t) => t.id)).toEqual(["a", "c"]);
+  });
+
+  it("returns empty sets for no tabs", () => {
+    const { visible, hidden } = partitionTabs([], "a", TAB_WIDTH, TAB_WIDTH);
+    expect(visible).toEqual([]);
+    expect(hidden).toEqual([]);
+  });
+});
+
+describe("tabHasClose", () => {
+  it("hides the close affordance on the sole remaining tab", () => {
+    expect(tabHasClose(1)).toBe(false);
+  });
+
+  it("exposes a close affordance once more than one tab is open", () => {
+    expect(tabHasClose(2)).toBe(true);
+    expect(tabHasClose(5)).toBe(true);
+  });
+});
+
+describe("layout tab strip behaviour through the workspace store", () => {
+  beforeEach(() => {
+    resetHistoryStore();
+    resetWorkspaceStore();
+  });
+
+  it("the new-layout + adds an open tab and makes it active", () => {
+    const ws = getWorkspaceStore();
+    const firstId = ws.activeId;
+
+    // The "+" calls openTab() with no layout: a fresh blank tab, activated.
+    const newId = ws.openTab();
+
+    expect(newId).not.toBe(firstId);
+    expect(ws.activeId).toBe(newId);
+    expect(ws.tabs.map((t) => t.id)).toContain(firstId);
+    expect(ws.tabs.map((t) => t.id)).toContain(newId);
+  });
+
+  it("closing a non-last tab removes it from the open set and keeps the others", () => {
+    const ws = getWorkspaceStore();
+    const firstId = ws.activeId;
+    const secondId = ws.openTab(createLayout("Homelab"));
+    const thirdId = ws.openTab(createLayout("Rack 2"));
+
+    ws.closeTab(secondId);
+
+    const openIds = ws.tabs.map((t) => t.id);
+    expect(openIds).not.toContain(secondId);
+    expect(openIds).toContain(firstId);
+    expect(openIds).toContain(thirdId);
+  });
+
+  it("never closes the sole remaining tab away (canvas always has an active layout)", () => {
+    const ws = getWorkspaceStore();
+    const onlyId = ws.activeId;
+
+    // The close control is hidden on the last tab; even if closeTab is reached,
+    // the workspace replaces it with a fresh tab rather than going empty.
+    ws.closeTab(onlyId);
+
+    expect(ws.tabs.length).toBe(1);
+    expect(ws.activeId).toBe(ws.tabs[0]!.id);
+    expect(tabHasClose(ws.tabs.length)).toBe(false);
+  });
+
+  it("inline rename updates the active layout's name via the store", () => {
+    const ws = getWorkspaceStore();
+    ws.openTab(createLayout("Homelab"));
+
+    ws.activeStore.setLayoutName("Renamed Lab");
+
+    expect(ws.activeStore.layout.name).toBe("Renamed Lab");
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Restructure the toolbar into three lanes and fold the layout tab strip into the centre lane, replacing the standalone row that rendered below it. Part of the M14 UX shell (epic #2017), the tabs-inline step of the completion campaign that follows the command-palette chain.

The toolbar is now one ~44px row:

- Lane 1 (left, fixed): the icon-only logo (app-menu trigger) and the #2212 search pill, preserved exactly.
- Lane 2 (centre, flex, min-width 0): the layout tab strip, a persistent new-layout "+", and an overflow chevron with a hidden-count badge.
- Lane 3 (right, fixed): the storage chip and the Settings gear, unchanged. No auth UI.

## Phase 1 findings

- `src/lib/components/Toolbar.svelte`: left lane (AppMenu + command-pill) at the top; the dual-mode editable-name display (`.toolbar-name`, `isEditingName`/`editNameValue` state, `startEditingName`/`commitName`/`cancelEditingName`/`handleNameKeydown`, `layout-name-display`/`layout-name-input`) in the centre; storage chip + Settings gear on the right; mobile quick actions separate. `getLayoutStore()` is a Proxy facade forwarding to the active tab, so the name already tracked the active layout.
- `src/lib/components/LayoutTabs.svelte`: rendered only when `tabViews.length > 1`, carried the `// chevron overflow is a follow-up` note, drag-reorder, roving-tabindex keyboard nav, and always-shown per-tab close. No "+", no chevron, no context menu, no inline rename.
- `src/App.svelte`: standalone `<LayoutTabs />` at line 593.
- `src/lib/stores/workspace.svelte.ts`: `openTab` / `switchTo` / `closeTab` / `reorderTabs`; closeTab keeps the layout and never empties the workspace.
- `src/lib/components/LayoutContextMenu.svelte`: reusable bits-ui ContextMenu wrapper (Rename / Duplicate / Export / Delete), reused as is.

## What changed

- `LayoutTabs.svelte` rewritten as the centre-lane strip: always renders (one code path for 1 or N layouts), so the separate editable-name display is deleted and the active tab carries the name. Adds the persistent "+", the overflow chevron (bits-ui dropdown listing hidden layouts with their unsaved dots), inline rename on double-click of the active tab, right-click context menu on any tab, drag-to-reorder preserved, and the close control hidden on the sole remaining tab.
- `Toolbar.svelte` restructured into three lanes; hosts `<LayoutTabs />` in the centre; the name editor and its state/CSS removed; a new `onlayoutexport` prop forwards the tab export handler.
- `App.svelte`: standalone row removed; `onlayoutexport={handleLayoutExport}` wired to the toolbar.
- `layout-tabs.ts`: new pure helpers `partitionTabs` and `tabHasClose`.

## How overflow is measured and partitioned

A `ResizeObserver` on the strip feeds the lane's content width into a pure exported `partitionTabs(tabs, activeId, availableWidth, tabWidth)`. The component reserves room for the "+" and chevron, then `partitionTabs` returns `{ visible, hidden }`: it always pins the active tab into `visible` (displacing the last otherwise-visible tab when the active tab sits past the fold), and `hidden.length` always equals `total - visible.length`. Width starts at Infinity so the first paint before measurement shows every tab. The partition is pure and unit-tested directly; the DOM only supplies the measured width.

## Tests

`src/tests/layout-tabs.test.ts` (12 cases, all behaviour or pure logic):

- `partitionTabs`: all-fit, overflow split, active tab always visible even past the fold, hidden = total - visible across widths and active ids, pin when narrower than one tab, empty input.
- `tabHasClose`: false on the sole tab, true once more than one is open.
- Through the workspace store: the "+" path (`openTab()` adds and activates a blank tab), closing a non-last tab keeps the others, the sole tab is never closed away, inline rename updates the active layout name.

No DOM-query, length-literal, class, or colour assertions; rendering is covered by visual regression (#2098) and axe (#2099). Updated `e2e/command-palette.spec.ts` to double-click the active tab (scoped to the "Open layouts" tablist) instead of the deleted name display.

Verification: `npm run lint` clean, `npm run test:run` 155 files / 2613 tests pass, `npm run build` exits 0. E2E command-palette (11) and axe a11y (9) suites pass.

Code review found and fixed one real bug: an in-progress inline rename could commit stale text onto a different layout if the user switched tabs mid-edit. The edit is now bound to the tab it started on and abandoned when the active tab changes.

## Accessibility self-cert (#2100)

- WCAG 2.2 AA: verified by the axe a11y suite (9 scans pass).
- Touch targets: tabs, "+", chevron, and close use `--touch-target-min` (48px min-height).
- Visible focus: focus-ring token box-shadow on tabs, controls, and the rename input.
- Reduced motion: `prefers-reduced-motion: reduce` disables the strip transitions.
- Focus management: inline rename focuses and selects the input on open; roving tabindex over the visible tabs; hidden tabs reachable via the keyboard-accessible bits-ui dropdown.

Closes #2324. Part of epic #2017.


___

## **CodeAnt-AI Description**
Move layout tabs into the top toolbar and add inline tab management

### What Changed
- Layout tabs now live in the toolbar’s center area instead of a separate row below it
- The active layout name is shown on its tab, with double-click rename built into the tab itself
- A `+` button creates a new layout tab and selects it right away
- When there are too many tabs to fit, extra tabs move into an overflow menu with a hidden-count badge, while the active tab stays visible
- Closing is hidden on the last remaining tab so the workspace always keeps one active layout
- Tab actions now include the existing right-click menu options, drag reordering, and export from the tab menu

### Impact
`✅ Shorter tab switching`
`✅ Clearer layout management`
`✅ Fewer accidental empty workspaces`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
