### PR TITLE
feat: mobile bottom-sheet focus management and placement-mode accessibility

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -14,32 +14,13 @@ import { test, expect } from "./helpers/base-test";
 import type { Page } from "@playwright/test";
 import {
   gotoWithRack,
-  EMPTY_RACK_SHARE,
+  gotoMobileWithRack,
   clickNewRack,
   locators,
 } from "./helpers";
 
 /** WCAG 2.5.5 Target Size (Level AAA) / 2.5.8 (Level AA) minimum. */
 const MIN_TOUCH_TARGET_PX = 44;
-
-/** A representative phone viewport for mobile-only accessibility checks. */
-const MOBILE_VIEWPORT = { width: 412, height: 915 };
-
-/**
- * Load the app at a phone viewport with a rack preloaded, dismissing the
- * mobile warning before navigation so it never intercepts interactions.
- */
-async function gotoMobileWithRack(page: Page): Promise<void> {
-  await page.setViewportSize(MOBILE_VIEWPORT);
-  await page.addInitScript(() => {
-    sessionStorage.setItem("rackula-mobile-warning-dismissed", "true");
-  });
-  await page.goto(`/?l=${EMPTY_RACK_SHARE}`);
-  await page
-    .locator(locators.rack.container)
-    .first()
-    .waitFor({ state: "visible" });
-}
 
 /**
  * Resolve the accessible role and name of the currently focused element.
@@ -286,7 +267,10 @@ test.describe("Accessibility", () => {
       await page.locator(locators.device.paletteItem).first().click();
 
       // Confirm the Placing banner is visible.
-      const banner = page.locator('[aria-live]').filter({ hasText: /placing:/i }).first();
+      const banner = page
+        .getByRole("status")
+        .filter({ hasText: /placing:/i })
+        .first();
       await expect(banner).toBeVisible();
 
       // Pressing Escape must cancel placement and hide the banner.

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -225,6 +225,76 @@ test.describe("Accessibility", () => {
     });
   });
 
+  test.describe("Mobile bottom sheet focus management", () => {
+    test.beforeEach(async ({ page, browserName }) => {
+      // Tab-based focus traversal relies on the browser visiting buttons in Tab
+      // order. WebKit skips buttons by default (macOS "Full Keyboard Access").
+      test.skip(
+        browserName === "webkit",
+        "WebKit skips buttons in Tab order by default (macOS keyboard setting)",
+      );
+      await gotoMobileWithRack(page);
+    });
+
+    test("mobile sheet traps Tab focus while open", async ({ page }) => {
+      // Open the Devices sheet via the bottom nav.
+      const devicesTab = page.getByRole("button", { name: "Devices" });
+      await devicesTab.focus();
+      await devicesTab.click();
+
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+
+      // Tab repeatedly; focus must stay inside the sheet on every stop.
+      for (let i = 0; i < 15; i++) {
+        await page.keyboard.press("Tab");
+        const focusInDialog = await dialog.evaluate((node) =>
+          node.contains(document.activeElement),
+        );
+        expect(focusInDialog).toBe(true);
+      }
+    });
+
+    test("closing a mobile sheet via Escape restores focus to the nav tab", async ({
+      page,
+    }) => {
+      // Open the View sheet via the bottom nav.
+      const viewTab = page.getByRole("button", { name: "View" });
+      await viewTab.focus();
+      await viewTab.click();
+
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible();
+
+      await page.keyboard.press("Escape");
+      await expect(dialog).not.toBeVisible();
+
+      // Focus must return to the View tab button that opened the sheet.
+      await expect(viewTab).toBeFocused();
+    });
+
+    test("Escape cancels active placement and hides the Placing banner", async ({
+      page,
+    }) => {
+      // Arm a device for placement via the Devices sheet.
+      const devicesTab = page.getByRole("button", { name: "Devices" });
+      await devicesTab.focus();
+      await devicesTab.click();
+      await expect(
+        page.locator(locators.device.paletteItem).first(),
+      ).toBeVisible();
+      await page.locator(locators.device.paletteItem).first().click();
+
+      // Confirm the Placing banner is visible.
+      const banner = page.locator('[aria-live]').filter({ hasText: /placing:/i }).first();
+      await expect(banner).toBeVisible();
+
+      // Pressing Escape must cancel placement and hide the banner.
+      await page.keyboard.press("Escape");
+      await expect(banner).not.toBeVisible();
+    });
+  });
+
   test.describe("Live regions", () => {
     test("a status live region announces tap-to-place on mobile", async ({
       page,
@@ -249,6 +319,33 @@ test.describe("Accessibility", () => {
         .filter({ hasText: /placing:/i })
         .first();
       await expect(status).toBeVisible();
+    });
+
+    test("placement cancellation is announced to screen readers", async ({
+      page,
+    }) => {
+      await gotoMobileWithRack(page);
+
+      // Arm a device for placement.
+      await page.getByRole("button", { name: "Devices" }).click();
+      await expect(
+        page.locator(locators.device.paletteItem).first(),
+      ).toBeVisible();
+      await page.locator(locators.device.paletteItem).first().click();
+
+      // The Placing banner must be visible before cancel.
+      const banner = page
+        .getByRole("status")
+        .filter({ hasText: /placing:/i })
+        .first();
+      await expect(banner).toBeVisible();
+
+      // Cancel via the Cancel button in the banner.
+      await page.getByRole("button", { name: /cancel placement/i }).click();
+
+      // The assertive announcer must carry the cancellation message.
+      const announcer = page.getByTestId("placement-sr-announcer");
+      await expect(announcer).toContainText(/cancelled/i);
     });
   });
 

--- a/e2e/axe.spec.ts
+++ b/e2e/axe.spec.ts
@@ -22,15 +22,36 @@
  */
 import { test } from "./helpers/base-test";
 import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   createTestLayout,
   gotoWithRack,
   selectDevice,
   clickExport,
   clickSettings,
