### PR TITLE
fix: resolve string|undefined svelte-check errors in EditPanelImage (#2331)

### DIFF
--- a/src/lib/components/EditPanelImage.svelte
+++ b/src/lib/components/EditPanelImage.svelte
@@ -19,7 +19,7 @@
   const layoutStore = getLayoutStore();
   const imageStore = getImageStore();
 
-  const layoutId = $derived(layoutStore.layout.metadata!.id);
+  const layoutId = $derived(layoutStore.layout.metadata?.id ?? "");
 
   // Get the current placement images (if any)
   const placementFrontImage = $derived.by(() =>


### PR DESCRIPTION
## **User description**
## Summary

`EditPanelImage.svelte` had 4 `svelte-check` errors (lines ~27, 34, 42, 54): a `string | undefined` value passed into `placementKey(layoutId: string, ...)`.

Root cause: `layoutId` was derived as `layoutStore.layout.metadata!.id`. Since `Layout.metadata` is `Partial<LayoutMetadata>`, the `!` only removes the `undefined` from `metadata` itself, not from the optional `.id` field, so `layoutId` was `string | undefined`.

Fix: narrow at source with `layout.metadata?.id ?? ""`, matching the dominant pattern already used by every other `placementKey` caller (`device.ts`, `device-type.ts`, `archive.ts`, `recorded-device-actions.ts`, `device-actions.ts`). `placementKey` already handles an empty/falsy `layoutId` via its designed legacy-fallback branch (`placement-{deviceId}`), so there is zero behavioural change for real layouts, and absent-id keys now route through that branch instead of stringifying `undefined`. No bare `!`, no cast, no ts-ignore.

## Verification

- `npx svelte-check`: 4 EditPanelImage errors cleared; no new errors introduced (one unrelated pre-existing `DialogOrchestrator.svelte` `theme` error remains, present on base).
- `npm run lint`: clean
- `npm run test:run`: 165 files, 2778 tests passed
- `npm run build`: passed

Closes #2331

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Avoid broken image key lookups when layout metadata is missing in the edit panel

### What Changed
- The edit panel now treats a missing layout ID as empty instead of passing an undefined value into image lookup
- Placement images continue to resolve through the existing fallback path when no layout ID is available
- Removes the source of the `svelte-check` errors in the image override panel

### Impact
`✅ Fewer edit panel image lookup errors`
`✅ Safer fallback when layout data is incomplete`
`✅ Cleaner build checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
