### PR TITLE
feat: desktop command palette placement cue and click-to-place (#2352)

### DIFF
--- a/docs/superpowers/specs/2026-06-16-desktop-placement-cue-design.md
+++ b/docs/superpowers/specs/2026-06-16-desktop-placement-cue-design.md
@@ -1,0 +1,132 @@
+# Desktop placement cue and click-to-place (#2352)
+
+## Problem
+
+The command palette "Add device..." sub-mode (#2214) and the mobile tap-to-place
+workflow both call `placementStore.startPlacement()`, which sets `isPlacing = true`.
+On mobile this arms a visible placement experience: a pink rack outline, pulsing
+valid-slot highlights, a "Tap to place: X" header with a cancel button, and
+tap-on-rack to place.
+
+On desktop none of that surfaces. Choosing a device from the palette closes the
+palette and arms placement, but the user sees no cue and there is no click-to-place,
+so the armed state is invisible. The palette comment even admits the design
+assumption: "The palette closing is the cue to position the device on the canvas."
+That assumption holds on mobile (the sheet slides away to reveal the armed rack) but
+not on desktop.
+
+This is an accelerator gap, not a regression: the canonical desktop placement path
+remains the Devices sidebar drag-and-drop.
+
+## Root cause
+
+The entire placement experience is gated by a single derived in `Rack.svelte`:
+
+```ts
+const isPlacementMode = $derived(
+  viewportStore.isMobile && placementStore.isPlacing,
+);
+```
+
+`isPlacementMode` drives the pink container outline, the valid-slot highlighting
+(`RackFrame` `validPlacementSlots`), and the `RackPlacementHeader` overlay. A second
+gate on the same condition guards the click-to-place handler in `handleClick`.
+
+The `isMobile` conjunct predates the palette. It came from the original mobile-only
+tap-to-place workflow (#1397/#1462). The underlying click and completion machinery is
+already device-agnostic:
+
+- `handlePlacementClick` (rack-interaction-handlers.ts) was written for "any pointing
+  device, in any browser" (#1757) precisely because desktop browsers do not synthesise
+  TouchEvents for a mouse.
+- `handlePlacementTap` -> `placeDeviceSmart` (RackCanvasView.svelte) is device-agnostic
+  completion.
+
+So desktop placement is roughly 90% built. The only things keeping it mobile-only are
+the two `isMobile` conjuncts.
+
+## Options considered
+
+- A. Un-gate the existing placement cue and click-to-place so they arm on desktop too.
+- B. Have the palette "Add device" path select the device in the sidebar or start a
+  desktop drag affordance instead of tap-to-place.
+- C. Scope the palette "Add device" sub-mode to mobile only.
+
+C removes value on the platform where Ctrl/Cmd+K matters most and contradicts #2214's
+intent. B cannot programmatically start HTML5 drag-and-drop from a keyboard-driven
+selection (DnD needs a real pointer gesture), and "select in sidebar" leaves the user
+mid-task with no placement, a half-built interaction.
+
+A is the smallest correct change because it reuses the already-built, already-tested,
+device-agnostic placement pipeline. It is consistent with the canonical desktop path:
+click-to-place is an accelerator that sits alongside sidebar drag-and-drop, not a
+replacement. This is un-gating a complete interaction, not building one from scratch.
+
+## Decision: Option A
+
+### Changes
+
+1. `Rack.svelte` — `isPlacementMode` becomes `$derived(placementStore.isPlacing)`.
+   This arms the pink outline, valid-slot pulse, and placement header on desktop.
+
+2. `Rack.svelte` `handleClick` — the placement branch guard becomes
+   `if (placementStore.isPlacing)` (drop the `isMobile` conjunct). The
+   `handlePlacementClick` path it calls is already device-agnostic. The existing
+   pan/drag debounce guards above it still prevent accidental placement after a pan.
+
+3. `Rack.svelte` `ontouchend` — stays gated on `viewportStore.isMobile`. It is the
+   only genuinely touch-specific handler; desktop pointer placement goes through
+   `handleClick`. Leaving it mobile-only avoids double-firing on touch (its
+   `preventDefault` suppresses the synthesised click) and keeps touch behaviour
+   unchanged.
+
+4. `RackPlacementHeader.svelte` — the copy "Tap to place: X" reads wrong for a mouse.
+   Add an `actionVerb` (or pass the full label) so desktop reads "Click to place: X"
+   and mobile keeps "Tap to place: X". Derive the verb in `Rack.svelte` from
+   `viewportStore.isMobile`.
+
+5. `RackCanvasView.svelte` `handleDeviceDrop` — when a native drag-and-drop
+   completes while placement is armed, cancel the armed placement. A completed
+   drop is an unambiguous choice of the DnD path; without this the desktop
+   click-to-place stays armed and the next rack click would silently place the
+   still-pending palette device. This footgun is only reachable now that desktop
+   click-to-place exists, so the guard ships with this change.
+
+No change to the completion path, the store, or the palette.
+
+### Cancel / escape
+
+The placement header's cancel button already calls `handleCancelPlacement`, which
+resets the store and refits the view. That works on desktop unchanged. Escape-to-cancel
+also already exists and is viewport-agnostic: `handleEscape` in `dispatch.ts` cancels
+placement when `isPlacing` is true. Both affordances are now reachable on desktop.
+
+### Multi-rack note
+
+On desktop multiple racks are visible at once. Each `Rack` instance independently
+derives its own `validPlacementSlots` and renders its own header, so arming placement
+highlights valid slots in every rack and a click in any rack places there (via
+`placeDeviceSmart` on that rack's id). No active-rack coupling is needed.
+
+## Testing
+
+The device-agnostic units are already covered:
+
+- `placement-pointer.test.ts` covers `handlePlacementClick` (valid places once, invalid
+  signals error). This is exactly the desktop path; no `isMobile` branch lives in that
+  function, so the existing test already proves desktop click-to-place at the unit
+  level.
+
+The only new behaviour is the gate change in `Rack.svelte`, which is a one-line derived
+and a one-line conditional. Per project policy we do not add render/DOM-structure tests
+for a Svelte component, and the placement algorithm itself is unchanged. No new unit
+test is warranted; the change is a removal of a viewport conjunct over already-tested
+machinery. Manual verification: on desktop, palette "Add device" then click a valid slot
+places the device and shows the header/highlight while armed.
+
+## Out of scope
+
+- The orphaned `PlacementIndicator.svelte` (not rendered anywhere) is untouched.
+- Cursor affordance changes (e.g. crosshair cursor) are not required; the header plus
+  slot highlighting are the cue.
+- Escape-to-cancel keybinding (cancel button is sufficient).

--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -14,6 +14,7 @@ import {
   RACK_WITH_DEVICE_SHARE,
   PLATFORM_MODIFIER,
   selectDevice,
+  locators,
 } from "./helpers";
 
 test.describe("Command palette", () => {
@@ -285,18 +286,47 @@ test.describe("Command palette", () => {
     );
   });
 
-  test("choosing a device closes the palette into placement", async ({
+  test("choosing a device arms desktop placement and click-to-place (#2352)", async ({
     page,
   }) => {
+    const devicesBefore = await page.locator(locators.rack.device).count();
+
     await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
     await page.getByTestId("command-palette-add-device").click();
     await page.getByTestId("command-palette-device-item-1u-server").click();
-    // Choosing a device closes the palette and arms placement via the shared
-    // tap-to-place path. The "tap to place" status cue and tap-to-place
-    // completion are mobile-only (Rack.svelte gates them on viewportStore.isMobile),
-    // so on desktop the observable outcome is the palette closing.
+
+    // Choosing a device closes the palette and arms placement (#2214/#2352).
     await expect(
       page.getByRole("dialog", { name: "Command palette" }),
     ).not.toBeVisible();
+
+    // On desktop the cue now surfaces: a "Click to place" status header. Scope
+    // by text since dual-view renders one in each face SVG.
+    const placementHeader = page
+      .getByRole("status")
+      .filter({ hasText: "Click to place" })
+      .first();
+    await expect(placementHeader).toBeVisible();
+
+    // Click a valid rack slot with the mouse to complete placement.
+    const rackSvg = page
+      .locator(`${locators.rackView.front} ${locators.rack.svg}`)
+      .first();
+    const box = await rackSvg.boundingBox();
+    if (!box) {
+      throw new Error(
+        "rackSvg boundingBox() returned null; cannot click placement target",
+      );
+    }
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height * 0.5);
+
+    // The device is placed and placement mode exits.
+    await expect(async () => {
+      const devicesAfter = await page.locator(locators.rack.device).count();
+      expect(devicesAfter).toBeGreaterThan(devicesBefore);
+    }).toPass({ timeout: 5000 });
+    await expect(async () => {
+      await expect(placementHeader).not.toBeVisible();
+    }).toPass({ timeout: 5000 });
   });
 });

--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -325,8 +325,8 @@ test.describe("Command palette", () => {
       const devicesAfter = await page.locator(locators.rack.device).count();
       expect(devicesAfter).toBeGreaterThan(devicesBefore);
     }).toPass({ timeout: 5000 });
-    await expect(async () => {
-      await expect(placementHeader).not.toBeVisible();
-    }).toPass({ timeout: 5000 });
+    // `not.toBeVisible()` already auto-retries, so a plain assertion with a
+    // timeout suffices for the post-placement settle.
+    await expect(placementHeader).not.toBeVisible({ timeout: 5000 });
   });
 });

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -279,9 +279,13 @@
   const blockedSlots = $derived(
     faceFilter ? getBlockedSlots(rack, faceFilter, deviceLibrary) : [],
   );
-  const isPlacementMode = $derived(
-    viewportStore.isMobile && placementStore.isPlacing,
-  );
+  // Placement is armed by the mobile tap-to-place flow and the desktop command
+  // palette "Add device" path (#2214/#2352) alike, so the cue surfaces on every
+  // viewport. Touch placement is completed by `ontouchend`; pointer placement by
+  // `handleClick` -> handlePlacementClick, both reading the same store.
+  const isPlacementMode = $derived(placementStore.isPlacing);
+  // "Tap" on touch viewports, "Click" on desktop, for the placement header copy.
+  const placementVerb = $derived(viewportStore.isMobile ? "Tap" : "Click");
 
   const validPlacementSlots = $derived.by(() => {
     if (!isPlacementMode || !placementStore.pendingDevice)
@@ -367,12 +371,12 @@
    *
    * Clicks synthesised at the end of a pan/drag gesture are ignored first
    * (`isPanning` stays true for ~50ms after `panend`), so neither placement nor
-   * selection fires unintentionally after a pan. Then, in mobile mode (viewport
-   * <= 1024px) a click while placing completes mouse/pointer tap-to-place
-   * (#1757) — desktop browsers do not synthesise TouchEvents for a mouse, so
-   * without this a mouse user could pick a device but never place it; touch
-   * input is handled separately by the SVG's `ontouchend`. Otherwise the click
-   * selects the rack.
+   * selection fires unintentionally after a pan. Then a click while placing
+   * completes mouse/pointer click-to-place (#1757/#2352) on any viewport:
+   * desktop browsers do not synthesise TouchEvents for a mouse, so without this
+   * a pointer user (mobile tap-to-place or the desktop palette "Add device"
+   * path) could pick a device but never place it. Touch input is handled
+   * separately by the SVG's `ontouchend`. Otherwise the click selects the rack.
    */
   function handleClick(event: MouseEvent) {
     if (canvasStore.isPanning) return;
@@ -380,7 +384,7 @@
       justFinishedDrag = false;
       return;
     }
-    if (viewportStore.isMobile && placementStore.isPlacing) {
+    if (placementStore.isPlacing) {
       const device = placementStore.pendingDevice;
       if (device && svgElement) {
         onPlacementClick(event, svgElement, handlerCtx, device, onplacementtap);
@@ -523,13 +527,14 @@
       />
     {/if}
 
-    <!-- Layer 4: Placement header (mobile) -->
+    <!-- Layer 4: Placement header (tap/click-to-place) -->
     {#if isPlacementMode && placementStore.pendingDevice}
       {@const pendingDevice = placementStore.pendingDevice}
       <RackPlacementHeader
         rackWidth={RACK_WIDTH}
         rackPadding={RACK_PADDING}
         deviceModel={pendingDevice.model ?? pendingDevice.slug}
+        actionVerb={placementVerb}
         oncancel={handleCancelPlacement}
       />
     {/if}

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -195,6 +195,11 @@
       toastStore.showToast("Can't place device here", "warning", 3000);
       return;
     }
+    // A completed drag-and-drop is an unambiguous choice of the DnD path, so
+    // abandon any placement armed via the command palette "Add device" flow
+    // (#2352). Without this the desktop click-to-place stays armed and the next
+    // rack click would silently place the still-pending device.
+    if (placementStore.isPlacing) placementStore.cancelPlacement();
     ondevicedrop?.(event);
   }
 

--- a/src/lib/components/RackPlacementHeader.svelte
+++ b/src/lib/components/RackPlacementHeader.svelte
@@ -1,6 +1,6 @@
 <!--
   RackPlacementHeader SVG Component
-  Renders the mobile tap-to-place header overlay inside the rack SVG.
+  Renders the tap/click-to-place header overlay inside the rack SVG.
   Shows the pending device name and a cancel button.
 
   This is a pure rendering component with a single cancel callback.
@@ -20,11 +20,19 @@
     rackPadding: number;
     /** Name of the device being placed */
     deviceModel: string;
+    /** Input verb for the prompt ("Tap" on touch, "Click" on desktop) */
+    actionVerb?: string;
     /** Callback when user cancels placement */
     oncancel?: () => void;
   }
 
-  let { rackWidth, rackPadding, deviceModel, oncancel }: Props = $props();
+  let {
+    rackWidth,
+    rackPadding,
+    deviceModel,
+    actionVerb = "Tap",
+    oncancel,
+  }: Props = $props();
 </script>
 
 <foreignObject
@@ -41,7 +49,7 @@
     xmlns="http://www.w3.org/1999/xhtml"
   >
     <span class="placement-text">
-      Tap to place: <strong>{deviceModel}</strong>
+      {actionVerb} to place: <strong>{deviceModel}</strong>
     </span>
     <button
       type="button"


### PR DESCRIPTION
## **User description**
## Summary

Closes #2352. Implements **Option A** from the issue: desktop users who pick a device from the command palette "Add device" sub-mode (#2214) now see a placement cue and can click on the rack to place. Previously, choosing a device on desktop armed `placementStore.isPlacing` but surfaced no cue and had no click-to-place, so the armed state was invisible (an accelerator gap).

Design spec: [`docs/superpowers/specs/2026-06-16-desktop-placement-cue-design.md`](https://github.com/RackulaLives/Rackula/blob/feat/2352-desktop-placement-cue/docs/superpowers/specs/2026-06-16-desktop-placement-cue-design.md).

## What changed

- **`Rack.svelte`**: the placement gates dropped the `viewportStore.isMobile` condition. `isPlacementMode` and the rack-click placement handler now read `placementStore.isPlacing` alone, so the cue and click-to-place surface on every viewport. A new `placementVerb` derives "Tap" on touch viewports and "Click" on desktop for the cue copy.
- **`RackPlacementHeader.svelte`**: added an `actionVerb` prop (default "Tap") so the cue reads "Click to place: ..." on desktop and "Tap to place: ..." on mobile.
- **`RackCanvasView.svelte`**: a completed sidebar drag-and-drop now cancels any palette-armed placement, so a stale armed device can't be silently placed by the next rack click. The canonical desktop path (sidebar DnD) is unchanged.
- **`command-palette.spec.ts`**: the existing palette-into-placement test now asserts the desktop cue appears and that a mouse click on the rack places the device and dismisses the cue.

## No mobile regression

The mobile tap-to-place path is untouched: touch completion still flows through the SVG's `ontouchend` (still gated on `viewportStore.isMobile`), the cue verb stays "Tap", and Escape still cancels via the action registry (already viewport-agnostic). Successful placement clears the armed state via `completePlacement()`, dismissing the cue.

## Verification

- `npm run lint` — clean
- `npm run test:run` — 2640 tests pass (158 files)
- `npm run build` — succeeds
- `e2e/command-palette.spec.ts` — all 16 tests pass (chromium), including the new desktop placement test

## Notes

- This is part of epic #2017.
- Implemented and reviewed locally with the `/code-review` skill (no findings). CodeRabbit's pre-push gate was rate-limited; the bot review on this PR is the cloud gate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show placement cue and click-to-place on desktop after choosing a device**

### What Changed
- After picking a device from the command palette on desktop, the rack now shows the placement cue and lets you click a valid slot to place it
- The placement message now says “Click to place” on desktop and keeps “Tap to place” on touch devices
- If you place a device by dragging it from the sidebar, any pending palette placement is canceled so the next click does not place the wrong device
- The command palette test now checks the desktop cue, mouse placement, and cue dismissal after placement

### Impact
`✅ Desktop device placement from the command palette`
`✅ Clearer placement prompts on mouse and touch`
`✅ Fewer accidental placements after sidebar drag-and-drop`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