+  EMPTY_RACK_SHARE,
   locators,
 } from "./helpers";
 import { expectNoA11yViolations } from "./helpers/a11y";
+
+/** A representative phone viewport for mobile-only scans. */
+const MOBILE_VIEWPORT = { width: 412, height: 915 };
+
+/**
+ * Load the app at a phone viewport, dismiss the mobile warning, and wait for
+ * the rack to be visible. Mirrors the pattern in accessibility.spec.ts.
+ */
+async function gotoMobileWithRack(page: Page): Promise<void> {
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.addInitScript(() => {
+    sessionStorage.setItem("rackula-mobile-warning-dismissed", "true");
+  });
+  await page.goto(`/?l=${EMPTY_RACK_SHARE}`);
+  await page
+    .locator(locators.rack.container)
+    .first()
+    .waitFor({ state: "visible" });
+}
 
 // A small, deterministic rack so the canvas and sidebar render real content for
 // the scan. Category codes are the single-char share abbreviations:
@@ -135,5 +156,61 @@ test.describe("axe accessibility scans", () => {
     await clickSettings(page);
     await expect(page.getByRole("dialog", { name: "Settings" })).toBeVisible();
     await expectNoA11yViolations(page, locators.dialog.root);
+  });
+});
+
+test.describe("axe accessibility scans - mobile viewport", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoMobileWithRack(page);
+  });
+
+  test("mobile canvas with bottom nav has no WCAG 2.2 AA violations", async ({
+    page,
+  }) => {
+    // Idle mobile canvas: the bottom nav is visible and no sheet is open.
+    await expectNoA11yViolations(page);
+  });
+
+  test("mobile Devices sheet has no WCAG 2.2 AA violations", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Devices" }).click();
+    await expect(page.getByRole("dialog", { name: "Device Library" })).toBeVisible();
+    await expectNoA11yViolations(page, locators.mobile.bottomSheet);
+  });
+
+  test("mobile View sheet has no WCAG 2.2 AA violations", async ({ page }) => {
+    await page.getByRole("button", { name: "View" }).click();
+    await expect(page.getByRole("dialog", { name: "View" })).toBeVisible();
+    await expectNoA11yViolations(page, locators.mobile.bottomSheet);
+  });
+
+  test("mobile Layouts sheet has no WCAG 2.2 AA violations", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Layouts" }).click();
+    await expect(page.getByRole("dialog", { name: "Layouts" })).toBeVisible();
+    await expectNoA11yViolations(page, locators.mobile.bottomSheet);
+  });
+
+  test("mobile Racks sheet has no WCAG 2.2 AA violations", async ({ page }) => {
+    await page.getByRole("button", { name: "Racks" }).click();
+    await expect(page.getByRole("dialog", { name: "Racks" })).toBeVisible();
+    await expectNoA11yViolations(page, locators.mobile.bottomSheet);
+  });
+
+  test("mobile Placing banner has no WCAG 2.2 AA violations", async ({
+    page,
+  }) => {
+    // Arm a device for placement so the PlacementIndicator banner renders.
+    await page.getByRole("button", { name: "Devices" }).click();
+    await expect(
+      page.locator(locators.device.paletteItem).first(),
+    ).toBeVisible();
+    await page.locator(locators.device.paletteItem).first().click();
+
+    // Wait for the sheet to close and the banner to appear.
+    await expect(page.getByRole("status").filter({ hasText: /placing:/i }).first()).toBeVisible();
+    await expectNoA11yViolations(page);
   });
 });

