### PR TITLE
fix: authenticate post-deploy dev smoke via Cloudflare Access service token (#2346)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -182,15 +182,32 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    env:
+      # d.racku.la sits behind Cloudflare Access. Map the service-token secrets
+      # to env so the curl gate and the browser smoke can authenticate, and so
+      # the browser smoke can skip when they are absent (forks) instead of
+      # failing on the login wall (#2346).
+      CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+      CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
     steps:
       # Fast curl gate: fails immediately if the server or API is unreachable,
       # before we spend time spinning up a browser.
       - name: Verify deployment responds
+        # Same fork guard as the browser smoke below: without the CF Access
+        # service token these requests only reach the login wall, so skip rather
+        # than report a misleading pass (#2346).
+        if: ${{ env.CF_ACCESS_CLIENT_ID != '' && env.CF_ACCESS_CLIENT_SECRET != '' }}
         run: |
           sleep 5
-          curl -sf --retry 5 --retry-delay 3 https://d.racku.la
-          curl -sf --retry 5 --retry-delay 3 https://d.racku.la/api/layouts
+          curl -sf --retry 5 --retry-delay 3 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://d.racku.la
+          curl -sf --retry 5 --retry-delay 3 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            https://d.racku.la/api/layouts
 
       # The vps-rackula runner is not ephemeral: it reuses _work across jobs, and
       # a prior sparse checkout can leave an index that makes actions/checkout's
@@ -232,6 +249,11 @@ jobs:
         run: npx playwright install --with-deps chromium || npx playwright install chromium
 
       - name: Browser smoke test against deployed app
+        # Skip rather than fail when the Cloudflare Access service token is not
+        # configured (e.g. forks): without it every request lands on the login
+        # wall, which no timeout bump can fix (#2346). The CF_ACCESS_* env vars
+        # are inherited by the smoke config (playwright.smoke.config.ts).
+        if: ${{ env.CF_ACCESS_CLIENT_ID != '' && env.CF_ACCESS_CLIENT_SECRET != '' }}
         env:
           SMOKE_TEST_URL: https://d.racku.la
         run: npm run test:e2e:smoke

--- a/e2e/playwright.smoke.config.ts
+++ b/e2e/playwright.smoke.config.ts
@@ -2,6 +2,22 @@ import { defineConfig, devices } from "@playwright/test";
 
 const smokeTestUrl = process.env.SMOKE_TEST_URL;
 
+// Cloudflare Access service-token credentials. When the smoke runs against a
+// CF-Access-gated deploy (d.racku.la), these authenticate non-interactively.
+// Playwright applies extraHTTPHeaders to both page navigations and the request
+// fixture, so the headers cover the page loads and the /version.json request.
+// Absent locally and in forks, where the smoke runs against an ungated URL or is
+// skipped by the workflow rather than hitting the login wall.
+const cfAccessClientId = process.env.CF_ACCESS_CLIENT_ID;
+const cfAccessClientSecret = process.env.CF_ACCESS_CLIENT_SECRET;
+const cfAccessHeaders =
+  cfAccessClientId && cfAccessClientSecret
+    ? {
+        "CF-Access-Client-Id": cfAccessClientId,
+        "CF-Access-Client-Secret": cfAccessClientSecret,
+      }
+    : undefined;
+
 /**
  * Playwright configuration for smoke tests.
  *
@@ -43,6 +59,7 @@ export default defineConfig({
     baseURL: smokeTestUrl || "http://localhost:4173",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
+    ...(cfAccessHeaders ? { extraHTTPHeaders: cfAccessHeaders } : {}),
   },
   projects: [
     {


### PR DESCRIPTION
## **User description**
## Summary

`d.racku.la` is gated by Cloudflare Access, so the unauthenticated post-deploy smoke hit the login wall on every run: page loads never reached the app and `GET /version.json` returned login HTML instead of JSON. The deploy itself was fine; only the verification was red.

- `e2e/playwright.smoke.config.ts`: when `SMOKE_TEST_URL` and `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` are set, send them as `CF-Access-Client-Id` / `CF-Access-Client-Secret` via `extraHTTPHeaders`. Playwright applies these to both page navigations and the `request` fixture, so the `/version.json` check is covered too.
- `.github/workflows/deploy-dev.yml`: map the service-token secrets into the `smoke-test` job env, authenticate the curl gate, and guard both the curl gate and the browser smoke on the secrets being present so forks skip rather than fail on the login wall.

## Acceptance criteria

- [x] Smoke authenticates against the CF-Access-gated `d.racku.la` via the service token
- [x] Token headers sent on both page loads and the `/version.json` request (`extraHTTPHeaders`)
- [x] Absent secrets (forks) degrade safely: both gated steps skip
- [x] No service-token values logged or committed (secrets to env; GitHub masks them)

## Out-of-band (done)

- Cloudflare Access service token created and added to the `d.racku.la` Access policy as Service Auth
- `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` set as GitHub Actions secrets

## Test plan

- [ ] Branch run of Deploy Dev (`workflow_dispatch`) passes the `smoke-test` job against live `d.racku.la`

Fixes #2346

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Authenticate dev smoke tests against Cloudflare Access**

### What Changed
- Dev smoke tests now send Cloudflare Access service-token headers when they are available, so the deployed app and `/version.json` can load without hitting the login wall.
- The deploy check now uses the same headers for `d.racku.la` requests.
- When the Cloudflare Access token is not configured, both smoke checks skip instead of failing on protected pages.

### Impact
`✅ Fewer false smoke test failures`
`✅ Successful checks on Cloudflare-protected dev deploys`
`✅ Safer runs from forks without access tokens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
