### PR TITLE
fix: rack chrome click selects the rack and populates the Edit panel (#2407)

### DIFF
--- a/e2e/rack-select-editpanel.spec.ts
+++ b/e2e/rack-select-editpanel.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "./helpers/base-test";
+import {
+  gotoWithRack,
+  clickNewRack,
+  completeWizardWithClicks,
+  locators,
+} from "./helpers";
+
+/**
+ * Regression: clicking a rack's canvas click target must populate the Edit
+ * panel for that rack, even when a different rack is the active rack (#2407).
+ *
+ * This exercises the real click -> handler -> selection-store -> panel path,
+ * which the unit test in side-panel-edit-context.test.ts cannot reach (it sets
+ * the store directly).
+ */
+test.describe("Rack selection populates the Edit panel (#2407)", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoWithRack(page);
+  });
+
+  test("clicking a rack while a different rack is active populates the Edit panel", async ({
+    page,
+  }) => {
+    // Two standalone racks.
+    await clickNewRack(page);
+    await completeWizardWithClicks(page, { name: "Second Rack", height: 24 });
+    await expect(page.locator(locators.rackView.dualViewName)).toHaveCount(2);
+
+    const firstRack = page.locator(locators.rackView.dualView).first();
+    const secondRack = page.locator(locators.rackView.dualView).nth(1);
+
+    // Select the FIRST rack: it becomes the active + selected rack and the
+    // Edit panel populates for it.
+    await firstRack.locator(locators.rackView.frontSvg).click();
+    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+
+    // Now select the SECOND rack via its click target while the first rack is
+    // active. The panel must update to the second rack, not fall back to its
+    // empty state (#2407).
+    await secondRack.locator(locators.rackView.frontSvg).click();
+    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    await expect(page.getByLabel("Name", { exact: true })).toHaveValue(
+      "Second Rack",
+    );
+  });
+
+  test("clicking the rack name / outer chrome (not the body) populates the Edit panel", async ({
+    page,
+  }) => {
+    await clickNewRack(page);
+    await completeWizardWithClicks(page, { name: "Second Rack", height: 24 });
+    await expect(page.locator(locators.rackView.dualViewName)).toHaveCount(2);
+
+    const firstRack = page.locator(locators.rackView.dualView).first();
+    const secondRack = page.locator(locators.rackView.dualView).nth(1);
+
+    // Make the first rack the active + selected one.
+    await firstRack.locator(locators.rackView.frontSvg).click();
+    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+
+    // Click the SECOND rack's name (outer chrome, not the rack body). This is
+    // the "area around the rack / the title" click target from #2407: it must
+    // select the rack and populate the Edit panel, not merely focus the
+    // container (whose focus outline looks identical to the selection box).
+    await secondRack.locator(locators.rackView.dualViewName).click();
+    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    await expect(page.getByLabel("Name", { exact: true })).toHaveValue(
+      "Second Rack",
+    );
+  });
+});

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -19,6 +19,8 @@
   import { dispatchContextMenuAtPoint } from "$lib/utils/context-menu";
   import { appDebug } from "$lib/utils/debug";
   import { hapticTap } from "$lib/utils/haptics";
+  import { getCanvasStore } from "$lib/stores/canvas.svelte";
+  import { getPlacementStore } from "$lib/stores/placement.svelte";
 
   interface Props {
     rack: RackType;
@@ -116,6 +118,9 @@
     ondelete,
   }: Props = $props();
 
+  const canvasStore = getCanvasStore();
+  const placementStore = getPlacementStore();
+
   // Element reference for long press
   let containerElement: HTMLDivElement | null = $state(null);
   const rackDualLongPressDebug = appDebug.mobile.extend("rack-dual-view");
@@ -211,8 +216,27 @@
     }
   }
 
