### PR TITLE
feat: move toast notifications to upper-right beneath the storage chip (#2405)

### DIFF
--- a/src/lib/components/ToastContainer.svelte
+++ b/src/lib/components/ToastContainer.svelte
@@ -16,13 +16,18 @@
 </div>
 
 <style>
+	/* Anchored top-right, beneath the top bar / storage chip. The stack grows
+	   downward: newest sits just under the chip and older toasts push down
+	   (column-reverse keeps the latest closest to its source, #2405). The right
+	   offset matches the storage chip's right edge (the toolbar right lane's
+	   --space-2 padding) so cause and effect line up vertically. */
 	.toast-container {
 		position: fixed;
-		bottom: calc(
-			1.5rem + var(--safe-area-bottom, 0px) + var(--keyboard-height, 0px)
+		top: calc(
+			var(--toolbar-height) + var(--space-3) + env(safe-area-inset-top, 0px)
 		);
-		right: 1.5rem;
-		z-index: 9999;
+		right: calc(var(--space-2) + env(safe-area-inset-right, 0px));
+		z-index: var(--z-toast);
 		display: flex;
 		flex-direction: column-reverse;
 		gap: 0.75rem;
@@ -33,13 +38,14 @@
 		pointer-events: auto;
 	}
 
-	/* Responsive positioning */
+	/* Responsive positioning: span the width beneath the top bar on small
+	   screens so messages stay readable, still stacking downward from the top. */
 	@media (max-width: 480px) {
 		.toast-container {
-			left: 1rem;
-			right: 1rem;
-			bottom: calc(
-				1rem + var(--safe-area-bottom, 0px) + var(--keyboard-height, 0px)
+			left: calc(var(--space-4) + env(safe-area-inset-left, 0px));
+			right: calc(var(--space-4) + env(safe-area-inset-right, 0px));
+			top: calc(
+				var(--toolbar-height) + var(--space-2) + env(safe-area-inset-top, 0px)
 			);
 		}
 


### PR DESCRIPTION
## **User description**
## Summary

Moves toast notifications from the lower-right corner to the upper-right, beneath the top bar and storage chip. Closes #2405. Part of the UX overhaul epic #2017; follows #2398 (storage chip in the top bar's right region).

With the storage chip now in the top-right and storage-state changes surfacing as toasts (#2063), anchoring the toast stack beneath the chip keeps cause and effect together instead of at opposite corners.

## Changes

- `src/lib/components/ToastContainer.svelte`: switch the `bottom`/`right` anchor to a `top`/`right` anchor below `--toolbar-height`.
- Right offset aligns the stack's right edge to the storage chip's right edge (the toolbar right lane's `--space-2` / 8px padding), so toasts line up vertically under the chip.
- Replace the hardcoded `z-index: 9999` with the `--z-toast` design token (300), which keeps toasts above the chip popover (`--z-dropdown` 250) so notifications stay readable.
- Drop the bottom-only `--keyboard-height` / `--safe-area-bottom` compensation (irrelevant to a top anchor); add `env(safe-area-inset-top/right/left)` for notched devices.
- Mobile: span the width beneath the top bar, still stacking downward from the top.

## Behaviour preserved

- `flex-direction: column-reverse` keeps the newest toast just under the chip; the stack grows downward as older toasts accumulate.
- Dismiss, slide-in/out animations, and success glow are unchanged (they live in `Toast.svelte`).
- Reduced motion is respected via the global `prefers-reduced-motion` rule in `app.css`.

## Acceptance criteria

- [x] Toasts appear in the upper-right, beneath the storage chip, aligned with the right region.
- [x] The stack grows downward; dismiss and animation behaviour preserved; reduced-motion respected.
- [x] No overlap with the top-bar controls (stack starts 12px below the 48px toolbar); toasts render above the chip popover so they stay readable if both are momentarily present.
- [x] Mobile/responsive position remains sensible (full width beneath the top bar).
- [x] Visual baselines: the visual-regression suite explicitly hides `.toast-container` (`neutralizeToasts` in `e2e/helpers/visual.ts`), so no toast appears in any baseline and none need regenerating.

## Testing

- `npm run lint`: clean.
- `npm run test:run`: 157 files / 2659 tests pass.
- `npm run build`: succeeds.
- Svelte autofixer: no issues.
- Pure visual change; per project TDD policy no styling tests added (visual regression #2098 and axe #2099 cover this region).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Move toast notifications to the upper-right under the storage chip**

### What Changed
- Toasts now appear in the upper-right, directly beneath the top bar and storage chip instead of the lower-right corner.
- The toast stack starts below the toolbar and grows downward, so newer messages stay closest to the chip.
- On small screens, toasts span the width under the top bar for easier reading.
- Toasts stay above other top-bar overlays and respect safe-area spacing on notched devices.

### Impact
`✅ Toasts are easier to connect with the action that triggered them`
`✅ Clearer notifications on small screens`
`✅ Fewer overlaps with top-bar controls`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
