### PR TITLE
fix: nosniff on asset GET at app and nginx edge, document read posture (#2529)

### DIFF
--- a/api/src/routes/assets.test.ts
+++ b/api/src/routes/assets.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Asset GET response-header tests (#2529)
+ *
+ * Covers:
+ * - A served asset carries X-Content-Type-Options: nosniff so a polyglot
+ *   upload cannot be MIME-sniffed into active content.
+ * - The served Content-Type matches the stored raster format.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp } from "../app";
+import type { EnvMap } from "../security";
+
+type App = Awaited<ReturnType<typeof createApp>>;
+
+const LAYOUT_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const DEVICE_UUID = "660e8400-e29b-41d4-a716-446655440001";
+
+// Minimal valid 1x1 RGBA PNG.
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII=";
+
+const originalDataDir = process.env.DATA_DIR;
+let testDir: string;
+let app: App;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "rackula-assets-test-"));
+  process.env.DATA_DIR = testDir;
+  app = await createApp({
+    NODE_ENV: "test",
+    DATA_DIR: testDir,
+    RACKULA_RATE_LIMIT_ENABLED: "false",
+  } satisfies EnvMap);
+});
+
+afterEach(async () => {
+  if (originalDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = originalDataDir;
+  }
+
+  try {
+    await rm(testDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup failures
+  }
+});
+
+async function createLayout(uuid: string): Promise<void> {
+  const yaml = `version: "1.0.0"\nname: Test\nracks: []`;
+  const res = await app.request(`/layouts/${uuid}`, {
+    method: "PUT",
+    headers: { "Content-Type": "text/yaml" },
+    body: yaml,
+  });
+  expect(res.status).toBe(201);
+}
+
+async function putAsset(): Promise<Response> {
+  const bytes = Buffer.from(PNG_BASE64, "base64");
+  return app.request(`/assets/${LAYOUT_UUID}/${DEVICE_UUID}/front`, {
+    method: "PUT",
+    headers: { "Content-Type": "image/png" },
+    body: bytes,
+  });
+}
+
+describe("GET /assets response headers", () => {
+  it("serves a stored asset with X-Content-Type-Options: nosniff", async () => {
+    await createLayout(LAYOUT_UUID);
+
+    const putRes = await putAsset();
+    expect(putRes.status).toBe(200);
+
+    const res = await app.request(
+      `/assets/${LAYOUT_UUID}/${DEVICE_UUID}/front`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Content-Type")).toBe("image/png");
+  });
+});

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -57,6 +57,9 @@ assets.get("/:layoutId/:deviceSlug/:face", async (c) => {
     return c.body(new Uint8Array(asset.data), 200, {
       "Content-Type": asset.contentType,
       "Cache-Control": "public, max-age=3600, must-revalidate",
+      // Stop MIME sniffing so a polyglot upload cannot be reinterpreted as
+      // active content (HTML/JS) when served from the app origin.
+      "X-Content-Type-Options": "nosniff",
     });
   } catch (error) {
     logger.error({ err: error }, `Failed to get asset`);

--- a/deploy/lxc/nginx.conf
+++ b/deploy/lxc/nginx.conf
@@ -87,6 +87,15 @@ server {
     }
 
     location /api/ {
+        # Own the security headers at the edge for proxied API responses,
+        # including served device images at /api/assets/. The upstream API also
+        # sets X-Content-Type-Options on asset GETs; this is the edge backstop.
+        # nginx add_header REPLACES, not merges: a future bare add_header in this
+        # block would drop every server-level header AND any upstream header of
+        # the same name, silently stripping the upstream nosniff. Keep this
+        # include so the headers are defined here explicitly.
+        include /etc/nginx/snippets/security-headers.conf;
+
         # Strip /api prefix: /api/layouts -> /layouts
         rewrite ^/api(/.*)$ $1 break;
 

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -202,6 +202,15 @@ server {
         resolver ${NGINX_RESOLVER} valid=30s;
         set $api_upstream ${API_HOST};
 
+        # Own the security headers at the edge for proxied API responses,
+        # including served device images at /api/assets/. The upstream API also
+        # sets X-Content-Type-Options on asset GETs; this is the edge backstop.
+        # nginx add_header REPLACES, not merges: a future bare add_header in this
+        # block would drop every server-level header AND any upstream header of
+        # the same name, silently stripping the upstream nosniff. Keep this
+        # include so the headers are defined here explicitly.
+        include /etc/nginx/snippets/security-headers.conf;
+
         # Strip /api prefix: /api/layouts -> /layouts
         # Using rewrite to capture path after /api and forward without prefix
         rewrite ^/api(/.*)$ $1 break;

--- a/docs/deployment/SELF-HOSTING.md
+++ b/docs/deployment/SELF-HOSTING.md
@@ -126,6 +126,14 @@ For reverse-proxy-based auth (outside the built-in modes):
 
 For a copy-pastable hardening path with Docker + NGINX (UI and API protection, deny-by-default route allowlist, Docker secrets, and API rate limits), use the stop-gap section below.
 
+#### Read access in write-token-only mode
+
+A write token (`RACKULA_API_WRITE_TOKEN`) gates only the write methods (`POST`, `PUT`, `DELETE`). It does not gate reads. In the common homelab config where a write token is set but `RACKULA_AUTH_MODE` is unset, `GET /layouts` and `GET /assets` are unauthenticated: anyone who can reach the API and supplies a valid layout UUID and device UUID can read your layouts and your custom device images. Asset reads inherit the same posture as layout reads here, so this is the existing behaviour for read access, not a new gap, and there is no separate read token.
+
+To gate reads, set `RACKULA_AUTH_MODE` to `local` or `oidc`. The session gate then covers `GET` requests too, so reads require a logged-in session. Enabling `RACKULA_AUTH_MODE` is the way to require auth for reading layouts and assets.
+
+Served assets carry `X-Content-Type-Options: nosniff` from both the API and the nginx edge, so a polyglot image cannot be MIME-sniffed into active content even when reads are open.
+
 ---
 
 ## Upgrading an existing deployment


### PR DESCRIPTION
## **User description**
Closes #2529

Part of epic #2513 (Wave 0, security). Server-mode only.

## Summary

Add `X-Content-Type-Options: nosniff` to the served device-image GET response in the API, own that header at the nginx edge for the `/api/` proxy blocks (Docker template and LXC), and document the asset read posture in SELF-HOSTING.md.

## Acceptance criteria coverage

- GET /assets now sets `X-Content-Type-Options: nosniff` at the Hono handler (`api/src/routes/assets.ts`), and the nginx `/api/` edge owns the header set so the upstream nosniff survives.
- `security-headers.conf` is now included in the `location /api/` blocks of both `deploy/nginx.conf.template` and `deploy/lxc/nginx.conf`, with a comment noting the nginx add_header replace-not-merge footgun (a future bare add_header would silently strip the upstream header).
- New test `api/src/routes/assets.test.ts` asserts the nosniff header (and the matching `image/png` Content-Type) on a served asset via a full PUT-then-GET round trip.
- SELF-HOSTING.md documents that asset GET inherits the layout read posture: open in write-token-only mode (no `RACKULA_AUTH_MODE`), session-gated under `AUTH_MODE=local|oidc`. No separate read token is introduced.
- No behavioural change to PUT/DELETE auth.

## Security notes

- nosniff stops a polyglot upload from being MIME-sniffed into active content (HTML/JS) when served from the app origin.
- The nginx include is the same proven pattern already used by the `/assets/` and `/config.js` blocks. It does not change the effective header set on `/api/` (those headers were already inherited from the server-level include); it makes ownership explicit so the headers cannot be silently dropped later. `add_header ... always` keeps nosniff present on both the 200 image response and error responses.
- Each nginx variant maps its own sibling `security-headers.conf` to the deployed `/etc/nginx/snippets/` path (Docker includes HSTS, LXC intentionally omits it); the asymmetry is preserved.
- Read posture is the existing layout posture, not a new regression. Enabling `AUTH_MODE` gates reads.

## Verification

- nginx not available locally; the header behaviour is asserted via the Hono handler test, and the nginx include is byte-identical to the proven `/assets/` block in the same files (verified deploy tooling maps each snippet to the runtime path).
- Local gates: ESLint clean, `bun test` (api) 310 pass, `vitest` 2805 pass, `npm run build` ok, prettier `--check` clean, api `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Protect served device images from being treated as active content**

### What Changed
- Served asset downloads now include `X-Content-Type-Options: nosniff`, so uploaded images are not MIME-sniffed as HTML or JavaScript when opened from the app origin.
- The API edge now explicitly carries the same security header for `/api/` responses, preventing it from being dropped by proxy header handling.
- Added a test that uploads and retrieves an asset, then checks both the `nosniff` header and the returned image type.
- The self-hosting guide now explains that asset reads are open in write-token-only mode, and that session-based auth is required if you want reads to be protected.

### Impact
`✅ Fewer image-to-script security risks`
`✅ Consistent protection for asset downloads`
`✅ Clearer self-hosting read-access setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
