### PR TITLE
fix: resolve string|undefined svelte-check errors in EditPanelImage (#2331)

### DIFF
--- a/src/lib/components/EditPanelImage.svelte
+++ b/src/lib/components/EditPanelImage.svelte
@@ -19,7 +19,7 @@
   const layoutStore = getLayoutStore();
   const imageStore = getImageStore();
 
-  const layoutId = $derived(layoutStore.layout.metadata!.id);
+  const layoutId = $derived(layoutStore.layout.metadata?.id ?? "");
 
   // Get the current placement images (if any)
   const placementFrontImage = $derived.by(() =>


### PR DESCRIPTION
## **User description**
## Summary

Clears 4 `svelte-check` `string | undefined` errors in `EditPanelImage.svelte` (lines 27, 34, 42, 54). All four trace to `layoutId`, which derived from `layoutStore.layout.metadata!.id`. The non-null assertion did not propagate, so the value reached `placementKey(layoutId, ...)` as `string | undefined`.

## Fix

Narrow at source:

```diff
-  const layoutId = $derived(layoutStore.layout.metadata!.id);
+  const layoutId = $derived(layoutStore.layout.metadata?.id ?? "");
```

No `!`, no `as string`, no `@ts-ignore`. The empty-string fallback routes through `placementKey`'s designed legacy-fallback branch (`placement-{deviceId}`) instead of emitting a literal `"undefined"` in the key, so this is also strictly better runtime behaviour than the old assertion.

## Verification

- `npx svelte-check`: the 4 EditPanelImage errors are gone; no new errors introduced. (One pre-existing, unrelated `DialogOrchestrator.svelte` error remains on `main` and is out of scope.)
- `npm run lint`: clean
- `npm run test:run`: 2778 tests pass
- `npm run build`: succeeds

No behavioural change; no new tests needed (svelte-check is the proof).

Closes #2331

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Avoid broken image keys when layout data is missing**

### What Changed
- Uses an empty fallback when the selected layout does not yet have an ID, instead of relying on a missing value.
- Prevents the edit panel from building an invalid placement key that could include `"undefined"`.

### Impact
`✅ Fewer edit-panel image lookup errors`
`✅ Safer image overrides when layout data is still loading`
`✅ Clearer fallback behavior for missing layout IDs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
