### PR TITLE
chore: reduce Remove-from-Rack button prominence in edit panel

### DIFF
--- a/src/lib/components/EditPanelActions.svelte
+++ b/src/lib/components/EditPanelActions.svelte
@@ -37,7 +37,7 @@
 <div class="actions">
   <button
     type="button"
-    class="btn-danger"
+    class="btn-remove"
     onclick={handleRemoveDevice}
     aria-label="Remove from rack"
   >
@@ -46,7 +46,7 @@
   {#if isSelectedDeviceCustom}
     <button
       type="button"
-      class="btn-danger btn-delete-type"
+      class="btn-delete-type"
       onclick={() => ondeletetype?.()}
       aria-label="Delete from library"
     >
@@ -58,13 +58,45 @@
 <style>
   .actions {
     margin-top: var(--space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
   }
 
-  .btn-danger {
+  /*
+    Remove from Rack affects a single placement, so it gets a quieter
+    ghost-danger treatment: destructive red is retained, but it no longer
+    dominates the panel's primary editing controls.
+  */
+  .btn-remove {
+    align-self: flex-start;
+    padding: var(--space-1-5) var(--space-3);
+    background: transparent;
+    border: 1px solid var(--colour-error);
+    border-radius: var(--radius-sm);
+    color: var(--colour-error);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast),
+      color var(--duration-fast);
+  }
+
+  .btn-remove:hover {
+    background: var(--colour-error-bg);
+  }
+
+  /*
+    Delete from Library removes the device type across every instance, a far
+    larger blast radius, so it keeps the loud full-width solid-danger styling
+    to read as the more serious action.
+  */
+  .btn-delete-type {
     width: 100%;
     padding: var(--space-3) var(--space-4);
     background: var(--colour-error);
-    border: none;
+    border: 1px solid var(--colour-error);
     border-radius: var(--radius-sm);
     color: var(--colour-text-inverse);
     font-size: var(--font-size-base);
@@ -73,11 +105,7 @@
     transition: background-color var(--duration-fast);
   }
 
-  .btn-danger:hover {
+  .btn-delete-type:hover {
     background: var(--colour-error-hover);
-  }
-
-  .btn-delete-type {
-    margin-top: var(--space-2);
   }
 </style>


### PR DESCRIPTION
## **User description**
## Summary

Reduces the visual prominence of the "Remove from Rack" control in the device edit panel so a destructive action is no longer the loudest element there, and differentiates it from the adjacent "Delete from Library" button whose blast radius is much larger.

- Remove from Rack: now a left-aligned ghost-danger button (transparent fill, red outline, smaller font/padding). Destructive red is retained but it no longer dominates the panel's primary editing controls. Remains discoverable and reachable; aria-label unchanged.
- Delete from Library: keeps the full-width solid-red treatment. Because it removes the device type across every instance, the louder styling now reads as the more serious action.
- The two destructive buttons are no longer identical full-width solid-red controls, making their differing scope legible.

Handlers, the `aria-label`s, and the confirm-dialog flow are unchanged. Spacing previously provided by `margin-top` is now handled by the `.actions` flex `gap`.

## Testing

- `npm run lint` - pass
- `npm run test:run` - 2805 tests pass (169 files)
- `npm run build` - pass
- `npm run format:check` - pass
- svelte-autofixer - no issues

Closes #2445

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make rack removal less prominent than library deletion**

### What Changed
- "Remove from Rack" now appears as a smaller outlined danger button instead of a full-width solid red button
- "Delete from Library" keeps the full-width solid red style, making it stand out as the more serious action
- The two actions are now stacked with consistent spacing, instead of relying on separate top margin spacing

### Impact
`✅ Clearer destructive action hierarchy`
`✅ Fewer accidental rack removals`
`✅ Easier-to-scan edit panel actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
