### PR TITLE
fix: rack click target populates the Edit panel (#2407)

### DIFF
--- a/src/lib/components/SidePanelContent.svelte
+++ b/src/lib/components/SidePanelContent.svelte
@@ -135,11 +135,17 @@
   // Delete-device-type confirmation lives at the host level (per #1398 contract).
   let showDeleteConfirm = $state(false);
 
+  // Count placements across every rack, not just the selected one: deleting a
+  // device type removes all of its instances layout-wide, so the confirmation's
+  // "All instances will be removed" must report the whole-layout count.
   const deviceTypePlacementCount = $derived.by(() => {
     if (!selectedDeviceInfo) return 0;
     const slug = selectedDeviceInfo.device.slug;
-    const rack = selectedDeviceInfo.rack;
-    return rack.devices.filter((d) => d.device_type === slug).length;
+    return layoutStore.racks.reduce(
+      (count, rack) =>
+        count + rack.devices.filter((d) => d.device_type === slug).length,
+      0,
+    );
   });
 
   function handleDeleteDeviceType() {

--- a/src/lib/components/SidePanelContent.svelte
+++ b/src/lib/components/SidePanelContent.svelte
@@ -58,10 +58,17 @@
   const layoutStore = getLayoutStore();
   const selectionStore = getSelectionStore();
 
-  // Dynamic active rack id from the store
-  const currentRackId = $derived(
-    layoutStore.activeRackId ?? layoutStore.racks[0]?.id ?? null,
-  );
+  // The rack the current selection refers to, resolved from the selection store
+  // rather than the active rack. Selecting a rack via any entry point (canvas
+  // click target, rack list, keyboard) is sufficient to populate the panel, even
+  // when a different rack is the active rack (#2407). For a device selection this
+  // is the rack that holds the device; for a rack/group selection it is the rack
+  // the selection names.
+  const selectedRackId = $derived(selectionStore.selectedRackId);
+  const selectionRack = $derived.by(() => {
+    if (!selectedRackId) return null;
+    return layoutStore.racks.find((r) => r.id === selectedRackId) ?? null;
+  });
 
   // The selected group if a bayed rack is selected
   const selectedGroup = $derived.by(() => {
@@ -74,14 +81,13 @@
     );
   });
 
-  // The selected rack (also resolves the active rack within a selected group)
+  // The selected rack (also resolves the active rack within a selected group).
+  // A group selection carries its active rack as selectedRackId, so both the
+  // single-rack and bayed-group cases resolve through selectionRack.
   const selectedRack = $derived.by(() => {
-    if (selectionStore.isGroupSelected && currentRackId) {
-      return layoutStore.activeRack;
-    }
-    if (!selectionStore.isRackSelected || !currentRackId) return null;
-    if (selectionStore.selectedRackId !== currentRackId) return null;
-    return layoutStore.activeRack;
+    if (selectionStore.isGroupSelected) return selectionRack;
+    if (!selectionStore.isRackSelected) return null;
+    return selectionRack;
   });
 
   // The selected device info, if a device is selected
@@ -93,7 +99,7 @@
     )
       return null;
 
-    const rack = layoutStore.activeRack;
+    const rack = selectionRack;
     if (!rack) return null;
 
     const deviceIndex = selectionStore.getSelectedDeviceIndex(rack.devices);
