### PR TITLE
docs: YAML schema validation guide (#2229)

### DIFF
--- a/docs/guides/yaml-schema-validation.md
+++ b/docs/guides/yaml-schema-validation.md
@@ -1,0 +1,177 @@
+# YAML Schema Validation Guide
+
+This guide explains how to validate hand-edited Rackula layout YAML in your editor using
+the published JSON Schema. Wiring the schema into an editor catches structural mistakes
+(missing required fields, wrong types, bad enum values) as you type, before you load the
+file back into Rackula.
+
+## What the schema validates
+
+The schema is generated from Rackula's authoritative Zod schema and describes the
+structural shape of a saved layout: the required fields, their types, and the allowed enum
+values. It catches the common hand-editing mistakes:
+
+- A required field is missing (for example a device without a `position`).
+- A field has the wrong type (a string where a number is expected).
+- An enum value is invalid (a `category` or `form_factor` that does not exist).
+
+It is a structural contract, not a full validator. The schema covers roughly 80 percent of
+what Rackula checks on load. The remaining rules (cross-field constraints, referential
+integrity, the load-time transform) live in the Zod schema and run only when Rackula opens
+the file. See [Limitations](#limitations) for the full list.
+
+## Schema URLs
+
+There are two URLs, and they serve different purposes.
+
+| URL | Purpose |
+| --- | --- |
+| `https://schemas.racku.la/layout/v1.json` | Canonical `$id`. The stable identifier written inside the schema. |
+| `https://count.racku.la/schemas/layout-v1.json` | Interim served URL. The fetchable location editors download to validate. |
+
+The canonical `$id` is an identifier, not a fetch target. Rackula itself decides whether it
+can load a file offline from the `metadata.schema_version` field and never resolves the
+`$id` over the network, so the canonical identifier is wired before the `schemas.racku.la`
+domain exists.
+
+Your editor is different: it must actually download the schema to validate against it. Use
+the interim served URL for any tooling that fetches a schema, including the
+`# yaml-language-server: $schema=...` hint below. When `schemas.racku.la` DNS is live it
+will serve the artifact at the canonical `$id` path and the fetch URL will converge on the
+`$id`. The dev environment serves the same artifact at
+`https://d.racku.la/schemas/layout-v1.json`.
+
+For the full identifier-versus-fetch rationale, see the Published Schema section of
+[SCHEMA.md](../reference/SCHEMA.md#published-schema).
+
+## Sample layout with inline schema hint
+
+Add a `# yaml-language-server: $schema=...` comment as the first line of your layout file.
+yaml-language-server reads this comment and validates the rest of the document against the
+schema it points to. This sample is a minimal but valid Rackula layout:
+
+```yaml
+# yaml-language-server: $schema=https://count.racku.la/schemas/layout-v1.json
+metadata:
+  id: 1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed
+  name: Homelab Rack
+  schema_version: "1.0"
+name: Homelab Rack
+rack:
+  id: rack-0
+  name: Primary Rack
+  height: 12
+  width: 19
+  desc_units: false
+  form_factor: 4-post-cabinet
+  starting_unit: 1
+  position: 0
+  devices:
+    - id: 550e8400-e29b-41d4-a716-446655440000
+      device_type: dell-r650
+      position: 10
+      face: front
+      name: Web Server
+    - id: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+      device_type: 2u-ups
+      position: 1
+      face: front
+      name: Main UPS
+device_types:
+  - slug: dell-r650
+    manufacturer: Dell
+    model: PowerEdge R650
+    u_height: 1
+    colour: "#8BE9FD"
+    category: server
+  - slug: 2u-ups
+    manufacturer: APC
+    model: Smart-UPS 3000
+    u_height: 2
+    colour: "#FF5555"
+    category: power
+settings:
+  display_mode: label
+  show_labels_on_images: false
+```
+
+The required fields the schema enforces here are:
+
+- Top level: `name`, `device_types`, `settings`.
+- `metadata`: `id`, `name`, `schema_version`.
+- Each rack: `name`, `height`, `width`, `desc_units`, `form_factor`, `starting_unit`,
+  `position`, `devices`.
+- Each device: `id`, `device_type`, `position`, `face`.
+- Each device type: `slug`, `u_height`, `colour`, `category`.
+- `settings`: `display_mode`, `show_labels_on_images`.
+
+For the full field reference, including optional fields and component arrays, see
+[SCHEMA.md](../reference/SCHEMA.md).
+
+## VS Code setup
+
+Validation in VS Code is provided by the Red Hat YAML extension
+([redhat.vscode-yaml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)),
+which bundles yaml-language-server.
+
+1. Install the YAML extension from the Extensions view (search for `redhat.vscode-yaml`).
+2. Tell the extension which schema applies to your file. Either approach works.
+
+### Option A: inline comment (per file)
+
+Add the schema hint as the first line of the file, exactly as in the sample above:
+
+```yaml
+# yaml-language-server: $schema=https://count.racku.la/schemas/layout-v1.json
+```
+
+The comment travels with the file, so anyone who opens it gets validation without changing
+their own settings. This is the recommended approach for files you share.
+
+### Option B: settings.json mapping (per workspace)
+
+Map a file glob to the schema in your workspace `.vscode/settings.json`. This validates
+matching files without an inline comment:
+
+```json
+{
+  "yaml.schemas": {
+    "https://count.racku.la/schemas/layout-v1.json": [
+      "*.rackula.yaml",
+      "*.rackula.yml"
+    ]
+  }
+}
+```
+
+Adjust the globs to match how you name your layout files.
+
+Other editors that use yaml-language-server (Neovim with a YAML LSP, JetBrains IDEs with a
+YAML plugin) read the same inline `# yaml-language-server: $schema=...` comment, so Option A
+works across editors.
+
+## Limitations
+
+JSON Schema describes structure. It cannot express the cross-field rules that Rackula
+enforces in code, so an editor can report a file as valid that Rackula will still reject on
+load. The schema's own `$description` states this directly: expect roughly 80 percent
+validation coverage, and the Zod schema in `src/lib/schemas/index.ts` is authoritative.
+
+The following are checked by Rackula on load but not by the schema in your editor:
+
+- Cross-field rules (Zod `.refine` and `.superRefine`): referential integrity (a device
+  referencing a parent or container that exists), carrier-first rail placement, and slot
+  fit.
+- Foreign keys: that a `device_type` slug on a placed device matches an entry in the
+  `device_types` library, and similar references between collections.
+- The load-time transform (Zod `.transform`): legacy position migration, rack id
+  generation, and unknown-field preservation, which run only when Rackula opens the file.
+
+Treat editor validation as a fast first pass that catches typos and shape errors. Loading
+the file into Rackula remains the authoritative check.
+
+## Related documentation
+
+- [SCHEMA.md](../reference/SCHEMA.md) - full field reference and the Published Schema
+  section.
+- [NETBOX-IMPORT.md](./NETBOX-IMPORT.md) - importing device types from the NetBox library.

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -129,6 +129,11 @@ served path matches the committed artifact's location. When `schemas.racku.la` i
 it will serve the artifact at the canonical `$id` path and the fetch URL converges on the
 `$id`.
 
+### Editor validation
+
+To validate hand-edited layout YAML in an editor (VS Code, Neovim, JetBrains) against this
+schema, see the [YAML Schema Validation Guide](../guides/yaml-schema-validation.md).
+
 ---
 
 ## DeviceType


### PR DESCRIPTION
## **User description**
## Summary

Adds `docs/guides/yaml-schema-validation.md`, a guide for validating hand-edited Rackula layout YAML in an editor against the published JSON Schema, and links it from the Published Schema section of `docs/reference/SCHEMA.md`.

## Acceptance Criteria

- [x] Publishes the canonical schema URL(s): a two-row table in the "Schema URLs" section gives the canonical `$id` (`https://schemas.racku.la/layout/v1.json`) and the interim served URL (`https://count.racku.la/schemas/layout-v1.json`), plus the dev served URL.
- [x] One sample YAML showing `# yaml-language-server: $schema=...` usage: the "Sample layout with inline schema hint" section, first line `# yaml-language-server: $schema=https://count.racku.la/schemas/layout-v1.json`.
- [x] Concise VS Code + yaml-language-server setup notes: the "VS Code setup" section covers the `redhat.vscode-yaml` extension, Option A (inline comment, per file) and Option B (`yaml.schemas` mapping in `.vscode/settings.json`), plus a note that other yaml-language-server editors read the same inline comment.
- [x] Explicit limitations section: the "Limitations" section lists cross-field rules (`.refine`/`.superRefine`: referential integrity, carrier-first rail placement, slot fit), foreign keys, and the load-time `.transform` migration, with the ~80% coverage framing and that the Zod schema is authoritative.

## Served URL used and why

The sample and the VS Code setup both use the fetchable served URL `https://count.racku.la/schemas/layout-v1.json`, because the editor must download the schema to validate. The canonical `$id` (`https://schemas.racku.la/layout/v1.json`) is a stable identifier, not a fetch target; `schemas.racku.la` DNS does not exist yet. The guide explains the identifier-versus-fetch distinction and mirrors the wording in `SCHEMA.md` (added by #2228).

## Validation

The sample layout was validated through the real Zod-backed `parseLayoutYaml` loader (a temporary vitest test, since removed) to confirm it is structurally correct, not bogus. Required-field coverage matches `static/schemas/layout-v1.json`. ESLint passes; prettier reports no changes; markdown is not gated in CI or pre-commit.

Closes #2229
Part of #571


___

## **CodeAnt-AI Description**
**Add a guide for validating layout YAML in editors**

### What Changed
- Added a guide for validating hand-edited Rackula layout YAML against the published schema in editors
- Explained the difference between the stable schema identifier and the fetchable URL editors should use
- Included a minimal valid sample file, VS Code setup steps, and an inline schema hint example
- Listed the schema limits so users know which layout rules still get checked only when Rackula opens the file
- Linked the new guide from the schema reference page

### Impact
`✅ Faster YAML error checks`
`✅ Fewer invalid layout files`
`✅ Clearer editor setup for schema validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
