### PR TITLE
fix: keep command launcher hotkey badge on one line (#2434)

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -288,7 +288,7 @@
     align-items: center;
     align-self: center;
     flex: 1 1 auto;
-    min-width: 0;
+    min-width: 14rem;
     height: 44px;
     margin-right: var(--space-2);
     padding: 0;
@@ -360,6 +360,8 @@
   }
 
   .command-pill-badge {
+    flex: 0 0 auto;
+    white-space: nowrap;
     font-family: var(--font-mono, monospace);
     font-size: var(--font-size-xs);
     padding: 1px var(--space-1);


### PR DESCRIPTION
## **User description**
## Summary

The global command launcher pill in `Toolbar.svelte` rendered its shortcut badge ("Cmd + K" / "Ctrl + K") without nowrap. On the narrow left lane the badge could break across two lines ("Cmd +" then "K"), which crowded the field and forced the placeholder to truncate to "Search or jump t...".

## Changes

- `.command-pill-badge`: add `white-space: nowrap` so the literal "Cmd + K" label never breaks across lines, and `flex: 0 0 auto` so the badge keeps its intrinsic width instead of being squeezed by the flex row.
- `.command-pill`: replace `min-width: 0` with a `min-width: 14rem` floor so the placeholder and badge both fit at the narrowest supported desktop width. The mobile `--icon` variant already overrides `min-width` with the touch-target size, so the floor does not affect the compact mobile search icon.

The literal "Cmd + K" label is preserved (no glyph substitution). Pure CSS, no behaviour change, no tests (layout-only fix per the issue).

## Acceptance criteria

- [x] Keep the literal "Cmd + K" label (no glyph substitution)
- [x] Apply nowrap to the badge so it never breaks across lines
- [x] Widen / set a min-width on the search field so the badge and placeholder both fit
- [x] Verify at the narrowest supported desktop width

Closes #2434

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Keep the command launcher shortcut badge on one line and preserve the search field text**

### What Changed
- The command launcher shortcut badge now stays on a single line, so “Cmd + K” / “Ctrl + K” no longer wraps in narrow layouts
- The command launcher keeps enough width for both the shortcut badge and the placeholder text, avoiding the truncated “Search or jump t...” display on the narrow desktop layout

### Impact
`✅ Clearer command launcher shortcut display`
`✅ Fewer truncated search prompts`
`✅ Better layout on narrow desktop screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
