### PR TITLE
feat: command palette polish — placeholder margin, larger right-aligned hints, settings gear (#2399)

### DIFF
--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -329,4 +329,26 @@ test.describe("Command palette", () => {
     // timeout suffices for the post-placement settle.
     await expect(placementHeader).not.toBeVisible({ timeout: 5000 });
   });
+
+  // --- #2399: input-row settings gear ---
+
+  test("the settings gear opens the Settings dialog and closes the palette", async ({
+    page,
+  }) => {
+    await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
+    await expect(
+      page.getByRole("dialog", { name: "Command palette" }),
+    ).toBeVisible();
+
+    await page.getByTestId("command-palette-settings").click();
+
+    // dialogStore is scalar: opening "settings" replaces the palette, so the
+    // palette closes and the Settings dialog takes its place.
+    await expect(
+      page.getByRole("dialog", { name: "Command palette" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("dialog", { name: "Settings" }),
+    ).toBeVisible();
+  });
 });

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -12,7 +12,13 @@
 -->
 <script lang="ts">
   import { Dialog, Command } from "bits-ui";
-  import { IconSearch, IconPlus, IconChevronLeft } from "./icons";
+  import {
+    IconSearch,
+    IconPlus,
+    IconChevronLeft,
+    IconGearBold,
+  } from "./icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
@@ -162,6 +168,14 @@
     resetState();
   }
 
+  // Settings gear in the input row. dialogStore is scalar (one dialog at a
+  // time), so closing the palette first would clobber the settings dialog;
+  // instead open settings directly, which replaces the palette in the store.
+  function openSettings() {
+    resetState();
+    dialogStore.open("settings");
+  }
+
   function run(id: ActionId) {
     // Record the run as a recent BEFORE closing: only commands actually picked
     // from the palette become recents (not keyboard-invoked actions).
@@ -230,6 +244,15 @@
               : "Search or jump to..."}
             data-testid="command-palette-input"
           />
+          <button
+            type="button"
+            class="command-settings"
+            onclick={openSettings}
+            aria-label="Settings"
+            data-testid="command-palette-settings"
+          >
+            <IconGearBold size={ICON_SIZE.md} />
+          </button>
         </div>
 
         <Command.List class="command-list" aria-label="Commands">
@@ -538,8 +561,13 @@
     height: var(--icon-size-md);
   }
 
-  /* Back affordance in the device sub-page input row. */
-  .command-back {
+  /* Icon buttons in the input row: the back affordance (device sub-page) and
+     the settings gear (trailing edge). Both get a 48px touch target, a
+     theme-aware muted colour, and a visible focus ring. The negative vertical
+     margin keeps the row height tied to the input, not the larger touch
+     target. */
+  .command-back,
+  .command-settings {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -554,11 +582,13 @@
     border-radius: var(--radius-sm);
   }
 
-  .command-back:hover {
+  .command-back:hover,
+  .command-settings:hover {
     color: var(--colour-text);
   }
 
-  .command-back:focus-visible {
+  .command-back:focus-visible,
+  .command-settings:focus-visible {
     outline: 2px solid var(--colour-focus-ring);
     outline-offset: -2px;
   }
@@ -570,7 +600,11 @@
 
   :global(.command-input) {
     flex: 1;
+    min-width: 0;
     min-height: var(--touch-target-min);
+    /* Breathing room so the placeholder and typed text do not sit flush against
+       the search icon and the row edge. */
+    padding-left: var(--space-2);
     border: none;
     background: transparent;
     color: var(--colour-text);
@@ -622,8 +656,13 @@
   }
 
   .command-item-shortcut {
+    /* Right-aligned hint column (Raycast/Linear scan pattern): margin-left:auto
+       pins it to the trailing edge so it stays scannable as the list grows. */
+    margin-left: auto;
+    flex-shrink: 0;
     font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-sm);
+    white-space: nowrap;
     color: var(--colour-text-muted);
   }
 


### PR DESCRIPTION
## **User description**
Closes #2399. Part of the UX overhaul epic #2017.

## What changed

Three input-row refinements to the command palette, all in `CommandPalette.svelte`:

1. Placeholder margin: `.command-input` gets a `padding-left` (and `min-width: 0` so it can still shrink on the mobile sheet) so the placeholder and typed text no longer sit flush against the search icon and row edge.
2. Larger right-aligned hints: `.command-item-shortcut` goes from `--font-size-xs` (11px) to `--font-size-sm` (13px), pinned to a right-aligned column with `margin-left: auto`, `flex-shrink: 0`, and `white-space: nowrap` so it stays scannable as the list grows (the Raycast/Linear scan pattern).
3. Settings gear: a gear button at the trailing edge of the input row opens the existing Settings dialog via `dialogStore.open("settings")`. Because `dialogStore` is scalar, opening settings replaces the palette in the store (no explicit close needed, which would clobber it).

Also consolidated the duplicate `.command-back` / `.command-settings` icon-button CSS into shared selector groups.

## Acceptance criteria

- [x] Placeholder text has clear left padding (not flush to the edge or search icon).
- [x] Shortcut hints are enlarged (~13px) and remain right-aligned in their column.
- [x] A settings gear sits at the top-right of the input row and opens the existing Settings dialog.
- [x] The gear has an accessible label (`aria-label="Settings"`), a 48px touch target (`--touch-target-min`, exceeds the 44px floor), and a visible `:focus-visible` ring (`--colour-focus-ring`); theme-aware via tokens.
- [ ] Visual regression baselines updated (will regenerate via the workflow artifact after CI runs).

## Testing

- Behaviour: E2E test added in `e2e/command-palette.spec.ts` asserting the gear opens the Settings dialog and closes the palette.
- Styling: covered by the visual regression suite (#2098) and axe CI (#2099). No unit tests added (styling is render-only; the only logic is the gear handler, covered by E2E).
- Local gates green: `npm run lint` (clean), `npm run test:run` (158 files / 2646 tests pass), `npm run build` (ok). Svelte autofixer reports no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Add a settings button to the command palette and improve input-row spacing**

### What Changed
- Added a settings gear in the command palette header that opens the Settings dialog and closes the palette
- Gave the search field more left padding so text no longer sits against the search icon or edge
- Made shortcut hints larger and fixed them to the right side of each command row so they are easier to scan
- Kept the new gear button accessible with a clear label, larger touch target, and visible focus state
- Added an end-to-end check that confirms the gear opens Settings from the command palette

### Impact
`✅ Faster access to settings`
`✅ Clearer command palette input`
`✅ Easier-to-scan shortcut hints`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
