### PR TITLE
chore: drop redundant Device heading from edit panel

### DIFF
--- a/src/lib/components/SidePanelContent.svelte
+++ b/src/lib/components/SidePanelContent.svelte
@@ -121,14 +121,16 @@
     selectedRack !== null || selectedDeviceInfo !== null,
   );
 
-  // Contextual heading naming the current selection kind. The branches mirror the
-  // tabpanel's render order (rack/group first, then device) so the heading never
-  // diverges from the body. A bayed rack group is the multi-rack selection the
-  // model supports; it reads as "Bayed Rack". With nothing selected the heading
+  // Contextual heading naming the current selection kind. A rack heading carries
+  // signal the Name field does not: "Rack" vs "Bayed Rack" tells you the selection
+  // kind, and a bayed group's Name field shows the group name rather than the fact
+  // that it is a multi-rack group. A device heading would be redundant (the Identity
+  // group's Name field already names the device, inside a tab labelled "Edit"), so a
+  // device selection renders no heading (#2525). With nothing selected the heading
   // stays the neutral tab name and the empty state shows.
   const editHeadingLabel = $derived.by(() => {
     if (selectedRack) return selectedGroup ? "Bayed Rack" : "Rack";
-    if (selectedDeviceInfo) return "Device";
+    if (selectedDeviceInfo) return null;
     return "Edit";
   });
 
@@ -216,13 +218,20 @@
     class="side-panel-tabpanel"
     data-testid="side-panel-panel-edit"
   >
-    <h2 id={editHeadingId} class="side-panel-heading" tabindex="-1">
-      {editHeadingLabel}
-    </h2>
+    <!-- A device selection renders no heading (#2525): the Identity group's Name
+         field already names the device, inside a tab labelled "Edit". The Edit
+         panel still needs a programmatic focus target for expand/tab-switch focus
+         management (#2076); in the device case the editHeadingId moves to the
+         device-view container, which only renders when no heading is present. -->
+    {#if editHeadingLabel}
+      <h2 id={editHeadingId} class="side-panel-heading" tabindex="-1">
+        {editHeadingLabel}
+      </h2>
+    {/if}
     {#if selectedRack}
       <EditPanelRack {selectedRack} {selectedGroup} />
     {:else if selectedDeviceInfo}
-      <div class="device-view">
+      <div id={editHeadingId} class="device-view" tabindex="-1">
         <EditPanelMetadata {selectedDeviceInfo} />
         <EditPanelPosition {selectedDeviceInfo} />
         <EditPanelImage {selectedDeviceInfo} />
@@ -370,6 +379,19 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-4);
+  }
+
+  /* When a device is selected the heading is dropped (#2525) and this container
+     becomes the Edit tab's programmatic focus target. Mirror the heading's focus
+     treatment: no ring for programmatic focus, a visible ring for keyboard. */
+  .device-view:focus {
+    outline: none;
+  }
+
+  .device-view:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
   }
 
   .side-panel-empty {

--- a/src/tests/side-panel-edit-context.test.ts
+++ b/src/tests/side-panel-edit-context.test.ts
@@ -111,7 +111,7 @@ describe("Edit tab contextual properties (#2077)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("names a selected device and shows its device properties", () => {
+  it("shows device properties without a redundant Device heading (#2525)", () => {
     const layoutStore = getLayoutStore();
     const selectionStore = getSelectionStore();
 
@@ -129,9 +129,15 @@ describe("Edit tab contextual properties (#2077)", () => {
 
     renderEditTab();
 
+    // No "Device" heading: the Identity group's Name field already names the
+    // device, inside a tab labelled "Edit" (#2525). The "Edit" empty-state
+    // heading must also be absent, since a device is selected.
     expect(
-      screen.getByRole("heading", { name: /^device$/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: /^device$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /^edit$/i }),
+    ).not.toBeInTheDocument();
     // The device name editor proves the device body rendered.
     expect(
       screen.getByRole("button", { name: /edit display name/i }),


### PR DESCRIPTION
## **User description**
## Summary

For a device selection the "Device" heading in the edit panel is redundant: the Identity group's Name field already names the device, inside a tab labelled "Edit". This drops it for the device case so the Identity group becomes the first visible content with correct top spacing.

The rack / bayed-rack heading is kept unchanged, because "Rack" vs "Bayed Rack" conveys the selection kind that the Name field does not (a bayed group's Name field shows the group name, not the fact that it is a multi-rack group).

## Focus management

The heading carried `id={editHeadingId}` + `tabindex="-1"` and was the Edit tab's programmatic focus target for expand / tab-switch focus management (#2076). In the device case those move to the `.device-view` container, with the same `:focus` / `:focus-visible` treatment, so keyboard and expand focus still land on a valid element. `SidePanel.svelte` resolves the target by id, so no host change is needed.

## AC coverage

- Device heading removed for a device selection; Identity group is now first content.
- Rack / bayed-rack heading kept.
- Empty-state ("Edit") and View-tab headings unaffected.
- Focus target preserved for the device case.

## Tests

Updated `side-panel-edit-context.test.ts`: the device case now asserts no "Device" (and no "Edit") heading is present while the device body still renders. Full suite (2805 tests), lint, build, and format:check all pass locally.

Closes #2525

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Remove the redundant Device heading from the Edit panel**

### What Changed
- Device selections no longer show a separate “Device” heading in the Edit panel; the device details start immediately with the Identity section
- The empty “Edit” heading no longer appears when a device is selected
- Rack and bayed rack selections still show their headings, since they communicate the selection type
- Keyboard and focus behavior stays intact when the Device heading is removed

### Impact
`✅ Cleaner device edit screens`
`✅ Less repeated labeling in the Edit panel`
`✅ Preserved keyboard focus on device details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
