### PR TITLE
feat: distinguish editable controls from read-only facts in edit panel

### DIFF
--- a/docs/superpowers/specs/2026-06-19-edit-panel-metadata-grouping-design.md
+++ b/docs/superpowers/specs/2026-06-19-edit-panel-metadata-grouping-design.md
@@ -1,10 +1,10 @@
 # Edit-panel metadata regrouping (B1 spike)
 
-Status: Decided
-Date: 2026-06-19
-Spike: #2441
-Implements via: #2442 (editable vs read-only treatment), #2443 (collapsible device-type block)
-Component: `src/lib/components/EditPanelMetadata.svelte`
+- Status: Decided
+- Date: 2026-06-19
+- Spike: #2441
+- Implements via: #2442 (editable vs read-only treatment), #2443 (collapsible device-type block)
+- Component: `src/lib/components/EditPanelMetadata.svelte`
 
 ## Problem
 

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -115,10 +115,10 @@ export const locators = {
   deviceDetail: {
     colourPickerContainer: ".colour-picker-container",
     displayNameText: ".display-name-text",
-    colourInfo: ".colour-info",
+    colourInfo: ".colour-value",
     categoryIconIndicator: ".category-icon-indicator svg",
     imagePreview: ".image-upload img, .image-preview img",
-    colourRowButton: "button.colour-row-btn",
+    colourRowButton: "button.colour-swatch-btn",
     colourPickerInput: '.colour-picker-container input[type="text"]',
   },
 

--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -1,8 +1,9 @@
 <!--
   EditPanelMetadata Component
-  Edit panel section: descriptive properties for the selected device:
-  name, device type/brand, height, category, colour, mounted face, power
-  ratings, device-type notes, IP/hostname, and placement notes.
+  Edit panel section: descriptive properties for the selected device, grouped
+  by meaning. Identity (name, colour), Device type details (read-only facts:
+  type, brand, height, category, power ratings, device-type notes), Placement
+  (mounted face), Network (IP/hostname), and Notes (placement notes).
 -->
 <script lang="ts">
   import { onDestroy } from "svelte";
@@ -83,6 +84,13 @@
   // is_full_depth undefined or true means full-depth.
   const isFullDepthDevice = $derived(
     authoritativeDevice.is_full_depth !== false,
+  );
+
+  // Resolved colour shown by the swatch button: placement override wins over the
+  // device-type default.
+  const resolvedColour = $derived(
+    selectedDeviceInfo.placedDevice.colour_override ??
+      selectedDeviceInfo.device.colour,
   );
 
   // Start editing device name
@@ -217,219 +225,240 @@
   }
 </script>
 
