### PR TITLE
feat: per-placement image override thumbnails with replace/clear (#2444)

### DIFF
--- a/src/lib/components/EditPanelImage.svelte
+++ b/src/lib/components/EditPanelImage.svelte
@@ -81,7 +81,11 @@
     }
 
     try {
-      const data = await fileToImageData(file, "device", face);
+      const data = await fileToImageData(
+        file,
+        selectedDeviceInfo.device.slug,
+        face,
+      );
       const deviceId = selectedDeviceInfo.placedDevice.id;
       imageStore.setDeviceImage(placementKey(layoutId, deviceId), face, data);
       layoutStore.updateDevicePlacementImage(

--- a/src/lib/components/EditPanelImage.svelte
+++ b/src/lib/components/EditPanelImage.svelte
@@ -1,12 +1,15 @@
 <!--
   EditPanelImage Component
   Edit panel section: front/rear placement image overrides for the selected device.
+  Each face shows a thumbnail when an override is set, with replace and clear
+  actions. When no override is set, the device type image is used as the fallback.
 -->
 <script lang="ts">
-  import ImageUpload from "./ImageUpload.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getImageStore } from "$lib/stores/images.svelte";
   import { placementKey } from "$lib/utils/placement-key";
+  import { validateImageFile, fileToImageData } from "$lib/utils/imageUpload";
+  import { SUPPORTED_IMAGE_FORMATS } from "$lib/types/constants";
   import type { SelectedDeviceInfo } from "$lib/types";
   import type { ImageData } from "$lib/types/images";
 
@@ -21,35 +24,81 @@
 
   const layoutId = $derived(layoutStore.layout.metadata?.id ?? "");
 
-  // Get the current placement images (if any)
-  const placementFrontImage = $derived.by(() =>
+  const acceptTypes = SUPPORTED_IMAGE_FORMATS.join(",");
+
+  // Per-face validation errors and hidden file inputs
+  let errors = $state<{ front: string | null; rear: string | null }>({
+    front: null,
+    rear: null,
+  });
+  let fileInputs = $state<{
+    front: HTMLInputElement | null;
+    rear: HTMLInputElement | null;
+  }>({ front: null, rear: null });
+
+  // Current placement overrides (if any)
+  const placementFrontImage = $derived(
     imageStore.getDeviceImage(
       placementKey(layoutId, selectedDeviceInfo.placedDevice.id),
       "front",
     ),
   );
-
-  const placementRearImage = $derived.by(() =>
+  const placementRearImage = $derived(
     imageStore.getDeviceImage(
       placementKey(layoutId, selectedDeviceInfo.placedDevice.id),
       "rear",
     ),
   );
 
-  // Handle placement image upload
-  function handlePlacementImageUpload(face: "front" | "rear", data: ImageData) {
-    const deviceId = selectedDeviceInfo.placedDevice.id;
-    imageStore.setDeviceImage(placementKey(layoutId, deviceId), face, data);
-    layoutStore.updateDevicePlacementImage(
-      selectedDeviceInfo.rack.id,
-      selectedDeviceInfo.deviceIndex,
-      face,
-      data.filename,
-    );
+  // Device type fallback images, keyed by slug in the image store
+  const deviceTypeFrontImage = $derived(
+    imageStore.getDeviceImage(selectedDeviceInfo.device.slug, "front"),
+  );
+  const deviceTypeRearImage = $derived(
+    imageStore.getDeviceImage(selectedDeviceInfo.device.slug, "rear"),
+  );
+
+  function imageSrc(image: ImageData | undefined): string | undefined {
+    return image?.url ?? image?.dataUrl;
   }
 
-  // Handle placement image removal
-  function handlePlacementImageRemove(face: "front" | "rear") {
+  function chooseFile(face: "front" | "rear") {
+    fileInputs[face]?.click();
+  }
+
+  async function handleFileChange(face: "front" | "rear", event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+
+    errors[face] = null;
+
+    const validation = validateImageFile(file);
+    if (!validation.valid) {
+      errors[face] = validation.error ?? "Invalid file";
+      input.value = "";
+      return;
+    }
+
+    try {
+      const data = await fileToImageData(file, "device", face);
+      const deviceId = selectedDeviceInfo.placedDevice.id;
+      imageStore.setDeviceImage(placementKey(layoutId, deviceId), face, data);
+      layoutStore.updateDevicePlacementImage(
+        selectedDeviceInfo.rack.id,
+        selectedDeviceInfo.deviceIndex,
+        face,
+        data.filename,
+      );
+    } catch {
+      errors[face] = "Failed to process image";
+    }
+
+    // Reset so the same file can be selected again
+    input.value = "";
+  }
+
+  function clearOverride(face: "front" | "rear") {
     const deviceId = selectedDeviceInfo.placedDevice.id;
     imageStore.removeDeviceImage(placementKey(layoutId, deviceId), face);
     layoutStore.updateDevicePlacementImage(
@@ -58,44 +107,217 @@
       face,
       undefined,
     );
+    errors[face] = null;
   }
 </script>
 
-<!-- Placement Image Overrides -->
-<div class="form-group">
-  <ImageUpload
-    face="front"
-    currentImage={placementFrontImage}
-    onupload={(data) => handlePlacementImageUpload("front", data)}
-    onremove={() => handlePlacementImageRemove("front")}
-  />
-  <p class="helper-text">
-    Override the device type front image for this placement
-  </p>
-</div>
+{#snippet imageSlot(
+  face: "front" | "rear",
+  override: ImageData | undefined,
+  deviceTypeImage: ImageData | undefined,
+)}
+  {@const label = face === "front" ? "Front Image" : "Rear Image"}
+  {@const overrideSrc = imageSrc(override)}
+  {@const fallbackSrc = imageSrc(deviceTypeImage)}
+  <div class="slot">
+    <span class="slot-label">{label}</span>
 
-<div class="form-group">
-  <ImageUpload
-    face="rear"
-    currentImage={placementRearImage}
-    onupload={(data) => handlePlacementImageUpload("rear", data)}
-    onremove={() => handlePlacementImageRemove("rear")}
-  />
-  <p class="helper-text">
-    Override the device type rear image for this placement
-  </p>
+    <input
+      type="file"
+      accept={acceptTypes}
+      class="sr-only"
+      aria-label="Choose {label.toLowerCase()} override"
+      bind:this={fileInputs[face]}
+      onchange={(event) => handleFileChange(face, event)}
+    />
+
+    {#if overrideSrc}
+      <div class="thumb-row">
+        <img class="thumb" src={overrideSrc} alt="{face} override preview" />
+        <div class="slot-actions">
+          <span class="slot-status">Override set</span>
+          <div class="button-row">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              onclick={() => chooseFile(face)}
+            >
+              Replace
+            </button>
+            <button
+              type="button"
+              class="btn btn-clear"
+              onclick={() => clearOverride(face)}
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      </div>
+    {:else}
+      <div class="thumb-row">
+        <div class="thumb thumb-empty" aria-hidden="true">
+          {#if fallbackSrc}
+            <img class="thumb-fallback" src={fallbackSrc} alt="" />
+          {:else}
+            <span class="thumb-placeholder">No image</span>
+          {/if}
+        </div>
+        <div class="slot-actions">
+          <span class="slot-status slot-status-muted">
+            {fallbackSrc ? "Using device type image" : "No device type image"}
+          </span>
+          <div class="button-row">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              onclick={() => chooseFile(face)}
+            >
+              Set override
+            </button>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    {#if errors[face]}
+      <span class="error-message" role="alert">{errors[face]}</span>
+    {/if}
+  </div>
+{/snippet}
+
+<div class="image-overrides">
+  {@render imageSlot("front", placementFrontImage, deviceTypeFrontImage)}
+  {@render imageSlot("rear", placementRearImage, deviceTypeRearImage)}
 </div>
 
 <style>
-  .form-group {
+  .image-overrides {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .slot {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .slot-label {
+    font-weight: 500;
+    color: var(--colour-text);
+    font-size: var(--font-size-base);
+  }
+
+  .thumb-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .thumb {
+    flex-shrink: 0;
+    width: 80px;
+    height: 60px;
+    object-fit: contain;
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-sm);
+    background: var(--colour-surface-secondary);
+  }
+
+  .thumb-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-style: dashed;
+    overflow: hidden;
+  }
+
+  .thumb-fallback {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    opacity: 0.55;
+  }
+
+  .thumb-placeholder {
+    font-size: var(--font-size-2xs);
+    color: var(--colour-text-muted);
+    text-align: center;
+    padding: var(--space-1);
+  }
+
+  .slot-actions {
     display: flex;
     flex-direction: column;
     gap: var(--space-1-5);
+    min-width: 0;
   }
 
-  .helper-text {
+  .slot-status {
     font-size: var(--font-size-sm);
-    margin: 0;
+    color: var(--colour-text);
+  }
+
+  .slot-status-muted {
     color: var(--colour-text-muted);
+  }
+
+  .button-row {
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .btn {
+    padding: var(--space-1-5) var(--space-3);
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 120ms ease;
+  }
+
+  .btn-secondary {
+    background: var(--button-bg);
+    color: var(--colour-text);
+    border-color: var(--button-border);
+  }
+
+  .btn-secondary:hover {
+    background: var(--button-bg-hover);
+  }
+
+  .btn-clear {
+    background: transparent;
+    color: var(--colour-error);
+    border-color: var(--colour-error);
+  }
+
+  .btn-clear:hover {
+    background: var(--colour-error-bg);
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .error-message {
+    font-size: var(--font-size-sm);
+    color: var(--colour-error);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 </style>


### PR DESCRIPTION
## **User description**
Closes #2444.

## Summary

Adds front/rear image thumbnails to the placement edit panel (`EditPanelImage.svelte`) with replace and clear affordances and an empty state. A placement can now override its device-type default image per face.

## Acceptance criteria

- [x] Front/rear image thumbnails render in the edit panel
- [x] Replace and clear controls per face
- [x] Empty state when no override is set; falls back to the device-type image

## Notes

- Save path preserved identically (`setDeviceImage` + `updateDevicePlacementImage` on set; `removeDeviceImage` + `updateDevicePlacementImage(..., undefined)` on clear).
- Fixes a previously-broken `--colour-bg-secondary` reference by using the defined `--colour-surface-secondary` token.
- Local gate green: prettier --check, eslint, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show placement image overrides with clear replace and remove actions**

### What Changed
- The edit panel now shows front and rear thumbnails for a placement image override.
- When no override is set, it shows the device type image or a clear empty state instead.
- Users can set, replace, or clear each face directly from the panel.
- Invalid image uploads now show an error message instead of failing silently.

### Impact
`✅ Clearer placement image management`
`✅ Fewer upload mistakes`
`✅ Easier override setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
