### PR TITLE
feat: server-mode load eager-fetches device images as blobs (#2531)

### DIFF
--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -3,7 +3,8 @@
  * Communicates with the API sidecar for layout CRUD
  * Uses UUID-based routing for stable URLs across renames
  */
-import { isApiAvailable } from "./availability.svelte";
+import { isApiAvailable, getStorageMode } from "./availability.svelte";
+import { eagerFetchServerImages } from "./server-load-images";
 import {
   hasPreCarrierMigrationPending,
   clearPreCarrierMigrationPending,
@@ -354,14 +355,42 @@ export async function loadSavedLayout(uuid: string): Promise<{
     uuid,
     yamlContent.length,
   );
+  let parsed: Awaited<ReturnType<typeof parseLayoutYamlWithImages>>;
   try {
-    const { layout, images, failedImagesCount, failedKeys } =
-      await parseLayoutYamlWithImages(yamlContent);
-    return { layout, images, failedImagesCount, failedKeys, updatedAt };
+    parsed = await parseLayoutYamlWithImages(yamlContent);
   } catch (error) {
     log("loadSavedLayout: failed to parse uuid=%s %O", uuid, error);
     throw new PersistenceError("Layout data is corrupted - could not parse");
   }
+
+  const { layout } = parsed;
+
+  // Server mode only: eager-fetch each placed device's custom faces from disk
+  // as blobs, so render and export reuse the existing blob path. A migrated
+  // layout carries face references but no embedded images; a not-yet-migrated
+  // one keeps its decoded embedded bytes (merged under the same keys), so it
+  // displays and then migrates on the next save (#2531). Browser/file/snapshot
+  // loads never reach here and stay on the embedded-image decode unchanged.
+  if (getStorageMode() === "server") {
+    const layoutId = layout.metadata?.id ?? uuid;
+    const { images, failedImagesCount, failedKeys } =
+      await eagerFetchServerImages(layout, layoutId, parsed.images);
+    return {
+      layout,
+      images,
+      failedImagesCount: parsed.failedImagesCount + failedImagesCount,
+      failedKeys: [...parsed.failedKeys, ...failedKeys],
+      updatedAt,
+    };
+  }
+
+  return {
+    layout,
+    images: parsed.images,
+    failedImagesCount: parsed.failedImagesCount,
+    failedKeys: parsed.failedKeys,
+    updatedAt,
+  };
 }
 
 /**

--- a/src/lib/storage/server-load-images.ts
+++ b/src/lib/storage/server-load-images.ts
@@ -101,11 +101,16 @@ export async function eagerFetchServerImages(
 }> {
   const images: ImageStoreMap = new Map(base);
   const failedKeys: string[] = [];
-  let failedImagesCount = 0;
 
   // Container children live flat in the same rack.devices[] array (linked by
   // container_id), so a single flatMap reaches every placed device.
   const devices = layout.racks.flatMap((rack) => rack.devices);
+
+  // One fetch task per placed face that carries a reference. Fetching every
+  // face concurrently (rather than awaiting in a loop) keeps total load time
+  // flat in face count, and one face's 10s timeout never blocks the rest.
+  const tasks: Promise<{ key: string; face: AssetFace; entry?: ImageData }>[] =
+    [];
 
   for (const device of devices) {
     const key = placementKey(layoutId, device.id);
@@ -113,44 +118,57 @@ export async function eagerFetchServerImages(
     // The placement key feeds a network fetch addressed by the device id path
     // segment. deviceKeyForWire asserts that segment is a bare UUID, so a
     // malformed id can never widen the server's path-traversal surface. A key
-    // that fails the gate is treated as a (recorded) failed face, never a throw.
-    let wireDeviceId: string;
+    // that fails the gate yields a recorded failure for each referenced face,
+    // never a throw and never a request.
+    let wireDeviceId: string | null = null;
     try {
       wireDeviceId = deviceKeyForWire(key);
     } catch (error) {
-      const refs = FACES.filter((face) => faceReference(device, face));
-      if (refs.length === 0) continue;
       log("eagerFetchServerImages: unsafe key %s rejected %O", key, error);
-      for (const _face of refs) {
-        failedKeys.push(key);
-        failedImagesCount++;
-      }
-      continue;
     }
 
     for (const face of FACES) {
       if (!faceReference(device, face)) continue;
 
-      try {
-        const blob = await getAssetBlob(layoutId, wireDeviceId, face);
-        const entry = await imageDataFromBlob(blob, key, face);
-        const existing = images.get(key) ?? {};
-        images.set(key, {
-          ...existing,
-          [face]: entry,
-        });
-      } catch (error) {
-        log(
-          "eagerFetchServerImages: face %s of %s failed %O",
-          face,
-          key,
-          error,
-        );
-        failedKeys.push(key);
-        failedImagesCount++;
+      if (wireDeviceId === null) {
+        tasks.push(Promise.resolve({ key, face }));
+        continue;
       }
+
+      const safeDeviceId = wireDeviceId;
+      tasks.push(
+        (async () => {
+          try {
+            const blob = await getAssetBlob(layoutId, safeDeviceId, face);
+            return {
+              key,
+              face,
+              entry: await imageDataFromBlob(blob, key, face),
+            };
+          } catch (error) {
+            log(
+              "eagerFetchServerImages: face %s of %s failed %O",
+              face,
+              key,
+              error,
+            );
+            return { key, face };
+          }
+        })(),
+      );
     }
   }
 
-  return { images, failedImagesCount, failedKeys };
+  // Merge after the concurrent phase so the map is mutated single-threaded and
+  // a device's two faces never race each other's read-modify-write.
+  for (const { key, face, entry } of await Promise.all(tasks)) {
+    if (entry) {
+      const existing = images.get(key) ?? {};
+      images.set(key, { ...existing, [face]: entry });
+    } else {
+      failedKeys.push(key);
+    }
+  }
+
+  return { images, failedImagesCount: failedKeys.length, failedKeys };
 }

--- a/src/lib/storage/server-load-images.ts
+++ b/src/lib/storage/server-load-images.ts
@@ -52,7 +52,8 @@ function blobToDataUrl(blob: Blob): Promise<string> {
       if (typeof reader.result === "string") resolve(reader.result);
       else reject(new Error("Unexpected FileReader result type"));
     };
-    reader.onerror = () => reject(reader.error ?? new Error("FileReader error"));
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("FileReader error"));
     reader.readAsDataURL(blob);
   });
 }

--- a/src/lib/storage/server-load-images.ts
+++ b/src/lib/storage/server-load-images.ts
@@ -1,0 +1,155 @@
+/**
+ * Server-mode load: eager-fetch each placed device's custom faces from disk as
+ * blobs (#2531, part of epic #2513).
+ *
+ * On a server-mode load, every placed device whose `front_image`/`rear_image`
+ * reference is set has its face bytes fetched up front via {@link getAssetBlob}
+ * and stored in the returned map as a blob-bearing {@link ImageData}, keyed by
+ * `placement-{layoutId}:{deviceId}`. Holding the bytes (not a lazy URL) is what
+ * lets render and export reuse the existing blob path: the multi-layout export
+ * archive gates entirely on entries carrying a `.blob`, so a load -> export
+ * round-trip preserves the image bytes.
+ *
+ * A face that 404s or otherwise fails to fetch is non-fatal: its placement key
+ * is collected into `failedKeys` and the count incremented, and the rest of the
+ * layout keeps loading. Surfacing those failures to the user (placeholder,
+ * toast, retry) is a separate frontend issue (#2532); this layer only exposes
+ * the failure data.
+ *
+ * Server-mode only. The browser, file-import, and snapshot load paths keep
+ * decoding embedded images via `parseLayoutYamlWithImages` unchanged.
+ */
+import type { Layout } from "$lib/types";
+import type { ImageData, ImageStoreMap } from "$lib/types/images";
+import { getAssetBlob, type AssetFace, deviceKeyForWire } from "./assets-api";
+import { placementKey } from "$lib/utils/placement-key";
+import { getImageExtension } from "$lib/utils/archive";
+import { persistenceDebug } from "$lib/utils/debug";
+
+const log = persistenceDebug.api;
+
+/** The two physical faces a placed device can carry a custom image on. */
+const FACES: readonly AssetFace[] = ["front", "rear"];
+
+/**
+ * The on-disk image reference a placed device carries for one face. Server-mode
+ * saves write an opaque filename marker into `front_image`/`rear_image`; this
+ * layer treats its presence as the signal that a face exists on disk and
+ * addresses the byte fetch by `(layoutId, deviceId, face)`.
+ */
+function faceReference(
+  device: { front_image?: string; rear_image?: string },
+  face: AssetFace,
+): string | undefined {
+  return face === "front" ? device.front_image : device.rear_image;
+}
+
+/** Read a blob's bytes as a base64 data URL. Rejects on a read error. */
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") resolve(reader.result);
+      else reject(new Error("Unexpected FileReader result type"));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("FileReader error"));
+    reader.readAsDataURL(blob);
+  });
+}
+
+/**
+ * Build a store entry that both renders and exports from the fetched bytes.
+ *
+ * Holds `blob` (the export archive gates on it) and `dataUrl` (render reads
+ * `url ?? dataUrl`, never the blob; the server YAML encoder also embeds from
+ * `dataUrl` until the disk reconcile lands). Using a base64 `dataUrl` rather
+ * than an object URL matches the embedded-decode path and needs no revoke.
+ */
+async function imageDataFromBlob(
+  blob: Blob,
+  key: string,
+  face: AssetFace,
+): Promise<ImageData> {
+  return {
+    blob,
+    dataUrl: await blobToDataUrl(blob),
+    filename: `${key}-${face}.${getImageExtension(blob.type)}`,
+  };
+}
+
+/**
+ * Eager-fetch every placed device's custom faces for a server-mode load.
+ *
+ * @param layout - The parsed layout (placed devices carry the face references).
+ * @param layoutId - The layout's stable UUID, used to build placement keys and
+ *   to address the asset endpoint. The save path persisted faces under this id.
+ * @param base - The image entries already decoded from the YAML (for a legacy
+ *   embedded `images:` block). Eager-fetched faces are merged on top so a
+ *   migrated layout displays from disk while a not-yet-migrated one still shows
+ *   its embedded bytes.
+ * @returns The merged image map plus the failure data for non-fatal misses.
+ */
+export async function eagerFetchServerImages(
+  layout: Layout,
+  layoutId: string,
+  base: ImageStoreMap,
+): Promise<{
+  images: ImageStoreMap;
+  failedImagesCount: number;
+  failedKeys: string[];
+}> {
+  const images: ImageStoreMap = new Map(base);
+  const failedKeys: string[] = [];
+  let failedImagesCount = 0;
+
+  // Container children live flat in the same rack.devices[] array (linked by
+  // container_id), so a single flatMap reaches every placed device.
+  const devices = layout.racks.flatMap((rack) => rack.devices);
+
+  for (const device of devices) {
+    const key = placementKey(layoutId, device.id);
+
+    // The placement key feeds a network fetch addressed by the device id path
+    // segment. deviceKeyForWire asserts that segment is a bare UUID, so a
+    // malformed id can never widen the server's path-traversal surface. A key
+    // that fails the gate is treated as a (recorded) failed face, never a throw.
+    let wireDeviceId: string;
+    try {
+      wireDeviceId = deviceKeyForWire(key);
+    } catch (error) {
+      const refs = FACES.filter((face) => faceReference(device, face));
+      if (refs.length === 0) continue;
+      log("eagerFetchServerImages: unsafe key %s rejected %O", key, error);
+      for (const _face of refs) {
+        failedKeys.push(key);
+        failedImagesCount++;
+      }
+      continue;
+    }
+
+    for (const face of FACES) {
+      if (!faceReference(device, face)) continue;
+
+      try {
+        const blob = await getAssetBlob(layoutId, wireDeviceId, face);
+        const entry = await imageDataFromBlob(blob, key, face);
+        const existing = images.get(key) ?? {};
+        images.set(key, {
+          ...existing,
+          [face]: entry,
+        });
+      } catch (error) {
+        log(
+          "eagerFetchServerImages: face %s of %s failed %O",
+          face,
+          key,
+          error,
+        );
+        failedKeys.push(key);
+        failedImagesCount++;
+      }
+    }
+  }
+
+  return { images, failedImagesCount, failedKeys };
+}

