### PR TITLE
feat: layout tabs fit-to-bar height and filled-pill restyle

### DIFF
--- a/src/lib/components/LayoutTabs.svelte
+++ b/src/lib/components/LayoutTabs.svelte
@@ -415,8 +415,9 @@
     gap: var(--space-1);
     min-width: 0;
     max-width: 220px;
-    min-height: var(--touch-target-min);
-    padding: 0 var(--space-1) 0 var(--space-2);
+    /* Hit area: fills the bar height (~44px). Visible pill is inset via padding. */
+    height: 44px;
+    padding: 6px var(--space-1) 6px var(--space-2);
     border: 1px solid transparent;
     border-radius: var(--radius-sm);
     background: transparent;
@@ -436,7 +437,8 @@
 
   .layout-tab.active {
     background: var(--colour-surface-active);
-    border-color: var(--colour-border);
+    /* Use border-hover (comment blue, #6272a4) so the border is visible against the fill (#44475a). */
+    border-color: var(--colour-border-hover);
     color: var(--colour-text);
   }
 
@@ -461,7 +463,7 @@
   .layout-tab-input {
     min-width: 120px;
     max-width: 220px;
-    min-height: var(--touch-target-min);
+    height: 44px;
     padding: 0 var(--space-2);
     border: 1px solid var(--dracula-cyan);
     border-radius: var(--radius-sm);
@@ -516,8 +518,9 @@
     align-items: center;
     justify-content: center;
     gap: var(--space-1);
-    min-width: var(--touch-target-min);
-    min-height: var(--touch-target-min);
+    /* Match tab hit area: 44px tall, at least 44px wide. */
+    width: 44px;
+    height: 44px;
     padding: 0 var(--space-1);
     background: transparent;
     border: 1px solid transparent;


### PR DESCRIPTION
## **User description**
## Summary

Make the layout tabs fit inside the top bar and give the active tab a clearly visible state. Part of the M14 workspace shell (epic #2017).

`.layout-tab` used `min-height: var(--touch-target-min)` (48px), which overflowed the bar, and the active state set both the fill and the border to `--colour-surface-active`/`--colour-border` (both `#44475a`), so the active border was invisible and active vs inactive was hard to tell apart.

## Changes (all in `src/lib/components/LayoutTabs.svelte`)

- Remove the 48px `min-height`. The tab hit area is now `height: 44px` (fills the bar) with `6px` vertical padding, so the visible filled pill reads ~32px tall and sits inside the bar with margin.
- Active tab: filled `--colour-surface-active` with `border-color: var(--colour-border-hover)` (`#6272a4`, comment blue) so the border is visible against the fill. Inactive tab stays transparent with muted text and a surface-hover hover.
- The rename input, the `+` add button, and the overflow button adopt the same 44px height / hit model (`+` and overflow are `44px x 44px`).
- The orange unsaved dot is unchanged and still renders for unbacked layouts.

## Merge order

This targets the 48px top bar from #2386. It should merge **after #2386** so the ~44px hit area fills the bar correctly. It does not depend on #2386's branch (implemented from latest `main`) and touches no other files, so there is no code conflict.

## Verification

- `npm run lint`: clean.
- `npm run test:run`: 158 files / 2641 tests pass.
- `npm run build`: passes.
- Svelte `svelte-autofixer`: no issues (only pre-existing advisory suggestions, none introduced).
- Manual before/after screenshots captured in dark and light themes, with two layouts open so active vs inactive is directly comparable. After: the active tab carries a visible border distinct from its fill, both themes; tabs sit inside the bar; no overflow; unsaved dots present.

### Visual regression baselines

The full-page `canvas-*` visual snapshots include the top bar, so the active-tab border colour and 44px height may move them. macOS-generated baselines are not committable (Linux-only, per `docs/guides/TESTING.md`). If the CI visual job flags a diff, regenerate via the "Update Visual Snapshots" workflow.

## Acceptance Criteria

- [x] Tabs sit inside the bar with visible margin (no overflow).
- [x] Active vs inactive is clearly distinguishable (visible border plus fill).
- [x] Each tab and the `+` button have a 44px or larger clickable target.
- [x] The unsaved dot still appears for unbacked layouts.

Closes #2387


___

## **CodeAnt-AI Description**
**Make layout tabs fit the top bar and show the active tab more clearly**

### What Changed
- Layout tabs now stay within the top bar instead of overflowing it
- The active tab now has a visible border, making it easier to tell apart from inactive tabs
- The rename field, add button, and overflow button now match the same 44px bar height

### Impact
`✅ Tabs no longer overflow the workspace bar`
`✅ Clearer active tab state`
`✅ More consistent tab controls in the top bar`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
