### PR TITLE
fix: server-side magic-byte sniff on asset writes, reject SVG/polyglot (#2528)

### DIFF
--- a/api/src/routes/assets.test.ts
+++ b/api/src/routes/assets.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Asset PUT route tests (#2528)
+ *
+ * Proves the full request chain: the declared Content-Type passes the route's
+ * allowlist check, then saveAsset's magic-byte sniff is the authority. A body
+ * that does not sniff to the declared raster type is rejected at the route with
+ * a 400 (not a 500), and nothing is written.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp } from "../app";
+import type { EnvMap } from "../security";
+
+type App = Awaited<ReturnType<typeof createApp>>;
+
+const LAYOUT_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const DEVICE_SLUG = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+const originalDataDir = process.env.DATA_DIR;
+let testDir: string;
+let app: App;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "rackula-assets-route-test-"));
+  process.env.DATA_DIR = testDir;
+  app = await createApp({
+    NODE_ENV: "test",
+    DATA_DIR: testDir,
+    RACKULA_RATE_LIMIT_ENABLED: "false",
+  } satisfies EnvMap);
+
+  // Create the layout so the assets dir can resolve on accept-path tests.
+  const yamlBody = `version: "1.0.0"\nname: Test\nmetadata:\n  id: "${LAYOUT_UUID}"\n  name: "Test"\n  schema_version: "1.0.0"\nracks: []`;
+  const res = await app.request(`/layouts/${LAYOUT_UUID}`, {
+    method: "PUT",
+    headers: { "Content-Type": "text/yaml" },
+    body: yamlBody,
+  });
+  expect(res.status).toBe(201);
+});
+
+afterEach(async () => {
+  if (originalDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = originalDataDir;
+  }
+  try {
+    await rm(testDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup failures
+  }
+});
+
+async function putAsset(
+  body: ArrayBuffer,
+  contentType: string,
+): Promise<Response> {
+  return app.request(`/assets/${LAYOUT_UUID}/${DEVICE_SLUG}/front`, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body,
+  });
+}
+
+async function assetFileCount(): Promise<number> {
+  const assetsDir = join(testDir);
+  let count = 0;
+  // The layout folder is `{slug}-{uuid}`; find it then walk assets/.
+  const folders = await readdir(assetsDir);
+  const layoutFolder = folders.find((f) => f.endsWith(LAYOUT_UUID));
+  if (!layoutFolder) return 0;
+  try {
+    const devices = await readdir(join(assetsDir, layoutFolder, "assets"));
+    for (const device of devices) {
+      try {
+        const files = await readdir(
+          join(assetsDir, layoutFolder, "assets", device),
+        );
+        count += files.length;
+      } catch {
+        // not a directory
+      }
+    }
+  } catch {
+    // no assets dir
+  }
+  return count;
+}
+
+function pngBytes(): ArrayBuffer {
+  return Uint8Array.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+  ]).buffer;
+}
+
+describe("PUT /assets sniff enforcement", () => {
+  it("accepts a real PNG declared as image/png (200)", async () => {
+    const res = await putAsset(pngBytes(), "image/png");
+    expect(res.status).toBe(200);
+    expect(await assetFileCount()).toBe(1);
+  });
+
+  it("rejects an <svg onload=...> body declared as image/png with 400 and writes nothing", async () => {
+    const svg = new TextEncoder().encode('<svg onload="alert(1)">')
+      .buffer as ArrayBuffer;
+    const res = await putAsset(svg, "image/png");
+    expect(res.status).toBe(400);
+    expect(await assetFileCount()).toBe(0);
+  });
+
+  it("rejects a PNG body declared as image/jpeg (sniff/header mismatch) with 400", async () => {
+    const res = await putAsset(pngBytes(), "image/jpeg");
+    expect(res.status).toBe(400);
+    expect(await assetFileCount()).toBe(0);
+  });
+
+  it("rejects a content type outside the allowlist (image/gif) with 400", async () => {
+    const gif = Uint8Array.from([0x47, 0x49, 0x46, 0x38]).buffer;
+    const res = await putAsset(gif, "image/gif");
+    expect(res.status).toBe(400);
+    expect(await assetFileCount()).toBe(0);
+  });
+});

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -20,6 +20,7 @@ import {
   deleteAsset,
   isValidImageType,
   isValidDeviceSlug,
+  AssetRejectedError,
   MAX_SIZE,
 } from "../storage/assets";
 import { logger } from "../logger";
