### PR TITLE
feat: surface storage mode misconfiguration in the chip (#2063)

### DIFF
--- a/docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
+++ b/docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md
@@ -284,6 +284,40 @@ offline" toast is removed.
 The data-safety and race-condition questions are resolved by spike #2019 (see Open
 questions: storage).
 
+### Storage mode misconfiguration
+
+The explicit storage mode introduces a failure class the original chip never named:
+the configured mode contradicting the observable deployment. The chip is the honest
+surface for it, so it distinguishes configured intent from observed reality (#2063).
+Two cases, both surfaced in the popover only, with no new toasts and a factual tone.
+
+Browser mode while a server is reachable. A compose --profile persist install without
+RACKULA_STORAGE_MODE=server, or a partially wired install, runs in browser mode while
+/api/health answers. Layouts silently stay in the browser with a working server one
+header away. The chip adds a passive popover line ("A Rackula server is reachable but
+this instance stores layouts in the browser. Set RACKULA_STORAGE_MODE=server to use
+it.") and changes nothing else: the dot, label, and durability status stay exactly as
+the browser build defines them, because the file is still the durable home here. No
+toast, no nagging. To detect this without re-introducing the runtime guesswork the
+explicit mode replaced, browser mode runs the same hardened /api/health probe (the one
+that validates a structured JSON payload, not an SPA fallback) purely to feed this hint.
+
+Server mode where the server was never reached since load. A frontend-only install that
+declares server mode gets the same treatment as a transient outage forever: an amber
+chip and an instance-named drop toast, with no hint the deployment itself is broken. The
+chip now splits the two error classes by whether the API has answered at least once this
+session, tracked by a one-way ever-reached latch that never falls back on a later loss.
+Never reached is a distinct chip state ("Server not found", popover copy "Check that the
+API container is running and RACKULA_STORAGE_MODE matches the deployment.") and fires no
+drop toast, since nothing was lost. Reached then lost keeps the existing offline
+treatment, and the instance-named drop toast stays reserved for it. The circuit-breaker
+trip is always reached-then-lost, since the breaker only opens after save attempts, which
+require a reachable server.
+
+These decisions follow the spike's messaging posture: name the broken state honestly,
+fail toward the honest label rather than the reassuring one, and never add a toast where
+a passive popover line will do.
+
 ## Creation and placement
 
 Creation is by placing, not by filling in a dialog. The one exception is defining a

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -31,6 +31,7 @@
     loadSessionWithTimestamp,
     setApiAvailable,
     initializePersistence,
+    probeServerForBrowserHint,
     getStorageMode,
     getServerInstanceLabel,
     detectModeFlip,
@@ -215,7 +216,11 @@
     const serverMode = getStorageMode() === "server";
 
     // Server mode only: probe the API so server autosave/load can enable when
-    // reachable. Browser mode skips the probe entirely (no server to reach).
+    // reachable. Browser mode skips the persistence probe (no server to reach),
+    // but fires a one-shot, fire-and-forget health probe so the chip can surface
+    // a passive "a server is reachable" hint if the deployment is misconfigured
+    // (browser mode while /api/health answers, #2063). It shows no toast and is
+    // never awaited on the entry path.
     const persistenceInitPromise = serverMode
       ? initializePersistence().catch((error) => {
           persistenceDebug.api(
@@ -226,6 +231,9 @@
           return false;
         })
       : Promise.resolve(false);
+    if (!serverMode) {
+      void probeServerForBrowserHint();
+    }
 
     // Priority 1: Check for shared layout in URL (highest priority)
     const shareParam = getShareParam();

--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -168,9 +168,13 @@
       align="end"
     >
       <p class="storage-chip-state">{durability.label}</p>
-      <p class="storage-chip-detail">
-        {durability.mode === "server" ? "Saved to server" : "Stored in this browser"}
-      </p>
+      <p class="storage-chip-detail">{durability.detail}</p>
+      {#if durability.serverHint}
+        <p class="storage-chip-hint" data-testid="storage-chip-server-hint">
+          A Rackula server is reachable but this instance stores layouts in the
+          browser. Set RACKULA_STORAGE_MODE=server to use it.
+        </p>
+      {/if}
       <div class="storage-chip-actions">
         <button
           type="button"
@@ -285,6 +289,20 @@
     padding: 0 var(--space-2) var(--space-2);
     font-size: var(--font-size-xs);
     color: var(--colour-text-muted-inverse);
+  }
+
+  /* Passive misconfiguration note: a server is reachable while this instance
+     stores layouts in the browser. Factual tone, popover only, no toast. The
+     left rule and inset set it apart from the state/detail lines without a new
+     colour or an alarm treatment. */
+  .storage-chip-hint {
+    margin: 0 var(--space-2) var(--space-2);
+    padding: var(--space-1) var(--space-2);
+    border-left: 2px solid var(--colour-border);
+    font-size: var(--font-size-xs);
+    line-height: var(--line-height-snug, 1.4);
+    color: var(--colour-text-muted-inverse);
+    white-space: normal;
   }
 
   .storage-chip-actions {

--- a/src/lib/storage/availability.svelte.ts
+++ b/src/lib/storage/availability.svelte.ts
@@ -29,6 +29,21 @@ export function getStorageMode(): StorageMode {
 // Reactive state for API availability
 let apiAvailable = $state<boolean | null>(null); // null = not checked yet
 
+// One-way latch: true once the API has answered at least once since load, and
+// never reset on a later loss. This is what lets the chip tell a broken
+// deployment (server mode, API never reached) apart from a transient outage
+// (reached, then lost). See computeLayoutStatus and issue #2063.
+let apiEverReached = $state(false);
+
+// Browser-mode-only misconfiguration signal: a server answered /api/health while
+// this instance is configured for browser storage. Kept SEPARATE from
+// apiAvailable on purpose. apiAvailable is the server-mode autosave/load signal:
+// the server-autosave effect (manager Effect 2) keys off isApiAvailable(), so
+// writing a reachable result into apiAvailable in browser mode would wrongly wake
+// server autosave and push browser-mode layouts to the server. This signal only
+// ever feeds the passive chip hint (#2063); it never enables any write path.
+let serverReachableInBrowser = $state(false);
+
 // Pending promise to prevent race conditions during initialization
 let pendingCheck: Promise<boolean> | null = null;
 
@@ -44,6 +59,34 @@ export function isApiAvailable(): boolean {
  */
 export function getApiAvailableState(): boolean | null {
   return apiAvailable;
+}
+
+/**
+ * Whether the API has answered at least once since this page load. Latches true
+ * on the first reach and never falls back, so a reconnect-then-drop reads as an
+ * outage rather than a never-reached misconfiguration.
+ */
+export function getApiEverReached(): boolean {
+  return apiEverReached;
+}
+
+/**
+ * Whether a server is reachable while this instance is in browser mode (#2063).
+ * Drives the passive chip hint only; never gates any read/write path.
+ */
+export function isServerReachableInBrowser(): boolean {
+  return serverReachableInBrowser;
+}
+
+/**
+ * Reset availability state (cached availability, the ever-reached latch, and the
+ * browser-mode reachability signal) to its pre-check baseline. Test-only seam:
+ * production has a single page lifetime, so this is never reset at runtime.
+ */
+export function resetAvailabilityState(): void {
+  apiAvailable = null;
+  apiEverReached = false;
+  serverReachableInBrowser = false;
 }
 
 /**
@@ -71,6 +114,7 @@ export async function initializePersistence(): Promise<boolean> {
   pendingCheck = checkApiHealth()
     .then((result) => {
       apiAvailable = result;
+      if (result) apiEverReached = true;
       log("initializePersistence: API availability determined: %s", result);
       return result;
     })
@@ -87,4 +131,31 @@ export async function initializePersistence(): Promise<boolean> {
 export function setApiAvailable(available: boolean): void {
   log("setApiAvailable: setting to %s", available);
   apiAvailable = available;
+  if (available) apiEverReached = true;
+}
+
+/**
+ * Browser-mode misconfiguration probe (#2063). Browser mode declares no server,
+ * so it never runs the server-mode autosave/health machinery. This one-shot
+ * background probe asks the same hardened /api/health endpoint purely so the chip
+ * can surface a passive popover hint when a server is in fact reachable (a
+ * compose --profile persist install left in browser mode, say).
+ *
+ * It writes only the browser-only serverReachableInBrowser signal, and only on a
+ * positive result, so it never touches apiAvailable (the server-mode write/load
+ * gate) and a failure or missing server stays the expected silent case. It shows
+ * no toast and is fire-and-forget; the caller never awaits it on the entry path.
+ */
+export async function probeServerForBrowserHint(): Promise<void> {
+  if (getStorageMode() !== "browser") return;
+  if (serverReachableInBrowser) return;
+  try {
+    const healthy = await checkApiHealth();
+    if (healthy) {
+      log("probeServerForBrowserHint: server reachable in browser mode");
+      serverReachableInBrowser = true;
+    }
+  } catch (error) {
+    log("probeServerForBrowserHint: probe failed %O", error);
+  }
 }

--- a/src/lib/storage/availability.svelte.ts
+++ b/src/lib/storage/availability.svelte.ts
@@ -47,6 +47,12 @@ let serverReachableInBrowser = $state(false);
 // Pending promise to prevent race conditions during initialization
 let pendingCheck: Promise<boolean> | null = null;
 
+// Bumped by resetAvailabilityState so an in-flight health check started before a
+// reset cannot resolve later and repopulate the freshly-cleared state (test-only
+// concern; production never resets). The init promise captures the generation at
+// start and discards its result if the generation changed while it was in flight.
+let availabilityGeneration = 0;
+
 /**
  * Check if API is available (cached result)
  */
@@ -87,6 +93,10 @@ export function resetAvailabilityState(): void {
   apiAvailable = null;
   apiEverReached = false;
   serverReachableInBrowser = false;
+  // Invalidate any in-flight init check and drop the cached pending promise so a
+  // stale resolution cannot repopulate the state we just cleared.
+  availabilityGeneration++;
+  pendingCheck = null;
 }
 
 /**
@@ -110,16 +120,28 @@ export async function initializePersistence(): Promise<boolean> {
 
   log("initializePersistence: starting API health check");
 
+  // Capture the generation so a reset that fires while this check is in flight
+  // invalidates the result rather than letting it repopulate cleared state.
+  const generation = availabilityGeneration;
+
   // Create and store the pending promise
   pendingCheck = checkApiHealth()
     .then((result) => {
+      if (generation !== availabilityGeneration) {
+        log("initializePersistence: stale check ignored (state was reset)");
+        return result;
+      }
       apiAvailable = result;
       if (result) apiEverReached = true;
       log("initializePersistence: API availability determined: %s", result);
       return result;
     })
     .finally(() => {
-      pendingCheck = null;
+      // Only clear the cached promise if it is still ours; a reset may have
+      // already replaced it with null and a newer check.
+      if (generation === availabilityGeneration) {
+        pendingCheck = null;
+      }
     });
 
   return pendingCheck;

--- a/src/lib/storage/availability.svelte.ts
+++ b/src/lib/storage/availability.svelte.ts
@@ -171,8 +171,16 @@ export function setApiAvailable(available: boolean): void {
 export async function probeServerForBrowserHint(): Promise<void> {
   if (getStorageMode() !== "browser") return;
   if (serverReachableInBrowser) return;
+  // Same generation guard as initializePersistence: a reset that fires while this
+  // probe is in flight must invalidate its result so it cannot set the signal
+  // after the pre-check baseline was cleared.
+  const generation = availabilityGeneration;
   try {
     const healthy = await checkApiHealth();
+    if (generation !== availabilityGeneration) {
+      log("probeServerForBrowserHint: stale probe ignored (state was reset)");
+      return;
+    }
     if (healthy) {
       log("probeServerForBrowserHint: server reachable in browser mode");
       serverReachableInBrowser = true;

--- a/src/lib/storage/durability.svelte.ts
+++ b/src/lib/storage/durability.svelte.ts
@@ -17,6 +17,8 @@ import {
 } from "./manager.svelte";
 import {
   getApiAvailableState,
+  getApiEverReached,
+  isServerReachableInBrowser,
   getStorageMode,
   type StorageMode,
 } from "./availability.svelte";
@@ -26,14 +28,36 @@ const MAX_SAVE_FAILURES = 3;
 
 export type DurabilityStatus = "saved" | "pending" | "error";
 
+/**
+ * A finer-grained discriminator than the three-value status (which only drives
+ * the icon and colour). The chip and popover read kind to pick copy, in
+ * particular to split the two server-mode error classes #2063 surfaces:
+ * "offline" (reached then lost, the transient-outage drop-toast case) from
+ * "server-not-found" (server mode but the API never answered, a broken
+ * deployment).
+ */
+export type DurabilityKind =
+  | "saved"
+  | "pending"
+  | "offline"
+  | "server-not-found";
+
 export interface LayoutDurability {
   status: DurabilityStatus;
+  kind: DurabilityKind;
   mode: StorageMode;
   changesSinceExport: number;
   hasEverExported: boolean;
   isHealthy: boolean;
   label: string;
+  detail: string;
   icon: DurabilityStatus;
+  /**
+   * Browser-mode misconfiguration signal: a server is reachable while this
+   * instance stores layouts in the browser. Surfaced as a passive popover line
+   * only, never a toast, and never changes the status/label/kind.
+   */
+  serverHint: boolean;
 }
 
 /**
@@ -53,37 +77,132 @@ export function computeLayoutStatus(
   apiAvailable: boolean | null,
   changesSinceExport: number,
   hasEverExported: boolean,
-): { status: DurabilityStatus; label: string; icon: DurabilityStatus } {
+  apiEverReached: boolean,
+): {
+  status: DurabilityStatus;
+  kind: DurabilityKind;
+  label: string;
+  detail: string;
+  icon: DurabilityStatus;
+} {
   if (storageMode === "browser") {
     // Durable iff exported AND no edits since. The hasEverExported guard is
     // critical: a never-exported cold start has changesSinceExport === 0 yet is
-    // not durable. Browser mode never reads saveStatus / apiAvailable.
+    // not durable. Browser mode never reads saveStatus / apiAvailable for the
+    // status: a reachable server is only a passive popover hint (computeServerHint).
     if (changesSinceExport === 0 && hasEverExported) {
-      return { status: "saved", label: "Saved", icon: "saved" };
+      return {
+        status: "saved",
+        kind: "saved",
+        label: "Saved",
+        detail: "Stored in this browser",
+        icon: "saved",
+      };
     }
-    return { status: "pending", label: "Unsaved changes", icon: "pending" };
+    return {
+      status: "pending",
+      kind: "pending",
+      label: "Unsaved changes",
+      detail: "Stored in this browser",
+      icon: "pending",
+    };
   }
 
   // Server mode, ordered most-severe first.
   if (consecutiveSaveFailures >= MAX_SAVE_FAILURES) {
-    return { status: "error", label: "Server unavailable", icon: "error" };
+    // The breaker only opens after save attempts, which require a reachable
+    // server, so this is always reached-then-lost: the transient-outage class,
+    // not a never-reached misconfiguration.
+    return {
+      status: "error",
+      kind: "offline",
+      label: "Server unavailable",
+      detail: "Working from your browser; reload to retry.",
+      icon: "error",
+    };
   }
   if (apiAvailable === null) {
-    return { status: "pending", label: "Checking connection", icon: "pending" };
+    return {
+      status: "pending",
+      kind: "pending",
+      label: "Checking connection",
+      detail: "Looking for the server.",
+      icon: "pending",
+    };
   }
   if (apiAvailable === false) {
-    return { status: "error", label: "Offline", icon: "error" };
+    // Split the two failure classes #2063 surfaces. Never reached since load is
+    // a broken deployment (frontend-only install declared server mode, or the
+    // API container is not running); reached then lost is a transient outage the
+    // drop toast already covers. Fail honest: only call it an outage once the
+    // server has genuinely answered.
+    if (apiEverReached) {
+      return {
+        status: "error",
+        kind: "offline",
+        label: "Offline",
+        detail: "Working from your browser; reload to retry.",
+        icon: "error",
+      };
+    }
+    return {
+      status: "error",
+      kind: "server-not-found",
+      label: "Server not found",
+      detail:
+        "Check that the API container is running and RACKULA_STORAGE_MODE matches the deployment.",
+      icon: "error",
+    };
   }
   if (saveStatus === "error") {
-    return { status: "error", label: "Save error", icon: "error" };
+    return {
+      status: "error",
+      kind: "offline",
+      label: "Save error",
+      detail: "The last save did not go through.",
+      icon: "error",
+    };
   }
   if (saveStatus === "saving") {
-    return { status: "pending", label: "Saving", icon: "pending" };
+    return {
+      status: "pending",
+      kind: "pending",
+      label: "Saving",
+      detail: "Saving to server.",
+      icon: "pending",
+    };
   }
   if (saveStatus === "saved") {
-    return { status: "saved", label: "Saved", icon: "saved" };
+    return {
+      status: "saved",
+      kind: "saved",
+      label: "Saved",
+      detail: "Saved to server",
+      icon: "saved",
+    };
   }
-  return { status: "pending", label: "Pending save", icon: "pending" };
+  return {
+    status: "pending",
+    kind: "pending",
+    label: "Pending save",
+    detail: "Saving to server.",
+    icon: "pending",
+  };
+}
+
+/**
+ * Browser-mode misconfiguration probe: true when storage is browser yet a server
+ * answered the dedicated browser-mode probe (serverReachableInBrowser). Pure so it
+ * unit-tests without DOM. The hint is passive (popover only, never a toast) and
+ * never feeds the durability status; it only tells the user a server is one header
+ * away. In server mode a reachable server is the expected state, so there is never
+ * a hint there.
+ */
+export function computeServerHint(
+  storageMode: StorageMode,
+  serverReachableInBrowser: boolean,
+): boolean {
+  return storageMode === "browser" && serverReachableInBrowser;
 }
 
 /**
@@ -107,6 +226,7 @@ export function getLayoutDurability(layoutStore: LayoutStore): LayoutDurability 
       getApiAvailableState(),
       layoutStore.changesSinceExport,
       layoutStore.hasEverExported,
+      getApiEverReached(),
     );
   return {
     get mode(): StorageMode {
@@ -121,14 +241,23 @@ export function getLayoutDurability(layoutStore: LayoutStore): LayoutDurability 
     get status(): DurabilityStatus {
       return compute().status;
     },
+    get kind(): DurabilityKind {
+      return compute().kind;
+    },
     get isHealthy(): boolean {
       return this.status !== "error";
     },
     get label(): string {
       return compute().label;
     },
+    get detail(): string {
+      return compute().detail;
+    },
     get icon(): DurabilityStatus {
       return compute().icon;
+    },
+    get serverHint(): boolean {
+      return computeServerHint(getStorageMode(), isServerReachableInBrowser());
     },
   };
 }
@@ -155,12 +284,15 @@ export function rollupDurabilities(
   if (!worst) {
     return {
       status: "saved",
+      kind: "saved",
       mode: getStorageMode(),
       changesSinceExport: 0,
       hasEverExported: false,
       isHealthy: true,
       label: "All saved",
+      detail: "",
       icon: "saved",
+      serverHint: false,
     };
   }
   return worst;

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -9,7 +9,10 @@ export {
   initializePersistence,
   isApiAvailable,
   getApiAvailableState,
+  getApiEverReached,
+  resetAvailabilityState,
   setApiAvailable,
+  probeServerForBrowserHint,
   getStorageMode,
   type StorageMode,
 } from "./availability.svelte";
@@ -63,9 +66,11 @@ export {
 } from "./reconcile";
 export {
   computeLayoutStatus,
+  computeServerHint,
   getLayoutDurability,
   rollupDurabilities,
   type DurabilityStatus,
+  type DurabilityKind,
   type LayoutDurability,
 } from "./durability.svelte";
 export {

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -566,6 +566,11 @@ export function initPersistenceEffects(): void {
     // Capture this run's schedule id; a later run (e.g. an edit during the
     // in-flight save) bumps it and marks an earlier save's success stale.
     const scheduleId = ++_serverSaveScheduleId;
+    // Server mode only, matching Effects 1 and 3. isApiAvailable() is the
+    // server-mode reachability signal; this explicit mode guard keeps a future
+    // browser-mode caller that sets apiAvailable (e.g. a misconfiguration probe)
+    // from ever waking server autosave in browser mode (#2063).
+    if (getStorageMode() !== "server") return;
     if (!isApiAvailable()) return;
     if (_consecutiveSaveFailures >= MAX_SAVE_FAILURES) return;
     const layout = layoutStore.layout;

--- a/src/tests/App.cleanupPrompt.test.ts
+++ b/src/tests/App.cleanupPrompt.test.ts
@@ -31,6 +31,7 @@ const persistenceStoreMocks = vi.hoisted(() => ({
   isApiAvailable: vi.fn(() => false),
   setApiAvailable: vi.fn(),
   getApiAvailableState: vi.fn(() => false),
+  getApiEverReached: vi.fn(() => false),
   getStorageMode: vi.fn(() => "server" as "browser" | "server"),
 }));
 
@@ -85,6 +86,7 @@ vi.mock("$lib/storage/availability.svelte", () => ({
   isApiAvailable: persistenceStoreMocks.isApiAvailable,
   setApiAvailable: persistenceStoreMocks.setApiAvailable,
   getApiAvailableState: persistenceStoreMocks.getApiAvailableState,
+  getApiEverReached: persistenceStoreMocks.getApiEverReached,
   getStorageMode: persistenceStoreMocks.getStorageMode,
 }));
 

--- a/src/tests/App.cleanupPrompt.test.ts
+++ b/src/tests/App.cleanupPrompt.test.ts
@@ -141,6 +141,8 @@ function resetHoistedMocks(): void {
   persistenceStoreMocks.setApiAvailable.mockReset();
   persistenceStoreMocks.getApiAvailableState.mockReset();
   persistenceStoreMocks.getApiAvailableState.mockReturnValue(false);
+  persistenceStoreMocks.getApiEverReached.mockReset();
+  persistenceStoreMocks.getApiEverReached.mockReturnValue(false);
   persistenceStoreMocks.getStorageMode.mockReset();
   persistenceStoreMocks.getStorageMode.mockReturnValue("server");
 

--- a/src/tests/App.startScreen.test.ts
+++ b/src/tests/App.startScreen.test.ts
@@ -131,6 +131,8 @@ describe("App entry (StartScreen removed, #2081)", { retry: 2, timeout: 30000 },
     persistenceStoreMocks.initializePersistence.mockResolvedValue(true);
     persistenceStoreMocks.isApiAvailable.mockReset();
     persistenceStoreMocks.isApiAvailable.mockReturnValue(true);
+    persistenceStoreMocks.getApiEverReached.mockReset();
+    persistenceStoreMocks.getApiEverReached.mockReturnValue(true);
     persistenceStoreMocks.getStorageMode.mockReset();
     persistenceStoreMocks.getStorageMode.mockReturnValue("server");
 

--- a/src/tests/App.startScreen.test.ts
+++ b/src/tests/App.startScreen.test.ts
@@ -31,6 +31,7 @@ const persistenceStoreMocks = vi.hoisted(() => ({
   isApiAvailable: vi.fn(() => true),
   setApiAvailable: vi.fn(),
   getApiAvailableState: vi.fn(() => true),
+  getApiEverReached: vi.fn(() => true),
   getStorageMode: vi.fn(() => "server" as "browser" | "server"),
 }));
 
@@ -79,6 +80,7 @@ vi.mock("$lib/storage/availability.svelte", () => ({
   isApiAvailable: persistenceStoreMocks.isApiAvailable,
   setApiAvailable: persistenceStoreMocks.setApiAvailable,
   getApiAvailableState: persistenceStoreMocks.getApiAvailableState,
+  getApiEverReached: persistenceStoreMocks.getApiEverReached,
   getStorageMode: persistenceStoreMocks.getStorageMode,
 }));
 

--- a/src/tests/durability.test.ts
+++ b/src/tests/durability.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   computeLayoutStatus,
+  computeServerHint,
   rollupDurabilities,
   type LayoutDurability,
 } from "$lib/storage/durability.svelte";
@@ -25,6 +26,7 @@ function status(
   apiAvailable: boolean | null,
   changesSinceExport: number,
   hasEverExported: boolean,
+  apiEverReached = false,
 ) {
   return computeLayoutStatus(
     saveStatus,
@@ -33,6 +35,7 @@ function status(
     apiAvailable,
     changesSinceExport,
     hasEverExported,
+    apiEverReached,
   );
 }
 
@@ -58,12 +61,43 @@ describe("computeLayoutStatus — browser mode", () => {
     expect(result.label).toBe("Unsaved changes");
   });
 
-  it("ignores saveStatus and apiAvailable in browser mode", () => {
-    // Even a server "error" / unreachable API is irrelevant in browser mode.
+  it("ignores saveStatus and apiAvailable for the status in browser mode", () => {
+    // Even a server "error" / reachable API is irrelevant to the durability
+    // status in browser mode: the file is the durable home.
     const exported = status("error", 5, BROWSER, false, 0, true);
     expect(exported.status).toBe("saved");
     const dirty = status("saved", 0, BROWSER, true, 1, true);
     expect(dirty.status).toBe("pending");
+  });
+
+  it("a reachable API in browser mode never changes the status or label", () => {
+    // The server-available hint is a passive popover line; it must not flip the
+    // chip's dot, label, or kind. A backed-up browser layout stays saved even
+    // when a server answers one header away.
+    const withServer = status("idle", 0, BROWSER, true, 0, true);
+    const withoutServer = status("idle", 0, BROWSER, false, 0, true);
+    expect(withServer.status).toBe(withoutServer.status);
+    expect(withServer.label).toBe(withoutServer.label);
+    expect(withServer.kind).toBe(withoutServer.kind);
+  });
+});
+
+describe("computeServerHint — browser mode misconfiguration", () => {
+  it("hints when browser mode runs while a server is reachable", () => {
+    // The misconfiguration: storage browser with a healthy API one header away.
+    // Surfaced as a passive popover line only, never a toast.
+    expect(computeServerHint(BROWSER, true)).toBe(true);
+  });
+
+  it("does not hint when no server answered the browser-mode probe", () => {
+    // false is also the pre-probe default, so this covers the "before the probe
+    // resolves" case too: no signal, no hint.
+    expect(computeServerHint(BROWSER, false)).toBe(false);
+  });
+
+  it("never hints in server mode (a reachable server is expected there)", () => {
+    expect(computeServerHint(SERVER, true)).toBe(false);
+    expect(computeServerHint(SERVER, false)).toBe(false);
   });
 });
 
@@ -80,10 +114,41 @@ describe("computeLayoutStatus — server mode", () => {
     expect(result.label).toBe("Checking connection");
   });
 
-  it("is error when the API is known unreachable", () => {
-    const result = status("idle", 0, SERVER, false, 0, false);
+  it("is the outage state when the API was reached then lost", () => {
+    // apiEverReached true: the server answered earlier this session, then went
+    // away. This is the transient-outage treatment the drop toast covers.
+    const result = status("idle", 0, SERVER, false, 0, false, true);
     expect(result.status).toBe("error");
     expect(result.label).toBe("Offline");
+    expect(result.kind).toBe("offline");
+  });
+
+  it("is the misconfiguration state when the API was never reached", () => {
+    // apiEverReached false: server mode was declared but the API has not
+    // answered once since load. That is a broken deployment, not a transient
+    // outage, so it gets a distinct state and copy, not the drop toast.
+    const result = status("idle", 0, SERVER, false, 0, false, false);
+    expect(result.status).toBe("error");
+    expect(result.label).toBe("Server not found");
+    expect(result.kind).toBe("server-not-found");
+    expect(result.detail).toMatch(/api container/i);
+  });
+
+  it("distinguishes never-reached from reached-then-lost by kind", () => {
+    const neverReached = status("idle", 0, SERVER, false, 0, false, false);
+    const reachedThenLost = status("idle", 0, SERVER, false, 0, false, true);
+    expect(neverReached.kind).not.toBe(reachedThenLost.kind);
+  });
+
+  it("circuit-breaker trip is always reached-then-lost, never misconfiguration", () => {
+    // The breaker only opens after save attempts, which require a reachable
+    // server, so a never-reached deployment can never reach this branch. Even
+    // with apiEverReached false it must read as the outage state, not
+    // server-not-found.
+    const result = status("saving", 3, SERVER, false, 0, false, false);
+    expect(result.status).toBe("error");
+    expect(result.label).toBe("Server unavailable");
+    expect(result.kind).toBe("offline");
   });
 
   it("is error when the last save failed but the server is reachable", () => {
@@ -123,12 +188,15 @@ describe("rollupDurabilities — worst-wins", () => {
   function durability(status: LayoutDurability["status"]): LayoutDurability {
     return {
       status,
+      kind: status === "error" ? "offline" : status,
       mode: BROWSER,
       changesSinceExport: 0,
       hasEverExported: true,
       isHealthy: status !== "error",
       label: status,
+      detail: "",
       icon: status,
+      serverHint: false,
     };
   }
 

--- a/src/tests/storage-mode.test.ts
+++ b/src/tests/storage-mode.test.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { getStorageMode } from "$lib/storage/availability.svelte";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  checkApiHealth: vi.fn(async () => false),
+}));
+vi.mock("$lib/storage/api", () => ({
+  checkApiHealth: apiMocks.checkApiHealth,
+}));
+
+import {
+  getStorageMode,
+  setApiAvailable,
+  getApiEverReached,
+  resetAvailabilityState,
+  getApiAvailableState,
+  isServerReachableInBrowser,
+  probeServerForBrowserHint,
+} from "$lib/storage/availability.svelte";
 
 /**
  * Storage mode is read explicitly from runtime config (window.__RACKULA_CONFIG__),
@@ -45,5 +61,96 @@ describe("getStorageMode", () => {
     expect(getStorageMode()).toBe("browser");
     window.__RACKULA_CONFIG__ = { storage: "" };
     expect(getStorageMode()).toBe("browser");
+  });
+});
+
+/**
+ * The "ever reached" latch is what lets the chip tell a broken deployment
+ * (server mode, API never answered) apart from a transient outage (reached,
+ * then lost). It must latch true on the first reach and never fall back to
+ * false on a later loss, so a reconnect-then-drop reads as an outage, not a
+ * misconfiguration. Locks issue #2063.
+ */
+describe("getApiEverReached latch", () => {
+  beforeEach(() => {
+    resetAvailabilityState();
+  });
+
+  it("starts false before the API is ever reached", () => {
+    expect(getApiEverReached()).toBe(false);
+  });
+
+  it("latches true the first time availability becomes true", () => {
+    setApiAvailable(true);
+    expect(getApiEverReached()).toBe(true);
+  });
+
+  it("stays true after a later loss (reached then lost)", () => {
+    setApiAvailable(true);
+    setApiAvailable(false);
+    expect(getApiEverReached()).toBe(true);
+  });
+
+  it("stays false while availability has only ever been false", () => {
+    setApiAvailable(false);
+    setApiAvailable(false);
+    expect(getApiEverReached()).toBe(false);
+  });
+});
+
+/**
+ * The browser-mode probe is the only thing that lets the chip notice a server is
+ * reachable while the instance is configured for browser storage (#2063). It must
+ * stay silent and leave the durability status untouched on the common case (no
+ * server), only flipping availability on a positive result, and never run in
+ * server mode (which has its own probe).
+ */
+describe("probeServerForBrowserHint", () => {
+  const original = window.__RACKULA_CONFIG__;
+
+  beforeEach(() => {
+    resetAvailabilityState();
+    apiMocks.checkApiHealth.mockReset();
+    delete window.__RACKULA_CONFIG__;
+  });
+
+  afterEach(() => {
+    window.__RACKULA_CONFIG__ = original;
+  });
+
+  it("flags a reachable server when one answers in browser mode", async () => {
+    apiMocks.checkApiHealth.mockResolvedValue(true);
+    await probeServerForBrowserHint();
+    expect(isServerReachableInBrowser()).toBe(true);
+  });
+
+  it("never touches apiAvailable, so it cannot wake server autosave", async () => {
+    // Regression guard (#2063): apiAvailable is the server-mode write/load gate.
+    // The browser probe must leave it null even on a positive result, or
+    // browser-mode layouts would start auto-saving to the reachable server.
+    apiMocks.checkApiHealth.mockResolvedValue(true);
+    await probeServerForBrowserHint();
+    expect(getApiAvailableState()).toBeNull();
+  });
+
+  it("leaves the signal off when no server answers", async () => {
+    apiMocks.checkApiHealth.mockResolvedValue(false);
+    await probeServerForBrowserHint();
+    expect(isServerReachableInBrowser()).toBe(false);
+    expect(getApiAvailableState()).toBeNull();
+  });
+
+  it("does not probe in server mode (it has its own probe)", async () => {
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+    await probeServerForBrowserHint();
+    expect(apiMocks.checkApiHealth).not.toHaveBeenCalled();
+  });
+
+  it("does not re-probe once a server has already been found", async () => {
+    apiMocks.checkApiHealth.mockResolvedValue(true);
+    await probeServerForBrowserHint();
+    apiMocks.checkApiHealth.mockClear();
+    await probeServerForBrowserHint();
+    expect(apiMocks.checkApiHealth).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

The explicit storage mode (#2036/#2037) introduced a failure class the chip never named: the configured mode contradicting the observable deployment. The chip is the honest-state surface, so it now distinguishes configured intent from observed reality. Both new states are popover-only, factual tone, no new toasts.

- Server mode, never-reached vs reached-then-lost. A one-way ever-reached latch (`getApiEverReached`, latches true on the first reach, never falls back) splits the two server-mode error classes. Never reached since load is a broken deployment: distinct chip state `Server not found` with popover copy "Check that the API container is running and RACKULA_STORAGE_MODE matches the deployment." and no drop toast. Reached then lost keeps the existing `Offline` treatment and the instance-named drop toast. The circuit-breaker trip is always reached-then-lost.
- Browser mode + healthy API. A dedicated one-shot `/api/health` probe (`probeServerForBrowserHint`, reusing the hardened content-type + payload-shape check) sets a browser-only `serverReachableInBrowser` signal that feeds a passive popover line: "A Rackula server is reachable but this instance stores layouts in the browser. Set RACKULA_STORAGE_MODE=server to use it." It never touches `apiAvailable` (the server-mode write/load gate), so it cannot wake server autosave in browser mode.

Effect 2 (server autosave) also gains the explicit `getStorageMode() === "server"` guard its siblings (Effects 1 and 3) already have, as defence in depth.

Decisions recorded in `docs/superpowers/specs/2026-06-09-canvas-ux-overhaul-design.md`.

## Acceptance criteria

- [x] Chip distinguishes never-reached from reached-then-lost in server mode
- [x] Browser mode surfaces a passive server-available hint when /api/health answers, popover only
- [x] No new toasts; factual tone
- [x] Decisions recorded back into the canvas UX overhaul spec

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test:run` 2658 tests pass (extended the durability state-machine matrix, the ever-reached latch, and the browser probe including a regression guard that the probe never sets `apiAvailable`)
- [x] `npm run build` succeeds
- State-machine logic tested via pure functions (`computeLayoutStatus`, `computeServerHint`), no DOM/colour/class assertions per the project test rules.

Closes #2063

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show clearer storage status and warn when browser mode can see a server**

### What Changed
- The storage chip now separates a broken server setup from a temporary outage in server mode, showing “Server not found” when the API never answered and keeping “Offline” for cases where it was reachable before
- Browser mode can now show a passive hint when a server is reachable, without changing the saved/pending state or triggering server autosave
- The chip popover now shows more specific detail text for each storage state, including the current save outcome and the new browser-mode server hint

### Impact
`✅ Clearer storage error messages`
`✅ Fewer false outage alerts`
`✅ Safer browser-mode behavior` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
