### PR TITLE
feat: command palette device-search sub-mode (#2214)

### DIFF
--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -291,7 +291,10 @@ test.describe("Command palette", () => {
     await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
     await page.getByTestId("command-palette-add-device").click();
     await page.getByTestId("command-palette-device-item-1u-server").click();
-    // Placement is entered and the palette closes; the placement cue is shown.
+    // Choosing a device closes the palette and arms placement via the shared
+    // tap-to-place path. The "tap to place" status cue and tap-to-place
+    // completion are mobile-only (Rack.svelte gates them on viewportStore.isMobile),
+    // so on desktop the observable outcome is the palette closing.
     await expect(
       page.getByRole("dialog", { name: "Command palette" }),
     ).not.toBeVisible();

--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -206,4 +206,89 @@ test.describe("Command palette", () => {
     // Command.Empty ("No matching commands") must not be in the DOM when items exist.
     await expect(page.getByText("No matching commands")).toHaveCount(0);
   });
+
+  // --- #2214: device-search sub-mode ---
+
+  test("Add device pushes a device sub-page without closing the palette", async ({
+    page,
+  }) => {
+    await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
+    const palette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(palette).toBeVisible();
+
+    await page.getByTestId("command-palette-add-device").click();
+
+    // The palette stays open; the device sub-page swaps in (back affordance and
+    // a device result row appear). 1u-server is a stable starter slug.
+    await expect(palette).toBeVisible();
+    await expect(page.getByTestId("command-palette-device-back")).toBeVisible();
+    await expect(
+      page.getByTestId("command-palette-device-item-1u-server"),
+    ).toBeVisible();
+  });
+
+  test("device rows never appear in the top-level command list", async ({
+    page,
+  }) => {
+    await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
+    // Type a query that matches a device model but no command. No device row may
+    // surface at the top level: device search lives only behind "Add device...".
+    await page.getByTestId("command-palette-input").fill("server");
+    await expect(
+      page.getByTestId("command-palette-device-item-1u-server"),
+    ).toHaveCount(0);
+  });
+
+  test("the back affordance returns to the command list", async ({ page }) => {
+    await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
+    await page.getByTestId("command-palette-add-device").click();
+    await expect(page.getByTestId("command-palette-device-back")).toBeVisible();
+
+    await page.getByTestId("command-palette-device-back").click();
+    // Back to commands: the command list returns and the device sub-page is gone.
+    await expect(
+      page.getByTestId("command-palette-item-fit-all"),
+    ).toBeVisible();
+    await expect(page.getByTestId("command-palette-device-back")).toHaveCount(
+      0,
+    );
+  });
+
+  test("Backspace on an empty device query returns to the command list", async ({
+    page,
+  }) => {
+    await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
+    await page.getByTestId("command-palette-add-device").click();
+    const input = page.getByTestId("command-palette-input");
+    await expect(input).toBeFocused();
+
+    // A typed query then Backspaces clears the text; a further Backspace on the
+    // now-empty query pops back to commands (it must not also delete a char).
+    await input.fill("srv");
+    await input.press("Backspace");
+    await input.press("Backspace");
+    await input.press("Backspace");
+    // Query is empty but still in device mode.
+    await expect(page.getByTestId("command-palette-device-back")).toBeVisible();
+    // One more Backspace on the empty query returns to commands.
+    await input.press("Backspace");
+    await expect(
+      page.getByTestId("command-palette-item-fit-all"),
+    ).toBeVisible();
+    await expect(page.getByTestId("command-palette-device-back")).toHaveCount(
+      0,
+    );
+  });
+
+  test("choosing a device closes the palette into placement", async ({
+    page,
+  }) => {
+    await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
+    await page.getByTestId("command-palette-add-device").click();
+    await page.getByTestId("command-palette-device-item-1u-server").click();
+    // Placement is entered and the palette closes; the placement cue is shown.
+    await expect(
+      page.getByRole("dialog", { name: "Command palette" }),
+    ).not.toBeVisible();
+  });
 });

--- a/src/lib/actions/palette-devices.ts
+++ b/src/lib/actions/palette-devices.ts
@@ -1,0 +1,59 @@
+/**
+ * Device-search projection for the command palette's "Add device..." sub-mode
+ * (#2214). The palette pushes an in-place device-search sub-page; this seam
+ * composes the same device library the Devices sidebar uses (starter library,
+ * brand packs, and custom/placed device types) and reuses searchDevices (Fuse.js)
+ * and filterPaletteDevicesByRackWidth so the sub-page never owns its own search
+ * or width logic. Pure and unit-testable; the component supplies the live source
+ * arrays and active-rack width.
+ */
+import type { DeviceType } from "$lib/types";
+import {
+  searchDevices,
+  filterPaletteDevicesByRackWidth,
+} from "$lib/utils/deviceFilters";
+
+/** Live device sources the palette device-search reads, supplied by the component. */
+export interface PaletteDeviceSources {
+  /** Starter library devices. */
+  starter: DeviceType[];
+  /** Devices contributed by brand packs. */
+  brandPackDevices: DeviceType[];
+  /** Custom/placed device types from the active layout. */
+  customDevices: DeviceType[];
+}
+
+/**
+ * Compose the searchable device pool: custom devices win over starter/brand
+ * entries that share a slug (the sidebar shadows starters with custom types of
+ * the same slug), so each slug yields exactly one row.
+ */
+function composeLibrary(sources: PaletteDeviceSources): DeviceType[] {
+  const bySlug = new Map<string, DeviceType>();
+  for (const device of sources.starter) bySlug.set(device.slug, device);
+  for (const device of sources.brandPackDevices)
+    bySlug.set(device.slug, device);
+  // Custom devices are applied last so they shadow same-slug starter/brand rows.
+  for (const device of sources.customDevices) bySlug.set(device.slug, device);
+  return [...bySlug.values()];
+}
+
+/**
+ * Project the device-search results for the palette sub-page. Filters the
+ * composed library by active rack width (when compatibleOnly is set) then runs
+ * the shared fuzzy search. An empty query returns the width-filtered library.
+ */
+export function searchPaletteDevices(
+  sources: PaletteDeviceSources,
+  query: string,
+  activeRackWidth: number,
+  compatibleOnly: boolean,
+): DeviceType[] {
+  const library = composeLibrary(sources);
+  const widthFiltered = filterPaletteDevicesByRackWidth(
+    library,
+    activeRackWidth,
+    compatibleOnly,
+  );
+  return searchDevices(widthFiltered, query);
+}

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -12,17 +12,23 @@
 -->
 <script lang="ts">
   import { Dialog, Command } from "bits-ui";
-  import { IconSearch } from "./icons";
+  import { IconSearch, IconPlus, IconChevronLeft } from "./icons";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getUIStore } from "$lib/stores/ui.svelte";
+  import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { getStorageMode } from "$lib/storage";
   import { canMoveSelectedDeviceSlot } from "$lib/actions/selection-actions";
   import {
     getPaletteCommands,
     getPaletteEmptyState,
   } from "$lib/actions/palette-commands";