@@ -117,6 +118,15 @@ assets.put("/:layoutId/:deviceSlug/:face", async (c) => {
 
     if (error instanceof Error && error.message.includes("too large")) {
       return c.json({ error: error.message }, 413);
+    }
+
+    // saveAsset throws AssetRejectedError when the bytes fail the magic-byte
+    // sniff (SVG/GIF/polyglot or a body that disagrees with the declared
+    // Content-Type). That is a bad request, not a server fault, so surface it
+    // as a 400. The message is a fixed category string that interpolates only
+    // server-validated allowlist values, so it is safe to return.
+    if (error instanceof AssetRejectedError) {
+      return c.json({ error: error.message }, 400);
     }
 
     return c.json({ error: "Failed to save asset" }, 500);

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -114,8 +114,10 @@ assets.put("/:layoutId/:deviceSlug/:face", async (c) => {
 
     return c.json({ message: "Asset uploaded" }, 200);
   } catch (error) {
-    logger.error({ err: error }, `Failed to save asset`);
-
+    // Client errors (oversized body, rejected bytes) are expected bad uploads,
+    // not server faults, so they return a 4xx without logging at error level.
+    // Logging them would make routine bad uploads look like server failures in
+    // logs and alerts.
     if (error instanceof Error && error.message.includes("too large")) {
       return c.json({ error: error.message }, 413);
     }
@@ -129,6 +131,8 @@ assets.put("/:layoutId/:deviceSlug/:face", async (c) => {
       return c.json({ error: error.message }, 400);
     }
 
+    // Anything reaching here is an unexpected server fault: log it.
+    logger.error({ err: error }, `Failed to save asset`);
     return c.json({ error: "Failed to save asset" }, 500);
   }
 });

--- a/api/src/storage/assets.test.ts
+++ b/api/src/storage/assets.test.ts
@@ -258,6 +258,18 @@ describe("saveAsset rejects content the bytes do not vouch for", () => {
     ).rejects.toThrow();
     expect(await countAssetFiles()).toBe(0);
   });
+
+  it("rejects a truncated PNG that lacks the full 8-byte signature", async () => {
+    // Only the first 4 PNG bytes (89 50 4E 47) without the 0D 0A 1A 0A
+    // continuation. The full signature is required, so this sniffs to null.
+    const partialPng = Uint8Array.from([
+      0x89, 0x50, 0x4e, 0x47, 0x00, 0x01,
+    ]).buffer;
+    await expect(
+      saveAsset(LAYOUT_UUID, DEVICE_SLUG, "front", partialPng, "image/png"),
+    ).rejects.toThrow(AssetRejectedError);
+    expect(await countAssetFiles()).toBe(0);
+  });
 });
 
 // ============================================================================

