### PR TITLE
feat: automated security triage via Claude Code (#2357)

### DIFF
--- a/.github/prompts/security-triage.md
+++ b/.github/prompts/security-triage.md
@@ -65,8 +65,9 @@ gh api --method PATCH "/repos/{owner}/{repo}/code-scanning/alerts/<NUMBER>" \
 
 If the finding is real:
 
-1. Create a branch `fix/security-<rule-id-slug>-<alert-number>` off `main`. The alert number
-   keeps the branch unique even when two findings share a rule id on the same commit.
+1. Create a branch `fix/security-<alert-number>` off `main`. The alert number is globally
+   unique, so this guarantees one branch per finding (no collisions when two findings share
+   a rule id on the same commit).
 2. If the fix is small and clear (a dependency bump, an input-validation guard, an encoding
    call), implement it directly with minimal, targeted edits. Do not refactor or touch
    unrelated code.

--- a/.github/prompts/security-triage.md
+++ b/.github/prompts/security-triage.md
@@ -65,7 +65,8 @@ gh api --method PATCH "/repos/{owner}/{repo}/code-scanning/alerts/<NUMBER>" \
 
 If the finding is real:
 
-1. Create a branch `fix/security-<rule-id-slug>-<short-sha>` off `main`.
+1. Create a branch `fix/security-<rule-id-slug>-<alert-number>` off `main`. The alert number
+   keeps the branch unique even when two findings share a rule id on the same commit.
 2. If the fix is small and clear (a dependency bump, an input-validation guard, an encoding
    call), implement it directly with minimal, targeted edits. Do not refactor or touch
    unrelated code.

--- a/.github/prompts/security-triage.md
+++ b/.github/prompts/security-triage.md
@@ -1,0 +1,98 @@
+# Security Triage Playbook
+
+You are a security analyst triaging automated findings from CodeQL and Trivy on the Rackula
+repository. Work autonomously: investigate each net-new finding, decide whether it is real,
+and either dismiss it (false positive) or open a draft PR with a suggested fix.
+
+The kickoff message tells you which scanner triggered this run (the triggering tool) and the
+scan start time. Use those to scope your work to net-new findings only.
+
+## Step 1: Find net-new alerts
+
+List open Code Scanning alerts for the triggering tool on the default branch, newest first:
+
+```bash
+gh api "/repos/{owner}/{repo}/code-scanning/alerts?state=open&ref=refs/heads/main&tool_name=<TOOL>&sort=created&direction=desc&per_page=100"
+```
+
+`<TOOL>` is `CodeQL` for the CodeQL workflow, or `Trivy` for the Trivy Security Scan workflow.
+
+A finding is net-new if its `created_at` is at or after (scan start time minus 30 minutes).
+The 30-minute margin absorbs scan plus SARIF-processing lag. Ignore alerts older than that:
+they were triaged on a previous run.
+
+If no scan start time is given (a manual `workflow_dispatch` dry run), do not time-filter:
+consider all currently-open alerts for the tool, still subject to the cap in Step 2.
+
+If there are no net-new alerts, stop and report that there is nothing to triage.
+
+## Step 2: Cap the work
+
+Triage at most 5 findings per run, ordered by severity (critical first). If there are more
+than 5 net-new findings, process the top 5 and clearly log which ones you skipped: they will
+be picked up on the next scheduled scan.
+
+## Step 3: Investigate each finding
+
+For each finding, read the affected file around the alert location and understand the data
+flow or dependency in context. Then judge whether it is a genuine, exploitable issue in this
+codebase.
+
+Common false positives to watch for:
+
+- CodeQL data-flow findings where the source is a config file, environment variable, or
+  hardcoded constant (not user-controlled).
+- Trivy CVEs in devDependencies that are not shipped to production, or in code paths that are
+  not reachable at runtime.
+- Findings in generated files, build output, or test fixtures.
+- Path-traversal findings where the path comes from an internal constant.
+- XSS findings where output is sanitized before rendering.
+
+The repo already excludes `scripts/**` from CodeQL (dev tooling that does fetch then write by
+design) - findings there are out of scope.
+
+## Step 4a: False positive -> dismiss
+
+If the finding is not real, dismiss it with a clear reason:
+
+```bash
+gh api --method PATCH "/repos/{owner}/{repo}/code-scanning/alerts/<NUMBER>" \
+  -f state=dismissed -f dismissed_reason="false positive" \
+  -f dismissed_comment="<one-paragraph explanation of why this is not exploitable here>"
+```
+
+## Step 4b: Real finding -> draft PR
+
+If the finding is real:
+
+1. Create a branch `fix/security-<rule-id-slug>-<short-sha>` off `main`.
+2. If the fix is small and clear (a dependency bump, an input-validation guard, an encoding
+   call), implement it directly with minimal, targeted edits. Do not refactor or touch
+   unrelated code.
+3. If the fix is not straightforward, do not guess at code. Instead write a triage document
+   to `docs/security-triage/<alert-number>-<rule-id-slug>.md` describing the finding, your
+   analysis, and a concrete suggested fix (with a before/after code example), so a human can
+   finish it.
+4. Commit, push the branch, and open a DRAFT PR against `main`. Title:
+   `security: triage <rule-id> in <file> (alert #<number>)`.
+5. The PR body must include: the tool, severity, your confidence, the file, the alert URL,
+   your triage reasoning, and the suggested fix (or the implemented fix if you made one).
+6. Label the PR `security` and `automated`.
+
+```bash
+gh pr create --draft --base main --head <branch> \
+  --title "..." --body "..." --label security --label automated
+```
+
+## Constraints
+
+- Open DRAFT PRs only. A human reviews and merges.
+- Only operate on the default branch. Never force-push, never touch other branches.
+- One branch and one draft PR per real finding.
+- Keep edits minimal and scoped to the finding. No drive-by changes.
+- For dependency CVEs, specify the exact minimum safe version from the advisory.
+
+## Report
+
+At the end, summarize what you did: how many net-new findings, how many dismissed as false
+positives, how many draft PRs opened (with their URLs), and how many skipped due to the cap.

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -1,0 +1,96 @@
+name: Security Triage
+
+# Fires when CodeQL or Trivy completes on the default branch. Runs Claude Code
+# (authenticated via a Claude subscription OAuth token, NOT an API key) to triage
+# net-new Code Scanning alerts: dismiss false positives, open a draft PR with a
+# suggested fix for real findings.
+#
+# Auth: CLAUDE_CODE_OAUTH_TOKEN, generated locally by a Claude Pro/Max subscriber
+# with `claude setup-token` and stored as a repo secret. This bills against the
+# subscription, not API credits. IMPORTANT: this job must NOT expose
+# ANTHROPIC_API_KEY - if present it takes auth precedence and bills the API account.
+# See docs/deployment/SECURITY-TRIAGE.md.
+
+on:
+  workflow_run:
+    workflows: ["CodeQL", "Trivy Security Scan"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      triggering_workflow:
+        description: "Workflow name to simulate (CodeQL or Trivy Security Scan)"
+        required: false
+        default: "CodeQL"
+
+permissions:
+  contents: write
+  pull-requests: write
+  security-events: write
+  issues: write
+
+jobs:
+  triage:
+    name: Triage new findings
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    # Skip if the triggering scan failed before uploading SARIF, unless this is a
+    # manual dispatch (which has no triggering workflow to inspect).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
+
+    env:
+      TRIGGERING_WORKFLOW: >-
+        ${{ github.event_name == 'workflow_dispatch'
+            && inputs.triggering_workflow
+            || github.event.workflow_run.name }}
+      # Empty on manual dispatch (no workflow_run in the payload): the playbook
+      # treats "no scan start time" as "triage all currently-open alerts" so a
+      # dry run actually sees something.
+      RUN_STARTED_AT: ${{ github.event.workflow_run.run_started_at }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: main
+          fetch-depth: 1
+
+      # Runners have no default git identity; Claude's git commit would abort
+      # without this. Use the github-actions[bot] identity for triage commits.
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # GitHub processes uploaded SARIF into Code Scanning alerts asynchronously.
+      # Wait so the new alerts are queryable before Claude looks for them.
+      - name: Wait for Code Scanning API to process SARIF
+        if: github.event_name == 'workflow_run'
+        run: sleep 90
+
+      - name: Run security triage
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
+        # Pass the OAuth token both as the action input and as the env var the
+        # underlying Claude CLI reads, so auth binds regardless of whether this
+        # pinned action version exposes the claude_code_oauth_token input.
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        with:
+          # Subscription OAuth token (NOT anthropic_api_key) so usage bills against
+          # the Claude Pro/Max subscription rather than API credits.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Read .github/prompts/security-triage.md and follow it exactly.
+
+            Triage net-new open Code Scanning alerts from the "${{ env.TRIGGERING_WORKFLOW }}"
+            scan that started at ${{ env.RUN_STARTED_AT }}.
+
+            Repository: ${{ github.repository }}
+            Default branch: main
+            Current HEAD SHA: ${{ github.sha }}
+          claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep"'

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -19,9 +19,15 @@ on:
   workflow_dispatch:
     inputs:
       triggering_workflow:
-        description: "Workflow name to simulate (CodeQL or Trivy Security Scan)"
+        description: "Workflow name to simulate"
+        # Constrained to the valid scanner names so a typo (e.g. trailing space
+        # or wrong case) can't bypass the per-scanner concurrency key below.
+        type: choice
         required: false
         default: "CodeQL"
+        options:
+          - CodeQL
+          - Trivy Security Scan
 
 permissions:
   contents: write

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -35,6 +35,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
+    # Serialize triage per scanner so two same-tool completions can't race on
+    # branch/PR creation for the same alerts. CodeQL and Trivy still run in
+    # parallel (distinct group keys). Do NOT cancel in-progress: this job opens
+    # PRs and dismisses alerts, so a cancelled run could orphan a pushed branch.
+    concurrency:
+      group: security-triage-${{ github.event.workflow_run.name || inputs.triggering_workflow }}
+      cancel-in-progress: false
+
     # Skip if the triggering scan failed before uploading SARIF, unless this is a
     # manual dispatch (which has no triggering workflow to inspect).
     if: >-

--- a/docs/deployment/SECURITY-TRIAGE.md
+++ b/docs/deployment/SECURITY-TRIAGE.md
@@ -1,0 +1,83 @@
+# Security Triage Automation
+
+The `security-triage.yml` workflow runs Claude Code to triage new findings from CodeQL and Trivy, then either dismisses false positives or opens a draft PR with a suggested fix.
+
+It authenticates with a Claude subscription OAuth token, so it bills against a Pro/Max subscription rather than API credits.
+
+## How It Works
+
+1. CodeQL or Trivy completes a scan on the `main` branch.
+2. `security-triage.yml` fires via `workflow_run`.
+3. Claude Code (run by `anthropics/claude-code-action`) reads `.github/prompts/security-triage.md` and follows it.
+4. It queries the GitHub Code Scanning API for net-new open alerts from that scan (up to 5 per run), reading the affected code for context.
+5. For false positives: it dismisses the alert via the Code Scanning API with an explanation.
+6. For real findings: it opens a draft PR on a branch `fix/security-<rule-id>-<short-sha>` with the triage reasoning and a suggested or implemented fix, labelled `security` and `automated`.
+
+## Required Secret: CLAUDE_CODE_OAUTH_TOKEN
+
+This workflow uses a Claude subscription, not API credits. A Pro/Max subscriber generates the token once:
+
+```bash
+claude setup-token
+```
+
+This prints a long-lived OAuth token (valid ~1 year, inference-scoped). Add it as a repository secret named `CLAUDE_CODE_OAUTH_TOKEN`:
+
+```bash
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+```
+
+Then paste the token when prompted.
+
+### Important: do not set ANTHROPIC_API_KEY in this job
+
+Claude Code's auth precedence puts `ANTHROPIC_API_KEY` ahead of `CLAUDE_CODE_OAUTH_TOKEN`. If both are present, the API key wins and usage is billed to the separate API account instead of the subscription. The `security-triage.yml` job deliberately passes only `claude_code_oauth_token` and never `anthropic_api_key`. Keep it that way.
+
+### Token expiry
+
+The token is valid for about one year and does not auto-refresh. When it expires, regenerate with `claude setup-token` and update the secret. Set a calendar reminder.
+
+### Action input compatibility
+
+If your pinned version of `anthropics/claude-code-action` does not expose the `claude_code_oauth_token` input, pass the token as an environment variable on the step instead:
+
+```yaml
+      - name: Run security triage
+        uses: anthropics/claude-code-action@<pin>
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: ...
+```
+
+## Usage Limits
+
+Running Claude Code in CI counts against the subscription's usage limits, the same pool as interactive Claude Code. The playbook caps triage at 5 findings per run to keep usage bounded; a noisy scan logs which findings it skipped, and the next scheduled scan picks them up. If CI triage starts competing with interactive usage, lower the cap in `.github/prompts/security-triage.md` or move this workflow to its own subscription/service account.
+
+## Reviewing Triage Output
+
+Draft PRs created by this workflow are labelled `security` and `automated`:
+
+```bash
+gh pr list --label "security,automated" --state open
+```
+
+For each draft PR:
+
+1. Read the triage analysis in the PR description.
+2. If you agree, finish or accept the fix on the same branch, mark the PR ready, and merge.
+3. If you disagree, close the PR with a comment explaining why.
+
+## Tuning
+
+- Triage playbook: `.github/prompts/security-triage.md` - edit to adjust guidance, the per-run cap, or the dismiss/PR rules.
+- SARIF processing delay: the `sleep 90` step in the workflow gives GitHub time to turn uploaded SARIF into Code Scanning alerts. Increase it if Claude reports zero findings immediately after a scan that produced results.
+
+## Testing
+
+Trigger the workflow manually to dry-run it against whatever open alerts currently exist:
+
+```bash
+gh workflow run security-triage.yml -f triggering_workflow=CodeQL
+```

--- a/docs/deployment/SECURITY-TRIAGE.md
+++ b/docs/deployment/SECURITY-TRIAGE.md
@@ -11,7 +11,7 @@ It authenticates with a Claude subscription OAuth token, so it bills against a P
 3. Claude Code (run by `anthropics/claude-code-action`) reads `.github/prompts/security-triage.md` and follows it.
 4. It queries the GitHub Code Scanning API for net-new open alerts from that scan (up to 5 per run), reading the affected code for context.
 5. For false positives: it dismisses the alert via the Code Scanning API with an explanation.
-6. For real findings: it opens a draft PR on a branch `fix/security-<rule-id>-<short-sha>` with the triage reasoning and a suggested or implemented fix, labelled `security` and `automated`.
+6. For real findings: it opens a draft PR on a branch `fix/security-<alert-number>` with the triage reasoning and a suggested or implemented fix, labelled `security` and `automated`.
 
 ## Required Secret: CLAUDE_CODE_OAUTH_TOKEN
 


### PR DESCRIPTION
## **User description**
## Summary

Adds a `security-triage.yml` workflow that triggers when CodeQL or Trivy completes on `main`, runs Claude Code to triage net-new Code Scanning alerts, dismisses false positives, and opens a draft PR with a suggested fix for real findings.

Authenticated with a Claude subscription OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`), so it bills against a Pro/Max subscription, not API credits.

Closes #2357

## Why OAuth, not an API key

The original plan called the Messages API directly with `ANTHROPIC_API_KEY`. Verified that a Max subscription does **not** cover direct API usage (billed to a separate API account). Pivoted to `anthropics/claude-code-action` + `CLAUDE_CODE_OAUTH_TOKEN`, which routes the work through the subscription. The job deliberately never sets `ANTHROPIC_API_KEY` (it takes auth precedence and would re-route billing to the API account).

## Files

- `.github/workflows/security-triage.yml` - `workflow_run` trigger on CodeQL + Trivy; OAuth auth; git identity; SARIF processing wait; agent step.
- `.github/prompts/security-triage.md` - the triage playbook the agent reads and follows (find net-new alerts, cap at 5, dismiss FPs, open draft PRs).
- `docs/deployment/SECURITY-TRIAGE.md` - setup, the `ANTHROPIC_API_KEY` precedence gotcha, token expiry, usage limits, testing.

## Required before this can run

Generate the token (Pro/Max subscriber) and add it as a repo secret:

\`\`\`bash
claude setup-token
gh secret set CLAUDE_CODE_OAUTH_TOKEN
\`\`\`

## Test plan

- [x] `actionlint` clean
- [x] workflow YAML parses
- [x] ESLint clean (no JS in final design)
- [ ] After the secret is set: `gh workflow run security-triage.yml -f triggering_workflow=CodeQL` dry run against current open alerts

## Self-review fixes applied

- Added a git identity step (runners have none; agent commits would abort).
- Pass the OAuth token as both action input and env var (binds regardless of action-version input support).
- Manual-dispatch dry run no longer time-filters (was excluding existing alerts).
- Fixed a GitHub Actions ternary footgun (`&& '' ||` falls through on falsy middle operand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Automate security alert triage and draft fixes for new scan findings**

### What Changed
- Added a workflow that watches CodeQL and Trivy results on `main`, then triages new security alerts automatically.
- False positives are dismissed with a reason; real findings open a draft PR with a suggested fix or a focused triage note for review.
- Triage is limited to the newest alerts from the current scan, with a cap of 5 findings per run to avoid overload.
- Added setup and usage docs, including the required Claude subscription token and how to review the draft PRs.

### Impact
`✅ Faster security alert review`
`✅ Fewer untriaged CodeQL and Trivy findings`
`✅ Earlier draft fixes for real vulnerabilities`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