+  import {
+    searchPaletteDevices,
+    type PaletteDeviceSources,
+  } from "$lib/actions/palette-devices";
   import {
     recordCommand,
     getRecents,
@@ -31,17 +37,32 @@
     createActionDispatch,
     type ActionDispatch,
   } from "$lib/actions/dispatch";
+  import { getStarterLibrary, getStarterSlugs } from "$lib/data/starterLibrary";
+  import { getBrandPacks, getBrandSlugs } from "$lib/data/brandPacks";
   import type { ActionId, ActionEnabledContext } from "$lib/actions/registry";
+  import type { DeviceType } from "$lib/types";
 
   const viewportStore = getViewportStore();
   const selectionStore = getSelectionStore();
   const layoutStore = getLayoutStore();
+  const uiStore = getUIStore();
+  const placementStore = getPlacementStore();
   const isSheet = $derived(viewportStore.isMobile);
 
   const open = $derived(dialogStore.isOpen("commandPalette"));
   const dispatch: ActionDispatch = createActionDispatch();
 
+  // Sub-mode: "commands" is the top-level command list; "devices" is the pushed
+  // device-search sub-page (#2214). bits-ui Command has no native page stack, so
+  // the sub-page is local state that swaps the list content inside the same
+  // Command.Root. Device rows live only in "devices" and never enter the
+  // top-level command projection.
+  let mode = $state<"commands" | "devices">("commands");
   let search = $state("");
