### PR TITLE
feat: specular glass treatment for the floating verb bar (#2344)

### DIFF
--- a/src/lib/components/VerbBar.svelte
+++ b/src/lib/components/VerbBar.svelte
@@ -111,11 +111,25 @@
     gap: var(--space-1);
     padding: var(--space-1);
     border-radius: var(--radius-full);
-    border: 1px solid var(--bottom-nav-border);
-    background: var(--verb-bar-bg);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    box-shadow: var(--shadow-lg);
+    border: 1px solid var(--verb-bar-border);
+    /* Sheen gradient layered over the translucent body so the bar reads as a
+       lens catching light, not frosted plastic. */
+    background: var(--verb-bar-sheen), var(--verb-bar-bg);
+    backdrop-filter: var(--verb-bar-backdrop);
+    -webkit-backdrop-filter: var(--verb-bar-backdrop);
+    /* Specular rim (inset light top edge + dark bottom) plus the floating
+       drop shadow. */
+    box-shadow: var(--verb-bar-rim), var(--shadow-lg);
+  }
+
+  /* Fall back to a near-solid background when the user reduces transparency,
+     so icon contrast stays legible without the backdrop blur. */
+  @media (prefers-reduced-transparency: reduce) {
+    .verb-bar {
+      background: var(--verb-bar-bg-solid);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
   }
 
   .verb-button {

--- a/src/lib/components/VerbBar.svelte
+++ b/src/lib/components/VerbBar.svelte
@@ -122,6 +122,15 @@
     box-shadow: var(--verb-bar-rim), var(--shadow-lg);
   }
 
+  /* Without backdrop-filter the translucent body has no blur to separate it
+     from the canvas, so fall back to a near-solid background. */
+  @supports not ((backdrop-filter: blur(1px)) or
+    (-webkit-backdrop-filter: blur(1px))) {
+    .verb-bar {
+      background: var(--verb-bar-bg-solid);
+    }
+  }
+
   /* Fall back to a near-solid background when the user reduces transparency,
      so icon contrast stays legible without the backdrop blur. */
   @media (prefers-reduced-transparency: reduce) {

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -365,7 +365,22 @@
   --bottom-nav-bg: rgba(33, 34, 44, 0.85);
   --bottom-nav-border: rgba(52, 55, 70, 0.6);
   --bottom-nav-blur: 20px;
-  --verb-bar-bg: rgba(33, 34, 44, 0.95);
+  --verb-bar-bg: rgba(33, 34, 44, 0.72);
+  /* Specular glass: translucent body lets devices show through; the rim and
+     sheen sell it as a lens. Dark theme uses a lighter top edge for the
+     highlight and a soft dark bottom for grounding. */
+  --verb-bar-bg-solid: rgba(33, 34, 44, 0.97);
+  --verb-bar-backdrop: blur(16px) saturate(1.6);
+  --verb-bar-border: rgba(248, 248, 242, 0.14);
+  --verb-bar-rim:
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 0 rgba(0, 0, 0, 0.28);
+  --verb-bar-sheen: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1) 0%,
+    rgba(255, 255, 255, 0.02) 38%,
+    rgba(255, 255, 255, 0) 60%
+  );
   --bottom-nav-active-pill-bg: rgba(139, 233, 253, 0.12);
   --bottom-nav-active-colour: var(--colour-primary);
   --bottom-nav-inactive-colour: var(--colour-text-muted);
@@ -601,7 +616,20 @@
   --bottom-nav-bg: rgba(239, 237, 220, 0.85);
   --bottom-nav-border: rgba(222, 220, 207, 0.6);
   --bottom-nav-active-pill-bg: rgba(3, 106, 150, 0.1);
-  --verb-bar-bg: rgba(239, 237, 220, 0.95);
+  --verb-bar-bg: rgba(239, 237, 220, 0.62);
+  /* Light theme: the cream body needs a brighter top sheen and a softer,
+     warmer bottom edge so the rim reads on a pale background. */
+  --verb-bar-bg-solid: rgba(243, 241, 226, 0.97);
+  --verb-bar-border: rgba(95, 90, 70, 0.18);
+  --verb-bar-rim:
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.7),
+    inset 0 -1px 0 0 rgba(95, 90, 70, 0.14);
+  --verb-bar-sheen: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.55) 0%,
+    rgba(255, 255, 255, 0.12) 38%,
+    rgba(255, 255, 255, 0) 60%
+  );
 
   --colour-error-hover: #b33030;
 


### PR DESCRIPTION
## **User description**
## Summary

Upgrades the floating object verb bar from a flat frosted pill to a specular glass treatment so it reads as glass catching light over the rack canvas it floats above (option B from #2344, pure cross-browser CSS).

What changed, tokens only, themed for both Dracula (dark) and Alucard (light):

- `backdrop-filter: blur(16px) saturate(1.6)` so the devices behind pop through.
- A specular rim via inset box-shadows: light top edge, soft dark bottom.
- A faint top sheen gradient layered over the translucent body.
- A refined translucent border.
- A `prefers-reduced-transparency: reduce` fallback to a near-solid background with no backdrop filter.

Option C (SVG `feTurbulence` + `feDisplacementMap` displacement) was rejected per the issue: Chromium-only, pixelated, and it warps the rack content behind the bar.

## Files changed

- `src/lib/styles/tokens.css`: new verb-bar specular tokens (`--verb-bar-bg-solid`, `--verb-bar-backdrop`, `--verb-bar-border`, `--verb-bar-rim`, `--verb-bar-sheen`) in both theme blocks; verb-bar body opacity lowered (0.95 -> 0.72 dark, 0.62 light) so the glass reads as a lens.
- `src/lib/components/VerbBar.svelte`: `.verb-bar` now consumes the new tokens; added the reduced-transparency fallback. No structural or behavioural change (roving-tabindex and verb dispatch untouched).

## Accessibility

- Icon contrast stays well above WCAG AA over the translucent body in both themes. Worst case computed (a pure-white device directly behind the bar) is 4.6:1 in dark; light theme is comfortably above 14:1. The reduced-transparency fallback only improves this.
- `prefers-reduced-transparency: reduce` falls back to a 0.97-opacity background and drops the blur.
- No new motion, so `prefers-reduced-motion` is honoured by construction. The only transition (on `.verb-button`) is pre-existing and still gated.

## Test Plan

- [x] `npm run lint` clean
- [x] verb-bar unit tests pass (45) and the two App integration files pass in isolation
- [x] `npm run build` succeeds
- [x] Token tracing: all 6 referenced tokens defined; `--verb-bar-backdrop` correctly inherits from `:root` into the light theme
- [ ] Visual: confirm the bar reads as specular glass in both Dracula and Alucard on the live preview

## Visual regression

This changes the verb bar's appearance, so a visual snapshot may legitimately need a baseline update. If the Visual Regression CI job flags the verb bar, the new baseline will be regenerated via the Update Visual Snapshots workflow and committed.

Closes #2344. Refs #2075, #2017.


___

## **CodeAnt-AI Description**
**Give the floating verb bar a glass-like finish and a clearer fallback**

### What Changed
- The floating verb bar now uses a specular glass look with a brighter rim, a soft sheen, and stronger blur so it reads like a lens over the canvas.
- The bar is more translucent in both dark and light themes, with theme-specific edge and highlight treatment to keep it visible on each background.
- When reduced transparency is enabled, the bar switches to a near-solid background and removes the blur for clearer icon contrast.

### Impact
`✅ Clearer verb bar visibility`
`✅ Better contrast with reduced transparency`
`✅ More polished floating toolbar appearance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