@@ -132,10 +138,8 @@
   const deviceTypePlacementCount = $derived.by(() => {
     if (!selectedDeviceInfo) return 0;
     const slug = selectedDeviceInfo.device.slug;
-    const activeRack = layoutStore.activeRack;
-    return activeRack
-      ? activeRack.devices.filter((d) => d.device_type === slug).length
-      : 0;
+    const rack = selectedDeviceInfo.rack;
+    return rack.devices.filter((d) => d.device_type === slug).length;
   });
 
   function handleDeleteDeviceType() {

--- a/src/tests/side-panel-edit-context.test.ts
+++ b/src/tests/side-panel-edit-context.test.ts
@@ -63,6 +63,34 @@ describe("Edit tab contextual properties (#2077)", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("populates the panel for a selected rack even when a different rack is active", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    // Two racks. Rack A is the active rack; rack B is the one the user selects
+    // via the canvas click target / title (#2407). Selection alone must populate
+    // the Edit panel, regardless of which rack the store considers active.
+    const rackA = layoutStore.addRack("Rack A", 42);
+    const rackB = layoutStore.addRack("Rack B", 24);
+    layoutStore.setActiveRack(rackA!.id);
+    selectionStore.selectRack(rackB!.id);
+
+    renderEditTab();
+
+    // The panel resolves to the SELECTED rack (B), not the empty state.
+    expect(
+      screen.getByRole("heading", { name: /^rack$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /delete rack/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("side-panel-edit-empty"),
+    ).not.toBeInTheDocument();
+    // The body shows rack B's properties: its name appears in the name field.
+    expect(screen.getByDisplayValue("Rack B")).toBeInTheDocument();
+  });
+
   it("names a bayed rack group as the multi-rack selection", () => {
     const layoutStore = getLayoutStore();
     const selectionStore = getSelectionStore();

--- a/src/tests/side-panel-edit-context.test.ts
+++ b/src/tests/side-panel-edit-context.test.ts
@@ -7,7 +7,7 @@
  * matching properties render; with no selection a clear empty state shows instead.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, fireEvent } from "@testing-library/svelte";
 import SidePanelContent from "$lib/components/SidePanelContent.svelte";
 import { resetLayoutStore, getLayoutStore } from "$lib/stores/layout.svelte";
 import {
@@ -141,5 +141,40 @@ describe("Edit tab contextual properties (#2077)", () => {
     expect(
       screen.queryByTestId("side-panel-edit-empty"),
     ).not.toBeInTheDocument();
+  });
+
+  it("counts device-type placements across all racks in the delete confirmation", async () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    // The same custom device type is placed in two different racks. Deleting the
+    // type removes every instance layout-wide, so the confirmation must report
+    // the whole-layout count, not just the selected rack's.
+    const rackA = layoutStore.addRack("Rack A", 42);
+    const rackB = layoutStore.addRack("Rack B", 42);
+    const deviceType = layoutStore.addDeviceType({
+      name: "Shared Server",
+      u_height: 1,
+      category: "server",
+      colour: "#4A90D9",
+    });
+    layoutStore.placeDevice(rackA!.id, deviceType.slug, 1, "front");
+    layoutStore.placeDevice(rackB!.id, deviceType.slug, 1, "front");
+
+    // Select the instance in rack A.
+    const deviceInA = layoutStore
+      .getRackById(rackA!.id)!
+      .devices.find((d) => d.device_type === deviceType.slug)!;
+    selectionStore.selectDevice(rackA!.id, deviceInA.id);
+
+    renderEditTab();
+
+    // Trigger the delete-device-type flow.
+    await fireEvent.click(
+      screen.getByRole("button", { name: /delete from library/i }),
+    );
+
+    // The confirmation reports both placements, not just the one in rack A.
+    expect(screen.getByText(/placed 2 times/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Selecting a rack via the canvas click target / title drew the selection box but
left the Edit panel on its empty state. The panel resolved the selected rack
through `layoutStore.activeRackId` (with a `racks[0]` fallback) and only rendered
when `selectedRackId === activeRackId`. Whenever the selected rack differed from
the active rack, the panel resolved to `null`.

This change resolves the panel's selected rack directly from
`selectionStore.selectedRackId`, so selection alone populates the panel,
consistently across every entry point (canvas click target, rack list, keyboard).
The device-info rack and its placement count route through the same selected rack.
The bayed-group case still resolves its active rack, which group selection carries
as `selectedRackId`.

## Root cause

`SidePanelContent.svelte` coupled panel resolution to the active rack rather than
the selection. Every UI select path happens to set both `setActiveRack` and
`selectRack` in lockstep, which masked the bug for the common flow; it surfaced
whenever the two diverged (a different rack active, then a rack selected).

## Test Plan

- [x] New behavioural test: selecting rack B while rack A is active populates the
      Edit panel for B (red before the fix, green after).
- [x] Existing side-panel Edit/View tests still pass (rack, bayed group, device,
      empty state, selection-switch).
- [x] `npm run lint` clean
- [x] `npm run test:run` (2660 tests) pass
- [x] `npm run build` succeeds

Closes #2407


___

## **CodeAnt-AI Description**
**Edit panel now follows the selected rack, not the active rack**

### What Changed
- Selecting a rack now fills the Edit panel even when a different rack is currently active
- Device details and placement counts now use the selected rack, so the panel matches the item the user picked
- Bayed rack group selections continue to open the correct rack details

### Impact
`✅ Fewer empty Edit panels after rack selection`
`✅ Consistent rack details from canvas, list, and keyboard selection`
`✅ Clearer device counts for the selected rack`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