--- a/api/src/storage/assets.test.ts
+++ b/api/src/storage/assets.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Asset storage layer tests
+ *
+ * Focus: the server-side magic-byte sniff inside saveAsset (#2528). The byte
+ * sniff is the security authority for the asset write path: the declared
+ * Content-Type is advisory and the on-disk extension is derived from the
+ * sniffed type, never the header. SVG/GIF/polyglot/mismatch are rejected with
+ * nothing written.
+ */
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtemp, mkdir, rm, readdir, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Override DATA_DIR before importing storage modules (same pattern as filesystem.test.ts)
+const testDir = await mkdtemp(join(tmpdir(), "rackula-assets-test-"));
+process.env.DATA_DIR = testDir;
+
+const { saveAsset, getAsset, MAX_SIZE, AssetRejectedError } =
+  await import("./assets");
+
+// ============================================================================
+// Test fixtures: real magic-byte headers
+// ============================================================================
+
+/** PNG signature: 89 50 4E 47 0D 0A 1A 0A, then a tiny body. */
+function pngBytes(): ArrayBuffer {
+  return Uint8Array.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+  ]).buffer;
+}
+
+/** JPEG signature: FF D8 FF, then a tiny body. */
+function jpegBytes(): ArrayBuffer {
+  return Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46])
+    .buffer;
+}
+
+/** WebP: "RIFF" at 0-3, size, "WEBP" at 8-11, then a tiny body. */
+function webpBytes(): ArrayBuffer {
+  return Uint8Array.from([
+    0x52,
+    0x49,
+    0x46,
+    0x46, // RIFF
+    0x1a,
+    0x00,
+    0x00,
+    0x00, // chunk size (arbitrary)
+    0x57,
+    0x45,
+    0x42,
+    0x50, // WEBP
+    0x56,
+    0x50,
+    0x38,
+    0x20, // VP8 chunk header
+  ]).buffer;
+}
+
+/** GIF signature: 47 49 46 38 ("GIF8"). Not in the raster allowlist. */
+function gifBytes(): ArrayBuffer {
+  return Uint8Array.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00])
+    .buffer;
+}
+
+/** Plain SVG markup. Starts with "<", sniffs to null. */
+function svgBytes(): ArrayBuffer {
+  return new TextEncoder().encode(
+    '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>',
+  ).buffer as ArrayBuffer;
+}
+
+/** Stored-XSS payload: an SVG event handler. Sniffs to null. */
+function svgOnloadBytes(): ArrayBuffer {
+  return new TextEncoder().encode('<svg onload="alert(document.domain)">')
+    .buffer as ArrayBuffer;
+}
+
+/** HTML/JS polyglot served as image/png. Sniffs to null (no PNG header). */
+function htmlPolyglotBytes(): ArrayBuffer {
+  return new TextEncoder().encode("<!doctype html><script>alert(1)</script>")
+    .buffer as ArrayBuffer;
+}
+
+// ============================================================================
+// Test layout setup
+// ============================================================================
+
+const LAYOUT_UUID = "11111111-2222-4333-8444-555555555555";
+const DEVICE_SLUG = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+/**
+ * Create a layout folder so getLayoutAssetsDir resolves. The asset layer
+ * resolves the assets dir by scanning for a `{slug}-{uuid}` folder, so a
+ * directory is all that is needed; the YAML body is irrelevant here.
+ */
+async function createLayoutFolder(): Promise<void> {
+  await mkdir(join(testDir, `test-layout-${LAYOUT_UUID}`), { recursive: true });
+}
+
+async function cleanupTestDir(): Promise<void> {
+  const files = await readdir(testDir);
+  for (const file of files) {
+    await rm(join(testDir, file), { recursive: true, force: true });
+  }
+}
+
+/** Count files written under the layout's assets dir (across all faces/devices). */
+async function countAssetFiles(): Promise<number> {
+  const assetsDir = join(testDir, `test-layout-${LAYOUT_UUID}`, "assets");
+  let count = 0;
+  try {
+    const devices = await readdir(assetsDir);
+    for (const device of devices) {
+      try {
+        const files = await readdir(join(assetsDir, device));
+        count += files.length;
+      } catch {
+        // not a directory
+      }
+    }
+  } catch {
+    // assets dir never created
+  }
+  return count;
+}
+
+beforeEach(async () => {
+  await cleanupTestDir();
+  await createLayoutFolder();
+});
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+// ============================================================================
+// Accept: real raster formats whose bytes match the declared type
+// ============================================================================
+
+describe("saveAsset accepts raster images that sniff to the declared type", () => {
+  it("writes a PNG with a .png extension", async () => {
+    await saveAsset(LAYOUT_UUID, DEVICE_SLUG, "front", pngBytes(), "image/png");
+
+    const asset = await getAsset(LAYOUT_UUID, DEVICE_SLUG, "front");
+    expect(asset).not.toBeNull();
+    expect(asset?.contentType).toBe("image/png");
+  });
+
+  it("writes a JPEG with a .jpg extension", async () => {
+    await saveAsset(
+      LAYOUT_UUID,
+      DEVICE_SLUG,
+      "front",
+      jpegBytes(),
+      "image/jpeg",
+    );
+
+    const asset = await getAsset(LAYOUT_UUID, DEVICE_SLUG, "front");
+    expect(asset?.contentType).toBe("image/jpeg");
+  });
+
+  it("writes a WebP with a .webp extension", async () => {
+    await saveAsset(
+      LAYOUT_UUID,
+      DEVICE_SLUG,
+      "front",
+      webpBytes(),
+      "image/webp",
+    );
+
+    const asset = await getAsset(LAYOUT_UUID, DEVICE_SLUG, "front");
+    expect(asset?.contentType).toBe("image/webp");
+  });
+});
+
+// ============================================================================
+// Extension is derived from the sniffed type, never the declared header
+// ============================================================================
+
+describe("on-disk extension comes from the sniffed bytes", () => {
+  it("stores PNG bytes as front.png even when nothing else is on disk", async () => {
+    await saveAsset(LAYOUT_UUID, DEVICE_SLUG, "front", pngBytes(), "image/png");
+
+    const deviceDir = join(
+      testDir,
+      `test-layout-${LAYOUT_UUID}`,
+      "assets",
+      DEVICE_SLUG,
+    );
+    const files = await readdir(deviceDir);
+    expect(files).toContain("front.png");
+  });
+});
+
+// ============================================================================
+// Reject: non-raster, disallowed, mismatched, and polyglot content
+// ============================================================================
+
+describe("saveAsset rejects content the bytes do not vouch for", () => {
+  it("rejects GIF (recognised header, not in the raster allowlist) and writes nothing", async () => {
+    // GIF declared as PNG: declared type passes the allowlist, bytes sniff to
+    // null, so the write must be rejected.
+    await expect(
+      saveAsset(LAYOUT_UUID, DEVICE_SLUG, "front", gifBytes(), "image/png"),
+    ).rejects.toThrow(AssetRejectedError);
+    expect(await countAssetFiles()).toBe(0);
+  });
+
+  it("rejects plain SVG markup declared as image/png and writes nothing", async () => {
+    await expect(
+      saveAsset(LAYOUT_UUID, DEVICE_SLUG, "front", svgBytes(), "image/png"),
+    ).rejects.toThrow(AssetRejectedError);
+    expect(await countAssetFiles()).toBe(0);
+  });
+
+  it("rejects a stored-XSS <svg onload=...> payload declared as image/png", async () => {
+    await expect(
+      saveAsset(
+        LAYOUT_UUID,
+        DEVICE_SLUG,
+        "front",
+        svgOnloadBytes(),
+        "image/png",
+      ),
+    ).rejects.toThrow(AssetRejectedError);
+    expect(await countAssetFiles()).toBe(0);
+  });
+
+  it("rejects an HTML/JS polyglot declared as image/png", async () => {
+    await expect(
+      saveAsset(
+        LAYOUT_UUID,
+        DEVICE_SLUG,
+        "front",
+        htmlPolyglotBytes(),
+        "image/png",
+      ),
+    ).rejects.toThrow(AssetRejectedError);
+    expect(await countAssetFiles()).toBe(0);
+  });
+
+  it("rejects a PNG body declared as image/jpeg (sniff disagrees with header)", async () => {
+    await expect(
+      saveAsset(LAYOUT_UUID, DEVICE_SLUG, "front", pngBytes(), "image/jpeg"),
+    ).rejects.toThrow(AssetRejectedError);
+    expect(await countAssetFiles()).toBe(0);
+  });
+
+  it("rejects a declared content type outside the allowlist (image/gif)", async () => {
+    // A disallowed declared type is caught by the content-type allowlist guard
+    // at the top of saveAsset (and at the route) BEFORE the sniff runs, so this
+    // throws a plain Error, not an AssetRejectedError. Either way nothing is
+    // written.
+    await expect(
+      saveAsset(LAYOUT_UUID, DEVICE_SLUG, "front", gifBytes(), "image/gif"),
+    ).rejects.toThrow();
+    expect(await countAssetFiles()).toBe(0);
+  });
+});
+
+// ============================================================================
+// Size behaviour unchanged: 5MB cap still enforced by saveAsset
+// ============================================================================
+
+describe("size cap is unchanged", () => {
+  it("rejects bytes over MAX_SIZE even with a valid PNG header", async () => {
+    const oversized = new Uint8Array(MAX_SIZE + 1);
+    oversized.set([0x89, 0x50, 0x4e, 0x47]); // PNG header
+    await expect(
+      saveAsset(
+        LAYOUT_UUID,
+        DEVICE_SLUG,
+        "front",
+        oversized.buffer,
+        "image/png",
+      ),
+    ).rejects.toThrow(/too large/);
+    expect(await countAssetFiles()).toBe(0);
+  });
+
+  it("does not write a file when an oversized image is rejected", async () => {
+    const oversized = new Uint8Array(MAX_SIZE + 1);
+    oversized.set([0x89, 0x50, 0x4e, 0x47]);
+    await saveAsset(
+      LAYOUT_UUID,
+      DEVICE_SLUG,
+      "front",
+      oversized.buffer,
+      "image/png",
+    ).catch(() => {});
+    const deviceDir = join(
+      testDir,
+      `test-layout-${LAYOUT_UUID}`,
+      "assets",
+      DEVICE_SLUG,
+    );
+    await expect(readFile(join(deviceDir, "front.png"))).rejects.toThrow();
+  });
+});

