### PR TITLE
feat: wire long-press zoom-to-device on mobile (#190)

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -26,6 +26,7 @@
   import LabelOverlaySVG from "./LabelOverlaySVG.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getCanvasStore } from "$lib/stores/canvas.svelte";
   import { placementKey } from "$lib/utils/placement-key";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { useLongPress } from "$lib/utils/gestures";
@@ -174,6 +175,7 @@
 
   // Viewport detection for mobile-specific interactions
   const viewportStore = getViewportStore();
+  const canvasStore = getCanvasStore();
 
   // SVG group element ref for long-press gesture
   let groupElement: SVGGElement | null = $state(null);
@@ -490,14 +492,18 @@
     );
   }
 
-  // Long-press handler for mobile/tablet (opens device actions)
+  // Long-press handler for mobile/tablet (zooms view to the pressed device)
   function handleLongPress() {
     if (!longPressPoint) return;
 
     longPressFired = true;
     hapticTap();
-    openDeviceContextMenu(longPressPoint.x, longPressPoint.y);
     longPressPoint = null;
+
+    const rack = layoutStore.getRackById(rackId);
+    if (rack) {
+      canvasStore.zoomToDevice(rack, deviceIndex, layoutStore.device_types);
+    }
   }
 
   // Context menu handler (right-click) - opens device context menu

--- a/src/tests/canvas-store.test.ts
+++ b/src/tests/canvas-store.test.ts
@@ -7,6 +7,17 @@ import {
   ZOOM_MAX,
 } from "$lib/stores/canvas.svelte";
 import { createMockPanzoom } from "./mocks/panzoom";
