### PR TITLE
chore: set verb-bar backdrop opacity to 0.92

### DIFF
--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -380,7 +380,7 @@
   --bottom-nav-bg: rgba(33, 34, 44, 0.85);
   --bottom-nav-border: rgba(52, 55, 70, 0.6);
   --bottom-nav-blur: 20px;
-  --verb-bar-bg: rgba(33, 34, 44, 0.85);
+  --verb-bar-bg: rgba(33, 34, 44, 0.92);
   /* Specular glass: translucent body lets devices show through; the rim and
      sheen sell it as a lens. Dark theme uses a lighter top edge for the
      highlight and a soft dark bottom for grounding. */
@@ -636,7 +636,7 @@
   --bottom-nav-bg: rgba(239, 237, 220, 0.85);
   --bottom-nav-border: rgba(222, 220, 207, 0.6);
   --bottom-nav-active-pill-bg: rgba(3, 106, 150, 0.1);
-  --verb-bar-bg: rgba(239, 237, 220, 0.85);
+  --verb-bar-bg: rgba(239, 237, 220, 0.92);
   /* Light theme: the cream body needs a brighter top sheen and a softer,
      warmer bottom edge so the rim reads on a pale background. */
   --verb-bar-bg-solid: rgba(243, 241, 226, 0.97);


### PR DESCRIPTION
## **User description**
## Summary

Raises the floating verb bar's translucent backdrop fill from `0.85` to `0.92` opacity in both the dark and light themes, so the device beneath shows through only faintly without sacrificing icon legibility.

Single token change in `src/lib/styles/tokens.css`:

- Dark theme: `--verb-bar-bg: rgba(33, 34, 44, 0.85)` -> `0.92`
- Light theme: `--verb-bar-bg: rgba(239, 237, 220, 0.85)` -> `0.92`

`VerbBar.svelte` consumes the token via `var(--verb-bar-bg)` (no hardcoded value). Icons, labels, and the opaque hover/focus/active fallback (`--verb-bar-bg-solid`, 0.97) are untouched.

## Acceptance Criteria

- [x] Verb-bar background/fill opacity is 0.92
- [x] Icons and labels remain at full opacity
- [x] Hover and focus behaviour unchanged

## Testing

- `npm run lint` clean
- `npm run test:run` 2778 tests pass
- `npm run build` succeeds

Closes #2436

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Make the verb bar slightly more opaque in both themes**

### What Changed
- Increased the floating verb bar’s translucent background opacity in both dark and light themes
- The bar now lets a little less of the device or page show through while keeping the same icons, labels, and hover/focus appearance

### Impact
`✅ Less distracting verb bar background`
`✅ Clearer icon and label readability`
`✅ Consistent appearance in dark and light themes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