--- a/api/src/storage/assets.ts
+++ b/api/src/storage/assets.ts
@@ -25,6 +25,75 @@ const ALLOWED_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
 const ALLOWED_EXTS = new Set(["png", "jpg", "webp"]);
 export const MAX_SIZE = 5 * 1024 * 1024; // 5MB
 
+/**
+ * Detect an image MIME type purely from leading magic bytes.
+ *
+ * Recognises PNG, JPEG, and WebP. Returns null for anything unrecognised
+ * (including GIF, SVG, and text/HTML starting with "<"), so the asset write
+ * path can reject untrusted or disallowed content without trusting the
+ * declared Content-Type. SVG is excluded by construction (it has no raster
+ * magic bytes), which keeps stored-XSS payloads off the app origin.
+ *
+ * ALLOWLIST PARITY: this is an independent copy of the client detector
+ * `detectImageMime` in `src/lib/utils/image-encoding.ts` (the Bun API cannot
+ * import the Svelte bundle). The two must accept the same formats; if you
+ * change one, change the other. The client pre-check is advisory; this server
+ * copy is the authority for what lands on disk.
+ */
+function detectImageMime(bytes: Uint8Array): string | null {
+  // PNG: 89 50 4E 47
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+
+  // JPEG: FF D8 FF
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+
+  // WebP: "RIFF" at 0-3 and "WEBP" at 8-11
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+
+  return null;
+}
+
+/**
+ * Thrown by saveAsset when a write is rejected because the bytes fail the
+ * magic-byte sniff (non-raster, SVG/GIF/polyglot) or sniff to a type that
+ * disagrees with the declared Content-Type. This is a client error (the upload
+ * is bad), so the route maps it to a 400. A typed error keeps that mapping
+ * robust against message rewording (a plain Error would fall through to a 500).
+ */
+export class AssetRejectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AssetRejectedError";
+  }
+}
+
 // Schema for device slug validation
 // Prevents path traversal attacks
 // Note: Device slugs allow underscores (unlike LayoutIdSchema) to support
