### PR TITLE
feat: embed yaml-language-server $schema comment in YAML export (#2230)

### DIFF
--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -42,6 +42,28 @@ function warnDuplicateDeviceIds(layout: Layout): void {
 const STANDARD_RACK_WIDTH = 19;
 
 /**
+ * Interim served base for the published layout JSON Schema. Editors that honour
+ * the `# yaml-language-server: $schema=...` hint fetch this URL, so it must be a
+ * real served, fetchable location, not the canonical `$id`
+ * (`https://schemas.racku.la/layout/v{MAJOR}.json`) whose DNS does not exist
+ * yet. The served path is the prod URL from the Published Schema section of
+ * docs/reference/SCHEMA.md. The `v{MAJOR}` segment is appended from the layout's
+ * `schema_version` MAJOR.
+ */
+const SCHEMA_FETCH_BASE = "https://count.racku.la/schemas/layout-v";
+
+/**
+ * Build the editor `$schema` hint comment, deriving the schema MAJOR from a
+ * `schema_version` string (e.g. "1.0" -> v1). Absent or unparseable versions
+ * default to MAJOR 1, matching the read-side default in SCHEMA.md.
+ */
+function buildSchemaHintComment(schemaVersion: string | undefined): string {
+  const major = Number.parseInt(schemaVersion ?? "1.0", 10);
+  const majorSegment = Number.isNaN(major) || major < 1 ? 1 : major;
+  return `# yaml-language-server: $schema=${SCHEMA_FETCH_BASE}${majorSegment}.json`;
+}
+
+/**
  * Lazily load js-yaml library
  * Cached after first load for subsequent calls
  */
@@ -359,7 +381,10 @@ export async function serializeLayoutToYaml(
 
   appendUnknownSections(layoutForSerialization, layout);
 
-  return serializeToYaml(layoutForSerialization);
+  // Prepend the editor schema hint so YAML language servers validate the export
+  // out of the box (#2230). A leading `#` comment is ignored on read.
+  const body = await serializeToYaml(layoutForSerialization);
+  return `${buildSchemaHintComment(layout.metadata?.schema_version)}\n${body}`;
 }
 
 /**
@@ -412,7 +437,10 @@ export async function serializeLayoutToYamlWithMetadata(
 
   appendUnknownSections(layoutForSerialization, layout);
 
-  return serializeToYaml(layoutForSerialization);
+  // Prepend the editor schema hint so the folder-ZIP `.rackula.yaml` validates
+  // out of the box too (#2230). MAJOR comes from the metadata written here.
+  const body = await serializeToYaml(layoutForSerialization);
+  return `${buildSchemaHintComment(metadata.schema_version)}\n${body}`;
 }
 
 /**

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { serializeLayoutToYaml, parseLayoutYaml } from "$lib/utils/yaml";
+import {
+  serializeLayoutToYaml,
+  serializeLayoutToYamlWithMetadata,
+  parseLayoutYaml,
+} from "$lib/utils/yaml";
 import type { DeviceType } from "$lib/types";
 import {
   createTestContainerChild,
@@ -101,6 +105,83 @@ describe("YAML layout round-trip", () => {
     const child = restored.racks[0]?.devices.find((d) => d.id === "child-1");
     expect(child?.container_id).toBe("container-1");
     expect(child?.slot_id).toBe("slot-left");
+  });
+});
+
+describe("YAML editor schema hint (#2230)", () => {
+  // Asserted via startsWith/string equality on a captured variable rather than a
+  // `toBe("#...")` literal: the latter trips the no-restricted-syntax hardcoded
+  // colour rule (any first arg matching /^#/), a false positive for a YAML
+  // comment line.
+  const HINT_PREFIX = "# yaml-language-server: $schema=";
+
+  it("prepends a yaml-language-server $schema comment as the first line for a v1 layout", async () => {
+    const layout = createTestLayout({
+      metadata: {
+        id: "11111111-1111-4111-8111-111111111111",
+        name: "Test Layout",
+        schema_version: "1.0",
+      },
+    });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    const firstLine = yaml.split("\n")[0];
+    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/layout-v1.json`;
+
+    expect(firstLine.startsWith(HINT_PREFIX)).toBe(true);
+    expect(firstLine === expected).toBe(true);
+  });
+
+  it("derives the schema URL MAJOR from the layout's schema_version", async () => {
+    const layout = createTestLayout({
+      metadata: {
+        id: "22222222-2222-4222-8222-222222222222",
+        name: "Future Layout",
+        schema_version: "2.3",
+      },
+    });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    const firstLine = yaml.split("\n")[0];
+    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/layout-v2.json`;
+
+    expect(firstLine === expected).toBe(true);
+  });
+
+  it("defaults to MAJOR 1 when schema_version is absent", async () => {
+    // createTestLayout has no metadata block, so there is no schema_version.
+    const yaml = await serializeLayoutToYaml(createTestLayout());
+    const firstLine = yaml.split("\n")[0];
+    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/layout-v1.json`;
+
+    expect(firstLine === expected).toBe(true);
+  });
+
+  it("still round-trips cleanly with the comment prepended", async () => {
+    const layout = createTestLayout({ name: "Round Trip Lab" });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    const restored = await parseLayoutYaml(yaml);
+
+    expect(restored.name).toBe("Round Trip Lab");
+  });
+
+  it("prepends the hint on the folder-ZIP metadata export path too", async () => {
+    // The .rackula.yaml inside a folder ZIP is an editor-openable export, so it
+    // carries the same hint, derived from the metadata's schema_version.
+    const yaml = await serializeLayoutToYamlWithMetadata(createTestLayout(), {
+      id: "33333333-3333-4333-8333-333333333333",
+      name: "Archive Lab",
+      schema_version: "1.0",
+    });
+    const firstLine = yaml.split("\n")[0];
+    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/layout-v1.json`;
+
+    expect(firstLine === expected).toBe(true);
+
+    // And the file still parses (the comment is ignored on read).
+    const restored = await parseLayoutYaml(yaml);
+    expect(restored.name).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

Prepend a `# yaml-language-server: $schema=...` comment to exported YAML so editor validation works out of the box.

The exact emitted first line (for a v1 layout):

```
# yaml-language-server: $schema=https://count.racku.la/schemas/layout-v1.json
```

## Acceptance Criteria

- [x] Exported YAML includes the `# yaml-language-server: $schema=...` comment pointing at the served URL.
- [x] Comment references the schema MAJOR matching `schema_version`.

## How MAJOR is derived

`buildSchemaHintComment` parses the layout's `schema_version` MAJOR (`Number.parseInt("1.0", 10)` -> `1`) and builds `https://count.racku.la/schemas/layout-v{MAJOR}.json`. Absent or unparseable versions default to MAJOR 1, matching the read-side default documented in `docs/reference/SCHEMA.md`. This keeps the hint correct automatically if MAJOR ever bumps.

## Served vs canonical URL

The comment points at the interim served, fetchable URL (`https://count.racku.la/schemas/layout-v1.json`), not the canonical `$id` (`https://schemas.racku.la/layout/v1.json`). yaml-language-server fetches the `$schema` URL to validate, and the canonical `schemas.racku.la` DNS does not exist yet. This mirrors the "Published Schema" section of `docs/reference/SCHEMA.md` (added by #2228), which designates the prod served URL as the interim fetch target. A small well-named local constant (`SCHEMA_FETCH_BASE`) holds the served base, commented as the interim fetch base; `SCHEMA_ID` was deliberately not reused since it is the non-fetchable canonical identifier.

## Scope

Applied to both editor-openable YAML export paths via one shared helper:

- `serializeLayoutToYaml` (standalone single-file save / share / API).
- `serializeLayoutToYamlWithMetadata` (the folder-ZIP `.rackula.yaml`). A self-review caught that this second user-facing export path would otherwise produce inconsistent YAML without the hint; both now carry it.

A leading `#` comment is ignored by js-yaml on read, so round-trip load is unaffected (covered by tests).

## Tests

TDD: behavioural tests in `src/tests/yaml-roundtrip.test.ts` assert the first line is the schema hint, that `v{MAJOR}` tracks `schema_version` (v1 default, v2 derived), and that the YAML still round-trips cleanly with the comment prepended, on both serializers.

## Note for the orchestrator

Same-file (different-region) overlap with PR #2418 (issue #2205): that PR edits the read/validation path in `src/lib/utils/yaml.ts`; this PR only touches the write/serializer path. No logical conflict; a textual merge conflict, if any, is trivial.

Closes #2230
Part of #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add a schema hint comment to exported YAML files

### What Changed
- YAML exports now start with a `yaml-language-server` schema comment so editors can validate the file right away
- The schema link matches the layout version in the export, and falls back to version 1 when no version is available
- The folder export’s `.rackula.yaml` file gets the same comment, and imports still work normally with the comment present
- Added coverage for the comment format, version-based schema link, fallback behavior, and round-trip loading

### Impact
`✅ Editor validation on exported YAML`
`✅ Clearer schema errors in YAML editors`
`✅ Fewer broken round-trips from commented exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
