### PR TITLE
chore: format files left unformatted by #2448 (unblock format gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,12 +164,7 @@ gh pr view <number> --comments
 
 ## Development Philosophy
 
-**Prior-release data is supported and tested:** Rackula has shipped releases that
-real users run with saved data. Reading data written by a prior release is a
-first-class, tested requirement. A schema change must be backward-compatible, or
-ship a migration plus a new fixture in the upgrade corpus
-(`src/tests/fixtures/upgrade-corpus/`). See the design at
-`docs/superpowers/specs/2026-06-17-upgrade-safety-harness-design.md`.
+**Prior-release data is supported and tested:** Rackula has shipped releases that real users run with saved data. Reading data written by a prior release is a first-class, tested requirement. A schema change must be backward-compatible, or ship a migration plus a new fixture in the upgrade corpus (`src/tests/fixtures/upgrade-corpus/`). See the design at `docs/superpowers/specs/2026-06-17-upgrade-safety-harness-design.md`.
 
 **Simplicity first:**
 
@@ -184,9 +179,7 @@ ship a migration plus a new fixture in the upgrade corpus
 - No `// removed` comments
 - If unused, delete it
 
-This is about dead code, not data. Migrations and legacy-data adapters that let
-prior-release layouts load are required code, not hacks; keep them and test them
-via the upgrade corpus.
+This is about dead code, not data. Migrations and legacy-data adapters that let prior-release layouts load are required code, not hacks; keep them and test them via the upgrade corpus.
 
 **File operations:**
 

--- a/src/tests/browser-upgrade.test.ts
+++ b/src/tests/browser-upgrade.test.ts
@@ -45,9 +45,18 @@ const V06_BODY = {
     id: "rack-a",
     name: "Rack A",
     height: 42,
-    devices: [{ id: "dev-1", device_type: "switch-1u", position: 5, face: "front" }],
+    devices: [
+      { id: "dev-1", device_type: "switch-1u", position: 5, face: "front" },
+    ],
   },
-  device_types: [{ slug: "switch-1u", u_height: 1, manufacturer: "Acme", category: "network" }],
+  device_types: [
+    {
+      slug: "switch-1u",
+      u_height: 1,
+      manufacturer: "Acme",
+      category: "network",
+    },
+  ],
 };
 
 // loadLayoutBody (browser-workspace.ts:200) checks:
