### PR TITLE
fix: mobile move up/down collision validation + feedback (#2453)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -69,6 +69,13 @@
     canMoveSelectedDeviceSlot,
   } from "$lib/actions/selection-actions";
   import { handleDelete } from "$lib/utils/dialog-actions";
+  import {
+    findNextValidPosition,
+    canMoveUp,
+    canMoveDown,
+    getMoveBlockedMessage,
+    type MoveDirection,
+  } from "$lib/utils/device-movement";
   import { getStorageMode } from "$lib/storage";
 
   const layoutStore = getLayoutStore();
@@ -531,7 +538,47 @@
     canMoveDeviceSlot: canMoveSelectedDeviceSlot(),
   });
 
-  const mobileVerbs = $derived(getSelectionVerbsWithState(mobileActionCtx));
+  // The rack and device index the mobile sheet is acting on. The bottom sheet
+  // renders activeRack.devices[selectedDeviceForSheet], so the nudge controls
+  // must validate against that same target.
+  const mobileMoveTarget = $derived.by(() => {
+    const rack = layoutStore.activeRack;
+    if (!rack || selectedDeviceForSheet === null) return null;
+    if (!rack.devices[selectedDeviceForSheet]) return null;
+    return { rack, deviceIndex: selectedDeviceForSheet };
+  });
+
+  // The registry's enabledWhen for the move verbs only checks isDeviceSelected,
+  // not whether the nudge would actually land (bounds plus neighbours). Resolve
+  // the real collision-aware reachability here so the mobile Move Up / Move Down
+  // controls disable when blocked, matching the desktop edit panel (#2453). The
+  // shared registry-bound move handler is tracked separately (#2471).
+  const mobileVerbs = $derived.by(() => {
+    const verbs = getSelectionVerbsWithState(mobileActionCtx);
+    const target = mobileMoveTarget;
+    if (!target) return verbs;
+
+    const upBlocked = !canMoveUp(
+      target.rack,
+      layoutStore.device_types,
+      target.deviceIndex,
+    );
+    const downBlocked = !canMoveDown(
+      target.rack,
+      layoutStore.device_types,
+      target.deviceIndex,
+    );
+
+    return verbs.map((verb) => {
+      if (verb.id === "move-device-up") {
+        return { ...verb, disabled: verb.disabled || upBlocked };
+      }
+      if (verb.id === "move-device-down") {
+        return { ...verb, disabled: verb.disabled || downBlocked };
+      }
+      return verb;
+    });
+  });
 
   // Inline-edit handlers for the mobile inspector fields. They write through
   // the recorded layout-store mutators (undo/redo aware) against the same rack
@@ -562,16 +609,44 @@
     );
   }
 
