### PR TITLE
feat: reposition verb bar above selection and raise opacity (#2388)

### DIFF
--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -365,13 +365,13 @@
   --bottom-nav-bg: rgba(33, 34, 44, 0.85);
   --bottom-nav-border: rgba(52, 55, 70, 0.6);
   --bottom-nav-blur: 20px;
-  --verb-bar-bg: rgba(33, 34, 44, 0.72);
+  --verb-bar-bg: rgba(33, 34, 44, 0.85);
   /* Specular glass: translucent body lets devices show through; the rim and
      sheen sell it as a lens. Dark theme uses a lighter top edge for the
      highlight and a soft dark bottom for grounding. */
   --verb-bar-bg-solid: rgba(33, 34, 44, 0.97);
   --verb-bar-backdrop: blur(16px) saturate(1.6);
-  --verb-bar-border: rgba(248, 248, 242, 0.14);
+  --verb-bar-border: rgba(248, 248, 242, 0.30);
   --verb-bar-rim:
     inset 0 1px 0 0 rgba(255, 255, 255, 0.18),
     inset 0 -1px 0 0 rgba(0, 0, 0, 0.28);
@@ -616,11 +616,11 @@
   --bottom-nav-bg: rgba(239, 237, 220, 0.85);
   --bottom-nav-border: rgba(222, 220, 207, 0.6);
   --bottom-nav-active-pill-bg: rgba(3, 106, 150, 0.1);
-  --verb-bar-bg: rgba(239, 237, 220, 0.62);
+  --verb-bar-bg: rgba(239, 237, 220, 0.85);
   /* Light theme: the cream body needs a brighter top sheen and a softer,
      warmer bottom edge so the rim reads on a pale background. */
   --verb-bar-bg-solid: rgba(243, 241, 226, 0.97);
-  --verb-bar-border: rgba(95, 90, 70, 0.18);
+  --verb-bar-border: rgba(95, 90, 70, 0.30);
   --verb-bar-rim:
     inset 0 1px 0 0 rgba(255, 255, 255, 0.7),
     inset 0 -1px 0 0 rgba(95, 90, 70, 0.14);

--- a/src/lib/utils/verb-bar-position.ts
+++ b/src/lib/utils/verb-bar-position.ts
@@ -11,7 +11,9 @@
  * 3. VERTICAL: placed above the target by default. Flips to below when the
  *    computed above-top would be less than VERB_BAR_FLIP_THRESHOLD pixels
  *    from the viewport top, so the bar does not occlude the device label
- *    or sit off-screen when the device is near the rack header.
+ *    or sit off-screen when the device is near the rack header. The flipped
+ *    position is clamped to the viewport so a tall target (e.g. a rack) cannot
+ *    push the bar off-screen.
  */
 
 /** Viewport-space bounding rectangle using plain numbers (no DOM dependency). */
@@ -88,7 +90,14 @@ export function computeVerbBarPosition(
   // Vertical: prefer above, but flip below when there is insufficient room.
   const aboveTop = target.top - VERB_BAR_MARGIN - bar.height;
   if (aboveTop < VERB_BAR_FLIP_THRESHOLD) {
-    const top = target.bottom + VERB_BAR_MARGIN;
+    // Clamp the flipped position to the viewport. A tall target (e.g. a rack
+    // container) can have its bottom far below the fold, which would otherwise
+    // push the bar off-screen and out of reach.
+    const maxTop = viewport.height - bar.height - VERB_BAR_MARGIN;
+    const top = Math.max(
+      VERB_BAR_MARGIN,
+      Math.min(target.bottom + VERB_BAR_MARGIN, maxTop),
+    );
     return { visible: true, left, top, placement: "below" };
   }
 

--- a/src/lib/utils/verb-bar-position.ts
+++ b/src/lib/utils/verb-bar-position.ts
@@ -1,5 +1,5 @@
 /**
- * Pure verb bar positioning math (#2075)
+ * Pure verb bar positioning math (#2075, #2388)
  *
  * Computes where to render a floating verb bar relative to a selected object.
  * No DOM access, no globals - all inputs are plain numeric rects so the
@@ -8,9 +8,10 @@
  * Rules:
  * 1. LOW ZOOM: hidden when scale < VERB_BAR_LOW_ZOOM_THRESHOLD.
  * 2. HORIZONTAL: centred over the target, clamped within viewport margins.
- * 3. VERTICAL: always placed above the target. When space above is tight the
- *    bar may overlap the rack name label or sit partly off the top of the
- *    viewport rather than flipping below.
+ * 3. VERTICAL: placed above the target by default. Flips to below when the
+ *    computed above-top would be less than VERB_BAR_FLIP_THRESHOLD pixels
+ *    from the viewport top, so the bar does not occlude the device label
+ *    or sit off-screen when the device is near the rack header.
  */
 
 /** Viewport-space bounding rectangle using plain numbers (no DOM dependency). */
@@ -40,7 +41,7 @@ export interface VerbBarPositionInput {
   scale: number;
 }
 
-export type VerbBarPlacement = "above";
+export type VerbBarPlacement = "above" | "below";
 
 export interface VerbBarPosition {
   visible: boolean;
@@ -56,12 +57,19 @@ export const VERB_BAR_MARGIN = 8;
 export const VERB_BAR_LOW_ZOOM_THRESHOLD = 0.5;
 
 /**
+ * Minimum viewport-top distance (px) for the above position.
+ * When the computed above-top is less than this, the bar flips below the
+ * target to avoid occluding the device label or sitting off-screen.
+ */
+export const VERB_BAR_FLIP_THRESHOLD = 80;
+
+/**
  * Compute viewport coordinates for a floating verb bar.
  *
  * Returns visible:false when zoomed out below the threshold. Otherwise
- * returns the clamped horizontal position and the above vertical position.
- * The bar always sits above the target; when space is tight it may overlap
- * the rack name label or sit partly off the top of the viewport.
+ * returns the clamped horizontal position and a vertical position that is
+ * above the target by default, flipping to below when the device is near
+ * the top of the viewport.
  */
 export function computeVerbBarPosition(
   input: VerbBarPositionInput,
@@ -77,8 +85,12 @@ export function computeVerbBarPosition(
   const maxLeft = viewport.width - bar.width - VERB_BAR_MARGIN;
   const left = Math.max(VERB_BAR_MARGIN, Math.min(rawLeft, maxLeft));
 
-  // Vertical: always above the target.
-  const top = target.top - VERB_BAR_MARGIN - bar.height;
+  // Vertical: prefer above, but flip below when there is insufficient room.
+  const aboveTop = target.top - VERB_BAR_MARGIN - bar.height;
+  if (aboveTop < VERB_BAR_FLIP_THRESHOLD) {
+    const top = target.bottom + VERB_BAR_MARGIN;
+    return { visible: true, left, top, placement: "below" };
+  }
 
-  return { visible: true, left, top, placement: "above" };
+  return { visible: true, left, top: aboveTop, placement: "above" };
 }

--- a/src/tests/verb-bar-position.test.ts
+++ b/src/tests/verb-bar-position.test.ts
@@ -183,3 +183,30 @@ describe("computeVerbBarPosition - horizontal clamping", () => {
     expect(result.left).toBe(expectedLeft);
   });
 });
+
+describe("computeVerbBarPosition - flip-below viewport clamping", () => {
+  it("clamps the flipped position so a tall target keeps the bar on-screen", () => {
+    // A rack container is tall: its top is near the viewport top (forcing a
+    // flip below) but its bottom is far below the fold. Without clamping, the
+    // bar would render at target.bottom, off-screen and unreachable.
+    const bar: Size = { width: 180, height: 36 };
+    const viewport: Size = { width: 1280, height: 800 };
+    const target = makeRect(10, 200, 480, 2000); // bottom = 2010, below the fold
+    const result = computeVerbBarPosition(input({ target, bar, viewport }));
+    expect(result.placement).toBe("below");
+    expect(result.visible).toBe(true);
+    const maxTop = viewport.height - bar.height - VERB_BAR_MARGIN;
+    expect(result.top).toBeLessThanOrEqual(maxTop);
+    expect(result.top + bar.height).toBeLessThanOrEqual(viewport.height);
+  });
+
+  it("leaves a short target's flipped position unclamped", () => {
+    // A device row near the top flips below; its bottom is on-screen, so the
+    // position stays at target.bottom + margin, not pinned to the fold.
+    const bar: Size = { width: 180, height: 36 };
+    const viewport: Size = { width: 1280, height: 800 };
+    const target = makeRect(20, 200, 120, 24); // bottom = 44, on-screen
+    const result = computeVerbBarPosition(input({ target, bar, viewport }));
+    expect(result.top).toBe(target.bottom + VERB_BAR_MARGIN);
+  });
+});

--- a/src/tests/verb-bar-position.test.ts
+++ b/src/tests/verb-bar-position.test.ts
@@ -1,7 +1,7 @@
 /**
- * Tests for the floating verb bar positioning math (#2075)
+ * Tests for the floating verb bar positioning math (#2075, #2388)
  *
- * Covers the pure computeVerbBarPosition function: always-above placement,
+ * Covers the pure computeVerbBarPosition function: above/below placement flip,
  * low-zoom hide, and horizontal clamping. All inputs are plain numeric rects
  * with no DOM dependency.
  */
@@ -10,6 +10,7 @@ import {
   computeVerbBarPosition,
   VERB_BAR_LOW_ZOOM_THRESHOLD,
   VERB_BAR_MARGIN,
+  VERB_BAR_FLIP_THRESHOLD,
   type Rect,
   type Size,
   type VerbBarPositionInput,
@@ -65,23 +66,52 @@ describe("computeVerbBarPosition - above placement", () => {
   });
 });
 
-describe("computeVerbBarPosition - always above near viewport top", () => {
-  it("stays above for the topmost target near the top of the viewport", () => {
-    // target at y=20; bar height=36; aboveTop = 20 - 8 - 36 = -24.
-    // The bar may sit partly off-screen or overlap the rack name label,
-    // but it never flips below the target.
-    const target = makeRect(20, 200, 120, 24);
+describe("computeVerbBarPosition - placement flip", () => {
+  it("places above when there is ample room above the target", () => {
+    // target.top = 300, bar height = 36, margin = 8 -> need 44px above.
+    // aboveTop = 300 - 8 - 36 = 256, well above VERB_BAR_FLIP_THRESHOLD.
+    const target = makeRect(300, 200, 120, 24);
     const bar: Size = { width: 180, height: 36 };
     const result = computeVerbBarPosition(input({ target, bar }));
     expect(result.placement).toBe("above");
-    expect(result.visible).toBe(true);
   });
 
-  it("keeps top at aboveTop for the topmost target", () => {
+  it("flips below when target is near the top and there is insufficient room above", () => {
+    // Place the target so aboveTop would be < VERB_BAR_FLIP_THRESHOLD.
+    // If VERB_BAR_FLIP_THRESHOLD = 80, target.top must be < 80 + bar.height + margin.
+    // bar.height=36, margin=8 -> target.top < 124. Use target.top=20.
     const target = makeRect(20, 200, 120, 24);
     const bar: Size = { width: 180, height: 36 };
     const result = computeVerbBarPosition(input({ target, bar }));
-    expect(result.top).toBe(target.top - VERB_BAR_MARGIN - bar.height);
+    expect(result.placement).toBe("below");
+    expect(result.visible).toBe(true);
+  });
+
+  it("sets top to just below target bottom when flipping below", () => {
+    const target = makeRect(20, 200, 120, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, bar }));
+    const expectedTop = target.bottom + VERB_BAR_MARGIN;
+    expect(result.top).toBe(expectedTop);
+  });
+
+  it("sets top to just above target top when placing above", () => {
+    const target = makeRect(300, 200, 120, 24);
+    const bar: Size = { width: 180, height: 36 };
+    const result = computeVerbBarPosition(input({ target, bar }));
+    const expectedTop = target.top - VERB_BAR_MARGIN - bar.height;
+    expect(result.top).toBe(expectedTop);
+  });
+
+  it("places above exactly at the flip threshold boundary", () => {
+    // target.top exactly at the minimum to remain above: flip when aboveTop < VERB_BAR_FLIP_THRESHOLD.
+    // aboveTop = target.top - margin - bar.height = target.top - 44.
+    // To be exactly at threshold: target.top - 44 = VERB_BAR_FLIP_THRESHOLD -> target.top = threshold + 44.
+    const bar: Size = { width: 180, height: 36 };
+    const targetTop = VERB_BAR_FLIP_THRESHOLD + VERB_BAR_MARGIN + bar.height;
+    const target = makeRect(targetTop, 200, 120, 24);
+    const result = computeVerbBarPosition(input({ target, bar }));
+    expect(result.placement).toBe("above");
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

- Float the verb bar just above the selected device's top edge with an 8px gap, so it no longer occludes the device label.
- Flip the bar to just below the device when the computed above-position would be within 80px of the viewport top (device near rack header).
- Raise `--verb-bar-bg` from 0.72 to 0.85 (dark) and 0.62 to 0.85 (light) for legibility over busy multicolour rack rows.
- Raise `--verb-bar-border` from 0.14 to 0.30 (dark) and 0.18 to 0.30 (light) for a firmer rim.
- Blur, `prefers-reduced-transparency` fallback, and `.is-interacting` pan/zoom behaviour are unchanged.

Part of M14 workspace shell epic #2017.

## Test Plan

- [x] Unit tests: `computeVerbBarPosition` placement flip logic covered by 5 new/updated tests (above with room, flips below near top, below-top calculation, above-top calculation, boundary at threshold)
- [x] `npm run lint` clean
- [x] `npm run test:run` 2644 tests pass
- [x] `npm run build` passes
- [ ] Manual: select devices at the top, middle, and bottom of a rack; confirm the placement flips near the top and the device label stays visible in both dark and light themes.

## Files Changed

- `src/lib/utils/verb-bar-position.ts` - Add `"below"` to `VerbBarPlacement`, add `VERB_BAR_FLIP_THRESHOLD = 80`, implement flip logic.
- `src/lib/styles/tokens.css` - Raise `--verb-bar-bg` and `--verb-bar-border` opacity in dark and light themes.
- `src/tests/verb-bar-position.test.ts` - Replace "always above" tests with flip coverage; add `VERB_BAR_FLIP_THRESHOLD` import.

Closes #2388

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Reposition the verb bar so it avoids covering device labels**

### What Changed
- The verb bar now appears above the selected device by default, with a small gap.
- When a device is near the top of the rack, the bar flips below it so the label stays visible and the bar stays on screen.
- The bar is more opaque in both dark and light themes, making it easier to read over busy rack rows.

### Impact
`✅ Fewer covered device labels`
`✅ Clearer verb bar visibility`
`✅ Less clipping near the rack header`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
