### PR TITLE
feat: server-mode save writes images to disk with set-diff reconcile (#2530)

### DIFF
--- a/api/src/routes/assets.test.ts
+++ b/api/src/routes/assets.test.ts
@@ -143,3 +143,69 @@ describe("GET /assets response headers", () => {
     expect(res.headers.get("Content-Type")).toBe("image/png");
   });
 });
+
+describe("GET /assets/:layoutId listing", () => {
+  it("returns the per-layout asset listing after a PUT", async () => {
+    const putRes = await putAsset(pngBytes(), "image/png");
+    expect(putRes.status).toBe(200);
+
+    const res = await app.request(`/assets/${LAYOUT_UUID}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      assets: Array<{
+        deviceSlug: string;
+        face: string;
+        ext: string;
+        size: number;
+      }>;
+    };
+    expect(body.assets).toContainEqual(
+      expect.objectContaining({
+        deviceSlug: DEVICE_SLUG,
+        face: "front",
+        ext: "png",
+      }),
+    );
+  });
+
+  it("returns an empty listing for a layout with no assets", async () => {
+    const res = await app.request(`/assets/${LAYOUT_UUID}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { assets: unknown[] };
+    expect(body.assets).toEqual([]);
+  });
+
+  it("returns an empty listing for a valid-but-unknown layout id", async () => {
+    // A reconcile may list before the layout folder exists (first save). A
+    // valid UUID that has no folder yet is "no assets on disk", not an error.
+    const unknown = "11111111-2222-4333-8444-555555555555";
+    const res = await app.request(`/assets/${unknown}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { assets: unknown[] };
+    expect(body.assets).toEqual([]);
+  });
+
+  it("rejects a non-UUID layout id with a 4xx (not 500)", async () => {
+    const res = await app.request(`/assets/not-a-uuid-../etc/passwd`);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+
+  it("returns a clean 4xx (not 500) for a route-valid but non-UUID id", async () => {
+    // `abc` passes LayoutIdSchema (lowercase alphanumeric) but is not a UUID, so
+    // listLayoutAssets throws "Invalid layout UUID". That must surface as a 400,
+    // not a 500.
+    const res = await app.request(`/assets/abc`);
+    expect(res.status).toBe(400);
+  });
+
+  it("is reachable at the /api alias", async () => {
+    const putRes = await putAsset(pngBytes(), "image/png");
+    expect(putRes.status).toBe(200);
+
+    const res = await app.request(`/api/assets/${LAYOUT_UUID}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { assets: unknown[] };
+    expect(body.assets.length).toBeGreaterThan(0);
+  });
+});

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -53,7 +53,10 @@ assets.get("/:layoutId", async (c) => {
   } catch (error) {
     // listLayoutAssets throws "Layout not found" when the layout folder is
     // absent. For the reconcile that means an empty on-disk set, not a failure.
-    if (error instanceof Error && error.message.startsWith("Layout not found")) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith("Layout not found")
+    ) {
       return c.json({ assets: [] }, 200);
     }
     // listLayoutAssets validates the id more strictly (full UUID) than the

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -18,6 +18,7 @@ import {
   getAsset,
   saveAsset,
   deleteAsset,
+  listLayoutAssets,
   isValidImageType,
   isValidDeviceSlug,
   AssetRejectedError,
@@ -31,6 +32,43 @@ const assets = new Hono();
 function isValidFace(face: string): face is "front" | "rear" {
   return face === "front" || face === "rear";
 }
+
+// List the on-disk asset faces for a layout. Drives the save-time set-diff
+// reconcile (#2530): the client diffs this against the layout's current custom
+// faces and deletes the difference. A valid UUID whose layout folder does not
+// exist yet (e.g. a reconcile run before the first YAML PUT lands) is "no
+// assets on disk", not an error, so it returns an empty list rather than a 404.
+// Inherits the per-asset GET read posture (no auth beyond app-level middleware).
+assets.get("/:layoutId", async (c) => {
+  const { layoutId } = c.req.param();
+
+  const idResult = LayoutIdSchema.safeParse(layoutId);
+  if (!idResult.success) {
+    return c.json({ error: "Invalid layout ID format" }, 400);
+  }
+
+  try {
+    const list = await listLayoutAssets(layoutId);
+    return c.json({ assets: list }, 200);
+  } catch (error) {
+    // listLayoutAssets throws "Layout not found" when the layout folder is
+    // absent. For the reconcile that means an empty on-disk set, not a failure.
+    if (error instanceof Error && error.message.startsWith("Layout not found")) {
+      return c.json({ assets: [] }, 200);
+    }
+    // listLayoutAssets validates the id more strictly (full UUID) than the
+    // route's LayoutIdSchema (which also accepts hyphenated non-UUID slugs). A
+    // route-valid id that is not a UUID is a bad request, not a server fault.
+    if (
+      error instanceof Error &&
+      error.message.startsWith("Invalid layout UUID")
+    ) {
+      return c.json({ error: "Invalid layout ID format" }, 400);
+    }
+    logger.error({ err: error }, `Failed to list assets`);
+    return c.json({ error: "Failed to list assets" }, 500);
+  }
+});
 
 // Get an asset
 assets.get("/:layoutId/:deviceSlug/:face", async (c) => {

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -16,6 +16,7 @@ import {
   deviceKeyForWire,
   type AssetFace,
 } from "./assets-api";
+import { isPlacementKey } from "$lib/utils/placement-key";
 import type { Layout } from "$lib/types";
 import type {
   ImageStoreMap,
@@ -559,6 +560,14 @@ export async function saveLayoutToServer(
 
   if (isServerMode) {
     for (const [key, deviceImages] of userImages) {
+      // Only placement-keyed instance images go to disk. Custom device-type
+      // images are keyed by the bare device-type slug (e.g. "server-1u"), which
+      // is not a placement key; routing them through deviceKeyForWire would
+      // throw and abort the save, so they stay embedded in the YAML.
+      if (!isPlacementKey(key)) {
+        retainedImages.set(key, deviceImages);
+        continue;
+      }
       for (const face of DISK_FACES) {
         const image = deviceImages[face];
         if (!image) continue;

--- a/src/lib/storage/api.ts
+++ b/src/lib/storage/api.ts
@@ -3,18 +3,33 @@
  * Communicates with the API sidecar for layout CRUD
  * Uses UUID-based routing for stable URLs across renames
  */
-import { isApiAvailable } from "./availability.svelte";
+import { isApiAvailable, getStorageMode } from "./availability.svelte";
 import {
   hasPreCarrierMigrationPending,
   clearPreCarrierMigrationPending,
 } from "./pre-carrier-migration-pending";
+import {
+  putAsset,
+  deleteAsset,
+  listAssets,
+  deviceKeyForWire,
+  type AssetFace,
+} from "./assets-api";
 import type { Layout } from "$lib/types";
-import type { ImageStoreMap } from "$lib/types/images";
+import type {
+  ImageStoreMap,
+  ImageData,
+  SupportedImageFormat,
+} from "$lib/types/images";
 import {
   serializeLayoutToYaml,
   parseLayoutYamlWithImages,
 } from "$lib/utils/yaml";
-import { encodeUserImagesToYaml } from "$lib/utils/image-encoding";
+import {
+  encodeUserImagesToYaml,
+  decodeDataUrl,
+  detectImageMime,
+} from "$lib/utils/image-encoding";
 import { persistenceDebug } from "$lib/utils/debug";
 import { z } from "zod";
 
@@ -364,6 +379,108 @@ export async function loadSavedLayout(uuid: string): Promise<{
   }
 }
 
+/** The two physical faces written to disk; "both" is never an on-disk face. */
+const DISK_FACES: readonly AssetFace[] = ["front", "rear"];
+
+/** A user image face resolved to verbatim bytes plus its server content type. */
+interface DiskFace {
+  deviceId: string;
+  face: AssetFace;
+  blob: Blob;
+  contentType: SupportedImageFormat;
+}
+
+/**
+ * Resolve one user image face to the verbatim bytes that will land on disk.
+ *
+ * Prefers decoding the verbatim `dataUrl` (fresh uploads and #2531-rehydrated
+ * migrate images both carry one) so the body PUT and the bytes sniffed for the
+ * content type are the same bytes; falls back to the in-memory `blob` only when
+ * no dataUrl is present. The bytes are sniffed by magic byte with the same
+ * client detector the YAML path uses: a face whose bytes do not sniff to an
+ * allowed raster format is NOT written to disk and is left to the caller to
+ * retain in the embedded block, so a malformed migrate payload is never lost.
+ * The server (#2528) re-sniffs every write as the authority.
+ *
+ * Returns null when no usable bytes resolve or the sniff fails; the caller then
+ * keeps the face embedded rather than dropping it.
+ */
+function resolveDiskFace(
+  deviceId: string,
+  face: AssetFace,
+  image: ImageData,
+): DiskFace | null {
+  // Decode the verbatim data URL when present so the sniffed bytes and the PUT
+  // body are identical. The blob is a fallback for a blob-only image.
+  const bytes = image.dataUrl ? decodeDataUrl(image.dataUrl) : null;
+  if (!bytes && !image.blob) return null;
+
+  // Content type comes from the actual bytes (never a declared MIME). With only
+  // a blob and no decodable data URL, trust the blob's type if it is an allowed
+  // raster format. A sniff that does not match an allowed format rejects the
+  // face so it stays embedded.
+  let contentType: SupportedImageFormat;
+  let blob: Blob;
+  if (bytes) {
+    const sniffed = detectImageMime(bytes);
+    if (!sniffed) return null;
+    contentType = sniffed as SupportedImageFormat;
+    blob = new Blob([bytes], { type: contentType });
+  } else if (
+    image.blob &&
+    (image.blob.type === "image/png" ||
+      image.blob.type === "image/jpeg" ||
+      image.blob.type === "image/webp")
+  ) {
+    contentType = image.blob.type;
+    blob = image.blob;
+  } else {
+    return null;
+  }
+
+  return { deviceId, face, blob, contentType };
+}
+
+/**
+ * Reconcile a server-mode layout's user images to disk via the asset API.
+ *
+ * Runs after the YAML PUT (which creates the layout folder the asset writes
+ * need). Returns nothing; any failed PUT/DELETE throws so the caller's save
+ * never reaches a clean state and the layout stays dirty for the next autosave
+ * retry (the originating #1426 bug was flipping to "saved" before images
+ * persisted).
+ *
+ * Set-diff: the desired set is the layout's current user faces; the on-disk set
+ * is `GET /assets/:layoutId`. Faces on disk but not desired are deleted (removed
+ * faces/devices and crash-leaked orphans). A face that is both replaced and at
+ * the quota limit is deleted before its replacement is PUT, because the quota
+ * check counts before the write (non-atomic), so a DELETE-then-PUT lets an
+ * at-limit layout still replace a face without tripping the 507.
+ */
+async function reconcileServerAssets(
+  layoutId: string,
+  diskFaces: DiskFace[],
+): Promise<void> {
+  // Desired on-disk identity per face: `${deviceId}/${face}`.
+  const desired = new Set(diskFaces.map((f) => `${f.deviceId}/${f.face}`));
+
+  // On-disk faces not in the desired set are orphans to delete. A desired face
+  // is deleted first too (DELETE-then-PUT) to dodge the non-atomic 507 on an
+  // at-limit replace; deleteAsset treats a 404 as a no-op so a first write is
+  // unaffected.
+  const onDisk = await listAssets(layoutId);
+  for (const entry of onDisk) {
+    const key = `${entry.deviceSlug}/${entry.face}`;
+    if (!desired.has(key)) {
+      await deleteAsset(layoutId, entry.deviceSlug, entry.face);
+    }
+  }
+  for (const f of diskFaces) {
+    await deleteAsset(layoutId, f.deviceId, f.face);
+    await putAsset(layoutId, f.deviceId, f.face, f.blob, f.contentType);
+  }
+}
+
 /**
  * Save a layout (create or update)
  * Uses the UUID from layout metadata for routing
@@ -401,15 +518,48 @@ export async function saveLayoutToServer(
     );
   }
 
+  // Server mode writes user images to disk via the asset API and saves the YAML
+  // without the embedded base64 block, so an image-heavy layout stays under the
+  // 1MB layout PUT cap (#2530, #2513, #1426). Each user face is resolved to its
+  // verbatim bytes; a face whose bytes fail the magic-byte sniff is NOT written
+  // to disk and stays embedded so a malformed migrate payload is never lost.
+  // Browser-mode callers (none today) keep the full embed.
+  const isServerMode = getStorageMode() === "server";
+  const diskFaces: DiskFace[] = [];
+  const retainedImages: ImageStoreMap = new Map();
+
+  if (isServerMode) {
+    for (const [key, deviceImages] of userImages) {
+      for (const face of DISK_FACES) {
+        const image = deviceImages[face];
+        if (!image) continue;
+        // The wire device id is the bare UUID from the placement key; a
+        // malformed key throws here (path-traversal guard) and fails the save.
+        const deviceId = deviceKeyForWire(key);
+        const resolved = resolveDiskFace(deviceId, face, image);
+        if (resolved) {
+          diskFaces.push(resolved);
+        } else {
+          // Sniff failed: retain the embedded payload rather than drop it.
+          const existing = retainedImages.get(key) ?? {};
+          retainedImages.set(key, { ...existing, [face]: image });
+        }
+      }
+    }
+  }
+
   // Embed user images so server-mode saves do not silently drop them (#617).
-  // The 1MB server PUT cap then trips loudly for image-heavy layouts; that is
-  // intentional until storage quotas exist (see image-encoding.ts SIZE DIVERGENCE).
-  const { serialized } = encodeUserImagesToYaml(userImages);
+  // In server mode only the retained (sniff-failed) faces are embedded; the rest
+  // go to disk. In browser mode every user image is embedded.
+  const { serialized } = encodeUserImagesToYaml(
+    isServerMode ? retainedImages : userImages,
+  );
   const yamlContent = await serializeLayoutToYaml(layout, serialized);
   log(
-    "saveLayoutToServer: uuid=%s yamlSize=%d bytes",
+    "saveLayoutToServer: uuid=%s yamlSize=%d bytes diskFaces=%d",
     uuid,
     yamlContent.length,
+    diskFaces.length,
   );
 
   const url = `${API_BASE_URL}/layouts/${encodeURIComponent(uuid)}`;
@@ -452,6 +602,14 @@ export async function saveLayoutToServer(
   // the mark so later saves of this layout do not re-send the header.
   if (needsPreCarrierBackup) {
     clearPreCarrierMigrationPending(uuid);
+  }
+
+  // Reconcile assets to disk AFTER the YAML PUT (which created the layout
+  // folder the asset writes need). This runs before the function returns its
+  // success, so any failed PUT/DELETE throws and the caller never reaches a
+  // clean save state: the layout stays dirty and the next autosave retries.
+  if (isServerMode) {
+    await reconcileServerAssets(uuid, diskFaces);
   }
 
   try {

--- a/src/tests/fixtures/upgrade-corpus/v26.6.0-embedded-images.expected.json
+++ b/src/tests/fixtures/upgrade-corpus/v26.6.0-embedded-images.expected.json
@@ -1,0 +1,9 @@
+{
+  "hasImages": true,
+  "allowList": [
+    {
+      "pathPattern": "^\\$\\.images\\.",
+      "reason": "embedded base64 images are extracted into the image store on load, not kept on the layout object; the save layer (#2530) writes them to disk verbatim"
+    }
+  ]
+}

--- a/src/tests/fixtures/upgrade-corpus/v26.6.0-embedded-images.rackula.yaml
+++ b/src/tests/fixtures/upgrade-corpus/v26.6.0-embedded-images.rackula.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://count.racku.la/schemas/layout-v1.json
+metadata:
+  id: 660e8400-e29b-41d4-a716-446655440000
+  name: Embedded Images Lab
+  schema_version: "1.0"
+version: "1.0"
+name: Embedded Images Lab
+racks:
+  - id: "rack-a"
+    name: "Rack A"
+    height: 42
+    width: 19
+    desc_units: false
+    show_rear: true
+    form_factor: "4-post-cabinet"
+    starting_unit: 1
+    position: 0
+    devices:
+      - id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        device_type: "server-2u"
+        position: 60
+        face: "front"
+device_types:
+  - slug: "server-2u"
+    u_height: 2
+    manufacturer: "Acme"
+    colour: "#336699"
+    category: "server"
+settings:
+  display_mode: "label"
+  show_labels_on_images: false
+images:
+  placement-660e8400-e29b-41d4-a716-446655440000:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee:
+    front: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"

--- a/src/tests/persistence-manager-autosave.test.ts
+++ b/src/tests/persistence-manager-autosave.test.ts
@@ -14,6 +14,7 @@ import {
 import { loadSessionWithTimestamp } from "$lib/storage/working-copy";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
+import { getImageStore, resetImageStore } from "$lib/stores/images.svelte";
 import { setApiAvailable } from "$lib/storage/availability.svelte";
 import { createTestLayout } from "./factories";
 
@@ -161,5 +162,85 @@ describe("echo threads into the next PUT header", () => {
     expect(secondHeaders.get("X-Rackula-Updated-At")).toBe(
       "2026-06-14T10:00:00.000Z",
     );
+  });
+});
+
+/**
+ * The originating bug (#1426): in server mode the save chip flipped to "saved"
+ * (markClean) immediately after the YAML PUT, before the images persisted, so a
+ * crash between the YAML save and the image write lost the images silently. The
+ * fix folds the asset writes into saveLayoutToServer, so a save reaches a clean
+ * state only after the YAML PUT and every asset PUT/DELETE resolve. A failed
+ * asset PUT must leave the layout dirty so the next autosave retries.
+ */
+describe("server-mode save stays dirty when an asset write fails (#1426)", () => {
+  const UUID = "44444444-4444-4444-8444-444444444444";
+  const PLACEMENT_KEY = `placement-${UUID}:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee`;
+  const originalConfig = window.__RACKULA_CONFIG__;
+  const PNG_BYTES = Uint8Array.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    0x49, 0x48, 0x44, 0x52,
+  ]);
+
+  beforeEach(() => {
+    resetLayoutStore();
+    resetToastStore();
+    resetImageStore();
+    resetPersistenceManager();
+    setServerBaseUpdatedAt(null);
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+    setApiAvailable(true);
+    vi.stubGlobal("AbortSignal", {
+      timeout: () => new AbortController().signal,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    resetImageStore();
+    setServerBaseUpdatedAt(null);
+    setApiAvailable(false);
+    window.__RACKULA_CONFIG__ = originalConfig;
+  });
+
+  it("does not markClean when the YAML PUT succeeds but the asset PUT fails", async () => {
+    const layoutStore = getLayoutStore();
+    layoutStore.loadLayout(createTestLayout({ metadata: { id: UUID } }));
+    layoutStore.markStarted();
+
+    // One user image so the save attempts an asset PUT.
+    getImageStore().setDeviceImage(PLACEMENT_KEY, "front", {
+      blob: new Blob([PNG_BYTES], { type: "image/png" }),
+      dataUrl: `data:image/png;base64,${btoa(String.fromCharCode(...PNG_BYTES))}`,
+      filename: "front.png",
+    });
+    layoutStore.markDirty();
+
+    // YAML PUT succeeds; the asset PUT fails (500). The reconcile listing GET
+    // returns an empty set.
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && /\/assets\/[^/]+$/.test(u)) {
+        return new Response(JSON.stringify({ assets: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (/\/assets\/[^/]+\/[^/]+\/[^/]+$/.test(u) && method === "PUT") {
+        return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+      }
+      return new Response(
+        JSON.stringify({ id: UUID, updatedAt: "2026-06-20T00:00:00.000Z" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ok = await handleSaveToServer(false);
+
+    expect(ok).toBe(false);
+    expect(layoutStore.isDirty).toBe(true);
   });
 });

--- a/src/tests/save-layout-to-server.test.ts
+++ b/src/tests/save-layout-to-server.test.ts
@@ -6,6 +6,103 @@ import {
   clearPreCarrierMigrationPending,
 } from "$lib/storage/pre-carrier-migration-pending";
 import { createTestLayout } from "./factories";
+import type { ImageStoreMap, DeviceImageData } from "$lib/types/images";
+
+// A 16-byte PNG body (full 8-byte signature plus tail) base64-encoded into a
+// data URL, so detectImageMime sniffs it as image/png on both client and server.
+const PNG_BYTES = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52,
+]);
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+const PNG_DATA_URL = `data:image/png;base64,${bytesToBase64(PNG_BYTES)}`;
+
+/** A user image face carrying both a blob and the verbatim data URL. */
+function userFace(): DeviceImageData {
+  return {
+    front: {
+      blob: new Blob([PNG_BYTES], { type: "image/png" }),
+      dataUrl: PNG_DATA_URL,
+      filename: "front.png",
+    },
+  };
+}
+
+/** A migrate-on-save face: embedded data URL only, no blob. */
+function embeddedOnlyFace(): DeviceImageData {
+  return {
+    front: {
+      dataUrl: PNG_DATA_URL,
+      filename: "front.png",
+    },
+  };
+}
+
+/** Build a user-image store map keyed by namespaced placement keys. */
+function imageMap(
+  entries: Array<[string, DeviceImageData]>,
+): ImageStoreMap {
+  return new Map(entries);
+}
+
+interface FetchCall {
+  url: string;
+  method: string;
+  body: BodyInit | null | undefined;
+}
+
+/**
+ * Route-aware fetch mock for the server save path. Records every call and lets
+ * a test fail specific asset PUTs. The YAML PUT and the asset listing succeed
+ * unless overridden.
+ */
+function makeRoutedFetch(opts?: {
+  listing?: Array<{
+    deviceSlug: string;
+    face: string;
+    ext: string;
+    size: number;
+  }>;
+  failAssetPut?: boolean;
+}) {
+  const calls: FetchCall[] = [];
+  const fetchMock = vi.fn(
+    async (url: string | URL, init?: RequestInit): Promise<Response> => {
+      const u = typeof url === "string" ? url : url.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      calls.push({ url: u, method, body: init?.body ?? null });
+
+      // GET /assets/:layoutId  (listing — no further path segments)
+      if (method === "GET" && /\/assets\/[^/]+$/.test(u)) {
+        return new Response(JSON.stringify({ assets: opts?.listing ?? [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // PUT/DELETE /assets/:layoutId/:deviceId/:face
+      if (/\/assets\/[^/]+\/[^/]+\/[^/]+$/.test(u)) {
+        if (method === "PUT" && opts?.failAssetPut) {
+          return new Response(JSON.stringify({ error: "boom" }), {
+            status: 500,
+          });
+        }
+        return new Response(JSON.stringify({ message: "ok" }), { status: 200 });
+      }
+      // PUT /layouts/:uuid  (YAML save)
+      return new Response(
+        JSON.stringify({ id: SERVER_UUID, updatedAt: "2026-06-20T00:00:00.000Z" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    },
+  );
+  return { fetchMock, calls };
+}
+
+const SERVER_UUID = "33333333-3333-4333-8333-333333333333";
 
 /**
  * In server-storage mode, a layout whose carrier-first migration was marked
@@ -32,6 +129,38 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
     );
   }
 
+  /**
+   * In server mode a save also lists assets (the reconcile). These tests pass an
+   * empty image map, so the listing must answer with an empty set; everything
+   * else delegates to the provided save-response factory.
+   */
+  function withListing(saveResponse: () => Response) {
+    return vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && /\/assets\/[^/]+$/.test(u)) {
+        return new Response(JSON.stringify({ assets: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return saveResponse();
+    });
+  }
+
+  /** All YAML-PUT requests (the layout save), in call order. */
+  function yamlPutCalls(
+    fetchMock: ReturnType<typeof vi.fn>,
+  ): Array<{ headers: HeadersInit }> {
+    return fetchMock.mock.calls
+      .filter(([url, init]) => {
+        const u = typeof url === "string" ? url : String(url);
+        const method = (init?.method ?? "GET").toUpperCase();
+        return method === "PUT" && /\/layouts\/[^/]+$/.test(u);
+      })
+      .map(([, init]) => init as { headers: HeadersInit });
+  }
+
   beforeEach(() => {
     window.__RACKULA_CONFIG__ = { storage: "server" };
     setApiAvailable(true);
@@ -48,7 +177,7 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
   });
 
   it("attaches the header when the uuid is pending", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(okSaveResponse(UUID));
+    const fetchMock = withListing(() => okSaveResponse(UUID));
     vi.stubGlobal("fetch", fetchMock);
 
     markPreCarrierMigrationPending(UUID);
@@ -58,15 +187,13 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
       null,
     );
 
-    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    const headers = new Headers(yamlPutCalls(fetchMock)[0].headers);
     expect(headers.get("X-Rackula-Pre-Carrier-Migration")).toBe("1");
   });
 
   it("does not re-attach the header on a subsequent save of the same uuid", async () => {
     // Fresh Response per call: a Response body can only be read once.
-    const fetchMock = vi
-      .fn()
-      .mockImplementation(async () => okSaveResponse(UUID));
+    const fetchMock = withListing(() => okSaveResponse(UUID));
     vi.stubGlobal("fetch", fetchMock);
 
     markPreCarrierMigrationPending(UUID);
@@ -81,12 +208,12 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
       null,
     );
 
-    const secondHeaders = new Headers(fetchMock.mock.calls[1][1].headers);
+    const secondHeaders = new Headers(yamlPutCalls(fetchMock)[1].headers);
     expect(secondHeaders.has("X-Rackula-Pre-Carrier-Migration")).toBe(false);
   });
 
   it("never attaches the header for a non-pending uuid", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(okSaveResponse(OTHER_UUID));
+    const fetchMock = withListing(() => okSaveResponse(OTHER_UUID));
     vi.stubGlobal("fetch", fetchMock);
 
     await saveLayoutToServer(
@@ -95,12 +222,12 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
       null,
     );
 
-    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    const headers = new Headers(yamlPutCalls(fetchMock)[0].headers);
     expect(headers.has("X-Rackula-Pre-Carrier-Migration")).toBe(false);
   });
 
   it("attaches the header alongside X-Rackula-Updated-At", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(okSaveResponse(UUID));
+    const fetchMock = withListing(() => okSaveResponse(UUID));
     vi.stubGlobal("fetch", fetchMock);
 
     markPreCarrierMigrationPending(UUID);
@@ -110,7 +237,7 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
       "2026-06-14T09:00:00.000Z",
     );
 
-    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    const headers = new Headers(yamlPutCalls(fetchMock)[0].headers);
     expect(headers.get("X-Rackula-Pre-Carrier-Migration")).toBe("1");
     expect(headers.get("X-Rackula-Updated-At")).toBe(
       "2026-06-14T09:00:00.000Z",
@@ -118,11 +245,23 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
   });
 
   it("retries with the header after a failed save so the backup is not skipped", async () => {
-    // First save fails (non-2xx), the retry succeeds.
-    const fetchMock = vi
-      .fn()
-      .mockImplementationOnce(async () => new Response("nope", { status: 503 }))
-      .mockImplementationOnce(async () => okSaveResponse(UUID));
+    // First save fails at the YAML PUT (non-2xx), the retry succeeds. The
+    // listing GET (reconcile) is answered with an empty set on the retry.
+    let yamlPuts = 0;
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && /\/assets\/[^/]+$/.test(u)) {
+        return new Response(JSON.stringify({ assets: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      yamlPuts += 1;
+      return yamlPuts === 1
+        ? new Response("nope", { status: 503 })
+        : okSaveResponse(UUID);
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     markPreCarrierMigrationPending(UUID);
@@ -142,7 +281,144 @@ describe("saveLayoutToServer pre-carrier migration header", () => {
       null,
     );
 
-    const retryHeaders = new Headers(fetchMock.mock.calls[1][1].headers);
+    const retryHeaders = new Headers(yamlPutCalls(fetchMock)[1].headers);
     expect(retryHeaders.get("X-Rackula-Pre-Carrier-Migration")).toBe("1");
+  });
+});
+
+/**
+ * Server-mode save writes user images to disk via the asset API (#2530, #2513,
+ * #1426). The layout YAML no longer carries the embedded base64 images block, so
+ * an image-heavy layout stays under the 1MB layout PUT cap, and the save reaches
+ * a clean state only after the YAML PUT and every asset PUT/DELETE resolve.
+ */
+describe("saveLayoutToServer asset reconcile (server mode)", () => {
+  const originalConfig = window.__RACKULA_CONFIG__;
+  const PLACEMENT_KEY = `placement-${SERVER_UUID}:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee`;
+  const DEVICE_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+  beforeEach(() => {
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+    setApiAvailable(true);
+    vi.stubGlobal("AbortSignal", {
+      timeout: () => new AbortController().signal,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    setApiAvailable(false);
+    window.__RACKULA_CONFIG__ = originalConfig;
+  });
+
+  function yamlBodyOf(calls: FetchCall[]): string {
+    const yamlPut = calls.find(
+      (c) => c.method === "PUT" && /\/layouts\/[^/]+$/.test(c.url),
+    );
+    return typeof yamlPut?.body === "string" ? yamlPut.body : "";
+  }
+
+  it("PUTs each user image to the asset API per (deviceId, face)", async () => {
+    const { fetchMock, calls } = makeRoutedFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: SERVER_UUID } }),
+      imageMap([[PLACEMENT_KEY, userFace()]]),
+      null,
+    );
+
+    const assetPut = calls.find(
+      (c) => c.method === "PUT" && c.url.includes(`/assets/${SERVER_UUID}/`),
+    );
+    expect(assetPut).toBeDefined();
+    expect(assetPut?.url).toContain(`/assets/${SERVER_UUID}/${DEVICE_ID}/front`);
+  });
+
+  it("omits the embedded base64 images block from the YAML body", async () => {
+    const { fetchMock, calls } = makeRoutedFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: SERVER_UUID } }),
+      imageMap([[PLACEMENT_KEY, userFace()]]),
+      null,
+    );
+
+    const body = yamlBodyOf(calls);
+    expect(body).not.toContain("data:image/png;base64");
+  });
+
+  it("a failed asset PUT rejects the save so the layout stays dirty for retry", async () => {
+    const { fetchMock } = makeRoutedFetch({ failAssetPut: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      saveLayoutToServer(
+        createTestLayout({ metadata: { id: SERVER_UUID } }),
+        imageMap([[PLACEMENT_KEY, userFace()]]),
+        null,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("deletes an on-disk face that is not in the desired set (orphan reconcile)", async () => {
+    // Disk has a rear face for the device; the layout no longer has any rear
+    // image, so the reconcile must DELETE it.
+    const { fetchMock, calls } = makeRoutedFetch({
+      listing: [
+        { deviceSlug: DEVICE_ID, face: "front", ext: "png", size: 16 },
+        { deviceSlug: DEVICE_ID, face: "rear", ext: "png", size: 16 },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: SERVER_UUID } }),
+      imageMap([[PLACEMENT_KEY, userFace()]]),
+      null,
+    );
+
+    // The rear orphan is deleted and never re-PUT.
+    const rearDelete = calls.find(
+      (c) =>
+        c.method === "DELETE" &&
+        c.url.endsWith(`/assets/${SERVER_UUID}/${DEVICE_ID}/rear`),
+    );
+    expect(rearDelete).toBeDefined();
+    const rearPut = calls.find(
+      (c) =>
+        c.method === "PUT" &&
+        c.url.endsWith(`/assets/${SERVER_UUID}/${DEVICE_ID}/rear`),
+    );
+    expect(rearPut).toBeUndefined();
+    // The desired front face is re-PUT (DELETE-then-PUT dodges the 507 on an
+    // at-limit replace).
+    const frontPut = calls.find(
+      (c) =>
+        c.method === "PUT" &&
+        c.url.endsWith(`/assets/${SERVER_UUID}/${DEVICE_ID}/front`),
+    );
+    expect(frontPut).toBeDefined();
+  });
+
+  it("migrate-on-save: writes an embedded-only image to disk and drops the embed", async () => {
+    const { fetchMock, calls } = makeRoutedFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: SERVER_UUID } }),
+      imageMap([[PLACEMENT_KEY, embeddedOnlyFace()]]),
+      null,
+    );
+
+    const assetPut = calls.find(
+      (c) =>
+        c.method === "PUT" &&
+        c.url.endsWith(`/assets/${SERVER_UUID}/${DEVICE_ID}/front`),
+    );
+    expect(assetPut).toBeDefined();
+    expect(yamlBodyOf(calls)).not.toContain("data:image/png;base64");
   });
 });

--- a/src/tests/save-layout-to-server.test.ts
+++ b/src/tests/save-layout-to-server.test.ts
@@ -424,4 +424,53 @@ describe("saveLayoutToServer asset reconcile (server mode)", () => {
     expect(assetPut).toBeDefined();
     expect(yamlBodyOf(calls)).not.toContain("data:image/png;base64");
   });
+
+  it("keeps a slug-keyed device-type image embedded and never aborts the save", async () => {
+    // Custom device-type images are keyed by the bare device-type slug (e.g.
+    // "server-1u"), not a placement key. They must not be routed to the asset
+    // API (deviceKeyForWire would throw on a non-placement key and abort the
+    // whole save); they stay embedded in the YAML.
+    const { fetchMock, calls } = makeRoutedFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: SERVER_UUID } }),
+      imageMap([["server-1u", userFace()]]),
+      null,
+    );
+
+    // No asset PUT for a slug-keyed image.
+    const assetPut = calls.find(
+      (c) => c.method === "PUT" && c.url.includes(`/assets/${SERVER_UUID}/`),
+    );
+    expect(assetPut).toBeUndefined();
+    // The slug-keyed image stays embedded in the YAML.
+    expect(yamlBodyOf(calls)).toContain("data:image/png;base64");
+  });
+
+  it("routes a placement-keyed image to disk while keeping a slug-keyed image embedded", async () => {
+    const { fetchMock, calls } = makeRoutedFetch();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveLayoutToServer(
+      createTestLayout({ metadata: { id: SERVER_UUID } }),
+      imageMap([
+        [PLACEMENT_KEY, userFace()],
+        ["server-1u", userFace()],
+      ]),
+      null,
+    );
+
+    // Placement image goes to disk.
+    const assetPut = calls.find(
+      (c) =>
+        c.method === "PUT" &&
+        c.url.endsWith(`/assets/${SERVER_UUID}/${DEVICE_ID}/front`),
+    );
+    expect(assetPut).toBeDefined();
+    // Slug image stays embedded; the placement image's base64 is dropped.
+    const body = yamlBodyOf(calls);
+    expect(body).toContain("server-1u");
+    expect(body).toContain("data:image/png;base64");
+  });
 });

--- a/src/tests/save-layout-to-server.test.ts
+++ b/src/tests/save-layout-to-server.test.ts
@@ -43,9 +43,7 @@ function embeddedOnlyFace(): DeviceImageData {
 }
 
 /** Build a user-image store map keyed by namespaced placement keys. */
-function imageMap(
-  entries: Array<[string, DeviceImageData]>,
-): ImageStoreMap {
+function imageMap(entries: Array<[string, DeviceImageData]>): ImageStoreMap {
   return new Map(entries);
 }
 
@@ -94,7 +92,10 @@ function makeRoutedFetch(opts?: {
       }
       // PUT /layouts/:uuid  (YAML save)
       return new Response(
-        JSON.stringify({ id: SERVER_UUID, updatedAt: "2026-06-20T00:00:00.000Z" }),
+        JSON.stringify({
+          id: SERVER_UUID,
+          updatedAt: "2026-06-20T00:00:00.000Z",
+        }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     },
@@ -333,7 +334,9 @@ describe("saveLayoutToServer asset reconcile (server mode)", () => {
       (c) => c.method === "PUT" && c.url.includes(`/assets/${SERVER_UUID}/`),
     );
     expect(assetPut).toBeDefined();
-    expect(assetPut?.url).toContain(`/assets/${SERVER_UUID}/${DEVICE_ID}/front`);
+    expect(assetPut?.url).toContain(
+      `/assets/${SERVER_UUID}/${DEVICE_ID}/front`,
+    );
   });
 
   it("omits the embedded base64 images block from the YAML body", async () => {

--- a/src/tests/save-layout-to-server.test.ts
+++ b/src/tests/save-layout-to-server.test.ts
@@ -21,6 +21,14 @@ function bytesToBase64(bytes: Uint8Array): string {
 }
 const PNG_DATA_URL = `data:image/png;base64,${bytesToBase64(PNG_BYTES)}`;
 
+// A distinct JPEG body (FF D8 FF signature) so its base64 differs from the PNG,
+// letting a mixed-routing test prove WHICH image's base64 survives in the YAML.
+const JPEG_BYTES = Uint8Array.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x02,
+  0x03, 0x04, 0x05,
+]);
+const JPEG_DATA_URL = `data:image/jpeg;base64,${bytesToBase64(JPEG_BYTES)}`;
+
 /** A user image face carrying both a blob and the verbatim data URL. */
 function userFace(): DeviceImageData {
   return {
@@ -28,6 +36,17 @@ function userFace(): DeviceImageData {
       blob: new Blob([PNG_BYTES], { type: "image/png" }),
       dataUrl: PNG_DATA_URL,
       filename: "front.png",
+    },
+  };
+}
+
+/** A distinct JPEG user image face, for tests that need two different payloads. */
+function jpegFace(): DeviceImageData {
+  return {
+    front: {
+      blob: new Blob([JPEG_BYTES], { type: "image/jpeg" }),
+      dataUrl: JPEG_DATA_URL,
+      filename: "front.jpg",
     },
   };
 }
@@ -452,25 +471,28 @@ describe("saveLayoutToServer asset reconcile (server mode)", () => {
     const { fetchMock, calls } = makeRoutedFetch();
     vi.stubGlobal("fetch", fetchMock);
 
+    // Distinct payloads (PNG for the placement, JPEG for the slug) so the body
+    // assertions can prove WHICH image's bytes survive: the placement PNG must
+    // be dropped (on disk), the slug JPEG must remain embedded.
     await saveLayoutToServer(
       createTestLayout({ metadata: { id: SERVER_UUID } }),
       imageMap([
         [PLACEMENT_KEY, userFace()],
-        ["server-1u", userFace()],
+        ["server-1u", jpegFace()],
       ]),
       null,
     );
 
-    // Placement image goes to disk.
+    // Placement PNG goes to disk.
     const assetPut = calls.find(
       (c) =>
         c.method === "PUT" &&
         c.url.endsWith(`/assets/${SERVER_UUID}/${DEVICE_ID}/front`),
     );
     expect(assetPut).toBeDefined();
-    // Slug image stays embedded; the placement image's base64 is dropped.
+    // The slug JPEG stays embedded; the placement PNG's base64 is gone.
     const body = yamlBodyOf(calls);
-    expect(body).toContain("server-1u");
-    expect(body).toContain("data:image/png;base64");
+    expect(body).toContain(JPEG_DATA_URL);
+    expect(body).not.toContain(PNG_DATA_URL);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Wires the server-mode save path to write user images to disk via the asset API (foundation #2527) and stop embedding them in the layout YAML. This fixes the originating bug (#1426 / part of epic #2513): today the storage chip reports "saved" before images persist, and image-heavy layouts 413 against the 1MB layout cap.

Four folded-together pieces, all behind `getStorageMode() === "server"`:

1. Save wiring: each user image face PUTs to the asset API per `(deviceId, face)`; the YAML saves without the embedded base64 `images:` block, so it stays under the 1MB PUT cap.
2. Listing route: new `GET /assets/:layoutId` returning `AssetInfo[]`, validated with `LayoutIdSchema`, served at both `/assets` and `/api/assets` via the existing mount.
3. Set-diff orphan reconcile: desired set = current user faces; on-disk set = the new listing route; DELETE the difference. DELETE-then-PUT per replaced face dodges the non-atomic 507 on an at-limit replace.
4. Migrate-on-next-save: an embedded-only (pre-feature) image is decoded verbatim, written to disk, and its embed dropped on the next natural save (no force-dirty). The server magic-byte sniff (#2528) is the authority; a sniff reject retains the embedded payload so nothing is lost.

## The core bug fix (#1426)

The save reaches "saved" / `markClean()` ONLY AFTER the YAML PUT AND every asset PUT/DELETE resolve. The reconcile runs inside `saveLayoutToServer` after the YAML PUT, so any partial asset failure throws and `finalizeSuccessfulSave` never runs: the layout stays dirty and the next autosave retries. A unit test and a manager-level integration test both prove "a failed asset PUT keeps the layout dirty."

## Ordering / data safety

Assets need the layout folder, which the YAML PUT creates, so the sequence is YAML PUT then asset reconcile. The only loss window (YAML saved sans embed, asset PUT fails, hard crash before retry) is bounded: the in-memory image store keeps the bytes for the session and the layout stays dirty. This is the documented #2513 tradeoff (eager-blob load + retry), not a new hole.

## Not regressed

`encodeUserImagesToYaml` is untouched (still shared by browser download, snapshots, and the YAML editor). Only the server save call site changed. `persistence-api.test.ts`, `yaml-images.test.ts`, and `save-layout-to-server.test.ts` stay green.

## Tests

- Server route: listing returns the per-layout set, empty for a missing folder, clean 400 for a route-valid non-UUID id, reachable at the `/api` alias.
- Client save: asset PUT per face, embed omitted from the YAML body, failed-PUT-rejects-the-save, orphan DELETE set-diff, migrate-on-save writes to disk and drops the embed.
- Manager: server-mode save stays dirty when an asset write fails (#1426 guard).
- Upgrade corpus: a new embedded-images server-layout fixture covers migrate-on-save fidelity.

Local gates: `npm run lint`, `npm run test:run` (2836 pass), `npm run build`, and the api suite (`bun test`, 333 pass) all green.

Closes #2530

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Save server-mode images to disk and keep failed saves dirty**

### What Changed
- Server-mode saves now write user images to disk and leave the layout YAML without the embedded image block, so large image-heavy layouts are less likely to hit the 1 MB save limit.
- When a save runs, the app now removes images that are no longer needed on disk and replaces changed images without failing at the storage limit.
- If an image write fails, the save does not switch to “saved”; the layout stays dirty so the next autosave can retry.
- Embedded-only images can now be moved to disk on the next save, while invalid image data stays embedded instead of being dropped.

### Impact
`✅ Fewer 1 MB save failures for image-heavy layouts`
`✅ Saved images persist on disk after server-mode saves`
`✅ Fewer “saved” states when images did not finish writing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
