### PR TITLE
docs: note the served schema URL goes live with the next release

### DIFF
--- a/docs/guides/yaml-schema-validation.md
+++ b/docs/guides/yaml-schema-validation.md
@@ -38,8 +38,15 @@ Your editor is different: it must actually download the schema to validate again
 the interim served URL for any tooling that fetches a schema, including the
 `# yaml-language-server: $schema=...` hint below. When `schemas.racku.la` DNS is live it
 will serve the artifact at the canonical `$id` path and the fetch URL will converge on the
-`$id`. The dev environment serves the same artifact at
-`https://d.racku.la/schemas/layout-v1.json`.
+`$id`.
+
+Availability: the served URL goes live with the next Rackula release. Production
+(`count.racku.la`) publishes the schema only on a tagged release, and the dev environment
+(`https://d.racku.la/schemas/layout-v1.json`) is behind access control, so neither is
+fetchable by an external editor until then. Until the artifact is published, an editor cannot
+download the schema and the `# yaml-language-server` hint is simply ignored: this does not
+block editing, and Rackula still loads and validates the file itself offline from
+`metadata.schema_version`.
 
 For the full identifier-versus-fetch rationale, see the Published Schema section of
 [SCHEMA.md](../reference/SCHEMA.md#published-schema).

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -114,12 +114,18 @@ network, so the canonical `$id` is wired before the `schemas.racku.la` domain ex
 
 ### Served location (interim fetch URL)
 
-`static/` is served at the deployment root, so the artifact is reachable today at:
+`static/` is served at the deployment root, so the artifact is published at these paths once
+a release deploys it:
 
 | Environment | URL                                            |
 | ----------- | ---------------------------------------------- |
 | Prod        | `https://count.racku.la/schemas/layout-v1.json` |
 | Dev         | `https://d.racku.la/schemas/layout-v1.json`     |
+
+Availability: production (`count.racku.la`) publishes the schema only on a tagged release, and
+the dev path is behind access control, so the artifact is not externally fetchable until the
+next release ships it. The committed file in `static/schemas/` is the source of truth, and the
+reader rule above works offline regardless of whether the schema is served.
 
 Until the `schemas.racku.la` DNS is live, use the prod served URL above as the fetch URL for
 tooling that resolves a schema (for example a `# yaml-language-server: $schema=...` editor


### PR DESCRIPTION
## **User description**
## Summary

The YAML schema validation guide (#2229) and the Published Schema section of SCHEMA.md (#2228) presented the prod served URL `https://count.racku.la/schemas/layout-v1.json` as fetchable today. It is not yet: production deploys only on a tagged release, and the latest release (v26.6.3) predates the schema artifact, so the path currently returns the SPA shell, not the JSON. The dev path is behind Cloudflare Access.

This adds a short availability caveat to both docs so an early reader is not misled by a non-resolving URL, and makes clear that an unreachable schema does not block editing: Rackula gates loadability offline on `metadata.schema_version` and never fetches the `$id`.

## Changes

- `docs/guides/yaml-schema-validation.md`: add an Availability note under Schema URLs; stop presenting the dev URL as an open fetch source (it is access controlled).
- `docs/reference/SCHEMA.md`: reword "reachable today" to "published once a release deploys it" and add an Availability note under Served location.

Docs-only. No app behaviour, no release required.

Refs #2228, #2229, #571.


___

## **CodeAnt-AI Description**
**Clarify when the published schema URL becomes available**

### What Changed
- Added a note that the served schema URL is only available after the next release ships
- Clarified that the production and dev schema URLs are not externally fetchable before that release
- Explained that editors can ignore the schema link for now without blocking file editing, since Rackula still loads and validates files offline

### Impact
`✅ Clearer schema availability guidance`
`✅ Fewer confusing editor setup attempts`
`✅ Less confusion about when the schema URL can be used`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