@@ -166,7 +235,28 @@ export async function saveAsset(
     );
   }
 
-  const ext = getExtFromContentType(contentType);
+  // Magic-byte sniff is the authority for what reaches disk. The declared
+  // Content-Type is advisory: a non-image body sent as image/png, an SVG, a
+  // GIF, or an HTML/JS polyglot would otherwise be stored and served from the
+  // app origin (stored XSS / MIME confusion). Reject when the bytes do not
+  // sniff to a raster format, or sniff to a format that disagrees with the
+  // declared type. Every disk write (PUT and the migration rewrite) flows
+  // through here, so both share this one chokepoint.
+  const sniffedType = detectImageMime(new Uint8Array(data));
+  if (!sniffedType) {
+    throw new AssetRejectedError(
+      "Rejected asset: bytes do not match an allowed image format (png/jpeg/webp)",
+    );
+  }
+  if (sniffedType !== contentType) {
+    throw new AssetRejectedError(
+      `Rejected asset: declared content type ${contentType} disagrees with sniffed type ${sniffedType}`,
+    );
+  }
+
+  // Derive the on-disk extension from the SNIFFED type, never the declared
+  // header, so a spoofed Content-Type cannot pick the filename.
+  const ext = getExtFromContentType(sniffedType);
   const assetPath = await buildAssetPath(layoutId, deviceSlug, face, ext);
 
   // Ensure directory exists (creates assets/ and device folder only when needed)

