### PR TITLE
docs: carrier-first sub-U documentation (#2165)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,10 @@ If none of those conditions are met, proceed immediately to the next prompt.
 
 ## Quick Reference
 
+### Invariants
+
+- Rail positions are whole-U integers; sub-U devices mount in containers; never reintroduce fractional rail positions. See [SPEC.md, Mounting Model](docs/reference/SPEC.md#mounting-model).
+
 ### Tech Stack
 
 - Svelte 5 with runes (`$state`, `$derived`, `$effect`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -115,6 +115,12 @@ All user actions that modify state go through the command pattern:
 - History stack in `src/lib/stores/history.svelte.ts`
 - Enables `Ctrl+Z` / `Ctrl+Shift+Z` undo/redo
 
+### Carrier-First Mounting
+
+Rail positions are whole-U integers. Internally, positions are stored in units of `UNITS_PER_U` (6 per U) so device heights can step in 0.5U, but a device registers to the rails only at a whole-U boundary. Devices smaller than a full U or narrower than full width mount inside a carrier (a bracket, tray, or shelf) that occupies a whole U; the carrier registers to the rails, and the small devices register to the carrier. Container children carry a `container_id` and `slot_id` and are positioned relative to their carrier, not the rails.
+
+See [SPEC.md, Mounting Model](reference/SPEC.md#mounting-model) for the authoritative rule, the EIA-310 rationale, and how legacy fractional positions are adapted on load.
+
 ### NetBox-Compatible Data Model
 
 Field names follow NetBox conventions (snake_case):

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -76,6 +76,27 @@ See `CLAUDE.md` for deployment environments and CI/CD details.
 
 > **Reference:** For complete schema documentation including all fields, validation rules, and YAML examples, see [SCHEMA.md](./SCHEMA.md).
 
+### Mounting Model
+
+Rackula models rack mounting carrier-first. This is a design principle: it decides where a device can sit and answers the recurring "why can't I place this at U5 1/3?" question with one authoritative rule.
+
+Rails register equipment at whole-U boundaries only, matching the EIA-310 standard. A U is defined by three mounting holes; those holes locate the boundary of a unit, they are not alternative mounting positions. There is no real 1/3U or 1/2U rail position on a physical rack, so Rackula does not offer one. Rail positions are whole-U integers.
+
+Devices smaller than a full U, or narrower than full width, do not bolt to the rails on their own. They mount inside a carrier: a bracket, tray, or shelf that occupies a whole U. The carrier registers to the rails at a whole-U boundary, and the small devices register to the carrier. A half-width pair, for example, is one carrier with two cells side by side. A MikroTik K-79 is a branded 2x2 carrier holding up to four small units in 1U.
+
+The mounting rule:
+
+| Device                                          | Mounts on  |
+| ----------------------------------------------- | ---------- |
+| Full-width, integer u_height                    | Rails      |
+| Sub-U height, non-integer height, or sub-width  | A carrier  |
+
+Carriers are ordinary devices with a face and a whole-U position. A device with `u_height` below 1, a non-integer `u_height`, or less than full width cannot be placed on the rails directly; it must be a child of a carrier. This rule is enforced in the schema, in store placement actions, and in drag-and-drop targeting, so a fractional rail position cannot be reintroduced from any path.
+
+Rationale: fractional rail offsets modelled a physical fiction and scattered paired half-width gear into impossible positions. Carrier-first keeps the data faithful to how equipment actually mounts, and gives sub-U devices a real parent rather than a floating coordinate.
+
+Legacy layouts and share links that used fractional rail positions are adapted on load: positions snap to the nearest whole U, and sub-U or paired half-width placements are wrapped in an automatically synthesized carrier. The adaptation runs once on the read path. Older files open with their gear intact, now mounted in carriers the user did not place by hand.
+
 ### Constraints
 
 | Constraint              | Value           |
@@ -92,11 +113,12 @@ See `CLAUDE.md` for deployment environments and CI/CD details.
 
 ### Collision Detection
 
-Two devices collide if **all** conditions are true:
+Two rail-level devices collide if **both** conditions are true:
 
 1. Their U ranges overlap (`position` to `position + u_height - 1`)
 2. Their faces collide (see rules below)
-3. Their slot positions overlap (left/right/full)
+
+Rail-level devices are all whole-U and full-width (see Mounting Model above), so there is no left/right slot dimension to compare at the rails. Sub-U gear lives inside carriers, where collision is checked per cell (see Container-Aware Collision below).
 
 **Face Collision Rules (Face-Authoritative Model):**
 


### PR DESCRIPTION
## **User description**
## Summary

Documents the carrier-first sub-U mounting model that shipped under epic #2158. Rails register equipment at whole-U boundaries per EIA-310; sub-U and sub-width gear mounts inside a carrier that itself registers to the rails. These are the code-independent, always-true structural docs.

## Sections added or updated

- `docs/reference/SPEC.md`: new authoritative "Mounting Model" section under Data Model. States the rule (whole-U rails, carrier-first for sub-U and sub-width gear), gives the EIA-310 rationale so "why not U5 1/3" has one answer, and describes load-time adaptation of legacy fractional layouts and share links. Also corrects the Collision Detection section, which still listed a left/right slot-overlap condition from the deleted fractional model.
- `docs/ARCHITECTURE.md`: new "Carrier-First Mounting" design decision describing whole-U rail positions and internal units (UNITS_PER_U), and how container children are positioned relative to their carrier. Links to SPEC.md rather than repeating it.
- `CLAUDE.md`: adds the invariant to the Quick Reference: rail positions are whole-U integers; sub-U devices mount in containers; never reintroduce fractional rail positions.

## Out of scope (deferred per the issue)

The issue states each checklist item ships with the implementation PR that makes its claim true, so these are intentionally left for their own PRs:

- CHANGELOG.md entry: ships via `/release` at ship time.
- In-app help drag hint (sub-U device mounts in a carrier): ships with the in-app implementation PR.
- Field mapping guide (#1209, carrier to `device_bays`): ships when NetBox interop lands.

Because three AC items remain, this PR uses `Refs` rather than `Closes`; the issue should stay open until the deferred items land. Flagging for the orchestrator to confirm.

## Verification

- Internal links resolve: `reference/SPEC.md#mounting-model` (from ARCHITECTURE.md) and `docs/reference/SPEC.md#mounting-model` (from CLAUDE.md) both point at the new heading.
- Content checked against the merged carrier-first code (`requiresCarrier`, whole-U `canPlaceDevice`, synthesized carriers) and the frozen design spec.
- `npm run lint`: no issues found.
- No em dashes, en dashes, smart quotes, or emoji in the additions.

The frozen decision record (`docs/superpowers/specs/2026-06-12-carrier-first-sub-u-design.md`) is not edited.

Part of #2158.
Refs #2165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Document carrier-first mounting for sub-U and sub-width equipment

### What Changed
- Added a clear rule that only full-width, whole-U devices mount directly on rails
- Explained that smaller or narrower devices must sit inside a carrier such as a bracket, tray, or shelf
- Clarified that old fractional rail layouts are now snapped to whole U positions and wrapped in carriers when opened
- Updated collision rules to reflect that rail-level devices no longer use left/right slot overlap, while container children are checked inside their carrier
- Added the same mounting invariant to the architecture guide and quick reference so it is easy to find and follow

### Impact
`✅ Clearer rack mounting rules`
`✅ Fewer invalid device placements`
`✅ Safer opening of older rack layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
