### PR TITLE
feat: mobile View options sheet - read-only lock, Theme removed (#2464)

### DIFF
--- a/src/lib/components/mobile/MobileViewSheet.svelte
+++ b/src/lib/components/mobile/MobileViewSheet.svelte
@@ -1,14 +1,16 @@
 <!--
   MobileViewSheet Component
-  Mobile bottom sheet controls for display mode, annotations, theme, and zoom.
-  The zoom stepper reads the shared canvas store directly (the same verbs the
-  desktop CanvasViewControls cluster uses) so mobile does not fork zoom logic.
+  Mobile bottom sheet controls for display mode, annotations, a read-only lock,
+  and zoom. The zoom stepper reads the shared canvas store directly (the same
+  verbs the desktop CanvasViewControls cluster uses) so mobile does not fork zoom
+  logic, and the read-only lock drives the shared UI store.
 -->
 <script lang="ts">
   import type { DisplayMode } from "$lib/types";
   import SegmentedControl from "$lib/components/SegmentedControl.svelte";
   import Switch from "$lib/components/Switch.svelte";
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
+  import { getUIStore } from "$lib/stores/ui.svelte";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import {
     IconMinusBold,
@@ -19,10 +21,8 @@
   interface Props {
     displayMode: DisplayMode;
     showAnnotations: boolean;
-    theme: "dark" | "light";
     ondisplaymodechange?: (mode: DisplayMode) => void;
     onannotationschange?: (enabled: boolean) => void;
-    onthemechange?: (theme: "dark" | "light") => void;
     onfitall?: () => void;
     onresetzoom?: () => void;
     onclose?: () => void;
@@ -31,23 +31,21 @@
   let {
     displayMode,
     showAnnotations,
-    theme,
     ondisplaymodechange,
     onannotationschange,
-    onthemechange,
     onfitall,
     onresetzoom,
     onclose,
   }: Props = $props();
 
   const canvasStore = getCanvasStore();
+  const uiStore = getUIStore();
 
   const displayModeOptions: Array<{ value: DisplayMode; label: string }> = [
     { value: "label", label: "Label" },
     { value: "image", label: "Image" },
     { value: "image-label", label: "Image + Label" },
   ];
-  const themeLabel = $derived(`Theme (${theme === "dark" ? "Dark" : "Light"})`);
 
   function handleDisplayModeChange(mode: DisplayMode) {
     ondisplaymodechange?.(mode);
@@ -57,8 +55,8 @@
     onannotationschange?.(enabled);
   }
 
-  function handleThemeChange(darkMode: boolean) {
-    onthemechange?.(darkMode ? "dark" : "light");
+  function handleReadOnlyChange(locked: boolean) {
+    uiStore.setReadOnly(locked);
   }
 
   function handleFitAll() {
@@ -94,10 +92,11 @@
 
   <section class="section">
     <Switch
-      id="mobile-view-theme"
-      checked={theme === "dark"}
-      label={themeLabel}
-      onchange={handleThemeChange}
+      id="mobile-view-readonly"
+      checked={uiStore.readOnly}
+      label="Read-only"
+      helperText="Lock the layout for viewing"
+      onchange={handleReadOnlyChange}
     />
   </section>
 

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -212,6 +212,9 @@ let sidePanelCollapsed = $state(initialSidePanelCollapsed);
 let warnOnUnsavedChanges = $state(initialWarnUnsaved);
 let promptCleanupOnSave = $state(initialPromptCleanup);
 let compatibleOnly = $state(initialCompatibleOnly);
+// Read-only lock: presentation safety valve that locks the layout for viewing.
+// Session-scoped (not persisted) so a reload always returns to an editable state.
+let readOnly = $state(false);
 
 // Derived values (using $derived rune)
 const canZoomIn = $derived(zoom < ZOOM_MAX);
@@ -242,6 +245,7 @@ export function resetUIStore(): void {
   warnOnUnsavedChanges = loadWarnUnsavedFromStorage();
   promptCleanupOnSave = loadPromptCleanupFromStorage();
   compatibleOnly = loadCompatibleOnlyFromStorage();
+  readOnly = false;
   applyThemeToDocument(theme);
 }
 
@@ -322,6 +326,11 @@ export function getUIStore() {
       return compatibleOnly;
     },
 
+    // Read-only lock state getter
+    get readOnly() {
+      return readOnly;
+    },
+
     // Theme actions
     toggleTheme,
     setTheme,
@@ -371,6 +380,10 @@ export function getUIStore() {
 
     // Compatible-only filter action
     toggleCompatibleOnly,
+
+    // Read-only lock actions
+    toggleReadOnly,
+    setReadOnly,
   };
 }
 
@@ -625,4 +638,19 @@ function setPromptCleanupOnSave(prompt: boolean): void {
 function toggleCompatibleOnly(): void {
   compatibleOnly = !compatibleOnly;
   saveCompatibleOnlyToStorage(compatibleOnly);
+}
+
+/**
+ * Toggle the read-only lock
+ */
+function toggleReadOnly(): void {
+  readOnly = !readOnly;
+}
+
+/**
+ * Set the read-only lock state explicitly
+ * @param locked - Whether the layout is locked for viewing
+ */
+function setReadOnly(locked: boolean): void {
+  readOnly = locked;
 }

--- a/src/tests/MobileViewSheet.test.ts
+++ b/src/tests/MobileViewSheet.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import MobileViewSheet from "$lib/components/mobile/MobileViewSheet.svelte";
 import { getCanvasStore, resetCanvasStore } from "$lib/stores/canvas.svelte";
+import { getUIStore, resetUIStore } from "$lib/stores/ui.svelte";
 import { createMockPanzoom } from "./mocks/panzoom";
 import type { DisplayMode } from "$lib/types";
 
@@ -9,10 +10,8 @@ function renderSheet(
   overrides: Partial<{
     displayMode: DisplayMode;
     showAnnotations: boolean;
-    theme: "dark" | "light";
     ondisplaymodechange: (mode: DisplayMode) => void;
     onannotationschange: (enabled: boolean) => void;
-    onthemechange: (theme: "dark" | "light") => void;
     onfitall: () => void;
     onresetzoom: () => void;
     onclose: () => void;
@@ -21,10 +20,8 @@ function renderSheet(
   const props = {
     displayMode: "label" as DisplayMode,
     showAnnotations: false,
-    theme: "dark" as const,
     ondisplaymodechange: vi.fn(),
     onannotationschange: vi.fn(),
-    onthemechange: vi.fn(),
     onfitall: vi.fn(),
     onresetzoom: vi.fn(),
     onclose: vi.fn(),
@@ -38,16 +35,19 @@ function renderSheet(
 describe("MobileViewSheet", () => {
   beforeEach(() => {
     resetCanvasStore();
+    resetUIStore();
   });
 
-  it("reflects current toggle state on open", () => {
-    renderSheet({
-      showAnnotations: true,
-      theme: "dark",
-    });
+  it("reflects current annotation state on open", () => {
+    renderSheet({ showAnnotations: true });
 
     expect(screen.getByRole("switch", { name: "Annotations" })).toBeChecked();
-    expect(screen.getByRole("switch", { name: /Theme/ })).toBeChecked();
+  });
+
+  it("omits the Theme control", () => {
+    renderSheet();
+
+    expect(screen.queryByRole("switch", { name: /Theme/ })).toBeNull();
   });
 
   it("calls ondisplaymodechange when display mode is changed", async () => {
@@ -58,17 +58,34 @@ describe("MobileViewSheet", () => {
     expect(props.ondisplaymodechange).toHaveBeenCalledWith("image");
   });
 
-  it("applies annotations and theme changes immediately", async () => {
-    const props = renderSheet({
-      showAnnotations: false,
-      theme: "light",
-    });
+  it("applies annotation changes immediately", async () => {
+    const props = renderSheet({ showAnnotations: false });
 
     await fireEvent.click(screen.getByRole("switch", { name: "Annotations" }));
-    await fireEvent.click(screen.getByRole("switch", { name: /Theme/ }));
 
     expect(props.onannotationschange).toHaveBeenCalledWith(true);
-    expect(props.onthemechange).toHaveBeenCalledWith("dark");
+  });
+
+  it("reflects the read-only lock state from the UI store", () => {
+    getUIStore().setReadOnly(true);
+
+    renderSheet();
+
+    expect(screen.getByRole("switch", { name: "Read-only" })).toBeChecked();
+  });
+
+  it("locks and unlocks the layout via the read-only toggle", async () => {
+    const uiStore = getUIStore();
+    renderSheet();
+
+    const lock = screen.getByRole("switch", { name: "Read-only" });
+    expect(uiStore.readOnly).toBe(false);
+
+    await fireEvent.click(lock);
+    expect(uiStore.readOnly).toBe(true);
+
+    await fireEvent.click(lock);
+    expect(uiStore.readOnly).toBe(false);
   });
 
   it("runs Fit to screen and closes the sheet", async () => {

--- a/src/tests/ui-store.test.ts
+++ b/src/tests/ui-store.test.ts
@@ -540,4 +540,49 @@ describe("UI Store", () => {
       expect(store.sidePanelCollapsed).toBe(true);
     });
   });
+
+  describe("Read-only lock", () => {
+    it("starts unlocked", () => {
+      const store = getUIStore();
+      expect(store.readOnly).toBe(false);
+    });
+
+    it("toggleReadOnly flips the lock both ways", () => {
+      const store = getUIStore();
+
+      store.toggleReadOnly();
+      expect(store.readOnly).toBe(true);
+
+      store.toggleReadOnly();
+      expect(store.readOnly).toBe(false);
+    });
+
+    it("setReadOnly sets the lock explicitly", () => {
+      const store = getUIStore();
+
+      store.setReadOnly(true);
+      expect(store.readOnly).toBe(true);
+
+      store.setReadOnly(false);
+      expect(store.readOnly).toBe(false);
+    });
+
+    it("does not persist the lock to localStorage", () => {
+      const store = getUIStore();
+      localStorageMock.setItem.mockClear();
+
+      store.setReadOnly(true);
+      store.toggleReadOnly();
+
+      expect(localStorageMock.setItem).not.toHaveBeenCalled();
+    });
+
+    it("resets to unlocked on store reset", () => {
+      const store = getUIStore();
+      store.setReadOnly(true);
+
+      resetUIStore();
+      expect(store.readOnly).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

Reconciles the mobile View options sheet (`MobileViewSheet.svelte`) with the M12 design spec (`docs/superpowers/specs/2026-06-18-mobile-ux-design.md`, View options section). This is a finish/reconcile, not a rebuild (per audit #2470).

- Adds a Read-only lock switch ("Lock the layout for viewing"), the presentation safety valve that replaces an explicit edit mode. It drives a new session-scoped `readOnly` state on the shared UI store.
- Removes the Theme control. Theme is intentionally omitted from mobile View options (added AC); light-theme retirement is tracked separately by #2468.
- Keeps Display mode, Annotations, the #2463 zoom stepper, Fit to screen, and Reset zoom unchanged.

## Architecture

The lock state lives on the shared UI store (`getUIStore()`), and the sheet reads it directly, mirroring how the sheet already reads the canvas store for zoom. No desktop logic is forked. The lock is session-scoped (not persisted) so a reload always returns to an editable state.

## Scope note / follow-up

The lock toggle persists state but does not yet have an enforcement consumer (suppressing edit affordances when locked lives in Canvas / DeviceDetails / DialogOrchestrator, which are out of scope here and owned by sibling M12 issues). A follow-up will wire enforcement.

## Tests

- `MobileViewSheet.test.ts`: Theme-omission assertion, read-only lock reflect + toggle behaviour; Theme assertions removed.
- `ui-store.test.ts`: read-only lock state, toggle/set, non-persistence, reset.
- Full suite green (161 files, 2721 tests), lint clean, build passes.

Closes #2464

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Add a read-only lock to the mobile View options sheet and remove Theme

### What Changed
- Replaced the Theme switch with a Read-only switch labeled “Lock the layout for viewing”
- The read-only lock updates the shared viewing state and resets to unlocked when the app reloads or the UI is reset
- Mobile View options now reflect the current lock state, while keeping display mode, annotations, and zoom controls unchanged
- Added coverage for the new lock behavior and confirmed the Theme control is no longer shown

### Impact
`✅ Clearer mobile view controls`
`✅ Fewer accidental edits while presenting`
`✅ Reset returns to an editable layout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
