### PR TITLE
chore: prune dangling Docker images after each deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -175,6 +175,9 @@ jobs:
           cd /opt/rackula/rackula-dev
           docker compose --profile persist pull
           docker compose --profile persist up -d --remove-orphans
+          # Each main build supersedes the previous :main image, leaving it
+          # dangling. Prune so untagged images don't accumulate on the VPS.
+          docker image prune -f
 
   smoke-test:
     needs: deploy

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -50,6 +50,9 @@ jobs:
           docker stop rackula-app 2>/dev/null && docker rm rackula-app 2>/dev/null || true
           docker compose pull
           docker compose up -d --remove-orphans
+          # Prune the image the new pull just superseded (now dangling);
+          # running containers keep their tagged images. Prevents disk fill.
+          docker image prune -f
 
   smoke-test:
     needs: [deploy]


### PR DESCRIPTION
## **User description**
## Problem

`vps-web-rackula` hit 100% disk (root fs 22G/23G used, 7.4M free). The culprit was ~296 dangling `<none>` Docker images: every deploy pulls a fresh image and leaves the previous one untagged, and nothing prunes them. They accumulated to ~8G of `overlay2` layers over ~11 days.

Both the dev (push-to-main, frequent) and prod (tag) deploys run on this same VPS, so both contribute.

## Fix

Add `docker image prune -f` after `docker compose up -d` in both deploy steps:

- `.github/workflows/deploy-dev.yml` (the frequent `:main` churn)
- `.github/workflows/deploy-prod.yml` (the `:latest` prod deploy)

`docker image prune -f` removes only untagged (dangling) images. The running containers keep their tagged images, so it is safe and idempotent. Build cache was 0B and there are no volumes, so nothing else needs pruning.

## Manual cleanup already done

The VPS was cleaned up out-of-band (100% -> 42%, ~13G freed): dangling image prune reclaimed 7.79G, plus CI caches and apt cache. All 3 containers verified healthy and prod returns HTTP 200. This PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent deploy images from filling the VPS disk**

### What Changed
- After both dev and prod deploys, the system now removes unused Docker images left behind by the new deployment
- This stops repeated deploys from piling up old image layers on the shared VPS
- Running containers keep working normally because only untagged images are removed

### Impact
`✅ Fewer disk-full deploy failures`
`✅ Less VPS storage growth after releases`
`✅ More reliable dev and prod deploys`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
