### PR TITLE
feat: redesign image-label display-mode toggle icon (#2335)

### DIFF
--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -556,7 +556,7 @@
             {:else if uiStore.displayMode === "image"}
               <IconImageBold size={ICON_SIZE.sm} />
             {:else}
-              <IconImageLabel size={ICON_SIZE.md} />
+              <IconImageLabel size={ICON_SIZE.sm} />
             {/if}
           </button>
         </Tooltip>

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -163,7 +163,7 @@
         {:else if displayMode === "image"}
           <IconImageBold size={ICON_SIZE.md} />
         {:else}
-          <IconImageLabel size={ICON_SIZE.lg} />
+          <IconImageLabel size={ICON_SIZE.md} />
         {/if}
       </button>
     </Tooltip>

--- a/src/lib/components/icons/IconImageLabel.svelte
+++ b/src/lib/components/icons/IconImageLabel.svelte
@@ -1,31 +1,36 @@
 <!--
-  IconImageLabel Component
-  Combined icon for "Both" display mode (Labels + Images)
-  Overlays text (T) and image icons
+  IconImageLabel Component (Phosphor Bold style)
+  Combined icon for the "Both" display mode (image + text label).
+  The framed photo reuses the IconImageBold path, compressed into the top of
+  the canvas, sitting above two text-label bars. Matches the sibling
+  IconImageBold / IconTextBold icons (viewBox 256, currentColor fill).
 -->
 <script lang="ts">
   interface Props {
     size?: number;
   }
 
-  let { size = 18 }: Props = $props();
+  let { size = 20 }: Props = $props();
 </script>
 
 <svg
   width={size}
   height={size}
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="currentColor"
-  stroke-width="2"
-  stroke-linecap="round"
-  stroke-linejoin="round"
+  viewBox="0 0 256 256"
+  fill="currentColor"
   aria-hidden="true"
 >
-  <!-- Image frame (background, slightly smaller) -->
-  <rect x="2" y="6" width="12" height="12" rx="1" opacity="0.6" />
-  <!-- Text T (foreground, offset) -->
-  <path d="M12 4V4h8v3" />
-  <path d="M16 4v10" />
-  <path d="M14 14h4" />
+  <!-- Framed photo (IconImageBold path), compressed into the top region -->
+  <g transform="translate(0,-7) scale(1,0.66)">
+    <path
+      d="M144,96a16,16,0,1,1,16,16A16,16,0,0,1,144,96Zm92-40V200a20,20,0,0,1-20,20H40a20,20,0,0,1-20-20V56A20,20,0,0,1,40,36H216A20,20,0,0,1,236,56ZM44,60v79.72l33.86-33.86a20,20,0,0,1,28.28,0L147.31,147l17.18-17.17a20,20,0,0,1,28.28,0L212,149.09V60Zm0,136H162.34L92,125.66l-48,48Zm168,0V183l-33.37-33.37L164.28,164l32,32Z"
+    />
+  </g>
+  <!-- Text-label bars (bottom) -->
+  <path
+    d="M232,200a12,12,0,0,1-12,12H36a12,12,0,0,1,0-24H220A12,12,0,0,1,232,200Z"
+  />
+  <path
+    d="M192,232a12,12,0,0,1-12,12H76a12,12,0,0,1,0-24H180A12,12,0,0,1,192,232Z"
+  />
 </svg>


### PR DESCRIPTION
## **User description**
## Summary

Redesigns the "text + image" (`image-label`, labelled "Both") display-mode toggle icon so it clearly reads as "image with a text label".

The old `IconImageLabel` was out of step with its siblings: a 24x24 viewBox, stroke-based, with a translucent (0.6 opacity) image rect overlapped by a hand-drawn "T". It read as muddy and confusing at icon size.

The new icon is a Phosphor Bold member of the same family as its siblings `IconImageBold` and `IconTextBold`:
- 256 viewBox, `fill="currentColor"`, no stroke (matches siblings exactly).
- A framed photo (reusing `IconImageBold`'s exact path, compressed into the top region) sitting above two distinct rounded label bars. This composition unambiguously says "picture + text label".

Also normalised the call-site sizes: the old icon was bumped up one size step at each consumer to compensate for its smaller 24-viewBox. With the new matching geometry it now uses the same `ICON_SIZE` step as its siblings (`.md` in the canvas control cluster, `.sm` in the device palette header).

Scope is the toggle icon only. No change to how devices render in this mode.

## Acceptance criteria

- [x] The image-label mode toggle uses a new icon that clearly conveys "image with a text label".
- [x] The icon is visually consistent with the other display-mode icons in the control cluster (same viewBox, fill convention, Phosphor Bold weight, and now matching sizes).
- [x] No change to how devices render in this mode.

## Files changed

- `src/lib/components/icons/IconImageLabel.svelte`: rewritten to the Phosphor Bold framed-photo + label-bars design.
- `src/lib/components/canvas/CanvasViewControls.svelte`: `IconImageLabel` size `lg` -> `md` to match siblings.
- `src/lib/components/DevicePalette.svelte`: `IconImageLabel` size `md` -> `sm` to match siblings.

## Test plan

- No unit tests: visual-only SVG component, per the project TDD policy (visual-only components are not unit tested).
- Validated the component with the Svelte MCP `svelte-autofixer` (no issues).
- Rendered the icon at 16/20/24/48px to confirm it reads as "framed image over two label lines" and stays legible at its smallest real call site (16px palette header).
- Local gates: `npm run lint` clean, `npm run build` clean, `npm run test:run` green (one unrelated pre-existing flake in `App.cleanupPrompt.test.ts`, a 30s timeout under full-suite load, confirmed green when re-run in isolation; it has no reference to the changed code).

## Visual regression note

This changes a rendered icon, so the control-cluster / palette visual snapshots may flag a legitimate, intended diff. If a baseline needs updating I will follow the Update Visual Snapshots workflow (download the artifact and commit the new png).

Fixes #2335

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the “both” display-mode toggle icon easier to understand**

### What Changed
- Replaced the old “text + image” toggle icon with a clearer image-and-label symbol that reads as a picture with text below it
- Matched the icon style and size with the other display-mode icons in both the canvas controls and device palette
- Kept the display mode behavior the same; only the icon shown in the toggle changed

### Impact
`✅ Clearer display-mode icons`
`✅ Faster mode selection`
`✅ More consistent toolbar and palette visuals`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
