### PR TITLE
chore: unify neutral control styling across side panels (#2524)

### DIFF
--- a/src/lib/components/DeviceFilterPopover.svelte
+++ b/src/lib/components/DeviceFilterPopover.svelte
@@ -150,18 +150,21 @@
 </Popover.Root>
 
 <style>
+  /* Neutral form-control vocabulary shared with the edit panel's colour swatch
+     and the palette create button (#2524): input-bg fill, input-border,
+     selection border on hover and focus. 44px square keeps the touch standard
+     (#2397). */
   :global(.filter-trigger) {
     position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    /* 44px square control, matching the search field and touch standard (#2397). */
     width: 44px;
     height: 44px;
     padding: 0;
     color: var(--colour-text-muted);
-    background: var(--colour-surface-secondary);
-    border: 1px solid var(--colour-border);
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
     border-radius: var(--radius-sm);
     cursor: pointer;
     flex-shrink: 0;
@@ -173,8 +176,7 @@
 
   :global(.filter-trigger:hover) {
     color: var(--colour-text);
-    background: var(--colour-surface-hover);
-    border-color: var(--colour-border-hover);
+    border-color: var(--colour-selection);
   }
 
   :global(.filter-trigger:focus-visible) {

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -774,11 +774,13 @@
       box-shadow var(--duration-fast) ease;
   }
 
+  /* Neutral form-control vocabulary shared with the edit panel's colour swatch
+     and name-edit controls (#2524): input-bg fill, input-border, selection
+     border on hover and focus. 44px square keeps the touch standard (#2397). */
   .create-device-btn {
     display: flex;
     align-items: center;
     justify-content: center;
-    /* 44px square controls, matching the search field and touch standard (#2397). */
     width: 44px;
     height: 44px;
     padding: 0;
@@ -786,8 +788,8 @@
     font-weight: 400;
     line-height: 1;
     color: var(--colour-text-muted);
-    background: var(--colour-surface-secondary);
-    border: 1px solid var(--colour-border);
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
     border-radius: var(--radius-sm);
     cursor: pointer;
     flex-shrink: 0;
@@ -799,8 +801,7 @@
 
   .create-device-btn:hover {
     color: var(--colour-text);
-    background: var(--colour-surface-hover);
-    border-color: var(--colour-border-hover);
+    border-color: var(--colour-selection);
   }
 
   .create-device-btn:focus-visible {

--- a/src/lib/components/EditPanelMetadata.svelte
+++ b/src/lib/components/EditPanelMetadata.svelte
@@ -746,6 +746,9 @@
     align-items: center;
     gap: var(--space-2);
     width: 100%;
+    /* 44px min height keeps the touch standard shared with the palette
+       controls and position arrows (#2524, #2100). */
+    min-height: 44px;
     padding: var(--space-2) var(--space-3);
     background: var(--input-bg);
     border: 1px solid var(--input-border);
@@ -798,6 +801,9 @@
     justify-content: space-between;
     gap: var(--space-2);
     width: 100%;
+    /* 44px min height keeps the touch standard shared with the palette
+       controls and position arrows (#2524, #2100). */
+    min-height: 44px;
     padding: var(--space-2) var(--space-3);
     background: var(--input-bg);
     border: 1px solid var(--input-border);
@@ -813,7 +819,7 @@
     border-color: var(--colour-selection);
   }
 
-  .display-name-display:focus {
+  .display-name-display:focus-visible {
     outline: 2px solid var(--colour-selection);
     outline-offset: 2px;
   }

--- a/src/lib/components/EditPanelPosition.svelte
+++ b/src/lib/components/EditPanelPosition.svelte
@@ -222,15 +222,19 @@
     gap: var(--space-1);
   }
 
+  /* Neutral form-control vocabulary shared with the edit panel's colour swatch
+     and the palette create/filter buttons (#2524): input-bg fill, input-border,
+     selection border on hover and focus. 44px square keeps the touch standard
+     (#2100). */
   .position-btn {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
+    width: 44px;
+    height: 44px;
     padding: 0;
-    background: var(--button-bg);
-    border: 1px solid var(--colour-border);
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
     border-radius: var(--radius-sm);
     color: var(--colour-text);
     cursor: pointer;
@@ -245,7 +249,6 @@
   }
 
   .position-btn:hover:not(:disabled) {
-    background: var(--button-bg-hover);
     border-color: var(--colour-selection);
   }
 
@@ -256,7 +259,7 @@
 
   .position-btn:focus-visible {
     outline: 2px solid var(--colour-selection);
-    outline-offset: 1px;
+    outline-offset: 2px;
   }
 
   .arrow-label {


### PR DESCRIPTION
## **User description**
Closes #2524.

## Summary

Harmonizes the neutral controls across the two side panels onto the colour swatch's established form-control vocabulary, so the panel chrome reads as one system. The canonical treatment (already on `.colour-swatch-btn`) is: `--input-bg` fill, `--input-border`, `--colour-selection` border on hover, and a `2px`/`offset-2px` `:focus-visible` outline.

Controls brought into consistency:

- Device palette create "+" button (`.create-device-btn`): swapped to `--input-bg`/`--input-border`, hover now darkens the selection border instead of the surface fill.
- Filter popover trigger (`.filter-trigger`): same vocabulary swap.
- Name-edit button (`.display-name-display`): `:focus` to `:focus-visible` to match the swatch; added a 44px min-height.
- Colour swatch (`.colour-swatch-btn`): added a 44px min-height (it was the canonical look but had no explicit touch floor).
- Position arrows (`.position-btn`): resized from 24px to 44px square and moved onto the form-control vocabulary.

## Out of scope (deliberately untouched)

`EditPanelActions.svelte` was not touched. The destructive Remove from Rack and Delete from Library buttons keep their distinct danger treatment so they do not read as neutral controls. Destructive styling is owned by #2445.

## Acceptance Criteria

- [x] Neutral controls (palette create + filter, name edit, colour swatch, position arrows) share a consistent treatment
- [x] Destructive buttons are NOT restyled to look neutral (EditPanelActions left as-is)
- [x] 44px touch targets preserved (position arrows fixed from 24px to 44px; swatch and name-edit given a 44px min-height)

## Notes

The `.group-toggle` collapse toggle is intentionally left as the quiet borderless section-header disclosure: boxing it as a form control would break the muted uppercase "Device type details" header design. It already shares the canonical `:focus-visible` vocabulary (`--colour-selection`, `2px`/`offset-2px`), so it is consistent without restyling.

Styling-only change: no logic, handlers, aria-labels, or markup semantics were altered. svelte-autofixer clean on all four components; lint, full unit suite (2829 tests), and build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make neutral controls look and feel consistent across side panels**

### What Changed
- The filter button, add-device button, position arrows, colour swatch, and name-edit control now share the same neutral control styling
- Hover and focus states now use the same selection border treatment across these controls
- The colour swatch and name-edit control now keep a 44px minimum touch target, and the position arrows are now 44px square instead of 24px
- The name-edit control now shows its focus outline only when keyboard-focused

### Impact
`✅ Consistent side-panel controls`
`✅ Easier tapping on small controls`
`✅ Clearer keyboard focus on editable fields`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
