### PR TITLE
feat: server-side pre-carrier backup so Docker upgrades cannot lose data

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -2,7 +2,10 @@ import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { logger as honoLogger } from "hono/logger";
 import { bodyLimit } from "hono/body-limit";
-import layouts, { UPDATED_AT_HEADER } from "./routes/layouts";
+import layouts, {
+  UPDATED_AT_HEADER,
+  PRE_CARRIER_MIGRATION_HEADER,
+} from "./routes/layouts";
 import assets from "./routes/assets";
 import {
   createSignedAuthSessionToken,
@@ -321,7 +324,12 @@ export async function createApp(
     cors({
       origin: securityConfig.corsOrigin,
       allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-      allowHeaders: ["Content-Type", "Authorization", UPDATED_AT_HEADER],
+      allowHeaders: [
+        "Content-Type",
+        "Authorization",
+        UPDATED_AT_HEADER,
+        PRE_CARRIER_MIGRATION_HEADER,
+      ],
       exposeHeaders: [UPDATED_AT_HEADER],
     }),
   );

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -9,6 +9,7 @@
  * GET    /layouts/:uuid/snapshots           - List pre-overwrite snapshots
  * GET    /layouts/:uuid/snapshots/:filename - Get a snapshot's YAML content
  * POST   /layouts/:uuid/snapshots           - Upload a losing local copy as a snapshot
+ * GET    /layouts/:uuid/pre-carrier-backup  - Get the durable pre-carrier-migration backup
  *
  * When accessed through nginx proxy (recommended), the same routes are
  * available under /api/layouts (nginx strips /api before forwarding).
@@ -28,6 +29,7 @@ import {
   listSnapshots,
   getSnapshot,
   saveSnapshot,
+  getPreCarrierBackup,
   SNAPSHOT_NAME_PATTERN,
 } from "../storage/filesystem";
 import { deleteLayoutAssets } from "../storage/assets";
@@ -35,6 +37,13 @@ import { logger } from "../logger";
 
 /** Header carrying the layout's updatedAt for echo-based conflict detection. */
 export const UPDATED_AT_HEADER = "X-Rackula-Updated-At";
+
+/**
+ * Header by which the client signals that this PUT is the one-time carrier-first
+ * migration write, so the server durably backs up the prior YAML before the
+ * overwrite. The enabling value is the exact string "1".
+ */
+export const PRE_CARRIER_MIGRATION_HEADER = "X-Rackula-Pre-Carrier-Migration";
 
 /** Matches a control character (C0 range plus DEL) anywhere in a string. */
 // eslint-disable-next-line no-control-regex -- intentionally rejecting control chars in filenames
@@ -155,6 +164,9 @@ layouts.put("/:uuid", async (c) => {
       yamlContent,
       uuidResult.data,
       c.req.header(UPDATED_AT_HEADER),
+      {
+        preCarrierMigration: c.req.header(PRE_CARRIER_MIGRATION_HEADER) === "1",
+      },
     );
 
     c.header(UPDATED_AT_HEADER, result.updatedAt);
@@ -310,6 +322,31 @@ layouts.post("/:uuid/snapshots", async (c) => {
       `Failed to save snapshot for layout ${uuidResult.data}`,
     );
     return c.json({ error: "Failed to save snapshot" }, 500);
+  }
+});
+
+// Get the durable pre-carrier-migration backup (read-only restore source)
+layouts.get("/:uuid/pre-carrier-backup", async (c) => {
+  const uuid = c.req.param("uuid");
+
+  const uuidResult = UuidSchema.safeParse(uuid);
+  if (!uuidResult.success) {
+    return c.json({ error: "Invalid layout UUID format" }, 400);
+  }
+
+  try {
+    const content = await getPreCarrierBackup(uuidResult.data);
+    if (content === null) {
+      return c.json({ error: "Pre-carrier backup not found" }, 404);
+    }
+
+    return c.text(content, 200, { "Content-Type": "text/yaml" });
+  } catch (error) {
+    logger.error(
+      { err: error },
+      `Failed to get pre-carrier backup for layout ${uuidResult.data}`,
+    );
+    return c.json({ error: "Failed to get pre-carrier backup" }, 500);
   }
 });
 

--- a/api/src/routes/pre-carrier-backup.test.ts
+++ b/api/src/routes/pre-carrier-backup.test.ts
@@ -12,10 +12,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createApp } from "../app";
 import type { EnvMap } from "../security";
+import { PRE_CARRIER_MIGRATION_HEADER } from "./layouts";
 
 type App = Awaited<ReturnType<typeof createApp>>;
 
-const MIGRATION_HEADER = "X-Rackula-Pre-Carrier-Migration";
+// Use the route's own constant so the test cannot drift from the real header.
+const MIGRATION_HEADER = PRE_CARRIER_MIGRATION_HEADER;
 const TEST_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const UNKNOWN_UUID = "00000000-0000-0000-0000-000000000999";
 

