### PR TITLE
chore: host versioned layout schema and wire canonical $id (#2228)

### DIFF
--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -92,6 +92,45 @@ encode), but that does not substitute for the gate.
 
 ---
 
+## Published Schema
+
+A language-agnostic JSON Schema is generated from the Zod source and committed at
+`static/schemas/layout-v1.json`. It is the structural contract for the saved-layout format.
+Run `npm run generate-schema` to regenerate it after changing the Zod schema; a CI drift check
+fails if the committed artifact and the generated output diverge.
+
+### Canonical `$id`
+
+The artifact carries the canonical identifier `https://schemas.racku.la/layout/v{MAJOR}.json`,
+which for the current MAJOR is:
+
+```text
+https://schemas.racku.la/layout/v1.json
+```
+
+The `$id` is an identifier, not a fetch target. Readers decide loadability offline from
+`metadata.schema_version` (see the reader rule above) and never resolve the `$id` over the
+network, so the canonical `$id` is wired before the `schemas.racku.la` domain exists.
+
+### Served location (interim fetch URL)
+
+`static/` is served at the deployment root, so the artifact is reachable today at:
+
+| Environment | URL                                            |
+| ----------- | ---------------------------------------------- |
+| Prod        | `https://count.racku.la/schemas/layout-v1.json` |
+| Dev         | `https://d.racku.la/schemas/layout-v1.json`     |
+
+Until the `schemas.racku.la` DNS is live, use the prod served URL above as the fetch URL for
+tooling that resolves a schema (for example a `# yaml-language-server: $schema=...` editor
+hint). The served path (`/schemas/layout-v1.json`) differs from the canonical `$id` path
+(`/layout/v1.json`) on purpose: the `$id` follows the long-term canonical shape while the
+served path matches the committed artifact's location. When `schemas.racku.la` is configured,
+it will serve the artifact at the canonical `$id` path and the fetch URL converges on the
+`$id`.
+
+---
+
 ## DeviceType
 
 Template definition for devices in the library. Referenced by `PlacedDevice.device_type`.

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -36,8 +36,15 @@ const OUTPUT_FILE = join(ROOT, "static", "schemas", "layout-v1.json");
 export const JSON_SCHEMA_DIALECT =
   "https://json-schema.org/draft/2020-12/schema";
 
-/** Canonical published location of this schema (static/ serves at site root). */
-export const SCHEMA_ID = "https://count.racku.la/schemas/layout-v1.json";
+/**
+ * Canonical schema identifier per docs/reference/SCHEMA.md
+ * (schemas.racku.la/layout/v{MAJOR}.json). This is an identifier, not a fetch
+ * target: readers gate loadability offline on metadata.schema_version, so the
+ * canonical $id is set before schemas.racku.la DNS exists. The artifact is
+ * served in the interim at the count.racku.la/d.racku.la /schemas/ path (see
+ * the Published Schema section of SCHEMA.md).
+ */
+export const SCHEMA_ID = "https://schemas.racku.la/layout/v1.json";
 
 export const SCHEMA_DESCRIPTION =
   "Beta. Generated from the Rackula Zod layout schema. Covers the structural " +

--- a/static/schemas/layout-v1.json
+++ b/static/schemas/layout-v1.json
@@ -1,6 +1,6 @@
 {
   "$description": "Beta. Generated from the Rackula Zod layout schema. Covers the structural shape of a saved layout but not cross-field rules expressed in Zod (.refine/.superRefine: referential integrity, carrier-first rail placement, slot fit) or the load-time .transform (legacy position migration, rack id generation, unknown-field preservation). Expect roughly 80 percent validation coverage; the Zod schema in src/lib/schemas/index.ts is authoritative.",
-  "$id": "https://count.racku.la/schemas/layout-v1.json",
+  "$id": "https://schemas.racku.la/layout/v1.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": {},
   "properties": {


### PR DESCRIPTION
## **User description**
## Summary

Wires the canonical `$id` for the published layout JSON Schema per `docs/reference/SCHEMA.md` (`schemas.racku.la/layout/v{MAJOR}.json`) and regenerates the committed artifact so it carries that id. The schema is already served at the deployment root via `static/`.

## Canonical strings (cited by downstream #2229 / #2230)

Use these verbatim:

- Canonical `$id` (identifier, written into the artifact):
  `https://schemas.racku.la/layout/v1.json`
- Interim served fetch URL (prod, stable today via `static/`):
  `https://count.racku.la/schemas/layout-v1.json`
- Interim served fetch URL (dev):
  `https://d.racku.la/schemas/layout-v1.json`

The `$id` path (`/layout/v1.json`) intentionally differs from the served path (`/schemas/layout-v1.json`). The `$id` is an identifier, not a fetch target: readers gate loadability offline on `metadata.schema_version` and never resolve the `$id` over the network, so the canonical `$id` is wired before `schemas.racku.la` DNS exists. Tooling that resolves a schema (for example a `# yaml-language-server: $schema=...` hint) should use the served prod URL in the interim.

## Acceptance criteria

- [x] `layout-v1.json` reachable at a stable served URL on prod: served at the site root via `static/` at `https://count.racku.la/schemas/layout-v1.json` (unchanged path, no infra added).
- [x] Canonical `$id` set to `schemas.racku.la/layout/v1.json` per policy: `SCHEMA_ID` in `scripts/generate-schema.ts` is now `https://schemas.racku.la/layout/v1.json`; the regenerated `static/schemas/layout-v1.json` carries it.
- [x] Documented interim fetch URL: new "Published Schema" section in `docs/reference/SCHEMA.md` documents the canonical `$id`, the served interim URLs, and why they differ.

## Changes

- `scripts/generate-schema.ts`: `SCHEMA_ID` -> canonical URL, with a doc comment explaining identifier-vs-fetch-target.
- `static/schemas/layout-v1.json`: regenerated via `npm run generate-schema` (only the `$id` line changes; generator is idempotent).
- `docs/reference/SCHEMA.md`: new "Published Schema" section.

The existing `src/tests/layout-json-schema.test.ts` asserts `artifact.$id === SCHEMA_ID`, so it auto-follows the constant (no test edit needed). Sibling PR #2227 adds a CI drift check; the regenerated artifact is committed in lockstep with the script so that check stays green.

## Local gates

- `npm run lint`: clean
- `npm run test:run`: 157 files / 2659 tests pass
- `npm run build`: success
- `grep '"\$id"' static/schemas/layout-v1.json` shows the canonical URL; re-running `npm run generate-schema` produces byte-identical output (idempotent)

Closes #2228

Related: parent #571, epic #570, policy #1113, sibling drift check #2227.


___

## **CodeAnt-AI Description**
**Publish the layout schema with its canonical identifier and document where to fetch it**

### What Changed
- The generated layout schema now carries the canonical `https://schemas.racku.la/layout/v1.json` identifier.
- The schema reference docs now explain the published schema, including the current served URLs for prod and dev.
- The docs clarify that the canonical identifier is not the fetch URL yet, so tooling should use the current served URL until the new domain is live.

### Impact
`✅ Clearer schema links for editor tooling`
`✅ Fewer broken schema lookups`
`✅ Easier access to the published layout schema`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
