### PR TITLE
chore: skip false-positive SecretsUsedInArgOrEnv build check on Dockerfile (#2348)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,3 +1,10 @@
+# check=skip=SecretsUsedInArgOrEnv
+# RACKULA_AUTH_MODE (set via ENV below) is an auth-mode selector with values
+# none|oidc|local, not a secret. The real secret, API_WRITE_TOKEN, is injected at
+# runtime and never set via ENV, so the build check correctly does not flag it. This
+# skip silences the SecretsUsedInArgOrEnv name heuristic; do not extend it to cover a
+# genuinely sensitive ENV.
+
 # Build stage
 FROM node:22-alpine AS build
 WORKDIR /app


### PR DESCRIPTION
## **User description**
## Summary

The Docker build check `SecretsUsedInArgOrEnv` flags `ENV RACKULA_AUTH_MODE` in `deploy/Dockerfile` as a secret. This is a false positive: `RACKULA_AUTH_MODE` is an auth-mode selector with values `none|oidc|local`, not a secret, and its default `none` carries no sensitive data. The rule is a name heuristic that trips on `AUTH` in the variable name.

The actual secret, `API_WRITE_TOKEN`, is already handled correctly: it is never set via `ENV`, only injected at runtime, which is exactly why the build check does not flag it.

This adds a file-level `# check=skip=SecretsUsedInArgOrEnv` directive (the only suppression mechanism Docker build checks support; there is no line-level skip) with an inline rationale and a warning not to extend the skip to a genuinely sensitive `ENV`.

## Test Plan

- [x] `# check=skip=` directive placed as line 1, before any instruction or regular comment (placement confirmed against Docker build-checks docs; a misplaced directive is silently a no-op)
- [x] No secret value added to any `ARG`/`ENV`; `API_WRITE_TOKEN` remains runtime-injected
- [ ] CI green (build checks are warnings, not errors; no Dockerfile gate fails on a comment directive)

Note: `docker build --check` was not run locally (docker unavailable in the dev environment); placement verified against the official docs instead.

Closes #2348


___

## **CodeAnt-AI Description**
**Skip a false secret warning in the Docker build check**

### What Changed
- The Dockerfile now skips a false warning that treated the `RACKULA_AUTH_MODE` setting as a secret
- This keeps the build check from flagging a non-sensitive auth mode value while leaving the real runtime secret handling unchanged
- A note was added to explain that the skip should not be extended to any truly sensitive setting

### Impact
`✅ Fewer false build warnings`
`✅ Clearer Docker build feedback`
`✅ Lower risk of hiding real secrets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
