### PR TITLE
feat: reject layouts with a newer major schema_version at the validation ingress (#2205)

### DIFF
--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -794,6 +794,51 @@ const LayoutSchemaInput = z
   .passthrough();
 
 /**
+ * Current data-format version the running app reads and writes (MAJOR.MINOR).
+ *
+ * This is the schema_version, distinct from the app `version` (provenance, bumps
+ * every release). A reader gates loadability strictly on the MAJOR component of a
+ * document's metadata.schema_version against this constant. See the versioning
+ * policy in docs/reference/SCHEMA.md (#1113).
+ */
+export const SCHEMA_VERSION = "1.0";
+
+/** MAJOR component of a MAJOR.MINOR version string (untrusted-input safe). */
+function majorOf(version: string): number {
+  const major = parseInt(version.trim().split(".")[0] ?? "", 10);
+  return Number.isFinite(major) ? major : 0;
+}
+
+/**
+ * Reject a layout whose data-format MAJOR is newer than the running app (#2205).
+ *
+ * Gates strictly on the MAJOR of metadata.schema_version, never the app `version`
+ * (which bumps every release and would over-reject). An absent schema_version is
+ * treated as the current format (MAJOR matches), so legacy files predating
+ * versioning load. Older MAJOR is not rejected here: it falls through to the
+ * migration path. The check is read-only and non-destructive: it throws before
+ * any parse or write so the original input is never modified.
+ *
+ * @param schemaVersion - The document's metadata.schema_version, if present.
+ * @throws Error when the document MAJOR is newer than the app understands.
+ */
+export function assertSchemaVersionSupported(
+  schemaVersion: string | undefined,
+): void {
+  // Absent schema_version reads as the current format (every file predating
+  // versioning is the current MAJOR by construction).
+  if (schemaVersion === undefined) {
+    return;
+  }
+  if (majorOf(schemaVersion) > majorOf(SCHEMA_VERSION)) {
+    throw new Error(
+      `This layout was created by a newer version of Rackula (format ${schemaVersion}). ` +
+        `Update Rackula to open it. Your file was not changed.`,
+    );
+  }
+}
+
+/**
  * Compare two semver version strings
  * Returns: -1 if a < b, 0 if a == b, 1 if a > b
  * Note: Pre-release suffixes (e.g., -dev, -alpha.1) and build metadata are stripped

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -15,7 +15,12 @@ import type {
   Cable,
   LayoutMetadata,
 } from "$lib/types";
-import { LayoutSchema, LayoutSchemaBase, type LayoutZod } from "$lib/schemas";
+import {
+  LayoutSchema,
+  LayoutSchemaBase,
+  assertSchemaVersionSupported,
+  type LayoutZod,
+} from "$lib/schemas";
 import { adaptLegacyLayout } from "$lib/storage";
 import { layoutDebug } from "$lib/utils/debug";
 import {
@@ -508,10 +513,34 @@ export function parseLayoutObject(parsed: unknown): Layout | null {
  * runtime Layout and appendUnknownSections never re-emits it on resave. The
  * stripped value is returned to the caller so it can be decoded separately.
  */
+/**
+ * Read metadata.schema_version off an untrusted parsed object, if it is a string.
+ * Returns undefined when absent or malformed (the gate treats absent as current).
+ */
+function readSchemaVersion(parsed: unknown): string | undefined {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const metadata = (parsed as Record<string, unknown>).metadata;
+  if (
+    metadata === null ||
+    typeof metadata !== "object" ||
+    Array.isArray(metadata)
+  ) {
+    return undefined;
+  }
+  const version = (metadata as Record<string, unknown>).schema_version;
+  return typeof version === "string" ? version : undefined;
+}
+
 function validateParsedLayout(parsed: unknown): {
   layout: Layout;
   rawImages: unknown;
 } {
+  // Forward-compat gate (#2205): reject a document whose data-format MAJOR is
+  // newer than this app before any parse or write. Read-only and non-destructive.
+  assertSchemaVersionSupported(readSchemaVersion(parsed));
+
   let rawImages: unknown;
 
   if (parsed !== null && typeof parsed === "object") {

--- a/src/tests/schema-version-gate.test.ts
+++ b/src/tests/schema-version-gate.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { serializeLayoutToYaml, parseLayoutYaml } from "$lib/utils/yaml";
+import { createTestLayout, createTestRack } from "./factories";
+import { generateId } from "$lib/utils/device";
+import type { Layout } from "$lib/types";
+
+/**
+ * Reject-newer-major schema gate (#2205).
+ *
+ * Policy (docs/reference/SCHEMA.md): a reader gates strictly on the MAJOR
+ * component of metadata.schema_version. A document whose MAJOR is newer than
+ * the running app understands is rejected non-destructively at the shared
+ * validation ingress (parseLayoutYaml / LayoutSchema). Same-MAJOR (any MINOR)
+ * loads; older MAJOR continues to migrate; absent schema_version reads as 1.0.
+ */
+function yamlWithSchemaVersion(
+  schema_version: string | undefined,
+): Promise<string> {
+  const layout: Layout = createTestLayout({
+    racks: [createTestRack({ devices: [] })],
+    metadata:
+      schema_version === undefined
+        ? undefined
+        : {
+            id: generateId(),
+            name: "Test Layout",
+            schema_version,
+          },
+  });
+  return serializeLayoutToYaml(layout);
+}
+
+describe("schema_version reject-newer-major gate (#2205)", () => {
+  it("rejects a layout whose schema_version MAJOR is newer than the app", async () => {
+    const yaml = await yamlWithSchemaVersion("2.0");
+    await expect(parseLayoutYaml(yaml)).rejects.toThrow(/newer/i);
+  });
+
+  it("rejects a far-newer MAJOR (boundary is MAJOR, not exact match)", async () => {
+    const yaml = await yamlWithSchemaVersion("99.0");
+    await expect(parseLayoutYaml(yaml)).rejects.toThrow(/newer/i);
+  });
+
+  it("loads a same-MAJOR newer-MINOR layout (tolerant reader)", async () => {
+    const yaml = await yamlWithSchemaVersion("1.5");
+    const layout = await parseLayoutYaml(yaml);
+    expect(layout.name).toBeTruthy();
+  });
+
+  it("loads when schema_version is absent (treated as 1.0)", async () => {
+    const yaml = await yamlWithSchemaVersion(undefined);
+    const layout = await parseLayoutYaml(yaml);
+    expect(layout.name).toBeTruthy();
+  });
+
+  it("does not reject on the app version (top-level `version`) alone", async () => {
+    // A future app `version` bump must never trigger the gate: it bumps every
+    // release and is provenance only. schema_version stays at the current MAJOR.
+    const layout: Layout = createTestLayout({
+      version: "999.0.0",
+      racks: [createTestRack({ devices: [] })],
+      metadata: {
+        id: generateId(),
+        name: "Test Layout",
+        schema_version: "1.0",
+      },
+    });
+    const yaml = await serializeLayoutToYaml(layout);
+    const restored = await parseLayoutYaml(yaml);
+    expect(restored.name).toBeTruthy();
+  });
+
+  it("does not write or mutate the input YAML on the reject path", async () => {
+    const yaml = await yamlWithSchemaVersion("2.0");
+    const before = yaml;
+    await expect(parseLayoutYaml(yaml)).rejects.toThrow();
+    // The reject path is read-only: the input string is untouched.
+    expect(yaml).toBe(before);
+  });
+
+  it("does not reject an older MAJOR (older majors migrate, never gate-reject)", async () => {
+    // schema_version started at 1.0, so MAJOR 0 is the only older major. It must
+    // fall through to the migration path, not be rejected by the newer-major gate.
+    const yaml = await yamlWithSchemaVersion("0.9");
+    const layout = await parseLayoutYaml(yaml);
+    expect(layout.name).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Reject a layout whose `metadata.schema_version` MAJOR is newer than the running app understands, at the shared validation ingress, instead of loading and silently misreading it.

The gate lives at the file/YAML/server-GET read ingress (`validateParsedLayout`, used by both `parseLayoutYaml` and `parseLayoutYamlWithImages`). It compares only the MAJOR component of the document's `metadata.schema_version` against the app's current data-format version (`SCHEMA_VERSION = "1.0"`), never the app `version` (which bumps every release). The check throws before any parse or write, so the reject path is read-only and the original file is never modified.

## How each acceptance criterion is met

- A document with `schema_version.major > app.major` is rejected non-destructively with a clear message: a new `assertSchemaVersionSupported` throws before any image-strip or structural parse in `validateParsedLayout`. The message tells the user the layout was created by a newer Rackula, to update, and that their file was not changed.
- Same-MAJOR (any MINOR) loads: a `>` boundary on the MAJOR int means `1.5` loads. Older MAJOR is not gate-rejected; it falls through to the existing migration path (`needsPositionMigration` / `migrateDevicePositions`).
- Absent `schema_version` reads as the current format: `assertSchemaVersionSupported(undefined)` returns without rejecting, so legacy files predating versioning load.
- The gate keys off `schema_version` only: an app `version` bump alone (`version: "999.0.0"`, `schema_version: "1.0"`) never rejects.

## Implementation

- `src/lib/schemas/index.ts`: new `SCHEMA_VERSION` constant, `majorOf` helper (untrusted-input-safe: trims, parses the MAJOR int, coerces NaN to 0), and `assertSchemaVersionSupported`.
- `src/lib/utils/yaml.ts`: new `readSchemaVersion` reads `metadata.schema_version` off the untrusted parsed object; `validateParsedLayout` asserts the gate first, before the images strip and structural parse.

Scoped per the issue and SCHEMA.md: the gate is added at the file/YAML ingress the AC names. The localStorage working-copy path (`parseLayoutObject`) is left unchanged, consistent with SCHEMA.md tracking it as a separate follow-up.

## Tests

New `src/tests/schema-version-gate.test.ts` (TDD, written first, watched fail):

- newer MAJOR (`2.0`, `99.0`) rejects with a "newer" message
- same-MAJOR newer-MINOR (`1.5`) loads
- absent `schema_version` loads (treated as current)
- app `version` bump alone never rejects
- older MAJOR (`0.9`) loads (migrates, not gate-rejected)
- reject path does not mutate the input

## Local gates

- `npm run lint`: clean
- `npm run test:run`: pass (one unrelated `App.cleanupPrompt.test.ts` timeout flake under full-suite parallelism; passes in isolation, no reference to schema/yaml code)
- `npm run build`: pass

Closes #2205


___

## **CodeAnt-AI Description**
**Reject layouts created with a newer schema version**

### What Changed
- Layout imports now stop immediately when the file’s schema version is newer than the app supports, and the file is left unchanged
- Files with the same major schema version still open, older versions still follow the normal migration path, and files without a schema version still load
- The check uses the layout schema version only, not the app release version
- Added tests for newer, older, missing, and matching schema versions, plus the non-destructive reject path

### Impact
`✅ Fewer broken layout imports`
`✅ Clearer upgrade prompts for unsupported files`
`✅ Safer opening of older layout files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
