### PR TITLE
fix: keep canvas verb bar below side panels in stacking order (#2491)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -722,6 +722,10 @@
     flex-direction: column;
     overflow: hidden;
     transition: width var(--duration-normal) var(--ease-in-out);
+    /* Stack above the canvas overlays (verb bar, placement indicator) so the
+       panel occludes them where they overlap the canvas edge (#2491). */
+    position: relative;
+    z-index: var(--z-sidebar);
   }
 
   /* Collapsed: shrink to the 44px strip; the strip owns its own outer border. */

--- a/src/lib/components/SidePanel.svelte
+++ b/src/lib/components/SidePanel.svelte
@@ -139,6 +139,10 @@
     border-left: 1px solid var(--colour-border);
     overflow: hidden;
     transition: width var(--duration-normal) var(--ease-in-out);
+    /* Stack above the canvas overlays (verb bar, placement indicator) so the
+       panel occludes them where they overlap the canvas edge (#2491). */
+    position: relative;
+    z-index: var(--z-sidebar);
   }
 
   /* Collapsed: shrink to the 44px strip. The strip owns its own outer border. */

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -356,9 +356,13 @@
 
   /* Z-Index Layers */
   --z-toolbar: 20;
-  --z-sidebar: 10;
+  /* Canvas overlays: anchored to the canvas, must sit under the side panels so
+     a panel occludes them where they overlap (#2491). */
   --z-placement-indicator: 50;
   --z-verb-bar: 50;
+  /* Side panels: persistent chrome that flanks the canvas. Above the canvas
+     overlays, below the drawer/modal/dropdown layers. */
+  --z-sidebar: 60;
   --z-drawer-backdrop: 99;
   --z-drawer: 100;
   --z-fab: 100;


### PR DESCRIPTION
## **User description**
## Summary

The canvas verb bar (`VerbBarOverlay.svelte`, `position: fixed`, `--z-verb-bar: 50`) is anchored to viewport coordinates, so it spans across the side-panel columns and floated *on top of* the persistent side panels where they overlap the canvas edge. The panels are persistent chrome, the verb bar is a canvas overlay, so the panel must win at the overlap.

## Changes

- `tokens.css`: raise `--z-sidebar` from 10 to 60. It now sits above the canvas overlays (`--z-verb-bar` / `--z-placement-indicator`, both 50) and below the drawer/modal/dropdown layers (99+), so dialogs, toasts, dropdowns and the toolbar are unaffected.
- `App.svelte` (`.sidebar-panel`, left device palette) and `SidePanel.svelte` (`.side-panel`, right Edit panel): add `position: relative` + `z-index: var(--z-sidebar)` so each panel establishes a stacking context and occludes the verb bar / placement indicator at the overlap.

CSS-only change. No script or markup logic touched.

## Verification

- `npm run lint`: clean
- `npm run test:run`: 2778 passed (165 files)
- `npm run build`: success
- svelte-autofixer on changed component: no issues

Closes #2491

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Keep the canvas verb bar behind the side panels**

### What Changed
- The left and right side panels now stay above the canvas verb bar and placement marker when they overlap the canvas edge
- The panels keep their existing size and layout, but now consistently cover canvas overlays instead of letting them appear on top
- Drawer, modal, dropdown, and toast layers remain unaffected

### Impact
`✅ Fewer overlay clashes at the canvas edges`
`✅ Clearer side-panel boundaries`
`✅ More predictable workspace layering`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