--- a/src/tests/persistence-api.test.ts
+++ b/src/tests/persistence-api.test.ts
@@ -8,7 +8,9 @@ import {
 } from "$lib/storage/api";
 import { setApiAvailable } from "$lib/storage/availability.svelte";
 import { serializeLayoutToYaml } from "$lib/utils/yaml";
-import { createTestLayout } from "./factories";
+import { createMultiLayoutArchive } from "$lib/utils/archive";
+import { placementKey } from "$lib/utils/placement-key";
+import { createTestLayout, createTestRack, createTestDevice } from "./factories";
 
 describe("checkApiHealth", () => {
   function stubBrowserGlobals(): void {
@@ -314,6 +316,155 @@ describe("loadSavedLayout", () => {
       "11111111-1111-4111-8111-111111111111",
     );
     expect(result.updatedAt).toBe("2026-06-14T10:00:00.000Z");
+  });
+});
+
+describe("loadSavedLayout server-mode image eager-fetch", () => {
+  const UUID = "11111111-1111-4111-8111-111111111111";
+  const DEVICE_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  // Minimal but valid PNG byte sequence (8-byte signature + a marker byte).
+  const PNG_BYTES = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01,
+  ]);
+
+  const originalConfig = window.__RACKULA_CONFIG__;
+
+  function stubBrowserGlobals(): void {
+    vi.stubGlobal("AbortSignal", {
+      timeout: () => new AbortController().signal,
+    });
+  }
+
+  /**
+   * A server-mode layout: one rack, one placed device whose `front_image`
+   * reference points at an on-disk face. The YAML carries no embedded `images:`
+   * block (the migrated, disk-backed shape).
+   */
+  async function serverLayoutYaml(): Promise<string> {
+    const layout = createTestLayout({
+      metadata: { id: UUID },
+      racks: [
+        createTestRack({
+          devices: [
+            createTestDevice({
+              id: DEVICE_ID,
+              front_image: `${DEVICE_ID}.front.png`,
+            }),
+          ],
+        }),
+      ],
+    });
+    return serializeLayoutToYaml(layout, "");
+  }
+
+  /**
+   * Route fetches by URL: the layout GET returns the YAML; an asset GET returns
+   * the PNG bytes unless `failAsset` is set, in which case it 404s.
+   */
+  function routedFetch(yaml: string, opts: { failAsset?: boolean } = {}) {
+    return vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/assets/")) {
+        if (opts.failAsset) {
+          return new Response(JSON.stringify({ error: "Not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(PNG_BYTES, {
+          status: 200,
+          headers: { "Content-Type": "image/png" },
+        });
+      }
+      return new Response(yaml, {
+        status: 200,
+        headers: { "Content-Type": "text/yaml" },
+      });
+    });
+  }
+
+  beforeEach(() => {
+    setApiAvailable(true);
+    stubBrowserGlobals();
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    setApiAvailable(false);
+    window.__RACKULA_CONFIG__ = originalConfig;
+  });
+
+  it("eager-fetches each custom face to a blob-bearing store entry keyed by placement key", async () => {
+    const yaml = await serverLayoutYaml();
+    vi.stubGlobal("fetch", routedFetch(yaml));
+
+    const { images, failedKeys, failedImagesCount } =
+      await loadSavedLayout(UUID);
+
+    const key = placementKey(UUID, DEVICE_ID);
+    const entry = images.get(key);
+    expect(entry?.front?.blob).toBeInstanceOf(Blob);
+    expect(failedKeys).toEqual([]);
+    expect(failedImagesCount).toBe(0);
+  });
+
+  it("gives each eager-fetched face a dataUrl so the server YAML encoder round-trips it", async () => {
+    const yaml = await serverLayoutYaml();
+    vi.stubGlobal("fetch", routedFetch(yaml));
+
+    const { images } = await loadSavedLayout(UUID);
+
+    // The store entry must carry a base64 dataUrl, not just a blob/object URL:
+    // encodeUserImagesToYaml embeds from dataUrl and silently drops faces that
+    // lack one, so a load -> edit -> autosave round-trip would otherwise lose
+    // the image. The encoder serializing it back proves the entry survives.
+    const key = placementKey(UUID, DEVICE_ID);
+    const front = images.get(key)?.front;
+    expect(front?.dataUrl).toMatch(/^data:image\/png;base64,/);
+
+    const { encodeUserImagesToYaml } = await import(
+      "$lib/utils/image-encoding"
+    );
+    const { serialized } = encodeUserImagesToYaml(images);
+    expect(serialized[key]?.front).toBe(front?.dataUrl);
+  });
+
+  it("populates blobs so a subsequent export archive carries the image bytes", async () => {
+    const yaml = await serverLayoutYaml();
+    vi.stubGlobal("fetch", routedFetch(yaml));
+
+    const { layout, images } = await loadSavedLayout(UUID);
+
+    // The store now holds a blob, satisfying createMultiLayoutArchive's .blob
+    // gate, so a load -> export round-trip preserves the bytes.
+    const archive = await createMultiLayoutArchive([{ layout, images }]);
+    expect(archive.size).toBeGreaterThan(0);
+
+    const { getJSZip } = await import("$lib/utils/archive");
+    const JSZip = await getJSZip();
+    const zip = await JSZip.loadAsync(archive);
+    const assetPaths = Object.keys(zip.files).filter(
+      (p) => p.includes("/assets/") && p.includes(DEVICE_ID),
+    );
+    expect(assetPaths.length).toBeGreaterThan(0);
+  });
+
+  it("treats a 404 face as non-fatal: the layout still loads and the key is reported", async () => {
+    const yaml = await serverLayoutYaml();
+    vi.stubGlobal("fetch", routedFetch(yaml, { failAsset: true }));
+
+    const { layout, images, failedKeys, failedImagesCount } =
+      await loadSavedLayout(UUID);
+
+    // The layout itself parsed fine.
+    expect(layout.racks[0]?.devices[0]?.id).toBe(DEVICE_ID);
+    // The missing face produced no blob entry but was recorded, not thrown.
+    const key = placementKey(UUID, DEVICE_ID);
+    expect(images.get(key)?.front?.blob).toBeUndefined();
+    expect(failedKeys).toContain(key);
+    expect(failedImagesCount).toBeGreaterThan(0);
   });
 });
 

