### PR TITLE
feat: mobile layout switcher sheet (#2460)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -23,6 +23,7 @@
   import MobileBottomNav from "$lib/components/mobile/MobileBottomNav.svelte";
   import RackEditSheet from "$lib/components/RackEditSheet.svelte";
   import MobileViewSheet from "$lib/components/mobile/MobileViewSheet.svelte";
+  import MobileLayoutsSheet from "$lib/components/mobile/MobileLayoutsSheet.svelte";
   import DevicePalette from "$lib/components/DevicePalette.svelte";
   import LoadDialog from "$lib/components/LoadDialog.svelte";
   import CommandPalette from "$lib/components/CommandPalette.svelte";
@@ -617,6 +618,13 @@
     dialogStore.closeSheet();
   }
 
+  // The Layouts sheet opens a fresh layout itself (via the workspace store) and
+  // then asks the orchestrator to raise the New Rack wizard, mirroring the
+  // desktop New layout flow.
+  function handleLayoutsNewLayout() {
+    dialogStore.open("newRack");
+  }
+
   function handleRacksTabClick() {
     dialogStore.openSheet("racks");
   }
@@ -828,7 +836,10 @@
     size="M"
     onclose={handleLayoutsSheetClose}
   >
-    <p class="sheet-placeholder">Layout switching is coming soon.</p>
+    <MobileLayoutsSheet
+      onnewlayout={handleLayoutsNewLayout}
+      onclose={handleLayoutsSheetClose}
+    />
   </Dialog>
 {/if}
 