--- a/api/src/storage/assets.ts
+++ b/api/src/storage/assets.ts
@@ -41,13 +41,17 @@ export const MAX_SIZE = 5 * 1024 * 1024; // 5MB
  * copy is the authority for what lands on disk.
  */
 function detectImageMime(bytes: Uint8Array): string | null {
-  // PNG: 89 50 4E 47
+  // PNG: full 8-byte signature 89 50 4E 47 0D 0A 1A 0A
   if (
-    bytes.length >= 4 &&
+    bytes.length >= 8 &&
     bytes[0] === 0x89 &&
     bytes[1] === 0x50 &&
     bytes[2] === 0x4e &&
-    bytes[3] === 0x47
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
   ) {
     return "image/png";
   }

--- a/src/lib/utils/image-encoding.ts
+++ b/src/lib/utils/image-encoding.ts
@@ -53,6 +53,12 @@ const MIME_TO_EXT: Record<string, string> = {
  * Recognises PNG, JPEG, and WebP. Returns null for anything unrecognised
  * (including GIF, SVG, and text starting with "<"), so callers can reject untrusted or
  * disallowed content without trusting any declared prefix.
+ *
+ * ALLOWLIST PARITY: an independent copy of this detector lives in the Bun API
+ * at `api/src/storage/assets.ts` (the server cannot import this Svelte bundle).
+ * This client copy is advisory; the server copy is the authority for what
+ * lands on disk. If you change the accepted formats here, change the server
+ * copy too.
  */
 export function detectImageMime(bytes: Uint8Array): string | null {
   // PNG: 89 50 4E 47

--- a/src/lib/utils/image-encoding.ts
+++ b/src/lib/utils/image-encoding.ts
@@ -61,13 +61,17 @@ const MIME_TO_EXT: Record<string, string> = {
  * copy too.
  */
 export function detectImageMime(bytes: Uint8Array): string | null {
-  // PNG: 89 50 4E 47
+  // PNG: full 8-byte signature 89 50 4E 47 0D 0A 1A 0A
   if (
-    bytes.length >= 4 &&
+    bytes.length >= 8 &&
     bytes[0] === 0x89 &&
     bytes[1] === 0x50 &&
     bytes[2] === 0x4e &&
-    bytes[3] === 0x47
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
   ) {
     return "image/png";
   }


### PR DESCRIPTION
## **User description**
Closes #2528. Part of epic #2513 (Wave 0).

## Summary

Closes a live security gap: the asset write path trusted the declared `Content-Type` and never inspected the bytes, so a non-image body sent as `image/png` was stored and served from the app origin (stored XSS / MIME confusion). Adds a server-side magic-byte sniff inside `saveAsset` so the PUT path and any future migration write share one chokepoint. The endpoint has zero frontend callers today, so this cannot break the app.

## Changes

- Port the client `detectImageMime` detector into the Bun API as an independent copy (the API cannot import the Svelte bundle). Cross-reference comments in both copies guard against allowlist drift: the client pre-check stays advisory, the server is the authority for what lands on disk.
- Put the sniff inside `saveAsset` (`api/src/storage/assets.ts`), before any directory creation or file write, so a rejected write leaves nothing on disk.
- Reject when the sniffed type is null (SVG/GIF/polyglot) or disagrees with the declared `Content-Type`. The route maps the typed `AssetRejectedError` to a 400 (ordered after the existing 413 "too large" branch, which it cannot shadow).
- Derive the on-disk extension from the sniffed type, never the declared header, so a spoofed `Content-Type` cannot pick the filename. SVG stays excluded by bytes.

## Tests (first for this surface)

- `api/src/storage/assets.test.ts`: accept PNG/JPEG/WebP, ext-from-sniffed-type, reject GIF/SVG/`<svg onload>`/HTML-polyglot/mismatch (nothing written), content-type allowlist guard, 5MB size cap unchanged.
- `api/src/routes/assets.test.ts`: full request chain proves a rejected body returns 400 (not 500) and writes nothing.

## Verification

- API suite: 325 pass, 0 fail (`bun test`); API typecheck clean.
- Root: lint clean, `test:run` 2805 pass, `build` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Reject unsafe or mismatched asset uploads**

### What Changed
- Asset uploads now check the file bytes before saving, so only real PNG, JPEG, and WebP images are accepted.
- Uploads are rejected when the bytes do not match the declared image type, including SVG, GIF, and HTML or script polyglots.
- Rejected uploads now return a 400 error and do not leave any file on disk.
- The saved file name now follows the detected image type, not the declared header.

### Impact
`✅ Fewer stored XSS uploads`
`✅ Clearer asset upload errors`
`✅ Fewer bad image files saved to disk`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
