### PR TITLE
feat: client asset-API helpers keyed by placement device UUID (#2527)

### DIFF
--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -33,6 +33,11 @@ function normalizeApiBaseUrl(raw: string | undefined): string {
   return `/${trimmed}`;
 }
 
+/**
+ * Normalized API base URL with no trailing slash. Either an absolute
+ * `http(s)://` origin (from `VITE_API_URL`) or a relative path (default
+ * `/api`). Callers append their route to it directly.
+ */
 export const API_BASE_URL: string = normalizeApiBaseUrl(
   import.meta.env.VITE_API_URL,
 );

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -33,7 +33,9 @@ function normalizeApiBaseUrl(raw: string | undefined): string {
   return `/${trimmed}`;
 }
 
-const API_BASE_URL: string = normalizeApiBaseUrl(import.meta.env.VITE_API_URL);
+export const API_BASE_URL: string = normalizeApiBaseUrl(
+  import.meta.env.VITE_API_URL,
+);
 
 /**
  * Human-readable label for the server instance, used in offline/recovery toasts.

--- a/src/lib/storage/assets-api.ts
+++ b/src/lib/storage/assets-api.ts
@@ -1,0 +1,254 @@
+/**
+ * Client transport for the server-mode asset API (#2513).
+ *
+ * Wraps the endpoints under `/assets`:
+ *   PUT/GET/DELETE /assets/:layoutId/:deviceId/:face
+ *   GET            /assets/:layoutId            (listing, for the save reconcile)
+ *
+ * The `:deviceId` path segment is ALWAYS the placed-device instance UUID (the
+ * `deviceId` portion of a placement key), never the device-type slug and never
+ * the full colon-namespaced placement key. `deviceKeyForWire` enforces this:
+ * it extracts the device id and asserts it is a bare lowercase UUID with no
+ * colon and no path characters, so a malformed key can never widen the
+ * server's path-traversal surface. The server `DeviceSlugSchema`
+ * (`api/src/storage/assets.ts`) is the backstop; a bare lowercase UUID passes
+ * it unchanged.
+ *
+ * Server-mode only. No save/load wiring lives here; the Save (#2530) and Load
+ * (#2531) layers build on these helpers.
+ */
+import { z } from "zod";
+import { API_BASE_URL, PersistenceError } from "./api";
+import { isApiAvailable } from "./availability.svelte";
+import {
+  SUPPORTED_IMAGE_FORMATS,
+  MAX_IMAGE_SIZE_BYTES,
+} from "$lib/types/constants";
+import { deviceIdFromPlacementKey } from "$lib/utils/placement-key";
+import { persistenceDebug } from "$lib/utils/debug";
+
+const log = persistenceDebug.api;
+
+/** Default timeout for asset requests (10 seconds), matching the layout API. */
+const ASSET_TIMEOUT_MS = 10_000;
+
+/** A persisted asset is stored per physical face; "both" is not an on-disk face. */
+export type AssetFace = "front" | "rear";
+
+/**
+ * A bare lowercase UUID: 32 hex digits in 8-4-4-4-12 groups. This is what
+ * `generateId()` (`src/lib/utils/device.ts`) emits and what the server
+ * `DeviceSlugSchema` accepts unchanged. The pattern forbids colons, dots,
+ * slashes, and backslashes by construction, so it doubles as the wire-safety
+ * gate for the `:deviceId` path segment.
+ */
+const BARE_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Resolve the wire-safe `:deviceId` path segment from a placement image key.
+ *
+ * Extracts the device id via {@link deviceIdFromPlacementKey} (handling both
+ * the namespaced `placement-{layoutId}:{deviceId}` and legacy
+ * `placement-{deviceId}` shapes), then asserts the result is a bare lowercase
+ * UUID. Throws a {@link PersistenceError} otherwise, so a colon-bearing or
+ * path-character-bearing segment can never reach the server.
+ */
+export function deviceKeyForWire(placementKey: string): string {
+  const deviceId = deviceIdFromPlacementKey(placementKey);
+  if (!BARE_UUID.test(deviceId)) {
+    throw new PersistenceError(
+      `Unsafe asset device key: expected a bare lowercase UUID, got "${deviceId}"`,
+    );
+  }
+  return deviceId;
+}
+
+/** Listing entry from `GET /assets/:layoutId` (route added in the Save issue). */
+const AssetListItemSchema = z.object({
+  deviceSlug: z.string().min(1),
+  face: z.enum(["front", "rear"]),
+  ext: z.string().min(1),
+  size: z.number().int().nonnegative(),
+});
+
+const AssetListResponseSchema = z.object({
+  assets: z.array(AssetListItemSchema),
+});
+
+export type AssetListItem = z.infer<typeof AssetListItemSchema>;
+
+/**
+ * Build the asset endpoint URL for one placed-device image face.
+ *
+ * Every path segment is percent-encoded; the `:deviceId` segment must already
+ * be a bare lowercase UUID (use {@link deviceKeyForWire} to derive it from a
+ * placement key). Exported so the load layer can address a face directly (for
+ * example as an `<img>` src) without re-fetching it as a Blob.
+ */
+export function assetUrl(
+  layoutId: string,
+  deviceId: string,
+  face: AssetFace,
+): string {
+  return `${API_BASE_URL}/assets/${encodeURIComponent(
+    layoutId,
+  )}/${encodeURIComponent(deviceId)}/${encodeURIComponent(face)}`;
+}
+
+async function errorMessage(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    try {
+      const data: unknown = JSON.parse(text);
+      if (data && typeof data === "object" && "error" in data) {
+        return String((data as { error: unknown }).error);
+      }
+    } catch {
+      // fall through to raw text
+    }
+    return text || response.statusText || "Unknown error";
+  } catch {
+    return response.statusText || "Unknown error";
+  }
+}
+
+/**
+ * Upload one image face for a placed device.
+ *
+ * Pre-checks the content type against the raster allowlist (rejecting SVG and
+ * anything else) and the 5MB size limit client-side, so a doomed PUT is never
+ * issued. The server is the backstop: it re-validates the type, the 5MB body
+ * limit (413), and the per-layout asset quota (507). Those server statuses
+ * surface as typed {@link PersistenceError}s.
+ */
+export async function putAsset(
+  layoutId: string,
+  deviceId: string,
+  face: AssetFace,
+  blob: Blob,
+  contentType: string,
+): Promise<void> {
+  if (!isApiAvailable()) {
+    throw new PersistenceError("API not available");
+  }
+
+  if (!SUPPORTED_IMAGE_FORMATS.includes(contentType)) {
+    const allowed = SUPPORTED_IMAGE_FORMATS.map((f) =>
+      f.replace("image/", "").toUpperCase(),
+    ).join(", ");
+    throw new PersistenceError(
+      `Unsupported image type: ${contentType}. Must be ${allowed}.`,
+    );
+  }
+
+  if (blob.size > MAX_IMAGE_SIZE_BYTES) {
+    throw new PersistenceError(
+      `Image too large: ${blob.size} bytes (max ${MAX_IMAGE_SIZE_BYTES})`,
+      413,
+    );
+  }
+
+  const url = assetUrl(layoutId, deviceId, face);
+  log("putAsset: PUT %s (%s)", url, contentType);
+
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": contentType },
+    body: blob,
+    signal: AbortSignal.timeout(ASSET_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const message = await errorMessage(response);
+    log("putAsset: error status=%d message=%s", response.status, message);
+    throw new PersistenceError(message, response.status);
+  }
+}
+
+/**
+ * Fetch one image face for a placed device as a Blob. The load layer
+ * eager-fetches every custom face with this and stores the bytes so render and
+ * export reuse the existing blob path.
+ */
+export async function getAssetBlob(
+  layoutId: string,
+  deviceId: string,
+  face: AssetFace,
+): Promise<Blob> {
+  if (!isApiAvailable()) {
+    throw new PersistenceError("API not available");
+  }
+
+  const url = assetUrl(layoutId, deviceId, face);
+  log("getAssetBlob: GET %s", url);
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(ASSET_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const message = await errorMessage(response);
+    log("getAssetBlob: error status=%d message=%s", response.status, message);
+    throw new PersistenceError(message, response.status);
+  }
+
+  return response.blob();
+}
+
+/** Delete one image face for a placed device (used by the save reconcile). */
+export async function deleteAsset(
+  layoutId: string,
+  deviceId: string,
+  face: AssetFace,
+): Promise<void> {
+  if (!isApiAvailable()) {
+    throw new PersistenceError("API not available");
+  }
+
+  const url = assetUrl(layoutId, deviceId, face);
+  log("deleteAsset: DELETE %s", url);
+
+  const response = await fetch(url, {
+    method: "DELETE",
+    signal: AbortSignal.timeout(ASSET_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const message = await errorMessage(response);
+    log("deleteAsset: error status=%d message=%s", response.status, message);
+    throw new PersistenceError(message, response.status);
+  }
+}
+
+/**
+ * List the faces present on disk for a layout, for the save-time set-diff
+ * reconcile. Targets `GET /assets/:layoutId` (the listing route is added in the
+ * Save issue, #2530; this helper is its client).
+ */
+export async function listAssets(layoutId: string): Promise<AssetListItem[]> {
+  if (!isApiAvailable()) {
+    throw new PersistenceError("API not available");
+  }
+
+  const url = `${API_BASE_URL}/assets/${encodeURIComponent(layoutId)}`;
+  log("listAssets: GET %s", url);
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(ASSET_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const message = await errorMessage(response);
+    log("listAssets: error status=%d message=%s", response.status, message);
+    throw new PersistenceError(message, response.status);
+  }
+
+  try {
+    const raw: unknown = await response.json();
+    return AssetListResponseSchema.parse(raw).assets;
+  } catch (error) {
+    log("listAssets: validation failed %O", error);
+    throw new PersistenceError("Invalid asset listing from API server");
+  }
+}

--- a/src/lib/storage/assets-api.ts
+++ b/src/lib/storage/assets-api.ts
@@ -24,7 +24,10 @@ import {
   SUPPORTED_IMAGE_FORMATS,
   MAX_IMAGE_SIZE_BYTES,
 } from "$lib/types/constants";
-import { deviceIdFromPlacementKey } from "$lib/utils/placement-key";
+import {
+  deviceIdFromPlacementKey,
+  isPlacementKey,
+} from "$lib/utils/placement-key";
 import { persistenceDebug } from "$lib/utils/debug";
 
 const log = persistenceDebug.api;
@@ -55,6 +58,11 @@ const BARE_UUID =
  * path-character-bearing segment can never reach the server.
  */
 export function deviceKeyForWire(placementKey: string): string {
+  if (!isPlacementKey(placementKey)) {
+    throw new PersistenceError(
+      `Unsafe asset device key: expected a "placement-" key, got "${placementKey}"`,
+    );
+  }
   const deviceId = deviceIdFromPlacementKey(placementKey);
   if (!BARE_UUID.test(deviceId)) {
     throw new PersistenceError(
@@ -64,9 +72,14 @@ export function deviceKeyForWire(placementKey: string): string {
   return deviceId;
 }
 
-/** Listing entry from `GET /assets/:layoutId` (route added in the Save issue). */
+/**
+ * Listing entry from `GET /assets/:layoutId` (route added in the Save issue).
+ * `deviceSlug` is constrained to the same bare lowercase UUID as the wire path
+ * segment, so malformed server data (a colon, a path char, an unexpected
+ * device-type slug) is rejected before it reaches the save reconcile.
+ */
 const AssetListItemSchema = z.object({
-  deviceSlug: z.string().min(1),
+  deviceSlug: z.string().regex(BARE_UUID),
   face: z.enum(["front", "rear"]),
   ext: z.string().min(1),
   size: z.number().int().nonnegative(),
@@ -76,6 +89,12 @@ const AssetListResponseSchema = z.object({
   assets: z.array(AssetListItemSchema),
 });
 
+/**
+ * One on-disk asset face for a placed device, as returned by `listAssets`.
+ * `deviceSlug` is the placed-device instance UUID; `face` is the physical face;
+ * `ext` is the stored file extension; `size` is the byte length on disk. The
+ * save reconcile set-diffs these against the layout's current custom faces.
+ */
 export type AssetListItem = z.infer<typeof AssetListItemSchema>;
 
 /**

--- a/src/lib/storage/assets-api.ts
+++ b/src/lib/storage/assets-api.ts
@@ -215,7 +215,14 @@ export async function getAssetBlob(
   return response.blob();
 }
 
-/** Delete one image face for a placed device (used by the save reconcile). */
+/**
+ * Delete one image face for a placed device (used by the save reconcile).
+ *
+ * Idempotent: a 404 means the face is already absent, which is the desired end
+ * state for a reconcile, so it resolves as a successful no-op rather than
+ * failing the save. A concurrent delete or a stale listing must not abort the
+ * reconcile loop.
+ */
 export async function deleteAsset(
   layoutId: string,
   deviceId: string,
@@ -232,6 +239,11 @@ export async function deleteAsset(
     method: "DELETE",
     signal: AbortSignal.timeout(ASSET_TIMEOUT_MS),
   });
+
+  if (response.status === 404) {
+    log("deleteAsset: 404 (already absent), treating as no-op");
+    return;
+  }
 
   if (!response.ok) {
     const message = await errorMessage(response);

--- a/src/tests/assets-api.test.ts
+++ b/src/tests/assets-api.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assetUrl,
+  deviceKeyForWire,
+  putAsset,
+  getAssetBlob,
+  deleteAsset,
+  listAssets,
+} from "$lib/storage/assets-api";
+import { PersistenceError } from "$lib/storage/api";
+import { setApiAvailable } from "$lib/storage/availability.svelte";
+import {
+  placementKey,
+  deviceIdFromPlacementKey,
+} from "$lib/utils/placement-key";
+
+const LAYOUT_ID = "11111111-1111-4111-8111-111111111111";
+
+/**
+ * The server backstop, pinned to `api/src/storage/assets.ts` (DeviceSlugSchema).
+ * Mirrored here (not imported) because the server module pulls in node-only
+ * deps (pino) that do not resolve in the frontend test env. The wire-safety
+ * contract is that a bare lowercase UUID passes this and a colon-namespaced
+ * placement key does not, with zero loosening of the pattern.
+ */
+const SERVER_DEVICE_SLUG = /^[a-z0-9][a-z0-9_-]*[a-z0-9]$|^[a-z0-9]$/;
+
+describe("deviceKeyForWire", () => {
+  it("round-trips the namespaced placement key back to the bare device UUID and placement key", () => {
+    const deviceId = crypto.randomUUID();
+    const key = placementKey(LAYOUT_ID, deviceId);
+    // placementKey(layoutId, uuid) -> uuid
+    const wire = deviceKeyForWire(key);
+    expect(wire).toBe(deviceId);
+    // uuid -> placementKey(layoutId, uuid)
+    expect(placementKey(LAYOUT_ID, wire)).toBe(key);
+  });
+
+  it("round-trips the legacy un-namespaced placement key back to the bare device UUID", () => {
+    const deviceId = crypto.randomUUID();
+    // legacy shape: placementKey("", deviceId) === `placement-${deviceId}`
+    const key = placementKey("", deviceId);
+    expect(key).toBe(`placement-${deviceId}`);
+    const wire = deviceKeyForWire(key);
+    expect(wire).toBe(deviceId);
+    expect(deviceIdFromPlacementKey(key)).toBe(deviceId);
+  });
+
+  it("accepts a bare lowercase crypto.randomUUID()", () => {
+    const deviceId = crypto.randomUUID();
+    expect(deviceKeyForWire(placementKey(LAYOUT_ID, deviceId))).toBe(deviceId);
+  });
+
+  it("rejects a device segment that still carries a colon", () => {
+    // A malformed key whose device portion contains a colon must not slip
+    // through onto the wire (would widen path-traversal surface).
+    const bad = `placement-${LAYOUT_ID}:${LAYOUT_ID}:evil`;
+    expect(() => deviceKeyForWire(bad)).toThrow();
+  });
+
+  it("rejects path characters in the device segment", () => {
+    for (const segment of ["..", "../etc", "a/b", "a\\b", "a.png"]) {
+      expect(() =>
+        deviceKeyForWire(`placement-${LAYOUT_ID}:${segment}`),
+      ).toThrow();
+    }
+  });
+
+  it("rejects an uppercase UUID (the server slug validator is lowercase-only)", () => {
+    const upper = crypto.randomUUID().toUpperCase();
+    expect(() => deviceKeyForWire(placementKey(LAYOUT_ID, upper))).toThrow();
+  });
+});
+
+describe("assetUrl", () => {
+  it("addresses the device-UUID face path with every segment percent-encoded", () => {
+    const deviceId = crypto.randomUUID();
+    const url = assetUrl(LAYOUT_ID, deviceId, "front");
+    expect(url).toContain(`/assets/${LAYOUT_ID}/${deviceId}/front`);
+    expect(url).not.toContain("placement-");
+  });
+
+  it("percent-encodes a path-traversal attempt in the device segment", () => {
+    // Defense in depth: even if a caller bypasses deviceKeyForWire, the URL
+    // builder must not emit raw traversal characters into the path.
+    const url = assetUrl(LAYOUT_ID, "../etc/passwd", "front");
+    expect(url).not.toContain("../");
+    expect(url).toContain("%2F");
+  });
+});
+
+describe("server DeviceSlugSchema agreement", () => {
+  it("accepts a bare lowercase UUID with zero validator changes", () => {
+    const deviceId = crypto.randomUUID();
+    expect(SERVER_DEVICE_SLUG.test(deviceId)).toBe(true);
+  });
+
+  it("rejects the colon-namespaced placement key", () => {
+    const key = placementKey(LAYOUT_ID, crypto.randomUUID());
+    expect(SERVER_DEVICE_SLUG.test(key)).toBe(false);
+  });
+
+  it("the wire key produced from a placement key passes the server validator", () => {
+    const key = placementKey(LAYOUT_ID, crypto.randomUUID());
+    const wire = deviceKeyForWire(key);
+    expect(SERVER_DEVICE_SLUG.test(wire)).toBe(true);
+  });
+});
+
+describe("asset transport wrappers", () => {
+  const DEVICE_ID = "22222222-2222-4222-8222-222222222222";
+
+  function stubBrowserGlobals(): void {
+    vi.stubGlobal("AbortSignal", {
+      timeout: () => new AbortController().signal,
+    });
+  }
+
+  beforeEach(() => {
+    setApiAvailable(true);
+    stubBrowserGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    setApiAvailable(false);
+  });
+
+  it("getAssetBlob returns the image bytes as a Blob", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(bytes, {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        }),
+      ),
+    );
+
+    const blob = await getAssetBlob(LAYOUT_ID, DEVICE_ID, "front");
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("image/png");
+    const roundTrip = new Uint8Array(await blob.arrayBuffer());
+    expect(Array.from(roundTrip)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("getAssetBlob targets the per-placement device UUID path segment", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getAssetBlob(LAYOUT_ID, DEVICE_ID, "rear");
+    const calledUrl = String(fetchMock.mock.calls[0]?.[0]);
+    expect(calledUrl).toContain(`/assets/${LAYOUT_ID}/${DEVICE_ID}/rear`);
+    expect(calledUrl).not.toContain("placement-");
+    // Assert on the path only: a colon in the device segment would be the wire
+    // hazard, but an absolute API_BASE_URL legitimately carries a scheme colon
+    // (http:), so check the resolved pathname rather than the whole URL.
+    const path = new URL(calledUrl, "http://test.local").pathname;
+    expect(path).not.toContain(":");
+  });
+
+  it("putAsset surfaces 507 (quota) as a typed PersistenceError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "quota exceeded" }), {
+          status: 507,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const blob = new Blob([new Uint8Array([1])], { type: "image/png" });
+    const err = await putAsset(
+      LAYOUT_ID,
+      DEVICE_ID,
+      "front",
+      blob,
+      "image/png",
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(PersistenceError);
+    expect((err as PersistenceError).statusCode).toBe(507);
+  });
+
+  it("putAsset surfaces 413 (oversize) as a typed PersistenceError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "too large" }), {
+          status: 413,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const blob = new Blob([new Uint8Array([1])], { type: "image/png" });
+    const err = await putAsset(
+      LAYOUT_ID,
+      DEVICE_ID,
+      "front",
+      blob,
+      "image/png",
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(PersistenceError);
+    expect((err as PersistenceError).statusCode).toBe(413);
+  });
+
+  it("putAsset PUTs with the supplied content type to the device-UUID path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "Asset uploaded" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const blob = new Blob([new Uint8Array([1])], { type: "image/png" });
+    await putAsset(LAYOUT_ID, DEVICE_ID, "front", blob, "image/png");
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain(`/assets/${LAYOUT_ID}/${DEVICE_ID}/front`);
+    expect((init as RequestInit).method).toBe("PUT");
+    const headers = new Headers((init as RequestInit).headers);
+    expect(headers.get("Content-Type")).toBe("image/png");
+  });
+
+  it("putAsset rejects an oversize blob client-side before any request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    // 5MB + 1 byte; the client must fail fast, not issue a doomed PUT.
+    const oversize = new Blob([new Uint8Array(5 * 1024 * 1024 + 1)], {
+      type: "image/png",
+    });
+    const err = await putAsset(
+      LAYOUT_ID,
+      DEVICE_ID,
+      "front",
+      oversize,
+      "image/png",
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(PersistenceError);
+    expect((err as PersistenceError).statusCode).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("putAsset rejects a content type outside the raster allowlist before any request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const blob = new Blob(["<svg/>"], { type: "image/svg+xml" });
+    await expect(
+      putAsset(LAYOUT_ID, DEVICE_ID, "front", blob, "image/svg+xml"),
+    ).rejects.toBeInstanceOf(PersistenceError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("deleteAsset resolves on 200 and surfaces non-2xx as PersistenceError", async () => {
+    const okFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "Asset deleted" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", okFetch);
+    await expect(
+      deleteAsset(LAYOUT_ID, DEVICE_ID, "front"),
+    ).resolves.toBeUndefined();
+
+    const errFetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 500 }));
+    vi.stubGlobal("fetch", errFetch);
+    await expect(
+      deleteAsset(LAYOUT_ID, DEVICE_ID, "front"),
+    ).rejects.toBeInstanceOf(PersistenceError);
+  });
+
+  it("listAssets returns the on-disk face set for the reconcile", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            assets: [
+              { deviceSlug: DEVICE_ID, face: "front", ext: "png", size: 12 },
+              { deviceSlug: DEVICE_ID, face: "rear", ext: "webp", size: 34 },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const assets = await listAssets(LAYOUT_ID);
+    expect(assets).toContainEqual(
+      expect.objectContaining({ deviceSlug: DEVICE_ID, face: "front" }),
+    );
+    expect(assets).toContainEqual(
+      expect.objectContaining({ deviceSlug: DEVICE_ID, face: "rear" }),
+    );
+  });
+
+  it("listAssets rejects a malformed listing body as a PersistenceError", async () => {
+    // A response that parses as JSON but violates the listing schema (wrong
+    // face enum, missing fields) must not flow through unvalidated.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ assets: [{ face: "both" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(listAssets(LAYOUT_ID)).rejects.toBeInstanceOf(
+      PersistenceError,
+    );
+  });
+
+  it("each wrapper throws when the API is unavailable", async () => {
+    setApiAvailable(false);
+    const blob = new Blob([new Uint8Array([1])], { type: "image/png" });
+    await expect(
+      putAsset(LAYOUT_ID, DEVICE_ID, "front", blob, "image/png"),
+    ).rejects.toBeInstanceOf(PersistenceError);
+    await expect(
+      getAssetBlob(LAYOUT_ID, DEVICE_ID, "front"),
+    ).rejects.toBeInstanceOf(PersistenceError);
+    await expect(
+      deleteAsset(LAYOUT_ID, DEVICE_ID, "front"),
+    ).rejects.toBeInstanceOf(PersistenceError);
+    await expect(listAssets(LAYOUT_ID)).rejects.toBeInstanceOf(
+      PersistenceError,
+    );
+  });
+});

--- a/src/tests/assets-api.test.ts
+++ b/src/tests/assets-api.test.ts
@@ -291,6 +291,23 @@ describe("asset transport wrappers", () => {
     ).rejects.toBeInstanceOf(PersistenceError);
   });
 
+  it("deleteAsset treats 404 as an idempotent no-op", async () => {
+    // An already-absent face is the reconcile's desired end state, so a 404
+    // must resolve rather than abort the save loop.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Asset not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    await expect(
+      deleteAsset(LAYOUT_ID, DEVICE_ID, "front"),
+    ).resolves.toBeUndefined();
+  });
+
   it("listAssets returns the on-disk face set for the reconcile", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/tests/assets-api.test.ts
+++ b/src/tests/assets-api.test.ts
@@ -70,6 +70,14 @@ describe("deviceKeyForWire", () => {
     const upper = crypto.randomUUID().toUpperCase();
     expect(() => deviceKeyForWire(placementKey(LAYOUT_ID, upper))).toThrow();
   });
+
+  it("rejects a key without the placement- prefix before extracting", () => {
+    // A bare or mis-prefixed key would mis-slice in deviceIdFromPlacementKey;
+    // the prefix guard fails fast rather than relying on the UUID assertion.
+    const uuid = crypto.randomUUID();
+    expect(() => deviceKeyForWire(uuid)).toThrow();
+    expect(() => deviceKeyForWire(`evil:${uuid}`)).toThrow();
+  });
 });
 
 describe("assetUrl", () => {


### PR DESCRIPTION
## **User description**
Closes #2527. Part of epic #2513 (persist custom device images to disk in server mode), Wave 0.

## What this delivers

The shared client-side asset-API transport that the server-mode save and load layers build on. No save/load wiring here, just the helper module and its wire-key safety.

New `src/lib/storage/assets-api.ts`:

- `putAsset` / `getAssetBlob` / `deleteAsset` wrap PUT/GET/DELETE `/assets/:layoutId/:deviceId/:face`
- `listAssets` wraps GET `/assets/:layoutId` for the save-time set-diff reconcile (the listing route lands in the Save issue; this is its client)
- `assetUrl` builds the face URL with every path segment percent-encoded (exported for the load layer to address a face directly)
- `deviceKeyForWire(placementKey)` extracts the device id via `deviceIdFromPlacementKey` and asserts a bare lowercase UUID

It reuses `API_BASE_URL`, `isApiAvailable`, and `PersistenceError` from `api.ts`, and maps 507 (quota) and 413 (too large) onto typed `PersistenceError` by preserving the raw `statusCode`, so the storage manager's existing `statusCode`-based classification (`manager.svelte.ts`) works unchanged.

## Wire-key safety

The `:deviceId` path segment is always the placed-device instance UUID, never the device-type slug and never the full colon-namespaced placement key. `deviceKeyForWire` enforces this with its own `BARE_UUID` regex (not a borrowed schema): a malformed key containing a colon or path characters throws before any request. The client check is strictly tighter than the server `DeviceSlugSchema` (`api/src/storage/assets.ts`, unchanged), so a value that passes the client can never be rejected by the server, and a bare lowercase `crypto.randomUUID()` passes the server validator with zero loosening.

## Tests

`src/tests/assets-api.test.ts`:

- `deviceKeyForWire` round-trips both the namespaced (`placement-{layoutId}:{deviceId}`) and legacy (`placement-{deviceId}`) shapes back to the bare UUID, and rejects colon / path-character / uppercase segments
- Server `DeviceSlugSchema` agreement: a bare lowercase UUID passes, the colon-namespaced key does not (the server regex is mirrored, not imported, because the server module pulls in node-only deps)
- Transport wrappers: `getAssetBlob` returns a Blob, 507 and 413 surface as typed `PersistenceError`, the device-UUID path is targeted, oversize/SVG are rejected client-side before any request, `listAssets` rejects a malformed listing body

## Scope

Wave 0 foundation, no callers yet. The browser-mode YAML embed path (#617) and the snapshot path are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add client helpers for saving, loading, and deleting device images by device UUID**

### What Changed
- Added client-side helpers for uploading, fetching, deleting, and listing stored face images for a layout
- Device IDs sent to the server are now checked to ensure they are bare UUIDs, so malformed placement keys cannot reach the asset path
- Image uploads now fail early for unsupported image types and oversized files instead of sending a request that would be rejected
- Server error responses and malformed asset listings are surfaced as typed errors, keeping asset handling consistent
- Added coverage for valid paths, rejected inputs, API-unavailable cases, and malformed server responses

### Impact
`✅ Safer asset uploads`
`✅ Fewer rejected image saves`
`✅ Clearer asset error handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
