### PR TITLE
feat: wire read-only lock into all mobile edit surfaces (#2483)

### DIFF
--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -163,13 +163,32 @@ export function createActionDispatch(): ActionDispatch {
     "toggle-annotations": () => getUIStore().toggleAnnotations(),
     "cycle-rack-prev": () => cycleActiveRack(-1),
     "cycle-rack-next": () => cycleActiveRack(1),
-    // selection
-    "delete-selection": handleDelete,
-    "move-device-up": moveSelectedDeviceUp,
-    "move-device-down": moveSelectedDeviceDown,
-    "move-device-slot": moveSelectedDeviceToSlot,
-    "duplicate-selection": duplicateSelection,
-    "flip-device-face": flipSelectedDeviceFace,
+    // selection — each mutation verb checks readOnly so keyboard shortcuts
+    // and the command palette respect the lock without per-call-site guards.
+    "delete-selection": () => {
+      if (getUIStore().readOnly) return;
+      handleDelete();
+    },
+    "move-device-up": () => {
+      if (getUIStore().readOnly) return;
+      moveSelectedDeviceUp();
+    },
+    "move-device-down": () => {
+      if (getUIStore().readOnly) return;
+      moveSelectedDeviceDown();
+    },
+    "move-device-slot": () => {
+      if (getUIStore().readOnly) return;
+      moveSelectedDeviceToSlot();
+    },
+    "duplicate-selection": () => {
+      if (getUIStore().readOnly) return;
+      duplicateSelection();
+    },
+    "flip-device-face": () => {
+      if (getUIStore().readOnly) return;
+      flipSelectedDeviceFace();
+    },
     // rack-actions take string[] not string; wrap selectedRackId in array
     "focus-rack": () => {
       const id = getSelectionStore().selectedRackId;

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -140,6 +140,12 @@ export interface ActionEnabledContext {
    * cells. False for full-width devices and single-cell carriers (#2322).
    */
   canMoveDeviceSlot: boolean;
+  /**
+   * Whether the layout is in read-only mode (presentation safety valve). When
+   * true, all mutation verbs are disabled regardless of selection state. Omit
+   * or set to false for normal edit mode.
+   */
+  readOnly?: boolean;
 }
 
 /**
@@ -245,7 +251,7 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     label: "Delete selected",
     scope: "selection",
     bindings: [{ key: "Delete" }, { key: "Backspace" }],
-    enabledWhen: (ctx) => ctx.hasSelection,
+    enabledWhen: (ctx) => !ctx.readOnly && ctx.hasSelection,
     helpGroup: "Editing",
     keywords: ["remove"],
   },
@@ -254,7 +260,7 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     label: "Move device up",
     scope: "selection",
     bindings: [{ key: "ArrowUp" }],
-    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    enabledWhen: (ctx) => !ctx.readOnly && ctx.isDeviceSelected,
     helpGroup: "Editing",
     helpKeyLabel: "↑ / ↓",
     keywords: ["nudge", "up"],
@@ -264,7 +270,7 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     label: "Move device down",
     scope: "selection",
     bindings: [{ key: "ArrowDown" }],
-    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    enabledWhen: (ctx) => !ctx.readOnly && ctx.isDeviceSelected,
     keywords: ["nudge", "down"],
   },
   {
@@ -272,7 +278,7 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     label: "Move to next cell",
     scope: "selection",
     bindings: [],
-    enabledWhen: (ctx) => ctx.canMoveDeviceSlot,
+    enabledWhen: (ctx) => !ctx.readOnly && ctx.canMoveDeviceSlot,
     keywords: ["cell", "carrier", "slot", "shuffle"],
   },
   {
@@ -283,7 +289,8 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
       { key: "d", ctrl: true },
       { key: "d", meta: true },
     ],
-    enabledWhen: (ctx) => ctx.isDeviceSelected || ctx.isRackSelected,
+    enabledWhen: (ctx) =>
+      !ctx.readOnly && (ctx.isDeviceSelected || ctx.isRackSelected),
     keywords: ["copy", "clone"],
   },
   {
@@ -291,7 +298,7 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     label: "Flip face",
     scope: "selection",
     bindings: [],
-    enabledWhen: (ctx) => ctx.isDeviceSelected,
+    enabledWhen: (ctx) => !ctx.readOnly && ctx.isDeviceSelected,
     keywords: ["rotate", "front", "rear", "face"],
   },
   {

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -66,6 +66,8 @@
   let inputEl = $state<HTMLElement | null>(null);
 
   // Live enable context for gating selection (and rack-dependent) commands.
+  // readOnly is included so that mutation commands are suppressed in the palette
+  // command list while the lock is active, matching the visual affordance.
   const ctx = $derived<ActionEnabledContext>({
     hasSelection: selectionStore.hasSelection,
     isDeviceSelected: selectionStore.isDeviceSelected,
@@ -75,6 +77,7 @@
     hasRacks: layoutStore.hasRack,
     mode: getStorageMode(),
     canMoveDeviceSlot: canMoveSelectedDeviceSlot(),
+    readOnly: uiStore.readOnly,
   });
 
   const groups = $derived(getPaletteCommands(ctx));

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -156,6 +156,8 @@
   }
 
   function placeDevice(device: DeviceType) {
+    // Tap-to-place is suppressed when the layout is locked for viewing.
+    if (uiStore.readOnly) return;
     // Mirror the mobile tap-to-place path: start placement, then close. The
     // palette closing is the cue to position the device on the canvas.
     placementStore.startPlacement(device);

--- a/src/lib/components/DeviceDetails.svelte
+++ b/src/lib/components/DeviceDetails.svelte
@@ -32,6 +32,12 @@
     /** Show the verb row, editable fields, and Remove. Used on mobile. */
     showActions?: boolean;
     /**
+     * Whether the layout is in read-only mode. When true the inspector hides
+     * all mutating verbs and editable fields, showing only the device summary
+     * line. The caller is still responsible for gating dispatched actions.
+     */
+    readOnly?: boolean;
+    /**
      * Registry-projected selection verbs with disabled state. When supplied
      * (with onaction), the action buttons render from the registry instead of
      * bespoke per-consumer callbacks.
@@ -55,6 +61,7 @@
     rackView: _rackView = "front",
     rackHeight: _rackHeight,
     showActions = false,
+    readOnly = false,
     verbs = [],
     onaction,
     ip = "",
@@ -178,108 +185,110 @@
     <div class="inspector">
       <p class="summary">{summary}</p>
 
-      <div class="verbs">
-        {#each rowVerbs as verb (verb.id)}
-          <button
-            type="button"
-            class="verb"
-            onclick={() => dispatch(verb.id)}
-            disabled={verb.disabled}
-            aria-label={verb.label}
-          >
-            {#if verb.id === "move-device-up"}
-              <IconChevronUp />
-              <span>Up</span>
-            {:else if verb.id === "move-device-down"}
-              <IconChevronDown />
-              <span>Down</span>
-            {:else if verb.id === "move-device-slot"}
-              <IconChevronRight size={ICON_SIZE.sm} />
-              <span>Move</span>
-            {:else if verb.id === "flip-device-face"}
-              <IconFlip size={ICON_SIZE.sm} />
-              <span>Flip</span>
-            {/if}
-          </button>
-        {/each}
-        {#if duplicateVerb}
-          <button
-            type="button"
-            class="verb"
-            onclick={() => dispatch(duplicateVerb.id)}
-            disabled={duplicateVerb.disabled}
-            aria-label={duplicateVerb.label}
-          >
-            <IconCopy size={ICON_SIZE.sm} />
-            <span>Duplicate</span>
-          </button>
-        {/if}
-      </div>
-
-      <div class="fields">
-        <div class="field">
-          <span class="field-label" id="inspector-name-label">Name</span>
-          {#if editingName}
-            <!-- svelte-ignore a11y_autofocus -->
-            <input
-              type="text"
-              class="field-input"
-              aria-labelledby="inspector-name-label"
-              bind:value={nameInput}
-              onblur={commitName}
-              onkeydown={handleNameKeydown}
-              autofocus
-            />
-          {:else}
+      {#if !readOnly}
+        <div class="verbs">
+          {#each rowVerbs as verb (verb.id)}
             <button
               type="button"
-              class="field-edit"
-              onclick={startEditingName}
-              aria-label="Edit name"
+              class="verb"
+              onclick={() => dispatch(verb.id)}
+              disabled={verb.disabled}
+              aria-label={verb.label}
             >
-              <span class="field-value">{displayName}</span>
-              <IconEdit />
+              {#if verb.id === "move-device-up"}
+                <IconChevronUp />
+                <span>Up</span>
+              {:else if verb.id === "move-device-down"}
+                <IconChevronDown />
+                <span>Down</span>
+              {:else if verb.id === "move-device-slot"}
+                <IconChevronRight size={ICON_SIZE.sm} />
+                <span>Move</span>
+              {:else if verb.id === "flip-device-face"}
+                <IconFlip size={ICON_SIZE.sm} />
+                <span>Flip</span>
+              {/if}
+            </button>
+          {/each}
+          {#if duplicateVerb}
+            <button
+              type="button"
+              class="verb"
+              onclick={() => dispatch(duplicateVerb.id)}
+              disabled={duplicateVerb.disabled}
+              aria-label={duplicateVerb.label}
+            >
+              <IconCopy size={ICON_SIZE.sm} />
+              <span>Duplicate</span>
             </button>
           {/if}
         </div>
 
-        <div class="field">
-          <label class="field-label" for="inspector-ip">IP</label>
-          <input
-            id="inspector-ip"
-            type="text"
-            class="field-input"
-            placeholder="e.g. 192.168.1.10"
-            bind:value={ipInput}
-            onblur={commitIp}
-          />
+        <div class="fields">
+          <div class="field">
+            <span class="field-label" id="inspector-name-label">Name</span>
+            {#if editingName}
+              <!-- svelte-ignore a11y_autofocus -->
+              <input
+                type="text"
+                class="field-input"
+                aria-labelledby="inspector-name-label"
+                bind:value={nameInput}
+                onblur={commitName}
+                onkeydown={handleNameKeydown}
+                autofocus
+              />
+            {:else}
+              <button
+                type="button"
+                class="field-edit"
+                onclick={startEditingName}
+                aria-label="Edit name"
+              >
+                <span class="field-value">{displayName}</span>
+                <IconEdit />
+              </button>
+            {/if}
+          </div>
+
+          <div class="field">
+            <label class="field-label" for="inspector-ip">IP</label>
+            <input
+              id="inspector-ip"
+              type="text"
+              class="field-input"
+              placeholder="e.g. 192.168.1.10"
+              bind:value={ipInput}
+              onblur={commitIp}
+            />
+          </div>
+
+          <div class="field field-notes">
+            <label class="field-label" for="inspector-notes">Notes</label>
+            <textarea
+              id="inspector-notes"
+              class="field-input notes-input"
+              rows="2"
+              placeholder="Add notes about this placement"
+              bind:value={notesInput}
+              onblur={commitNotes}></textarea>
+          </div>
         </div>
 
-        <div class="field field-notes">
-          <label class="field-label" for="inspector-notes">Notes</label>
-          <textarea
-            id="inspector-notes"
-            class="field-input notes-input"
-            rows="2"
-            placeholder="Add notes about this placement"
-            bind:value={notesInput}
-            onblur={commitNotes}></textarea>
-        </div>
-      </div>
-
-      {#if deleteVerb}
-        <div class="foot">
-          <button
-            type="button"
-            class="remove"
-            onclick={() => dispatch(deleteVerb.id)}
-            disabled={deleteVerb.disabled}
-            aria-label={deleteVerb.label}
-          >
-            <IconTrash size={ICON_SIZE.sm} />
-            <span>Remove</span>
-          </button>
-        </div>
+        {#if deleteVerb}
+          <div class="foot">
+            <button
+              type="button"
+              class="remove"
+              onclick={() => dispatch(deleteVerb.id)}
+              disabled={deleteVerb.disabled}
+              aria-label={deleteVerb.label}
+            >
+              <IconTrash size={ICON_SIZE.sm} />
+              <span>Remove</span>
+            </button>
+          </div>
+        {/if}
       {/if}
     </div>
   {:else}

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -528,7 +528,8 @@
 
   // Build the live enabledWhen context from the stores, mirroring
   // VerbBarOverlay's desktop projection so mobile and desktop share one
-  // source of truth for verb availability.
+  // source of truth for verb availability. readOnly gates all mutation verbs
+  // through the registry, so no individual call site needs to check it.
   const mobileActionCtx = $derived<ActionEnabledContext>({
     hasSelection: selectionStore.hasSelection,
     isDeviceSelected: selectionStore.isDeviceSelected,
@@ -538,6 +539,7 @@
     hasRacks: layoutStore.rackCount > 0,
     mode: getStorageMode(),
     canMoveDeviceSlot: canMoveSelectedDeviceSlot(),
+    readOnly: uiStore.readOnly,
   });
 
   // The rack and device index the mobile sheet is acting on. The bottom sheet
@@ -641,8 +643,13 @@
 
   // Dispatch a registry verb by action id to the shared handler. The handlers
   // read live selection state from the stores, so they act on the same device
-  // the mobile bottom sheet is showing.
+  // the mobile bottom sheet is showing. The readOnly guard here is defence-in-
+  // depth: the registry's enabledWhen already disables all mutation verbs when
+  // readOnly is set, and DeviceDetails hides the controls entirely, so this
+  // path should not be reachable while locked. Belt-and-suspenders keeps it safe
+  // even if a future refactor opens another route to this function.
   function handleMobileVerb(id: ActionId): void {
+    if (uiStore.readOnly) return;
     switch (id) {
       case "move-device-up":
         nudgeSelectedDevice(1);
@@ -733,6 +740,8 @@
   function handleMobileDeviceSelect(
     event: CustomEvent<{ device: import("$lib/types").DeviceType }>,
   ) {
+    // Tap-to-place is suppressed when the layout is locked for viewing.
+    if (uiStore.readOnly) return;
     const { device } = event.detail;
     hapticTap();
     placementStore.startPlacement(device);
@@ -783,6 +792,7 @@
         rackView={activeRack.view}
         {rackHeight}
         showActions={true}
+        readOnly={uiStore.readOnly}
         verbs={mobileVerbs}
         onaction={handleMobileVerb}
         ip={deviceIp}

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -30,6 +30,7 @@
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
+  import { getUIStore } from "$lib/stores/ui.svelte";
   import { getStorageMode } from "$lib/storage";
 
   interface Props {
@@ -48,6 +49,7 @@
   const selection = getSelectionStore();
   const layout = getLayoutStore();
   const canvas = getCanvasStore();
+  const ui = getUIStore();
 
   const ctx = $derived<ActionEnabledContext>({
     hasSelection: selection.hasSelection,
@@ -58,6 +60,7 @@
     hasRacks: layout.rackCount > 0,
     mode: getStorageMode(),
     canMoveDeviceSlot: canMoveSelectedDeviceSlot(),
+    readOnly: ui.readOnly,
   });
 
   const verbs = $derived(

--- a/src/tests/DeviceDetails.test.ts
+++ b/src/tests/DeviceDetails.test.ts
@@ -397,4 +397,116 @@ describe("DeviceDetails", () => {
       expect(oneditname).not.toHaveBeenCalled();
     });
   });
+
+  describe("Read-only lock", () => {
+    // Verbs as supplied by the registry projection in a fully-capable context.
+    const allVerbs: SelectionVerbItem[] = [
+      { id: "move-device-up", label: "Move device up", disabled: false },
+      { id: "move-device-down", label: "Move device down", disabled: false },
+      { id: "flip-device-face", label: "Flip face", disabled: false },
+      {
+        id: "duplicate-selection",
+        label: "Duplicate selection",
+        disabled: false,
+      },
+      { id: "delete-selection", label: "Delete selected", disabled: false },
+    ];
+
+    it("hides action verbs when readOnly is true", () => {
+      render(DeviceDetails, {
+        props: {
+          device: createTestPlacedDevice(),
+          deviceType: createTestDeviceType(),
+          showActions: true,
+          readOnly: true,
+          verbs: allVerbs,
+        },
+      });
+      expect(
+        screen.queryByRole("button", { name: /move device up/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /flip face/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /duplicate/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /delete selected/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides editable fields when readOnly is true", () => {
+      render(DeviceDetails, {
+        props: {
+          device: createTestPlacedDevice(),
+          deviceType: createTestDeviceType(),
+          showActions: true,
+          readOnly: true,
+          verbs: allVerbs,
+          ip: "10.0.0.1",
+        },
+      });
+      expect(
+        screen.queryByRole("button", { name: /edit name/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("textbox", { name: /ip/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("textbox", { name: /notes/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows action verbs when readOnly is false", () => {
+      render(DeviceDetails, {
+        props: {
+          device: createTestPlacedDevice(),
+          deviceType: createTestDeviceType(),
+          showActions: true,
+          readOnly: false,
+          verbs: allVerbs,
+        },
+      });
+      expect(
+        screen.getByRole("button", { name: /move device up/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /delete selected/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows action verbs when readOnly is omitted (default unlocked)", () => {
+      render(DeviceDetails, {
+        props: {
+          device: createTestPlacedDevice(),
+          deviceType: createTestDeviceType(),
+          showActions: true,
+          verbs: allVerbs,
+        },
+      });
+      expect(
+        screen.getByRole("button", { name: /move device up/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("does not call onaction when verb button click is attempted while readOnly (verbs hidden)", async () => {
+      // When readOnly=true the verb buttons are not in the DOM, so clicks cannot
+      // reach them. This test verifies the component does not fire onaction via
+      // any other path.
+      const onaction = vi.fn();
+      render(DeviceDetails, {
+        props: {
+          device: createTestPlacedDevice(),
+          deviceType: createTestDeviceType(),
+          showActions: true,
+          readOnly: true,
+          verbs: allVerbs,
+          onaction,
+        },
+      });
+      // No clickable verb buttons exist; onaction must never be called.
+      expect(onaction).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/tests/verb-bars.test.ts
+++ b/src/tests/verb-bars.test.ts
@@ -272,4 +272,79 @@ describe("verb-bars projection", () => {
       expect(upVerb?.label).toBe(registryAction?.label);
     });
   });
+
+  describe("read-only lock: enabledWhen respects ctx.readOnly", () => {
+    const readOnlyCtx: ActionEnabledContext = {
+      ...deviceCtx,
+      canMoveDeviceSlot: true,
+      readOnly: true,
+    };
+
+    it("disables all device mutation verbs when readOnly is true", () => {
+      const result = getSelectionVerbsWithState(readOnlyCtx);
+      for (const verb of result) {
+        expect(verb.disabled).toBe(true);
+      }
+    });
+
+    it("move-device-up is disabled when readOnly", () => {
+      const result = getSelectionVerbsWithState(readOnlyCtx);
+      const verb = result.find((v) => v.id === "move-device-up");
+      expect(verb?.disabled).toBe(true);
+    });
+
+    it("move-device-down is disabled when readOnly", () => {
+      const result = getSelectionVerbsWithState(readOnlyCtx);
+      const verb = result.find((v) => v.id === "move-device-down");
+      expect(verb?.disabled).toBe(true);
+    });
+
+    it("move-device-slot is disabled when readOnly (even if canMoveDeviceSlot is true)", () => {
+      const result = getSelectionVerbsWithState(readOnlyCtx);
+      const verb = result.find((v) => v.id === "move-device-slot");
+      expect(verb?.disabled).toBe(true);
+    });
+
+    it("flip-device-face is disabled when readOnly", () => {
+      const result = getSelectionVerbsWithState(readOnlyCtx);
+      const verb = result.find((v) => v.id === "flip-device-face");
+      expect(verb?.disabled).toBe(true);
+    });
+
+    it("duplicate-selection is disabled when readOnly", () => {
+      const result = getSelectionVerbsWithState(readOnlyCtx);
+      const verb = result.find((v) => v.id === "duplicate-selection");
+      expect(verb?.disabled).toBe(true);
+    });
+
+    it("delete-selection is disabled when readOnly", () => {
+      const result = getSelectionVerbsWithState(readOnlyCtx);
+      const verb = result.find((v) => v.id === "delete-selection");
+      expect(verb?.disabled).toBe(true);
+    });
+
+    it("all device mutation verbs are enabled when readOnly is false", () => {
+      const readWriteCtx: ActionEnabledContext = {
+        ...deviceCtx,
+        canMoveDeviceSlot: true,
+        readOnly: false,
+      };
+      const result = getSelectionVerbsWithState(readWriteCtx);
+      for (const verb of result) {
+        expect(verb.disabled).toBe(false);
+      }
+    });
+
+    it("all device mutation verbs are enabled when readOnly is omitted", () => {
+      // Backward-compatibility: omitting readOnly is identical to false.
+      const ctxWithSlot: ActionEnabledContext = {
+        ...deviceCtx,
+        canMoveDeviceSlot: true,
+      };
+      const result = getSelectionVerbsWithState(ctxWithSlot);
+      for (const verb of result) {
+        expect(verb.disabled).toBe(false);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

- Adds `readOnly` to `ActionEnabledContext` in the actions registry. All mutation verb `enabledWhen` predicates now gate on `!ctx.readOnly`, so the lock propagates through the registry to every consumer at once (mobile inspector, desktop verb bar, command palette, keyboard handler).
- `DeviceDetails`: new `readOnly` prop hides all verb buttons and editable fields when locked, showing only the device summary line.
- `DialogOrchestrator`: wires `readOnly` into `mobileActionCtx` and `DeviceDetails`; guards `handleMobileDeviceSelect` (tap-to-place arm) and `handleMobileVerb` (belt-and-suspenders dispatch gate).
- `VerbBarOverlay`: includes `readOnly` in its `ActionEnabledContext` so the desktop floating verb bar also hides mutation verbs when locked.
- `dispatch.ts`: wraps every selection mutation verb to check `uiStore.readOnly` before running, closing keyboard shortcut bypass (Delete, ArrowUp/Down, Ctrl+D).
- `CommandPalette`: guards `placeDevice()` against `readOnly`, closing the command-palette tap-to-place bypass.

## Bypass audit (all paths verified closed)

| Path | Guard |
|---|---|
| Mobile inspector verbs | `enabledWhen` via registry + `DeviceDetails` hides controls |
| Mobile editable fields (name/IP/notes) | `DeviceDetails` hides fields when `readOnly` |
| Mobile tap-to-place (Device Library sheet) | `handleMobileDeviceSelect` returns early |
| Command palette tap-to-place | `placeDevice()` returns early |
| Keyboard shortcuts (Delete/ArrowUp/Down/Ctrl+D) | `dispatch.ts` wrappers return early |
| Desktop floating verb bar | `VerbBarOverlay` passes `readOnly` to context |

## Test plan

- [x] `npm run test:run` - all 2765 tests pass
- [x] `npm run lint` - no issues
- [x] `npm run build` - clean build
- [x] New `verb-bars.test.ts` coverage: `readOnly` disables all mutation verbs via `getSelectionVerbsWithState`
- [x] New `DeviceDetails.test.ts` coverage: `readOnly=true` hides verbs and editable fields; `readOnly=false` shows them

Closes #2483

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Read-only mode now hides and blocks all editing actions across mobile and desktop**

### What Changed
- When the layout is locked, mutation actions are no longer shown in the device inspector, desktop verb bar, or command palette.
- The mobile device inspector now hides edit fields and action buttons entirely in read-only mode, showing only the device summary.
- Tap-to-place and keyboard-driven selection changes are blocked while locked, so devices cannot be moved, duplicated, flipped, or deleted through any shortcut path.
- Unlocking restores the full set of edit controls and actions.

### Impact
`✅ Fewer accidental edits in presentation mode`
`✅ Clearer locked-state controls on mobile and desktop`
`✅ No shortcut-based bypasses for device changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