--- a/e2e/axe.spec.ts
+++ b/e2e/axe.spec.ts
@@ -22,36 +22,16 @@
  */
 import { test } from "./helpers/base-test";
 import { expect } from "@playwright/test";
-import type { Page } from "@playwright/test";
 import {
   createTestLayout,
   gotoWithRack,
+  gotoMobileWithRack,
   selectDevice,
   clickExport,
   clickSettings,
-  EMPTY_RACK_SHARE,
   locators,
 } from "./helpers";
 import { expectNoA11yViolations } from "./helpers/a11y";
-
-/** A representative phone viewport for mobile-only scans. */
-const MOBILE_VIEWPORT = { width: 412, height: 915 };
-
-/**
- * Load the app at a phone viewport, dismiss the mobile warning, and wait for
- * the rack to be visible. Mirrors the pattern in accessibility.spec.ts.
- */
-async function gotoMobileWithRack(page: Page): Promise<void> {
-  await page.setViewportSize(MOBILE_VIEWPORT);
-  await page.addInitScript(() => {
-    sessionStorage.setItem("rackula-mobile-warning-dismissed", "true");
-  });
-  await page.goto(`/?l=${EMPTY_RACK_SHARE}`);
-  await page
-    .locator(locators.rack.container)
-    .first()
-    .waitFor({ state: "visible" });
-}
 
 // A small, deterministic rack so the canvas and sidebar render real content for
 // the scan. Category codes are the single-char share abbreviations:
@@ -175,7 +155,9 @@ test.describe("axe accessibility scans - mobile viewport", () => {
     page,
   }) => {
     await page.getByRole("button", { name: "Devices" }).click();
-    await expect(page.getByRole("dialog", { name: "Device Library" })).toBeVisible();
+    await expect(
+      page.getByRole("dialog", { name: "Device Library" }),
+    ).toBeVisible();
     await expectNoA11yViolations(page, locators.mobile.bottomSheet);
   });
 
@@ -210,7 +192,12 @@ test.describe("axe accessibility scans - mobile viewport", () => {
     await page.locator(locators.device.paletteItem).first().click();
 
     // Wait for the sheet to close and the banner to appear.
-    await expect(page.getByRole("status").filter({ hasText: /placing:/i }).first()).toBeVisible();
+    await expect(
+      page
+        .getByRole("status")
+        .filter({ hasText: /placing:/i })
+        .first(),
+    ).toBeVisible();
     await expectNoA11yViolations(page);
   });
 });

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -12,6 +12,7 @@ export {
   RACK_WITH_DEVICE_SHARE,
   createTestLayout,
   gotoWithRack,
+  gotoMobileWithRack,
 } from "./test-layouts";
 
 // Device actions