@@ -76,10 +85,18 @@ describe("browser upgrade: localStorage ingress", () => {
     // Both are intentional transformations declared in the allow list.
     // All other distinctive values (ids, names, slugs, face) must survive.
     const losses = findSilentLosses(V06_BODY, result.layout, [
-      { pathPattern: "position$", reason: "U value scaled to internal units by migrateLayout" },
-      { pathPattern: "\\.version$", reason: "migrateLayout stamps current VERSION after position migration" },
+      {
+        pathPattern: "position$",
+        reason: "U value scaled to internal units by migrateLayout",
+      },
+      {
+        pathPattern: "\\.version$",
+        reason: "migrateLayout stamps current VERSION after position migration",
+      },
     ]);
-    expect(losses, `silent loss:\n${JSON.stringify(losses, null, 2)}`).toEqual([]);
+    expect(losses, `silent loss:\n${JSON.stringify(losses, null, 2)}`).toEqual(
+      [],
+    );
   });
 
   it("loadWorkspaceIndex still finds layouts under the current key structure", () => {

--- a/src/tests/fixtures/upgrade-corpus/pre-carrier-slot-position.expected.json
+++ b/src/tests/fixtures/upgrade-corpus/pre-carrier-slot-position.expected.json
@@ -1,6 +1,12 @@
 {
   "allowList": [
-    { "pathPattern": "slot_position$", "reason": "consumed by carrier adapter into container placement" },
-    { "pathPattern": "\\.position$", "reason": "carrier adapter collapses N co-located device positions into one carrier position; children get position 0" }
+    {
+      "pathPattern": "slot_position$",
+      "reason": "consumed by carrier adapter into container placement"
+    },
+    {
+      "pathPattern": "\\.position$",
+      "reason": "carrier adapter collapses N co-located device positions into one carrier position; children get position 0"
+    }
   ]
 }

--- a/src/tests/upgrade-corpus-helpers.test.ts
+++ b/src/tests/upgrade-corpus-helpers.test.ts
@@ -20,7 +20,9 @@ describe("findSilentLosses", () => {
   it("allows a declared drop when every source path matches the allow-list", () => {
     const raw = { racks: [{ devices: [{ slot_position: "0" }] }] };
     const loaded = { racks: [{ devices: [{}] }] };
-    const allow = [{ pathPattern: "slot_position$", reason: "consumed by carrier adapter" }];
+    const allow = [
+      { pathPattern: "slot_position$", reason: "consumed by carrier adapter" },
+    ];
     expect(findSilentLosses(raw, loaded, allow)).toEqual([]);
   });
 

--- a/src/tests/upgrade-corpus-helpers.ts
+++ b/src/tests/upgrade-corpus-helpers.ts
@@ -27,14 +27,20 @@ export interface SilentLoss {
   paths: string[];
 }
 
-export function collectLeaves(node: unknown, path = "$", acc?: LeafIndex): LeafIndex {
+export function collectLeaves(
+  node: unknown,
+  path = "$",
+  acc?: LeafIndex,
+): LeafIndex {
   const index: LeafIndex = acc ?? { values: new Map(), paths: new Map() };
   if (node === undefined) return index; // undefined never appears in parsed YAML/JSON
   if (node !== null && typeof node === "object") {
     if (Array.isArray(node)) {
       node.forEach((item, i) => collectLeaves(item, `${path}[${i}]`, index));
     } else {
-      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      for (const [key, value] of Object.entries(
+        node as Record<string, unknown>,
+      )) {
         collectLeaves(value, `${path}.${key}`, index);
       }
     }

--- a/src/tests/upgrade-corpus.test.ts
+++ b/src/tests/upgrade-corpus.test.ts
@@ -1,7 +1,14 @@
 // src/tests/upgrade-corpus.test.ts
 import { describe, it, expect } from "vitest";
-import { parseLayoutYaml, parseLayoutYamlWithImages, parseYaml } from "$lib/utils/yaml";
-import { findSilentLosses, type AllowListEntry } from "./upgrade-corpus-helpers";
+import {
+  parseLayoutYaml,
+  parseLayoutYamlWithImages,
+  parseYaml,
+} from "$lib/utils/yaml";
+import {
+  findSilentLosses,
+  type AllowListEntry,
+} from "./upgrade-corpus-helpers";
 
 interface Sidecar {
   reject?: boolean;


### PR DESCRIPTION
## **User description**
## Summary

PR #2448 (upgrade-safety harness) merged six files onto an unprotected `main` that fail the repo-wide prettier gate (`validate` -> Check formatting). Because that gate runs `prettier --check` on the whole repo, **every open PR currently fails `validate`** through no fault of its own (confirmed on #2492).

This runs `prettier --write` on exactly those six files to turn `main` green again.

## Files

- `CLAUDE.md` — #2448 added hard-wrapped paragraphs; unwrapped to one line per paragraph to match the repo `proseWrap: "never"` policy.
- `src/tests/browser-upgrade.test.ts`, `src/tests/upgrade-corpus-helpers.test.ts`, `src/tests/upgrade-corpus-helpers.ts`, `src/tests/upgrade-corpus.test.ts` — standard formatting.
- `src/tests/fixtures/upgrade-corpus/pre-carrier-slot-position.expected.json` — whitespace only. The fixture is consumed via `import.meta.glob(...*.expected.json)` (parsed to an object, compared with `.toEqual`), so reformatting is inert.

## Verification

- `prettier --check` on all six: clean.
- `npm run lint`: clean.
- upgrade-corpus tests (the only suite touching these files): 13/13 pass.
- No semantic changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Reformat files so formatting checks pass again**

### What Changed
- Rewrapped the project guidance document to match the repository’s line-length style
- Reformatted upgrade test files and the related fixture without changing test behavior
- Kept the upgrade corpus coverage and saved-data checks unchanged

### Impact
`✅ Fewer formatting check failures`
`✅ Unblocked PR validation`
`✅ No change to upgrade behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