+import { createTestRack, createTestDeviceType } from "./factories";
+import {
+  U_HEIGHT_PX,
+  BASE_RACK_WIDTH,
+  RAIL_WIDTH,
+  BASE_RACK_PADDING,
+  RACK_ROW_PADDING,
+  DUAL_VIEW_GAP,
+  DUAL_VIEW_EXTRA_HEIGHT,
+} from "$lib/constants/layout";
+import { toInternalUnits } from "$lib/utils/position";
 
 describe("Canvas Store", () => {
   beforeEach(() => {
@@ -494,6 +505,268 @@ describe("Canvas Store", () => {
 
       // Should call zoomAbs and moveTo to center the content
       expect(mockPanzoom.zoomAbs).toHaveBeenCalled();
+      expect(mockPanzoom.moveTo).toHaveBeenCalled();
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("zoomToDevice", () => {
+    function setupCanvasAndPanzoom(
+      viewportWidth: number,
+      viewportHeight: number,
+      initialScale = 1,
+    ) {
+      const store = getCanvasStore();
+      const mockPanzoom = createMockPanzoom(initialScale);
+
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn(() => ({ matches: false })),
+      );
+
+      const mockCanvas = document.createElement("div");
+      Object.defineProperty(mockCanvas, "clientWidth", {
+        value: viewportWidth,
+      });
+      Object.defineProperty(mockCanvas, "clientHeight", {
+        value: viewportHeight,
+      });
+
+      store.setCanvasElement(mockCanvas);
+      store.setPanzoomInstance(
+        mockPanzoom as ReturnType<typeof import("panzoom").default>,
+      );
+
+      return { store, mockPanzoom };
+    }
+
+    it("does nothing when no panzoom instance is set", () => {
+      const store = getCanvasStore();
+      const rack = createTestRack({ height: 42, devices: [] });
+      const deviceType = createTestDeviceType({ u_height: 2 });
+
+      // No panzoom set - should not throw
+      expect(() => store.zoomToDevice(rack, 0, [deviceType])).not.toThrow();
+    });
+
+    it("does nothing when deviceIndex is out of range", () => {
+      const { store, mockPanzoom } = setupCanvasAndPanzoom(400, 700);
+      const rack = createTestRack({ height: 42, devices: [] });
+      const deviceType = createTestDeviceType({ u_height: 2 });
+
+      store.zoomToDevice(rack, 0, [deviceType]);
+
+      // No devices in rack: index 0 is out of range, nothing should be called
+      expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
+      expect(mockPanzoom.zoomAbs).not.toHaveBeenCalled();
+
+      vi.unstubAllGlobals();
+    });
+
+    it("does nothing when device type is not found in library", () => {
+      const { store, mockPanzoom } = setupCanvasAndPanzoom(400, 700);
+      const rack = createTestRack({
+        height: 42,
+        devices: [
+          {
+            id: "placed-1",
+            device_type: "unknown-slug",
+            position: toInternalUnits(1),
+            face: "front",
+          },
+        ],
+      });
+      const deviceType = createTestDeviceType({
+        slug: "different-slug",
+        u_height: 2,
+      });
+
+      store.zoomToDevice(rack, 0, [deviceType]);
+
+      expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
+      expect(mockPanzoom.zoomAbs).not.toHaveBeenCalled();
+
+      vi.unstubAllGlobals();
+    });
+
+    it("clamps target zoom to ZOOM_MAX for small devices in large viewports", () => {
+      // A 1U device in a 42U rack with a 700px viewport will produce a zoom
+      // well above ZOOM_MAX if unclamped. Verify it is clamped.
+      const { store, mockPanzoom } = setupCanvasAndPanzoom(400, 700);
+      const rack = createTestRack({
+        height: 42,
+        devices: [
+          {
+            id: "placed-1",
+            device_type: "tiny-switch",
+            position: toInternalUnits(1),
+            face: "front",
+          },
+        ],
+      });
+      const deviceType = createTestDeviceType({
+        slug: "tiny-switch",
+        u_height: 1,
+      });
+
+      store.zoomToDevice(rack, 0, [deviceType]);
+
+      // smoothZoomAbs is called by smoothMoveTo (reduced motion = false)
+      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
+      const [, , scale] = mockPanzoom.smoothZoomAbs.mock.calls[0] as [
+        number,
+        number,
+        number,
+      ];
+      expect(scale).toBeLessThanOrEqual(ZOOM_MAX);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("clamps target zoom to ZOOM_MIN for very tall devices", () => {
+      // A rack-height device in a tiny viewport could produce a zoom below
+      // ZOOM_MIN. Verify it is clamped.
+      const { store, mockPanzoom } = setupCanvasAndPanzoom(100, 100);
+      const rack = createTestRack({
+        height: 42,
+        devices: [
+          {
+            id: "placed-1",
+            device_type: "tall-chassis",
+            position: toInternalUnits(1),
+            face: "front",
+          },
+        ],
+      });
+      const deviceType = createTestDeviceType({
+        slug: "tall-chassis",
+        u_height: 42,
+      });
+
+      store.zoomToDevice(rack, 0, [deviceType]);
+
+      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
+      const [, , scale] = mockPanzoom.smoothZoomAbs.mock.calls[0] as [
+        number,
+        number,
+        number,
+      ];
+      expect(scale).toBeGreaterThanOrEqual(ZOOM_MIN);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("centers the device in the viewport", () => {
+      // For a known device position, verify that the pan places the device
+      // center at the viewport center.
+      const viewportWidth = 400;
+      const viewportHeight = 700;
+      const { store, mockPanzoom } = setupCanvasAndPanzoom(
+        viewportWidth,
+        viewportHeight,
+      );
+
+      const rackHeight = 42;
+      const deviceUHeight = 2;
+      const positionU = 1; // human U position at which device starts
+      const deviceInternalPos = toInternalUnits(positionU);
+
+      const rack = createTestRack({
+        height: rackHeight,
+        devices: [
+          {
+            id: "placed-1",
+            device_type: "test-server",
+            position: deviceInternalPos,
+            face: "front",
+          },
+        ],
+      });
+      const deviceType = createTestDeviceType({
+        slug: "test-server",
+        u_height: deviceUHeight,
+      });
+
+      store.zoomToDevice(rack, 0, [deviceType]);
+
+      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
+      const [, , zoom] = mockPanzoom.smoothZoomAbs.mock.calls[0] as [
+        number,
+        number,
+        number,
+      ];
+
+      // Compute expected pan based on the same math as zoomToDevice
+      const deviceYInRack =
+        (rackHeight - positionU - deviceUHeight + 1) * U_HEIGHT_PX;
+      const deviceHeight = deviceUHeight * U_HEIGHT_PX;
+      const deviceAbsY =
+        RACK_ROW_PADDING +
+        DUAL_VIEW_EXTRA_HEIGHT +
+        BASE_RACK_PADDING +
+        RAIL_WIDTH +
+        deviceYInRack;
+      const dualViewWidth = BASE_RACK_WIDTH * 2 + DUAL_VIEW_GAP;
+      const deviceAbsX = RACK_ROW_PADDING + dualViewWidth / 2;
+      const expectedPanX = viewportWidth / 2 - deviceAbsX * zoom;
+      const expectedPanY =
+        viewportHeight / 2 - (deviceAbsY + deviceHeight / 2) * zoom;
+
+      // smoothMoveTo calls smoothZoomAbs then moveTo asynchronously via
+      // setTimeout. We can only check the zoom call synchronously.
+      // Pan is delivered async; verify only that zoom is in bounds.
+      expect(zoom).toBeGreaterThanOrEqual(ZOOM_MIN);
+      expect(zoom).toBeLessThanOrEqual(ZOOM_MAX);
+
+      // Verify the expected pan values are finite (sanity check on the math)
+      expect(Number.isFinite(expectedPanX)).toBe(true);
+      expect(Number.isFinite(expectedPanY)).toBe(true);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("uses instant transition when reduced motion is preferred", () => {
+      const store = getCanvasStore();
+      const mockPanzoom = createMockPanzoom(1);
+
+      // Stub matchMedia to return true for reduced motion
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn(() => ({ matches: true })),
+      );
+
+      const mockCanvas = document.createElement("div");
+      Object.defineProperty(mockCanvas, "clientWidth", { value: 400 });
+      Object.defineProperty(mockCanvas, "clientHeight", { value: 700 });
+
+      store.setCanvasElement(mockCanvas);
+      store.setPanzoomInstance(
+        mockPanzoom as ReturnType<typeof import("panzoom").default>,
+      );
+
+      const rack = createTestRack({
+        height: 42,
+        devices: [
+          {
+            id: "placed-1",
+            device_type: "test-server",
+            position: toInternalUnits(1),
+            face: "front",
+          },
+        ],
+      });
+      const deviceType = createTestDeviceType({
+        slug: "test-server",
+        u_height: 2,
+      });
+
+      store.zoomToDevice(rack, 0, [deviceType]);
+
+      // Reduced motion: uses zoomAbs (instant) not smoothZoomAbs
+      expect(mockPanzoom.zoomAbs).toHaveBeenCalled();
+      expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
+      // And moveTo is called synchronously
       expect(mockPanzoom.moveTo).toHaveBeenCalled();
 
       vi.unstubAllGlobals();

--- a/src/tests/canvas-store.test.ts
+++ b/src/tests/canvas-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   getCanvasStore,
   resetCanvasStore,
@@ -512,17 +512,23 @@ describe("Canvas Store", () => {
   });
 
   describe("zoomToDevice", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    });
+
     function setupCanvasAndPanzoom(
       viewportWidth: number,
       viewportHeight: number,
       initialScale = 1,
+      prefersReducedMotion = false,
     ) {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(initialScale);
 
       vi.stubGlobal(
         "matchMedia",
-        vi.fn(() => ({ matches: false })),
+        vi.fn(() => ({ matches: prefersReducedMotion })),
       );
 
       const mockCanvas = document.createElement("div");
@@ -560,8 +566,6 @@ describe("Canvas Store", () => {
       // No devices in rack: index 0 is out of range, nothing should be called
       expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
       expect(mockPanzoom.zoomAbs).not.toHaveBeenCalled();
-
-      vi.unstubAllGlobals();
     });
 
     it("does nothing when device type is not found in library", () => {
@@ -586,8 +590,6 @@ describe("Canvas Store", () => {
 
       expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
       expect(mockPanzoom.zoomAbs).not.toHaveBeenCalled();
-
-      vi.unstubAllGlobals();
     });
 
     it("clamps target zoom to ZOOM_MAX for small devices in large viewports", () => {
@@ -620,8 +622,6 @@ describe("Canvas Store", () => {
         number,
       ];
       expect(scale).toBeLessThanOrEqual(ZOOM_MAX);
-
-      vi.unstubAllGlobals();
     });
 
     it("clamps target zoom to ZOOM_MIN for very tall devices", () => {
@@ -653,8 +653,6 @@ describe("Canvas Store", () => {
         number,
       ];
       expect(scale).toBeGreaterThanOrEqual(ZOOM_MIN);
-
-      vi.unstubAllGlobals();
     });
 
     it("centers the device in the viewport", () => {
@@ -688,6 +686,7 @@ describe("Canvas Store", () => {
         u_height: deviceUHeight,
       });
 
+      vi.useFakeTimers();
       store.zoomToDevice(rack, 0, [deviceType]);
 
       expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
@@ -713,37 +712,19 @@ describe("Canvas Store", () => {
       const expectedPanY =
         viewportHeight / 2 - (deviceAbsY + deviceHeight / 2) * zoom;
 
-      // smoothMoveTo calls smoothZoomAbs then moveTo asynchronously via
-      // setTimeout. We can only check the zoom call synchronously.
-      // Pan is delivered async; verify only that zoom is in bounds.
-      expect(zoom).toBeGreaterThanOrEqual(ZOOM_MIN);
-      expect(zoom).toBeLessThanOrEqual(ZOOM_MAX);
+      // smoothMoveTo delivers the moveTo call via setTimeout(..., 0).
+      // Flush all pending timers so moveTo fires synchronously here.
+      vi.runAllTimers();
 
-      // Verify the expected pan values are finite (sanity check on the math)
-      expect(Number.isFinite(expectedPanX)).toBe(true);
-      expect(Number.isFinite(expectedPanY)).toBe(true);
-
-      vi.unstubAllGlobals();
+      expect(mockPanzoom.moveTo).toHaveBeenCalledOnce();
+      const [panX, panY] = mockPanzoom.moveTo.mock.calls[0] as [number, number];
+      expect(panX).toBeCloseTo(expectedPanX, 5);
+      expect(panY).toBeCloseTo(expectedPanY, 5);
     });
 
     it("uses instant transition when reduced motion is preferred", () => {
-      const store = getCanvasStore();
-      const mockPanzoom = createMockPanzoom(1);
-
-      // Stub matchMedia to return true for reduced motion
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn(() => ({ matches: true })),
-      );
-
-      const mockCanvas = document.createElement("div");
-      Object.defineProperty(mockCanvas, "clientWidth", { value: 400 });
-      Object.defineProperty(mockCanvas, "clientHeight", { value: 700 });
-
-      store.setCanvasElement(mockCanvas);
-      store.setPanzoomInstance(
-        mockPanzoom as ReturnType<typeof import("panzoom").default>,
-      );
+      // prefersReducedMotion=true routes through the instant path (zoomAbs + moveTo)
+      const { store, mockPanzoom } = setupCanvasAndPanzoom(400, 700, 1, true);
 
       const rack = createTestRack({
         height: 42,
@@ -766,10 +747,8 @@ describe("Canvas Store", () => {
       // Reduced motion: uses zoomAbs (instant) not smoothZoomAbs
       expect(mockPanzoom.zoomAbs).toHaveBeenCalled();
       expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
-      // And moveTo is called synchronously
+      // moveTo is called synchronously (no timer on the reduced-motion path)
       expect(mockPanzoom.moveTo).toHaveBeenCalled();
-
-      vi.unstubAllGlobals();
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

- Wires the existing `canvasStore.zoomToDevice()` function (previously unconnected) to the mobile long-press gesture on devices in `RackDevice.svelte`
- Replaces the floating context menu as the long-press target; device actions remain reachable via tap-to-select bottom sheet (M12 PR #2481)
- Respects `prefers-reduced-motion`: smooth transition when not set, instant when set

## M12 alignment

Long-press on a device previously opened `DeviceContextMenu` (floating menu with edit/duplicate/move/flip/delete). After M12 (PR #2481), all those actions are in the tap-to-select bottom sheet, making the floating context menu a redundant surface. The M12 spec states "Nothing important is reachable only by long-press or double-tap" -- this condition is now satisfied by tap, so long-press is free for navigation. Zoom-to-device is a view aid, not a hidden critical action, consistent with the spec intent.

## What changed

`src/lib/components/RackDevice.svelte`:
- Import `getCanvasStore`
- `handleLongPress` now calls `canvasStore.zoomToDevice(rack, deviceIndex, layoutStore.device_types)` instead of `openDeviceContextMenu`. Desktop right-click context menu is unchanged.

`src/tests/canvas-store.test.ts`:
- 7 new tests for `zoomToDevice`: no-op guards (no panzoom, index OOB, type not found), ZOOM_MAX clamping, ZOOM_MIN clamping, reduced-motion instant path

## Visual baselines

No visual snapshot changes expected (mobile long-press does not affect static screenshots; #2472 handles coordinated baseline regen).

## Local gates

- `npm run lint`: clean
- `npm run test:run`: 2772 tests pass
- `npm run build`: clean
- `coderabbit --agent --type committed`: 0 findings

Closes #190

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Long-pressing a device on mobile now zooms the canvas to that device instead of opening the floating device menu

### What Changed
- Long-press on mobile/tablet now zooms the view to the pressed device
- The old long-press device menu is no longer the mobile target; device actions stay available through tap-to-select
- If reduced motion is enabled, the zoom happens instantly instead of using an animated transition
- Added coverage for device zoom behavior, including missing device data, zoom limits, centering, and reduced-motion handling

### Impact
`✅ Faster access to a selected device on mobile`
`✅ Fewer accidental menu popups on long-press`
`✅ Clearer motion behavior for users who prefer reduced motion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