--- a/e2e/helpers/test-layouts.ts
+++ b/e2e/helpers/test-layouts.ts
@@ -175,6 +175,28 @@ export function createTestLayout(overrides?: {
   return encodeMinimal(layout);
 }
 
+/** A representative phone viewport for mobile-only test helpers. */
+const MOBILE_VIEWPORT = { width: 412, height: 915 };
+
+/**
+ * Navigate to the app at a phone viewport with a rack preloaded, dismissing
+ * the mobile warning before navigation so it never intercepts interactions.
+ * Mirrors the same setup in accessibility.spec.ts and axe.spec.ts.
+ */
+export async function gotoMobileWithRack(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await page.addInitScript(() => {
+    sessionStorage.setItem("rackula-mobile-warning-dismissed", "true");
+  });
+  await page.goto(`/?l=${EMPTY_RACK_SHARE}`);
+  await page
+    .locator(locators.rack.container)
+    .first()
+    .waitFor({ state: "visible" });
+}
+
 /**
  * Navigate to app with pre-loaded rack
  * @param page - Playwright page

--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -95,6 +95,12 @@ function handleEscape(): void {
     handleFitAll();
     return;
   }
+  // Close any open mobile sheet before clearing selection so Escape gives the
+  // user a progressive exit: sheet first, then selection.
+  if (dialogStore.currentSheet !== null) {
+    dialogStore.closeSheet();
+    return;
+  }
   selectionStore.clearSelection();
   layoutStore.setActiveRack(null);
   uiStore.closeLeftDrawer();

--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -96,9 +96,13 @@ function handleEscape(): void {
     return;
   }
   // Close any open mobile sheet before clearing selection so Escape gives the
-  // user a progressive exit: sheet first, then selection.
+  // user a progressive exit: sheet first, then selection. Clear selection at
+  // the same time so the device-details $effect in DialogOrchestrator (which
+  // auto-opens that sheet whenever a device is selected on mobile) does not
+  // immediately reopen the sheet we just closed.
   if (dialogStore.currentSheet !== null) {
     dialogStore.closeSheet();
+    selectionStore.clearSelection();
     return;
   }
   selectionStore.clearSelection();

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -1040,3 +1040,21 @@
   style="display: none;"
   aria-label="Import device library file"
 />
+
+<!--
+  Placement outcome SR announcer (#2473).
+  Assertive live region announces placement transitions (placed, cancelled).
+  The PlacementIndicator banner already covers the active-placing state via a
+  polite region; this assertive region interrupts immediately when placement ends.
+  No explicit role: role="alert" would redundantly duplicate aria-live="assertive"
+  and could trigger axe-core's redundant-role rule. The region is always in the
+  DOM so assistive technology registers it before any content arrives.
+-->
+<div
+  aria-live="assertive"
+  aria-atomic="true"
+  class="sr-only"
+  data-testid="placement-sr-announcer"
+>
+  {placementStore.placementAnnouncement ?? ""}
+</div>

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -199,7 +199,7 @@
     // abandon any placement armed via the command palette "Add device" flow
     // (#2352). Without this the desktop click-to-place stays armed and the next
     // rack click would silently place the still-pending device.
-    if (placementStore.isPlacing) placementStore.cancelPlacement();
+    if (placementStore.isPlacing) placementStore.abandonPlacement();
     ondevicedrop?.(event);
   }
 

--- a/src/lib/components/mobile/MobileBottomNav.svelte
+++ b/src/lib/components/mobile/MobileBottomNav.svelte
@@ -37,6 +37,21 @@
   }: Props = $props();
 
   const viewportStore = getViewportStore();
+
+  /**
+   * Focus the tapped button before invoking the sheet-open handler.
+   * Touch taps do not move keyboard focus on mobile by default, so bits-ui
+   * cannot capture a "previously focused element" for focus restoration on
+   * sheet close. Calling focus() first ensures the button is the pre-focus
+   * element that bits-ui restores when the sheet closes.
+   */
+  function handleTabClick(
+    event: MouseEvent,
+    handler: (() => void) | undefined,
+  ): void {
+    (event.currentTarget as HTMLElement).focus();
+    handler?.();
+  }
 </script>
 
 {#if viewportStore.isMobile}
@@ -52,7 +67,8 @@
       type="button"
       data-testid="nav-tab-layouts"
       aria-current={activeTab === "layouts" ? "page" : undefined}
-      onclick={onlayoutsclick}
+      aria-expanded={activeTab === "layouts"}
+      onclick={(e) => handleTabClick(e, onlayoutsclick)}
     >
       <IconFolderBold size={ICON_SIZE.xl} />
       <span class="nav-label">Layouts</span>
@@ -64,7 +80,8 @@
       type="button"
       data-testid="nav-tab-racks"
       aria-current={activeTab === "racks" ? "page" : undefined}
-      onclick={onracksclick}
+      aria-expanded={activeTab === "racks"}
+      onclick={(e) => handleTabClick(e, onracksclick)}
     >
       <IconServerBold size={ICON_SIZE.xl} />
       <span class="nav-label">Racks</span>
@@ -76,7 +93,8 @@
       type="button"
       data-testid="nav-tab-devices"
       aria-current={activeTab === "devices" ? "page" : undefined}
-      onclick={ondevicesclick}
+      aria-expanded={activeTab === "devices"}
+      onclick={(e) => handleTabClick(e, ondevicesclick)}
     >
       <IconImageBold size={ICON_SIZE.xl} />
       <span class="nav-label">Devices</span>
@@ -88,7 +106,8 @@
       type="button"
       data-testid="nav-tab-view"
       aria-current={activeTab === "view" ? "page" : undefined}
-      onclick={onviewclick}
+      aria-expanded={activeTab === "view"}
+      onclick={(e) => handleTabClick(e, onviewclick)}
     >
       <IconFitAllBold size={ICON_SIZE.xl} />
       <span class="nav-label">View</span>

--- a/src/lib/stores/placement.svelte.ts
+++ b/src/lib/stores/placement.svelte.ts
@@ -67,8 +67,10 @@ function abandonPlacement(): void {
  * Complete placement mode after successfully placing the device.
  */
 function completePlacement(): void {
-  const deviceName = pendingDevice?.model ?? pendingDevice?.slug ?? "Device";
-  placementAnnouncement = `${deviceName} placed`;
+  if (isPlacing) {
+    const deviceName = pendingDevice?.model ?? pendingDevice?.slug ?? "Device";
+    placementAnnouncement = `${deviceName} placed`;
+  }
   resetState();
 }
 

--- a/src/lib/stores/placement.svelte.ts
+++ b/src/lib/stores/placement.svelte.ts
@@ -42,9 +42,22 @@ function resetState(): void {
 
 /**
  * Cancel placement mode without placing the device.
+ * Announces "Placement cancelled" to screen readers via the assertive live region.
+ * Use abandonPlacement() for silent internal resets that should not be announced.
  */
 function cancelPlacement(): void {
   placementAnnouncement = "Placement cancelled";
+  resetState();
+}
+
+/**
+ * Silently abandon placement without a screen-reader announcement.
+ * Use this when placement is being cleared as an internal side-effect of another
+ * action (e.g. a drag-and-drop completing while click-to-place was still armed),
+ * not when the user has explicitly cancelled. cancelPlacement() would announce
+ * "Placement cancelled" in that case, which would be misleading.
+ */
+function abandonPlacement(): void {
   resetState();
 }
 
@@ -99,6 +112,7 @@ export function getPlacementStore() {
     },
     startPlacement,
     cancelPlacement,
+    abandonPlacement,
     completePlacement,
     setTargetFace,
   };

--- a/src/lib/stores/placement.svelte.ts
+++ b/src/lib/stores/placement.svelte.ts
@@ -46,7 +46,9 @@ function resetState(): void {
  * Use abandonPlacement() for silent internal resets that should not be announced.
  */
 function cancelPlacement(): void {
-  placementAnnouncement = "Placement cancelled";
+  if (isPlacing) {
+    placementAnnouncement = "Placement cancelled";
+  }
   resetState();
 }
 

--- a/src/lib/stores/placement.svelte.ts
+++ b/src/lib/stores/placement.svelte.ts
@@ -12,11 +12,19 @@ let pendingDevice = $state<DeviceType | null>(null);
 let targetFace = $state<DeviceFace>("front");
 
 /**
+ * Screen-reader announcement for placement state transitions.
+ * Set on cancel and complete so assistive technologies can announce the outcome.
+ * Cleared on the next startPlacement so stale text is never re-read.
+ */
+let placementAnnouncement = $state<string | null>(null);
+
+/**
  * Start placement mode with a device.
  * @param device - The device type to place
  * @param face - Target face for half-depth devices (default: 'front')
  */
 function startPlacement(device: DeviceType, face: DeviceFace = "front"): void {
+  placementAnnouncement = null;
   isPlacing = true;
   pendingDevice = device;
   targetFace = face;
@@ -36,6 +44,7 @@ function resetState(): void {
  * Cancel placement mode without placing the device.
  */
 function cancelPlacement(): void {
+  placementAnnouncement = "Placement cancelled";
   resetState();
 }
 
@@ -43,6 +52,8 @@ function cancelPlacement(): void {
  * Complete placement mode after successfully placing the device.
  */
 function completePlacement(): void {
+  const deviceName = pendingDevice?.model ?? pendingDevice?.slug ?? "Device";
+  placementAnnouncement = `${deviceName} placed`;
   resetState();
 }
 
@@ -58,6 +69,7 @@ function setTargetFace(face: DeviceFace): void {
  * Reset placement store state (for testing).
  */
 export function resetPlacementStore(): void {
+  placementAnnouncement = null;
   resetState();
 }
 
@@ -75,6 +87,15 @@ export function getPlacementStore() {
     },
     get targetFace() {
       return targetFace;
+    },
+    /**
+     * Screen-reader announcement text for the most recent placement state
+     * transition (placed or cancelled). Null while idle or during active
+     * placement. Rendered in an assertive aria-live region so screen readers
+     * announce the outcome immediately.
+     */
+    get placementAnnouncement() {
+      return placementAnnouncement;
     },
     startPlacement,
     cancelPlacement,

--- a/src/tests/placement-store.test.ts
+++ b/src/tests/placement-store.test.ts
@@ -161,6 +161,8 @@ describe("placement store", () => {
       const store = getPlacementStore();
       expect(() => store.completePlacement()).not.toThrow();
       expect(store.isPlacing).toBe(false);
+      // No active placement means nothing to announce to screen readers.
+      expect(store.placementAnnouncement).toBeNull();
     });
   });
 

--- a/src/tests/placement-store.test.ts
+++ b/src/tests/placement-store.test.ts
@@ -113,6 +113,24 @@ describe("placement store", () => {
       expect(() => store.cancelPlacement()).not.toThrow();
       expect(store.isPlacing).toBe(false);
     });
+
+    it("sets placementAnnouncement to cancelled text", () => {
+      const store = getPlacementStore();
+      store.startPlacement(mockDevice);
+      store.cancelPlacement();
+      expect(store.placementAnnouncement).toBe("Placement cancelled");
+    });
+  });
+
+  describe("abandonPlacement()", () => {
+    it("resets placement state without an SR announcement", () => {
+      const store = getPlacementStore();
+      store.startPlacement(mockDevice);
+      store.abandonPlacement();
+      expect(store.isPlacing).toBe(false);
+      expect(store.pendingDevice).toBeNull();
+      expect(store.placementAnnouncement).toBeNull();
+    });
   });
 
   describe("completePlacement()", () => {

--- a/src/tests/placement-store.test.ts
+++ b/src/tests/placement-store.test.ts
@@ -112,6 +112,8 @@ describe("placement store", () => {
       const store = getPlacementStore();
       expect(() => store.cancelPlacement()).not.toThrow();
       expect(store.isPlacing).toBe(false);
+      // No active placement means nothing to announce to screen readers.
+      expect(store.placementAnnouncement).toBeNull();
     });
 
     it("sets placementAnnouncement to cancelled text", () => {


### PR DESCRIPTION
## **User description**
## Summary

- Bottom sheets restore focus to the triggering nav-tab button on close. `MobileBottomNav` explicitly focuses each button before opening its sheet so bits-ui focus-scope captures the pre-open element and restores it on close. Adds `aria-expanded` to each tab button to reflect its open/closed state.
- Escape progressively dismisses mobile sheets then clears selection. `handleEscape` in `dispatch.ts` closes the active sheet first (returning early) so Escape is not consumed by selection clearing while a sheet is visible.
- Placement state transitions announced to screen readers. `cancelPlacement()` and `completePlacement()` now set a `placementAnnouncement` string in the placement store. `DialogOrchestrator` renders a persistent `aria-live="assertive"` region that broadcasts the outcome. `startPlacement()` clears the announcement so stale text is not re-read.
- E2E coverage added for mobile a11y surfaces.

## Visual baseline note

No visual baselines were regenerated (none of these changes affect rendering). The `aria-live` region is `sr-only` and the `aria-expanded` attribute is non-visual.

## Test plan

- [x] `npm run lint` passes (ESLint: No issues found)
- [x] `npm run test:run` passes (2769 tests)
- [x] `npm run build` passes
- [x] Svelte autofixer: no issues on changed components
- [ ] `e2e/accessibility.spec.ts`: mobile sheet focus trap, Escape-restores-focus, Escape-cancels-placement, placement-cancellation SR-announcement
- [ ] `e2e/axe.spec.ts`: WCAG 2.2 AA scans for mobile canvas, all four sheets (Devices, View, Layouts, Racks), and the Placing banner

Closes #2473

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Improve mobile sheet focus handling and placement announcements**

### What Changed
- Mobile bottom tabs now keep keyboard focus on the button that opened them, and their open state is exposed to assistive technologies.
- Pressing Escape now closes an open mobile sheet before clearing selection, so users can dismiss the sheet first instead of jumping straight out of the current device view.
- Placement now announces when it is cancelled or completed, and the previous placing message is cleared when a new placement starts.
- Added mobile accessibility coverage for sheet focus trapping, Escape behavior, placement cancellation announcements, and WCAG scans across the mobile canvas and bottom sheets.

### Impact
`✅ Restored focus after closing mobile sheets`
`✅ Fewer accidental sheet reopenings on Escape`
`✅ Clearer screen-reader feedback for placement changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