+  // Nudge the sheet's device one whole U, surfacing a toast when the move is
+  // blocked instead of silently doing nothing (#2453). Reuses the shared
+  // collision logic (findNextValidPosition) to decide, then defers the actual
+  // recorded move to the shared selection handler so undo/redo still applies.
+  function nudgeSelectedDevice(direction: MoveDirection): void {
+    const target = mobileMoveTarget;
+    if (!target) return;
+
+    const result = findNextValidPosition(
+      target.rack,
+      layoutStore.device_types,
+      target.deviceIndex,
+      direction,
+    );
+
+    const blockedMessage = getMoveBlockedMessage(result, direction);
+    if (blockedMessage) {
+      toastStore.showToast(blockedMessage, "warning");
+      return;
+    }
+
+    if (direction === 1) {
+      moveSelectedDeviceUp();
+    } else {
+      moveSelectedDeviceDown();
+    }
+  }
+
   // Dispatch a registry verb by action id to the shared handler. The handlers
   // read live selection state from the stores, so they act on the same device
   // the mobile bottom sheet is showing.
   function handleMobileVerb(id: ActionId): void {
     switch (id) {
       case "move-device-up":
-        moveSelectedDeviceUp();
+        nudgeSelectedDevice(1);
         break;
       case "move-device-down":
-        moveSelectedDeviceDown();
+        nudgeSelectedDevice(-1);
         break;
       case "move-device-slot":
         moveSelectedDeviceToSlot();

--- a/src/lib/utils/device-movement.ts
+++ b/src/lib/utils/device-movement.ts
@@ -160,6 +160,35 @@ export function canMoveDown(
 }
 
 /**
+ * Human-readable feedback for a blocked nudge, or null when the move succeeded.
+ *
+ * The mobile selection inspector disables its Move Up / Move Down controls when
+ * a nudge is impossible, but a tap that still reaches a blocked move must give
+ * the user a reason rather than silently doing nothing. This turns the shared
+ * MoveResult into that message so the mobile handler reuses the same collision
+ * logic the desktop edit panel uses, without reimplementing it.
+ *
+ * @param result - The outcome from findNextValidPosition
+ * @param direction - 1 for up (higher U), -1 for down (lower U)
+ * @returns A feedback message when the move was blocked, or null when it moved
+ */
+export function getMoveBlockedMessage(
+  result: MoveResult,
+  direction: MoveDirection,
+): string | null {
+  if (result.success) return null;
+
+  const directionWord = direction === 1 ? "up" : "down";
+
+  if (result.reason === "at_boundary") {
+    const edge = direction === 1 ? "top" : "bottom";
+    return `Already at the ${edge} of the rack`;
+  }
+
+  return `No free slot to move ${directionWord}`;
+}
+
+/**
  * Get the placed device and its type for a given index
  * Helper function to reduce boilerplate in callers
  *

--- a/src/tests/device-movement.test.ts
+++ b/src/tests/device-movement.test.ts
@@ -9,6 +9,7 @@ import {
   canMoveUp,
   canMoveDown,
   getDeviceWithType,
+  getMoveBlockedMessage,
 } from "$lib/utils/device-movement";
 import type { Rack, DeviceType, PlacedDevice } from "$lib/types";
 import { toInternalUnits } from "$lib/utils/position";
@@ -407,6 +408,58 @@ describe("Device Movement Utility", () => {
       const deviceTypes = createDeviceTypes();
 
       expect(canMoveDown(rack, deviceTypes, 0)).toBe(false);
+    });
+  });
+
+  // The mobile selection inspector nudges a device with Move Up / Move Down.
+  // A blocked nudge must give the user feedback (a toast) instead of silently
+  // doing nothing, mirroring the desktop edit panel's disabled controls. This
+  // helper turns a MoveResult into that feedback message so the mobile handler
+  // can surface it without reimplementing collision logic.
+  describe("getMoveBlockedMessage", () => {
+    it("returns null when the move succeeded (no feedback needed)", () => {
+      const rack = createTestRack(42, [pd("1u-server", 10, "front")]);
+      const deviceTypes = createDeviceTypes();
+      const result = findNextValidPosition(rack, deviceTypes, 0, 1);
+
+      expect(getMoveBlockedMessage(result, 1)).toBeNull();
+    });
+
+    it("reports the top boundary when moving up from the top", () => {
+      const rack = createTestRack(42, [pd("1u-server", 42, "front")]);
+      const deviceTypes = createDeviceTypes();
+      const result = findNextValidPosition(rack, deviceTypes, 0, 1);
+
+      const message = getMoveBlockedMessage(result, 1);
+      expect(message).not.toBeNull();
+      expect(message?.toLowerCase()).toContain("top");
+    });
+
+    it("reports the bottom boundary when moving down from the bottom", () => {
+      const rack = createTestRack(42, [pd("1u-server", 1, "front")]);
+      const deviceTypes = createDeviceTypes();
+      const result = findNextValidPosition(rack, deviceTypes, 0, -1);
+
+      const message = getMoveBlockedMessage(result, -1);
+      expect(message).not.toBeNull();
+      expect(message?.toLowerCase()).toContain("bottom");
+    });
+
+    it("reports a blocked move when neighbours fill the way to the boundary", () => {
+      const rack = createTestRack(10, [
+        pd("1u-server", 5, "front"), // device to move
+        pd("1u-server", 6, "front"),
+        pd("1u-server", 7, "front"),
+        pd("1u-server", 8, "front"),
+        pd("1u-server", 9, "front"),
+        pd("1u-server", 10, "front"),
+      ]);
+      const deviceTypes = createDeviceTypes();
+      const result = findNextValidPosition(rack, deviceTypes, 0, 1);
+
+      const message = getMoveBlockedMessage(result, 1);
+      expect(message).not.toBeNull();
+      expect(message?.toLowerCase()).toContain("up");
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Fixes the mobile device sheet's Move Up / Move Down, which did nothing when a nudge was blocked and gave no feedback.

The mobile selection inspector's move verbs only checked `isDeviceSelected` for their enabled state, so the button stayed active even when a rack boundary or a neighbouring device blocked the move, and a tap silently failed.

## Changes

- Disable the Move Up / Move Down verbs when the nudge is blocked by bounds or a neighbour, using the shared `canMoveUp` / `canMoveDown` collision checks (the same logic the desktop edit panel uses).
- Surface a warning toast on a blocked nudge instead of failing silently. The wording matches the existing blocked-placement toast (`"Can't place device here"`), and `"warning"` matches the codebase's blocked-action convention.
- Add `getMoveBlockedMessage` to `device-movement.ts` so the mobile handler reuses the shared collision result rather than reimplementing collision math.

The actual recorded move still routes through the shared selection handler, so undo/redo is preserved. The registry-bound shared move handler (so this fix is inherited by desktop, palette, and mobile from one source) is tracked separately in #2471; this PR is the localised mobile fix.

## Acceptance criteria

- [x] Port the desktop validation (use `canPlaceDevice` via the shared `findNextValidPosition`) before calling `moveDevice`
- [x] Disable the nudge button when the move is blocked by bounds or a neighbour
- [x] Show a toast on a blocked move

## Tests

TDD on the new pure helper `getMoveBlockedMessage`: a successful move yields no message; a blocked move (top boundary, bottom boundary, and neighbours filling the way) yields direction-aware feedback. The underlying collision/leapfrog math was already covered.

## Local gates

- `npm run lint` clean
- `npm run test:run` 159 test files pass
- `npm run build` succeeds
- `/code-review` (extra-high effort): one finding (toast type `info` -> `warning`), applied

Closes #2453

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make mobile move up/down show blocked moves instead of failing silently**

### What Changed
- Mobile Move Up / Move Down now disable when the device cannot move because of rack limits or another device in the way
- If a blocked move is still triggered, the app now shows a warning message instead of doing nothing
- The mobile sheet now uses the same move checks as the rest of the app, so it matches desktop behavior for blocked nudges

### Impact
`✅ Fewer silent mobile move failures`
`✅ Clearer blocked-move feedback`
`✅ More consistent move controls on mobile`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
