### PR TITLE
chore: remove redundant display-style toggle from device search row (#2439)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -581,10 +581,7 @@
                 oncollapse={handleCollapseSidebar}
               />
               {#if uiStore.sidebarTab === "devices"}
-                <DevicePalette
-                  oncreatedevice={handleAddDevice}
-                  ontoggledisplaymode={handleToggleDisplayMode}
-                />
+                <DevicePalette oncreatedevice={handleAddDevice} />
               {:else if uiStore.sidebarTab === "racks"}
                 <RackList
                   onnewrack={handleNewRack}
@@ -611,6 +608,8 @@
               onshare={handleShare}
               onfitall={handleFitAll}
               onresetzoom={() => canvasStore.resetZoom()}
+              displayMode={uiStore.displayMode}
+              ontoggledisplaymode={handleToggleDisplayMode}
               {partyMode}
               enableLongPress={false}
               onracklongpress={handleRackLongPress}
@@ -640,6 +639,8 @@
           onshare={handleShare}
           onfitall={handleFitAll}
           onresetzoom={() => canvasStore.resetZoom()}
+          displayMode={uiStore.displayMode}
+          ontoggledisplaymode={handleToggleDisplayMode}
           {partyMode}
           enableLongPress={viewportStore.isMobile && !placementStore.isPlacing}
           onracklongpress={handleRackLongPress}

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -23,7 +23,7 @@
   import { dispatchContextMenuAtPoint } from "$lib/utils/context-menu";
   import { hapticTap } from "$lib/utils/haptics";
   import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
-  import type { DeviceFace } from "$lib/types";
+  import type { DeviceFace, DisplayMode } from "$lib/types";
   import {
     loadStarterTemplates,
     type StarterTemplate,
@@ -48,6 +48,10 @@
     onshare?: () => void;
     onfitall?: () => void;
     onresetzoom?: () => void;
+    /** Current display mode, for the canvas context-menu toggle entry */
+    displayMode?: DisplayMode;
+    /** Cycle the canvas display mode from the context menu */
+    ontoggledisplaymode?: () => void;
     onrackselect?: (event: CustomEvent<{ rackId: string }>) => void;
     ondeviceselect?: (
       event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
@@ -103,6 +107,8 @@
     onshare,
     onfitall,
     onresetzoom,
+    displayMode,
+    ontoggledisplaymode,
     onrackselect,
     ondeviceselect,
     ondevicedrop,
@@ -403,6 +409,8 @@
   onnewrack={handleNewRack}
   onfitall={() => onfitall?.() ?? canvasStore.fitAll(racks)}
   onresetzoom={() => onresetzoom?.() ?? canvasStore.resetZoom()}
+  {displayMode}
+  {ontoggledisplaymode}
 >
   <div
     class="canvas"

--- a/src/lib/components/CanvasContextMenu.svelte
+++ b/src/lib/components/CanvasContextMenu.svelte
@@ -6,6 +6,7 @@
 <script lang="ts">
   import { ContextMenu } from "bits-ui";
   import type { Snippet } from "svelte";
+  import { DISPLAY_MODE_LABELS, type DisplayMode } from "$lib/types";
   import "$lib/styles/context-menus.css";
 
   interface Props {
@@ -19,6 +20,10 @@
     onfitall?: () => void;
     /** Reset zoom to 100% callback */
     onresetzoom?: () => void;
+    /** Current display mode, used to label the toggle entry */
+    displayMode?: DisplayMode;
+    /** Cycle the canvas display mode (label -> image -> image-label) */
+    ontoggledisplaymode?: () => void;
     /** Trigger element (the canvas) */
     children: Snippet;
   }
@@ -29,6 +34,8 @@
     onnewrack,
     onfitall,
     onresetzoom,
+    displayMode,
+    ontoggledisplaymode,
     children,
   }: Props = $props();
 
@@ -82,6 +89,21 @@
       >
         <span class="context-menu-label">Reset Zoom</span>
       </ContextMenu.Item>
+
+      {#if ontoggledisplaymode}
+        <ContextMenu.Separator class="context-menu-separator" />
+
+        <ContextMenu.Item
+          class="context-menu-item"
+          data-testid="ctx-menu-item"
+          onSelect={handleSelect(ontoggledisplaymode)}
+        >
+          <span class="context-menu-label">
+            Display{displayMode ? `: ${DISPLAY_MODE_LABELS[displayMode]}` : ""}
+          </span>
+          <span class="context-menu-shortcut">I</span>
+        </ContextMenu.Item>
+      {/if}
     </ContextMenu.Content>
   </ContextMenu.Portal>
 </ContextMenu.Root>

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -38,22 +38,16 @@
   import BrandIcon from "./BrandIcon.svelte";
   import SegmentedControl from "./SegmentedControl.svelte";
   import Tooltip from "./Tooltip.svelte";
-  import IconTextBold from "./icons/IconTextBold.svelte";
-  import IconImageBold from "./icons/IconImageBold.svelte";
-  import IconImageLabel from "./icons/IconImageLabel.svelte";
   import IconPin from "./icons/IconPin.svelte";
   import { ICON_SIZE } from "$lib/constants/sizing";
-  import type { DeviceType, DisplayMode } from "$lib/types";
+  import type { DeviceType } from "$lib/types";
 
   interface Props {
     ondeviceselect?: (event: CustomEvent<{ device: DeviceType }>) => void;
     oncreatedevice?: () => void;
-    /** Cycle the canvas display mode (label -> image -> image-label). The
-     *  palette toggle mirrors the canonical lens; it does not own the state. */
-    ontoggledisplaymode?: () => void;
   }
 
-  let { ondeviceselect, oncreatedevice, ontoggledisplaymode }: Props = $props();
+  let { ondeviceselect, oncreatedevice }: Props = $props();
 
   // Estimated palette row height in pixels, used by the virtualized lists.
   // Rows are a flex line with var(--touch-target-min) min-height (48px) plus
@@ -103,14 +97,6 @@
     favouriteSlugs = toggleFavourite(favouriteSlugs, event.detail.device.slug);
     saveFavouritesToStorage(favouriteSlugs);
   }
-
-  // Display mode mirrors the canonical canvas lens (uiStore.displayMode); the
-  // palette only reflects and forwards toggle requests, it never owns the state.
-  const displayModeLabels: Record<DisplayMode, string> = {
-    label: "Labels",
-    image: "Images",
-    "image-label": "Both",
-  };
 
   // Accordion mode and state tracking
   let accordionMode = $state<"single" | "multiple">("single");
@@ -540,29 +526,6 @@
         aria-label="Search devices"
         data-testid="search-devices"
       />
-      {#if ontoggledisplaymode}
-        <Tooltip
-          text={`Display: ${displayModeLabels[uiStore.displayMode]}`}
-          shortcut="I"
-          position="bottom"
-        >
-          <button
-            type="button"
-            class="palette-header-btn"
-            onclick={ontoggledisplaymode}
-            aria-label="Toggle device display mode"
-            data-testid="btn-palette-display-mode"
-          >
-            {#if uiStore.displayMode === "label"}
-              <IconTextBold size={ICON_SIZE.sm} />
-            {:else if uiStore.displayMode === "image"}
-              <IconImageBold size={ICON_SIZE.sm} />
-            {:else}
-              <IconImageLabel size={ICON_SIZE.sm} />
-            {/if}
-          </button>
-        </Tooltip>
-      {/if}
       {#if oncreatedevice}
         <Tooltip text="Create custom device" position="bottom">
           <button
@@ -766,8 +729,7 @@
       box-shadow var(--duration-fast) ease;
   }
 
-  .create-device-btn,
-  .palette-header-btn {
+  .create-device-btn {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -790,21 +752,18 @@
       border-color var(--duration-fast) ease;
   }
 
-  .create-device-btn:hover,
-  .palette-header-btn:hover {
+  .create-device-btn:hover {
     color: var(--colour-text);
     background: var(--colour-surface-hover);
     border-color: var(--colour-border-hover);
   }
 
-  .create-device-btn:focus-visible,
-  .palette-header-btn:focus-visible {
+  .create-device-btn:focus-visible {
     outline: 2px solid var(--colour-selection);
     outline-offset: 2px;
   }
 
-  .create-device-btn:active,
-  .palette-header-btn:active {
+  .create-device-btn:active {
     background: var(--colour-surface-active);
   }
 

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -13,7 +13,7 @@
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
-  import type { DisplayMode } from "$lib/types";
+  import { DISPLAY_MODE_LABELS, type DisplayMode } from "$lib/types";
   import Tooltip from "../Tooltip.svelte";
   import {
     IconFitAllBold,
@@ -37,12 +37,6 @@
   const canvasStore = getCanvasStore();
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
-
-  const displayModeLabels: Record<DisplayMode, string> = {
-    label: "Labels",
-    image: "Images",
-    "image-label": "Both",
-  };
 
   function handleUndo() {
     if (!layoutStore.canUndo) return;
@@ -146,7 +140,7 @@
     </Tooltip>
 
     <Tooltip
-      text={`Display: ${displayModeLabels[displayMode]}`}
+      text={`Display: ${DISPLAY_MODE_LABELS[displayMode]}`}
       shortcut="I"
       position="top"
     >

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -74,6 +74,13 @@ export type FormFactor =
  */
 export type DisplayMode = "label" | "image" | "image-label";
 
+/** Short human labels for each display mode, shown on the display-mode controls. */
+export const DISPLAY_MODE_LABELS: Record<DisplayMode, string> = {
+  label: "Labels",
+  image: "Images",
+  "image-label": "Both",
+};
+
 /**
  * Annotation field for rack-side annotation column
  * - 'name': Custom placement name


### PR DESCRIPTION
## **User description**
## Summary

Removes the display-style toggle from the DevicePalette search row, which duplicated the canonical display-mode control in the lower-left canvas toolbar. The toggle is added to the canvas right-click (context) menu so it stays reachable, and the `I` keyboard shortcut is unchanged.

## Changes

- Remove the display-mode toggle button (and its icons, label map, CSS, and `ontoggledisplaymode` prop) from `DevicePalette.svelte`.
- Add a `Display` entry to `CanvasContextMenu.svelte`, labelled with the current mode and showing the `I` shortcut.
- Wire `displayMode` + `ontoggledisplaymode` through `Canvas.svelte` to the context menu, fed from `App.svelte` (both desktop and mobile Canvas instances).
- Hoist the shared display-mode label map to a `DISPLAY_MODE_LABELS` constant beside the `DisplayMode` type, so the toolbar (`CanvasViewControls`) and the new context-menu entry share one source of truth instead of duplicating it.

## Acceptance criteria

- [x] Display-style toggle removed from the device search row
- [x] Display-mode toggle added to the canvas right-click menu
- [x] Lower-left canvas toolbar toggle unchanged and primary
- [x] No loss of function: the `I` keyboard shortcut still works

## Verification

- `npm run lint` clean
- `npm run test:run` 2789 tests pass
- `npm run build` succeeds
- svelte-autofixer clean on all touched components

Closes #2439

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Move the display mode toggle out of the device search row and into the canvas menu**

### What Changed
- Removed the display mode toggle from the device search area, leaving the search row focused on finding and creating devices
- Added a display mode option to the canvas right-click menu, so users can still switch between Labels, Images, and Both from the canvas
- Kept the existing display mode button in the bottom-left canvas controls, with the same keyboard shortcut and current mode label

### Impact
`✅ Cleaner device search area`
`✅ Easier access to display mode from the canvas`
`✅ No lost display mode shortcut`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