--- a/api/src/routes/pre-carrier-backup.test.ts
+++ b/api/src/routes/pre-carrier-backup.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Pre-carrier server backup route + end-to-end header tests (#2517).
+ *
+ * Covers the X-Rackula-Pre-Carrier-Migration PUT header that triggers a durable
+ * one-time backup of the prior on-disk YAML, the read-only restore endpoint
+ * GET /layouts/:uuid/pre-carrier-backup, idempotency, and the backup's
+ * invisibility to layout listing and retrieval.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp } from "../app";
+import type { EnvMap } from "../security";
+
+type App = Awaited<ReturnType<typeof createApp>>;
+
+const MIGRATION_HEADER = "X-Rackula-Pre-Carrier-Migration";
+const TEST_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const UNKNOWN_UUID = "00000000-0000-0000-0000-000000000999";
+
+const originalDataDir = process.env.DATA_DIR;
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "rackula-pre-carrier-test-"));
+  process.env.DATA_DIR = testDir;
+});
+
+afterEach(async () => {
+  if (originalDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = originalDataDir;
+  }
+
+  try {
+    await rm(testDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup failures
+  }
+});
+
+function buildEnv(overrides: EnvMap = {}): EnvMap {
+  return {
+    NODE_ENV: "test",
+    DATA_DIR: testDir,
+    RACKULA_RATE_LIMIT_ENABLED: "false",
+    ...overrides,
+  };
+}
+
+function createLayoutYaml(name: string, marker: string): string {
+  return `version: "1.0.0"\nname: ${name}\ndescription: ${marker}\nracks: []`;
+}
+
+async function putLayout(
+  app: App,
+  uuid: string,
+  body: string,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return app.request(`/layouts/${uuid}`, {
+    method: "PUT",
+    headers: { "Content-Type": "text/yaml", ...headers },
+    body,
+  });
+}
+
+describe("GET /layouts/:uuid/pre-carrier-backup", () => {
+  it("returns the prior YAML after a migrating PUT", async () => {
+    const app = await createApp(buildEnv());
+    const v1 = createLayoutYaml("My Layout", "v1");
+    await putLayout(app, TEST_UUID, v1);
+
+    const v2 = createLayoutYaml("My Layout", "v2");
+    await putLayout(app, TEST_UUID, v2, { [MIGRATION_HEADER]: "1" });
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/pre-carrier-backup`,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/yaml");
+    expect(await response.text()).toBe(v1);
+  });
+
+  it("returns 404 when no backup exists", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/pre-carrier-backup`,
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 for an unknown uuid", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await app.request(
+      `/layouts/${UNKNOWN_UUID}/pre-carrier-backup`,
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 for a malformed uuid", async () => {
+    const app = await createApp(buildEnv());
+
+    const response = await app.request(
+      "/layouts/not-a-uuid/pre-carrier-backup",
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("keeps the bytes from before the FIRST migrating PUT across two migrations", async () => {
+    const app = await createApp(buildEnv());
+    const v1 = createLayoutYaml("My Layout", "v1");
+    await putLayout(app, TEST_UUID, v1);
+
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v2"), {
+      [MIGRATION_HEADER]: "1",
+    });
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v3"), {
+      [MIGRATION_HEADER]: "1",
+    });
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/pre-carrier-backup`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(v1);
+  });
+});
+
+describe("pre-carrier backup invisibility", () => {
+  it("does not surface the backup in layout listing or retrieval", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+    const latest = createLayoutYaml("My Layout", "v2");
+    await putLayout(app, TEST_UUID, latest, { [MIGRATION_HEADER]: "1" });
+
+    const list = await app.request("/layouts");
+    const body = await list.json();
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: the durable backup must never surface as a layout
+    expect(body.layouts).toHaveLength(1);
+    expect(body.layouts[0].id).toBe(TEST_UUID);
+
+    const single = await app.request(`/layouts/${TEST_UUID}`);
+    expect(single.status).toBe(200);
+    expect(await single.text()).toBe(latest);
+  });
+});
+
+describe("pre-carrier migration PUT header", () => {
+  it("writes no backup on a PUT without the header", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v2"));
+
+    const response = await app.request(
+      `/layouts/${TEST_UUID}/pre-carrier-backup`,
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/api/src/storage/filesystem.test.ts
+++ b/api/src/storage/filesystem.test.ts
@@ -18,8 +18,15 @@ import { isUuid } from "../schemas/layout";
 const testDir = await mkdtemp(join(tmpdir(), "rackula-test-"));
 process.env.DATA_DIR = testDir;
 
-const { listLayouts, getLayout, saveLayout, deleteLayout, slugify } =
-  await import("./filesystem");
+const {
+  listLayouts,
+  getLayout,
+  saveLayout,
+  deleteLayout,
+  slugify,
+  getPreCarrierBackup,
+  PRE_CARRIER_BACKUP_FILENAME,
+} = await import("./filesystem");
 
 // ============================================================================
 // Test Helpers
@@ -294,6 +301,179 @@ describe("deleteLayout", () => {
   it("rejects path traversal attempts", async () => {
     const deleted = await deleteLayout("../../../etc/passwd");
     expect(deleted).toBe(false);
+  });
+});
+
+describe("pre-carrier server backup", () => {
+  beforeEach(async () => {
+    await cleanupTestDir();
+  });
+
+  /**
+   * Locate the layout folder matching a UUID (case-insensitive suffix) and
+   * return its full path, or null when absent.
+   */
+  async function folderForUuid(uuid: string): Promise<string | null> {
+    const entries = await readdir(testDir, { withFileTypes: true });
+    const folder = entries.find(
+      (entry) => entry.isDirectory() && entry.name.toLowerCase().endsWith(uuid),
+    );
+    return folder ? join(testDir, folder.name) : null;
+  }
+
+  /** Read the durable backup file's bytes for a UUID, or null when missing. */
+  async function readBackup(uuid: string): Promise<string | null> {
+    const folder = await folderForUuid(uuid);
+    if (!folder) return null;
+    try {
+      return await readFile(join(folder, PRE_CARRIER_BACKUP_FILENAME), "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  it("copies the prior on-disk YAML to the durable backup on a migrating save", async () => {
+    const v1 = createLayoutYaml({ name: "My Layout" });
+    const created = await saveLayout(v1);
+
+    const v2 = createLayoutYaml({
+      name: "My Layout",
+      racks: [{ devices: [] }],
+    });
+    await saveLayout(v2, created.id, undefined, { preCarrierMigration: true });
+
+    // Backup holds the PRIOR bytes; the layout file holds the NEW bytes.
+    expect(await readBackup(created.id)).toBe(v1);
+    const current = await getLayout(created.id);
+    expect(current?.content).toBe(v2);
+  });
+
+  it("does not overwrite the backup on a second migrating save (idempotent)", async () => {
+    const v1 = createLayoutYaml({ name: "My Layout" });
+    const created = await saveLayout(v1);
+
+    const v2 = createLayoutYaml({
+      name: "My Layout",
+      racks: [{ devices: [] }],
+    });
+    await saveLayout(v2, created.id, undefined, { preCarrierMigration: true });
+
+    const v3 = createLayoutYaml({
+      name: "My Layout",
+      racks: [{ devices: [{ id: "d1" }] }],
+    });
+    await saveLayout(v3, created.id, undefined, { preCarrierMigration: true });
+
+    // Backup still holds v1 (the bytes from before the FIRST migrating save).
+    expect(await readBackup(created.id)).toBe(v1);
+  });
+
+  it("writes no backup for a brand-new layout even with the flag set", async () => {
+    const v1 = createLayoutYaml({ name: "Brand New" });
+    const created = await saveLayout(v1, undefined, undefined, {
+      preCarrierMigration: true,
+    });
+
+    expect(await readBackup(created.id)).toBeNull();
+  });
+
+  it("writes no backup on a normal overwrite when the flag is not set", async () => {
+    const v1 = createLayoutYaml({ name: "My Layout" });
+    const created = await saveLayout(v1);
+
+    const v2 = createLayoutYaml({
+      name: "My Layout",
+      racks: [{ devices: [] }],
+    });
+    await saveLayout(v2, created.id);
+
+    expect(await readBackup(created.id)).toBeNull();
+  });
+
+  it("writes the backup against the correct folder and survives a rename", async () => {
+    const v1 = createLayoutYaml({ name: "Original" });
+    const created = await saveLayout(v1);
+
+    // Rename (new folder name) in the same migrating save.
+    const v2 = createLayoutYaml({ name: "Renamed" });
+    await saveLayout(v2, created.id, undefined, { preCarrierMigration: true });
+
+    // The backup exists post-rename, in the renamed folder, holding prior bytes.
+    const folder = await folderForUuid(created.id);
+    expect(folder).not.toBeNull();
+    expect(folder!.endsWith(created.id)).toBe(true);
+    expect(await readBackup(created.id)).toBe(v1);
+    const current = await getLayout(created.id);
+    expect(current?.content).toBe(v2);
+  });
+
+  it("writes both a snapshot and the durable backup when echo diverges, and the backup is never pruned", async () => {
+    const v1 = createLayoutYaml({ name: "My Layout" });
+    const created = await saveLayout(v1);
+
+    // A migrating save that also diverges on echoedUpdatedAt: stale echo forces
+    // the rolling snapshot, and the migration flag forces the durable backup.
+    const v2 = createLayoutYaml({
+      name: "My Layout",
+      racks: [{ devices: [] }],
+    });
+    await saveLayout(v2, created.id, "1999-01-01T00:00:00.000Z", {
+      preCarrierMigration: true,
+    });
+
+    const folder = await folderForUuid(created.id);
+    expect(folder).not.toBeNull();
+
+    // A snapshots/ entry exists from the divergence.
+    const snapshots = await readdir(join(folder!, "snapshots"));
+    expect(snapshots.length).toBeGreaterThan(0);
+
+    // The durable backup lives outside snapshots/ and holds the prior bytes.
+    expect(await readBackup(created.id)).toBe(v1);
+
+    // Push past the snapshot retention bound with more diverging migrating
+    // saves; the durable backup must remain (it is never pruned).
+    for (let i = 3; i <= 9; i += 1) {
+      const next = createLayoutYaml({
+        name: "My Layout",
+        racks: [{ devices: [{ id: `d${i}` }] }],
+      });
+      await saveLayout(next, created.id, "1999-01-01T00:00:00.000Z", {
+        preCarrierMigration: true,
+      });
+    }
+    expect(await readBackup(created.id)).toBe(v1);
+  });
+});
+
+describe("getPreCarrierBackup", () => {
+  beforeEach(async () => {
+    await cleanupTestDir();
+  });
+
+  it("returns the prior YAML after a migrating save", async () => {
+    const v1 = createLayoutYaml({ name: "My Layout" });
+    const created = await saveLayout(v1);
+    const v2 = createLayoutYaml({
+      name: "My Layout",
+      racks: [{ devices: [] }],
+    });
+    await saveLayout(v2, created.id, undefined, { preCarrierMigration: true });
+
+    expect(await getPreCarrierBackup(created.id)).toBe(v1);
+  });
+
+  it("returns null when no backup exists", async () => {
+    const v1 = createLayoutYaml({ name: "My Layout" });
+    const created = await saveLayout(v1);
+
+    expect(await getPreCarrierBackup(created.id)).toBeNull();
+  });
+
+  it("returns null for an unknown uuid", async () => {
+    expect(
+      await getPreCarrierBackup("00000000-0000-0000-0000-000000000999"),
+    ).toBeNull();
   });
 });
 

--- a/api/src/storage/filesystem.test.ts
+++ b/api/src/storage/filesystem.test.ts
@@ -315,8 +315,11 @@ describe("pre-carrier server backup", () => {
    */
   async function folderForUuid(uuid: string): Promise<string | null> {
     const entries = await readdir(testDir, { withFileTypes: true });
+    const normalizedUuid = uuid.toLowerCase();
     const folder = entries.find(
-      (entry) => entry.isDirectory() && entry.name.toLowerCase().endsWith(uuid),
+      (entry) =>
+        entry.isDirectory() &&
+        entry.name.toLowerCase().endsWith(normalizedUuid),
     );
     return folder ? join(testDir, folder.name) : null;
   }
@@ -327,8 +330,11 @@ describe("pre-carrier server backup", () => {
     if (!folder) return null;
     try {
       return await readFile(join(folder, PRE_CARRIER_BACKUP_FILENAME), "utf-8");
-    } catch {
-      return null;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw error;
     }
   }
 

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -33,6 +33,14 @@ const SNAPSHOTS_DIR = "snapshots";
 const MAX_SNAPSHOTS_PER_LAYOUT = 5;
 
 /**
+ * Filename of the one-time durable pre-carrier-migration backup, stored at the
+ * layout folder root (outside snapshots/, so it is never pruned). Written once
+ * via exclusive create on the first migrating save and read back by
+ * {@link getPreCarrierBackup}.
+ */
+export const PRE_CARRIER_BACKUP_FILENAME = "pre-carrier-backup.yaml";
+
+/**
  * Per-layout in-process write locks, keyed by layout uuid.
  *
  * The API is a single-process Bun container, so a chained promise per uuid
@@ -316,6 +324,28 @@ export async function getSnapshot(
 
   try {
     return await readFile(join(folder, SNAPSHOTS_DIR, filename), "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Read the durable pre-carrier-migration backup for a layout.
+ * Returns null when the layout folder or the backup file is missing.
+ */
+export async function getPreCarrierBackup(
+  uuid: string,
+): Promise<string | null> {
+  const folder = await findFolderByUuid(uuid);
+  if (!folder) {
+    return null;
+  }
+
+  try {
+    return await readFile(join(folder, PRE_CARRIER_BACKUP_FILENAME), "utf-8");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return null;
@@ -714,6 +744,12 @@ async function legacyLayoutExists(slug: string): Promise<boolean> {
  * YAML is copied into the layout's snapshots folder before the write.
  * Last write wins; the save is never rejected.
  *
+ * When `options.preCarrierMigration` is set and the layout already exists, the
+ * current on-disk YAML is also copied once to a durable pre-carrier-migration
+ * backup ({@link PRE_CARRIER_BACKUP_FILENAME}) before the overwrite. The backup
+ * is written with exclusive create, so a later migrating save never clobbers
+ * it (idempotent), and it lives outside snapshots/ so it is never pruned.
+ *
  * Returns the layout UUID, whether it was a new layout, and the stored
  * file's updatedAt (mtime, ISO 8601) for clients to echo on the next save
  */
@@ -721,6 +757,7 @@ export async function saveLayout(
   yamlContent: string,
   existingId?: string,
   echoedUpdatedAt?: string,
+  options?: { preCarrierMigration?: boolean },
 ): Promise<{ id: string; isNew: boolean; updatedAt: string }> {
   await ensureDataDir();
 
@@ -816,12 +853,34 @@ export async function saveLayout(
           try {
             const existingStats = await handle.stat();
             overwrittenMtimeMs = existingStats.mtime.getTime();
-            if (
-              echoedUpdatedAt &&
-              existingStats.mtime.toISOString() !== echoedUpdatedAt
-            ) {
-              const existingContent = await handle.readFile("utf-8");
+            const diverged =
+              echoedUpdatedAt !== undefined &&
+              existingStats.mtime.toISOString() !== echoedUpdatedAt;
+            // Read the prior bytes once when either the rolling snapshot
+            // (echo divergence) or the durable pre-carrier backup needs them.
+            let existingContent: string | undefined;
+            if (diverged || options?.preCarrierMigration) {
+              existingContent = await handle.readFile("utf-8");
+            }
+            if (diverged && existingContent !== undefined) {
               await writeSnapshot(existingFolder, existingContent);
+            }
+            // Durable one-time pre-carrier-migration backup. Runs against the
+            // pre-rename folder (existingFolder), with exclusive create so a
+            // second migrating save never clobbers the original backup; an
+            // EEXIST is the idempotent no-op for "already backed up".
+            if (options?.preCarrierMigration && existingContent !== undefined) {
+              try {
+                await writeFile(
+                  join(existingFolder, PRE_CARRIER_BACKUP_FILENAME),
+                  existingContent,
+                  { encoding: "utf-8", flag: "wx" },
+                );
+              } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+                  throw error;
+                }
+              }
             }
           } finally {
             await handle.close();

--- a/docs/guides/DOCKER-UPGRADE-TESTING.md
+++ b/docs/guides/DOCKER-UPGRADE-TESTING.md
@@ -11,7 +11,7 @@ Saved layouts live in the `/data` volume and are stored by the API as YAML, verb
 
 Field-level migration of a layout (for example a pre-carrier `slot_position` layout becoming a carrier layout) happens in the browser, not the server. That path is covered separately by the Vitest upgrade corpus. This guide does not cover it.
 
-One gap to be aware of: the migration is one-way and the first save rewrites the file in the new format. Browser users get an automatic pre-migration backup; server-storage (Docker) deployments do not, and a routine migrating save is not snapshotted. Until that is closed (#2517), backing up `/data` before an upgrade is the reliable safety net. The smoke test confirms a pre-carrier file is served back unchanged after a pull with no save, but it does not yet assert the migrating save retains the original; that assertion lands with #2517.
+The migration is one-way: the first save rewrites the file in the new format. Both storage modes keep an automatic pre-migration backup. Browser users get a one-time localStorage snapshot; server-storage (Docker) deployments get a durable `pre-carrier-backup.yaml` written once inside the layout folder when the migrating save lands (the app signals it with the `X-Rackula-Pre-Carrier-Migration` header). It is retrievable at `GET /layouts/:uuid/pre-carrier-backup`. Backing up `/data` before an upgrade is still recommended as a belt-and-suspenders measure. The smoke test asserts both that a pre-carrier file is served back unchanged after a pull with no save, and that a migrating save preserves the original in the durable backup.
 
 ## The two layers
 
@@ -51,6 +51,8 @@ A successful run ends with `PASS: upgrade from <tag> preserved the seeded layout
 | no data loss | The layout is byte-identical after the upgrade. Since the API stores YAML verbatim, any difference is corruption. |
 | pre-carrier discovery | The new release lists a layout written in the pre-carrier (`slot_position`) format. |
 | pre-carrier untouched at rest | A pre-carrier layout is served back byte-identical after a pull with no save. The server does not transform data at rest; migration happens only when the app loads and saves it. |
+| migrating save backs up the original | A save carrying the migration header writes a durable `pre-carrier-backup.yaml` holding the pre-migration bytes, retrievable at `GET /layouts/:uuid/pre-carrier-backup`. |
+| backup is one-time | A second migrating save does not overwrite the backup, so the original pre-carrier copy is never lost to a later autosave. |
 | snapshots survive | Snapshots written by the old release are still readable. This is skipped when the old release predates the snapshot feature. |
 | writes work under read_only | The upgraded container can still persist a change with a read-only rootfs and only `/data` and `/tmp` writable. |
 | the write created a snapshot | The new build snapshots the prior copy before overwriting it. |

--- a/scripts/upgrade-smoke.sh
+++ b/scripts/upgrade-smoke.sh
@@ -221,6 +221,31 @@ check "the write created a snapshot (${SNAP_NEW} -> ${SNAP_WRITE})" "[[ '${SNAP_
 
 check "version endpoint responds" "curl -fsS '${BASE}/version' | grep -q version"
 
+# The migrating save must preserve the pre-carrier original (#2517). Simulate the
+# client's carrier-first autosave: PUT a changed body for the pre-carrier layout
+# with the migration header, then confirm the durable backup holds the ORIGINAL
+# pre-carrier bytes, so an existing deployment can recover from the one-way
+# rewrite even without a manual /data backup.
+sed 's/Pre-Carrier Slot Position Lab/Pre-Carrier MIGRATED/' \
+  "${WORKDIR}/before-precarrier.yaml" >"${WORKDIR}/precarrier-migrated.yaml"
+mig_code="$(curl -s -X PUT "${BASE}/layouts/${PRECARRIER_UUID}" \
+  -H "Content-Type: text/yaml" -H "X-Rackula-Pre-Carrier-Migration: 1" \
+  --data-binary "@${WORKDIR}/precarrier-migrated.yaml" -o /dev/null -w '%{http_code}' 2>/dev/null || echo "000")"
+check "migrating save accepted (http=${mig_code})" "[[ '${mig_code}' == '200' ]]"
+backup_code="$(curl -s -o "${WORKDIR}/precarrier-backup.yaml" -w '%{http_code}' \
+  "${BASE}/layouts/${PRECARRIER_UUID}/pre-carrier-backup" 2>/dev/null || echo "000")"
+check "migrating save created a pre-carrier backup (http=${backup_code})" "[[ '${backup_code}' == '200' ]]"
+check "backup holds the ORIGINAL pre-carrier bytes" \
+  "cmp -s '${WORKDIR}/before-precarrier.yaml' '${WORKDIR}/precarrier-backup.yaml'"
+# One-time guard: a second migrating save must not clobber the original backup.
+curl -s -X PUT "${BASE}/layouts/${PRECARRIER_UUID}" \
+  -H "Content-Type: text/yaml" -H "X-Rackula-Pre-Carrier-Migration: 1" \
+  --data-binary "@${WORKDIR}/precarrier-migrated.yaml" -o /dev/null 2>/dev/null || true
+curl -s -o "${WORKDIR}/precarrier-backup2.yaml" \
+  "${BASE}/layouts/${PRECARRIER_UUID}/pre-carrier-backup" 2>/dev/null || true
+check "backup is one-time (second migrating save preserves the original)" \
+  "cmp -s '${WORKDIR}/before-precarrier.yaml' '${WORKDIR}/precarrier-backup2.yaml'"
+
 echo "===== result: ${pass} passed, ${fail} failed, ${skip} skipped =====" >&2
 [[ "$fail" -eq 0 ]] || die "upgrade smoke FAILED"
 echo "PASS: upgrade from ${OLD_TAG} preserved the seeded layout" >&2

--- a/src/lib/storage/adapt-legacy-layout.ts
+++ b/src/lib/storage/adapt-legacy-layout.ts
@@ -25,6 +25,8 @@ import { UNITS_PER_U } from "$lib/types/constants";
 import { generateId } from "$lib/utils/device";
 import { findStarterDevice } from "$lib/data/starterLibrary";
 import { ensurePreCarrierBackup } from "./pre-carrier-backup";
+import { getStorageMode } from "./availability.svelte";
+import { markPreCarrierMigrationPending } from "./pre-carrier-migration-pending";
 
 /**
  * A placed device as it may appear in raw legacy input. The carrier-first model
@@ -374,9 +376,18 @@ export function adaptLegacyLayout(layout: Layout): Layout {
 
   if (!racksChanged && !typesChanged) return layout;
 
-  // Snapshot the pre-carrier browser state once, before the adapted layout can
-  // be written back over the original by autosave.
-  ensurePreCarrierBackup();
+  // Preserve the pre-carrier state once before the adapted layout can be written
+  // back over the original. The two storage modes are mutually exclusive:
+  // browser mode snapshots the whole localStorage state locally; server mode
+  // instead marks this layout's uuid pending, so its next save-to-server signals
+  // the server to durably back up the prior YAML (#2517).
+  if (getStorageMode() === "server") {
+    if (layout.metadata?.id) {
+      markPreCarrierMigrationPending(layout.metadata.id);
+    }
+  } else {
+    ensurePreCarrierBackup();
+  }
 
   return {
     ...layout,

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -4,6 +4,7 @@
  * Uses UUID-based routing for stable URLs across renames
  */
 import { isApiAvailable } from "./availability.svelte";
+import { takePreCarrierMigrationPending } from "./pre-carrier-migration-pending";
 import type { Layout } from "$lib/types";
 import type { ImageStoreMap } from "$lib/types/images";
 import {
@@ -407,6 +408,12 @@ export async function saveLayoutToServer(
   const headers: Record<string, string> = { "Content-Type": "text/yaml" };
   if (lastKnownUpdatedAt) {
     headers["X-Rackula-Updated-At"] = lastKnownUpdatedAt;
+  }
+  // Signal the one-time carrier-first migration to the server so it durably
+  // backs up the prior YAML before this overwrite. Consume-once: the mark is
+  // cleared here so only the first save after the migration carries it (#2517).
+  if (takePreCarrierMigrationPending(uuid)) {
+    headers["X-Rackula-Pre-Carrier-Migration"] = "1";
   }
 
   const response = await fetch(url, {

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -4,7 +4,10 @@
  * Uses UUID-based routing for stable URLs across renames
  */
 import { isApiAvailable } from "./availability.svelte";
-import { takePreCarrierMigrationPending } from "./pre-carrier-migration-pending";
+import {
+  hasPreCarrierMigrationPending,
+  clearPreCarrierMigrationPending,
+} from "./pre-carrier-migration-pending";
 import type { Layout } from "$lib/types";
 import type { ImageStoreMap } from "$lib/types/images";
 import {
@@ -410,9 +413,11 @@ export async function saveLayoutToServer(
     headers["X-Rackula-Updated-At"] = lastKnownUpdatedAt;
   }
   // Signal the one-time carrier-first migration to the server so it durably
-  // backs up the prior YAML before this overwrite. Consume-once: the mark is
-  // cleared here so only the first save after the migration carries it (#2517).
-  if (takePreCarrierMigrationPending(uuid)) {
+  // backs up the prior YAML before this overwrite (#2517). Peek here, but only
+  // clear the mark after a successful save: if this request fails, the retry
+  // must still carry the header so the server backup is never skipped.
+  const needsPreCarrierBackup = hasPreCarrierMigrationPending(uuid);
+  if (needsPreCarrierBackup) {
     headers["X-Rackula-Pre-Carrier-Migration"] = "1";
   }
 
@@ -434,6 +439,12 @@ export async function saveLayoutToServer(
       error.error ?? "Failed to save layout",
       response.status,
     );
+  }
+
+  // The save landed (2xx), so the server has taken the durable backup; clear
+  // the mark so later saves of this layout do not re-send the header.
+  if (needsPreCarrierBackup) {
+    clearPreCarrierMigrationPending(uuid);
   }
 
   try {

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -106,5 +106,6 @@ export {
 } from "./pre-carrier-backup";
 export {
   markPreCarrierMigrationPending,
-  takePreCarrierMigrationPending,
+  hasPreCarrierMigrationPending,
+  clearPreCarrierMigrationPending,
 } from "./pre-carrier-migration-pending";

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -104,3 +104,7 @@ export {
   restorePreCarrierBackup,
   discardPreCarrierBackup,
 } from "./pre-carrier-backup";
+export {
+  markPreCarrierMigrationPending,
+  takePreCarrierMigrationPending,
+} from "./pre-carrier-migration-pending";

--- a/src/lib/storage/pre-carrier-migration-pending.ts
+++ b/src/lib/storage/pre-carrier-migration-pending.ts
@@ -21,9 +21,16 @@ export function markPreCarrierMigrationPending(uuid: string): void {
 }
 
 /**
- * Return whether the uuid was pending and clear it (consume-once). A second
- * call for the same uuid returns false until it is marked again.
+ * Whether this layout still needs the pre-carrier-migration header on its next
+ * save. Non-destructive: the mark is only cleared once a save has succeeded
+ * (via {@link clearPreCarrierMigrationPending}), so a failed-then-retried save
+ * still signals the server and the durable backup is never skipped.
  */
-export function takePreCarrierMigrationPending(uuid: string): boolean {
-  return pending.delete(uuid);
+export function hasPreCarrierMigrationPending(uuid: string): boolean {
+  return pending.has(uuid);
+}
+
+/** Clear the mark after a migrating save has succeeded. Idempotent. */
+export function clearPreCarrierMigrationPending(uuid: string): void {
+  pending.delete(uuid);
 }

--- a/src/lib/storage/pre-carrier-migration-pending.ts
+++ b/src/lib/storage/pre-carrier-migration-pending.ts
@@ -1,0 +1,29 @@
+/**
+ * Pending pre-carrier-migration registry (server-storage mode, #2517).
+ *
+ * In server-storage mode the client signals the one-time carrier-first
+ * migration to the server rather than snapshotting locally (browser mode keeps
+ * ensurePreCarrierBackup). When adapt-legacy-layout actually changes a layout,
+ * it marks that layout's uuid pending here. The next save-to-server consumes
+ * the mark and attaches the X-Rackula-Pre-Carrier-Migration header, so the
+ * server backs up the prior YAML exactly once before the migrating overwrite.
+ *
+ * The registry is module-level process state (a Set keyed by uuid). It is
+ * consume-once: taking a uuid returns whether it was pending and clears it.
+ */
+
+const pending = new Set<string>();
+
+/** Mark a layout uuid as needing the pre-carrier-migration header on its next save. */
+export function markPreCarrierMigrationPending(uuid: string): void {
+  if (!uuid) return;
+  pending.add(uuid);
+}
+
+/**
+ * Return whether the uuid was pending and clear it (consume-once). A second
+ * call for the same uuid returns false until it is marked again.
+ */
+export function takePreCarrierMigrationPending(uuid: string): boolean {
+  return pending.delete(uuid);
+}

--- a/src/tests/pre-carrier-migration-pending.test.ts
+++ b/src/tests/pre-carrier-migration-pending.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, it, expect } from "vitest";
+import {
+  markPreCarrierMigrationPending,
+  takePreCarrierMigrationPending,
+} from "$lib/storage/pre-carrier-migration-pending";
+import { adaptLegacyLayout } from "$lib/storage/adapt-legacy-layout";
+import {
+  createTestDevice,
+  createTestDeviceType,
+  createTestLayout,
+  createTestRack,
+} from "./factories";
+import type { Layout } from "$lib/types";
+
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+const UUID_B = "22222222-2222-4222-8222-222222222222";
+
+describe("pre-carrier migration pending registry", () => {
+  it("returns true once then false (consume-once) for a marked uuid", () => {
+    markPreCarrierMigrationPending(UUID_A);
+    expect(takePreCarrierMigrationPending(UUID_A)).toBe(true);
+    expect(takePreCarrierMigrationPending(UUID_A)).toBe(false);
+  });
+
+  it("tracks distinct uuids independently", () => {
+    markPreCarrierMigrationPending(UUID_A);
+    markPreCarrierMigrationPending(UUID_B);
+
+    expect(takePreCarrierMigrationPending(UUID_A)).toBe(true);
+    // Taking A does not consume B.
+    expect(takePreCarrierMigrationPending(UUID_B)).toBe(true);
+    expect(takePreCarrierMigrationPending(UUID_B)).toBe(false);
+  });
+
+  it("returns false when taking a uuid that was never marked", () => {
+    expect(
+      takePreCarrierMigrationPending("33333333-3333-4333-8333-333333333333"),
+    ).toBe(false);
+  });
+});
+
+/**
+ * adaptLegacyLayout branches on storage mode: in server mode a changed layout
+ * marks its uuid pending (the client signals the server), while in browser mode
+ * it falls through to the local ensurePreCarrierBackup and never marks. A layout
+ * that does not change marks nothing in either mode.
+ */
+describe("adaptLegacyLayout pre-carrier migration signalling", () => {
+  const original = window.__RACKULA_CONFIG__;
+
+  beforeEach(() => {
+    delete window.__RACKULA_CONFIG__;
+    // Drain any leftover marks so each test starts clean.
+    takePreCarrierMigrationPending(UUID_A);
+  });
+
+  afterEach(() => {
+    window.__RACKULA_CONFIG__ = original;
+  });
+
+  /** A layout whose only half-width device forces a carrier wrap (changed=true). */
+  function changedLayout(uuid: string): Layout {
+    const half = createTestDeviceType({
+      slug: "half-width",
+      u_height: 1,
+      slot_width: 1,
+    });
+    return createTestLayout({
+      metadata: { id: uuid },
+      device_types: [half],
+      racks: [
+        createTestRack({
+          devices: [
+            createTestDevice({
+              id: "half-dev",
+              device_type: "half-width",
+              position: 10,
+            }),
+          ],
+        }),
+      ],
+    });
+  }
+
+  it("marks the layout uuid pending in server mode when the layout changed", () => {
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+
+    adaptLegacyLayout(changedLayout(UUID_A));
+
+    expect(takePreCarrierMigrationPending(UUID_A)).toBe(true);
+  });
+
+  it("does not mark in browser mode even when the layout changed", () => {
+    window.__RACKULA_CONFIG__ = { storage: "browser" };
+
+    adaptLegacyLayout(changedLayout(UUID_A));
+
+    expect(takePreCarrierMigrationPending(UUID_A)).toBe(false);
+  });
+
+  it("does not mark when nothing changed (server mode)", () => {
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+
+    // A plain layout with no half-width / sub-U gear is already carrier-first.
+    const layout = createTestLayout({
+      metadata: { id: UUID_A },
+      device_types: [createTestDeviceType({ slug: "srv-1u", u_height: 1 })],
+      racks: [
+        createTestRack({
+          devices: [
+            createTestDevice({
+              id: "srv",
+              device_type: "srv-1u",
+              position: 6,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    adaptLegacyLayout(layout);
+
+    expect(takePreCarrierMigrationPending(UUID_A)).toBe(false);
+  });
+});

--- a/src/tests/pre-carrier-migration-pending.test.ts
+++ b/src/tests/pre-carrier-migration-pending.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import {
   markPreCarrierMigrationPending,
-  takePreCarrierMigrationPending,
+  hasPreCarrierMigrationPending,
+  clearPreCarrierMigrationPending,
 } from "$lib/storage/pre-carrier-migration-pending";
 import { adaptLegacyLayout } from "$lib/storage/adapt-legacy-layout";
 import {
@@ -16,25 +17,33 @@ const UUID_A = "11111111-1111-4111-8111-111111111111";
 const UUID_B = "22222222-2222-4222-8222-222222222222";
 
 describe("pre-carrier migration pending registry", () => {
-  it("returns true once then false (consume-once) for a marked uuid", () => {
+  afterEach(() => {
+    clearPreCarrierMigrationPending(UUID_A);
+    clearPreCarrierMigrationPending(UUID_B);
+  });
+
+  it("peek is non-destructive and clear removes the mark", () => {
     markPreCarrierMigrationPending(UUID_A);
-    expect(takePreCarrierMigrationPending(UUID_A)).toBe(true);
-    expect(takePreCarrierMigrationPending(UUID_A)).toBe(false);
+    expect(hasPreCarrierMigrationPending(UUID_A)).toBe(true);
+    // Peeking again must not clear it: a failed save retries with the header.
+    expect(hasPreCarrierMigrationPending(UUID_A)).toBe(true);
+    clearPreCarrierMigrationPending(UUID_A);
+    expect(hasPreCarrierMigrationPending(UUID_A)).toBe(false);
   });
 
   it("tracks distinct uuids independently", () => {
     markPreCarrierMigrationPending(UUID_A);
     markPreCarrierMigrationPending(UUID_B);
 
-    expect(takePreCarrierMigrationPending(UUID_A)).toBe(true);
-    // Taking A does not consume B.
-    expect(takePreCarrierMigrationPending(UUID_B)).toBe(true);
-    expect(takePreCarrierMigrationPending(UUID_B)).toBe(false);
+    clearPreCarrierMigrationPending(UUID_A);
+    // Clearing A leaves B marked.
+    expect(hasPreCarrierMigrationPending(UUID_A)).toBe(false);
+    expect(hasPreCarrierMigrationPending(UUID_B)).toBe(true);
   });
 
-  it("returns false when taking a uuid that was never marked", () => {
+  it("has is false for a uuid that was never marked", () => {
     expect(
-      takePreCarrierMigrationPending("33333333-3333-4333-8333-333333333333"),
+      hasPreCarrierMigrationPending("33333333-3333-4333-8333-333333333333"),
     ).toBe(false);
   });
 });
@@ -51,7 +60,7 @@ describe("adaptLegacyLayout pre-carrier migration signalling", () => {
   beforeEach(() => {
     delete window.__RACKULA_CONFIG__;
     // Drain any leftover marks so each test starts clean.
-    takePreCarrierMigrationPending(UUID_A);
+    clearPreCarrierMigrationPending(UUID_A);
   });
 
   afterEach(() => {
@@ -87,7 +96,7 @@ describe("adaptLegacyLayout pre-carrier migration signalling", () => {
 
     adaptLegacyLayout(changedLayout(UUID_A));
 
-    expect(takePreCarrierMigrationPending(UUID_A)).toBe(true);
+    expect(hasPreCarrierMigrationPending(UUID_A)).toBe(true);
   });
 
   it("does not mark in browser mode even when the layout changed", () => {
@@ -95,7 +104,7 @@ describe("adaptLegacyLayout pre-carrier migration signalling", () => {
 
     adaptLegacyLayout(changedLayout(UUID_A));
 
-    expect(takePreCarrierMigrationPending(UUID_A)).toBe(false);
+    expect(hasPreCarrierMigrationPending(UUID_A)).toBe(false);
   });
 
   it("does not mark when nothing changed (server mode)", () => {
@@ -120,6 +129,6 @@ describe("adaptLegacyLayout pre-carrier migration signalling", () => {
 
     adaptLegacyLayout(layout);
 
-    expect(takePreCarrierMigrationPending(UUID_A)).toBe(false);
+    expect(hasPreCarrierMigrationPending(UUID_A)).toBe(false);
   });
 });

--- a/src/tests/save-layout-to-server.test.ts
+++ b/src/tests/save-layout-to-server.test.ts
@@ -1,14 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveLayoutToServer } from "$lib/storage/api";
 import { setApiAvailable } from "$lib/storage/availability.svelte";
-import { markPreCarrierMigrationPending } from "$lib/storage/pre-carrier-migration-pending";
+import {
+  markPreCarrierMigrationPending,
+  clearPreCarrierMigrationPending,
+} from "$lib/storage/pre-carrier-migration-pending";
 import { createTestLayout } from "./factories";
 
 /**
  * In server-storage mode, a layout whose carrier-first migration was marked
- * pending (by adapt-legacy-layout) must carry the X-Rackula-Pre-Carrier-Migration
- * header on its NEXT save only (consume-once), so the server takes the durable
- * backup exactly once. The header coexists with X-Rackula-Updated-At.
+ * pending (by adapt-legacy-layout) carries the X-Rackula-Pre-Carrier-Migration
+ * header on its next save. The mark is cleared only after a save succeeds, so a
+ * failed save retries with the header and the durable backup is never skipped.
+ * The header coexists with X-Rackula-Updated-At.
  */
 describe("saveLayoutToServer pre-carrier migration header", () => {
   const originalConfig = window.__RACKULA_CONFIG__;
@@ -39,6 +43,8 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
     vi.restoreAllMocks();
     setApiAvailable(false);
     window.__RACKULA_CONFIG__ = originalConfig;
+    clearPreCarrierMigrationPending(UUID);
+    clearPreCarrierMigrationPending(OTHER_UUID);
   });
 
   it("attaches the header when the uuid is pending", async () => {
@@ -109,5 +115,34 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
     expect(headers.get("X-Rackula-Updated-At")).toBe(
       "2026-06-14T09:00:00.000Z",
     );
+  });
+
+  it("retries with the header after a failed save so the backup is not skipped", async () => {
+    // First save fails (non-2xx), the retry succeeds.
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => new Response("nope", { status: 503 }))
+      .mockImplementationOnce(async () => okSaveResponse(UUID));
+    vi.stubGlobal("fetch", fetchMock);
+
+    markPreCarrierMigrationPending(UUID);
+
+    await expect(
+      saveLayoutToServer(
+        createTestLayout({ metadata: { id: UUID } }),
+        new Map(),
+        null,
+      ),
+    ).rejects.toThrow();
+
+    // The failed save must not have consumed the mark.
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: UUID } }),
+      new Map(),
+      null,
+    );
+
+    const retryHeaders = new Headers(fetchMock.mock.calls[1][1].headers);
+    expect(retryHeaders.get("X-Rackula-Pre-Carrier-Migration")).toBe("1");
   });
 });

--- a/src/tests/save-layout-to-server.test.ts
+++ b/src/tests/save-layout-to-server.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveLayoutToServer } from "$lib/storage/api";
+import { setApiAvailable } from "$lib/storage/availability.svelte";
+import { markPreCarrierMigrationPending } from "$lib/storage/pre-carrier-migration-pending";
+
+/**
+ * In server-storage mode, a layout whose carrier-first migration was marked
+ * pending (by adapt-legacy-layout) must carry the X-Rackula-Pre-Carrier-Migration
+ * header on its NEXT save only (consume-once), so the server takes the durable
+ * backup exactly once. The header coexists with X-Rackula-Updated-At.
+ */
+describe("saveLayoutToServer pre-carrier migration header", () => {
+  const originalConfig = window.__RACKULA_CONFIG__;
+  const UUID = "11111111-1111-4111-8111-111111111111";
+  const OTHER_UUID = "22222222-2222-4222-8222-222222222222";
+
+  function stubBrowserGlobals(): void {
+    vi.stubGlobal("AbortSignal", {
+      timeout: () => new AbortController().signal,
+    });
+  }
+
+  function layoutWithId(id: string) {
+    return { name: "L", racks: [], device_types: [], metadata: { id } };
+  }
+
+  function okSaveResponse(id: string): Response {
+    return new Response(
+      JSON.stringify({ id, updatedAt: "2026-06-14T10:00:00.000Z" }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  beforeEach(() => {
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+    setApiAvailable(true);
+    stubBrowserGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    setApiAvailable(false);
+    window.__RACKULA_CONFIG__ = originalConfig;
+  });
+
+  it("attaches the header when the uuid is pending", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okSaveResponse(UUID));
+    vi.stubGlobal("fetch", fetchMock);
+
+    markPreCarrierMigrationPending(UUID);
+    await saveLayoutToServer(layoutWithId(UUID) as never, new Map(), null);
+
+    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    expect(headers.get("X-Rackula-Pre-Carrier-Migration")).toBe("1");
+  });
+
+  it("does not re-attach the header on a subsequent save of the same uuid", async () => {
+    // Fresh Response per call: a Response body can only be read once.
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async () => okSaveResponse(UUID));
+    vi.stubGlobal("fetch", fetchMock);
+
+    markPreCarrierMigrationPending(UUID);
+    await saveLayoutToServer(layoutWithId(UUID) as never, new Map(), null);
+    await saveLayoutToServer(layoutWithId(UUID) as never, new Map(), null);
+
+    const secondHeaders = new Headers(fetchMock.mock.calls[1][1].headers);
+    expect(secondHeaders.has("X-Rackula-Pre-Carrier-Migration")).toBe(false);
+  });
+
+  it("never attaches the header for a non-pending uuid", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okSaveResponse(OTHER_UUID));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveLayoutToServer(
+      layoutWithId(OTHER_UUID) as never,
+      new Map(),
+      null,
+    );
+
+    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    expect(headers.has("X-Rackula-Pre-Carrier-Migration")).toBe(false);
+  });
+
+  it("attaches the header alongside X-Rackula-Updated-At", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okSaveResponse(UUID));
+    vi.stubGlobal("fetch", fetchMock);
+
+    markPreCarrierMigrationPending(UUID);
+    await saveLayoutToServer(
+      layoutWithId(UUID) as never,
+      new Map(),
+      "2026-06-14T09:00:00.000Z",
+    );
+
+    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    expect(headers.get("X-Rackula-Pre-Carrier-Migration")).toBe("1");
+    expect(headers.get("X-Rackula-Updated-At")).toBe(
+      "2026-06-14T09:00:00.000Z",
+    );
+  });
+});

--- a/src/tests/save-layout-to-server.test.ts
+++ b/src/tests/save-layout-to-server.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveLayoutToServer } from "$lib/storage/api";
 import { setApiAvailable } from "$lib/storage/availability.svelte";
 import { markPreCarrierMigrationPending } from "$lib/storage/pre-carrier-migration-pending";
+import { createTestLayout } from "./factories";
 
 /**
  * In server-storage mode, a layout whose carrier-first migration was marked
@@ -18,10 +19,6 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
     vi.stubGlobal("AbortSignal", {
       timeout: () => new AbortController().signal,
     });
-  }
-
-  function layoutWithId(id: string) {
-    return { name: "L", racks: [], device_types: [], metadata: { id } };
   }
 
   function okSaveResponse(id: string): Response {
@@ -49,7 +46,11 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     markPreCarrierMigrationPending(UUID);
-    await saveLayoutToServer(layoutWithId(UUID) as never, new Map(), null);
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: UUID } }),
+      new Map(),
+      null,
+    );
 
     const headers = new Headers(fetchMock.mock.calls[0][1].headers);
     expect(headers.get("X-Rackula-Pre-Carrier-Migration")).toBe("1");
@@ -63,8 +64,16 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     markPreCarrierMigrationPending(UUID);
-    await saveLayoutToServer(layoutWithId(UUID) as never, new Map(), null);
-    await saveLayoutToServer(layoutWithId(UUID) as never, new Map(), null);
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: UUID } }),
+      new Map(),
+      null,
+    );
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: UUID } }),
+      new Map(),
+      null,
+    );
 
     const secondHeaders = new Headers(fetchMock.mock.calls[1][1].headers);
     expect(secondHeaders.has("X-Rackula-Pre-Carrier-Migration")).toBe(false);
@@ -75,7 +84,7 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await saveLayoutToServer(
-      layoutWithId(OTHER_UUID) as never,
+      createTestLayout({ metadata: { id: OTHER_UUID } }),
       new Map(),
       null,
     );
@@ -90,7 +99,7 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
 
     markPreCarrierMigrationPending(UUID);
     await saveLayoutToServer(
-      layoutWithId(UUID) as never,
+      createTestLayout({ metadata: { id: UUID } }),
       new Map(),
       "2026-06-14T09:00:00.000Z",
     );


### PR DESCRIPTION
## **User description**
Closes #2517. Release blocker for the carrier-first release (priority:urgent).

## Why

The carrier-first refactor (#2158) migrates legacy layouts on load; the first save rewrites the file in the new format, one-way. Browser users get an automatic pre-migration backup (`ensurePreCarrierBackup`). Server-storage (Docker) deployments had no equivalent: the migrating autosave overwrites the `/data` file with no backup, and the server snapshot only fires on a write conflict, not a routine save. Since most self-hosters track `:latest`, a routine `docker compose pull` would migrate-and-overwrite their data with no automatic way back. User data loss is the worst case; this closes that gap.

## What

Client-signalled, server-stored, one-time durable backup:

- API (`saveLayout`): on the `X-Rackula-Pre-Carrier-Migration: 1` header, the current on-disk YAML is copied once to `{layout folder}/pre-carrier-backup.yaml` via exclusive create (`flag: "wx"`), before the overwrite. It lives outside `snapshots/` so it is never pruned, and is invisible to discovery, snapshot listing, and quota. Read it back at `GET /layouts/:uuid/pre-carrier-backup`.
- Client: `adapt-legacy-layout` marks a layout pending (per-uuid, consume-once) when it actually migrates in server-storage mode; `saveLayoutToServer` attaches the header on that layout's next save. Browser mode keeps `ensurePreCarrierBackup` (the two modes are mutually exclusive).
- Detection is client-driven on purpose: the adapter knows it migrated, so this also covers pre-carrier shapes that have no `slot_position` marker (bare co-located pairs, fractional positions) that a server content-sniff would miss.

Restore is read-only retrieval for now; a restore-write endpoint and UI affordance are a deliberate follow-up.

## Verification

- API: 309 bun tests pass (36 across the two new backup test files). Client: the new pending-registry and header-attachment suites pass. Lint and repo-wide prettier clean.
- End-to-end on a Debian 13 VM (v26.6.3 to a working-tree build), via `scripts/upgrade-smoke.sh`: 11 passed, 1 skipped. The new Phase C asserts a migrating save creates the durable backup, the backup holds the ORIGINAL pre-carrier bytes, and a second migrating save does not clobber it.

## Docs

`docs/guides/DOCKER-UPGRADE-TESTING.md` updated: the gap is now closed (durable server backup), `/data` backup is belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep a durable backup of migrated layouts in server storage**

### What Changed
- When a legacy layout is saved in server-storage mode, the app now sends a one-time migration signal so the server saves the pre-migration YAML before overwriting it
- The server stores that backup as `pre-carrier-backup.yaml`, keeps it outside snapshot cleanup, and exposes it through `GET /layouts/:uuid/pre-carrier-backup`
- A second migrating save leaves the original backup unchanged, and normal saves do not create this backup
- Browser storage keeps its existing local backup flow; the two storage modes stay separate

### Impact
`✅ Fewer data-loss upgrades in Docker`
`✅ Easier recovery after carrier-first migration`
`✅ Safer one-way layout saves`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
