### PR TITLE
feat: device attribute filter model and predicate (#2189)

### DIFF
--- a/src/lib/utils/deviceFilters.ts
+++ b/src/lib/utils/deviceFilters.ts
@@ -334,3 +334,101 @@ export function getRackWidthIncompatibilityReason(
 function resolveDeviceRackWidths(device: DeviceType): number[] {
   return device.rack_widths?.length ? device.rack_widths : DEFAULT_RACK_WIDTHS;
 }
+
+/**
+ * Height bucket facets for attribute filtering.
+ * `"0.5"` covers all sub-1U devices; `"1"`/`"2"`/`"3"` are exact U heights;
+ * `"4plus"` covers 4U and taller.
+ */
+export type HeightBucket = "0.5" | "1" | "2" | "3" | "4plus";
+
+/**
+ * Attribute filter selections for the device palette.
+ * An empty object (no heights, both width flags false, facets false) is a no-op.
+ */
+export interface DeviceAttributeFilters {
+  /** Selected height buckets. OR within the group. */
+  heights: Set<HeightBucket>;
+  /** Keep half-width devices (`slot_width === 1`). */
+  halfWidth: boolean;
+  /** Keep full-width devices (`slot_width === 2` or unset). */
+  fullWidth: boolean;
+  /** Keep only devices with a front or rear image. */
+  hasImage: boolean;
+  /** Keep only custom (user-created) devices. */
+  customOnly: boolean;
+}
+
+/** Whether a device's height falls into the given bucket. */
+function matchesHeightBucket(uHeight: number, bucket: HeightBucket): boolean {
+  switch (bucket) {
+    case "0.5":
+      return uHeight < 1;
+    case "4plus":
+      return uHeight >= 4;
+    default:
+      return uHeight === Number(bucket);
+  }
+}
+
+/**
+ * Filter devices by attribute facets: height bucket, half/full width,
+ * has-image, and custom-only. Pure function; custom detection is injected
+ * via `isCustom` rather than imported, so the predicate stays testable.
+ *
+ * Within the height group, buckets are OR'd. Width is OR'd too: selecting both
+ * or neither half and full applies no width filter. Across groups the result is
+ * AND'd, so a group with no active selection is skipped and empty filters return
+ * the input array unchanged.
+ *
+ * @param devices - Devices to filter
+ * @param filters - Active attribute selections
+ * @param isCustom - Predicate returning true for custom (user-created) device slugs
+ * @returns Filtered devices (the original array reference when no filter is active)
+ */
+export function filterDevicesByAttributes(
+  devices: DeviceType[],
+  filters: DeviceAttributeFilters,
+  isCustom: (slug: string) => boolean,
+): DeviceType[] {
+  const filterByHeight = filters.heights.size > 0;
+  // Both or neither selected means no width filtering.
+  const filterByWidth = filters.halfWidth !== filters.fullWidth;
+
+  if (
+    !filterByHeight &&
+    !filterByWidth &&
+    !filters.hasImage &&
+    !filters.customOnly
+  ) {
+    return devices;
+  }
+
+  return devices.filter((device) => {
+    if (
+      filterByHeight &&
+      ![...filters.heights].some((bucket) =>
+        matchesHeightBucket(device.u_height, bucket),
+      )
+    ) {
+      return false;
+    }
+
+    if (filterByWidth) {
+      const isHalf = device.slot_width === 1;
+      if (filters.halfWidth !== isHalf) {
+        return false;
+      }
+    }
+
+    if (filters.hasImage && !(device.front_image || device.rear_image)) {
+      return false;
+    }
+
+    if (filters.customOnly && !isCustom(device.slug)) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/src/tests/device-attribute-filter.test.ts
+++ b/src/tests/device-attribute-filter.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Device Attribute Filter Tests
+ *
+ * Tests for the pure attribute-filter predicate that powers the device palette
+ * filter UI (height bucket, half/full width, has-image, custom-only).
+ * Custom detection is injected so the predicate stays pure and testable.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  filterDevicesByAttributes,
+  type DeviceAttributeFilters,
+  type HeightBucket,
+} from "$lib/utils/deviceFilters";
+import type { DeviceType } from "$lib/types";
+import { createTestDeviceType } from "./factories";
+
+/** Build a filters object, defaulting to the no-op empty state. */
+function makeFilters(
+  overrides: Partial<DeviceAttributeFilters> = {},
+): DeviceAttributeFilters {
+  return {
+    heights: new Set<HeightBucket>(),
+    halfWidth: false,
+    fullWidth: false,
+    hasImage: false,
+    customOnly: false,
+    ...overrides,
+  };
+}
+
+/** No device is custom. */
+const noneCustom = (): boolean => false;
+
+describe("filterDevicesByAttributes", () => {
+  describe("empty filters", () => {
+    it("returns the input unchanged when no filters are active", () => {
+      const devices = [
+        createTestDeviceType({ slug: "a", u_height: 1 }),
+        createTestDeviceType({ slug: "b", u_height: 2 }),
+      ];
+
+      const result = filterDevicesByAttributes(
+        devices,
+        makeFilters(),
+        noneCustom,
+      );
+
+      expect(result).toBe(devices);
+    });
+  });
+
+  describe("height buckets", () => {
+    const sub1 = createTestDeviceType({ slug: "sub-1u", u_height: 0.5 });
+    const one = createTestDeviceType({ slug: "one-u", u_height: 1 });
+    const two = createTestDeviceType({ slug: "two-u", u_height: 2 });
+    const three = createTestDeviceType({ slug: "three-u", u_height: 3 });
+    const four = createTestDeviceType({ slug: "four-u", u_height: 4 });
+    const six = createTestDeviceType({ slug: "six-u", u_height: 6 });
+    const devices = [sub1, one, two, three, four, six];
+
+    it("0.5 bucket matches only sub-1U devices", () => {
+      const result = filterDevicesByAttributes(
+        devices,
+        makeFilters({ heights: new Set<HeightBucket>(["0.5"]) }),
+        noneCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("sub-1u");
+      expect(slugs).not.toContain("one-u");
+      expect(slugs).not.toContain("two-u");
+    });
+
+    it("a numeric bucket matches only the exact U height", () => {
+      const result = filterDevicesByAttributes(
+        devices,
+        makeFilters({ heights: new Set<HeightBucket>(["2"]) }),
+        noneCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("two-u");
+      expect(slugs).not.toContain("sub-1u");
+      expect(slugs).not.toContain("one-u");
+      expect(slugs).not.toContain("three-u");
+    });
+
+    it("4plus bucket matches 4U and taller", () => {
+      const result = filterDevicesByAttributes(
+        devices,
+        makeFilters({ heights: new Set<HeightBucket>(["4plus"]) }),
+        noneCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("four-u");
+      expect(slugs).toContain("six-u");
+      expect(slugs).not.toContain("three-u");
+      expect(slugs).not.toContain("sub-1u");
+    });
+
+    it("multiple buckets OR within the height group", () => {
+      const result = filterDevicesByAttributes(
+        devices,
+        makeFilters({ heights: new Set<HeightBucket>(["1", "4plus"]) }),
+        noneCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("one-u");
+      expect(slugs).toContain("four-u");
+      expect(slugs).toContain("six-u");
+      expect(slugs).not.toContain("two-u");
+      expect(slugs).not.toContain("three-u");
+      expect(slugs).not.toContain("sub-1u");
+    });
+  });
+
+  describe("width", () => {
+    const half = createTestDeviceType({ slug: "half", slot_width: 1 });
+    const full = createTestDeviceType({ slug: "full", slot_width: 2 });
+    // slot_width undefined defaults to full-width.
+    const defaultFull = createTestDeviceType({ slug: "default-full" });
+    const devices = [half, full, defaultFull];
+
+    it("half-only keeps only slot_width === 1", () => {
+      const result = filterDevicesByAttributes(
+        devices,
+        makeFilters({ halfWidth: true }),
+        noneCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("half");
+      expect(slugs).not.toContain("full");
+      expect(slugs).not.toContain("default-full");
+    });
+
+    it("full-only keeps slot_width === 2 and undefined (default full)", () => {
+      const result = filterDevicesByAttributes(
+        devices,
+        makeFilters({ fullWidth: true }),
+        noneCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("full");
+      expect(slugs).toContain("default-full");
+      expect(slugs).not.toContain("half");
+    });
+
+    it("half + full selected behaves as no width filter", () => {
+      const result = filterDevicesByAttributes(
+        devices,
+        makeFilters({ halfWidth: true, fullWidth: true }),
+        noneCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("half");
+      expect(slugs).toContain("full");
+      expect(slugs).toContain("default-full");
+    });
+  });
+
+  describe("has-image", () => {
+    it("keeps devices with a front or rear image flag", () => {
+      const noImage = createTestDeviceType({ slug: "no-image" });
+      const frontOnly: DeviceType = {
+        ...createTestDeviceType({ slug: "front-only" }),
+        front_image: true,
+      };
+      const rearOnly: DeviceType = {
+        ...createTestDeviceType({ slug: "rear-only" }),
+        rear_image: true,
+      };
+
+      const result = filterDevicesByAttributes(
+        [noImage, frontOnly, rearOnly],
+        makeFilters({ hasImage: true }),
+        noneCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("front-only");
+      expect(slugs).toContain("rear-only");
+      expect(slugs).not.toContain("no-image");
+    });
+  });
+
+  describe("custom-only", () => {
+    it("keeps only devices the injected isCustom marks as custom", () => {
+      const builtIn = createTestDeviceType({ slug: "built-in" });
+      const custom = createTestDeviceType({ slug: "my-custom" });
+
+      const isCustom = (slug: string): boolean => slug === "my-custom";
+
+      const result = filterDevicesByAttributes(
+        [builtIn, custom],
+        makeFilters({ customOnly: true }),
+        isCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      expect(slugs).toContain("my-custom");
+      expect(slugs).not.toContain("built-in");
+    });
+  });
+
+  describe("AND across groups", () => {
+    it("combines height and custom filters with AND", () => {
+      const customTwoU = createTestDeviceType({
+        slug: "custom-2u",
+        u_height: 2,
+      });
+      const customOneU = createTestDeviceType({
+        slug: "custom-1u",
+        u_height: 1,
+      });
+      const builtInTwoU = createTestDeviceType({
+        slug: "builtin-2u",
+        u_height: 2,
+      });
+
+      const isCustom = (slug: string): boolean => slug.startsWith("custom-");
+
+      const result = filterDevicesByAttributes(
+        [customTwoU, customOneU, builtInTwoU],
+        makeFilters({
+          heights: new Set<HeightBucket>(["2"]),
+          customOnly: true,
+        }),
+        isCustom,
+      );
+      const slugs = result.map((d) => d.slug);
+
+      // Only the device that is both 2U AND custom survives.
+      expect(slugs).toContain("custom-2u");
+      expect(slugs).not.toContain("custom-1u"); // wrong height
+      expect(slugs).not.toContain("builtin-2u"); // not custom
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Adds the pure predicate that powers attribute filtering in the device palette. Logic only; the UI lands in a follow-up issue.

- `HeightBucket` and `DeviceAttributeFilters` types in `src/lib/utils/deviceFilters.ts`
- `filterDevicesByAttributes(devices, filters, isCustom)` as a pure function, with custom detection injected (not imported) to keep it testable
- Height buckets: `0.5` (`u_height < 1`), `1`/`2`/`3` (`=== N`), `4plus` (`>= 4`); OR within the group
- Width: half = `slot_width === 1`, full = `slot_width === 2` or unset; OR within the group; both-or-neither selected = no width filter
- Has-image = `Boolean(front_image || rear_image)`; custom = `isCustom(slug)`
- AND across groups; empty filters return the input unchanged

## Tests

Behavioural unit tests in `src/tests/device-attribute-filter.test.ts` following `rack-width-filter.test.ts` style: bucket boundaries, width OR, has-image, custom-only, AND across groups, and empty pass-through. No exact-length assertions on data arrays.

Local gates: lint, full unit suite (2789 tests), and production build all pass.

Closes #2189

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Add device palette filtering by height, width, image, and custom status**

### What Changed
- Devices can now be filtered by height bucket, half/full width, image availability, and whether they are custom-created
- Height filtering supports sub-1U, exact 1U/2U/3U, and 4U-plus groups
- Selecting both width options, or neither, leaves width unfiltered
- The filter returns all devices unchanged when no options are selected
- Added tests covering each filter rule and how they combine

### Impact
`✅ Faster device browsing`
`✅ Quicker way to find matching rack devices`
`✅ Fewer false matches in device search`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