--- a/src/tests/persistence-api.test.ts
+++ b/src/tests/persistence-api.test.ts
@@ -10,7 +10,11 @@ import { setApiAvailable } from "$lib/storage/availability.svelte";
 import { serializeLayoutToYaml } from "$lib/utils/yaml";
 import { createMultiLayoutArchive } from "$lib/utils/archive";
 import { placementKey } from "$lib/utils/placement-key";
-import { createTestLayout, createTestRack, createTestDevice } from "./factories";
+import {
+  createTestLayout,
+  createTestRack,
+  createTestDevice,
+} from "./factories";
 
 describe("checkApiHealth", () => {
   function stubBrowserGlobals(): void {
@@ -424,9 +428,8 @@ describe("loadSavedLayout server-mode image eager-fetch", () => {
     const front = images.get(key)?.front;
     expect(front?.dataUrl).toMatch(/^data:image\/png;base64,/);
 
-    const { encodeUserImagesToYaml } = await import(
-      "$lib/utils/image-encoding"
-    );
+    const { encodeUserImagesToYaml } =
+      await import("$lib/utils/image-encoding");
     const { serialized } = encodeUserImagesToYaml(images);
     expect(serialized[key]?.front).toBe(front?.dataUrl);
   });


### PR DESCRIPTION
## **User description**
Closes #2531. Wave 1 of epic #2513 (persist custom device images to disk in server mode). This is the server-mode LOAD layer.

## What changed

When `getStorageMode() === 'server'`, `loadSavedLayout` now walks each placed device and, for every device carrying a `front_image` / `rear_image` reference, eager-fetches that face from disk as a Blob via `getAssetBlob` (the #2527 foundation helper). Each fetched face is returned in the image map keyed by `placement-{layoutId}:{deviceId}`.

The new logic lives in `src/lib/storage/server-load-images.ts` (`eagerFetchServerImages`); `api.ts` gains a small server-mode branch after the YAML parse. Browser, file-import, and snapshot load paths keep decoding embedded images via `parseLayoutYamlWithImages` unchanged.

## Why eager-to-blob (not lazy URLs)

The multi-layout export archive (`createMultiLayoutArchive`) gates entirely on each store entry carrying a `.blob`. A url-only entry would export an archive with no images. Eager-fetching to blobs on load is what makes a load -> export round-trip preserve the bytes. The real `exportAllServer()` path calls `loadSavedLayout(item.id)` then feeds the returned map straight into the archive, so this lights up immediately.

Each entry carries both:
- `blob` - for the export archive gate.
- `dataUrl` (base64) - render reads `url ?? dataUrl` (never the blob), and the server YAML encoder embeds from `dataUrl` until the disk reconcile lands. A base64 dataUrl (rather than an object URL) matches the embedded-decode path and needs no revoke, so it avoids both a data-loss-on-autosave bug and an object-URL leak.

## Non-fatal failures

A 404 or fetch failure for a face is non-fatal: its placement key is collected into `failedKeys` and `failedImagesCount` is incremented, and the rest of the layout keeps loading. The helper never throws. User-facing surfacing (placeholder, toast, retry) is the separate frontend issue #2532; this layer only exposes the failure data.

## Security

The device-id path segment that addresses each fetch is gated through `deviceKeyForWire` (bare-UUID assertion), so a crafted layout reference cannot widen the server's path-traversal surface. A key that fails the gate is recorded as a failed face, never used to build a request.

## Acceptance criteria

- [x] Server-mode load populates the image store with blob-backed entries from disk.
- [x] Exporting a server-mode layout produces an archive containing the image bytes (load -> export round-trip), proven by an integration test that inspects the zip.
- [x] A 404 / missing face is non-fatal; the rest of the layout loads.
- [x] Eager entries carry a `dataUrl`, so a load -> edit -> autosave round-trip does not silently drop disk-loaded images (regression-guarded).
- [x] Browser / file / snapshot load paths still decode embedded images unchanged (`yaml-images.test.ts` green).

## Notes for reviewers

`failedKeys` pushes the placement key once per failed face (so a device with both faces failing yields the key twice). This is intentional and consistent with the existing `decodeYamlImages` contract, which pushes per-face the same way. Deduping / face-tagging is deferred to the #2532 consumer rather than diverging the contract here.

## Verification

- `npm run lint` - clean
- `npm run test:run` - 170 files, 2833 tests passing
- `npm run build` - clean
- Merged current `origin/main` (sibling #2530-adjacent API changes) with no conflicts; suite re-run green on the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Load server-stored device images when opening a layout**

### What Changed
- Server-mode layout loads now fetch each placed device’s saved front and rear images from disk instead of relying only on embedded image data
- The loaded images are kept in a form that works for both on-screen display and export, so a load-and-export flow preserves the image bytes
- Missing or unreachable face images no longer stop the layout from loading; the layout still opens and the failed image is reported
- Added tests for successful image loading, export round-tripping, and non-fatal missing-image handling

### Impact
`✅ Preserved device images after opening and re-exporting server layouts`
`✅ Fewer broken layouts when a stored face image is missing`
`✅ Safer server layout loads with image handling covered by tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