-  // Note: Selection is handled by the Rack component's onselect callback
-  // No need for separate click handlers on wrapper divs
+  function handleContainerClick(event: MouseEvent) {
+    // Clicks on the rack views (front/rear) are handled by the Rack component.
+    // Only clicks on the container's own chrome (the rack name and the padding
+    // around the views) reach here unhandled. Without this they merely focus
+    // the container, whose focus outline is the same colour and weight as the
+    // selection outline, so the rack looks selected while the Edit panel stays
+    // empty (#2407). Select the rack so the chrome is a real click target,
+    // consistent with the keyboard handler above.
+    if (
+      event.target instanceof Element &&
+      event.target.closest(
+        '[data-testid="rack-front"], [data-testid="rack-rear"]',
+      )
+    ) {
+      return;
+    }
+    // Mirror Rack's guards so a post-pan synthetic click or a click during
+    // device placement does not select the rack from its chrome.
+    if (canvasStore.isPanning || placementStore.isPlacing) return;
+    handleSelect();
+  }
 
   // Handle device drop on front view - add face: 'front' to the event
   function handleFrontDeviceDrop(
@@ -275,6 +299,7 @@
       : 'front view only'}{isActive ? ', active' : ''}{selected
       ? ', selected'
       : ''}"
+    onclick={handleContainerClick}
     onkeydown={handleKeyDown}
     style:--long-press-progress={longPressProgress}
   >


### PR DESCRIPTION
## **User description**
## Summary

Reopened bug #2407: clicking a rack's outer click target (the rack name / the area around the rack) drew what looked like a selection box but left the Edit panel on its empty state. The earlier fix (#2417) was deployed to dev but the symptom persisted.

## Root cause

The `.rack-dual-view` container is `tabindex="0"` / `role="option"`. Its chrome (the rack name and surrounding padding) had no click handler, so the only effect of clicking it was DOM focus. The focus outline:

```css
.rack-dual-view:focus    { outline: 2px solid var(--colour-selection); outline-offset: 2px; }
.rack-dual-view.selected { outline: 2px solid var(--colour-selection); outline-offset: 4px; }
```

uses the same colour and weight as the selection outline, so the rack appeared selected while `selectionStore.selectedRackId` was never set and the Edit panel (which #2417 switched to read `selectedRackId`) stayed empty. Clicking the rack body worked because the SVG's own `onclick` fires `selectRack`. #2417 changed how the panel reads the selection but never made the chrome click set it, which is why the fix looked deployed but ineffective.

## Fix

Give the `.rack-dual-view` container a click handler that selects the rack for clicks on its chrome. Clicks that land on the rack views (front/rear) return early and stay with the `Rack` component, which already owns selection, click-to-place, and post-pan synthetic-click guarding. The handler mirrors `Rack`'s `isPanning` / `isPlacing` guards so chrome clicks behave consistently, and reuses the stable `data-testid` anchors to discriminate body clicks from chrome clicks.

## Test Plan

- [x] New E2E spec `e2e/rack-select-editpanel.spec.ts` exercises the real click -> selection store -> panel path for both the rack body and the rack chrome (the unit test in #2417 could only set the store directly, so it never caught this). The chrome-click test fails on `main` and passes with this change.
- [x] `npm run lint` clean on changed files
- [x] `svelte-check` clean for `RackDualView.svelte`
- [x] Regression set green: `basic-workflow`, `dual-view`, `keyboard`, `view-reset`, `multi-rack`, `mobile-placement-mouse`, `device-name`

Closes #2407


___

## **CodeAnt-AI Description**
**Clicking a rack’s name or outer area now selects it and opens its Edit panel**

### What Changed
- Clicking the rack body or the rack’s outer chrome now selects that rack and fills the Edit panel with its details
- Clicking the rack name or surrounding padding no longer leaves the rack looking selected while the panel stays empty
- Rack chrome clicks are ignored while the app is panning or placing devices, matching the behavior of the rack body
- Added a regression test that covers both rack-body clicks and rack-chrome clicks through the full selection flow

### Impact
`✅ Fewer empty Edit panels after rack clicks`
`✅ Clearer rack selection from the name area`
`✅ Safer click behavior during panning and device placement`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