+  let deviceQuery = $state("");
+  // The single persistent input element, kept focused across mode switches so a
+  // mouse-driven push/pop still lands the caret in the search box.
+  let inputEl = $state<HTMLElement | null>(null);
 
   // Live enable context for gating selection (and rack-dependent) commands.
   const ctx = $derived<ActionEnabledContext>({
@@ -59,12 +80,86 @@
   const showEmptyState = $derived(search.trim() === "");
   const emptyState = $derived(getPaletteEmptyState(ctx, getRecents()));
 
+  // "Add device..." is an accelerator into placement, offered only when there is
+  // a rack to place into. It is a palette-internal mode switch, NOT a registry
+  // action, so it can never leak into the dispatch map, app menu, or help.
+  const canAddDevice = $derived(layoutStore.hasRack);
+
+  // Static library sources; brand packs are constant, starter/custom resolve per
+  // call so newly created custom types appear without reopening the palette.
+  const brandPacks = getBrandPacks();
+  const activeRackWidth = $derived(layoutStore.activeRack?.width ?? 19);
+  const deviceSources = $derived.by<PaletteDeviceSources>(() => {
+    const starterSlugs = getStarterSlugs();
+    const brandSlugs = getBrandSlugs();
+    const placed = layoutStore.device_types;
+    const placedSlugs = new Set(placed.map((d) => d.slug));
+    return {
+      starter: getStarterLibrary().filter((d) => !placedSlugs.has(d.slug)),
+      brandPackDevices: brandPacks.flatMap((pack) => pack.devices),
+      // Placed starter overrides and genuinely custom types; brand-pack placed
+      // copies are dropped so brand rows are not duplicated.
+      customDevices: placed.filter(
+        (d) => starterSlugs.has(d.slug) || !brandSlugs.has(d.slug),
+      ),
+    };
+  });
+  const deviceResults = $derived(
+    searchPaletteDevices(
+      deviceSources,
+      deviceQuery,
+      activeRackWidth,
+      uiStore.compatibleOnly,
+    ),
+  );
+
+  function deviceLabel(device: DeviceType): string {
+    const model = device.model ?? device.slug;
+    return device.manufacturer ? `${device.manufacturer} ${model}` : model;
+  }
+
+  function resetState() {
+    mode = "commands";
+    search = "";
+    deviceQuery = "";
+  }
+
   function handleOpenChange(next: boolean) {
     if (next) return;
     // Only clear the store if the palette is still the current dialog; a command
     // run from the palette may have already opened a different dialog.
     if (dialogStore.isOpen("commandPalette")) dialogStore.close();
-    search = "";
+    resetState();
+  }
+
+  function enterDeviceMode() {
+    deviceQuery = "";
+    mode = "devices";
+    inputEl?.focus();
+  }
+
+  function exitDeviceMode() {
+    deviceQuery = "";
+    mode = "commands";
+    inputEl?.focus();
+  }
+
+  // Backspace on an empty device query returns to the command list (mirrors the
+  // VS Code Quick Open back gesture). Guarded on empty so it never also deletes
+  // a character mid-query.
+  function handleDeviceInputKeydown(event: KeyboardEvent) {
+    if (event.key === "Backspace" && deviceQuery === "") {
+      event.preventDefault();
+      exitDeviceMode();
+    }
+  }
+
+  function placeDevice(device: DeviceType) {
+    // Mirror the mobile tap-to-place path: start placement, then close. The
+    // palette closing is the cue to position the device on the canvas.
+    placementStore.startPlacement(device);
+    dialogStore.close();
+    resetState();
   }
 
   function run(id: ActionId) {
@@ -74,8 +169,8 @@
     // Close the palette BEFORE running the command. dialogStore is scalar (one
     // dialog at a time): a command that opens its own dialog (share, view-yaml,
     // new-layout, ...) would be clobbered if we closed AFTER dispatch.
-    search = "";
     dialogStore.close();
+    resetState();
     dispatch[id]?.();
   }
 </script>
@@ -92,28 +187,123 @@
       <!-- Visually-hidden accessible name for the dialog. -->
       <Dialog.Title class="sr-only">Command palette</Dialog.Title>
 
-      <Command.Root label="Command palette" loop class="command-root">
+      <Command.Root
+        label="Command palette"
+        loop
+        shouldFilter={mode !== "devices"}
+        class="command-root"
+      >
         <div class="command-input-row">
-          <span class="command-input-icon" aria-hidden="true">
-            <IconSearch />
-          </span>
+          {#if mode === "devices"}
+            <button
+              type="button"
+              class="command-back"
+              onclick={exitDeviceMode}
+              aria-label="Back to commands"
+              data-testid="command-palette-device-back"
+            >
+              <IconChevronLeft />
+            </button>
+          {:else}
+            <span class="command-input-icon" aria-hidden="true">
+              <IconSearch />
+            </span>
+          {/if}
+          <!-- One persistent input across modes so focus survives the sub-page
+               push/pop. bind:value swaps between the command and device queries;
+               onkeydown handles Backspace-at-empty only while in device mode. -->
           <Command.Input
-            bind:value={search}
+            bind:ref={inputEl}
+            bind:value={
+              () => (mode === "devices" ? deviceQuery : search),
+              (v) => {
+                if (mode === "devices") deviceQuery = v;
+                else search = v;
+              }
+            }
+            onkeydown={mode === "devices"
+              ? handleDeviceInputKeydown
+              : undefined}
             class="command-input"
-            placeholder="Search or jump to..."
+            placeholder={mode === "devices"
+              ? "Add device..."
+              : "Search or jump to..."}
             data-testid="command-palette-input"
           />
         </div>
 
         <Command.List class="command-list" aria-label="Commands">
           <Command.Viewport class="command-viewport">
-            <Command.Empty class="command-empty">
-              No matching commands
-            </Command.Empty>
+            {#if mode !== "devices"}
+              <Command.Empty class="command-empty">
+                No matching commands
+              </Command.Empty>
+            {/if}
 
-            {#if showEmptyState}
+            {#if mode === "devices"}
+              {#if deviceResults.length === 0}
+                <p
+                  class="command-empty"
+                  data-testid="command-palette-device-empty"
+                >
+                  No matching devices
+                </p>
+              {:else}
+                <Command.Group
+                  class="command-group"
+                  data-testid="command-palette-device-results"
+                >
+                  <Command.GroupHeading class="command-group-heading">
+                    Add device
+                  </Command.GroupHeading>
+                  <Command.GroupItems>
+                    {#each deviceResults as device (device.slug)}
+                      <Command.Item
+                        value={device.slug}
+                        onSelect={() => placeDevice(device)}
+                        class="command-item"
+                        data-testid={`command-palette-device-item-${device.slug}`}
+                      >
+                        <span class="command-item-label"
+                          >{deviceLabel(device)}</span
+                        >
+                        <span class="command-item-shortcut"
+                          >{device.u_height}U</span
+                        >
+                      </Command.Item>
+                    {/each}
+                  </Command.GroupItems>
+                </Command.Group>
+              {/if}
+            {:else if showEmptyState}
               {@const hasRecent = emptyState.recent.length > 0}
               {@const hasSelection = emptyState.selection.length > 0}
+              {#if canAddDevice}
+                <Command.Group class="command-group">
+                  <Command.GroupItems>
+                    <Command.Item
+                      value="Add device..."
+                      keywords={[
+                        "add",
+                        "device",
+                        "place",
+                        "insert",
+                        "hardware",
+                      ]}
+                      onSelect={enterDeviceMode}
+                      class="command-item command-item--lead"
+                      data-testid="command-palette-add-device"
+                    >
+                      <span class="command-item-lead">
+                        <span class="command-item-icon" aria-hidden="true">
+                          <IconPlus />
+                        </span>
+                        <span class="command-item-label">Add device...</span>
+                      </span>
+                    </Command.Item>
+                  </Command.GroupItems>
+                </Command.Group>
+              {/if}
               {#if hasRecent}
                 <Command.Group
                   class="command-group"
@@ -176,7 +366,7 @@
               {/if}
 
               {#each emptyState.commands as group, groupIndex (group.heading)}
-                {#if hasRecent || hasSelection || groupIndex > 0}
+                {#if canAddDevice || hasRecent || hasSelection || groupIndex > 0}
                   <Command.Separator class="command-separator" />
                 {/if}
                 <Command.Group class="command-group">
@@ -204,8 +394,34 @@
                 </Command.Group>
               {/each}
             {:else}
+              {#if canAddDevice}
+                <Command.Group class="command-group">
+                  <Command.GroupItems>
+                    <Command.Item
+                      value="Add device..."
+                      keywords={[
+                        "add",
+                        "device",
+                        "place",
+                        "insert",
+                        "hardware",
+                      ]}
+                      onSelect={enterDeviceMode}
+                      class="command-item command-item--lead"
+                      data-testid="command-palette-add-device"
+                    >
+                      <span class="command-item-lead">
+                        <span class="command-item-icon" aria-hidden="true">
+                          <IconPlus />
+                        </span>
+                        <span class="command-item-label">Add device...</span>
+                      </span>
+                    </Command.Item>
+                  </Command.GroupItems>
+                </Command.Group>
+              {/if}
               {#each groups as group, groupIndex (group.heading)}
-                {#if groupIndex > 0}
+                {#if canAddDevice || groupIndex > 0}
                   <Command.Separator class="command-separator" />
                 {/if}
                 <Command.Group class="command-group">
@@ -322,6 +538,36 @@
     height: var(--icon-size-md);
   }
 
+  /* Back affordance in the device sub-page input row. */
+  .command-back {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--touch-target-min);
+    min-height: var(--touch-target-min);
+    margin: calc(var(--space-2) * -1) 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--colour-text-muted);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+  }
+
+  .command-back:hover {
+    color: var(--colour-text);
+  }
+
+  .command-back:focus-visible {
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: -2px;
+  }
+
+  .command-back :global(svg) {
+    width: var(--icon-size-md);
+    height: var(--icon-size-md);
+  }
+
   :global(.command-input) {
     flex: 1;
     min-height: var(--touch-target-min);
@@ -379,6 +625,27 @@
     font-family: var(--font-mono);
     font-size: var(--font-size-xs);
     color: var(--colour-text-muted);
+  }
+
+  /* "Add device..." lead row: icon plus label, reads as an entry point. */
+  .command-item-lead {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .command-item-icon {
+    display: inline-flex;
+    color: var(--colour-text-muted);
+  }
+
+  .command-item-icon :global(svg) {
+    width: var(--icon-size-md);
+    height: var(--icon-size-md);
+  }
+
+  :global(.command-item--lead[data-selected]) .command-item-icon {
+    color: var(--colour-text);
   }
 
   :global(.command-separator) {

--- a/src/tests/palette-devices.test.ts
+++ b/src/tests/palette-devices.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  searchPaletteDevices,
+  type PaletteDeviceSources,
+} from "$lib/actions/palette-devices";
+import { createTestDeviceType } from "./factories";
+
+function sources(
+  overrides: Partial<PaletteDeviceSources> = {},
+): PaletteDeviceSources {
+  return {
+    starter: [],
+    brandPackDevices: [],
+    customDevices: [],
+    ...overrides,
+  };
+}
+
+describe("searchPaletteDevices", () => {
+  it("reuses searchDevices: a query narrows the library by fuzzy match", () => {
+    const src = sources({
+      starter: [
+        createTestDeviceType({ slug: "dell-r740", model: "PowerEdge R740" }),
+        createTestDeviceType({ slug: "ubnt-sw", model: "UniFi Switch" }),
+      ],
+    });
+    const results = searchPaletteDevices(src, "PowerEdge", 19, false);
+    const slugs = results.map((d) => d.slug);
+    expect(slugs).toContain("dell-r740");
+    expect(slugs).not.toContain("ubnt-sw");
+  });
+
+  it("filters by active rack width when compatibleOnly is true", () => {
+    const src = sources({
+      starter: [
+        createTestDeviceType({
+          slug: "wide",
+          model: "Wide",
+          rack_widths: [23],
+        }),
+        createTestDeviceType({
+          slug: "narrow",
+          model: "Narrow",
+          rack_widths: [19],
+        }),
+      ],
+    });
+    const compatible = searchPaletteDevices(src, "", 19, true).map(
+      (d) => d.slug,
+    );
+    expect(compatible).toContain("narrow");
+    expect(compatible).not.toContain("wide");
+
+    const all = searchPaletteDevices(src, "", 19, false).map((d) => d.slug);
+    expect(all).toContain("wide");
+    expect(all).toContain("narrow");
+  });
+
+  it("combines starter, brand pack, and custom devices into one searchable pool", () => {
+    const src = sources({
+      starter: [createTestDeviceType({ slug: "s1", model: "Starter One" })],
+      brandPackDevices: [
+        createTestDeviceType({ slug: "b1", model: "Brand One" }),
+      ],
+      customDevices: [
+        createTestDeviceType({ slug: "c1", model: "Custom One" }),
+      ],
+    });
+    const slugs = searchPaletteDevices(src, "", 19, false).map((d) => d.slug);
+    expect(slugs).toEqual(expect.arrayContaining(["s1", "b1", "c1"]));
+  });
+
+  it("custom devices shadow a starter device that shares its slug (no duplicate row)", () => {
+    const src = sources({
+      starter: [createTestDeviceType({ slug: "dup", model: "Starter Dup" })],
+      customDevices: [
+        createTestDeviceType({ slug: "dup", model: "Custom Dup" }),
+      ],
+    });
+    const results = searchPaletteDevices(src, "", 19, false);
+    const dupRows = results.filter((d) => d.slug === "dup");
+    // eslint-disable-next-line no-restricted-syntax -- dedup invariant: one row per slug
+    expect(dupRows).toHaveLength(1);
+    expect(dupRows[0]?.model).toBe("Custom Dup");
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Adds an opt-in "Add device..." entry to the command palette. Selecting it pushes a device-search sub-page inside the same palette (it does not close the palette), which searches the device library and enters placement. The Devices sidebar stays the canonical placement path; this is an accelerator that mirrors the VS Code Palette / Quick Open split.

Part of epic #2017 (M14). Closes #2214.

## Phase 1 findings (where things live)

- `src/lib/components/CommandPalette.svelte`: composes bits-ui `Command.*` inside `Dialog.*`; command rows are projected from the registry via `getPaletteCommands`/`getPaletteEmptyState`; `run(id)` records a recent then closes then dispatches.
- `src/lib/actions/palette-commands.ts`: the registry projection, with an `EXCLUDED` set keeping non-pickable actions out.
- `src/lib/utils/deviceFilters.ts:114` `searchDevices` (Fuse.js, keys model/manufacturer/slug/category, threshold 0.3) and `:306` `filterPaletteDevicesByRackWidth(devices, rackWidth, compatibleOnly)`.
- `src/lib/stores/placement.svelte.ts:19` `startPlacement(device, face = "front")`; the mobile path is `DialogOrchestrator.svelte:598` `handleMobileDeviceSelect` (start placement, then close the sheet).
- `src/lib/components/DevicePalette.svelte:270` library composition (starter minus placed slugs, brand packs, custom devices) and `:176` `activeRackWidth = layoutStore.activeRack?.width ?? 19`.

## Sub-page approach

bits-ui `Command` has NO native pages stack (no page references in its dist types), so the sub-page is modeled with local component state: a `mode` rune (`"commands" | "devices"`) that swaps the rendered list inside one `Command.Root`. A single persistent `Command.Input` is bound via a function-binding to either `search` or `deviceQuery` by mode, so focus survives the push/pop; `inputEl?.focus()` re-focuses it on mode change for mouse users. `shouldFilter` is disabled in device mode because results are pre-filtered by Fuse. Backspace-at-empty-query (guarded on empty so it never deletes a character) and a back affordance both return to the command list.

The "Add device..." row is a palette-internal mode switch, NOT a registry action, so device search can never leak into the dispatch map, app menu, help overlay, or the top-level command list. It is gated on `hasRack` (no rack, nowhere to place).

## What changed

- `src/lib/actions/palette-devices.ts` (new): pure `searchPaletteDevices()` that composes the library (starter + brand packs + custom, custom shadows same-slug) and reuses `filterPaletteDevicesByRackWidth` + `searchDevices`.
- `src/lib/components/CommandPalette.svelte`: device sub-mode state, the "Add device..." lead row (empty-state and filtered branches), the device-results sub-page, single persistent input, back affordance, focus restore. Tokens only, 44px touch targets, visible focus, prefers-reduced-motion inherited from the shell.
- `src/tests/palette-devices.test.ts` (new): pure-logic tests.
- `e2e/command-palette.spec.ts`: 5 new sub-mode tests.

## Tests

- Unit: 157 files / 2618 tests pass. New `palette-devices.test.ts` (4 tests) covers: reuse of `searchDevices` for narrowing; rack-width filtering when `compatibleOnly` is set; the combined starter/brand/custom pool; and the slug-shadow dedup invariant (the one exact-length assertion carries an `eslint-disable` justification). These assert pure projection behaviour, not the DOM (rendering is covered by visual #2098 / axe #2099), so they comply with the strict testing rules.
- E2E: `command-palette.spec.ts` 16 tests pass, including 5 new ones: Add device pushes the sub-page without closing; device rows never appear in the top-level list; the back affordance returns; Backspace-at-empty returns (and does not delete a character first); choosing a device closes the palette into placement.
- Lint clean; build succeeds.

## Accessibility self-cert (#2100)

- WCAG 2.2 AA: device rows and the back button are real interactive elements with the same `Command.Item` combobox/listbox model as the shell; the back button has an `aria-label`.
- 44x44 touch: rows and the back button use `var(--touch-target-min)`.
- prefers-reduced-motion: inherited from the palette shell (no new animation added).
- Visible focus: `:focus-visible` outline on the input and back button; selection highlight on rows.
- Focus management: a single persistent input keeps focus across the push/pop, and focus is restored to it on mode change.


___

## **CodeAnt-AI Description**
**Add an in-palette device search step for placing hardware**

### What Changed
- Added an “Add device...” entry in the command palette that opens a device-search view inside the same palette instead of closing it.
- Device search now uses the same device library as the app, shows one row per device, and respects the current rack width and compatible-device setting.
- A back button and Backspace on an empty device query return to the command list; choosing a device starts placement and closes the palette.
- Added coverage for the new palette flow and device-search behavior.

### Impact
`✅ Faster device placement`
`✅ Fewer palette reopen steps`
`✅ Clearer device search results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
