### PR TITLE
chore: drive mobile chrome from the shared command registry (#2465)

### DIFF
--- a/docs/superpowers/specs/2026-06-18-mobile-ux-design.md
+++ b/docs/superpowers/specs/2026-06-18-mobile-ux-design.md
@@ -1,9 +1,6 @@
 # Mobile UX Design
 
-Status: Draft for review
-Date: 2026-06-18
-Milestone: M12 -- Mobile & Touch UX
-Supersedes: the prior `Epic: Mobile Phone Experience` (#1044, closed without a usable result)
+Status: Draft for review Date: 2026-06-18 Milestone: M12 -- Mobile & Touch UX Supersedes: the prior `Epic: Mobile Phone Experience` (#1044, closed without a usable result)
 
 ## Context
 

--- a/docs/superpowers/specs/assets/2026-06-18-mobile-ux/mockup.html
+++ b/docs/superpowers/specs/assets/2026-06-18-mobile-ux/mockup.html
@@ -1,309 +1,895 @@
 <!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Rackula mobile mockup</title>
-<style>
-  :root {
-    --bg: #16161c;            /* near-black canvas */
-    --bg-darker: #21222c;
-    --surface: #282a36;
-    --surface-light: #343746;
-    --surface-lighter: #424450;
-    --selection: #44475a;
-    --pink: #ff79c6;
-    --pink-muted: #c45b9a;
-    --purple: #bd93f9;
-    --cyan: #8be9fd;
-    --green: #50fa7b;
-    --red: #ff5555;
-    --text: #f8f8f2;
-    --muted: #9a9a9a;
-    --comment: #6272a4;
-    --border: #343746;
-    --radius: 10px;
-    --radius-sm: 7px;
-    font-family: -apple-system, "Segoe UI", Inter, system-ui, sans-serif;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  html, body { width: 834px; height: 1180px; }
-  body { background: var(--bg); color: var(--text); overflow: hidden; }
-  .app { display: flex; flex-direction: column; height: 1180px; }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Rackula mobile mockup</title>
+    <style>
+      :root {
+        --bg: #16161c; /* near-black canvas */
+        --bg-darker: #21222c;
+        --surface: #282a36;
+        --surface-light: #343746;
+        --surface-lighter: #424450;
+        --selection: #44475a;
+        --pink: #ff79c6;
+        --pink-muted: #c45b9a;
+        --purple: #bd93f9;
+        --cyan: #8be9fd;
+        --green: #50fa7b;
+        --red: #ff5555;
+        --text: #f8f8f2;
+        --muted: #9a9a9a;
+        --comment: #6272a4;
+        --border: #343746;
+        --radius: 10px;
+        --radius-sm: 7px;
+        font-family: -apple-system, "Segoe UI", Inter, system-ui, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html,
+      body {
+        width: 834px;
+        height: 1180px;
+      }
+      body {
+        background: var(--bg);
+        color: var(--text);
+        overflow: hidden;
+      }
+      .app {
+        display: flex;
+        flex-direction: column;
+        height: 1180px;
+      }
 
-  /* ---------- top bar ---------- */
-  .topbar {
-    position: relative;
-    height: 60px; flex: 0 0 60px; display: flex; align-items: center; justify-content: space-between;
-    padding: 0 20px; background: var(--bg-darker);
-    border-bottom: 1px solid var(--border);
-  }
-  .tb-left { display: flex; align-items: center; gap: 18px; }
-  .tb-right { display: flex; align-items: center; }
-  .logo {
-    width: 46px; height: 46px; border-radius: 11px; background: var(--surface-light);
-    display: grid; place-items: center; color: var(--purple); font-size: 22px;
-    border: 1px solid var(--border);
-  }
-  .iconbtn { width: 46px; height: 46px; border-radius: 11px; display: grid; place-items: center;
-    color: var(--muted); font-size: 19px; }
-  .iconbtn.boxed { background: var(--surface-light); border: 1px solid var(--border); }
-  .layoutname { font-size: 19px; font-weight: 600; position: absolute; left: 50%; top: 50%;
-    transform: translate(-50%, -50%); white-space: nowrap; }
-  .layoutname .chev { color: var(--muted); font-size: 13px; }
-  .spacer { flex: 1; }
-  .undoredo { display: flex; gap: 4px; }
-  .undoredo .iconbtn { background: var(--surface); border: 1px solid var(--border); border-radius: 999px; }
-  .chip { display: flex; align-items: center; gap: 8px; padding: 10px 15px; border-radius: 10px;
-    background: var(--surface); border: 1px solid var(--border); font-size: 14px; color: var(--text); }
-  .chip .dot { width: 9px; height: 9px; border-radius: 50%; background: #ffb86c; }
-  .chip-target { color: var(--muted); }
-  .canvas-history { position: absolute; left: 26px; bottom: 22px; display: flex; gap: 8px; }
-  .histbtn { width: 64px; height: 64px; border-radius: 12px; background: var(--bg-darker);
-    border: 1px solid var(--border); display: grid; place-items: center; font-size: 26px; color: var(--text);
-    box-shadow: 0 5px 16px rgba(0,0,0,0.45); }
-  body[data-mode="placement"] .canvas-history { display: none; }
+      /* ---------- top bar ---------- */
+      .topbar {
+        position: relative;
+        height: 60px;
+        flex: 0 0 60px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 20px;
+        background: var(--bg-darker);
+        border-bottom: 1px solid var(--border);
+      }
+      .tb-left {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+      }
+      .tb-right {
+        display: flex;
+        align-items: center;
+      }
+      .logo {
+        width: 46px;
+        height: 46px;
+        border-radius: 11px;
+        background: var(--surface-light);
+        display: grid;
+        place-items: center;
+        color: var(--purple);
+        font-size: 22px;
+        border: 1px solid var(--border);
+      }
+      .iconbtn {
+        width: 46px;
+        height: 46px;
+        border-radius: 11px;
+        display: grid;
+        place-items: center;
+        color: var(--muted);
+        font-size: 19px;
+      }
+      .iconbtn.boxed {
+        background: var(--surface-light);
+        border: 1px solid var(--border);
+      }
+      .layoutname {
+        font-size: 19px;
+        font-weight: 600;
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        white-space: nowrap;
+      }
+      .layoutname .chev {
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .spacer {
+        flex: 1;
+      }
+      .undoredo {
+        display: flex;
+        gap: 4px;
+      }
+      .undoredo .iconbtn {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 999px;
+      }
+      .chip {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 15px;
+        border-radius: 10px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        font-size: 14px;
+        color: var(--text);
+      }
+      .chip .dot {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: #ffb86c;
+      }
+      .chip-target {
+        color: var(--muted);
+      }
+      .canvas-history {
+        position: absolute;
+        left: 26px;
+        bottom: 22px;
+        display: flex;
+        gap: 8px;
+      }
+      .histbtn {
+        width: 64px;
+        height: 64px;
+        border-radius: 12px;
+        background: var(--bg-darker);
+        border: 1px solid var(--border);
+        display: grid;
+        place-items: center;
+        font-size: 26px;
+        color: var(--text);
+        box-shadow: 0 5px 16px rgba(0, 0, 0, 0.45);
+      }
+      body[data-mode="placement"] .canvas-history {
+        display: none;
+      }
 
-  /* placement banner replaces the top bar in placement mode */
-  .banner {
-    height: 60px; flex: 0 0 60px; display: none; align-items: center; gap: 12px;
-    padding: 0 20px; background: rgba(189,147,249,0.14);
-    border-bottom: 1px solid var(--purple); font-size: 18px; font-weight: 600;
-  }
-  .banner .dot { color: var(--purple); font-size: 22px; }
-  .banner .cancel { margin-left: auto; padding: 11px 18px; border-radius: 9px;
-    border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 15px; }
+      /* placement banner replaces the top bar in placement mode */
+      .banner {
+        height: 60px;
+        flex: 0 0 60px;
+        display: none;
+        align-items: center;
+        gap: 12px;
+        padding: 0 20px;
+        background: rgba(189, 147, 249, 0.14);
+        border-bottom: 1px solid var(--purple);
+        font-size: 18px;
+        font-weight: 600;
+      }
+      .banner .dot {
+        color: var(--purple);
+        font-size: 22px;
+      }
+      .banner .cancel {
+        margin-left: auto;
+        padding: 11px 18px;
+        border-radius: 9px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--text);
+        font-size: 15px;
+      }
 
-  /* ---------- canvas ---------- */
-  .canvas { flex: 1; position: relative; display: flex; flex-direction: column;
-    align-items: center; padding-top: 40px; }
-  .title { color: var(--pink); font-size: 32px; font-weight: 700; margin-bottom: 30px; letter-spacing: .3px; }
-  .racks { display: flex; gap: 46px; }
-  .rack { width: 300px; background: rgba(40,42,54,0.45); border: 1px solid var(--border);
-    border-radius: 12px; padding: 14px 14px 18px; }
-  .rack h3 { text-align: center; color: var(--muted); font-size: 15px; letter-spacing: 3px;
-    font-weight: 600; margin-bottom: 12px; }
-  .slot { display: flex; align-items: center; gap: 10px; height: 38px; margin-bottom: 5px; }
-  .u { width: 16px; text-align: right; color: var(--comment); font-size: 13px; flex: 0 0 16px; }
-  .dev { flex: 1; height: 36px; border-radius: 7px; display: flex; align-items: center;
-    gap: 10px; padding: 0 12px; color: #fff; font-size: 16px; font-weight: 600;
-    box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08); }
-  .dev .ic { width: 20px; height: 20px; flex: 0 0 20px; opacity: .92; }
-  .dev.firewall { background: linear-gradient(180deg,#e0574f,#c93f37); }
-  .dev.switch { background: linear-gradient(180deg,#7468ad,#665aa3); }
-  .dev.cable { background: linear-gradient(180deg,#5566a6,#4a5b9c); }
-  .dev.pdu { background: linear-gradient(180deg,#a85050,#8f4242); }
-  .empty { flex: 1; height: 36px; border-radius: 7px; border: 1px dashed rgba(196,91,154,0.5); }
-  .gesture { margin-top: 26px; color: var(--muted); font-size: 14px; }
+      /* ---------- canvas ---------- */
+      .canvas {
+        flex: 1;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding-top: 40px;
+      }
+      .title {
+        color: var(--pink);
+        font-size: 32px;
+        font-weight: 700;
+        margin-bottom: 30px;
+        letter-spacing: 0.3px;
+      }
+      .racks {
+        display: flex;
+        gap: 46px;
+      }
+      .rack {
+        width: 300px;
+        background: rgba(40, 42, 54, 0.45);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 14px 14px 18px;
+      }
+      .rack h3 {
+        text-align: center;
+        color: var(--muted);
+        font-size: 15px;
+        letter-spacing: 3px;
+        font-weight: 600;
+        margin-bottom: 12px;
+      }
+      .slot {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        height: 38px;
+        margin-bottom: 5px;
+      }
+      .u {
+        width: 16px;
+        text-align: right;
+        color: var(--comment);
+        font-size: 13px;
+        flex: 0 0 16px;
+      }
+      .dev {
+        flex: 1;
+        height: 36px;
+        border-radius: 7px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 0 12px;
+        color: #fff;
+        font-size: 16px;
+        font-weight: 600;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+      }
+      .dev .ic {
+        width: 20px;
+        height: 20px;
+        flex: 0 0 20px;
+        opacity: 0.92;
+      }
+      .dev.firewall {
+        background: linear-gradient(180deg, #e0574f, #c93f37);
+      }
+      .dev.switch {
+        background: linear-gradient(180deg, #7468ad, #665aa3);
+      }
+      .dev.cable {
+        background: linear-gradient(180deg, #5566a6, #4a5b9c);
+      }
+      .dev.pdu {
+        background: linear-gradient(180deg, #a85050, #8f4242);
+      }
+      .empty {
+        flex: 1;
+        height: 36px;
+        border-radius: 7px;
+        border: 1px dashed rgba(196, 91, 154, 0.5);
+      }
+      .gesture {
+        margin-top: 26px;
+        color: var(--muted);
+        font-size: 14px;
+      }
 
-  /* floating canvas controls (zoom lives here, not in the nav) */
-  .canvas-fit { position: absolute; right: 26px; bottom: 22px; display: flex;
-    flex-direction: column; align-items: center; gap: 6px; }
-  .fitbtn { width: 54px; height: 54px; border-radius: 999px; background: var(--bg-darker);
-    border: 1px solid var(--border); display: grid; place-items: center; color: var(--text);
-    font-size: 24px; box-shadow: 0 5px 16px rgba(0,0,0,0.45); }
-  .zoomread { font-size: 12px; color: var(--muted); }
-  body[data-mode="placement"] .canvas-fit { display: none; }
+      /* floating canvas controls (zoom lives here, not in the nav) */
+      .canvas-fit {
+        position: absolute;
+        right: 26px;
+        bottom: 22px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 6px;
+      }
+      .fitbtn {
+        width: 54px;
+        height: 54px;
+        border-radius: 999px;
+        background: var(--bg-darker);
+        border: 1px solid var(--border);
+        display: grid;
+        place-items: center;
+        color: var(--text);
+        font-size: 24px;
+        box-shadow: 0 5px 16px rgba(0, 0, 0, 0.45);
+      }
+      .zoomread {
+        font-size: 12px;
+        color: var(--muted);
+      }
+      body[data-mode="placement"] .canvas-fit {
+        display: none;
+      }
 
-  /* selected + valid-slot states */
-  body[data-mode="edit"] #u8 .dev { box-shadow: 0 0 0 2px var(--pink); }
-  body[data-mode="placement"] .empty.valid {
-    border: 1px solid var(--green); background: rgba(80,250,123,0.13);
-  }
+      /* selected + valid-slot states */
+      body[data-mode="edit"] #u8 .dev {
+        box-shadow: 0 0 0 2px var(--pink);
+      }
+      body[data-mode="placement"] .empty.valid {
+        border: 1px solid var(--green);
+        background: rgba(80, 250, 123, 0.13);
+      }
 
-  /* ---------- bottom nav (view) ---------- */
-  .bottomnav { height: 78px; flex: 0 0 78px; display: none; align-items: center;
-    justify-content: space-around; background: var(--bg-darker); border-top: 1px solid var(--border);
-    padding-bottom: 6px; }
-  .navitem { display: flex; flex-direction: column; align-items: center; gap: 5px;
-    color: var(--muted); font-size: 13px; }
-  .navitem .ic { width: 24px; height: 24px; display: grid; place-items: center; }
-  .navitem.active { color: var(--text); }
+      /* ---------- bottom nav (view) ---------- */
+      .bottomnav {
+        height: 78px;
+        flex: 0 0 78px;
+        display: none;
+        align-items: center;
+        justify-content: space-around;
+        background: var(--bg-darker);
+        border-top: 1px solid var(--border);
+        padding-bottom: 6px;
+      }
+      .navitem {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 5px;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .navitem .ic {
+        width: 24px;
+        height: 24px;
+        display: grid;
+        place-items: center;
+      }
+      .navitem.active {
+        color: var(--text);
+      }
 
-  /* ---------- inspector sheet (edit) ---------- */
-  .sheet { display: none; flex: 0 0 auto; background: var(--bg-darker);
-    border-top: 1px solid var(--border); border-radius: 18px 18px 0 0; padding: 18px 22px 26px; }
-  .grab { width: 40px; height: 4px; border-radius: 2px; background: var(--selection);
-    margin: 0 auto 16px; }
-  .sheet .head { display: flex; align-items: center; }
-  .sheet .head .name { font-size: 22px; font-weight: 700; }
-  .sheet .head .x { margin-left: auto; color: var(--muted); font-size: 22px; }
-  .sheet .sub { color: var(--muted); font-size: 15px; margin: 4px 0 18px; }
-  .verbs { display: flex; gap: 10px; margin-bottom: 18px; }
-  .verb { flex: 1; height: 50px; border-radius: 11px; background: var(--surface-light);
-    border: 1px solid var(--border); display: flex; align-items: center; justify-content: center;
-    gap: 7px; font-size: 15px; font-weight: 600; color: var(--text); }
-  .verb .ic { width: 18px; height: 18px; }
-  .field { display: flex; align-items: center; height: 48px; border-bottom: 1px solid var(--border);
-    font-size: 16px; }
-  .field .lab { width: 70px; color: var(--muted); }
-  .field .val { flex: 1; }
-  .field .pen { color: var(--muted); font-size: 15px; }
-  .sheet .foot { display: flex; align-items: center; margin-top: 18px; }
-  .more { color: var(--muted); font-size: 15px; }
-  .remove { margin-left: auto; display: flex; align-items: center; gap: 8px;
-    padding: 10px 18px; border-radius: 9px; border: 1px solid #6e3a3a;
-    background: rgba(168,74,74,0.18); color: #ff9b9b; font-size: 15px; font-weight: 600; }
+      /* ---------- inspector sheet (edit) ---------- */
+      .sheet {
+        display: none;
+        flex: 0 0 auto;
+        background: var(--bg-darker);
+        border-top: 1px solid var(--border);
+        border-radius: 18px 18px 0 0;
+        padding: 18px 22px 26px;
+      }
+      .grab {
+        width: 40px;
+        height: 4px;
+        border-radius: 2px;
+        background: var(--selection);
+        margin: 0 auto 16px;
+      }
+      .sheet .head {
+        display: flex;
+        align-items: center;
+      }
+      .sheet .head .name {
+        font-size: 22px;
+        font-weight: 700;
+      }
+      .sheet .head .x {
+        margin-left: auto;
+        color: var(--muted);
+        font-size: 22px;
+      }
+      .sheet .sub {
+        color: var(--muted);
+        font-size: 15px;
+        margin: 4px 0 18px;
+      }
+      .verbs {
+        display: flex;
+        gap: 10px;
+        margin-bottom: 18px;
+      }
+      .verb {
+        flex: 1;
+        height: 50px;
+        border-radius: 11px;
+        background: var(--surface-light);
+        border: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 7px;
+        font-size: 15px;
+        font-weight: 600;
+        color: var(--text);
+      }
+      .verb .ic {
+        width: 18px;
+        height: 18px;
+      }
+      .field {
+        display: flex;
+        align-items: center;
+        height: 48px;
+        border-bottom: 1px solid var(--border);
+        font-size: 16px;
+      }
+      .field .lab {
+        width: 70px;
+        color: var(--muted);
+      }
+      .field .val {
+        flex: 1;
+      }
+      .field .pen {
+        color: var(--muted);
+        font-size: 15px;
+      }
+      .sheet .foot {
+        display: flex;
+        align-items: center;
+        margin-top: 18px;
+      }
+      .more {
+        color: var(--muted);
+        font-size: 15px;
+      }
+      .remove {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 18px;
+        border-radius: 9px;
+        border: 1px solid #6e3a3a;
+        background: rgba(168, 74, 74, 0.18);
+        color: #ff9b9b;
+        font-size: 15px;
+        font-weight: 600;
+      }
 
-  /* view-options sheet (option C: zoom/fit/display live here) */
-  .seg { display: flex; border: 1px solid var(--border); border-radius: 9px; overflow: hidden; flex: 1; height: 66px; }
-  .seg span { flex: 1; display: flex; align-items: center; justify-content: center; font-size: 16px; color: var(--muted); }
-  .seg span.on { background: var(--surface-light); color: var(--text); font-weight: 600; }
-  .vrow { display: flex; align-items: center; gap: 16px; height: 92px; border-bottom: 1px solid var(--border); font-size: 16px; }
-  .vrow .lab { width: 86px; color: var(--muted); flex: 0 0 86px; }
-  .stepper { display: flex; align-items: center; flex: 1; border: 1px solid var(--border);
-    border-radius: 9px; overflow: hidden; }
-  .stepper .pm { width: 98px; height: 66px; display: grid; place-items: center; font-size: 30px;
-    background: var(--surface-light); color: var(--text); }
-  .stepper .val { flex: 1; text-align: center; height: 66px; line-height: 66px; font-size: 18px;
-    border-left: 1px solid var(--border); border-right: 1px solid var(--border); }
-  .vrow.tall { height: 92px; border-bottom: none; gap: 14px; }
-  .fitinline { height: 66px; padding: 0 24px; border-radius: 10px; background: var(--surface-light);
-    border: 1px solid var(--border); color: var(--text); font-size: 16px; font-weight: 600;
-    display: flex; align-items: center; gap: 9px; flex: 0 0 auto; }
-  .lockswitch { width: 58px; height: 34px; border-radius: 9px; background: var(--surface-light);
-    border: 1px solid var(--border); position: relative; flex: 0 0 auto; }
-  .lockswitch .knob { position: absolute; top: 3px; left: 4px; width: 26px; height: 26px; border-radius: 5px;
-    background: var(--muted); }
-  .lrow { display: flex; align-items: center; justify-content: space-between; height: 66px;
-    border-bottom: 1px solid var(--border); font-size: 17px; padding: 0 4px; }
-  .lrow .meta { color: var(--muted); font-size: 14px; }
-  .lrow.current { border-left: 3px solid var(--pink); padding-left: 12px; margin-left: -4px; }
-  .lrow.current .meta { color: var(--pink); }
-  .newrow { margin-top: 18px; height: 60px; width: 100%; border-radius: 10px; border: 1px dashed var(--border);
-    background: transparent; color: var(--text); font-size: 16px; font-weight: 600; }
-  .fitrow { display: flex; align-items: center; justify-content: space-between; height: 64px; margin-top: 4px; }
-  .fitrow .cap { color: var(--muted); font-size: 15px; }
-  .fitbig { display: flex; align-items: center; gap: 9px; padding: 12px 20px; border-radius: 10px;
-    background: var(--surface-light); border: 1px solid var(--border); font-size: 16px; font-weight: 600; }
+      /* view-options sheet (option C: zoom/fit/display live here) */
+      .seg {
+        display: flex;
+        border: 1px solid var(--border);
+        border-radius: 9px;
+        overflow: hidden;
+        flex: 1;
+        height: 66px;
+      }
+      .seg span {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 16px;
+        color: var(--muted);
+      }
+      .seg span.on {
+        background: var(--surface-light);
+        color: var(--text);
+        font-weight: 600;
+      }
+      .vrow {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        height: 92px;
+        border-bottom: 1px solid var(--border);
+        font-size: 16px;
+      }
+      .vrow .lab {
+        width: 86px;
+        color: var(--muted);
+        flex: 0 0 86px;
+      }
+      .stepper {
+        display: flex;
+        align-items: center;
+        flex: 1;
+        border: 1px solid var(--border);
+        border-radius: 9px;
+        overflow: hidden;
+      }
+      .stepper .pm {
+        width: 98px;
+        height: 66px;
+        display: grid;
+        place-items: center;
+        font-size: 30px;
+        background: var(--surface-light);
+        color: var(--text);
+      }
+      .stepper .val {
+        flex: 1;
+        text-align: center;
+        height: 66px;
+        line-height: 66px;
+        font-size: 18px;
+        border-left: 1px solid var(--border);
+        border-right: 1px solid var(--border);
+      }
+      .vrow.tall {
+        height: 92px;
+        border-bottom: none;
+        gap: 14px;
+      }
+      .fitinline {
+        height: 66px;
+        padding: 0 24px;
+        border-radius: 10px;
+        background: var(--surface-light);
+        border: 1px solid var(--border);
+        color: var(--text);
+        font-size: 16px;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        flex: 0 0 auto;
+      }
+      .lockswitch {
+        width: 58px;
+        height: 34px;
+        border-radius: 9px;
+        background: var(--surface-light);
+        border: 1px solid var(--border);
+        position: relative;
+        flex: 0 0 auto;
+      }
+      .lockswitch .knob {
+        position: absolute;
+        top: 3px;
+        left: 4px;
+        width: 26px;
+        height: 26px;
+        border-radius: 5px;
+        background: var(--muted);
+      }
+      .lrow {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        height: 66px;
+        border-bottom: 1px solid var(--border);
+        font-size: 17px;
+        padding: 0 4px;
+      }
+      .lrow .meta {
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .lrow.current {
+        border-left: 3px solid var(--pink);
+        padding-left: 12px;
+        margin-left: -4px;
+      }
+      .lrow.current .meta {
+        color: var(--pink);
+      }
+      .newrow {
+        margin-top: 18px;
+        height: 60px;
+        width: 100%;
+        border-radius: 10px;
+        border: 1px dashed var(--border);
+        background: transparent;
+        color: var(--text);
+        font-size: 16px;
+        font-weight: 600;
+      }
+      .fitrow {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        height: 64px;
+        margin-top: 4px;
+      }
+      .fitrow .cap {
+        color: var(--muted);
+        font-size: 15px;
+      }
+      .fitbig {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        padding: 12px 20px;
+        border-radius: 10px;
+        background: var(--surface-light);
+        border: 1px solid var(--border);
+        font-size: 16px;
+        font-weight: 600;
+      }
 
-  .phone-note { position: absolute; bottom: 90px; left: 50%; transform: translateX(-50%);
-    color: var(--comment); font-size: 12px; }
-</style>
-</head>
-<body data-mode="view">
-<div class="app">
-
-  <!-- TOP BAR (view / edit) -->
-  <div class="topbar" id="topbar">
-    <div class="tb-left">
-      <div class="logo">&#9776;</div>
-      <div class="iconbtn boxed"><svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="20.5" y1="20.5" x2="16.5" y2="16.5"></line></svg></div>
-    </div>
-    <div class="layoutname">Network Closet</div>
-    <div class="tb-right">
-      <div class="chip"><span class="dot"></span>Unsaved <span class="chip-target">&middot; Browser</span></div>
-    </div>
-  </div>
-
-  <!-- PLACEMENT BANNER -->
-  <div class="banner" id="banner">
-    <span class="dot">&#10753;</span> Placing: PowerEdge R320 (1U)
-    <span class="cancel">Cancel</span>
-  </div>
-
-  <!-- CANVAS (shared) -->
-  <div class="canvas">
-    <div class="title">Network Closet</div>
-    <div class="racks">
-      <div class="rack">
-        <h3>FRONT</h3>
-        <div class="slot"><span class="u">9</span><div class="dev firewall"><span class="ic">&#9670;</span>Edge Firewall</div></div>
-        <div class="slot" id="u8"><span class="u">8</span><div class="dev switch"><span class="ic">&#9776;</span>Access Switch A</div></div>
-        <div class="slot"><span class="u">7</span><div class="dev cable"><span class="ic">&#8767;</span>Cable Manager</div></div>
-        <div class="slot"><span class="u">6</span><div class="dev switch"><span class="ic">&#9776;</span>Access Switch B</div></div>
-        <div class="slot"><span class="u">5</span><div class="dev cable"><span class="ic">&#8767;</span>Cable Manager</div></div>
-        <div class="slot"><span class="u">4</span><div class="empty valid"></div></div>
-        <div class="slot"><span class="u">3</span><div class="empty valid"></div></div>
-        <div class="slot"><span class="u">2</span><div class="empty valid"></div></div>
-        <div class="slot"><span class="u">1</span><div class="dev pdu"><span class="ic">&#9889;</span>PDU</div></div>
+      .phone-note {
+        position: absolute;
+        bottom: 90px;
+        left: 50%;
+        transform: translateX(-50%);
+        color: var(--comment);
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body data-mode="view">
+    <div class="app">
+      <!-- TOP BAR (view / edit) -->
+      <div class="topbar" id="topbar">
+        <div class="tb-left">
+          <div class="logo">&#9776;</div>
+          <div class="iconbtn boxed">
+            <svg
+              width="21"
+              height="21"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+            >
+              <circle cx="11" cy="11" r="7"></circle>
+              <line x1="20.5" y1="20.5" x2="16.5" y2="16.5"></line>
+            </svg>
+          </div>
+        </div>
+        <div class="layoutname">Network Closet</div>
+        <div class="tb-right">
+          <div class="chip">
+            <span class="dot"></span>Unsaved
+            <span class="chip-target">&middot; Browser</span>
+          </div>
+        </div>
       </div>
-      <div class="rack">
-        <h3>REAR</h3>
-        <div class="slot"><span class="u">9</span><div class="empty"></div></div>
-        <div class="slot"><span class="u">8</span><div class="empty"></div></div>
-        <div class="slot"><span class="u">7</span><div class="empty"></div></div>
-        <div class="slot"><span class="u">6</span><div class="empty"></div></div>
-        <div class="slot"><span class="u">5</span><div class="empty"></div></div>
-        <div class="slot"><span class="u">4</span><div class="empty"></div></div>
-        <div class="slot"><span class="u">3</span><div class="empty"></div></div>
-        <div class="slot"><span class="u">2</span><div class="empty"></div></div>
-        <div class="slot"><span class="u">1</span><div class="empty"></div></div>
+
+      <!-- PLACEMENT BANNER -->
+      <div class="banner" id="banner">
+        <span class="dot">&#10753;</span> Placing: PowerEdge R320 (1U)
+        <span class="cancel">Cancel</span>
+      </div>
+
+      <!-- CANVAS (shared) -->
+      <div class="canvas">
+        <div class="title">Network Closet</div>
+        <div class="racks">
+          <div class="rack">
+            <h3>FRONT</h3>
+            <div class="slot">
+              <span class="u">9</span>
+              <div class="dev firewall">
+                <span class="ic">&#9670;</span>Edge Firewall
+              </div>
+            </div>
+            <div class="slot" id="u8">
+              <span class="u">8</span>
+              <div class="dev switch">
+                <span class="ic">&#9776;</span>Access Switch A
+              </div>
+            </div>
+            <div class="slot">
+              <span class="u">7</span>
+              <div class="dev cable">
+                <span class="ic">&#8767;</span>Cable Manager
+              </div>
+            </div>
+            <div class="slot">
+              <span class="u">6</span>
+              <div class="dev switch">
+                <span class="ic">&#9776;</span>Access Switch B
+              </div>
+            </div>
+            <div class="slot">
+              <span class="u">5</span>
+              <div class="dev cable">
+                <span class="ic">&#8767;</span>Cable Manager
+              </div>
+            </div>
+            <div class="slot">
+              <span class="u">4</span>
+              <div class="empty valid"></div>
+            </div>
+            <div class="slot">
+              <span class="u">3</span>
+              <div class="empty valid"></div>
+            </div>
+            <div class="slot">
+              <span class="u">2</span>
+              <div class="empty valid"></div>
+            </div>
+            <div class="slot">
+              <span class="u">1</span>
+              <div class="dev pdu"><span class="ic">&#9889;</span>PDU</div>
+            </div>
+          </div>
+          <div class="rack">
+            <h3>REAR</h3>
+            <div class="slot">
+              <span class="u">9</span>
+              <div class="empty"></div>
+            </div>
+            <div class="slot">
+              <span class="u">8</span>
+              <div class="empty"></div>
+            </div>
+            <div class="slot">
+              <span class="u">7</span>
+              <div class="empty"></div>
+            </div>
+            <div class="slot">
+              <span class="u">6</span>
+              <div class="empty"></div>
+            </div>
+            <div class="slot">
+              <span class="u">5</span>
+              <div class="empty"></div>
+            </div>
+            <div class="slot">
+              <span class="u">4</span>
+              <div class="empty"></div>
+            </div>
+            <div class="slot">
+              <span class="u">3</span>
+              <div class="empty"></div>
+            </div>
+            <div class="slot">
+              <span class="u">2</span>
+              <div class="empty"></div>
+            </div>
+            <div class="slot">
+              <span class="u">1</span>
+              <div class="empty"></div>
+            </div>
+          </div>
+        </div>
+        <div class="gesture" id="gesture">
+          pinch to zoom &middot; two-finger pan &middot; double-tap to fit
+        </div>
+        <div class="canvas-history">
+          <div class="histbtn">&#8634;</div>
+          <div class="histbtn">&#8635;</div>
+        </div>
+      </div>
+
+      <!-- BOTTOM NAV (view) -->
+      <div class="bottomnav" id="bottomnav">
+        <div class="navitem active"><span class="ic">&#9636;</span>Layouts</div>
+        <div class="navitem"><span class="ic">&#9707;</span>Racks</div>
+        <div class="navitem"><span class="ic">&#9783;</span>Devices</div>
+        <div class="navitem">
+          <span class="ic"
+            ><svg
+              width="22"
+              height="22"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path>
+              <circle cx="12" cy="12" r="3"></circle></svg></span
+          >View
+        </div>
+      </div>
+
+      <!-- INSPECTOR SHEET (edit) -->
+      <div class="sheet" id="sheet">
+        <div class="grab"></div>
+        <div class="head">
+          <span class="name">Access Switch A</span
+          ><span class="x">&#10005;</span>
+        </div>
+        <div class="sub">
+          Switch (48-Port) &middot; 1U &middot; U8 &middot; Front
+        </div>
+        <div class="verbs">
+          <div class="verb"><span class="ic">&#9650;</span>Up</div>
+          <div class="verb"><span class="ic">&#9660;</span>Down</div>
+          <div class="verb"><span class="ic">&#8646;</span>Flip</div>
+          <div class="verb"><span class="ic">&#10697;</span>Duplicate</div>
+        </div>
+        <div class="field">
+          <span class="lab">Name</span><span class="val">Access Switch A</span
+          ><span class="pen">&#9998;</span>
+        </div>
+        <div class="field">
+          <span class="lab">IP</span
+          ><span class="val" style="color: var(--muted)">e.g. 192.168.1.10</span
+          ><span class="pen">&#9998;</span>
+        </div>
+        <div class="foot">
+          <span class="more">&#8943; More fields</span
+          ><span class="remove">&#128465; Remove</span>
+        </div>
+      </div>
+
+      <!-- VIEW OPTIONS SHEET (option C) -->
+      <div class="sheet" id="viewsheet">
+        <div class="grab"></div>
+        <div class="head">
+          <span class="name">View</span><span class="x">&#10005;</span>
+        </div>
+        <div style="height: 14px"></div>
+        <div class="vrow">
+          <span class="lab">Display</span>
+          <div class="seg">
+            <span class="on">Labels</span><span>Images</span><span>Both</span>
+          </div>
+        </div>
+        <div class="vrow">
+          <span class="lab">Read-only</span>
+          <span class="cap" style="flex: 1">Lock the layout for viewing</span>
+          <div class="lockswitch"><span class="knob"></span></div>
+        </div>
+        <div class="vrow tall">
+          <span class="lab">Zoom</span>
+          <div class="stepper">
+            <div class="pm">&#8722;</div>
+            <div class="val">100%</div>
+            <div class="pm">&#43;</div>
+          </div>
+          <button class="fitinline">&#10530; Fit to screen</button>
+        </div>
+      </div>
+
+      <!-- LAYOUTS SHEET (from the bottom Layouts tab) -->
+      <div class="sheet" id="layoutsheet">
+        <div class="grab"></div>
+        <div class="head">
+          <span class="name">Layouts</span><span class="x">&#10005;</span>
+        </div>
+        <div style="height: 10px"></div>
+        <div class="lrow current">
+          <span>Network Closet</span
+          ><span class="meta">2 racks &middot; current</span>
+        </div>
+        <div class="lrow">
+          <span>Home Lab</span><span class="meta">1 rack</span>
+        </div>
+        <div class="lrow">
+          <span>Studio Rack</span><span class="meta">3 racks</span>
+        </div>
+        <button class="newrow">+ New layout</button>
       </div>
     </div>
-    <div class="gesture" id="gesture">pinch to zoom &middot; two-finger pan &middot; double-tap to fit</div>
-    <div class="canvas-history"><div class="histbtn">&#8634;</div><div class="histbtn">&#8635;</div></div>
-  </div>
-
-  <!-- BOTTOM NAV (view) -->
-  <div class="bottomnav" id="bottomnav">
-    <div class="navitem active"><span class="ic">&#9636;</span>Layouts</div>
-    <div class="navitem"><span class="ic">&#9707;</span>Racks</div>
-    <div class="navitem"><span class="ic">&#9783;</span>Devices</div>
-    <div class="navitem"><span class="ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"></path><circle cx="12" cy="12" r="3"></circle></svg></span>View</div>
-  </div>
-
-  <!-- INSPECTOR SHEET (edit) -->
-  <div class="sheet" id="sheet">
-    <div class="grab"></div>
-    <div class="head"><span class="name">Access Switch A</span><span class="x">&#10005;</span></div>
-    <div class="sub">Switch (48-Port) &middot; 1U &middot; U8 &middot; Front</div>
-    <div class="verbs">
-      <div class="verb"><span class="ic">&#9650;</span>Up</div>
-      <div class="verb"><span class="ic">&#9660;</span>Down</div>
-      <div class="verb"><span class="ic">&#8646;</span>Flip</div>
-      <div class="verb"><span class="ic">&#10697;</span>Duplicate</div>
-    </div>
-    <div class="field"><span class="lab">Name</span><span class="val">Access Switch A</span><span class="pen">&#9998;</span></div>
-    <div class="field"><span class="lab">IP</span><span class="val" style="color:var(--muted)">e.g. 192.168.1.10</span><span class="pen">&#9998;</span></div>
-    <div class="foot"><span class="more">&#8943; More fields</span><span class="remove">&#128465; Remove</span></div>
-  </div>
-
-  <!-- VIEW OPTIONS SHEET (option C) -->
-  <div class="sheet" id="viewsheet">
-    <div class="grab"></div>
-    <div class="head"><span class="name">View</span><span class="x">&#10005;</span></div>
-    <div style="height:14px"></div>
-    <div class="vrow"><span class="lab">Display</span>
-      <div class="seg"><span class="on">Labels</span><span>Images</span><span>Both</span></div></div>
-    <div class="vrow"><span class="lab">Read-only</span>
-      <span class="cap" style="flex:1">Lock the layout for viewing</span>
-      <div class="lockswitch"><span class="knob"></span></div></div>
-    <div class="vrow tall"><span class="lab">Zoom</span>
-      <div class="stepper"><div class="pm">&#8722;</div><div class="val">100%</div><div class="pm">&#43;</div></div>
-      <button class="fitinline">&#10530; Fit to screen</button></div>
-  </div>
-
-  <!-- LAYOUTS SHEET (from the bottom Layouts tab) -->
-  <div class="sheet" id="layoutsheet">
-    <div class="grab"></div>
-    <div class="head"><span class="name">Layouts</span><span class="x">&#10005;</span></div>
-    <div style="height:10px"></div>
-    <div class="lrow current"><span>Network Closet</span><span class="meta">2 racks &middot; current</span></div>
-    <div class="lrow"><span>Home Lab</span><span class="meta">1 rack</span></div>
-    <div class="lrow"><span>Studio Rack</span><span class="meta">3 racks</span></div>
-    <button class="newrow">+ New layout</button>
-  </div>
-
-</div>
-<script>
-  const mode = new URLSearchParams(location.search).get('mode') || 'view';
-  document.body.dataset.mode = mode;
-  const show = (id, on, disp='flex') => { const e=document.getElementById(id); if(e) e.style.display = on?disp:'none'; };
-  show('layoutsheet', false);
-  if (mode === 'view') {
-    show('bottomnav', true); show('sheet', false); show('viewsheet', false); show('topbar', true); show('banner', false);
-  } else if (mode === 'edit') {
-    show('bottomnav', false); show('sheet', true, 'block'); show('viewsheet', false); show('topbar', true); show('banner', false);
-    document.getElementById('gesture').style.display='none';
-  } else if (mode === 'placement') {
-    show('bottomnav', false); show('sheet', false); show('viewsheet', false); show('topbar', false); show('banner', true);
-    document.getElementById('gesture').textContent = 'canvas pan paused while placing';
-  } else if (mode === 'viewopts') {
-    show('bottomnav', false); show('sheet', false); show('viewsheet', true, 'block'); show('topbar', true); show('banner', false);
-  } else if (mode === 'layouts') {
-    show('bottomnav', false); show('sheet', false); show('viewsheet', false); show('layoutsheet', true, 'block'); show('topbar', true); show('banner', false);
-  }
-</script>
-</body>
+    <script>
+      const mode = new URLSearchParams(location.search).get("mode") || "view";
+      document.body.dataset.mode = mode;
+      const show = (id, on, disp = "flex") => {
+        const e = document.getElementById(id);
+        if (e) e.style.display = on ? disp : "none";
+      };
+      show("layoutsheet", false);
+      if (mode === "view") {
+        show("bottomnav", true);
+        show("sheet", false);
+        show("viewsheet", false);
+        show("topbar", true);
+        show("banner", false);
+      } else if (mode === "edit") {
+        show("bottomnav", false);
+        show("sheet", true, "block");
+        show("viewsheet", false);
+        show("topbar", true);
+        show("banner", false);
+        document.getElementById("gesture").style.display = "none";
+      } else if (mode === "placement") {
+        show("bottomnav", false);
+        show("sheet", false);
+        show("viewsheet", false);
+        show("topbar", false);
+        show("banner", true);
+        document.getElementById("gesture").textContent =
+          "canvas pan paused while placing";
+      } else if (mode === "viewopts") {
+        show("bottomnav", false);
+        show("sheet", false);
+        show("viewsheet", true, "block");
+        show("topbar", true);
+        show("banner", false);
+      } else if (mode === "layouts") {
+        show("bottomnav", false);
+        show("sheet", false);
+        show("viewsheet", false);
+        show("layoutsheet", true, "block");
+        show("topbar", true);
+        show("banner", false);
+      }
+    </script>
+  </body>
 </html>

--- a/docs/superpowers/specs/assets/2026-06-18-mobile-ux/mockup.html
+++ b/docs/superpowers/specs/assets/2026-06-18-mobile-ux/mockup.html
@@ -823,7 +823,7 @@
             <div class="val">100%</div>
             <div class="pm">&#43;</div>
           </div>
-          <button class="fitinline">&#10530; Fit to screen</button>
+          <button type="button" class="fitinline">&#10530; Fit to screen</button>
         </div>
       </div>
 
@@ -844,7 +844,7 @@
         <div class="lrow">
           <span>Studio Rack</span><span class="meta">3 racks</span>
         </div>
-        <button class="newrow">+ New layout</button>
+        <button type="button" class="newrow">+ New layout</button>
       </div>
     </div>
     <script>

--- a/src/lib/actions/verb-bars.ts
+++ b/src/lib/actions/verb-bars.ts
@@ -5,6 +5,11 @@
  *
  * Priority: when isDeviceSelected is true, the device list is used regardless
  * of isRackSelected (device selection takes precedence).
+ *
+ * Two projection modes: the desktop floating verb bar filters out disabled
+ * verbs (getVerbsForSelection), while the mobile selection inspector keeps
+ * disabled verbs visible but flagged (getSelectionVerbsWithState) so the user
+ * sees the control but cannot activate it at a rack boundary.
  */
 
 import {
@@ -57,6 +62,46 @@ export function getVerbsForSelection(
     if (action.enabledWhen === undefined || action.enabledWhen(ctx)) {
       result.push(action);
     }
+  }
+  return result;
+}
+
+/** A projected verb with its resolved disabled state, for surfaces that show disabled controls. */
+export interface SelectionVerbItem {
+  id: ActionId;
+  label: string;
+  disabled: boolean;
+}
+
+/**
+ * Project the selection verbs with their enabledWhen-derived disabled state.
+ * Unlike getVerbsForSelection (which filters out disabled verbs for the
+ * desktop floating bar), this keeps every verb visible so the mobile
+ * selection inspector can render disabled buttons at rack boundaries rather
+ * than hiding the control. Returns an empty array when nothing is selected.
+ */
+export function getSelectionVerbsWithState(
+  ctx: ActionEnabledContext,
+): SelectionVerbItem[] {
+  let ids: ActionId[];
+
+  if (ctx.isDeviceSelected) {
+    ids = DEVICE_VERB_IDS;
+  } else if (ctx.isRackSelected) {
+    ids = RACK_VERB_IDS;
+  } else {
+    return [];
+  }
+
+  const result: SelectionVerbItem[] = [];
+  for (const id of ids) {
+    const action = getActionById(id);
+    if (!action) continue;
+    result.push({
+      id: action.id,
+      label: action.label,
+      disabled: action.enabledWhen ? !action.enabledWhen(ctx) : false,
+    });
   }
   return result;
 }

--- a/src/lib/components/DeviceDetails.svelte
+++ b/src/lib/components/DeviceDetails.svelte
@@ -86,16 +86,12 @@
   // the registry did not include it (e.g. move-device-slot is absent for
   // full-width devices), so the template guards with {#if}.
   const moveUpVerb = $derived(verbs.find((v) => v.id === "move-device-up"));
-  const moveDownVerb = $derived(
-    verbs.find((v) => v.id === "move-device-down"),
-  );
+  const moveDownVerb = $derived(verbs.find((v) => v.id === "move-device-down"));
   const flipVerb = $derived(verbs.find((v) => v.id === "flip-device-face"));
   const duplicateVerb = $derived(
     verbs.find((v) => v.id === "duplicate-selection"),
   );
-  const deleteVerb = $derived(
-    verbs.find((v) => v.id === "delete-selection"),
-  );
+  const deleteVerb = $derived(verbs.find((v) => v.id === "delete-selection"));
 
   function dispatch(id: ActionId) {
     onaction?.(id);

--- a/src/lib/components/DeviceDetails.svelte
+++ b/src/lib/components/DeviceDetails.svelte
@@ -1,12 +1,24 @@
 <!--
   DeviceDetails Component
-  Displays detailed information about a device
-  Used in bottom sheet (mobile) and potentially edit panel (desktop)
+  Displays detailed information about a device.
+  Used in bottom sheet (mobile) and potentially edit panel (desktop).
+  When verbs are supplied, the action buttons are projected from the shared
+  actions registry (metadata + enabledWhen) and dispatched by action id, so
+  mobile and desktop share one source of truth for command labels, availability,
+  and behaviour.
 -->
 <script lang="ts">
   import type { PlacedDevice, DeviceType, RackView } from "$lib/types";
+  import type { ActionId } from "$lib/actions/registry";
+  import type { SelectionVerbItem } from "$lib/actions/verb-bars";
   import CategoryIcon from "./CategoryIcon.svelte";
-  import { IconChevronUp, IconChevronDown, IconTrash } from "./icons";
+  import {
+    IconChevronUp,
+    IconChevronDown,
+    IconTrash,
+    IconFlip,
+    IconCopy,
+  } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import { formatPosition, UNITS_PER_U } from "$lib/utils/position";
 
@@ -15,18 +27,16 @@
     deviceType: DeviceType;
     rackView?: RackView;
     rackHeight?: number;
-    /** Show action buttons (remove, move) - used on mobile */
+    /** Show action buttons - used on mobile */
     showActions?: boolean;
-    /** Callback when remove button is clicked */
-    onremove?: () => void;
-    /** Callback when move up button is clicked */
-    onmoveup?: () => void;
-    /** Callback when move down button is clicked */
-    onmovedown?: () => void;
-    /** Whether device can move up (not at top of rack) */
-    canMoveUp?: boolean;
-    /** Whether device can move down (not at bottom of rack) */
-    canMoveDown?: boolean;
+    /**
+     * Registry-projected selection verbs with disabled state. When supplied
+     * (with onaction), the action buttons render from the registry instead of
+     * the legacy bespoke callbacks.
+     */
+    verbs?: SelectionVerbItem[];
+    /** Dispatch a registry verb by action id. */
+    onaction?: (id: ActionId) => void;
   }
 
   let {
@@ -35,11 +45,8 @@
     rackView: _rackView = "front",
     rackHeight: _rackHeight,
     showActions = false,
-    onremove,
-    onmoveup,
-    onmovedown,
-    canMoveUp = true,
-    canMoveDown = true,
+    verbs = [],
+    onaction,
   }: Props = $props();
 
   // Display name: custom name if set, otherwise device type model/slug
@@ -74,6 +81,25 @@
 
   // Height display (e.g., "2U")
   const heightDisplay = $derived(`${deviceType.u_height}U`);
+
+  // Resolve individual verbs from the projected list. Each is undefined when
+  // the registry did not include it (e.g. move-device-slot is absent for
+  // full-width devices), so the template guards with {#if}.
+  const moveUpVerb = $derived(verbs.find((v) => v.id === "move-device-up"));
+  const moveDownVerb = $derived(
+    verbs.find((v) => v.id === "move-device-down"),
+  );
+  const flipVerb = $derived(verbs.find((v) => v.id === "flip-device-face"));
+  const duplicateVerb = $derived(
+    verbs.find((v) => v.id === "duplicate-selection"),
+  );
+  const deleteVerb = $derived(
+    verbs.find((v) => v.id === "delete-selection"),
+  );
+
+  function dispatch(id: ActionId) {
+    onaction?.(id);
+  }
 </script>
 
 <div class="device-details">
@@ -130,40 +156,73 @@
     </div>
   {/if}
 
-  <!-- Action buttons (mobile) -->
-  {#if showActions}
+  <!-- Action buttons (mobile), projected from the actions registry -->
+  {#if showActions && verbs.length > 0}
     <div class="detail-section actions-section">
-      <div class="move-buttons">
+      {#if moveUpVerb || moveDownVerb}
+        <div class="move-buttons">
+          {#if moveUpVerb}
+            <button
+              type="button"
+              class="btn btn-secondary"
+              onclick={() => dispatch(moveUpVerb.id)}
+              disabled={moveUpVerb.disabled}
+              aria-label={moveUpVerb.label}
+            >
+              <IconChevronUp />
+              {moveUpVerb.label}
+            </button>
+          {/if}
+          {#if moveDownVerb}
+            <button
+              type="button"
+              class="btn btn-secondary"
+              onclick={() => dispatch(moveDownVerb.id)}
+              disabled={moveDownVerb.disabled}
+              aria-label={moveDownVerb.label}
+            >
+              <IconChevronDown />
+              {moveDownVerb.label}
+            </button>
+          {/if}
+        </div>
+      {/if}
+      {#if flipVerb}
         <button
           type="button"
           class="btn btn-secondary"
-          onclick={onmoveup}
-          disabled={!canMoveUp}
-          aria-label="Move device up"
+          onclick={() => dispatch(flipVerb.id)}
+          disabled={flipVerb.disabled}
+          aria-label={flipVerb.label}
         >
-          <IconChevronUp />
-          Move Up
+          <IconFlip size={ICON_SIZE.sm} />
+          {flipVerb.label}
         </button>
+      {/if}
+      {#if duplicateVerb}
         <button
           type="button"
           class="btn btn-secondary"
-          onclick={onmovedown}
-          disabled={!canMoveDown}
-          aria-label="Move device down"
+          onclick={() => dispatch(duplicateVerb.id)}
+          disabled={duplicateVerb.disabled}
+          aria-label={duplicateVerb.label}
         >
-          <IconChevronDown />
-          Move Down
+          <IconCopy size={ICON_SIZE.sm} />
+          {duplicateVerb.label}
         </button>
-      </div>
-      <button
-        type="button"
-        class="btn btn-danger"
-        onclick={onremove}
-        aria-label="Remove device from rack"
-      >
-        <IconTrash size={ICON_SIZE.sm} />
-        Remove from Rack
-      </button>
+      {/if}
+      {#if deleteVerb}
+        <button
+          type="button"
+          class="btn btn-danger"
+          onclick={() => dispatch(deleteVerb.id)}
+          disabled={deleteVerb.disabled}
+          aria-label={deleteVerb.label}
+        >
+          <IconTrash size={ICON_SIZE.sm} />
+          {deleteVerb.label}
+        </button>
+      {/if}
     </div>
   {/if}
 </div>

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -69,6 +69,7 @@
   import {
     moveSelectedDeviceUp,
     moveSelectedDeviceDown,
+    moveSelectedDeviceToSlot,
     flipSelectedDeviceFace,
     duplicateSelection,
     canMoveSelectedDeviceSlot,
@@ -555,6 +556,9 @@
         break;
       case "move-device-down":
         moveSelectedDeviceDown();
+        break;
+      case "move-device-slot":
+        moveSelectedDeviceToSlot();
         break;
       case "flip-device-face":
         flipSelectedDeviceFace();

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -64,6 +64,18 @@
   import type { DisplayMode, Layout, RackWidth } from "$lib/types";
   import type { ImportResult } from "$lib/utils/netbox-import";
 
+  import { getSelectionVerbsWithState } from "$lib/actions/verb-bars";
+  import type { ActionEnabledContext, ActionId } from "$lib/actions/registry";
+  import {
+    moveSelectedDeviceUp,
+    moveSelectedDeviceDown,
+    flipSelectedDeviceFace,
+    duplicateSelection,
+    canMoveSelectedDeviceSlot,
+  } from "$lib/actions/selection-actions";
+  import { handleDelete } from "$lib/utils/dialog-actions";
+  import { getStorageMode } from "$lib/storage";
+
   const layoutStore = getLayoutStore();
   const selectionStore = getSelectionStore();
   const uiStore = getUIStore();
@@ -515,44 +527,44 @@
     handleFitAll();
   }
 
-  function handleMobileRemoveDevice() {
-    const activeRack = layoutStore.activeRack;
-    if (selectedDeviceForSheet !== null && activeRack) {
-      layoutStore.removeDeviceFromRack(activeRack.id, selectedDeviceForSheet);
-      handleBottomSheetClose();
-    }
-  }
+  // --- Mobile selection inspector: registry-driven verbs ---
 
-  function handleMobileMoveDeviceUp() {
-    const activeRack = layoutStore.activeRack;
-    if (selectedDeviceForSheet !== null && activeRack) {
-      const device = activeRack.devices[selectedDeviceForSheet];
-      const deviceType = layoutStore.device_types.find(
-        (dt) => dt.slug === device?.device_type,
-      );
-      if (device && deviceType) {
-        const newPosition = device.position + 1;
-        layoutStore.moveDevice(
-          activeRack.id,
-          selectedDeviceForSheet,
-          newPosition,
-        );
-      }
-    }
-  }
+  // Build the live enabledWhen context from the stores, mirroring
+  // VerbBarOverlay's desktop projection so mobile and desktop share one
+  // source of truth for verb availability.
+  const mobileActionCtx = $derived<ActionEnabledContext>({
+    hasSelection: selectionStore.hasSelection,
+    isDeviceSelected: selectionStore.isDeviceSelected,
+    isRackSelected: selectionStore.isRackSelected,
+    canUndo: layoutStore.canUndo,
+    canRedo: layoutStore.canRedo,
+    hasRacks: layoutStore.rackCount > 0,
+    mode: getStorageMode(),
+    canMoveDeviceSlot: canMoveSelectedDeviceSlot(),
+  });
 
-  function handleMobileMoveDeviceDown() {
-    const activeRack = layoutStore.activeRack;
-    if (selectedDeviceForSheet !== null && activeRack) {
-      const device = activeRack.devices[selectedDeviceForSheet];
-      if (device && device.position > 1) {
-        const newPosition = device.position - 1;
-        layoutStore.moveDevice(
-          activeRack.id,
-          selectedDeviceForSheet,
-          newPosition,
-        );
-      }
+  const mobileVerbs = $derived(getSelectionVerbsWithState(mobileActionCtx));
+
+  // Dispatch a registry verb by action id to the shared handler. The handlers
+  // read live selection state from the stores, so they act on the same device
+  // the mobile bottom sheet is showing.
+  function handleMobileVerb(id: ActionId): void {
+    switch (id) {
+      case "move-device-up":
+        moveSelectedDeviceUp();
+        break;
+      case "move-device-down":
+        moveSelectedDeviceDown();
+        break;
+      case "flip-device-face":
+        flipSelectedDeviceFace();
+        break;
+      case "duplicate-selection":
+        duplicateSelection();
+        break;
+      case "delete-selection":
+        handleDelete();
+        break;
     }
   }
 
@@ -634,9 +646,6 @@
     : null}
   {#if device && deviceType}
     {@const rackHeight = activeRack.height}
-    {@const maxPosition = rackHeight - deviceType.u_height + 1}
-    {@const canMoveUp = device.position < maxPosition}
-    {@const canMoveDown = device.position > 1}
     <Dialog
       open={bottomSheetOpen}
       title={deviceType.model ?? "Device"}
@@ -649,11 +658,8 @@
         rackView={activeRack.view}
         {rackHeight}
         showActions={true}
-        onremove={handleMobileRemoveDevice}
-        onmoveup={handleMobileMoveDeviceUp}
-        onmovedown={handleMobileMoveDeviceDown}
-        {canMoveUp}
-        {canMoveDown}
+        verbs={mobileVerbs}
+        onaction={handleMobileVerb}
       />
     </Dialog>
   {/if}

--- a/src/tests/DeviceDetails.test.ts
+++ b/src/tests/DeviceDetails.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/svelte";
 import DeviceDetails from "$lib/components/DeviceDetails.svelte";
 import type { DeviceType, PlacedDevice } from "$lib/types";
+import type { SelectionVerbItem } from "$lib/actions/verb-bars";
 import { toInternalUnits } from "$lib/utils/position";
 
 describe("DeviceDetails", () => {
@@ -115,6 +116,17 @@ describe("DeviceDetails", () => {
   });
 
   describe("Action Buttons", () => {
+    // Verb items as the registry projection would produce them for a
+    // selected device. Labels match the registry definitions.
+    const allVerbs: SelectionVerbItem[] = [
+      { id: "move-device-up", label: "Move device up", disabled: false },
+      { id: "move-device-down", label: "Move device down", disabled: false },
+      { id: "move-device-slot", label: "Move to next cell", disabled: true },
+      { id: "flip-device-face", label: "Flip face", disabled: false },
+      { id: "duplicate-selection", label: "Duplicate selection", disabled: false },
+      { id: "delete-selection", label: "Delete selected", disabled: false },
+    ];
+
     it("does not show action buttons by default", () => {
       render(DeviceDetails, {
         props: {
@@ -123,17 +135,14 @@ describe("DeviceDetails", () => {
         },
       });
       expect(
-        screen.queryByRole("button", { name: /remove/i }),
+        screen.queryByRole("button", { name: /delete selected/i }),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: /move up/i }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: /move down/i }),
+        screen.queryByRole("button", { name: /move device up/i }),
       ).not.toBeInTheDocument();
     });
 
-    it("shows action buttons when showActions is true", () => {
+    it("does not show action buttons when showActions is true but no verbs are supplied", () => {
       render(DeviceDetails, {
         props: {
           device: createTestPlacedDevice(),
@@ -142,123 +151,106 @@ describe("DeviceDetails", () => {
         },
       });
       expect(
-        screen.getByRole("button", { name: /remove device from rack/i }),
-      ).toBeInTheDocument();
+        screen.queryByRole("button", { name: /delete selected/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows registry-projected action buttons when verbs are supplied", () => {
+      render(DeviceDetails, {
+        props: {
+          device: createTestPlacedDevice(),
+          deviceType: createTestDeviceType(),
+          showActions: true,
+          verbs: allVerbs,
+        },
+      });
       expect(
         screen.getByRole("button", { name: /move device up/i }),
       ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /move device down/i }),
       ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /flip face/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /duplicate selection/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /delete selected/i }),
+      ).toBeInTheDocument();
     });
 
-    it("calls onremove when Remove button is clicked", async () => {
-      const handleRemove = vi.fn();
+    it("dispatches move-device-up via onaction when Move Up is clicked", async () => {
+      const onaction = vi.fn();
       render(DeviceDetails, {
         props: {
           device: createTestPlacedDevice(),
           deviceType: createTestDeviceType(),
           showActions: true,
-          onremove: handleRemove,
+          verbs: allVerbs,
+          onaction,
         },
       });
 
-      const removeButton = screen.getByRole("button", {
-        name: /remove device from rack/i,
-      });
-      await fireEvent.click(removeButton);
-
-      expect(handleRemove).toHaveBeenCalledTimes(1);
+      await fireEvent.click(
+        screen.getByRole("button", { name: /move device up/i }),
+      );
+      expect(onaction).toHaveBeenCalledWith("move-device-up");
     });
 
-    it("calls onmoveup when Move Up button is clicked", async () => {
-      const handleMoveUp = vi.fn();
+    it("dispatches delete-selection via onaction when Delete is clicked", async () => {
+      const onaction = vi.fn();
       render(DeviceDetails, {
         props: {
           device: createTestPlacedDevice(),
           deviceType: createTestDeviceType(),
           showActions: true,
-          onmoveup: handleMoveUp,
+          verbs: allVerbs,
+          onaction,
         },
       });
 
-      const moveUpButton = screen.getByRole("button", {
-        name: /move device up/i,
-      });
-      await fireEvent.click(moveUpButton);
-
-      expect(handleMoveUp).toHaveBeenCalledTimes(1);
+      await fireEvent.click(
+        screen.getByRole("button", { name: /delete selected/i }),
+      );
+      expect(onaction).toHaveBeenCalledWith("delete-selection");
     });
 
-    it("calls onmovedown when Move Down button is clicked", async () => {
-      const handleMoveDown = vi.fn();
+    it("renders disabled state from the registry projection", () => {
+      const verbsWithDisabledUp: SelectionVerbItem[] = allVerbs.map((v) =>
+        v.id === "move-device-up" ? { ...v, disabled: true } : v,
+      );
       render(DeviceDetails, {
         props: {
           device: createTestPlacedDevice(),
           deviceType: createTestDeviceType(),
           showActions: true,
-          onmovedown: handleMoveDown,
+          verbs: verbsWithDisabledUp,
         },
       });
 
-      const moveDownButton = screen.getByRole("button", {
-        name: /move device down/i,
-      });
-      await fireEvent.click(moveDownButton);
-
-      expect(handleMoveDown).toHaveBeenCalledTimes(1);
+      expect(
+        screen.getByRole("button", { name: /move device up/i }),
+      ).toBeDisabled();
     });
 
-    it("disables Move Up button when canMoveUp is false", () => {
+    it("enables move buttons when the projection says they are enabled", () => {
       render(DeviceDetails, {
         props: {
           device: createTestPlacedDevice(),
           deviceType: createTestDeviceType(),
           showActions: true,
-          canMoveUp: false,
+          verbs: allVerbs,
         },
       });
 
-      const moveUpButton = screen.getByRole("button", {
-        name: /move device up/i,
-      });
-      expect(moveUpButton).toBeDisabled();
-    });
-
-    it("disables Move Down button when canMoveDown is false", () => {
-      render(DeviceDetails, {
-        props: {
-          device: createTestPlacedDevice(),
-          deviceType: createTestDeviceType(),
-          showActions: true,
-          canMoveDown: false,
-        },
-      });
-
-      const moveDownButton = screen.getByRole("button", {
-        name: /move device down/i,
-      });
-      expect(moveDownButton).toBeDisabled();
-    });
-
-    it("enables both move buttons by default when showActions is true", () => {
-      render(DeviceDetails, {
-        props: {
-          device: createTestPlacedDevice(),
-          deviceType: createTestDeviceType(),
-          showActions: true,
-        },
-      });
-
-      const moveUpButton = screen.getByRole("button", {
-        name: /move device up/i,
-      });
-      const moveDownButton = screen.getByRole("button", {
-        name: /move device down/i,
-      });
-
-      expect(moveUpButton).not.toBeDisabled();
-      expect(moveDownButton).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /move device up/i }),
+      ).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /move device down/i }),
+      ).not.toBeDisabled();
     });
   });
 

--- a/src/tests/DeviceDetails.test.ts
+++ b/src/tests/DeviceDetails.test.ts
@@ -123,7 +123,11 @@ describe("DeviceDetails", () => {
       { id: "move-device-down", label: "Move device down", disabled: false },
       { id: "move-device-slot", label: "Move to next cell", disabled: true },
       { id: "flip-device-face", label: "Flip face", disabled: false },
-      { id: "duplicate-selection", label: "Duplicate selection", disabled: false },
+      {
+        id: "duplicate-selection",
+        label: "Duplicate selection",
+        disabled: false,
+      },
       { id: "delete-selection", label: "Delete selected", disabled: false },
     ];
 

--- a/src/tests/verb-bars.test.ts
+++ b/src/tests/verb-bars.test.ts
@@ -3,6 +3,7 @@ import {
   DEVICE_VERB_IDS,
   RACK_VERB_IDS,
   getVerbsForSelection,
+  getSelectionVerbsWithState,
 } from "$lib/actions/verb-bars";
 import { getActionById } from "$lib/actions/registry";
 import type { ActionEnabledContext } from "$lib/actions/registry";
@@ -214,6 +215,61 @@ describe("verb-bars projection", () => {
     it("export-rack enabledWhen passes for rack selection", () => {
       const action = getActionById("export-rack");
       expect(action?.enabledWhen?.(rackCtx)).toBe(true);
+    });
+  });
+
+  describe("getSelectionVerbsWithState - mobile projection", () => {
+    it("includes all device verbs (even disabled ones) for a device selection", () => {
+      const result = getSelectionVerbsWithState(deviceCtx);
+      // move-device-slot is disabled (canMoveDeviceSlot=false) but still present,
+      // unlike getVerbsForSelection which filters it out.
+      expect(result.map((v) => v.id)).toEqual(DEVICE_VERB_IDS);
+    });
+
+    it("marks move-device-slot as disabled when canMoveDeviceSlot is false", () => {
+      const result = getSelectionVerbsWithState(deviceCtx);
+      const slotVerb = result.find((v) => v.id === "move-device-slot");
+      expect(slotVerb?.disabled).toBe(true);
+    });
+
+    it("marks move-device-slot as enabled when canMoveDeviceSlot is true", () => {
+      const childCtx = { ...deviceCtx, canMoveDeviceSlot: true };
+      const result = getSelectionVerbsWithState(childCtx);
+      const slotVerb = result.find((v) => v.id === "move-device-slot");
+      expect(slotVerb?.disabled).toBe(false);
+    });
+
+    it("marks all device verbs enabled for a fully-capable device context", () => {
+      const childCtx = { ...deviceCtx, canMoveDeviceSlot: true };
+      const result = getSelectionVerbsWithState(childCtx);
+      for (const verb of result) {
+        expect(verb.disabled).toBe(false);
+      }
+    });
+
+    it("returns rack verbs with state when a rack is selected", () => {
+      const result = getSelectionVerbsWithState(rackCtx);
+      expect(result.map((v) => v.id)).toEqual(RACK_VERB_IDS);
+    });
+
+    it("returns an empty array when nothing is selected", () => {
+      expect(getSelectionVerbsWithState(emptyCtx)).toEqual([]);
+    });
+
+    it("device verbs take precedence when both device and rack are selected", () => {
+      const bothCtx: ActionEnabledContext = {
+        ...deviceCtx,
+        isRackSelected: true,
+      };
+      const ids = getSelectionVerbsWithState(bothCtx).map((v) => v.id);
+      expect(ids).toEqual(DEVICE_VERB_IDS);
+    });
+
+    it("labels come from the registry, not hardcoded", () => {
+      const result = getSelectionVerbsWithState(deviceCtx);
+      const upVerb = result.find((v) => v.id === "move-device-up");
+      const registryAction = getActionById("move-device-up");
+      expect(upVerb?.label).toBe(registryAction?.label);
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Route the mobile selection inspector verbs (move up, move down, flip, duplicate, delete) through the shared actions registry instead of bespoke handlers. Mobile now projects available actions from the registry (metadata + enabledWhen) and binds run closures at the call site keyed by action id, following the same pattern as AppMenu and VerbBarOverlay.

- Add `getSelectionVerbsWithState` to `verb-bars.ts`: projects selection verbs with disabled state (not filtered out), so mobile shows disabled buttons at rack boundaries rather than hiding them.
- Refactor `DeviceDetails.svelte` to accept registry-projected verbs + `onaction` dispatch instead of bespoke `onmoveup`/`onmovedown`/`onremove` callbacks with `canMoveUp`/`canMoveDown` booleans. Now renders flip and duplicate verbs from the registry, which were previously absent on mobile.
- Wire `DialogOrchestrator.svelte` mobile bottom sheet to the shared `selection-actions` handlers (`moveSelectedDeviceUp`/`Down`, `flipSelectedDeviceFace`, `duplicateSelection`, `handleDelete`). This also fixes the mobile move bug: the bespoke handlers were bounds-only with no collision check, while the shared handlers use `findNextValidPosition` for collision-aware movement.

## Acceptance Criteria

- [x] Mobile chrome actions come from the registry, not bespoke handlers
- [x] enabledWhen context drives mobile action availability
- [x] No duplicated command definitions between mobile and desktop

## Scope boundary

The move run-handler centralization (one shared closure for both desktop and mobile move) is deferred to #2471. This issue makes mobile registry-aware: metadata + enabledWhen + labels projected from the registry, run closures bound at the mobile call site keyed by action id. As a side effect of using the shared `selection-actions` handlers, mobile move is now collision-aware (was bounds-only).

## Test plan

- [x] `npm run lint` passes
- [x] `npm run test:run` passes (2685 tests, 0 failures)
- [x] `npm run build` passes
- [x] New tests for `getSelectionVerbsWithState` in `verb-bars.test.ts`
- [x] Updated `DeviceDetails.test.ts` to test registry-projected verb rendering and dispatch

Closes #2465

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Show mobile device actions from the shared command registry**

### What Changed
- Mobile device details now show the same actions as the shared registry, including move, flip, duplicate, and delete.
- Disabled actions stay visible on mobile with a disabled state instead of disappearing at rack edges.
- Tapping a mobile action now routes through the shared behavior, so device moves follow the same placement rules as the rest of the app.

### Impact
`✅ Consistent mobile and desktop device actions`
`✅ Fewer hidden controls at rack boundaries`
`✅ Fewer invalid device moves on mobile`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
