### PR TITLE
feat: mobile-friendly first-run template picker (#2469)

### DIFF
--- a/src/lib/components/TemplatePicker.svelte
+++ b/src/lib/components/TemplatePicker.svelte
@@ -308,8 +308,8 @@
   }
 
   .template-picker.is-mobile .card-preview {
-    flex: 0 0 96px;
-    height: 96px;
+    flex: 0 0 calc(var(--space-12) * 2);
+    height: calc(var(--space-12) * 2);
   }
 
   .template-picker.is-mobile .card-body {
@@ -335,7 +335,7 @@
 
   .template-picker.is-mobile .action-button {
     width: 100%;
-    min-height: 48px;
+    min-height: var(--touch-target-min);
     font-size: var(--font-size-base);
   }
 </style>

--- a/src/lib/components/TemplatePicker.svelte
+++ b/src/lib/components/TemplatePicker.svelte
@@ -15,8 +15,11 @@
 -->
 <script lang="ts">
   import type { StarterTemplate } from "$lib/templates/starter-templates";
+  import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { renderLayoutPreviewSvg } from "./layout-preview-render";
   import { IconPlus, IconUpload, IconShareBold } from "./icons";
+
+  const viewportStore = getViewportStore();
 
   interface Props {
     /** Starter templates to offer. Empty array renders the blank-only state. */
@@ -53,7 +56,11 @@
   }
 </script>
 
-<section class="template-picker" aria-labelledby="template-picker-heading">
+<section
+  class="template-picker"
+  class:is-mobile={viewportStore.isMobile}
+  aria-labelledby="template-picker-heading"
+>
   <header class="picker-header">
     <h2 id="template-picker-heading" class="picker-title">
       Start a new layout
@@ -269,5 +276,66 @@
     .template-card:hover {
       transform: none;
     }
+  }
+
+  /* Mobile: a touch-friendly, single-column picker that reads well on a
+     narrow viewport. Cards stack full-width with larger tap areas, and the
+     text steps up a size so a new user on a phone can scan and choose. */
+  .template-picker.is-mobile {
+    gap: var(--space-5);
+    width: 100%;
+    padding: var(--space-5) var(--space-4);
+  }
+
+  .template-picker.is-mobile .picker-title {
+    font-size: var(--font-size-2xl);
+  }
+
+  .template-picker.is-mobile .picker-subtitle {
+    font-size: var(--font-size-base);
+  }
+
+  .template-picker.is-mobile .template-grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
+  }
+
+  .template-picker.is-mobile .template-card {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-4);
+  }
+
+  .template-picker.is-mobile .card-preview {
+    flex: 0 0 96px;
+    height: 96px;
+  }
+
+  .template-picker.is-mobile .card-body {
+    flex: 1 1 auto;
+    min-width: 0;
+    gap: var(--space-1);
+  }
+
+  .template-picker.is-mobile .card-name {
+    font-size: var(--font-size-lg);
+  }
+
+  .template-picker.is-mobile .card-meta {
+    font-size: var(--font-size-sm);
+  }
+
+  .template-picker.is-mobile .picker-actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: var(--space-2);
+  }
+
+  .template-picker.is-mobile .action-button {
+    width: 100%;
+    min-height: 48px;
+    font-size: var(--font-size-base);
   }
 </style>


### PR DESCRIPTION
## **User description**
## Summary

Polishes the first-run TemplatePicker for mobile so a new user on a phone or tablet lands on real content via a touch-friendly picker. Desktop is unchanged.

The mobile treatment keys off the shared `viewportStore.isMobile` signal (1024px breakpoint in `viewport.svelte.ts`), the same store every other mobile-chrome component uses, so the breakpoint stays single-sourced rather than forked into a CSS media query. No new component: the existing picker and starter-template data are reused, with a `.is-mobile` class toggling a responsive layer.

## What changes on mobile

- Template cards stack single-column, full-width, in a row layout (preview left, name/meta right) for easy scanning and tapping.
- Heading and subtitle step up a size; card name and meta step up for legibility.
- Action buttons (Blank layout, Import file, Share) stack full-width at 48px min-height for comfortable thumb targets; cards already meet the 44px minimum.
- Picker padding tightened so it fits a narrow viewport without horizontal overflow.

## Acceptance criteria

- Touch-friendly and legible on mobile: tap targets >=44px (action buttons 48px), text sizes increased.
- A new mobile user can pick a starter template and land on a populated rack: the picker's `onchoosetemplate` wiring (Canvas -> loadLayout) is unchanged, so selection still loads the template.
- Implicitly demonstrates tap-to-place by landing the user on a populated sample.

## Testing

Pure responsive/touch styling plus one reactive class binding; no testable behaviour beyond the existing pass-through callback, so no unit test added per the project TDD protocol (visual/responsive change). Local gates: `npm run lint`, `npm run test:run` (160 files, 2719 tests), and `npm run build` all pass.

## Note for reviewers

This alters the picker rendering on mobile, so the `visual regression` CI check may need new baselines. Not blocking from this branch; baselines can be regenerated on merge.

Closes #2469

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the first-run template picker easier to use on mobile**

### What Changed
- The first-run template picker now switches to a mobile layout on small screens.
- Template cards stack in a single column, show larger previews and text, and use tighter spacing so they fit narrow viewports without overflow.
- The action buttons now stack full width with larger touch targets for easier tapping.
- Desktop behavior stays the same.

### Impact
`✅ Easier template selection on phones`
`✅ Cleaner first-run screen on narrow displays`
`✅ Fewer missed taps on action buttons`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
