### PR TITLE
fix: mobile empty-state hint uses tap-to-place guidance (#2456)

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -432,9 +432,16 @@
 
     {#if hasRacks && allRacksEmpty && !hintDismissed}
       <div class="onboarding-hint" role="status" aria-live="polite">
-        <span
-          >Open the Devices tab on the left and drag items into your rack.</span
-        >
+        {#if viewportStore.isMobile}
+          <span
+            >Open the Devices tab, tap a device to arm it, then tap a rack slot
+            to place it.</span
+          >
+        {:else}
+          <span
+            >Open the Devices tab on the left and drag items into your rack.</span
+          >
+        {/if}
         <button
           class="hint-dismiss"
           onclick={dismissOnboardingHint}


### PR DESCRIPTION
## **User description**
## Summary

The empty-rack onboarding hint read "Open the Devices tab on the left and drag items into your rack." Both "on the left" (the desktop sidebar) and "drag items" (desktop drag-and-drop) reference affordances that do not exist on a mobile viewport, so the hint sent mobile users to a dead end.

This branches the hint on `viewportStore.isMobile` (already imported in Canvas.svelte). Mobile users now see tap-to-place guidance that matches the bottom-nav + tap-to-place model shipped in #2454/#2453. Desktop copy is unchanged.

- Mobile: "Open the Devices tab, tap a device to arm it, then tap a rack slot to place it."
- Desktop: "Open the Devices tab on the left and drag items into your rack."

## Scope

Confirmed location: `src/lib/components/Canvas.svelte` line 368 (the prior audit searched for the literal string "drag from left menu", which is not what the code says, hence the false negative).

Scanned `src/` for other stale mobile hints:
- `DevicePalette.svelte:632` "Add a device to get started" only renders when the device library is empty (no devices exist at all). It does not reference a desktop-only affordance, so it is correct on mobile and left unchanged.
- `Canvas.svelte:311` "No racks configured" is a screen-reader-only description, not a visible hint. No change needed.

## Testing

No test warranted: this is a copy-only change with no behavioural logic. Per CLAUDE.md, a "renders the hint" DOM/structure test is explicitly disallowed (ESLint blocks `querySelector`/structure assertions), and TypeScript already verifies the template compiles.

Local gates: `npm run lint`, `npm run test:run`, and `npm run build` all pass. Svelte autofixer reports no issues on the change.

## Visual baselines

This adds a conditional branch to the mobile empty-state hint copy. Mobile visual snapshots are not regenerated here (#2472 handles baseline regen at close).

Closes #2456

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Show mobile-friendly setup guidance for empty racks**

### What Changed
- Mobile users now see tap-to-place instructions when an empty rack is shown
- Desktop users keep the existing drag-and-drop hint
- The hint dismissal button remains available in both views

### Impact
`✅ Clearer empty-state guidance on mobile`
`✅ Fewer dead-end onboarding hints`
`✅ Shorter time to place the first device`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
