### PR TITLE
fix: default the edit-panel Device type details block to collapsed

### DIFF
--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -217,8 +217,9 @@ let compatibleOnly = $state(initialCompatibleOnly);
 let readOnly = $state(false);
 // Device type details disclosure in the edit panel: a single UI flag shared
 // across device selections (not per device), so toggling it stays sticky as the
-// user clicks between devices. Defaults to expanded. Session-scoped.
-let deviceTypeDetailsExpanded = $state(true);
+// user clicks between devices. Defaults to collapsed to keep the read-only type
+// facts out of the way of the editable fields. Session-scoped.
+let deviceTypeDetailsExpanded = $state(false);
 
 // Derived values (using $derived rune)
 const canZoomIn = $derived(zoom < ZOOM_MAX);
@@ -250,7 +251,7 @@ export function resetUIStore(): void {
   promptCleanupOnSave = loadPromptCleanupFromStorage();
   compatibleOnly = loadCompatibleOnlyFromStorage();
   readOnly = false;
-  deviceTypeDetailsExpanded = true;
+  deviceTypeDetailsExpanded = false;
   applyThemeToDocument(theme);
 }
 

--- a/src/tests/edit-panel-device-type-details-collapse.test.ts
+++ b/src/tests/edit-panel-device-type-details-collapse.test.ts
@@ -3,9 +3,9 @@
  * panel.
  *
  * The read-only type facts live behind a disclosure toggle. The block defaults
- * to expanded, and the collapsed state is a single UI flag shared across device
- * selections (not stored per device), so toggling it stays sticky as the user
- * clicks between devices.
+ * to collapsed (#2535), and the expanded state is a single UI flag shared across
+ * device selections (not stored per device), so toggling it stays sticky as the
+ * user clicks between devices.
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
@@ -55,37 +55,40 @@ describe("EditPanel Device type details collapse (#2443)", () => {
     return { layoutStore, selectionStore, rackId };
   }
 
-  it("defaults to expanded, showing the read-only facts", () => {
+  it("defaults to collapsed, hiding the read-only facts but showing the count", () => {
     setupSelectedDevice();
     renderEditTab();
 
-    expect(getDetailsToggle()).toHaveAttribute("aria-expanded", "true");
-    // A read-only fact label is visible when the block is expanded.
-    expect(screen.getByText("Brand")).toBeInTheDocument();
+    const toggle = getDetailsToggle();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    // The read-only facts are hidden while the block is collapsed.
+    expect(screen.queryByText("Brand")).not.toBeInTheDocument();
+    // The header surfaces the hidden-fact count, e.g. "Device type details (4)".
+    expect(toggle).toHaveAccessibleName(/device type details\s*\(\d+\)/i);
   });
 
-  it("toggling hides and shows the read-only facts", async () => {
+  it("toggling shows and hides the read-only facts", async () => {
     setupSelectedDevice();
     renderEditTab();
 
     const toggle = getDetailsToggle();
 
-    // Collapse: facts disappear and aria-expanded flips to false.
-    await fireEvent.click(toggle);
-    await waitFor(() => {
-      expect(toggle).toHaveAttribute("aria-expanded", "false");
-    });
-    expect(screen.queryByText("Brand")).not.toBeInTheDocument();
-
-    // Expand again: facts come back.
+    // Expand: facts appear and aria-expanded flips to true.
     await fireEvent.click(toggle);
     await waitFor(() => {
       expect(toggle).toHaveAttribute("aria-expanded", "true");
     });
     expect(screen.getByText("Brand")).toBeInTheDocument();
+
+    // Collapse again: facts disappear.
+    await fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+    });
+    expect(screen.queryByText("Brand")).not.toBeInTheDocument();
   });
 
-  it("keeps the collapsed state across device selections (single UI flag)", async () => {
+  it("keeps the expanded state across device selections (single UI flag)", async () => {
     const layoutStore = getLayoutStore();
     const selectionStore = getSelectionStore();
 
@@ -104,18 +107,18 @@ describe("EditPanel Device type details collapse (#2443)", () => {
     selectionStore.selectDevice(rackId, deviceA.id);
     renderEditTab();
 
-    // Collapse while device A is selected.
+    // Expand while device A is selected (default is collapsed).
     await fireEvent.click(getDetailsToggle());
     await waitFor(() => {
-      expect(getDetailsToggle()).toHaveAttribute("aria-expanded", "false");
+      expect(getDetailsToggle()).toHaveAttribute("aria-expanded", "true");
     });
 
-    // Switch to device B: the block stays collapsed (sticky single flag).
+    // Switch to device B: the block stays expanded (sticky single flag).
     selectionStore.selectDevice(rackId, deviceB.id);
     await waitFor(() => {
       expect(selectionStore.selectedDeviceId).toBe(deviceB.id);
     });
-    expect(getDetailsToggle()).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("Brand")).not.toBeInTheDocument();
+    expect(getDetailsToggle()).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Brand")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

The collapsible "Device type details" block in the device edit panel (shipped in #2443) defaulted to expanded, re-cluttering the panel with read-only type facts (Type, Brand, Height, Category, power, device-type notes) and pushing the editable Placement, Network, and Notes sections below the fold. This defaults the single session-scoped `deviceTypeDetailsExpanded` flag in `ui.svelte.ts` to `false` (collapsed).

## Changes

- `src/lib/stores/ui.svelte.ts`: `deviceTypeDetailsExpanded` defaults to `false`; `resetUIStore` resets it to `false`.
- `src/tests/edit-panel-device-type-details-collapse.test.ts`: inverted assertions to cover the new behaviour: defaults to collapsed (facts hidden, count surfaced in the header via the accessible name), expanding reveals the facts, and the choice persists across device selections.

## Acceptance Criteria

- [x] The "Device type details" block defaults to collapsed on first load
- [x] The header shows the hidden-fact count when collapsed
- [x] The expanded / collapsed choice still persists across device selections

Closes #2535

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Default the device type details panel to collapsed**

### What Changed
- The “Device type details” section in the device edit panel now opens collapsed instead of expanded
- The section header still shows how many read-only details are hidden while collapsed
- Expanding or collapsing the section still stays the same when switching between devices

### Impact
`✅ Less clutter in the edit panel`
`✅ Faster access to editable fields`
`✅ Fewer accidental scrolls past read-only details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
