### PR TITLE
docs: reconcile SELF-HOSTING.md and SCHEMA.md with on-disk asset behaviour

### DIFF
--- a/docs/deployment/SELF-HOSTING.md
+++ b/docs/deployment/SELF-HOSTING.md
@@ -37,7 +37,7 @@ docker run -d -p 8080:8080 ghcr.io/rackulalives/rackula:latest
 - **Layouts saved as YAML** in per-layout folders under `./data/`
 - **Access from any browser** on your network
 - **Optional write-route token auth** for `PUT`/`DELETE` API routes
-- **Custom device images** stored under each layout folder in `assets/`
+- **Custom device images** stored as files on disk under each layout folder in `assets/{deviceId}/{face}.{ext}`, not embedded in the YAML
 
 **Architecture:**
 
@@ -133,6 +133,48 @@ A write token (`RACKULA_API_WRITE_TOKEN`) gates only the write methods (`POST`, 
 To gate reads, set `RACKULA_AUTH_MODE` to `local` or `oidc`. The session gate then covers `GET` requests too, so reads require a logged-in session. Enabling `RACKULA_AUTH_MODE` is the way to require auth for reading layouts and assets.
 
 Served assets carry `X-Content-Type-Options: nosniff` from both the API and the nginx edge, so a polyglot image cannot be MIME-sniffed into active content even when reads are open.
+
+---
+
+## Custom device image storage
+
+In server-side persistence mode, custom device images live as files on disk, not embedded in the layout YAML. This keeps image-heavy layouts under the 1MB layout-body cap (see [Size limits](#size-limits) below) and lets the API serve each image directly.
+
+### Three `assets/` shapes
+
+The string `assets/` appears in three different contexts with three different layouts. They are not interchangeable. Know which one you are looking at:
+
+| Context | Path shape | Folder key | Image bytes |
+| --- | --- | --- | --- |
+| Server API on disk | `assets/{deviceId}/{face}.{ext}` | per-placement device UUID | a file per face |
+| Browser ZIP export (`.Rackula.zip`) | `assets/{device_type-slug}/{deviceId}-{face}.{ext}` | device-type slug | a file per face, named with the placement UUID |
+| Browser `.rackula.yaml` | no `assets/` folder | not applicable | embedded as base64 in the YAML |
+
+The server on-disk shape and the browser ZIP shape differ by design: the on-disk folder is keyed by the placement's device UUID, while the ZIP groups images under the device-type slug and carries the placement UUID in the filename. The browser `.rackula.yaml` single-file save embeds images as base64 data URIs and has no `assets/` folder at all; this is unchanged.
+
+### When `assets/` appears (migrate on next save)
+
+A layout written by an earlier server-mode release may still carry its images embedded in the YAML. Those images move to disk on the next save of that layout, not when you open it. So `assets/` appears after you next save a layout that had embedded images; reopening a layout read-only does not create it. The embedded copy continues to load until that save happens.
+
+### Size limits
+
+Three separate caps apply. They are distinct and enforced independently:
+
+| Limit | Default | Override | Response when exceeded |
+| --- | --- | --- | --- |
+| Per-asset image size | 5MB | `MAX_ASSET_SIZE` (bytes) | HTTP 413 |
+| Per-layout asset count | 50 | `RACKULA_MAX_ASSETS_PER_LAYOUT` (`0` for unlimited) | HTTP 507 |
+| Per-layout YAML body size | 1MB | not configurable | HTTP 413 |
+
+Moving images to disk is what keeps the layout YAML under the 1MB body cap: the YAML stores only the structure and references, while the image bytes count against the per-asset and per-layout asset limits instead.
+
+### Type safety for served images
+
+Custom images are accepted only when their leading bytes sniff to PNG, JPEG, or WebP, regardless of the declared content type. SVG and other formats are rejected. Served images rely on this byte allowlist plus the `nosniff` header described under [Read access in write-token-only mode](#read-access-in-write-token-only-mode) for type safety; they are not gated by a Content-Security-Policy.
+
+### Snapshots are structure only
+
+Server-mode keeps a per-layout snapshot before an overwrite that conflicts with a copy changed elsewhere (see [Upgrading an existing deployment](#upgrading-an-existing-deployment)). A snapshot captures the layout YAML, that is, its structure, only. Image bytes are not copied into the snapshot. Restoring an older snapshot therefore pairs the older structure with the current on-disk assets: if an image was replaced since the snapshot, you get the current image, and if it was deleted, that face shows as missing. Restoring does not bring back the image as it was at snapshot time. Snapshots taken by an earlier release that still embed images continue to load via the backward-compatible decoder, so older snapshots are not lost.
 
 ---
 
@@ -832,12 +874,14 @@ tar xzf rackula-backup.tar.gz -C ./data
 ├── my-homelab-11111111-1111-4111-8111-111111111111/
 │   ├── my-homelab.rackula.yaml
 │   └── assets/
-│       └── custom-nas/
+│       └── 33333333-3333-4333-8333-333333333333/
 │           ├── front.png
 │           └── rear.png
 └── production-rack-22222222-2222-4222-8222-222222222222/
     └── production-rack.rackula.yaml
 ```
+
+Each layout lives in its own folder named `{layout-name}-{layout-UUID}`, holding one `*.rackula.yaml` file. Custom device images are stored on disk, not in the YAML. The `assets/` folder appears only when a layout has at least one custom image, and each placed device that has an image gets a folder named after that placement's device UUID, with one file per face: `assets/{deviceId}/{face}.{ext}`. The face is `front` or `rear`; the extension is `png`, `jpg`, or `webp`, derived from the image's sniffed bytes (see [Custom device image storage](#custom-device-image-storage) below).
 
 ### Security Hardening
 
@@ -898,6 +942,8 @@ When a quota is exceeded:
 - Asset limit reached returns HTTP 507 with a message to remove existing assets
 
 Layout quota only applies to new layouts. Updating an existing layout always succeeds.
+
+Two request-body size caps apply alongside these count quotas: each uploaded image is limited to 5MB (override with `MAX_ASSET_SIZE` in bytes), and each layout YAML body is limited to 1MB. Both return HTTP 413 when exceeded. These are distinct from the count quotas above; see [Custom device image storage](#custom-device-image-storage) for how the caps interact.
 
 ### Logging
 

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -134,6 +134,20 @@ Template definition for devices in the library. Referenced by `PlacedDevice.devi
 | `front_image` | `boolean` | No       | Front image available |
 | `rear_image`  | `boolean` | No       | Rear image available  |
 
+`front_image` and `rear_image` are boolean availability flags, not the image data. They record whether a face has a custom image; the bytes are stored separately depending on the storage mode.
+
+#### Where image bytes are stored
+
+The image bytes referenced by `front_image` and `rear_image` are not part of the schema fields above. Their storage depends on the mode:
+
+| Mode | Where bytes live |
+| --- | --- |
+| Server-side persistence | On disk, one file per face, at `assets/{deviceId}/{face}.{ext}` inside the layout folder. The YAML holds only the boolean flags. |
+| Browser, `.rackula.yaml` single file | Embedded in the YAML as base64 data URIs. |
+| Browser, `.Rackula.zip` archive | Stored in the archive at `assets/{device_type-slug}/{deviceId}-{face}.{ext}`. |
+
+In server-side persistence mode, no base64 image data appears in the stored layout YAML. For the on-disk layout, the per-asset and per-layout limits, and the snapshot behaviour, see the [Self-Hosting Guide](../deployment/SELF-HOSTING.md#custom-device-image-storage).
+
 #### Rackula Fields
 
 | Field      | Type             | Required | Description                       |


### PR DESCRIPTION
## **User description**
Closes #2533

Wave 3 (final) of epic #2513. Docs-only: make the documentation true to the on-disk asset behaviour shipped by #2530 (save), #2531 (load), and #2529 (read posture + nosniff). Builds on the read-posture note #2529 added to SELF-HOSTING.md without duplicating or contradicting it.

## What changed

`docs/deployment/SELF-HOSTING.md`

- Fixed the What You Get bullet and the Data Directory Structure example to show the real server on-disk shape `assets/{deviceId}/{face}.{ext}` (per-placement device UUID folder), replacing the misleading `custom-nas/front.png` example.
- Added a Custom device image storage section that documents:
  - The three distinct `assets/` shapes so they are not conflated: server API on disk `assets/{deviceId}/{face}.{ext}`, browser ZIP export `assets/{device_type-slug}/{deviceId}-{face}.{ext}`, and browser `.rackula.yaml` which embeds images as base64 (unchanged).
  - The migrate-on-next-save nuance: embedded images move to disk on the next save, not on open, so `assets/` appears only after that save.
  - The size limits: 5MB per asset (HTTP 413), 50 assets per layout via `RACKULA_MAX_ASSETS_PER_LAYOUT` (HTTP 507), and the 1MB layout YAML body cap (HTTP 413), and how moving images to disk keeps layouts under the 1MB cap.
  - The byte-allowlist-plus-nosniff type-safety posture (PNG/JPEG/WebP, sniffed bytes, not CSP), cross-linked to the existing read-posture note.
  - The structure-only snapshot behaviour: restoring an older snapshot uses current on-disk assets (or shows a missing face); pre-existing embedded-image snapshots still load via the backward-compatible decoder.
- Noted the per-asset and per-layout body size caps in the Storage Quotas section.

`docs/reference/SCHEMA.md`

- Clarified that `front_image`/`rear_image` are availability flags, not data, and documented where the bytes live per storage mode (disk vs embedded base64), with no stale embed-in-YAML claim for server mode.

## Verification

- Every claim was checked against source: server path is keyed by the per-placement device UUID (`src/lib/storage/assets-api.ts` `deviceKeyForWire` / the `:deviceId` wire segment), 5MB / 1MB caps (`api/src/app.ts`), 50 default and HTTP 507 (`api/src/security/config.ts`, storage-quota middleware), browser ZIP shape (`src/lib/utils/archive.ts`), snapshots are YAML-only (`api/src/storage/filesystem.ts` `writeSnapshot`), nosniff at API and nginx edge.
- `npm run lint` clean, `npx prettier --check` on both docs clean, all in-doc anchors and the SCHEMA->SELF-HOSTING cross-link resolve.

Docs-only, so no dev deploy is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Clarify where custom device images are stored and how they behave**

### What Changed
- Explains that `front_image` and `rear_image` are only availability flags, and points to where the actual image bytes live in server storage, browser ZIP exports, and single-file YAML saves
- Documents the server-side on-disk image layout, when embedded images move to disk, and how snapshots use the current on-disk images rather than preserving old image bytes
- Adds the image size, asset count, and layout body limits, plus the supported image types and `nosniff`-based handling for served images

### Impact
`✅ Clearer image storage docs`
`✅ Fewer surprises after saving layouts`
`✅ Easier recovery and quota planning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
