### PR TITLE
feat: Layouts sidebar panel as the full layout library (#2325)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -44,6 +44,7 @@
     uploadSnapshot,
     setServerBaseUpdatedAt,
     resolveBrowserLaunch,
+    deleteLayoutBody,
   } from "$lib/storage";
   import { serializeLayoutToYaml } from "$lib/utils/yaml";
   import {
@@ -333,10 +334,13 @@
       }
 
       // restoreWorkspace hydrates the active tab and restores its durability
-      // (dirty by autosave convention, not explicitly saved).
+      // (dirty by autosave convention, not explicitly saved). deleteBody wires
+      // true library deletion (#2325): removing a layout drops its persisted
+      // body and index entry, not just the open tab.
       workspaceStore.restoreWorkspace({
         index: launch.index,
         loadBody: launch.loadBody,
+        deleteBody: deleteLayoutBody,
       });
       requestAnimationFrame(() => {
         if (!canvasStore.restoreViewport()) {

--- a/src/lib/components/LayoutsLibrary.svelte
+++ b/src/lib/components/LayoutsLibrary.svelte
@@ -1,26 +1,32 @@
 <!--
   LayoutsLibrary Component
 
-  Third sidebar tab (beside Devices and Racks). Lists the layouts the user is
-  working with as a compact row list and keeps it in sync with the open tabs.
+  Third sidebar tab (beside Devices and Racks). Lists the full library of saved
+  layouts (#2325): open layouts (one per workspace tab) and closed-but-saved
+  layouts (in the catalogue with no open tab). The toolbar tab strip (#2324)
+  holds the open working set; this panel is where the user browses, reopens, and
+  manages every layout.
 
-  Source of truth for this slice is the workspace store's OPEN set (#2079): one
-  row per open layout. The durable browser-mode library of every saved layout
-  depends on the multi-layout storage schema (#2179/#2080), which is a separate
-  slice; cached mini-render previews are #2083. Neither is built here, and the
-  row markup leaves room for a leading preview without restructuring.
+  Activating a row opens-or-switches: an open layout's tab is focused, a closed
+  layout's body is hydrated into a new tab. Closing a layout (the inline X on an
+  open row) keeps it in the library, recoverable. Deleting (context menu, with
+  confirmation) removes it from the library and closes its tab if open.
 
-  Indicators are never colour-only (WCAG 1.4.1): the active/open dot is paired
-  with a text label and an aria-selected state. The list is fully keyboard
-  navigable (Up/Down to move, Home/End to jump, Enter to open, Delete to remove
-  with confirmation).
+  Indicators are never colour-only (WCAG 1.4.1): each row pairs a state dot
+  (filled for open, outline for closed) with a text label (Active / Open /
+  Closed) and, for open rows, an aria-selected state. The list is keyboard
+  navigable (Up/Down to move, Home/End to jump, Enter to open).
 -->
 <script lang="ts">
   import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { generateId } from "$lib/utils/device";
   import type { Layout } from "$lib/types";
-  import { buildLayoutRows, nextDuplicateName } from "./layouts-library";
+  import {
+    buildLayoutRows,
+    nextDuplicateName,
+    type LayoutRow,
+  } from "./layouts-library";
   import {
     layoutPreviewKey,
     createLayoutPreviewCache,
@@ -44,53 +50,94 @@
   const toastStore = getToastStore();
 
   const rows = $derived(
-    buildLayoutRows(workspaceStore.tabs, workspaceStore.activeId),
+    buildLayoutRows(
+      workspaceStore.tabs,
+      workspaceStore.activeId,
+      workspaceStore.library,
+    ),
   );
 
-  // Cached mini-render previews (#2083). The cache is bounded and session-only:
-  // durable persistence of previews belongs to the storage slice (#2080). Keyed
-  // by tab id and invalidated by a content hash, so a preview is re-rendered
-  // only when the layout's rendered image would actually change (placing or
-  // moving a device, resizing a rack, recolouring a device type), and a rename
-  // never throws the thumbnail away.
+  /** Stable per-row key: the tab id for an open row, the layout id for a closed one. */
+  function rowKey(row: LayoutRow): string {
+    return row.tabId ?? row.layoutId ?? "";
+  }
+
+  /**
+   * Open or switch to the layout a row represents (#2325). An open row focuses
+   * its tab; a closed row hydrates its persisted body into a new tab and
+   * switches to it. Both route through the workspace store, which guarantees an
+   * already-open layout never gets a duplicate tab.
+   */
+  function activateRow(row: LayoutRow) {
+    if (row.layoutId) {
+      workspaceStore.openFromLibrary(row.layoutId);
+    } else if (row.tabId) {
+      workspaceStore.switchTo(row.tabId);
+    }
+  }
+
+  // Cached mini-render previews (#2083). The cache is bounded and session-only.
+  // Keyed by the row key (open tab id or closed layout id) and invalidated by a
+  // content hash, so a preview is re-rendered only when the layout's rendered
+  // image would actually change, and a rename never throws the thumbnail away.
+  // A closed layout's body is read once through the workspace store (no tab is
+  // opened) and cached, so reopening does not re-read it from storage.
   const previewCache = createLayoutPreviewCache();
 
   /**
-   * Resolve the preview SVG for a tab, rendering and caching it on a miss.
-   * Returns null when there is nothing to draw (no racks), so the row shows a
-   * placeholder instead of an empty frame.
+   * Resolve the preview SVG for a row, rendering and caching it on a miss.
+   * Open rows render their live tab layout; closed rows read the persisted body
+   * through the workspace store. Returns null when there is nothing to draw (no
+   * body or no racks), so the row shows a placeholder instead of an empty frame.
    */
-  function previewFor(tabId: string): string | null {
-    const tab = workspaceStore.tabs.find((t) => t.id === tabId);
-    if (!tab) return null;
+  function previewFor(row: LayoutRow): string | null {
+    const key = rowKey(row);
+    if (!key) return null;
 
-    const layout = tab.store.layout;
-    const key = layoutPreviewKey(layout);
-    const cached = previewCache.get(tabId, key);
+    if (row.isOpen && row.tabId) {
+      const layout = workspaceStore.tabs.find((t) => t.id === row.tabId)?.store
+        .layout;
+      if (!layout) return null;
+      const contentKey = layoutPreviewKey(layout);
+      const cached = previewCache.get(key, contentKey);
+      if (cached !== undefined) return cached;
+      const svg = renderLayoutPreviewSvg(layout);
+      if (svg === null) return null;
+      previewCache.set(key, contentKey, svg);
+      return svg;
+    }
+
+    if (!row.layoutId) return null;
+    // A closed layout's body is immutable while closed, so the layout id is a
+    // stable content key: a cache hit serves without re-reading the body from
+    // storage, and a miss reads it exactly once per session.
+    const contentKey = `closed:${row.layoutId}`;
+    const cached = previewCache.get(key, contentKey);
     if (cached !== undefined) return cached;
-
+    const layout = workspaceStore.peekLibraryBody(row.layoutId);
+    if (!layout) return null;
     const svg = renderLayoutPreviewSvg(layout);
     if (svg === null) return null;
-    previewCache.set(tabId, key, svg);
+    previewCache.set(key, contentKey, svg);
     return svg;
   }
 
-  // Drop cache entries for tabs that have closed so the cache tracks the open
-  // set and does not grow unbounded across a long session.
+  // Drop cache entries for rows that have left the list so the cache tracks the
+  // visible set and does not grow unbounded across a long session.
   $effect(() => {
-    const openIds = new Set(workspaceStore.tabs.map((t) => t.id));
+    const liveKeys = new Set(rows.map(rowKey));
     for (const id of previewCache.keys()) {
-      if (!openIds.has(id)) previewCache.delete(id);
+      if (!liveKeys.has(id)) previewCache.delete(id);
     }
   });
 
-  // Delete confirmation state.
+  // Confirmation state for deleting (removing from the library entirely).
   let deleteConfirmOpen = $state(false);
-  let layoutToDelete = $state<{ tabId: string; name: string } | null>(null);
+  let rowToDelete = $state<LayoutRow | null>(null);
 
-  // Rename dialog state.
+  // Rename dialog state. Keyed by the row's stable key.
   let renameOpen = $state(false);
-  let renameTabId = $state<string | null>(null);
+  let renameRowKey = $state<string | null>(null);
   let renameValue = $state("");
 
   // The listbox container. Each row is wrapped in a ContextMenu.Trigger, so a
@@ -98,14 +145,14 @@
   // rows off this bound element keeps arrow-key navigation working.
   let listEl = $state<HTMLElement | null>(null);
 
-  function openLayout(tabId: string) {
-    workspaceStore.switchTo(tabId);
+  function findRow(key: string): LayoutRow | undefined {
+    return rows.find((r) => rowKey(r) === key);
   }
 
-  function handleRowKeydown(event: KeyboardEvent, tabId: string) {
+  function handleRowKeydown(event: KeyboardEvent, row: LayoutRow) {
     // Only act on keys aimed at the row itself. The row contains a focusable
     // close button; without this guard, Enter/Space on that button would bubble
-    // here, fire openLayout, and preventDefault would swallow the button's own
+    // here, fire activateRow, and preventDefault would swallow the button's own
     // activation.
     if (event.target !== event.currentTarget) return;
 
@@ -118,7 +165,7 @@
       case "Enter":
       case " ":
         event.preventDefault();
-        openLayout(tabId);
+        activateRow(row);
         break;
       case "ArrowDown":
         event.preventDefault();
@@ -139,38 +186,73 @@
       case "Delete":
       case "Backspace":
         event.preventDefault();
-        initiateDelete(tabId);
+        initiateDelete(row);
         break;
     }
   }
 
-  function initiateDelete(tabId: string) {
-    const row = rows.find((r) => r.tabId === tabId);
-    if (!row) return;
-    layoutToDelete = { tabId, name: row.name };
+  // Close an open layout: it leaves the open set but stays in the library,
+  // recoverable. Distinct from delete, which removes it everywhere.
+  function closeLayout(row: LayoutRow) {
+    if (!row.tabId) return;
+    workspaceStore.closeTab(row.tabId);
+    toastStore.showToast(`Closed "${row.name}"`, "info");
+  }
+
+  function initiateDelete(row: LayoutRow) {
+    rowToDelete = row;
     deleteConfirmOpen = true;
   }
 
   function confirmDelete() {
-    if (layoutToDelete) {
-      workspaceStore.closeTab(layoutToDelete.tabId);
-      toastStore.showToast(`Closed "${layoutToDelete.name}"`, "info");
+    const row = rowToDelete;
+    if (row) {
+      // Delete removes the layout from the library and closes its tab if open.
+      // A closed row deletes by layout id; an open in-session row that never
+      // reached the persisted library (no layout id) just closes its tab.
+      if (row.layoutId) {
+        workspaceStore.deleteLayout(row.layoutId);
+      } else if (row.tabId) {
+        workspaceStore.closeTab(row.tabId);
+      }
+      toastStore.showToast(`Deleted "${row.name}"`, "info");
     }
     deleteConfirmOpen = false;
-    layoutToDelete = null;
+    rowToDelete = null;
   }
 
   function cancelDelete() {
     deleteConfirmOpen = false;
-    layoutToDelete = null;
+    rowToDelete = null;
   }
 
-  function duplicateLayout(tabId: string) {
-    const tab = workspaceStore.tabs.find((t) => t.id === tabId);
-    if (!tab) return;
-    const source = tab.store.layout;
-    const existingNames = workspaceStore.tabs.map((t) => t.store.layout.name);
-    const name = nextDuplicateName(existingNames, source.name);
+  // The source layout for an action that needs the full body: an open row reads
+  // its live tab; a closed row reads its persisted body through the store (no
+  // tab opened). Returns null when a closed body is unreadable.
+  function sourceLayoutFor(row: LayoutRow): Layout | null {
+    if (row.isOpen && row.tabId) {
+      return (
+        workspaceStore.tabs.find((t) => t.id === row.tabId)?.store.layout ??
+        null
+      );
+    }
+    if (row.layoutId) return workspaceStore.peekLibraryBody(row.layoutId);
+    return null;
+  }
+
+  // Names already taken across the whole library (open tabs and closed rows),
+  // so a duplicate of a closed layout still avoids colliding with a closed one.
+  function libraryNames(): string[] {
+    return rows.map((r) => r.name);
+  }
+
+  function duplicateLayout(row: LayoutRow) {
+    const source = sourceLayoutFor(row);
+    if (!source) {
+      toastStore.showToast(`Cannot duplicate "${row.name}"`, "error");
+      return;
+    }
+    const name = nextDuplicateName(libraryNames(), source.name);
     const clone: Layout = structuredClone($state.snapshot(source));
     clone.name = name;
     clone.metadata = { ...clone.metadata, id: generateId(), name };
@@ -178,27 +260,33 @@
     toastStore.showToast(`Duplicated as "${name}"`, "info");
   }
 
-  function openRename(tabId: string) {
-    const row = rows.find((r) => r.tabId === tabId);
-    if (!row) return;
-    renameTabId = tabId;
+  function openRename(row: LayoutRow) {
+    renameRowKey = rowKey(row);
     renameValue = row.name;
     renameOpen = true;
   }
 
   function confirmRename() {
-    const tabId = renameTabId;
+    const key = renameRowKey;
     const trimmed = renameValue.trim();
-    if (tabId && trimmed) {
-      const tab = workspaceStore.tabs.find((t) => t.id === tabId);
-      tab?.store.setLayoutName(trimmed);
+    if (key && trimmed) {
+      const row = findRow(key);
+      if (row) {
+        // Open the layout (focuses an open tab, or hydrates a closed one) so the
+        // rename runs against the live store and persists like any edit.
+        activateRow(row);
+        const active = workspaceStore.tabs.find(
+          (t) => t.id === workspaceStore.activeId,
+        );
+        active?.store.setLayoutName(trimmed);
+      }
     }
     closeRename();
   }
 
   function closeRename() {
     renameOpen = false;
-    renameTabId = null;
+    renameRowKey = null;
     renameValue = "";
   }
 
@@ -209,9 +297,18 @@
     }
   }
 
+  // Export a row's layout. Open rows export directly; a closed row is opened
+  // first so the existing tab-based export path has a live tab to work from.
+  function exportLayout(row: LayoutRow) {
+    if (!onexport) return;
+    activateRow(row);
+    const activeTabId = workspaceStore.activeId;
+    onexport(activeTabId);
+  }
+
   function getDeleteMessage(): string {
-    if (!layoutToDelete) return "";
-    return `Close "${layoutToDelete.name}"? It will be removed from the open layouts.`;
+    if (!rowToDelete) return "";
+    return `Delete "${rowToDelete.name}"? This removes it from your library and cannot be undone.`;
   }
 </script>
 
@@ -241,28 +338,30 @@
     role="listbox"
     aria-label="Layout library"
   >
-    {#each rows as row (row.tabId)}
-      {@const previewSvg = previewFor(row.tabId)}
+    {#each rows as row (rowKey(row))}
+      {@const previewSvg = previewFor(row)}
       <LayoutContextMenu
-        onopen={() => openLayout(row.tabId)}
-        onrename={() => openRename(row.tabId)}
-        onduplicate={() => duplicateLayout(row.tabId)}
-        onexport={onexport ? () => onexport(row.tabId) : undefined}
-        ondelete={() => initiateDelete(row.tabId)}
+        onopen={() => activateRow(row)}
+        onrename={() => openRename(row)}
+        onduplicate={() => duplicateLayout(row)}
+        onexport={onexport ? () => exportLayout(row) : undefined}
+        ondelete={() => initiateDelete(row)}
       >
         <div
           class="layout-item"
           class:active={row.isActive}
-          onclick={() => openLayout(row.tabId)}
-          onkeydown={(e) => handleRowKeydown(e, row.tabId)}
+          class:closed={!row.isOpen}
+          onclick={() => activateRow(row)}
+          onkeydown={(e) => handleRowKeydown(e, row)}
           role="option"
           aria-selected={row.isActive}
           tabindex={row.isActive ? 0 : -1}
-          data-testid="layout-item-{row.tabId}"
+          data-testid="layout-item-{rowKey(row)}"
         >
           <span
             class="layout-indicator"
             class:is-active={row.isActive}
+            class:is-open={row.isOpen}
             aria-hidden="true"
           ></span>
           <span class="layout-preview" aria-hidden="true">
@@ -276,33 +375,43 @@
           <span class="layout-info">
             <span class="layout-name">{row.name}</span>
             <span class="layout-meta">
-              <span class="layout-state"
-                >{row.isActive ? "Active" : "Open"}</span
-              >
-              <span aria-hidden="true">·</span>
-              {row.rackCount} rack{row.rackCount !== 1 ? "s" : ""} ·
-              {row.deviceCount} device{row.deviceCount !== 1 ? "s" : ""}
+              <span class="layout-state">
+                {#if row.isActive}
+                  Active
+                {:else if row.isOpen}
+                  Open
+                {:else}
+                  Closed
+                {/if}
+              </span>
+              {#if row.isOpen}
+                <span aria-hidden="true">·</span>
+                {row.rackCount} rack{row.rackCount !== 1 ? "s" : ""} ·
+                {row.deviceCount} device{row.deviceCount !== 1 ? "s" : ""}
+              {/if}
             </span>
           </span>
-          <button
-            type="button"
-            class="layout-delete"
-            onclick={(e) => {
-              e.stopPropagation();
-              initiateDelete(row.tabId);
-            }}
-            aria-label="Close {row.name}"
-            title="Close layout"
-          >
-            ✕
-          </button>
+          {#if row.isOpen}
+            <button
+              type="button"
+              class="layout-delete"
+              onclick={(e) => {
+                e.stopPropagation();
+                closeLayout(row);
+              }}
+              aria-label="Close {row.name}"
+              title="Close layout"
+            >
+              ✕
+            </button>
+          {/if}
         </div>
       </LayoutContextMenu>
     {/each}
 
     {#if rows.length === 0}
       <div class="empty-state">
-        <p class="empty-message">No layouts open</p>
+        <p class="empty-message">No saved layouts</p>
         <p class="empty-hint">Create a layout to get started</p>
       </div>
     {/if}
@@ -311,9 +420,9 @@
 
 <ConfirmDialog
   open={deleteConfirmOpen}
-  title="Close Layout"
+  title="Delete Layout"
   message={getDeleteMessage()}
-  confirmLabel="Close"
+  confirmLabel="Delete"
   onconfirm={confirmDelete}
   oncancel={cancelDelete}
 />
@@ -438,6 +547,11 @@
     outline-offset: -2px;
   }
 
+  /* State dot. Shape carries the open/closed distinction independent of colour
+     (WCAG 1.4.1): a closed layout is a hollow outline ring, an open one is a
+     filled dot, and the active one is filled in the success colour. The text
+     state label (Active / Open / Closed) is the primary, fully colour-free cue;
+     the dot reinforces it. */
   .layout-indicator {
     flex-shrink: 0;
     width: 8px;
@@ -447,9 +561,20 @@
     background: transparent;
   }
 
+  .layout-indicator.is-open {
+    background: var(--colour-text-muted);
+    border-color: var(--colour-text-muted);
+  }
+
   .layout-indicator.is-active {
-    background: var(--colour-success, #2e7d32);
-    border-color: var(--colour-success, #2e7d32);
+    background: var(--colour-success);
+    border-color: var(--colour-success);
+  }
+
+  /* A closed layout reads as available-but-inactive: the name stays legible, the
+     row is slightly recessed so the open working set stands out. */
+  .layout-item.closed .layout-name {
+    color: var(--colour-text-muted);
   }
 
   /* Cached mini-render of the layout (#2083). Decorative (aria-hidden): the row

--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -81,7 +81,11 @@
       const layoutId = tab.layoutId ?? tab.store.layout.metadata?.id;
       if (!layoutId) continue;
       if (tab.id === workspaceStore.activeId) activeLayoutId = layoutId;
-      if (tab.hydrated) {
+      // An unreadable tab holds only a name placeholder, never the real body
+      // (#2018/#2325). Persist it as a shell so its index entry and name survive,
+      // but its placeholder is NEVER written over the original Rackula:layout:<id>
+      // body, which may be only transiently unreadable and must stay recoverable.
+      if (tab.hydrated && !tab.unreadable) {
         tabs.push({
           layoutId,
           hydrated: true,

--- a/src/lib/components/layouts-library.ts
+++ b/src/lib/components/layouts-library.ts
@@ -1,47 +1,56 @@
 /**
  * Layouts library logic
  *
- * Pure helpers backing the Layouts sidebar tab (#2082). The library lists the
- * layouts the user is working with. For this slice the source of truth is the
- * workspace store's OPEN set (one tab per open layout, #2079); the durable
- * browser-mode library of every saved layout depends on the multi-layout
- * storage schema (#2179/#2080), which does not exist yet, so it is out of
- * scope here.
+ * Pure helpers backing the Layouts sidebar tab (#2082, #2325). The panel lists
+ * the full library of saved layouts: open layouts (one per workspace tab) and
+ * closed-but-saved layouts (in the library catalogue with no open tab). Open
+ * rows carry their live name and rack/device counts from the tab; closed rows
+ * carry the catalogue name and no counts (no body is loaded until opened).
  */
 
-import type { WorkspaceTab } from "$lib/stores/workspace.svelte";
+import type { WorkspaceTab, LibraryLayout } from "$lib/stores/workspace.svelte";
 
 /** Placeholder shown when a layout has no name yet. */
 export const UNTITLED_LAYOUT_NAME = "Untitled layout";
 
 /** A single row in the Layouts library list. */
 export interface LayoutRow {
-  /** Workspace tab id backing this row (stable identity for actions). */
-  tabId: string;
+  /**
+   * Workspace tab id backing this row, when the layout is open. Null for a
+   * closed row (no tab). Open rows key by tabId; closed rows key by layoutId.
+   */
+  tabId: string | null;
+  /** Persisted layout id, when known (always set for closed rows). */
+  layoutId: string | null;
   /** Display name, falling back to a placeholder when blank. */
   name: string;
   /** True when this is the active tab. */
   isActive: boolean;
-  /** True when the layout is open in a tab (always true for this slice). */
+  /** True when the layout is open in a tab. */
   isOpen: boolean;
-  /** Number of racks in the layout. */
+  /** Number of racks in the layout. Zero for a closed row (body not loaded). */
   rackCount: number;
-  /** Total number of devices across all racks. */
+  /** Total devices across all racks. Zero for a closed row (body not loaded). */
   deviceCount: number;
 }
 
 /**
- * Build the library row list from the workspace's open tabs.
+ * Build the library row list from the open tabs and the library catalogue.
  *
- * Row order follows tab order so the list and the tab strip stay in sync. The
- * active tab is flagged so the UI can highlight it (paired with text, never
- * colour-only).
+ * Open layouts come first, in tab order, so the panel and the tab strip stay in
+ * sync; closed layouts (in the library with no open tab) follow. An open
+ * layout that is also in the library renders once, as an open row, never as a
+ * duplicate closed row. The active tab is flagged so the UI can highlight it
+ * (paired with text, never colour-only).
  */
 export function buildLayoutRows(
   tabs: readonly WorkspaceTab[],
   activeId: string,
+  library: Readonly<Record<string, LibraryLayout>>,
 ): LayoutRow[] {
-  return tabs.map((tab) => {
+  const openLayoutIds = new Set<string>();
+  const openRows: LayoutRow[] = tabs.map((tab) => {
+    if (tab.layoutId) openLayoutIds.add(tab.layoutId);
     const { layout } = tab.store;
     const racks = layout.racks ?? [];
     const deviceCount = racks.reduce(
@@ -50,6 +59,7 @@ export function buildLayoutRows(
     );
     return {
       tabId: tab.id,
+      layoutId: tab.layoutId ?? null,
       name: layout.name.trim() || UNTITLED_LAYOUT_NAME,
       isActive: tab.id === activeId,
       isOpen: true,
@@ -57,6 +67,20 @@ export function buildLayoutRows(
       deviceCount,
     };
   });
+
+  const closedRows: LayoutRow[] = Object.entries(library)
+    .filter(([id]) => !openLayoutIds.has(id))
+    .map(([id, entry]) => ({
+      tabId: null,
+      layoutId: id,
+      name: entry.name.trim() || UNTITLED_LAYOUT_NAME,
+      isActive: false,
+      isOpen: false,
+      rackCount: 0,
+      deviceCount: 0,
+    }));
+
+  return [...openRows, ...closedRows];
 }
 
 /**

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -14,21 +14,22 @@
  * - Every content swap into a tab (open, restore) goes through one
  *   clear-then-load primitive that clears that tab's history first.
  *
+ * Library: the workspace also tracks the full set of saved layouts (#2325),
+ * not only the open tabs. The library is the durable catalogue of every layout
+ * the user has, open or closed; the open tabs are the working subset. The
+ * persistence layer seeds the library on restore and supplies the body reader
+ * and deleter (dependency-inverted, like loadBody); the store never imports
+ * storage directly.
+ *
  * Persistence: tabs are in-memory session state here. The browser-mode
  * multi-layout storage schema (spike #2179: `Rackula:workspace` index +
- * `Rackula:layout:<id>` bodies) is a separate slice (#2080) that layers onto
- * this store; it is intentionally not built here.
+ * `Rackula:layout:<id>` bodies) layers onto this store via restoreWorkspace
+ * (#2080): the index seeds the library and supplies the lazy body reader.
  */
 
 import type { Layout } from "$lib/types";
-import {
-  createLayoutStore,
-  type LayoutStore,
-} from "./layout.svelte";
-import {
-  createHistoryStore,
-  getHistoryStore,
-} from "./history.svelte";
+import { createLayoutStore, type LayoutStore } from "./layout.svelte";
+import { createHistoryStore, getHistoryStore } from "./history.svelte";
 import { createLayout } from "$lib/utils/serialization";
 
 /** A single open tab: a stable id plus the layout store backing it. */
@@ -57,9 +58,7 @@ export interface WorkspaceTab {
 }
 
 /** Result of reading a persisted layout body during lazy restore. */
-export type RestoreBodyResult =
-  | { ok: true; layout: Layout }
-  | { ok: false };
+export type RestoreBodyResult = { ok: true; layout: Layout } | { ok: false };
 
 /** Per-layout fields lazy restore reads from the index library. */
 export interface RestoreLibraryEntry {
@@ -75,11 +74,22 @@ export interface RestoreIndex {
   library: Record<string, RestoreLibraryEntry>;
 }
 
+/** A library row's display metadata, for a layout with no open tab (#2325). */
+export interface LibraryLayout {
+  name: string;
+}
+
 /** Inputs for restoring a workspace from the persisted browser index. */
 export interface RestoreWorkspaceArgs {
   index: RestoreIndex;
   /** Reads a persisted layout body by id (lazy, injected for testability). */
   loadBody: (id: string) => RestoreBodyResult;
+  /**
+   * Removes a layout's persisted body and library entry (#2325). Injected so
+   * the store stays storage-agnostic. Omitted in cold-start sessions that have
+   * no persistence wired; deleteLayout still drops the in-memory entry.
+   */
+  deleteBody?: (id: string) => void;
 }
 
 let tabIdCounter = 0;
@@ -133,14 +143,22 @@ export function createWorkspaceStore() {
   // The body loader injected by restoreWorkspace, used for lazy hydration on
   // first focus of a restored shell tab. Null until a restore has run.
   let loadBodyFn: ((id: string) => RestoreBodyResult) | null = null;
+  // The body deleter injected by restoreWorkspace, used by deleteLayout to drop
+  // a layout's persisted body and library entry. Null until a restore has run.
+  let deleteBodyFn: ((id: string) => void) | null = null;
   // Per-layout durability from the restored index, applied on hydration so the
   // chip and tab dots reflect true backup state (not reset to zero by the body
   // load). Keyed by persisted layout id.
   let restoreLibrary: Record<string, RestoreLibraryEntry> = {};
 
-  const activeTab = $derived(
-    tabs.find((t) => t.id === activeId) ?? tabs[0]!,
-  );
+  // The full library of saved layouts (open + closed), keyed by persisted
+  // layout id (#2325). Seeded on restore from the index, grown when a layout is
+  // opened or created in-session, and pruned on delete. Open layouts are also
+  // here; buildLayoutRows reconciles them against the open tabs so an open
+  // layout never renders twice.
+  let library = $state<Record<string, LibraryLayout>>({});
+
+  const activeTab = $derived(tabs.find((t) => t.id === activeId) ?? tabs[0]!);
   const activeStore = $derived(activeTab.store);
 
   function getTab(id: string): WorkspaceTab | undefined {
@@ -157,6 +175,9 @@ export function createWorkspaceStore() {
     const tab: WorkspaceTab = {
       id: nextTabId(),
       store: createLayoutStore(createHistoryStore()),
+      // Tag the tab with the layout's persistent id so the library can match it
+      // to its catalogue entry (open vs closed). Persistence reads the same id.
+      layoutId: layout?.metadata?.id,
       hydrated: true,
       unreadable: false,
     };
@@ -167,8 +188,83 @@ export function createWorkspaceStore() {
       // Reserve ids live in other open tabs so an opened copy never aliases the
       // global image store's placement-<deviceId> keys (#2182).
       tab.store.loadLayout(layout, deviceIdsInOtherTabs(tab.id));
+      // Record the opened layout in the library catalogue (#2325) so a new or
+      // duplicated layout appears in the Layouts panel and survives a close.
+      if (layout.metadata?.id) {
+        library = {
+          ...library,
+          [layout.metadata.id]: { name: layout.name },
+        };
+      }
     }
     return tab.id;
+  }
+
+  /**
+   * Open a layout from the library by its persisted id (#2325). If a tab already
+   * backs that layout, focus switches to it (no duplicate tab). Otherwise the
+   * body is read through the injected loader and opened into a new tab. An
+   * unreadable body still opens a tab, flagged unreadable for the #2018
+   * orphan/error state, and the library entry is kept so it stays recoverable.
+   */
+  function openFromLibrary(layoutId: string): void {
+    const existing = tabs.find((t) => t.layoutId === layoutId);
+    if (existing) {
+      switchTo(existing.id);
+      return;
+    }
+    const result = loadBodyFn?.(layoutId);
+    if (result?.ok) {
+      openTab(result.layout);
+      return;
+    }
+    // The body could not be read. Open a shell tab carrying the library name,
+    // flagged unreadable so the interaction layer offers Retry/Remove (#2018).
+    // The library entry is left intact: a bad body must never lose the catalogue
+    // record.
+    const name = library[layoutId]?.name ?? "";
+    const placeholder: Layout = {
+      ...createLayout(name),
+      metadata: { id: layoutId, name },
+    };
+    const tab: WorkspaceTab = {
+      id: nextTabId(),
+      store: createLayoutStore(createHistoryStore()),
+      layoutId,
+      hydrated: true,
+      unreadable: true,
+    };
+    tab.store.loadLayout(placeholder);
+    tabs = [...tabs, tab];
+    activeId = tab.id;
+  }
+
+  /**
+   * Read a library layout's persisted body without opening a tab (#2325).
+   * Used to render a preview thumbnail for a closed layout. Returns null when
+   * there is no body reader wired or the body is unreadable; the caller shows a
+   * placeholder rather than a broken frame.
+   */
+  function peekLibraryBody(layoutId: string): Layout | null {
+    const result = loadBodyFn?.(layoutId);
+    return result?.ok ? result.layout : null;
+  }
+
+  /**
+   * Delete a layout from the library by its persisted id (#2325). Drops the
+   * in-memory catalogue entry and the persisted body (via the injected deleter),
+   * and closes its tab if one is open. Deletion is the only destructive path:
+   * closing a tab keeps the layout, deleting removes it everywhere.
+   */
+  function deleteLayout(layoutId: string): void {
+    const open = tabs.find((t) => t.layoutId === layoutId);
+    if (open) closeTab(open.id);
+    if (layoutId in library) {
+      const next = { ...library };
+      delete next[layoutId];
+      library = next;
+    }
+    deleteBodyFn?.(layoutId);
   }
 
   /**
@@ -292,12 +388,24 @@ export function createWorkspaceStore() {
    * blank tab. No-op when there are no open tabs.
    */
   function restoreWorkspace(args: RestoreWorkspaceArgs): void {
-    const { index, loadBody } = args;
-    const openIds = index.openTabs.filter((id) => id in index.library);
-    if (openIds.length === 0) return;
+    const { index, loadBody, deleteBody } = args;
 
     loadBodyFn = loadBody;
+    deleteBodyFn = deleteBody ?? null;
     restoreLibrary = index.library;
+
+    // Seed the library catalogue from the index (#2325): every saved layout,
+    // open or closed, so the Layouts panel lists the full set. Done before the
+    // open-tabs guard so a workspace with saved-but-closed layouts and no open
+    // tab still populates the library.
+    const seeded: Record<string, LibraryLayout> = {};
+    for (const [id, entry] of Object.entries(index.library)) {
+      seeded[id] = { name: entry.name };
+    }
+    library = seeded;
+
+    const openIds = index.openTabs.filter((id) => id in index.library);
+    if (openIds.length === 0) return;
 
     // A placeholder layout carries the persisted name so the tab shell renders
     // before its body is read. metadata.id holds the persisted id so a later
@@ -310,7 +418,13 @@ export function createWorkspaceStore() {
       };
       const store = createLayoutStore(createHistoryStore());
       store.loadLayout(placeholder);
-      return { id: nextTabId(), store, layoutId, hydrated: false, unreadable: false };
+      return {
+        id: nextTabId(),
+        store,
+        layoutId,
+        hydrated: false,
+        unreadable: false,
+      };
     });
 
     tabs = restored;
@@ -337,7 +451,13 @@ export function createWorkspaceStore() {
     get activeStore() {
       return activeStore;
     },
+    get library() {
+      return library;
+    },
     openTab,
+    openFromLibrary,
+    peekLibraryBody,
+    deleteLayout,
     switchTo,
     closeTab,
     reorderTabs,

--- a/src/tests/layouts-library.test.ts
+++ b/src/tests/layouts-library.test.ts
@@ -27,7 +27,7 @@ describe("buildLayoutRows", () => {
     const firstId = ws.activeId;
     const secondId = ws.openTab(createLayout("Homelab"));
 
-    const rows = buildLayoutRows(ws.tabs, ws.activeId);
+    const rows = buildLayoutRows(ws.tabs, ws.activeId, ws.library);
 
     expect(rows.map((r) => r.tabId)).toEqual([firstId, secondId]);
     expect(rows.find((r) => r.tabId === secondId)?.isActive).toBe(true);
@@ -38,12 +38,12 @@ describe("buildLayoutRows", () => {
     const ws = getWorkspaceStore();
     ws.openTab(createLayout("Homelab"));
 
-    const rows = buildLayoutRows(ws.tabs, ws.activeId);
+    const rows = buildLayoutRows(ws.tabs, ws.activeId, ws.library);
 
     expect(rows.every((r) => r.isOpen)).toBe(true);
   });
 
-  it("reports the layout name and rack/device counts for each row", () => {
+  it("reports the layout name and rack/device counts for each open row", () => {
     const ws = getWorkspaceStore();
     const layout = createTestLayout({
       name: "Rack Room",
@@ -63,7 +63,7 @@ describe("buildLayoutRows", () => {
     });
     const tabId = ws.openTab(layout);
 
-    const rows = buildLayoutRows(ws.tabs, ws.activeId);
+    const rows = buildLayoutRows(ws.tabs, ws.activeId, ws.library);
     const row = rows.find((r) => r.tabId === tabId);
 
     expect(row?.name).toBe("Rack Room");
@@ -71,13 +71,76 @@ describe("buildLayoutRows", () => {
     expect(row?.deviceCount).toBe(3);
   });
 
-  it("falls back to a placeholder name for an unnamed layout", () => {
+  it("falls back to a placeholder name for an unnamed open layout", () => {
     const ws = getWorkspaceStore();
     const tabId = ws.openTab(createTestLayout({ name: "" }));
 
-    const rows = buildLayoutRows(ws.tabs, ws.activeId);
+    const rows = buildLayoutRows(ws.tabs, ws.activeId, ws.library);
 
     expect(rows.find((r) => r.tabId === tabId)?.name).toBe("Untitled layout");
+  });
+
+  it("lists a saved layout that has no open tab as a closed row", () => {
+    const ws = getWorkspaceStore();
+    ws.restoreWorkspace({
+      index: {
+        activeId: "open-id",
+        openTabs: ["open-id"],
+        library: {
+          "open-id": {
+            name: "Open One",
+            changesSinceExport: 0,
+            hasEverExported: false,
+          },
+          "closed-id": {
+            name: "Closed One",
+            changesSinceExport: 0,
+            hasEverExported: false,
+          },
+        },
+      },
+      loadBody: (id) => ({
+        ok: true,
+        layout: { ...createLayout(id), metadata: { id, name: id } },
+      }),
+    });
+
+    const rows = buildLayoutRows(ws.tabs, ws.activeId, ws.library);
+    const closed = rows.find((r) => r.layoutId === "closed-id");
+    const open = rows.find((r) => r.layoutId === "open-id");
+
+    expect(closed).toBeDefined();
+    expect(closed?.isOpen).toBe(false);
+    expect(closed?.name).toBe("Closed One");
+    expect(open?.isOpen).toBe(true);
+  });
+
+  it("does not duplicate a layout that is both in the library and open", () => {
+    const ws = getWorkspaceStore();
+    ws.restoreWorkspace({
+      index: {
+        activeId: "open-id",
+        openTabs: ["open-id"],
+        library: {
+          "open-id": {
+            name: "Open One",
+            changesSinceExport: 0,
+            hasEverExported: false,
+          },
+        },
+      },
+      loadBody: (id) => ({
+        ok: true,
+        layout: { ...createLayout(id), metadata: { id, name: id } },
+      }),
+    });
+
+    const rows = buildLayoutRows(ws.tabs, ws.activeId, ws.library);
+    const matching = rows.filter((r) => r.layoutId === "open-id");
+
+    // eslint-disable-next-line no-restricted-syntax -- one library layout that is open must yield exactly one row, never an open + closed pair
+    expect(matching).toHaveLength(1);
+    expect(matching[0]?.isOpen).toBe(true);
   });
 });
 

--- a/src/tests/workspace-store.test.ts
+++ b/src/tests/workspace-store.test.ts
@@ -207,7 +207,10 @@ describe("Workspace Store", () => {
         index: makeIndex(),
         loadBody: (id) => {
           loaded.push(id);
-          return { ok: true, layout: bodyFor(id, id === "id-a" ? "Alpha" : "Beta") };
+          return {
+            ok: true,
+            layout: bodyFor(id, id === "id-a" ? "Alpha" : "Beta"),
+          };
         },
       });
 
@@ -309,8 +312,14 @@ describe("Workspace Store", () => {
         index: makeIndex(),
         loadBody: (id) =>
           id === "id-a"
-            ? { ok: true, layout: { ...bodyFor("id-a", "Alpha"), racks: [aRack] } }
-            : { ok: true, layout: { ...bodyFor("id-b", "Beta"), racks: [bRack] } },
+            ? {
+                ok: true,
+                layout: { ...bodyFor("id-a", "Alpha"), racks: [aRack] },
+              }
+            : {
+                ok: true,
+                layout: { ...bodyFor("id-b", "Beta"), racks: [bRack] },
+              },
       });
 
       // Tab A keeps the shared id.
@@ -358,6 +367,167 @@ describe("Workspace Store", () => {
       ws.closeTab(ws.tabs[0]!.id);
       expect(loaded).toEqual(["id-a", "id-b"]);
       expect(ws.activeStore.layout.name).toBe("Body-id-b");
+    });
+  });
+
+  describe("library set", () => {
+    function bodyFor(id: string, name: string): Layout {
+      return { ...createLayout(name), metadata: { id, name } };
+    }
+
+    function makeIndex(): WorkspaceIndex {
+      return {
+        schemaVersion: 2,
+        activeId: "id-a",
+        openTabs: ["id-a"],
+        library: {
+          "id-a": {
+            name: "Alpha",
+            updatedAt: "",
+            changesSinceExport: 0,
+            hasEverExported: false,
+            writeFailed: false,
+            storageMode: "browser",
+          },
+          "id-b": {
+            name: "Beta",
+            updatedAt: "",
+            changesSinceExport: 0,
+            hasEverExported: false,
+            writeFailed: false,
+            storageMode: "browser",
+          },
+        },
+      };
+    }
+
+    it("exposes every saved layout, including ones with no open tab", () => {
+      const ws = getWorkspaceStore();
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) => ({ ok: true, layout: bodyFor(id, id) }),
+      });
+
+      // id-a is open; id-b is closed-but-saved. Both are in the library set.
+      expect(Object.keys(ws.library).sort()).toEqual(["id-a", "id-b"]);
+      expect(ws.library["id-b"]?.name).toBe("Beta");
+    });
+
+    it("adds a layout opened in-session to the library set", () => {
+      const ws = getWorkspaceStore();
+      const layout = bodyFor("fresh-id", "Fresh");
+      ws.openTab(layout);
+
+      expect(ws.library["fresh-id"]?.name).toBe("Fresh");
+    });
+
+    describe("openFromLibrary", () => {
+      it("opens a closed layout into exactly one new tab and makes it active", () => {
+        const ws = getWorkspaceStore();
+        ws.restoreWorkspace({
+          index: makeIndex(),
+          loadBody: (id) => ({ ok: true, layout: bodyFor(id, "Body-" + id) }),
+        });
+        const tabsBefore = ws.tabs.length;
+
+        ws.openFromLibrary("id-b");
+
+        // Opening a closed layout must add exactly one tab (no duplicates).
+        expect(ws.tabs.length).toBe(tabsBefore + 1);
+        const active = ws.tabs.find((t) => t.id === ws.activeId)!;
+        expect(active.layoutId).toBe("id-b");
+        expect(ws.activeStore.layout.name).toBe("Body-id-b");
+      });
+
+      it("switches to an already-open layout without adding a tab", () => {
+        const ws = getWorkspaceStore();
+        ws.restoreWorkspace({
+          index: makeIndex(),
+          loadBody: (id) => ({ ok: true, layout: bodyFor(id, "Body-" + id) }),
+        });
+        // Open id-b so it has a tab, then focus id-a.
+        ws.openFromLibrary("id-b");
+        ws.switchTo(ws.tabs[0]!.id);
+        const tabsBefore = ws.tabs.length;
+        const idbTab = ws.tabs.find((t) => t.layoutId === "id-b")!;
+
+        ws.openFromLibrary("id-b");
+
+        expect(ws.tabs.length).toBe(tabsBefore);
+        expect(ws.activeId).toBe(idbTab.id);
+      });
+
+      it("leaves an unreadable closed body recoverable in the library", () => {
+        const ws = getWorkspaceStore();
+        ws.restoreWorkspace({
+          index: makeIndex(),
+          loadBody: (id) =>
+            id === "id-a"
+              ? { ok: true, layout: bodyFor("id-a", "Alpha") }
+              : { ok: false },
+        });
+
+        ws.openFromLibrary("id-b");
+
+        // A bad body must not lose the library entry; the tab surfaces the
+        // orphan/error state (#2018) rather than vanishing.
+        expect(ws.library["id-b"]).toBeDefined();
+        const idbTab = ws.tabs.find((t) => t.layoutId === "id-b");
+        expect(idbTab?.unreadable).toBe(true);
+      });
+    });
+
+    describe("deleteLayout", () => {
+      it("removes a closed layout from the library set", () => {
+        const ws = getWorkspaceStore();
+        const deleted: string[] = [];
+        ws.restoreWorkspace({
+          index: makeIndex(),
+          loadBody: (id) => ({ ok: true, layout: bodyFor(id, id) }),
+          deleteBody: (id) => deleted.push(id),
+        });
+
+        ws.deleteLayout("id-b");
+
+        expect(ws.library["id-b"]).toBeUndefined();
+        expect(deleted).toContain("id-b");
+        // The closed layout never had a tab, so the open set is untouched.
+        expect(ws.tabs.every((t) => t.layoutId !== "id-b")).toBe(true);
+      });
+
+      it("removes an open layout from the library and closes its tab", () => {
+        const ws = getWorkspaceStore();
+        const deleted: string[] = [];
+        ws.restoreWorkspace({
+          index: makeIndex(),
+          loadBody: (id) => ({ ok: true, layout: bodyFor(id, id) }),
+          deleteBody: (id) => deleted.push(id),
+        });
+        ws.openFromLibrary("id-b");
+        expect(ws.tabs.some((t) => t.layoutId === "id-b")).toBe(true);
+
+        ws.deleteLayout("id-b");
+
+        expect(ws.library["id-b"]).toBeUndefined();
+        expect(deleted).toContain("id-b");
+        expect(ws.tabs.some((t) => t.layoutId === "id-b")).toBe(false);
+      });
+    });
+
+    it("keeps a closed layout retrievable from the library set", () => {
+      const ws = getWorkspaceStore();
+      ws.restoreWorkspace({
+        index: makeIndex(),
+        loadBody: (id) => ({ ok: true, layout: bodyFor(id, "Body-" + id) }),
+      });
+      // Open id-b, then close its tab. It must stay in the library (its name now
+      // reflects the loaded body, not the stale index entry).
+      ws.openFromLibrary("id-b");
+      const idbTab = ws.tabs.find((t) => t.layoutId === "id-b")!;
+      ws.closeTab(idbTab.id);
+
+      expect(ws.tabs.some((t) => t.layoutId === "id-b")).toBe(false);
+      expect(ws.library["id-b"]?.name).toBe("Body-id-b");
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Make the Layouts sidebar panel list every saved layout, open and closed, not just the open tabs. After #2324 the toolbar holds the open layout tabs (the working set); the Layouts panel becomes the library to browse, reopen, and manage all saved layouts.

Closes #2325. Part of epic #2017 (M14 UX shell).

## Phase 1 prerequisite findings (closeTab retention)

The prerequisite holds: closing a layout already retains its persisted body. Evidence:

- `src/lib/stores/workspace.svelte.ts` `closeTab` operates only on the in-memory `tabs` array. It never deletes a body and never touches localStorage; it removes the tab from the open set and falls focus back to a neighbour.
- Persistence is driven separately by `src/lib/components/PersistenceEffects.svelte` (a debounced autosave effect) calling `persistBrowserWorkspace`.
- `src/lib/storage/browser-workspace-persist.ts` reads the existing index, spreads its `library` forward (`{ ...current.library }`), then layers in entries for the currently-open tabs and writes `openTabs: tabs.map(t => t.layoutId)`. The library is never pruned to the open set, so a closed layout drops out of `openTabs` while its `library[id]` entry and its `Rackula:layout:<id>` body both survive. The file header states this explicitly: "Closing a tab is non-destructive ... entries are retained across persists, not pruned when a tab closes."
- `deleteLayoutBody` (the only function that removes a body and its library entry) had no non-test caller before this change, so true deletion was not wired anywhere.

So retention works. What this PR builds: expose a reactive library set on the store, add open-from-library and delete actions, wire true delete, and render the full library.

## What changed

- `src/lib/stores/workspace.svelte.ts`: a reactive `library` map of all saved layouts (seeded from the index on restore, grown on open, pruned on delete); `openFromLibrary` (switch to an open layout or hydrate a closed one, never a duplicate tab); `deleteLayout` (drop the library entry, delete the persisted body via an injected deleter, and close the tab if open); `peekLibraryBody` (read-only body read for closed-layout previews). `openTab` now tags the tab with its persistent layout id.
- `src/lib/components/layouts-library.ts`: `buildLayoutRows(tabs, activeId, library)` emits one row per open tab plus one row per library entry with no open tab, deduplicated so an open layout never renders twice.
- `src/lib/components/LayoutsLibrary.svelte`: renders the full library; closed rows get a non-colour-only open/closed indicator; row activation routes through switch-or-open; the inline X closes (keeps the layout), the context-menu Delete removes it from the library with confirmation; rename/duplicate/export work on closed rows; previews render for closed rows (body read once, cached).
- `src/lib/components/PersistenceEffects.svelte`: an unreadable tab is now persisted as a name-only shell so its placeholder is never written over the original `Rackula:layout:<id>` body. This keeps a transiently-unreadable layout fully recoverable and repairs the same latent gap in the lazy-restore path.
- `src/App.svelte`: wires `deleteLayoutBody` as the store's `deleteBody`.

## Tests

- `npm run lint`: No issues found.
- `npm run test:run`: 157 files, 2636 tests passed.
- `npm run build`: built successfully.

Added behaviour and pure-logic tests (no DOM/class/colour assertions; exact counts only on behavioural invariants with a justification):
- `buildLayoutRows` over a library with open and closed entries marks open vs closed correctly, and never renders an open layout twice.
- Opening a closed layout adds exactly one tab and makes it active; opening an already-open layout adds no tab and switches.
- An unreadable closed body still opens a tab flagged unreadable, and stays in the library (recoverable).
- Closing a non-last layout keeps it retrievable from the library set.
- Deleting removes the entry from the library set and closes its tab if open.

## Accessibility self-cert (#2100)

- WCAG 2.2 AA: open vs closed is conveyed by a text state label (Active / Open / Closed) plus a dot whose fill/outline shape also differs, not by colour alone (WCAG 1.4.1).
- 44px touch targets: rows keep the existing min-height: 44px; the inline close control stays visible on touch.
- prefers-reduced-motion, visible focus, focus management: row transitions and focus-visible outlines follow the existing component idiom; roving tabindex keeps one focusable row, with arrow/Home/End navigation.
- No new colours; Dracula tokens only.

## Data safety

Closing a layout, from the toolbar or the panel, never loses it: it leaves the open set but stays in the library and on disk. Only Delete (with confirmation) removes it. Verified that closing does not prune the persisted body and that an unreadable open does not clobber the real body.


___

## **CodeAnt-AI Description**
**Turn the Layouts panel into a full saved-layout library**

### What Changed
- The Layouts panel now shows every saved layout, including closed ones, instead of only the open tabs
- Clicking a closed layout opens it in a tab; clicking an open one switches to its existing tab without creating a duplicate
- Closing a layout keeps it in the library, while Delete removes it from the library and closes it if needed
- Closed layouts can still be renamed, duplicated, exported, and previewed from the panel
- Saved layouts now stay listed even when their body cannot be read, so they remain recoverable instead of disappearing

### Impact
`✅ Browse all saved layouts in one place`
`✅ Fewer duplicate tabs when reopening layouts`
`✅ Fewer accidental layout losses after closing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
