### PR TITLE
feat: collapsible Device type details block in edit panel (#2443)

### DIFF
--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -12,9 +12,10 @@
   import BrandIcon from "./BrandIcon.svelte";
   import MarkdownPreview from "./MarkdownPreview.svelte";
   import Tooltip from "./Tooltip.svelte";
-  import { IconEdit } from "./icons";
+  import { IconEdit, IconChevronDown } from "./icons";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
+  import { getUIStore } from "$lib/stores/ui.svelte";
   import { getCategoryDisplayName } from "$lib/utils/deviceFilters";
   import { findDeviceType } from "$lib/utils/device-lookup";
   import { getBrandIconSlug } from "$lib/data/brandPacks";
@@ -31,6 +32,19 @@
 
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
+  const uiStore = getUIStore();
+
+  // Count of device type facts shown in the collapsible block, so the header can
+  // report how many are hidden when collapsed. Type, Brand, Height and Category
+  // always show; outlet count, VA rating and device-type notes are conditional.
+  const deviceTypeFactCount = $derived.by(() => {
+    const device = selectedDeviceInfo.device;
+    let count = 4; // Type, Brand, Height, Category
+    if (device.category === "power" && device.outlet_count) count += 1;
+    if (device.category === "power" && device.va_rating) count += 1;
+    if (device.notes) count += 1;
+    return count;
+  });
 
   // Authoritative device definition from the starter/brand library, falling back
   // to the layout copy. The layout copy can be stale (e.g. a device placed before
@@ -301,61 +315,87 @@
   </div>
 </section>
 
-<!-- Device type details: read-only reference facts (muted, non-interactive) -->
+<!-- Device type details: read-only reference facts (muted, non-interactive),
+     collapsible behind a disclosure toggle. The expanded flag is shared across
+     device selections, not stored per device. -->
 <section class="field-group">
-  <h3 class="group-header">Device type details</h3>
-  <div class="facts">
-    <div class="fact-row">
-      <span class="fact-label">Type</span>
-      <span class="fact-value fact-value-icon">
-        <ColourSwatch
-          colour={selectedDeviceInfo.device.colour}
-          size={ICON_SIZE.sm}
-        />
-        {selectedDeviceInfo.device.model ?? selectedDeviceInfo.device.slug}
-      </span>
-    </div>
-    <div class="fact-row">
-      <span class="fact-label">Brand</span>
-      <span class="fact-value fact-value-icon">
-        <BrandIcon
-          slug={getBrandIconSlug(authoritativeDevice.slug)}
-          size={ICON_SIZE.sm}
-        />
-        {authoritativeDevice.manufacturer ??
-          selectedDeviceInfo.device.manufacturer ??
-          "Generic"}
-      </span>
-    </div>
-    <div class="fact-row">
-      <span class="fact-label">Height</span>
-      <span class="fact-value">{selectedDeviceInfo.device.u_height}U</span>
-    </div>
-    <div class="fact-row">
-      <span class="fact-label">Category</span>
-      <span class="fact-value"
-        >{getCategoryDisplayName(selectedDeviceInfo.device.category)}</span
+  <h3 class="group-header-heading">
+    <button
+      type="button"
+      class="group-header group-toggle"
+      aria-expanded={uiStore.deviceTypeDetailsExpanded}
+      aria-controls="device-type-details-facts"
+      onclick={uiStore.toggleDeviceTypeDetailsExpanded}
+    >
+      <span
+        class="group-chevron"
+        class:group-chevron-collapsed={!uiStore.deviceTypeDetailsExpanded}
+        aria-hidden="true"
       >
+        <IconChevronDown size={ICON_SIZE.sm} />
+      </span>
+      <span>Device type details</span>
+      {#if !uiStore.deviceTypeDetailsExpanded}
+        <span class="group-count">({deviceTypeFactCount})</span>
+      {/if}
+    </button>
+  </h3>
+  {#if uiStore.deviceTypeDetailsExpanded}
+    <div class="facts" id="device-type-details-facts">
+      <div class="fact-row">
+        <span class="fact-label">Type</span>
+        <span class="fact-value fact-value-icon">
+          <ColourSwatch
+            colour={selectedDeviceInfo.device.colour}
+            size={ICON_SIZE.sm}
+          />
+          {selectedDeviceInfo.device.model ?? selectedDeviceInfo.device.slug}
+        </span>
+      </div>
+      <div class="fact-row">
+        <span class="fact-label">Brand</span>
+        <span class="fact-value fact-value-icon">
+          <BrandIcon
+            slug={getBrandIconSlug(authoritativeDevice.slug)}
+            size={ICON_SIZE.sm}
+          />
+          {authoritativeDevice.manufacturer ??
+            selectedDeviceInfo.device.manufacturer ??
+            "Generic"}
+        </span>
+      </div>
+      <div class="fact-row">
+        <span class="fact-label">Height</span>
+        <span class="fact-value">{selectedDeviceInfo.device.u_height}U</span>
+      </div>
+      <div class="fact-row">
+        <span class="fact-label">Category</span>
+        <span class="fact-value"
+          >{getCategoryDisplayName(selectedDeviceInfo.device.category)}</span
+        >
+      </div>
+      {#if selectedDeviceInfo.device.category === "power" && selectedDeviceInfo.device.outlet_count}
+        <div class="fact-row">
+          <span class="fact-label">Outlets</span>
+          <span class="fact-value"
+            >{selectedDeviceInfo.device.outlet_count}</span
+          >
+        </div>
+      {/if}
+      {#if selectedDeviceInfo.device.category === "power" && selectedDeviceInfo.device.va_rating}
+        <div class="fact-row">
+          <span class="fact-label">VA Rating</span>
+          <span class="fact-value">{selectedDeviceInfo.device.va_rating}</span>
+        </div>
+      {/if}
+      {#if selectedDeviceInfo.device.notes}
+        <div class="fact-notes">
+          <span class="fact-label">Device type notes</span>
+          <p class="fact-notes-text">{selectedDeviceInfo.device.notes}</p>
+        </div>
+      {/if}
     </div>
-    {#if selectedDeviceInfo.device.category === "power" && selectedDeviceInfo.device.outlet_count}
-      <div class="fact-row">
-        <span class="fact-label">Outlets</span>
-        <span class="fact-value">{selectedDeviceInfo.device.outlet_count}</span>
-      </div>
-    {/if}
-    {#if selectedDeviceInfo.device.category === "power" && selectedDeviceInfo.device.va_rating}
-      <div class="fact-row">
-        <span class="fact-label">VA Rating</span>
-        <span class="fact-value">{selectedDeviceInfo.device.va_rating}</span>
-      </div>
-    {/if}
-    {#if selectedDeviceInfo.device.notes}
-      <div class="fact-notes">
-        <span class="fact-label">Device type notes</span>
-        <p class="fact-notes-text">{selectedDeviceInfo.device.notes}</p>
-      </div>
-    {/if}
-  </div>
+  {/if}
 </section>
 
 <!-- Placement: editable mounted face -->
@@ -449,6 +489,56 @@
     color: var(--colour-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.05em;
+  }
+
+  /* Heading wrapper keeps the section landmark while the toggle does the work. */
+  .group-header-heading {
+    margin: 0;
+  }
+
+  /* Disclosure toggle for Device type details: a real button that keeps the
+     muted group-header look, full-width so the whole row is the hit target. */
+  .group-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    width: 100%;
+    padding: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .group-toggle:hover {
+    color: var(--colour-text);
+  }
+
+  .group-toggle:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: 2px;
+    border-radius: var(--radius-xs);
+  }
+
+  .group-count {
+    color: var(--colour-text-muted);
+  }
+
+  .group-chevron {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    transition: transform var(--duration-fast) ease;
+  }
+
+  .group-chevron-collapsed {
+    transform: rotate(-90deg);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .group-chevron {
+      transition: none;
+    }
   }
 
   .form-group {

--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -324,7 +324,9 @@
       type="button"
       class="group-header group-toggle"
       aria-expanded={uiStore.deviceTypeDetailsExpanded}
-      aria-controls="device-type-details-facts"
+      aria-controls={uiStore.deviceTypeDetailsExpanded
+        ? "device-type-details-facts"
+        : undefined}
       onclick={uiStore.toggleDeviceTypeDetailsExpanded}
     >
       <span

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -215,6 +215,10 @@ let compatibleOnly = $state(initialCompatibleOnly);
 // Read-only lock: presentation safety valve that locks the layout for viewing.
 // Session-scoped (not persisted) so a reload always returns to an editable state.
 let readOnly = $state(false);
+// Device type details disclosure in the edit panel: a single UI flag shared
+// across device selections (not per device), so toggling it stays sticky as the
+// user clicks between devices. Defaults to expanded. Session-scoped.
+let deviceTypeDetailsExpanded = $state(true);
 
 // Derived values (using $derived rune)
 const canZoomIn = $derived(zoom < ZOOM_MAX);
@@ -246,6 +250,7 @@ export function resetUIStore(): void {
   promptCleanupOnSave = loadPromptCleanupFromStorage();
   compatibleOnly = loadCompatibleOnlyFromStorage();
   readOnly = false;
+  deviceTypeDetailsExpanded = true;
   applyThemeToDocument(theme);
 }
 
@@ -331,6 +336,11 @@ export function getUIStore() {
       return readOnly;
     },
 
+    // Device type details disclosure getter
+    get deviceTypeDetailsExpanded() {
+      return deviceTypeDetailsExpanded;
+    },
+
     // Theme actions
     toggleTheme,
     setTheme,
@@ -384,6 +394,9 @@ export function getUIStore() {
     // Read-only lock actions
     toggleReadOnly,
     setReadOnly,
+
+    // Device type details disclosure action
+    toggleDeviceTypeDetailsExpanded,
   };
 }
 
@@ -653,4 +666,11 @@ function toggleReadOnly(): void {
  */
 function setReadOnly(locked: boolean): void {
   readOnly = locked;
+}
+
+/**
+ * Toggle the device type details disclosure in the edit panel
+ */
+function toggleDeviceTypeDetailsExpanded(): void {
+  deviceTypeDetailsExpanded = !deviceTypeDetailsExpanded;
 }

--- a/src/tests/edit-panel-device-type-details-collapse.test.ts
+++ b/src/tests/edit-panel-device-type-details-collapse.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for Issue #2443: collapsible "Device type details" block in the edit
+ * panel.
+ *
+ * The read-only type facts live behind a disclosure toggle. The block defaults
+ * to expanded, and the collapsed state is a single UI flag shared across device
+ * selections (not stored per device), so toggling it stays sticky as the user
+ * clicks between devices.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import SidePanelContent from "$lib/components/SidePanelContent.svelte";
+import { resetLayoutStore, getLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  resetSelectionStore,
+  getSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { resetUIStore } from "$lib/stores/ui.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+
+function renderEditTab() {
+  return render(SidePanelContent, {
+    props: { activeTab: "edit", onTabChange: () => {} },
+  });
+}
+
+function getDetailsToggle() {
+  return screen.getByRole("button", { name: /device type details/i });
+}
+
+describe("EditPanel Device type details collapse (#2443)", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetUIStore();
+    resetToastStore();
+  });
+
+  function setupSelectedDevice() {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const rack = layoutStore.addRack("Test Rack", 42);
+    const rackId = rack!.id;
+
+    const deviceType = layoutStore.addDeviceType({
+      name: "Server Type",
+      u_height: 1,
+      category: "server",
+      colour: "#4A90D9",
+    });
+
+    layoutStore.placeDevice(rackId, deviceType.slug, 1, "front");
+    const device = layoutStore.rack!.devices[0]!;
+    selectionStore.selectDevice(rackId, device.id);
+
+    return { layoutStore, selectionStore, rackId };
+  }
+
+  it("defaults to expanded, showing the read-only facts", () => {
+    setupSelectedDevice();
+    renderEditTab();
+
+    expect(getDetailsToggle()).toHaveAttribute("aria-expanded", "true");
+    // A read-only fact label is visible when the block is expanded.
+    expect(screen.getByText("Brand")).toBeInTheDocument();
+  });
+
+  it("toggling hides and shows the read-only facts", async () => {
+    setupSelectedDevice();
+    renderEditTab();
+
+    const toggle = getDetailsToggle();
+
+    // Collapse: facts disappear and aria-expanded flips to false.
+    await fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+    });
+    expect(screen.queryByText("Brand")).not.toBeInTheDocument();
+
+    // Expand again: facts come back.
+    await fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+    });
+    expect(screen.getByText("Brand")).toBeInTheDocument();
+  });
+
+  it("keeps the collapsed state across device selections (single UI flag)", async () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const rack = layoutStore.addRack("Test Rack", 42);
+    const rackId = rack!.id;
+
+    const deviceType = layoutStore.addDeviceType({
+      name: "Server Type",
+      u_height: 1,
+      category: "server",
+      colour: "#4A90D9",
+    });
+
+    layoutStore.placeDevice(rackId, deviceType.slug, 1, "front");
+    layoutStore.placeDevice(rackId, deviceType.slug, 2, "front");
+    const deviceA = layoutStore.rack!.devices[0]!;
+    const deviceB = layoutStore.rack!.devices[1]!;
+
+    selectionStore.selectDevice(rackId, deviceA.id);
+    renderEditTab();
+
+    // Collapse while device A is selected.
+    await fireEvent.click(getDetailsToggle());
+    await waitFor(() => {
+      expect(getDetailsToggle()).toHaveAttribute("aria-expanded", "false");
+    });
+
+    // Switch to device B: the block stays collapsed (sticky single flag).
+    selectionStore.selectDevice(rackId, deviceB.id);
+    await waitFor(() => {
+      expect(selectionStore.selectedDeviceId).toBe(deviceB.id);
+    });
+    expect(getDetailsToggle()).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Brand")).not.toBeInTheDocument();
+  });
+});

--- a/src/tests/edit-panel-device-type-details-collapse.test.ts
+++ b/src/tests/edit-panel-device-type-details-collapse.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
 import SidePanelContent from "$lib/components/SidePanelContent.svelte";
 import { resetLayoutStore, getLayoutStore } from "$lib/stores/layout.svelte";
+import { createTestDeviceTypeInput } from "./factories";
 import {
   resetSelectionStore,
   getSelectionStore,
@@ -43,12 +44,9 @@ describe("EditPanel Device type details collapse (#2443)", () => {
     const rack = layoutStore.addRack("Test Rack", 42);
     const rackId = rack!.id;
 
-    const deviceType = layoutStore.addDeviceType({
-      name: "Server Type",
-      u_height: 1,
-      category: "server",
-      colour: "#4A90D9",
-    });
+    const deviceType = layoutStore.addDeviceType(
+      createTestDeviceTypeInput({ name: "Server Type" }),
+    );
 
     layoutStore.placeDevice(rackId, deviceType.slug, 1, "front");
     const device = layoutStore.rack!.devices[0]!;
@@ -94,12 +92,9 @@ describe("EditPanel Device type details collapse (#2443)", () => {
     const rack = layoutStore.addRack("Test Rack", 42);
     const rackId = rack!.id;
 
-    const deviceType = layoutStore.addDeviceType({
-      name: "Server Type",
-      u_height: 1,
-      category: "server",
-      colour: "#4A90D9",
-    });
+    const deviceType = layoutStore.addDeviceType(
+      createTestDeviceTypeInput({ name: "Server Type" }),
+    );
 
     layoutStore.placeDevice(rackId, deviceType.slug, 1, "front");
     layoutStore.placeDevice(rackId, deviceType.slug, 2, "front");


### PR DESCRIPTION
## **User description**
## Summary

Makes the edit panel's "Device type details" group (built as a static muted block in #2442) collapsible behind a disclosure toggle.

- The group header is now a real `<button>` with `aria-expanded` reflecting the open state and `aria-controls` pointing at the facts region.
- Defaults to expanded.
- When collapsed, the header shows the count of hidden facts, e.g. "Device type details (6)".
- The block stays where #2442 placed it: after Identity, before Placement.
- Reduced motion is respected: the chevron rotation transition is disabled under `prefers-reduced-motion`.

## Persistence

The expanded flag lives on the UI store (`src/lib/stores/ui.svelte.ts`) as a single session-scoped `$state` value, mirroring the existing `readOnly` precedent. Because it is module-level (not component-local), it is a single shared UI flag, not per device, and survives the panel re-rendering when the user clicks between device selections.

## Tests

`src/tests/edit-panel-device-type-details-collapse.test.ts` (behavioural, renders the real edit panel via `SidePanelContent`):

- defaults to expanded, showing the read-only facts
- toggling hides and shows the facts
- collapsed state persists across device selections (single UI flag)

## Verification

- `npm run lint`, `npm run test:run` (2794 passed), `npm run build`, `npm run format:check` all green.
- Svelte autofixer clean on the changed component.
- Visual-regression baselines unaffected (that suite never selects a device, so it never renders EditPanelMetadata).

Design authority: `docs/superpowers/specs/2026-06-19-edit-panel-metadata-grouping-design.md` (spike #2441).

Closes #2443

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Make the “Device type details” section collapsible in the edit panel

### What Changed
- The “Device type details” block now opens and closes with a click instead of always staying open.
- When collapsed, the header shows how many device facts are hidden, and the section remembers its state while switching between devices.
- The section still starts expanded, keeps the same order in the panel, and shows reduced-motion-friendly arrow behavior.
- Added coverage for the open/close behavior, the default expanded state, and the shared collapsed state across device selections.

### Impact
`✅ Smaller edit panels`
`✅ Faster access to other device settings`
`✅ Fewer repeated expands when switching devices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