--- a/src/lib/components/mobile/MobileLayoutsSheet.svelte
+++ b/src/lib/components/mobile/MobileLayoutsSheet.svelte
@@ -1,0 +1,262 @@
+<!--
+  MobileLayoutsSheet Component
+
+  Body of the mobile Layouts bottom sheet (#2460). Lists every layout the user
+  has, marks the current one, switches the active layout on tap, and offers a
+  New layout action. It reads the shared workspace store directly and routes
+  switching through the same verbs the desktop LayoutsLibrary uses
+  (openFromLibrary / switchTo), so mobile does not fork the layout-switching
+  logic. Creating a new layout opens a fresh tab and lets the parent raise the
+  New Rack wizard via onnewlayout.
+
+  Indicators are never colour-only (WCAG 1.4.1): each row pairs a state dot with
+  a text label (Active / Open / Closed), and the active row carries
+  aria-selected.
+-->
+<script lang="ts">
+  import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
+  import { createLayout } from "$lib/utils/serialization";
+  import { buildLayoutRows, type LayoutRow } from "../layouts-library";
+  import { IconPlusBold } from "$lib/components/icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+
+  interface Props {
+    /** Raise the New Rack wizard after a fresh layout is opened. */
+    onnewlayout?: () => void;
+    /** Dismiss the sheet (after a switch or a create). */
+    onclose?: () => void;
+  }
+
+  let { onnewlayout, onclose }: Props = $props();
+
+  const workspaceStore = getWorkspaceStore();
+
+  const rows = $derived(
+    buildLayoutRows(
+      workspaceStore.tabs,
+      workspaceStore.activeId,
+      workspaceStore.library,
+    ),
+  );
+
+  /** Stable per-row key: the tab id for an open row, the layout id for a closed one. */
+  function rowKey(row: LayoutRow): string {
+    return row.tabId ?? row.layoutId ?? "";
+  }
+
+  // Switch to the layout a row represents, then dismiss the sheet. An open row
+  // focuses its tab; a closed row hydrates its persisted body into a new tab.
+  // Both route through the workspace store, which never opens a duplicate tab.
+  function activateRow(row: LayoutRow) {
+    if (row.layoutId) {
+      workspaceStore.openFromLibrary(row.layoutId);
+    } else if (row.tabId) {
+      workspaceStore.switchTo(row.tabId);
+    }
+    onclose?.();
+  }
+
+  // Open a fresh empty layout in its own tab, make it active, then let the
+  // parent raise the New Rack wizard and dismiss the sheet. Mirrors the desktop
+  // New layout flow (App.handleNewLayout) so the two stay aligned.
+  function handleNewLayout() {
+    workspaceStore.openTab(createLayout());
+    onnewlayout?.();
+    onclose?.();
+  }
+</script>
+
+<div class="mobile-layouts-sheet">
+  <button
+    type="button"
+    class="new-layout"
+    onclick={handleNewLayout}
+    data-testid="mobile-new-layout"
+  >
+    <IconPlusBold size={ICON_SIZE.sm} />
+    New layout
+  </button>
+
+  <div class="layout-list" role="listbox" aria-label="Layouts">
+    {#each rows as row (rowKey(row))}
+      <button
+        type="button"
+        class="layout-row"
+        class:active={row.isActive}
+        role="option"
+        aria-selected={row.isActive}
+        onclick={() => activateRow(row)}
+        data-testid="mobile-layout-row-{rowKey(row)}"
+      >
+        <span
+          class="row-indicator"
+          class:is-active={row.isActive}
+          class:is-open={row.isOpen}
+          aria-hidden="true"
+        ></span>
+        <span class="row-info">
+          <span class="row-name">{row.name}</span>
+          <span class="row-meta">
+            <span class="row-state">
+              {#if row.isActive}
+                Active
+              {:else if row.isOpen}
+                Open
+              {:else}
+                Closed
+              {/if}
+            </span>
+            {#if row.isOpen}
+              <span aria-hidden="true">·</span>
+              {row.rackCount} rack{row.rackCount !== 1 ? "s" : ""} ·
+              {row.deviceCount} device{row.deviceCount !== 1 ? "s" : ""}
+            {/if}
+          </span>
+        </span>
+      </button>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .mobile-layouts-sheet {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-1) var(--space-1) var(--space-4);
+  }
+
+  .new-layout {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    width: 100%;
+    min-height: var(--touch-target-min);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    background: var(--colour-surface);
+    color: var(--colour-text);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .new-layout:hover {
+    background: var(--colour-surface-hover);
+    border-color: var(--colour-text-muted);
+  }
+
+  .new-layout:active {
+    background: var(--colour-surface-hover);
+    scale: 0.98;
+  }
+
+  .new-layout:focus-visible {
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .layout-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .layout-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    min-height: var(--touch-target-min);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--colour-text);
+    text-align: left;
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .layout-row:hover {
+    background: var(--colour-surface-hover);
+  }
+
+  .layout-row:active {
+    scale: 0.99;
+  }
+
+  .layout-row.active {
+    background: var(--colour-surface-active);
+    border-color: var(--colour-selection);
+  }
+
+  .layout-row:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: -2px;
+  }
+
+  /* State dot. Shape carries the open/closed distinction independent of colour
+     (WCAG 1.4.1): a closed layout is a hollow ring, an open one is a filled
+     dot, and the active one is filled in the success colour. The text state
+     label is the primary, fully colour-free cue; the dot reinforces it. */
+  .row-indicator {
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1px solid var(--colour-border);
+    background: transparent;
+  }
+
+  .row-indicator.is-open {
+    background: var(--colour-text-muted);
+    border-color: var(--colour-text-muted);
+  }
+
+  .row-indicator.is-active {
+    background: var(--colour-success);
+    border-color: var(--colour-success);
+  }
+
+  .row-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    min-width: 0;
+  }
+
+  .row-name {
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .row-meta {
+    font-size: var(--font-size-xs);
+    color: var(--colour-text-muted);
+  }
+
+  .row-state {
+    font-weight: var(--font-weight-medium);
+  }
+
+  .layout-row.active .row-state {
+    color: var(--colour-success);
+  }
+</style>

--- a/src/tests/MobileLayoutsSheet.test.ts
+++ b/src/tests/MobileLayoutsSheet.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import MobileLayoutsSheet from "$lib/components/mobile/MobileLayoutsSheet.svelte";
+import {
+  getWorkspaceStore,
+  resetWorkspaceStore,
+} from "$lib/stores/workspace.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+import { createLayout } from "$lib/utils/serialization";
+
+function renderSheet(
+  overrides: Partial<{ onnewlayout: () => void; onclose: () => void }> = {},
+) {
+  const props = {
+    onnewlayout: vi.fn(),
+    onclose: vi.fn(),
+    ...overrides,
+  };
+  render(MobileLayoutsSheet, { props });
+  return props;
+}
+
+describe("MobileLayoutsSheet", () => {
+  beforeEach(() => {
+    // The first tab shares the app-session history singleton; reset it so each
+    // test starts with a clean workspace and undo/redo stack.
+    resetHistoryStore();
+    resetWorkspaceStore();
+    resetToastStore();
+  });
+
+  it("switches the active layout when a different layout row is tapped", async () => {
+    const ws = getWorkspaceStore();
+    const firstId = ws.activeId;
+    ws.activeStore.setLayoutName("Homelab");
+
+    // Open a second layout; it becomes active.
+    const secondId = ws.openTab(createLayout("Office"));
+    expect(ws.activeId).toBe(secondId);
+
+    renderSheet();
+
+    // Tapping the first layout's row switches focus back to it.
+    await fireEvent.click(screen.getByRole("option", { name: /Homelab/ }));
+
+    expect(ws.activeId).toBe(firstId);
+  });
+
+  it("marks exactly the active layout as selected", () => {
+    const ws = getWorkspaceStore();
+    ws.activeStore.setLayoutName("Homelab");
+    const secondId = ws.openTab(createLayout("Office"));
+
+    renderSheet();
+
+    expect(ws.activeId).toBe(secondId);
+    expect(screen.getByRole("option", { name: /Office/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("option", { name: /Homelab/ })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+  });
+
+  it("creates and activates a new layout from the sheet", async () => {
+    const ws = getWorkspaceStore();
+    const startingTabIds = ws.tabs.map((t) => t.id);
+
+    renderSheet();
+
+    await fireEvent.click(screen.getByRole("button", { name: /New layout/ }));
+
+    const newTab = ws.tabs.find((t) => !startingTabIds.includes(t.id));
+    expect(newTab).toBeDefined();
+    expect(ws.activeId).toBe(newTab!.id);
+  });
+
+  it("closes the sheet after creating a new layout", async () => {
+    const props = renderSheet();
+
+    await fireEvent.click(screen.getByRole("button", { name: /New layout/ }));
+
+    expect(props.onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the sheet after switching layouts", async () => {
+    const ws = getWorkspaceStore();
+    ws.activeStore.setLayoutName("Homelab");
+    ws.openTab(createLayout("Office"));
+
+    const props = renderSheet();
+
+    await fireEvent.click(screen.getByRole("option", { name: /Homelab/ }));
+
+    expect(props.onclose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Populates the mobile Layouts bottom sheet body (M12, epic #2452). The Layouts tab now opens a real switcher instead of a "coming soon" placeholder.

- Lists every layout (open and closed-but-saved), marks the current one with an Active/Open/Closed text label plus a state dot (never colour-only, WCAG 1.4.1).
- Tap a row to switch the active layout, then the sheet dismisses.
- New layout button creates a fresh layout, activates it, and raises the New Rack wizard.

## Approach

Net-new mobile body that reuses desktop logic rather than forking it. The new `MobileLayoutsSheet.svelte` reads the shared workspace store directly and routes switching through the same verbs the desktop `LayoutsLibrary` uses (`openFromLibrary` / `switchTo`) via the shared `buildLayoutRows` helper. New layout mirrors `App.handleNewLayout`. The only change to `DialogOrchestrator.svelte` is the import plus swapping the placeholder for `<MobileLayoutsSheet>` in the layouts render region (sheet id and Layouts tab already exist from #2459).

## Tests

Behavioural tests in `MobileLayoutsSheet.test.ts`: switching selects a different layout as active, the active layout is marked selected, New layout creates and activates a layout, and the sheet closes after both actions.

## Gates

Local: `npm run lint`, `npm run test:run`, `npm run build` all pass; `/code-review` clean (no bugs; one cosmetic indentation fix applied). The new sheet body may need a visual-regression baseline since it adds a new mobile sheet render; flagging for the orchestrator, not blocking.

Closes #2460

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Add a working mobile layout switcher sheet**

### What Changed
- The mobile Layouts sheet now shows every layout, highlights the current one, and lets you switch layouts with a tap
- The sheet now includes a New layout action that creates a fresh layout, makes it active, and opens the New Rack flow
- The active layout is clearly labeled, and open/closed layouts are shown with both text and a visual marker
- The sheet closes after switching layouts or creating a new one

### Impact
`✅ Faster layout switching on mobile`
`✅ Clearer active layout selection`
`✅ Shorter path to creating a new layout on mobile`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
