### PR TITLE
feat: wire "Import devices" palette command (#2341)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -69,6 +69,7 @@
     handleRackContextExport,
     handleRackContextFocus,
   } from "$lib/utils/rack-actions";
+  import { runImportDevices } from "$lib/actions/import-devices-trigger";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
   import { createLayout } from "$lib/utils/serialization";
@@ -525,9 +526,9 @@
   }
 
   function handleImportDevices() {
-    // Delegates to DialogOrchestrator's hidden file input via dialogStore
-    // The DialogOrchestrator handles the actual file input click
-    dialogOrchestrator.handleImportDevices();
+    // Opens DialogOrchestrator's hidden file input via the module-level
+    // trigger the orchestrator registers on mount.
+    runImportDevices();
   }
 
   function handleOpenSettings() {
@@ -556,9 +557,6 @@
   function handleRackContextRename(rackId: string) {
     handleRackContextEdit(rackId);
   }
-
-  // DialogOrchestrator component reference for delegating calls
-  let dialogOrchestrator: DialogOrchestrator;
 </script>
 
 <svelte:window onkeydown={(e) => konamiDetector.handleKeyDown(e)} />
@@ -689,7 +687,7 @@
       {/if}
     </main>
 
-    <DialogOrchestrator bind:this={dialogOrchestrator} />
+    <DialogOrchestrator />
 
     <KeyboardHandler />
 

--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -48,6 +48,7 @@ import {
   handleRackContextExport,
 } from "$lib/utils/rack-actions";
 import { handleLoad } from "$lib/storage";
+import { runImportDevices } from "$lib/actions/import-devices-trigger";
 
 export type ActionDispatch = Record<ActionId, () => void>;
 
@@ -133,11 +134,9 @@ function handleToggleDisplayMode(): void {
 }
 
 /**
- * Build the dispatch map. Every ActionId has an entry so the map is total;
- * selection verbs with no app behaviour fall back to a no-op.
+ * Build the dispatch map. Every ActionId has an entry so the map is total.
  */
 export function createActionDispatch(): ActionDispatch {
-  const noop = () => {};
   return {
     // global
     escape: handleEscape,
@@ -153,7 +152,7 @@ export function createActionDispatch(): ActionDispatch {
     load: handleLoad,
     "view-yaml": handleOpenYamlEditor,
     "new-layout": resetAndOpenNewRack,
-    "import-devices": noop, // device library import is a hidden file input owned by DialogOrchestrator
+    "import-devices": runImportDevices,
     "import-netbox": handleImportFromNetBox,
     "new-custom-device": handleAddDevice,
     "command-palette": () => dialogStore.open("commandPalette"),

--- a/src/lib/actions/import-devices-trigger.ts
+++ b/src/lib/actions/import-devices-trigger.ts
@@ -1,0 +1,32 @@
+/**
+ * Module-level seam for the "Import devices" trigger.
+ *
+ * The device-library import opens a hidden <input type="file"> that lives in
+ * DialogOrchestrator (the element and its onchange parser must stay in the
+ * component). DialogOrchestrator registers its file-picker trigger here on
+ * mount; the module dispatch (createActionDispatch) and App both run the
+ * command through runImportDevices, so the palette, app menu, and keyboard all
+ * reach the one trigger identically.
+ *
+ * Mirrors how the rest of the dispatch resolves singletons: callers depend on
+ * this module, not on a component-instance ref.
+ */
+type ImportDevicesTrigger = () => void;
+
+let trigger: ImportDevicesTrigger | null = null;
+
+/**
+ * Register the file-picker trigger. DialogOrchestrator calls this on mount and
+ * passes the cleanup it returns to its $effect teardown.
+ */
+export function registerImportDevicesTrigger(fn: ImportDevicesTrigger): () => void {
+  trigger = fn;
+  return () => {
+    if (trigger === fn) trigger = null;
+  };
+}
+
+/** Open the device-library file picker. No-op before the orchestrator mounts. */
+export function runImportDevices(): void {
+  trigger?.();
+}

--- a/src/lib/actions/palette-commands.ts
+++ b/src/lib/actions/palette-commands.ts
@@ -35,10 +35,6 @@ export interface PaletteCommandGroup {
 const EXCLUDED: ReadonlySet<ActionId> = new Set<ActionId>([
   "command-palette",
   "escape",
-  // import-devices trigger is component-owned (DialogOrchestrator.handleImportDevices
-  // via bind:this ref in App.svelte) and not callable from the module dispatch.
-  // Excluded until that trigger is lifted to a module-level action.
-  "import-devices",
 ]);
 
 /** Group heading order in the palette. */

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -57,6 +57,7 @@
     resetAndOpenNewRack,
   } from "$lib/utils/app-actions";
   import { parseDeviceLibraryImport } from "$lib/utils/import";
+  import { registerImportDevicesTrigger } from "$lib/actions/import-devices-trigger";
   import { hapticTap } from "$lib/utils/haptics";
   import { appDebug, dialogDebug } from "$lib/utils/debug";
   import type { ImageData } from "$lib/types/images";
@@ -435,7 +436,13 @@
 
   // --- Device library import handlers ---
 
-  export function handleImportDevices() {
+  // The file picker lives here (the hidden <input> below), but the command
+  // dispatch needs a module-level trigger. Register the picker opener on mount
+  // so the palette, app menu, and keyboard all run import-devices through the
+  // same seam (see $lib/actions/import-devices-trigger).
+  $effect(() => registerImportDevicesTrigger(openDeviceImportPicker));
+
+  function openDeviceImportPicker() {
     deviceImportInputRef?.click();
   }
 

--- a/src/tests/dispatch.test.ts
+++ b/src/tests/dispatch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { createActionDispatch } from "$lib/actions/dispatch";
 import { dialogStore } from "$lib/stores/dialogs.svelte";
 import * as appActions from "$lib/utils/app-actions";
+import { registerImportDevicesTrigger } from "$lib/actions/import-devices-trigger";
 
 describe("createActionDispatch", () => {
   afterEach(() => {
@@ -28,5 +29,17 @@ describe("createActionDispatch", () => {
     const dispatch = createActionDispatch();
     dispatch["fit-all"]();
     expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("runs the registered trigger when import-devices runs", () => {
+    const trigger = vi.fn();
+    const unregister = registerImportDevicesTrigger(trigger);
+    try {
+      const dispatch = createActionDispatch();
+      dispatch["import-devices"]();
+      expect(trigger).toHaveBeenCalledOnce();
+    } finally {
+      unregister();
+    }
   });
 });

--- a/src/tests/palette-commands.test.ts
+++ b/src/tests/palette-commands.test.ts
@@ -31,8 +31,8 @@ describe("getPaletteCommands", () => {
     expect(ids(baseCtx)).not.toContain("command-palette");
   });
 
-  it("excludes import-devices (component-owned trigger, not module-dispatchable)", () => {
-    expect(ids(baseCtx)).not.toContain("import-devices");
+  it("lists import-devices now that its trigger is module-dispatchable", () => {
+    expect(ids(baseCtx)).toContain("import-devices");
   });
 
   it("hides selection commands when nothing is selected", () => {


### PR DESCRIPTION
## **User description**
## Summary

Makes the "Import devices" command reachable from the command palette (Ctrl/Cmd+K).

The action was excluded from the palette because its trigger was a
component-instance method (`DialogOrchestrator.handleImportDevices()`), reached
via a `bind:this` ref in `App.svelte`. The module-level dispatch could not call
it, so it was mapped to a no-op and hidden from the palette to avoid a dead row.

This takes approach A from the issue: a small module-level trigger seam.
`DialogOrchestrator` registers its file-picker opener on mount; the dispatch and
`App` both run the command through `runImportDevices`. The hidden file input and
its parser stay in the component, so the import flow itself is unchanged.

## Changes

- `src/lib/actions/import-devices-trigger.ts` (new): module-level register/run seam for the file-picker trigger.
- `src/lib/components/DialogOrchestrator.svelte`: registers `openDeviceImportPicker` via `$effect` (cleanup on unmount); drops the exported component method.
- `src/lib/actions/dispatch.ts`: maps `import-devices` to `runImportDevices`; removes the dead no-op.
- `src/lib/actions/palette-commands.ts`: removes `import-devices` from the palette `EXCLUDED` set.
- `src/App.svelte`: `handleImportDevices` now runs the module trigger; removes the now-dead `bind:this={dialogOrchestrator}` ref.
- Tests: palette listing asserts `import-devices` is now listed; dispatch test asserts running `import-devices` invokes the registered trigger.

## Acceptance criteria

- [x] Selecting "Import devices" from the palette runs the same flow as the app menu (one shared trigger seam).
- [x] `import-devices` removed from the palette `EXCLUDED` set; a test asserts it is now listed.
- [x] No regression to the app-menu import path (`actions-registry.test.ts` still asserts the app-menu projection; the Toolbar `onimportdevices` handler still runs the same trigger).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:run` green
- [x] `npm run build` green

Closes #2341
Refs #2212. Part of epic #2017.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Make “Import devices” available from the command palette**

### What Changed
- “Import devices” now appears in the command palette and runs the same import flow as the app menu
- The app no longer depends on a direct component reference to open the device import picker, so the command can be triggered consistently from palette, menu, and keyboard
- Tests now cover that the command is listed in the palette and that dispatching it opens the registered import trigger

### Impact
`✅ Import devices from the command palette`
`✅ Same import flow from menu, palette, and keyboard`
`✅ Fewer hidden or unavailable commands`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