-<!-- Display Name at top (click-to-edit) -->
-<div class="form-group">
-  <label for="device-display-name">Name</label>
-  {#if editingDeviceName}
-    <input
-      id="device-display-name"
-      type="text"
-      class="input-field"
-      bind:value={deviceNameInput}
-      onblur={saveDeviceName}
-      onkeydown={handleDeviceNameKeydown}
-    />
-  {:else}
+<!-- Identity: editable name and colour -->
+<section class="field-group">
+  <h3 class="group-header">Identity</h3>
+
+  <!-- Display Name (click-to-edit) -->
+  <div class="form-group">
+    <label for="device-display-name">Name</label>
+    {#if editingDeviceName}
+      <input
+        id="device-display-name"
+        type="text"
+        class="input-field"
+        bind:value={deviceNameInput}
+        onblur={saveDeviceName}
+        onkeydown={handleDeviceNameKeydown}
+      />
+    {:else}
+      <button
+        id="device-display-name"
+        type="button"
+        class="display-name-display"
+        onclick={startEditingDeviceName}
+        aria-label="Edit display name"
+      >
+        <span class="display-name-text">
+          {selectedDeviceInfo.placedDevice.name ??
+            selectedDeviceInfo.device.model ??
+            selectedDeviceInfo.device.slug}
+        </span>
+        <span class="edit-icon-wrapper"><IconEdit /></span>
+      </button>
+    {/if}
+  </div>
+
+  <!-- Colour (click-to-edit swatch button, opens picker) -->
+  <div class="form-group">
+    <span class="field-label" id="device-colour-label">Colour</span>
     <button
-      id="device-display-name"
       type="button"
-      class="display-name-display"
-      onclick={startEditingDeviceName}
-      aria-label="Edit display name"
+      class="colour-swatch-btn"
+      onclick={() => (showColourPicker = !showColourPicker)}
+      aria-expanded={showColourPicker}
+      aria-labelledby="device-colour-label"
     >
-      <span class="display-name-text">
-        {selectedDeviceInfo.placedDevice.name ??
-          selectedDeviceInfo.device.model ??
-          selectedDeviceInfo.device.slug}
+      <ColourSwatch colour={resolvedColour} size={ICON_SIZE.sm} />
+      <span class="colour-value">
+        {resolvedColour}
+        {#if selectedDeviceInfo.placedDevice.colour_override}
+          <span class="colour-badge">custom</span>
+        {/if}
       </span>
       <span class="edit-icon-wrapper"><IconEdit /></span>
     </button>
-  {/if}
-</div>
+    {#if showColourPicker}
+      <div class="colour-picker-container">
+        <ColourPicker
+          value={resolvedColour}
+          defaultValue={selectedDeviceInfo.device.colour}
+          onchange={(colour) =>
+            layoutStore.updateDeviceColour(
+              selectedDeviceInfo.rack.id,
+              selectedDeviceInfo.deviceIndex,
+              colour,
+            )}
+          onreset={() =>
+            layoutStore.updateDeviceColour(
+              selectedDeviceInfo.rack.id,
+              selectedDeviceInfo.deviceIndex,
+              undefined,
+            )}
+        />
+      </div>
+    {/if}
+  </div>
+</section>
 
-<!-- Device Type (read-only) -->
-<div class="info-section">
-  <div class="info-row">
-    <span class="info-label">Device Type</span>
-    <span class="info-value device-type">
-      <ColourSwatch
-        colour={selectedDeviceInfo.device.colour}
-        size={ICON_SIZE.sm}
-      />
-      {selectedDeviceInfo.device.model ?? selectedDeviceInfo.device.slug}
-    </span>
+<!-- Device type details: read-only reference facts (muted, non-interactive) -->
+<section class="field-group">
+  <h3 class="group-header">Device type details</h3>
+  <div class="facts">
+    <div class="fact-row">
+      <span class="fact-label">Type</span>
+      <span class="fact-value fact-value-icon">
+        <ColourSwatch
+          colour={selectedDeviceInfo.device.colour}
+          size={ICON_SIZE.sm}
+        />
+        {selectedDeviceInfo.device.model ?? selectedDeviceInfo.device.slug}
+      </span>
+    </div>
+    <div class="fact-row">
+      <span class="fact-label">Brand</span>
+      <span class="fact-value fact-value-icon">
+        <BrandIcon
+          slug={getBrandIconSlug(authoritativeDevice.slug)}
+          size={ICON_SIZE.sm}
+        />
+        {authoritativeDevice.manufacturer ??
+          selectedDeviceInfo.device.manufacturer ??
+          "Generic"}
+      </span>
+    </div>
+    <div class="fact-row">
+      <span class="fact-label">Height</span>
+      <span class="fact-value">{selectedDeviceInfo.device.u_height}U</span>
+    </div>
+    <div class="fact-row">
+      <span class="fact-label">Category</span>
+      <span class="fact-value"
+        >{getCategoryDisplayName(selectedDeviceInfo.device.category)}</span
+      >
+    </div>
+    {#if selectedDeviceInfo.device.category === "power" && selectedDeviceInfo.device.outlet_count}
+      <div class="fact-row">
+        <span class="fact-label">Outlets</span>
+        <span class="fact-value">{selectedDeviceInfo.device.outlet_count}</span>
+      </div>
+    {/if}
+    {#if selectedDeviceInfo.device.category === "power" && selectedDeviceInfo.device.va_rating}
+      <div class="fact-row">
+        <span class="fact-label">VA Rating</span>
+        <span class="fact-value">{selectedDeviceInfo.device.va_rating}</span>
+      </div>
+    {/if}
+    {#if selectedDeviceInfo.device.notes}
+      <div class="fact-notes">
+        <span class="fact-label">Device type notes</span>
+        <p class="fact-notes-text">{selectedDeviceInfo.device.notes}</p>
+      </div>
+    {/if}
   </div>
-  <div class="info-row">
-    <span class="info-label">Brand</span>
-    <span class="info-value brand-info">
-      <BrandIcon
-        slug={getBrandIconSlug(authoritativeDevice.slug)}
-        size={ICON_SIZE.sm}
-      />
-      {authoritativeDevice.manufacturer ??
-        selectedDeviceInfo.device.manufacturer ??
-        "Generic"}
-    </span>
-  </div>
-</div>
+</section>
 
-<div class="info-section">
-  <div class="info-row">
-    <span class="info-label">Height</span>
-    <span class="info-value">{selectedDeviceInfo.device.u_height}U</span>
-  </div>
-  <div class="info-row">
-    <span class="info-label">Category</span>
-    <span class="info-value"
-      >{getCategoryDisplayName(selectedDeviceInfo.device.category)}</span
+<!-- Placement: editable mounted face -->
+<section class="field-group">
+  <h3 class="group-header">Placement</h3>
+  <div class="form-group">
+    <label for="device-face">Mounted Face</label>
+    <select
+      id="device-face"
+      class="input-field"
+      value={selectedDeviceInfo.placedDevice.face}
+      onchange={(e) =>
+        handleFaceChange((e.target as HTMLSelectElement).value as DeviceFace)}
     >
+      <option value="front">Front</option>
+      <option value="rear">Rear</option>
+      <option value="both">Both (full-depth)</option>
+    </select>
+    {#if isFullDepthDevice && selectedDeviceInfo.placedDevice.face !== "both"}
+      <p class="helper-text">Overriding default full-depth setting</p>
+    {/if}
   </div>
-  <!-- Colour row - clickable to open picker -->
-  <button
-    type="button"
-    class="info-row colour-row-btn"
-    onclick={() => (showColourPicker = !showColourPicker)}
-    aria-expanded={showColourPicker}
-    aria-label="Edit device colour"
-  >
-    <span class="info-label">Colour</span>
-    <span class="info-value colour-info">
-      <ColourSwatch
-        colour={selectedDeviceInfo.placedDevice.colour_override ??
-          selectedDeviceInfo.device.colour}
-        size={ICON_SIZE.sm}
-      />
-      {#if selectedDeviceInfo.placedDevice.colour_override}
-        {selectedDeviceInfo.placedDevice.colour_override}
-        <span class="colour-badge">custom</span>
-      {:else}
-        {selectedDeviceInfo.device.colour}
+</section>
+
+<!-- Network: editable IP/hostname -->
+<section class="field-group">
+  <h3 class="group-header">Network</h3>
+  <div class="form-group">
+    <label for="device-ip">
+      IP Address/Hostname
+      {#if ipSaved}
+        <Tooltip text="Saved">
+          <span class="saved-indicator" data-testid="saved-indicator-ip">✓</span
+          >
+        </Tooltip>
       {/if}
-    </span>
-  </button>
-  {#if showColourPicker}
-    <div class="colour-picker-container">
-      <ColourPicker
-        value={selectedDeviceInfo.placedDevice.colour_override ??
-          selectedDeviceInfo.device.colour}
-        defaultValue={selectedDeviceInfo.device.colour}
-        onchange={(colour) =>
-          layoutStore.updateDeviceColour(
-            selectedDeviceInfo.rack.id,
-            selectedDeviceInfo.deviceIndex,
-            colour,
-          )}
-        onreset={() =>
-          layoutStore.updateDeviceColour(
-            selectedDeviceInfo.rack.id,
-            selectedDeviceInfo.deviceIndex,
-            undefined,
-          )}
-      />
-    </div>
-  {/if}
-</div>
+    </label>
+    <input
+      type="text"
+      id="device-ip"
+      class="input-field"
+      bind:value={deviceIp}
+      onblur={handleDeviceIpBlur}
+      placeholder="e.g., 192.168.1.100"
+    />
+  </div>
+</section>
 
-<!-- Face selector (dropdown) - enabled for all devices per issue #144 -->
-<div class="form-group">
-  <label for="device-face">Mounted Face</label>
-  <select
-    id="device-face"
-    class="input-field"
-    value={selectedDeviceInfo.placedDevice.face}
-    onchange={(e) =>
-      handleFaceChange((e.target as HTMLSelectElement).value as DeviceFace)}
-  >
-    <option value="front">Front</option>
-    <option value="rear">Rear</option>
-    <option value="both">Both (full-depth)</option>
-  </select>
-  {#if isFullDepthDevice && selectedDeviceInfo.placedDevice.face !== "both"}
-    <p class="helper-text">Overriding default full-depth setting</p>
-  {/if}
-</div>
-
-<!-- Power device properties -->
-{#if selectedDeviceInfo.device.category === "power" && (selectedDeviceInfo.device.outlet_count || selectedDeviceInfo.device.va_rating)}
-  <div class="info-section">
-    {#if selectedDeviceInfo.device.outlet_count}
-      <div class="info-row">
-        <span class="info-label">Outlets</span>
-        <span class="info-value">{selectedDeviceInfo.device.outlet_count}</span>
-      </div>
-    {/if}
-    {#if selectedDeviceInfo.device.va_rating}
-      <div class="info-row">
-        <span class="info-label">VA Rating</span>
-        <span class="info-value">{selectedDeviceInfo.device.va_rating}</span>
+<!-- Notes: editable placement notes -->
+<section class="field-group">
+  <h3 class="group-header">Notes</h3>
+  <div class="form-group">
+    <label for="device-notes">
+      Placement notes
+      {#if notesSaved}
+        <Tooltip text="Saved">
+          <span class="saved-indicator" data-testid="saved-indicator-notes"
+            >✓</span
+          >
+        </Tooltip>
+      {/if}
+    </label>
+    <textarea
+      id="device-notes"
+      class="input-field textarea"
+      bind:value={deviceNotes}
+      onblur={handleDeviceNotesBlur}
+      rows="4"
+      placeholder="Add notes about this device placement..."></textarea>
+    {#if deviceNotes.trim()}
+      <div class="notes-preview">
+        <span class="preview-label">Preview</span>
+        <MarkdownPreview content={deviceNotes} />
       </div>
     {/if}
   </div>
-{/if}
-
-<!-- Device Type Notes (read-only) -->
-{#if selectedDeviceInfo.device.notes}
-  <div class="notes-section">
-    <span class="info-label">Device Type Notes</span>
-    <p class="notes-text">{selectedDeviceInfo.device.notes}</p>
-  </div>
-{/if}
-
-<!-- IP Address/Hostname (editable) -->
-<div class="form-group">
-  <label for="device-ip">
-    IP Address/Hostname
-    {#if ipSaved}
-      <Tooltip text="Saved">
-        <span class="saved-indicator" data-testid="saved-indicator-ip">✓</span>
-      </Tooltip>
-    {/if}
-  </label>
-  <input
-    type="text"
-    id="device-ip"
-    class="input-field"
-    bind:value={deviceIp}
-    onblur={handleDeviceIpBlur}
-    placeholder="e.g., 192.168.1.100"
-  />
-</div>
-
-<!-- Placement Notes (editable) -->
-<div class="form-group">
-  <label for="device-notes">
-    Notes
-    {#if notesSaved}
-      <Tooltip text="Saved">
-        <span class="saved-indicator" data-testid="saved-indicator-notes"
-          >✓</span
-        >
-      </Tooltip>
-    {/if}
-  </label>
-  <textarea
-    id="device-notes"
-    class="input-field textarea"
-    bind:value={deviceNotes}
-    onblur={handleDeviceNotesBlur}
-    rows="4"
-    placeholder="Add notes about this device placement..."></textarea>
-  {#if deviceNotes.trim()}
-    <div class="notes-preview">
-      <span class="preview-label">Preview</span>
-      <MarkdownPreview content={deviceNotes} />
-    </div>
-  {/if}
-</div>
+</section>
 
 <style>
+  /* Section wrapper grouping related fields under a header. */
+  .field-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .group-header {
+    margin: 0;
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
   .form-group {
     display: flex;
     flex-direction: column;
     gap: var(--space-1-5);
   }
 
-  .form-group label {
+  .form-group label,
+  .field-label {
     font-size: var(--font-size-base);
     font-weight: var(--font-weight-medium);
     color: var(--colour-text);
@@ -505,53 +534,87 @@
     color: var(--colour-text-muted);
   }
 
-  .info-section {
+  /* Device type details: borderless, muted, non-interactive facts. */
+  .facts {
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
   }
 
-  .info-row {
+  .fact-row {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: var(--space-2);
   }
 
-  .info-label {
+  .fact-label {
     font-size: var(--font-size-sm);
     color: var(--colour-text-muted);
   }
 
-  .info-value {
+  .fact-value {
     font-size: var(--font-size-base);
-    color: var(--colour-text);
+    color: var(--colour-text-muted);
+    text-align: right;
   }
 
-  .colour-info {
+  .fact-value-icon {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .fact-notes {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .fact-notes-text {
+    font-size: var(--font-size-base);
+    color: var(--colour-text-muted);
+    margin: 0;
+    white-space: pre-wrap;
+    line-height: 1.5;
+  }
+
+  /* Colour swatch button: a real interactive control with form-control
+     affordance (border, hover, focus), distinct from the muted facts. */
+  .colour-swatch-btn {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    text-align: left;
+    color: var(--colour-text);
+    font-size: var(--font-size-base);
+    transition: border-color 0.15s ease;
+  }
+
+  .colour-swatch-btn:hover {
+    border-color: var(--colour-selection);
+  }
+
+  .colour-swatch-btn:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: 2px;
+  }
+
+  .colour-value {
+    flex: 1;
     display: flex;
     align-items: center;
     gap: var(--space-2);
     font-family: monospace;
-  }
-
-  .colour-row-btn {
-    width: 100%;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    text-align: left;
-    padding: var(--space-1) 0;
-    border-radius: var(--radius-sm);
-    transition: background-color var(--duration-fast);
-  }
-
-  .colour-row-btn:hover {
-    background: var(--colour-surface-hover);
-  }
-
-  .colour-row-btn:focus-visible {
-    outline: 2px solid var(--colour-selection);
-    outline-offset: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .colour-badge {
@@ -569,18 +632,6 @@
     margin-bottom: var(--space-2);
   }
 
-  .device-type {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
-
-  .brand-info {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
-
   .display-name-display {
     display: flex;
     align-items: center;
@@ -588,8 +639,8 @@
     gap: var(--space-2);
     width: 100%;
     padding: var(--space-2) var(--space-3);
-    background: var(--colour-surface);
-    border: 1px solid var(--colour-border);
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
     border-radius: var(--radius-sm);
     cursor: pointer;
     text-align: left;
@@ -626,22 +677,9 @@
     height: var(--icon-size-xs);
   }
 
-  .display-name-display:hover .edit-icon-wrapper {
+  .display-name-display:hover .edit-icon-wrapper,
+  .colour-swatch-btn:hover .edit-icon-wrapper {
     opacity: 1;
-  }
-
-  .notes-section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1-5);
-  }
-
-  .notes-text {
-    font-size: var(--font-size-base);
-    color: var(--colour-text-muted);
-    margin: 0;
-    white-space: pre-wrap;
-    line-height: 1.5;
   }
 
   /* Markdown preview for notes */

--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -409,7 +409,7 @@
   <h3 class="group-header">Notes</h3>
   <div class="form-group">
     <label for="device-notes">
-      Placement notes
+      Notes
       {#if notesSaved}
         <Tooltip text="Saved">
           <span class="saved-indicator" data-testid="saved-indicator-notes"


### PR DESCRIPTION
## **User description**
## Summary

Regroups `EditPanelMetadata` by meaning and gives editable fields real form-control affordances so they read as distinct from read-only reference facts.

Sections, top to bottom:

- Identity: Name (text input), Colour (swatch button)
- Device type details: read-only facts as borderless muted text under a header (Type, Brand, Height, Category, power Outlets/VA Rating, device-type notes)
- Placement: Mounted Face (select)
- Network: IP/Hostname (text input)
- Notes: placement notes (textarea)

The key fix: the Colour row used to render as a read-only-looking `info-row` despite opening the colour picker. It now lives in the Identity group as a clear interactive swatch button (bordered, hover and focus states, edit icon), consistent with Name and IP. It still opens the picker and applies or resets the override.

The Device type details block is a static muted group with a header. The collapse toggle is out of scope here and tracked by #2443.

## Affordance treatment

- Editable controls: bordered input/select/swatch with hover and focus states.
- Read-only facts: borderless muted text, not focusable form controls.

## Accessibility

Editable controls keep visible labels and `for`/`id` associations. The Colour swatch button is associated via `aria-labelledby` and exposes `aria-expanded` for the picker. Read-only facts stay plain text.

## Tests

Behaviour is unchanged at the store level; the colour apply/reset-override path is already covered by `src/tests/layout-device-actions.test.ts`. The change is visual; the colour-override E2E specs continue to exercise the control via the updated locators (`colour-swatch-btn`, `colour-value`). The visual-regression suite does not screenshot the device edit panel, so no baselines change.

Design authority: `docs/superpowers/specs/2026-06-19-edit-panel-metadata-grouping-design.md` (B1 spike #2441).

Closes #2442

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Group edit fields by meaning and keep colour editing working**

### What Changed
- The edit panel now separates editable fields from read-only device details with clear section headers: Identity, Device type details, Placement, Network, and Notes
- The Colour field is now shown as a clear clickable swatch button in Identity, while device type information is kept as muted, non-editable reference text
- The colour picker keeps working with the renamed colour control, and the shared E2E locators were updated so colour override tests continue to target the right elements

### Impact
`✅ Clearer edit panel layout`
`✅ Easier to tell editable fields from read-only facts`
`✅ Fewer broken colour override tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
