### PR TITLE
fix: close sheet before dialog to fix mobile remove-confirm layering

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -268,7 +268,23 @@
 
   function handleCancelDelete() {
     dialogStore.close();
-    handleFitAll();
+    // On mobile a device removal was triggered from the device-details bottom
+    // sheet. handleDelete() closed the sheet so the confirm dialog would not
+    // render behind it (#2490). If the device is still selected (cancel path),
+    // reopen the sheet so the user can continue editing.
+    if (viewportStore.isMobile && selectionStore.isDeviceSelected) {
+      const activeRack = layoutStore.activeRack;
+      if (activeRack) {
+        const deviceIndex = selectionStore.getSelectedDeviceIndex(
+          activeRack.devices,
+        );
+        if (deviceIndex !== null) {
+          dialogStore.openSheet("deviceDetails", deviceIndex);
+        }
+      }
+    } else {
+      handleFitAll();
+    }
   }
 
   // --- Export / Share handlers ---
@@ -385,7 +401,6 @@
   // --- Add device handlers ---
 
   function handleAddDevice() {
-    dialogStore.closeSheet();
     dialogStore.open("addDevice");
   }
 

--- a/src/lib/stores/dialogs.svelte.ts
+++ b/src/lib/stores/dialogs.svelte.ts
@@ -54,9 +54,14 @@ let openSheet = $state<SheetId | null>(null);
 let selectedDeviceIndex = $state<number | null>(null);
 
 /**
- * Open a dialog by ID. Closes any other open dialog.
+ * Open a dialog by ID. Closes any other open dialog and any open sheet so
+ * dialogs always render without a sheet underneath them. On mobile this
+ * prevents the device-details bottom sheet from occluding a confirm dialog
+ * that opens on top of it (#2490).
  */
 function open(id: DialogId) {
+  openSheet = null;
+  selectedDeviceIndex = null;
   openDialog = id;
 }
 

--- a/src/lib/utils/dialog-actions.ts
+++ b/src/lib/utils/dialog-actions.ts
@@ -61,7 +61,6 @@ export function handleHelp(): void {
 
 /** Close any open sheet, then open the Add Device dialog. */
 export function handleAddDevice(): void {
-  dialogStore.closeSheet();
   dialogStore.open("addDevice");
 }
 

--- a/src/tests/dialog-actions.test.ts
+++ b/src/tests/dialog-actions.test.ts
@@ -1,0 +1,88 @@
+/**
+ * dialog-actions behavioural tests
+ *
+ * Covers the handleDelete() seam that wires the mobile remove-confirm flow.
+ * The critical invariant: dialogStore.open() closes any open sheet so dialogs
+ * always render without a sheet underneath them. This prevents the mobile
+ * device-details bottom sheet from occluding the confirm dialog (#2490).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { handleDelete } from "$lib/utils/dialog-actions";
+import { dialogStore } from "$lib/stores/dialogs.svelte";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getSelectionStore,
+  resetSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { createTestDeviceType } from "./factories";
+
+function resetAll() {
+  resetLayoutStore();
+  resetSelectionStore();
+  dialogStore.close();
+  dialogStore.closeSheet();
+}
+
+/** Place one device in a new rack and select it. Returns rackId and device id. */
+function placeAndSelectDevice() {
+  const layoutStore = getLayoutStore();
+  const selectionStore = getSelectionStore();
+
+  const rack = layoutStore.addRack("Test Rack", 42);
+  if (!rack) throw new Error("addRack returned null");
+
+  const dt = createTestDeviceType({ slug: "test-server", u_height: 1 });
+  layoutStore.addDeviceTypeRaw(dt);
+
+  const ok = layoutStore.placeDevice(rack.id, dt.slug, 10, "front");
+  if (!ok) throw new Error("placeDevice failed");
+
+  const placed = layoutStore.getRackById(rack.id)!.devices[0]!;
+  selectionStore.selectDevice(rack.id, placed.id);
+
+  return { rackId: rack.id, deviceId: placed.id };
+}
+
+describe("handleDelete", () => {
+  beforeEach(resetAll);
+
+  it("opens the confirmDelete dialog when a device is selected", () => {
+    placeAndSelectDevice();
+    expect(dialogStore.isOpen("confirmDelete")).toBe(false);
+
+    handleDelete();
+
+    expect(dialogStore.isOpen("confirmDelete")).toBe(true);
+  });
+
+  it("sets deleteTarget to device type when a device is selected", () => {
+    placeAndSelectDevice();
+
+    handleDelete();
+
+    expect(dialogStore.deleteTarget).toMatchObject({ type: "device" });
+  });
+
+  it("closes any open sheet when opening the confirm dialog (dialogStore.open invariant)", () => {
+    placeAndSelectDevice();
+    // Simulate the state that exists when Remove is tapped from the mobile
+    // device-details bottom sheet: the sheet is open and the device is selected.
+    dialogStore.openSheet("deviceDetails", 0);
+    expect(dialogStore.isSheetOpen("deviceDetails")).toBe(true);
+
+    handleDelete();
+
+    // dialogStore.open() closes any open sheet as a built-in invariant (#2490).
+    expect(dialogStore.isSheetOpen("deviceDetails")).toBe(false);
+    expect(dialogStore.isOpen("confirmDelete")).toBe(true);
+  });
+
+  it("does nothing when no device or rack is selected", () => {
+    // No selection: handleDelete should be a no-op.
+    handleDelete();
+
+    expect(dialogStore.isOpen("confirmDelete")).toBe(false);
+    expect(dialogStore.deleteTarget).toBeNull();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Fixes mobile device removal being impossible: the confirm dialog rendered behind the device-details bottom sheet and could not be reached
- Root cause: `dialogStore.open()` left any open sheet visible while the dialog mounted, creating two overlapping modal layers with conflicting dismiss semantics
- Fix: `dialogStore.open()` now closes any open sheet as a built-in invariant (two lines in `dialogs.svelte.ts`), preventing all dialogs from rendering over sheets
- `handleCancelDelete()` reopens the device-details sheet on mobile when the device is still selected after cancel, restoring inspector state

## Approach

The fix is at the right layer: `dialogStore.open()` gains a sheet-close invariant rather than patching each individual call site. This also removes two pre-existing redundant `closeSheet()` calls in `handleAddDevice()` that were working around the same gap.

No visual snapshot changes — the confirm dialog already had correct styles; this is purely a layering/state fix.

## Test plan

- New `src/tests/dialog-actions.test.ts` covers the behavioural contract: when Remove is tapped with the device-details sheet open, the sheet is closed and the confirmDelete dialog is open (not both simultaneously)
- 165 test files, 2769 tests all pass locally
- Lint clean, production build clean

Closes #2490

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Fix mobile delete confirmation and restore the device sheet after cancel**

### What Changed
- Opening a dialog now closes any open bottom sheet first, so the delete confirmation appears on top instead of hidden behind the mobile device details sheet
- Cancelling device removal on mobile brings the device details sheet back if the device is still selected
- Adding a device no longer needs a separate sheet-close step because dialogs now handle that automatically
- Added tests for the mobile remove-confirm flow and the sheet-closing behavior

### Impact
`✅ Visible delete confirmations on mobile`
`✅ Fewer failed device removals`
`✅ Restored device-details sheet after cancel`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
