### PR TITLE
feat: mobile selection inspector - registry verbs, flip/duplicate (#2462)

### DIFF
--- a/src/lib/components/DeviceDetails.svelte
+++ b/src/lib/components/DeviceDetails.svelte
@@ -1,42 +1,52 @@
 <!--
   DeviceDetails Component
-  Displays detailed information about a device.
-  Used in bottom sheet (mobile) and potentially edit panel (desktop).
-  When verbs are supplied, the action buttons are projected from the shared
-  actions registry (metadata + enabledWhen) and dispatched by action id, so
-  mobile and desktop share one source of truth for command labels, availability,
-  and behaviour.
+  The mobile selection inspector: one bottom sheet for the selected device.
+  Carries the device facts, the registry-driven verbs (nudge up/down, optional
+  slot move, flip, duplicate), inline-editable fields (name, IP, notes), and a
+  quiet, de-emphasised Remove. Verbs project from the shared actions registry
+  (metadata + enabledWhen) and dispatch by action id, so mobile and desktop
+  share one source of truth for command labels, availability, and behaviour.
 -->
 <script lang="ts">
   import type { PlacedDevice, DeviceType, RackView } from "$lib/types";
   import type { ActionId } from "$lib/actions/registry";
   import type { SelectionVerbItem } from "$lib/actions/verb-bars";
-  import CategoryIcon from "./CategoryIcon.svelte";
   import {
     IconChevronUp,
     IconChevronDown,
     IconTrash,
     IconFlip,
     IconCopy,
+    IconChevronRight,
+    IconEdit,
   } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import { formatPosition, UNITS_PER_U } from "$lib/utils/position";
+  import { getCategoryDisplayName } from "$lib/utils/deviceFilters";
 
   interface Props {
     device: PlacedDevice;
     deviceType: DeviceType;
     rackView?: RackView;
     rackHeight?: number;
-    /** Show action buttons - used on mobile */
+    /** Show the verb row, editable fields, and Remove. Used on mobile. */
     showActions?: boolean;
     /**
      * Registry-projected selection verbs with disabled state. When supplied
      * (with onaction), the action buttons render from the registry instead of
-     * the legacy bespoke callbacks.
+     * bespoke per-consumer callbacks.
      */
     verbs?: SelectionVerbItem[];
     /** Dispatch a registry verb by action id. */
     onaction?: (id: ActionId) => void;
+    /** Current IP/hostname for the placement (held outside PlacedDevice). */
+    ip?: string;
+    /** Commit a new placement name (empty string clears the custom name). */
+    oneditname?: (name: string) => void;
+    /** Commit a new IP/hostname (empty string clears it). */
+    oneditip?: (ip: string) => void;
+    /** Commit new placement notes (empty string clears them). */
+    oneditnotes?: (notes: string) => void;
   }
 
   let {
@@ -47,179 +57,266 @@
     showActions = false,
     verbs = [],
     onaction,
+    ip = "",
+    oneditname,
+    oneditip,
+    oneditnotes,
   }: Props = $props();
 
-  // Display name: custom name if set, otherwise device type model/slug
+  // Display name: custom name if set, otherwise device type model/slug.
   const displayName = $derived(
     device.name ?? deviceType.model ?? deviceType.slug,
   );
 
-  // Format position display as whole-U (e.g., "U12-U13, Front" or "U1, Front")
-  const positionDisplay = $derived.by(() => {
-    // Format bottom position
-    const bottomPosition = formatPosition(device.position);
-
-    // Calculate top position in internal units and format
+  // Compact one-line summary: Type - height - position - face.
+  const positionLabel = $derived.by(() => {
+    const bottom = formatPosition(device.position);
     const topInternal =
       device.position + (deviceType.u_height - 1) * UNITS_PER_U;
-    const topPosition = formatPosition(topInternal);
-
-    // For multi-U devices, show range; for 1U devices, show single position
-    const positionStr =
-      deviceType.u_height === 1
-        ? bottomPosition
-        : `${bottomPosition}-${topPosition}`;
-
-    const faceStr =
-      device.face === "both"
-        ? "Both Faces"
-        : device.face === "front"
-          ? "Front"
-          : "Rear";
-    return `${positionStr}, ${faceStr}`;
+    const top = formatPosition(topInternal);
+    return deviceType.u_height === 1 ? bottom : `${bottom}-${top}`;
   });
 
-  // Height display (e.g., "2U")
-  const heightDisplay = $derived(`${deviceType.u_height}U`);
+  const faceLabel = $derived(
+    device.face === "both"
+      ? "Both Faces"
+      : device.face === "front"
+        ? "Front"
+        : "Rear",
+  );
 
-  // Resolve individual verbs from the projected list. Each is undefined when
-  // the registry did not include it (e.g. move-device-slot is absent for
-  // full-width devices), so the template guards with {#if}.
+  const summary = $derived(
+    `${getCategoryDisplayName(deviceType.category)} · ${deviceType.u_height}U · ${positionLabel} · ${faceLabel}`,
+  );
+
+  // Resolve verbs from the registry projection. Each is undefined when the
+  // registry did not include it (e.g. move-device-slot is absent for
+  // full-width devices), so the template guards with {#if}. The verb row holds
+  // the affirmative verbs; delete is surfaced separately as a quiet Remove.
   const moveUpVerb = $derived(verbs.find((v) => v.id === "move-device-up"));
   const moveDownVerb = $derived(verbs.find((v) => v.id === "move-device-down"));
+  const slotVerb = $derived(verbs.find((v) => v.id === "move-device-slot"));
   const flipVerb = $derived(verbs.find((v) => v.id === "flip-device-face"));
   const duplicateVerb = $derived(
     verbs.find((v) => v.id === "duplicate-selection"),
   );
   const deleteVerb = $derived(verbs.find((v) => v.id === "delete-selection"));
 
+  // Affirmative verbs for the row, in mockup order: Up, Down, [Slot], Flip.
+  // Duplicate is appended in the template. Delete is surfaced as a quiet Remove.
+  const rowVerbs = $derived(
+    [moveUpVerb, moveDownVerb, slotVerb, flipVerb].filter(
+      (v): v is SelectionVerbItem => v !== undefined,
+    ),
+  );
+
   function dispatch(id: ActionId) {
     onaction?.(id);
+  }
+
+  // --- Inline name editing (click to edit, commit on blur/Enter) ---
+  let editingName = $state(false);
+  let nameInput = $state("");
+
+  function startEditingName() {
+    nameInput = device.name ?? deviceType.model ?? deviceType.slug;
+    editingName = true;
+  }
+
+  function commitName() {
+    if (!editingName) return;
+    editingName = false;
+    const next = nameInput.trim();
+    const typeName = deviceType.model ?? deviceType.slug;
+    oneditname?.(next === typeName ? "" : next);
+  }
+
+  function handleNameKeydown(event: KeyboardEvent) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitName();
+    } else if (event.key === "Escape") {
+      editingName = false;
+    }
+  }
+
+  // --- IP editing (bind:value, commit on blur) ---
+  // Writable derived resets to the supplied ip when the selection changes.
+  let ipInput = $derived(ip);
+
+  function commitIp() {
+    const next = ipInput.trim();
+    if (next === ip.trim()) return;
+    oneditip?.(next);
+  }
+
+  // --- Notes editing (bind:value, commit on blur) ---
+  let notesInput = $derived(device.notes ?? "");
+
+  function commitNotes() {
+    const next = notesInput.trim();
+    if (next === (device.notes ?? "").trim()) return;
+    oneditnotes?.(next);
   }
 </script>
 
 <div class="device-details">
-  <!-- Device Name -->
-  <div class="detail-section name-section">
-    <h3 class="device-name">{displayName}</h3>
-  </div>
-
-  <!-- Primary Info (Height, Category, Position) -->
-  <div class="detail-section info-section">
-    <div class="info-row">
-      <span class="info-label">Height</span>
-      <span class="info-value">{heightDisplay}</span>
-    </div>
-
-    <div class="info-row">
-      <span class="info-label">Category</span>
-      <span class="info-value category-value">
-        <CategoryIcon category={deviceType.category} size={ICON_SIZE.sm} />
-        <span>{deviceType.category}</span>
-      </span>
-    </div>
-
-    <div class="info-row">
-      <span class="info-label">Position</span>
-      <span class="info-value">{positionDisplay}</span>
-    </div>
-  </div>
-
-  <!-- Optional Info (Manufacturer, Part Number) -->
-  {#if deviceType.manufacturer || deviceType.part_number}
-    <div class="detail-section optional-section">
-      {#if deviceType.manufacturer}
-        <div class="info-row">
-          <span class="info-label">Manufacturer</span>
-          <span class="info-value">{deviceType.manufacturer}</span>
-        </div>
-      {/if}
-
-      {#if deviceType.part_number}
-        <div class="info-row">
-          <span class="info-label">Part Number</span>
-          <span class="info-value">{deviceType.part_number}</span>
-        </div>
-      {/if}
-    </div>
-  {/if}
-
-  <!-- Notes -->
-  {#if device.notes}
-    <div class="detail-section notes-section">
-      <span class="info-label">Notes</span>
-      <p class="notes-text">{device.notes}</p>
-    </div>
-  {/if}
-
-  <!-- Action buttons (mobile), projected from the actions registry -->
   {#if showActions && verbs.length > 0}
-    <div class="detail-section actions-section">
-      {#if moveUpVerb || moveDownVerb}
-        <div class="move-buttons">
-          {#if moveUpVerb}
-            <button
-              type="button"
-              class="btn btn-secondary"
-              onclick={() => dispatch(moveUpVerb.id)}
-              disabled={moveUpVerb.disabled}
-              aria-label={moveUpVerb.label}
-            >
+    <!-- Compact inspector: summary, verb row, editable fields, quiet Remove -->
+    <div class="inspector">
+      <p class="summary">{summary}</p>
+
+      <div class="verbs">
+        {#each rowVerbs as verb (verb.id)}
+          <button
+            type="button"
+            class="verb"
+            onclick={() => dispatch(verb.id)}
+            disabled={verb.disabled}
+            aria-label={verb.label}
+          >
+            {#if verb.id === "move-device-up"}
               <IconChevronUp />
-              {moveUpVerb.label}
-            </button>
-          {/if}
-          {#if moveDownVerb}
+              <span>Up</span>
+            {:else if verb.id === "move-device-down"}
+              <IconChevronDown />
+              <span>Down</span>
+            {:else if verb.id === "move-device-slot"}
+              <IconChevronRight size={ICON_SIZE.sm} />
+              <span>Move</span>
+            {:else if verb.id === "flip-device-face"}
+              <IconFlip size={ICON_SIZE.sm} />
+              <span>Flip</span>
+            {/if}
+          </button>
+        {/each}
+        {#if duplicateVerb}
+          <button
+            type="button"
+            class="verb"
+            onclick={() => dispatch(duplicateVerb.id)}
+            disabled={duplicateVerb.disabled}
+            aria-label={duplicateVerb.label}
+          >
+            <IconCopy size={ICON_SIZE.sm} />
+            <span>Duplicate</span>
+          </button>
+        {/if}
+      </div>
+
+      <div class="fields">
+        <div class="field">
+          <span class="field-label" id="inspector-name-label">Name</span>
+          {#if editingName}
+            <!-- svelte-ignore a11y_autofocus -->
+            <input
+              type="text"
+              class="field-input"
+              aria-labelledby="inspector-name-label"
+              bind:value={nameInput}
+              onblur={commitName}
+              onkeydown={handleNameKeydown}
+              autofocus
+            />
+          {:else}
             <button
               type="button"
-              class="btn btn-secondary"
-              onclick={() => dispatch(moveDownVerb.id)}
-              disabled={moveDownVerb.disabled}
-              aria-label={moveDownVerb.label}
+              class="field-edit"
+              onclick={startEditingName}
+              aria-label="Edit name"
             >
-              <IconChevronDown />
-              {moveDownVerb.label}
+              <span class="field-value">{displayName}</span>
+              <IconEdit />
             </button>
           {/if}
         </div>
-      {/if}
-      {#if flipVerb}
-        <button
-          type="button"
-          class="btn btn-secondary"
-          onclick={() => dispatch(flipVerb.id)}
-          disabled={flipVerb.disabled}
-          aria-label={flipVerb.label}
-        >
-          <IconFlip size={ICON_SIZE.sm} />
-          {flipVerb.label}
-        </button>
-      {/if}
-      {#if duplicateVerb}
-        <button
-          type="button"
-          class="btn btn-secondary"
-          onclick={() => dispatch(duplicateVerb.id)}
-          disabled={duplicateVerb.disabled}
-          aria-label={duplicateVerb.label}
-        >
-          <IconCopy size={ICON_SIZE.sm} />
-          {duplicateVerb.label}
-        </button>
-      {/if}
+
+        <div class="field">
+          <label class="field-label" for="inspector-ip">IP</label>
+          <input
+            id="inspector-ip"
+            type="text"
+            class="field-input"
+            placeholder="e.g. 192.168.1.10"
+            bind:value={ipInput}
+            onblur={commitIp}
+          />
+        </div>
+
+        <div class="field field-notes">
+          <label class="field-label" for="inspector-notes">Notes</label>
+          <textarea
+            id="inspector-notes"
+            class="field-input notes-input"
+            rows="2"
+            placeholder="Add notes about this placement"
+            bind:value={notesInput}
+            onblur={commitNotes}
+          ></textarea>
+        </div>
+      </div>
+
       {#if deleteVerb}
-        <button
-          type="button"
-          class="btn btn-danger"
-          onclick={() => dispatch(deleteVerb.id)}
-          disabled={deleteVerb.disabled}
-          aria-label={deleteVerb.label}
-        >
-          <IconTrash size={ICON_SIZE.sm} />
-          {deleteVerb.label}
-        </button>
+        <div class="foot">
+          <button
+            type="button"
+            class="remove"
+            onclick={() => dispatch(deleteVerb.id)}
+            disabled={deleteVerb.disabled}
+            aria-label={deleteVerb.label}
+          >
+            <IconTrash size={ICON_SIZE.sm} />
+            <span>Remove</span>
+          </button>
+        </div>
       {/if}
     </div>
+  {:else}
+    <!-- Read-only facts (non-inspector consumers) -->
+    <div class="detail-section name-section">
+      <h3 class="device-name">{displayName}</h3>
+    </div>
+
+    <div class="detail-section info-section">
+      <div class="info-row">
+        <span class="info-label">Height</span>
+        <span class="info-value">{deviceType.u_height}U</span>
+      </div>
+      <div class="info-row">
+        <span class="info-label">Category</span>
+        <span class="info-value"
+          >{getCategoryDisplayName(deviceType.category)}</span
+        >
+      </div>
+      <div class="info-row">
+        <span class="info-label">Position</span>
+        <span class="info-value">{positionLabel}, {faceLabel}</span>
+      </div>
+    </div>
+
+    {#if deviceType.manufacturer || deviceType.part_number}
+      <div class="detail-section optional-section">
+        {#if deviceType.manufacturer}
+          <div class="info-row">
+            <span class="info-label">Manufacturer</span>
+            <span class="info-value">{deviceType.manufacturer}</span>
+          </div>
+        {/if}
+        {#if deviceType.part_number}
+          <div class="info-row">
+            <span class="info-label">Part Number</span>
+            <span class="info-value">{deviceType.part_number}</span>
+          </div>
+        {/if}
+      </div>
+    {/if}
+
+    {#if device.notes}
+      <div class="detail-section notes-section">
+        <span class="info-label">Notes</span>
+        <p class="notes-text">{device.notes}</p>
+      </div>
+    {/if}
   {/if}
 </div>
 
@@ -231,6 +328,175 @@
     font-size: 0.875rem;
   }
 
+  /* ---------- Mobile inspector ---------- */
+  .inspector {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .summary {
+    margin: 0;
+    color: var(--colour-text-muted);
+    font-size: var(--font-size-sm);
+  }
+
+  .verbs {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .verb {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-1-5);
+    min-height: var(--touch-target-min);
+    padding: var(--space-2);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text);
+    background: var(--colour-surface-secondary);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+  }
+
+  .verb :global(svg) {
+    width: var(--icon-size-sm);
+    height: var(--icon-size-sm);
+    flex-shrink: 0;
+  }
+
+  .verb:hover:not(:disabled) {
+    background: var(--colour-bg-light);
+  }
+
+  .verb:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .field {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    min-height: var(--touch-target-min);
+    padding: var(--space-1) 0;
+    border-bottom: 1px solid var(--colour-border);
+  }
+
+  .field-notes {
+    align-items: flex-start;
+    padding-top: var(--space-2);
+  }
+
+  .field-label {
+    flex-shrink: 0;
+    width: 4.5rem;
+    color: var(--colour-text-muted);
+    font-size: var(--font-size-base);
+  }
+
+  .field-edit {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    min-height: var(--touch-target-min);
+    padding: var(--space-1) 0;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    color: var(--colour-text);
+    font-size: var(--font-size-base);
+  }
+
+  .field-edit :global(svg) {
+    width: var(--icon-size-xs);
+    height: var(--icon-size-xs);
+    flex-shrink: 0;
+    color: var(--colour-text-muted);
+  }
+
+  .field-value {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .field-input {
+    flex: 1;
+    width: 100%;
+    min-height: var(--touch-target-min);
+    padding: var(--space-1) 0;
+    background: transparent;
+    border: none;
+    color: var(--colour-text);
+    font-size: var(--font-size-base);
+    font-family: inherit;
+  }
+
+  .field-input:focus {
+    outline: none;
+  }
+
+  .field-input::placeholder {
+    color: var(--colour-text-muted);
+  }
+
+  .notes-input {
+    resize: vertical;
+    line-height: 1.4;
+  }
+
+  .foot {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: var(--space-2);
+  }
+
+  .remove {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: var(--touch-target-min);
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    color: var(--dracula-red);
+    background: color-mix(in srgb, var(--dracula-red) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--dracula-red) 45%, transparent);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+  }
+
+  .remove :global(svg) {
+    width: var(--icon-size-sm);
+    height: var(--icon-size-sm);
+  }
+
+  .remove:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--dracula-red) 22%, transparent);
+  }
+
+  .remove:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* ---------- Read-only facts (non-inspector) ---------- */
   .detail-section {
     display: flex;
     flex-direction: column;
@@ -275,13 +541,6 @@
     flex-grow: 1;
   }
 
-  .category-value {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 0.5rem;
-  }
-
   .notes-section {
     padding-top: 0.5rem;
     border-top: 1px solid var(--color-border);
@@ -292,65 +551,5 @@
     color: var(--color-text);
     white-space: pre-wrap;
     word-break: break-word;
-  }
-
-  /* Action buttons */
-  .actions-section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
-    padding-top: var(--space-3);
-    border-top: 1px solid var(--color-border);
-  }
-
-  .move-buttons {
-    display: flex;
-    gap: var(--space-2);
-  }
-
-  .btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-2);
-    min-height: var(--touch-target-min);
-    padding: var(--space-2) var(--space-3);
-    font-size: var(--font-size-sm);
-    font-weight: 500;
-    border: none;
-    border-radius: var(--radius-md);
-    cursor: pointer;
-    transition:
-      background-color 0.15s ease,
-      opacity 0.15s ease;
-  }
-
-  .btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .btn-secondary {
-    flex: 1;
-    background: var(--colour-surface-secondary);
-    color: var(--colour-text);
-  }
-
-  .btn-secondary :global(svg) {
-    width: var(--icon-size-sm);
-    height: var(--icon-size-sm);
-  }
-
-  .btn-secondary:hover:not(:disabled) {
-    background: var(--colour-bg-light);
-  }
-
-  .btn-danger {
-    background: var(--dracula-red);
-    color: var(--dracula-fg);
-  }
-
-  .btn-danger:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--dracula-red), black 15%);
   }
 </style>

--- a/src/lib/components/DeviceDetails.svelte
+++ b/src/lib/components/DeviceDetails.svelte
@@ -251,8 +251,7 @@
             rows="2"
             placeholder="Add notes about this placement"
             bind:value={notesInput}
-            onblur={commitNotes}
-          ></textarea>
+            onblur={commitNotes}></textarea>
         </div>
       </div>
 

--- a/src/lib/components/DeviceDetails.svelte
+++ b/src/lib/components/DeviceDetails.svelte
@@ -115,17 +115,29 @@
   }
 
   // --- Inline name editing (click to edit, commit on blur/Enter) ---
-  let editingName = $state(false);
+  // editingDeviceId pins the edit to the placement it started on. A blur can
+  // fire after the selection has advanced to another placement, so commits and
+  // the open editor are gated on the current device still matching (mirrors the
+  // desktop EditPanelMetadata guard, #2223).
+  let editingDeviceId = $state<string | null>(null);
   let nameInput = $state("");
+  const editingName = $derived(
+    editingDeviceId !== null && device.id === editingDeviceId,
+  );
 
   function startEditingName() {
     nameInput = device.name ?? deviceType.model ?? deviceType.slug;
-    editingName = true;
+    editingDeviceId = device.id;
   }
 
   function commitName() {
-    if (!editingName) return;
-    editingName = false;
+    // Abort if the selection moved to a different placement mid-edit, so a
+    // pending commit never lands on the wrong device.
+    if (device.id !== editingDeviceId) {
+      editingDeviceId = null;
+      return;
+    }
+    editingDeviceId = null;
     const next = nameInput.trim();
     const typeName = deviceType.model ?? deviceType.slug;
     oneditname?.(next === typeName ? "" : next);
@@ -136,7 +148,7 @@
       event.preventDefault();
       commitName();
     } else if (event.key === "Escape") {
-      editingName = false;
+      editingDeviceId = null;
     }
   }
 
@@ -504,14 +516,14 @@
 
   .name-section {
     padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: 1px solid var(--colour-border);
   }
 
   .device-name {
     font-size: 1.25rem;
     font-weight: 600;
     margin: 0;
-    color: var(--color-text);
+    color: var(--colour-text);
   }
 
   .info-section,
@@ -530,24 +542,24 @@
 
   .info-label {
     font-weight: 500;
-    color: var(--color-text-secondary);
+    color: var(--colour-text-muted);
     flex-shrink: 0;
   }
 
   .info-value {
     text-align: right;
-    color: var(--color-text);
+    color: var(--colour-text);
     flex-grow: 1;
   }
 
   .notes-section {
     padding-top: 0.5rem;
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid var(--colour-border);
   }
 
   .notes-text {
     margin: 0;
-    color: var(--color-text);
+    color: var(--colour-text);
     white-space: pre-wrap;
     word-break: break-word;
   }

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -539,7 +539,11 @@
   function handleEditDeviceName(name: string): void {
     const rackId = layoutStore.activeRack?.id;
     if (rackId == null || selectedDeviceForSheet === null) return;
-    layoutStore.updateDeviceName(rackId, selectedDeviceForSheet, name || undefined);
+    layoutStore.updateDeviceName(
+      rackId,
+      selectedDeviceForSheet,
+      name || undefined,
+    );
   }
 
   function handleEditDeviceIp(ip: string): void {
@@ -673,7 +677,9 @@
   {#if device && deviceType}
     {@const rackHeight = activeRack.height}
     {@const deviceIp =
-      typeof device.custom_fields?.ip === "string" ? device.custom_fields.ip : ""}
+      typeof device.custom_fields?.ip === "string"
+        ? device.custom_fields.ip
+        : ""}
     <Dialog
       open={bottomSheetOpen}
       title={deviceType.model ?? "Device"}

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -533,6 +533,31 @@
 
   const mobileVerbs = $derived(getSelectionVerbsWithState(mobileActionCtx));
 
+  // Inline-edit handlers for the mobile inspector fields. They write through
+  // the recorded layout-store mutators (undo/redo aware) against the same rack
+  // and device index the bottom sheet is showing.
+  function handleEditDeviceName(name: string): void {
+    const rackId = layoutStore.activeRack?.id;
+    if (rackId == null || selectedDeviceForSheet === null) return;
+    layoutStore.updateDeviceName(rackId, selectedDeviceForSheet, name || undefined);
+  }
+
+  function handleEditDeviceIp(ip: string): void {
+    const rackId = layoutStore.activeRack?.id;
+    if (rackId == null || selectedDeviceForSheet === null) return;
+    layoutStore.updateDeviceIp(rackId, selectedDeviceForSheet, ip || undefined);
+  }
+
+  function handleEditDeviceNotes(notes: string): void {
+    const rackId = layoutStore.activeRack?.id;
+    if (rackId == null || selectedDeviceForSheet === null) return;
+    layoutStore.updateDeviceNotes(
+      rackId,
+      selectedDeviceForSheet,
+      notes || undefined,
+    );
+  }
+
   // Dispatch a registry verb by action id to the shared handler. The handlers
   // read live selection state from the stores, so they act on the same device
   // the mobile bottom sheet is showing.
@@ -647,6 +672,8 @@
     : null}
   {#if device && deviceType}
     {@const rackHeight = activeRack.height}
+    {@const deviceIp =
+      typeof device.custom_fields?.ip === "string" ? device.custom_fields.ip : ""}
     <Dialog
       open={bottomSheetOpen}
       title={deviceType.model ?? "Device"}
@@ -661,6 +688,10 @@
         showActions={true}
         verbs={mobileVerbs}
         onaction={handleMobileVerb}
+        ip={deviceIp}
+        oneditname={handleEditDeviceName}
+        oneditip={handleEditDeviceIp}
+        oneditnotes={handleEditDeviceNotes}
       />
     </Dialog>
   {/if}

--- a/src/tests/DeviceDetails.test.ts
+++ b/src/tests/DeviceDetails.test.ts
@@ -330,9 +330,7 @@ describe("DeviceDetails", () => {
       renderInspector({ oneditname });
 
       // The name field opens an editor when activated.
-      await fireEvent.click(
-        screen.getByRole("button", { name: /edit name/i }),
-      );
+      await fireEvent.click(screen.getByRole("button", { name: /edit name/i }));
       const input = screen.getByRole("textbox", { name: /name/i });
       await fireEvent.input(input, { target: { value: "Web Server" } });
       await fireEvent.blur(input);

--- a/src/tests/DeviceDetails.test.ts
+++ b/src/tests/DeviceDetails.test.ts
@@ -365,5 +365,36 @@ describe("DeviceDetails", () => {
       }) as HTMLInputElement;
       expect(input.value).toBe("192.168.1.10");
     });
+
+    it("aborts a pending name commit when the selection changes mid-edit", async () => {
+      const oneditname = vi.fn();
+      const deviceType = createTestDeviceType({ model: "Dell PowerEdge R740" });
+      const { rerender } = render(DeviceDetails, {
+        props: {
+          device: createTestPlacedDevice({ id: "device-a" }),
+          deviceType,
+          showActions: true,
+          verbs: allVerbs,
+          oneditname,
+        },
+      });
+
+      await fireEvent.click(screen.getByRole("button", { name: /edit name/i }));
+      const input = screen.getByRole("textbox", { name: /name/i });
+      await fireEvent.input(input, { target: { value: "Web Server" } });
+
+      // Selection advances to a different placement before the input blurs.
+      await rerender({
+        device: createTestPlacedDevice({ id: "device-b" }),
+        deviceType,
+        showActions: true,
+        verbs: allVerbs,
+        oneditname,
+      });
+      await fireEvent.blur(input);
+
+      // The stale edit must not land on the newly selected device.
+      expect(oneditname).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/tests/DeviceDetails.test.ts
+++ b/src/tests/DeviceDetails.test.ts
@@ -180,6 +180,8 @@ describe("DeviceDetails", () => {
       expect(
         screen.getByRole("button", { name: /duplicate selection/i }),
       ).toBeInTheDocument();
+      // Remove resolves from the registry (delete-selection) but lives in the
+      // footer, de-emphasised, not in the primary verb row.
       expect(
         screen.getByRole("button", { name: /delete selected/i }),
       ).toBeInTheDocument();
@@ -287,6 +289,85 @@ describe("DeviceDetails", () => {
         },
       });
       expect(screen.getByText("Primary database server")).toBeTruthy();
+    });
+  });
+
+  describe("Editable fields", () => {
+    // Editable fields only render in the mobile inspector (showActions + verbs).
+    const allVerbs: SelectionVerbItem[] = [
+      { id: "move-device-up", label: "Move device up", disabled: false },
+      { id: "move-device-down", label: "Move device down", disabled: false },
+      { id: "flip-device-face", label: "Flip face", disabled: false },
+      {
+        id: "duplicate-selection",
+        label: "Duplicate selection",
+        disabled: false,
+      },
+      { id: "delete-selection", label: "Delete selected", disabled: false },
+    ];
+
+    function renderInspector(overrides: {
+      device?: Partial<PlacedDevice>;
+      ip?: string;
+      oneditname?: (name: string) => void;
+      oneditip?: (ip: string) => void;
+      oneditnotes?: (notes: string) => void;
+    }) {
+      const { device, ...rest } = overrides;
+      return render(DeviceDetails, {
+        props: {
+          device: createTestPlacedDevice(device),
+          deviceType: createTestDeviceType({ model: "Dell PowerEdge R740" }),
+          showActions: true,
+          verbs: allVerbs,
+          ...rest,
+        },
+      });
+    }
+
+    it("commits a name edit through oneditname", async () => {
+      const oneditname = vi.fn();
+      renderInspector({ oneditname });
+
+      // The name field opens an editor when activated.
+      await fireEvent.click(
+        screen.getByRole("button", { name: /edit name/i }),
+      );
+      const input = screen.getByRole("textbox", { name: /name/i });
+      await fireEvent.input(input, { target: { value: "Web Server" } });
+      await fireEvent.blur(input);
+
+      expect(oneditname).toHaveBeenCalledWith("Web Server");
+    });
+
+    it("commits an IP edit through oneditip", async () => {
+      const oneditip = vi.fn();
+      renderInspector({ oneditip });
+
+      const input = screen.getByRole("textbox", { name: /ip/i });
+      await fireEvent.input(input, { target: { value: "10.0.0.5" } });
+      await fireEvent.blur(input);
+
+      expect(oneditip).toHaveBeenCalledWith("10.0.0.5");
+    });
+
+    it("commits a notes edit through oneditnotes", async () => {
+      const oneditnotes = vi.fn();
+      renderInspector({ oneditnotes });
+
+      const input = screen.getByRole("textbox", { name: /notes/i });
+      await fireEvent.input(input, { target: { value: "Rebooted nightly" } });
+      await fireEvent.blur(input);
+
+      expect(oneditnotes).toHaveBeenCalledWith("Rebooted nightly");
+    });
+
+    it("seeds the IP editor with the supplied ip value", () => {
+      renderInspector({ ip: "192.168.1.10" });
+      const input = screen.getByRole("textbox", {
+        name: /ip/i,
+      }) as HTMLInputElement;
+      expect(input.value).toBe("192.168.1.10");
     });
   });
 });

--- a/src/tests/DeviceDetails.test.ts
+++ b/src/tests/DeviceDetails.test.ts
@@ -180,8 +180,6 @@ describe("DeviceDetails", () => {
       expect(
         screen.getByRole("button", { name: /duplicate selection/i }),
       ).toBeInTheDocument();
-      // Remove resolves from the registry (delete-selection) but lives in the
-      // footer, de-emphasised, not in the primary verb row.
       expect(
         screen.getByRole("button", { name: /delete selected/i }),
       ).toBeInTheDocument();


### PR DESCRIPTION
## **User description**
## Summary

Reworks the mobile device-details bottom sheet into a single selection inspector matching the M12 design spec mockup (`docs/superpowers/specs/2026-06-18-mobile-ux-design.md`, selection-inspector section).

- Compact one-line summary (type, height, position, face) replaces the verbose read-only info rows.
- Verb row resolves from the shared actions registry (Up, Down, optional slot Move, Flip, Duplicate), each honouring its `enabledWhen` state. No bespoke per-consumer verb handling.
- Inline-editable Name, IP, and Notes fields, committed through the recorded layout-store mutators (undo/redo aware) via callbacks, keeping `DeviceDetails` a pure presentation component.
- Remove is de-emphasised: a quiet, outlined, muted-red button in the footer, not a full-width loud danger button. It still resolves from the registry (`delete-selection`).

The non-inspector read-only render path is preserved for any consumer that passes no verbs.

## Acceptance criteria

- [x] Inspector shows the device facts plus editable fields (Name, IP, Notes)
- [x] Verbs (nudge, flip, duplicate, delete) resolve from the registry
- [x] Remove is de-emphasised (not a full-width loud button)
- [x] Verbs and fields match the mockup in the spec

## Scope

Touches only `DeviceDetails.svelte`, the inspector wiring in `DialogOrchestrator.svelte`, and the `DeviceDetails` test. The mobile move up/down handlers (#2453's scope) are untouched.

## Testing

- `npm run lint` clean
- `npm run test:run` 2702 passed (160 files), including 4 new editable-field behaviour tests
- `npm run build` passes (type check + bundle)

Builds on #2465 (registry dispatch path) and #2459 (bottom nav + sheet ids).

Closes #2462

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Turn the mobile device details sheet into an editable selection inspector**

### What Changed
- The mobile device sheet now shows a compact summary, action buttons, editable Name/IP/Notes fields, and a quieter Remove button instead of a read-only details view.
- Name, IP, and Notes can be edited directly in the sheet and saved when focus leaves the field; clearing a value removes it.
- The sheet now shows the current IP value when one is available and keeps the older read-only details view for non-inspector use.

### Impact
`✅ Faster mobile device edits`
`✅ Fewer taps to update placement details`
`✅ Clearer delete action on mobile`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
