### PR TITLE
feat: discoverable mobile rack editing via Racks sheet (#2461)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -24,6 +24,7 @@
   import RackEditSheet from "$lib/components/RackEditSheet.svelte";
   import MobileViewSheet from "$lib/components/mobile/MobileViewSheet.svelte";
   import MobileLayoutsSheet from "$lib/components/mobile/MobileLayoutsSheet.svelte";
+  import MobileRacksSheet from "$lib/components/mobile/MobileRacksSheet.svelte";
   import DevicePalette from "$lib/components/DevicePalette.svelte";
   import LoadDialog from "$lib/components/LoadDialog.svelte";
   import CommandPalette from "$lib/components/CommandPalette.svelte";
@@ -683,8 +684,9 @@
     dialogStore.openSheet("deviceLibrary");
   }
 
-  // The Layouts and Racks tabs open titled scaffold sheets; their bodies are
-  // populated by #2460 (layout switcher) and #2461 (rack editing) respectively.
+  // The Layouts and Racks tabs open titled bottom sheets: Layouts switches the
+  // active layout (#2460) and Racks lists racks and opens their properties
+  // (#2461).
   function handleLayoutsTabClick() {
     dialogStore.openSheet("layouts");
   }
@@ -706,6 +708,12 @@
 
   function handleRacksSheetClose() {
     dialogStore.closeSheet();
+  }
+
+  // The Racks sheet raises the New Rack wizard, mirroring the desktop New rack
+  // flow. The wizard's create handler places the rack and centres the canvas.
+  function handleRacksNewRack() {
+    dialogStore.open("newRack");
   }
 
   function handleDeviceLibrarySheetClose() {
@@ -918,7 +926,7 @@
   </Dialog>
 {/if}
 
-<!-- Racks tab sheet: scaffold. #2461 populates rack list and properties. -->
+<!-- Racks tab sheet: lists racks and opens their properties (#2461). -->
 {#if viewportStore.isMobile && racksSheetOpen}
   <Dialog
     open={racksSheetOpen}
@@ -926,7 +934,10 @@
     size="M"
     onclose={handleRacksSheetClose}
   >
-    <p class="sheet-placeholder">Rack editing is coming soon.</p>
+    <MobileRacksSheet
+      onnewrack={handleRacksNewRack}
+      onclose={handleRacksSheetClose}
+    />
   </Dialog>
 {/if}
 
@@ -1004,12 +1015,3 @@
   style="display: none;"
   aria-label="Import device library file"
 />
-
-<style>
-  .sheet-placeholder {
-    margin: 0;
-    padding: var(--space-4) 0;
-    color: var(--colour-text-muted);
-    text-align: center;
-  }
-</style>

--- a/src/lib/components/mobile/MobileRacksSheet.svelte
+++ b/src/lib/components/mobile/MobileRacksSheet.svelte
@@ -1,0 +1,209 @@
+<!--
+  MobileRacksSheet Component
+
+  Body of the mobile Racks bottom sheet (#2461). Lists every rack in the current
+  layout and, on tap, opens the existing RackEditSheet for that rack. This makes
+  rack property editing (name, size, view) discoverable from the Racks tab
+  instead of relying on the undiscoverable long-press shortcut.
+
+  It reuses the rack-edit entry point that the long-press flow already uses
+  (setActiveRack -> selectRack -> open the rackEdit sheet), so the rack-edit
+  logic is not forked. Creating a rack raises the parent New Rack wizard via
+  onnewrack, mirroring the Layouts sheet's New layout flow.
+-->
+<script lang="ts">
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getSelectionStore } from "$lib/stores/selection.svelte";
+  import { dialogStore } from "$lib/stores/dialogs.svelte";
+  import { IconPlusBold, IconChevronRight } from "$lib/components/icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+  import type { Rack } from "$lib/types";
+
+  interface Props {
+    /** Raise the New Rack wizard so a rack can be added from this sheet. */
+    onnewrack?: () => void;
+    /** Dismiss the sheet (after opening a rack or starting a new one). */
+    onclose?: () => void;
+  }
+
+  let { onnewrack, onclose }: Props = $props();
+
+  const layoutStore = getLayoutStore();
+  const selectionStore = getSelectionStore();
+
+  const racks = $derived(layoutStore.racks);
+
+  // Open the existing rack-edit sheet for the tapped rack. This routes through
+  // the same verbs as the long-press flow (App.handleRackLongPress) so mobile
+  // does not fork rack-edit logic: the rack becomes active and selected, the
+  // racks sheet closes, and RackEditSheet renders the now-active rack.
+  function openRack(rack: Rack) {
+    layoutStore.setActiveRack(rack.id);
+    selectionStore.selectRack(rack.id);
+    onclose?.();
+    dialogStore.openSheet("rackEdit");
+  }
+
+  // Raise the parent New Rack wizard, then dismiss the sheet. Mirrors the
+  // Layouts sheet's New layout action.
+  function handleNewRack() {
+    onnewrack?.();
+    onclose?.();
+  }
+</script>
+
+<div class="mobile-racks-sheet">
+  <button
+    type="button"
+    class="new-rack"
+    onclick={handleNewRack}
+    data-testid="mobile-new-rack"
+  >
+    <IconPlusBold size={ICON_SIZE.sm} />
+    New rack
+  </button>
+
+  {#if racks.length === 0}
+    <p class="empty">No racks yet. Add one to get started.</p>
+  {:else}
+    <div class="rack-list">
+      {#each racks as rack (rack.id)}
+        <button
+          type="button"
+          class="rack-row"
+          onclick={() => openRack(rack)}
+          data-testid="mobile-rack-row-{rack.id}"
+        >
+          <span class="row-info">
+            <span class="row-name">{rack.name}</span>
+            <span class="row-meta">
+              {rack.height}U ·
+              {rack.devices.length} device{rack.devices.length !== 1 ? "s" : ""}
+            </span>
+          </span>
+          <IconChevronRight size={ICON_SIZE.sm} />
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .mobile-racks-sheet {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-1) var(--space-1) var(--space-4);
+  }
+
+  .new-rack {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    width: 100%;
+    min-height: var(--touch-target-min);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    background: var(--colour-surface);
+    color: var(--colour-text);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .new-rack:hover {
+    background: var(--colour-surface-hover);
+    border-color: var(--colour-text-muted);
+  }
+
+  .new-rack:active {
+    background: var(--colour-surface-hover);
+    scale: 0.98;
+  }
+
+  .new-rack:focus-visible {
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .empty {
+    margin: 0;
+    padding: var(--space-4) 0;
+    color: var(--colour-text-muted);
+    text-align: center;
+    font-size: var(--font-size-sm);
+  }
+
+  .rack-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .rack-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    min-height: var(--touch-target-min);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--colour-text);
+    text-align: left;
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .rack-row:hover {
+    background: var(--colour-surface-hover);
+  }
+
+  .rack-row:active {
+    scale: 0.99;
+  }
+
+  .rack-row:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: -2px;
+  }
+
+  .row-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    min-width: 0;
+  }
+
+  .row-name {
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .row-meta {
+    font-size: var(--font-size-xs);
+    color: var(--colour-text-muted);
+  }
+
+  .rack-row :global(svg) {
+    flex-shrink: 0;
+    color: var(--colour-text-muted);
+  }
+</style>

--- a/src/tests/MobileRacksSheet.test.ts
+++ b/src/tests/MobileRacksSheet.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import MobileRacksSheet from "$lib/components/mobile/MobileRacksSheet.svelte";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getSelectionStore,
+  resetSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { dialogStore } from "$lib/stores/dialogs.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+
+function renderSheet(
+  overrides: Partial<{ onnewrack: () => void; onclose: () => void }> = {},
+) {
+  const props = {
+    onnewrack: vi.fn(),
+    onclose: vi.fn(),
+    ...overrides,
+  };
+  render(MobileRacksSheet, { props });
+  return props;
+}
+
+describe("MobileRacksSheet", () => {
+  beforeEach(() => {
+    resetHistoryStore();
+    resetLayoutStore();
+    resetSelectionStore();
+    resetToastStore();
+    dialogStore.closeSheet();
+  });
+
+  it("lists every rack in the current layout", () => {
+    const layout = getLayoutStore();
+    layout.addRack("Edge", 42);
+    layout.addRack("Core", 24);
+
+    renderSheet();
+
+    expect(screen.getByRole("button", { name: /Edge/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Core/ })).toBeInTheDocument();
+  });
+
+  it("opens rack properties for the tapped rack", async () => {
+    const layout = getLayoutStore();
+    layout.addRack("Edge", 42);
+    const core = layout.addRack("Core", 24);
+
+    renderSheet();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Core/ }));
+
+    // The tapped rack becomes active and the rack-edit sheet opens, so editing
+    // is reachable without the long-press shortcut.
+    expect(layout.activeRackId).toBe(core!.id);
+    expect(dialogStore.isSheetOpen("rackEdit")).toBe(true);
+  });
+
+  it("selects the tapped rack so the edit sheet acts on it", async () => {
+    const layout = getLayoutStore();
+    const edge = layout.addRack("Edge", 42);
+
+    const selection = getSelectionStore();
+    renderSheet();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Edge/ }));
+
+    expect(selection.isRackSelected).toBe(true);
+    expect(selection.selectedRackId).toBe(edge!.id);
+  });
+
+  it("closes the racks sheet after opening rack properties", async () => {
+    const layout = getLayoutStore();
+    layout.addRack("Edge", 42);
+
+    const props = renderSheet();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Edge/ }));
+
+    expect(props.onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("raises the New Rack flow and closes the sheet from the New rack action", async () => {
+    const props = renderSheet();
+
+    await fireEvent.click(screen.getByRole("button", { name: /New rack/ }));
+
+    expect(props.onnewrack).toHaveBeenCalledTimes(1);
+    expect(props.onclose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Fills the mobile Racks bottom-sheet body (previously a "coming soon" placeholder). The sheet now lists every rack in the current layout; tapping a rack opens the existing `RackEditSheet` for it, so rack property editing (name, size, view) is reachable from the Racks tab instead of only via the undiscoverable long-press.

A New rack action raises the existing New Rack wizard, mirroring the Layouts sheet's New layout flow (#2460).

## How it works

`MobileRacksSheet` reuses the rack-edit entry point the long-press flow already uses (`App.handleRackLongPress`): `setActiveRack` -> `selectRack` -> close the racks sheet -> open the `rackEdit` sheet. Rack-edit logic is not forked. The close-before-open ordering matters because sheets share a single open-slot.

## Acceptance criteria

- [x] The Racks tab lists racks and opens rack properties
- [x] Editing name/size/view works from the sheet (via the existing RackEditSheet)
- [x] Long-press remains as a shortcut but is no longer the only entry

## Scope

Touches only the Racks sheet body + its render block in `DialogOrchestrator`. The Layouts sheet (#2460), mobile move-handler region (#2453), `DeviceDetails.svelte`, and `MobileViewSheet.svelte` are untouched.

## Testing

`MobileRacksSheet.test.ts` covers the high-value behaviour: the list reflects the current layout's racks, tapping a row opens RackEditSheet for that rack (active + selected), the sheet closes after opening, and the New rack action raises the wizard.

Local gates: `npm run lint`, `npm run test:run` (161 files, 2731 tests), `npm run build` all pass.

Note: a new sheet body likely needs a visual-regression baseline; not blocking on it here.

Closes #2461

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Make mobile rack editing available from the Racks tab**

### What Changed
- The mobile Racks sheet now shows every rack in the current layout instead of a placeholder message
- Tapping a rack opens its edit screen so rack name, size, and view can be changed from the Racks tab
- The tapped rack is selected and set as active before the edit screen opens, so edits apply to the right rack
- The sheet also includes a New rack action that starts the existing rack creation flow and closes the sheet

### Impact
`✅ Easier mobile rack editing`
`✅ Fewer hidden long-press actions`
`✅ Faster rack creation from the Racks tab`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
