### PR TITLE
feat: show device-type tags as chips in edit-panel device-type details (#2538)

### DIFF
--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -2,7 +2,7 @@
   EditPanelMetadata Component
   Edit panel section: descriptive properties for the selected device, grouped
   by meaning. Identity (name, colour), Device type details (read-only facts:
-  type, brand, height, category, power ratings, device-type notes), Placement
+  type, brand, height, category, power ratings, tags, device-type notes), Placement
   (mounted face), Network (IP/hostname), and Notes (placement notes).
 -->
 <script lang="ts">
@@ -36,13 +36,14 @@
 
   // Count of device type facts shown in the collapsible block, so the header can
   // report how many are hidden when collapsed. Type, Brand, Height, Depth, Width
-  // and Category always show; outlet count, VA rating and device-type notes are
-  // conditional.
+  // and Category always show; outlet count, VA rating, tags and device-type notes
+  // are conditional.
   const deviceTypeFactCount = $derived.by(() => {
     const device = selectedDeviceInfo.device;
     let count = 6; // Type, Brand, Height, Depth, Width, Category
     if (device.category === "power" && device.outlet_count) count += 1;
     if (device.category === "power" && device.va_rating) count += 1;
+    if (deviceTags.length > 0) count += 1;
     if (device.notes) count += 1;
     return count;
   });
@@ -53,6 +54,12 @@
   // resolve against the current library value.
   const authoritativeDevice = $derived(
     findDeviceType(selectedDeviceInfo.device.slug) ?? selectedDeviceInfo.device,
+  );
+
+  // Read-only tag chips. Resolves against the authoritative library value first,
+  // falling back to the layout copy, mirroring Brand/Depth/Width.
+  const deviceTags = $derived(
+    authoritativeDevice.tags ?? selectedDeviceInfo.device.tags ?? [],
   );
 
   // State for device name editing. editingDeviceId pins the edit to the device
@@ -418,6 +425,16 @@
           <span class="fact-value">{selectedDeviceInfo.device.va_rating}</span>
         </div>
       {/if}
+      {#if deviceTags.length > 0}
+        <div class="fact-tags">
+          <span class="fact-label">Tags</span>
+          <div class="tag-chips">
+            {#each deviceTags as tag, i (i)}
+              <span class="tag-chip">{tag}</span>
+            {/each}
+          </div>
+        </div>
+      {/if}
       {#if selectedDeviceInfo.device.notes}
         <div class="fact-notes">
           <span class="fact-label">Device type notes</span>
@@ -697,6 +714,29 @@
     margin: 0;
     white-space: pre-wrap;
     line-height: 1.5;
+  }
+
+  /* Read-only tag chips. Matches DeviceFilterPopover's quiet chip styling
+     (rounded, muted, bordered) but non-interactive to fit the read-only group. */
+  .fact-tags {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .tag-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1-5);
+  }
+
+  .tag-chip {
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--font-size-sm);
+    color: var(--colour-text-muted);
+    background: transparent;
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-full);
   }
 
   /* Colour swatch button: a real interactive control with form-control

--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -34,20 +34,6 @@
   const toastStore = getToastStore();
   const uiStore = getUIStore();
 
-  // Count of device type facts shown in the collapsible block, so the header can
-  // report how many are hidden when collapsed. Type, Brand, Height, Depth, Width
-  // and Category always show; outlet count, VA rating, tags and device-type notes
-  // are conditional.
-  const deviceTypeFactCount = $derived.by(() => {
-    const device = selectedDeviceInfo.device;
-    let count = 6; // Type, Brand, Height, Depth, Width, Category
-    if (device.category === "power" && device.outlet_count) count += 1;
-    if (device.category === "power" && device.va_rating) count += 1;
-    if (deviceTags.length > 0) count += 1;
-    if (device.notes) count += 1;
-    return count;
-  });
-
   // Authoritative device definition from the starter/brand library, falling back
   // to the layout copy. The layout copy can be stale (e.g. a device placed before
   // its library definition gained a manufacturer), so brand and full-depth display
@@ -61,6 +47,20 @@
   const deviceTags = $derived(
     authoritativeDevice.tags ?? selectedDeviceInfo.device.tags ?? [],
   );
+
+  // Count of device type facts shown in the collapsible block, so the header can
+  // report how many are hidden when collapsed. Type, Brand, Height, Depth, Width
+  // and Category always show; outlet count, VA rating, tags and device-type notes
+  // are conditional.
+  const deviceTypeFactCount = $derived.by(() => {
+    const device = selectedDeviceInfo.device;
+    let count = 6; // Type, Brand, Height, Depth, Width, Category
+    if (device.category === "power" && device.outlet_count) count += 1;
+    if (device.category === "power" && device.va_rating) count += 1;
+    if (deviceTags.length > 0) count += 1;
+    if (device.notes) count += 1;
+    return count;
+  });
 
   // State for device name editing. editingDeviceId pins the edit to the device
   // it started on; the editor is only open while the current selection still


### PR DESCRIPTION
## **User description**
Closes #2538.

## Summary

Surfaces the optional device-type `tags?: string[]` field as quiet, read-only chips in the collapsible "Device type details" group of the edit panel, below the existing facts (after Category / the conditional power rows). Tags resolve against the authoritative library copy first, falling back to the layout copy, matching the existing Brand/Depth/Width pattern. Chip styling mirrors the muted filter chips in `DeviceFilterPopover` for consistency; no new dependency.

## Acceptance criteria

- [x] Device-type tags render as small chips in the "Device type details" group when present, below the existing facts. Source: authoritative-device fallback then `selectedDeviceInfo.device.tags`.
- [x] The tags row is omitted entirely when the type has no tags (guarded with `{#if deviceTags.length > 0}`): no empty label, no empty container.
- [x] Consistent styling with the existing read-only facts and the project's existing chip styling (matches `DeviceFilterPopover`), kept visually quiet and non-interactive. No new dependency.
- [x] No schema change (the `tags` field already exists).

## Fact count

`deviceTypeFactCount` now counts tags as a single conditional fact (`+ (deviceTags.length > 0 ? 1 : 0)`), matching how outlets/VA are counted, so the collapsed count badge stays accurate.

## Tests

The existing `edit-panel-device-type-details-collapse.test.ts` passes unchanged (the fixture has no tags, so the count stays 6 and the `\(\d+\)` regex still matches). No new low-value unit tests added, per the project TDD policy for read-only display wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show device-type tags as read-only chips in the edit panel**

### What Changed
- Device type tags now appear in the “Device type details” section as muted, read-only chips.
- The tags row is hidden completely when a device type has no tags.
- The collapsed fact count now includes tags, so the section badge stays accurate.
- Tags are shown using the current library value first, with a fallback to the layout copy.

### Impact
`✅ Clearer device details`
`✅ Accurate collapsed section counts`
`✅ Fewer empty fields in the edit panel`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
