### PR TITLE
feat: show Depth and Width in edit-panel device-type details (#2536)

### DIFF
--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -35,11 +35,12 @@
   const uiStore = getUIStore();
 
   // Count of device type facts shown in the collapsible block, so the header can
-  // report how many are hidden when collapsed. Type, Brand, Height and Category
-  // always show; outlet count, VA rating and device-type notes are conditional.
+  // report how many are hidden when collapsed. Type, Brand, Height, Depth, Width
+  // and Category always show; outlet count, VA rating and device-type notes are
+  // conditional.
   const deviceTypeFactCount = $derived.by(() => {
     const device = selectedDeviceInfo.device;
-    let count = 4; // Type, Brand, Height, Category
+    let count = 6; // Type, Brand, Height, Depth, Width, Category
     if (device.category === "power" && device.outlet_count) count += 1;
     if (device.category === "power" && device.va_rating) count += 1;
     if (device.notes) count += 1;
@@ -98,6 +99,25 @@
   // is_full_depth undefined or true means full-depth.
   const isFullDepthDevice = $derived(
     authoritativeDevice.is_full_depth !== false,
+  );
+
+  // Read-only depth fact label. Resolves against the authoritative library value
+  // first, falling back to the layout copy. is_full_depth undefined or true means
+  // full-depth; false means half-depth.
+  const depthLabel = $derived(
+    (authoritativeDevice.is_full_depth ??
+      selectedDeviceInfo.device.is_full_depth) === false
+      ? "Half"
+      : "Full",
+  );
+
+  // Read-only width fact label. slot_width 2 (or undefined) means full-width;
+  // 1 means half-width.
+  const widthLabel = $derived(
+    (authoritativeDevice.slot_width ?? selectedDeviceInfo.device.slot_width) ===
+      1
+      ? "Half"
+      : "Full",
   );
 
   // Resolved colour shown by the swatch button: placement override wins over the
@@ -369,6 +389,14 @@
       <div class="fact-row">
         <span class="fact-label">Height</span>
         <span class="fact-value">{selectedDeviceInfo.device.u_height}U</span>
+      </div>
+      <div class="fact-row">
+        <span class="fact-label">Depth</span>
+        <span class="fact-value">{depthLabel}</span>
+      </div>
+      <div class="fact-row">
+        <span class="fact-label">Width</span>
+        <span class="fact-value">{widthLabel}</span>
       </div>
       <div class="fact-row">
         <span class="fact-label">Category</span>


### PR DESCRIPTION
## **User description**
Closes #2536.

## Summary

Adds two read-only facts to the "Device type details" group in `EditPanelMetadata.svelte`: Depth and Width, grouped next to Height since all three are physical dimensions.

- Depth resolves from `is_full_depth` (undefined/true = Full, false = Half).
- Width resolves from `slot_width` (2/undefined = Full, 1 = Half).
- Both use the file's existing authoritative-device fallback pattern.
- Labels are plain Full / Half (maintainer-decided; no inch units).
- Base fact count bumped 4 to 6 so the collapsed badge stays accurate.

## Acceptance criteria

- [x] Depth fact shows Full / Half
- [x] Width fact shows Full / Half
- [x] Both styled like existing Type/Brand/Height/Category rows in the read-only group
- [x] Brand remains shown
- [x] Collapse count badge accurate (existing collapse test passes, 3/3)

## Notes

No schema change. Read-only display wiring; no new unit tests per the project TDD policy. Local gate green: format:check, lint, collapse test, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Show depth and width in device type details

### What Changed
- Added read-only Depth and Width rows to the device type details panel, alongside Height
- Depth now shows Full or Half based on the device’s depth setting
- Width now shows Full or Half based on the device’s width setting
- The collapsed fact count now includes the two new rows, so the hidden-items badge stays accurate

### Impact
`✅ Clearer device specs`
`✅ Fewer missing details in the edit panel`
`✅ Accurate collapsed fact counts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
