### PR TITLE
docs: spike #2437 side panel collapse affordance research

### DIFF
--- a/docs/research/2437-codebase.md
+++ b/docs/research/2437-codebase.md
@@ -1,0 +1,39 @@
+# Spike #2437 Codebase Findings
+
+How the two side panels collapse today, and where a clickable-border affordance would attach.
+
+## Files Examined
+
+- `src/lib/components/SidePanel.svelte` (166 lines): right-panel chrome. Holds the `aside.side-panel`, toggles between `CollapsedPanelStrip` (collapsed) and `SidePanelContent` (expanded). Owns expand/collapse focus management (#2076).
+- `src/lib/components/SidePanelContent.svelte` (410 lines): the tabbed Edit/View content. Renders the in-row collapse chevron `.side-panel-collapse-btn` (IconChevronRight, `»`) at the far-right of the tab row when an `oncollapse` prop is passed.
+- `src/lib/components/SidebarTabs.svelte` (190 lines): left-panel tab row (Layouts / Racks / Devices). Renders the in-row collapse chevron `.sidebar-collapse-btn` (IconChevronLeft, `«`) at the far-left of the tab row.
+- `src/lib/components/CollapsedPanelStrip.svelte` (113 lines): the shared 44px collapsed strip for BOTH panels, mirrored via a `side` prop. The whole strip is one reopen button.
+- `src/App.svelte` (around lines 561-603): composes the left panel directly as `aside.sidebar-panel`, switching between `CollapsedPanelStrip` and `SidebarTabs` + the active list. Defines `handleCollapseSidebar` / `handleExpandSidebar`.
+- `src/lib/stores/ui.svelte.ts`: holds `sidebarCollapsed` and `sidePanelCollapsed` `$state`, with `setSidebarCollapsed`, `toggleSidebarCollapsed`, `setSidePanelCollapsed`, `toggleSidePanelCollapsed`. Both persist to localStorage and restore on load.
+- `src/lib/styles/tokens.css`: relevant tokens are `--colour-border`, `--colour-border-hover`, `--colour-surface-hover`, `--colour-selection`, `--side-panel-width: 320px`, `--panel-collapsed-strip-width: 44px`.
+
+## Existing Patterns
+
+- Symmetric design: both panels collapse outward to an identical 44px strip via the same `CollapsedPanelStrip` component (#2397). The strip shows a reopen chevron plus the active tab name as a rotated vertical label, and is itself one big button.
+- Expanded, each panel exposes a single 44px-square chevron button in its tab row: `«` on the left panel (far-left), `»` on the right panel (far-right). Both point toward the edge they collapse to.
+- Collapse state is centralised in the UI store and persisted, so any new affordance just needs to call the same `set*Collapsed(true)` setters. No new state is required.
+- The right panel auto-expands on selection (`SidePanel.svelte` effect on `selectionStore.hasSelection`); the left panel does not auto-collapse.
+- Edges: the expanded right panel draws `border-left: 1px solid var(--colour-border)`; the left panel draws its border on the inner edge of its content. The collapsed strips draw their own outer border (`--left` border-right, `--right` border-left). There is currently no interactive behaviour on these borders.
+
+## Integration Points
+
+A clickable-border affordance would attach at the panel edge that faces the canvas:
+
+- Right panel: the `border-left` of `aside.side-panel` in `SidePanel.svelte`. A grip element would live inside that aside, absolutely positioned on the left edge.
+- Left panel: the inner (canvas-facing, right) edge of `aside.sidebar-panel` in `App.svelte`. A grip would live inside that aside, absolutely positioned on the right edge.
+- Both grips would call the existing `handleCollapse*` / `set*Collapsed(true)` handlers. No store change needed.
+- Mobile is unaffected: both the strip and the in-row chevron are desktop/tablet only; on phone the same content composes into a bottom sheet. Any border grip must also be gated to non-mobile.
+
+## Constraints
+
+- Svelte 5 runes only (`$state`, `$derived`, `$effect`); no Svelte 4 stores.
+- Touch standard: interactive targets are 44px on mobile (ACCESSIBILITY standards, #2100). A border-only target is far thinner than 44px, so a border-collapse must not be the only collapse path on touch and needs an adequately sized hit area on pointer devices.
+- A11y: panels are labelled landmarks; expand moves focus to the active tab heading, collapse returns focus to the strip reopen button (#2076). Any new control must be keyboard reachable and not strand focus. A grip should not become a second confusing tab stop with an unclear label.
+- `prefers-reduced-motion: reduce` is respected throughout; any grip reveal animation must honour it.
+- The collapsed strip (reopen path) is already a large, discoverable target. The open question is only the COLLAPSE (close) affordance, not reopen.
+- The fixed 320px panel width keeps canvas fit-to-view stable; a border-collapse must not turn into a drag-to-resize handle (out of scope, would change width).

--- a/docs/research/2437-external.md
+++ b/docs/research/2437-external.md
@@ -1,0 +1,155 @@
+# Spike #2437 External Research
+
+Research question: can the collapse chevron on a side panel be replaced by a
+clickable panel border/edge without losing discoverability? This compares that
+against keeping a visible chevron or handle. Findings are drawn from VS Code and
+Figma behaviour, plus established UX guidance on signifiers and hit targets.
+
+## Industry Practices
+
+The pattern across mature editors is layered controls, not a single hidden one.
+None of the editors surveyed rely on a bare clickable border as the only way to
+collapse a panel. Each pairs an always-visible control with a keyboard shortcut,
+and treats the draggable border as a resize affordance rather than the primary
+collapse control.
+
+- VS Code, Primary Side Bar: collapses with Ctrl+B (Cmd+B on Mac), the most
+  documented method. It also keeps a persistent Activity Bar on the edge whose
+  icons re-open a view, and a "Customize Layout" control plus View menu entries
+  that toggle visibility. The border between the side bar and editor is a
+  draggable sash for resizing, separate from collapsing. So VS Code keeps
+  multiple visible affordances (Activity Bar icons, menu items, layout control)
+  in addition to the keyboard shortcut. The draggable border is never the only
+  way in.
+- VS Code, Secondary Side Bar and Panel: same model. They are repositionable and
+  toggleable via menu commands and shortcuts, not via a hidden edge. The Panel
+  has a visible close affordance and shortcut (Ctrl+J).
+- Figma, left and right panels: in the current UI (UI3) the panels minimise and
+  expand with Shift+\ (both panels together). There is also a visible control in
+  the interface: a minimise-UI button and collapse arrows you can click, rather
+  than relying on the keyboard alone. Earlier UI (UI2) allowed independent
+  left/right collapse, and users have actively requested that independence back,
+  which shows the collapse control is something users look for and expect to be
+  reachable, not hidden.
+
+Takeaway for #2437: a clickable border can be one entry point, but the
+prevailing practice is to also keep at least one persistently visible affordance
+(an icon, an arrow, or a labelled control) and a keyboard shortcut. Replacing the
+chevron with a border alone would diverge from how VS Code and Figma ship.
+
+## Hidden vs Visible Affordances
+
+The governing principle is Don Norman's distinction between affordances and
+signifiers. An affordance is a possible action an object permits. A signifier is
+the perceivable signal that tells a person the action exists and how to do it.
+
+Norman's core argument, from his essay "Signifiers, not affordances": affordances
+"did not have to be perceivable or even knowable, they simply existed," and
+because of that, "what people need, and what design must provide, are
+signifiers." His point is that an action that is genuinely possible is still
+useless if the user cannot detect that it is possible. A clickable panel border
+is an affordance with a missing or weak signifier: the click works, but nothing
+on screen tells a first-time user it is there.
+
+Nielsen Norman Group reinforces this for screen interfaces. In "Beyond Blue
+Links: Making Clickable Elements Recognizable," NN/g notes that on a screen every
+pixel can be clicked even though most clicks do nothing, so users will not play a
+"minesweeping game" hunting for what is actionable. The article's blunt summary,
+"life is too short to click on things you don't understand," captures the cost of
+hidden controls. It explicitly warns that over-minimal flat design strips away
+the signals (borders, shape, contrast, depth) that tell users something is
+interactive, and that removing them "without substituting clear alternatives
+creates ambiguity about what's clickable." A border with no visible mark is
+exactly that ambiguity.
+
+Conclusion: a border-only collapse fails the signifier test. To keep it without
+losing discoverability you must add a perceptible signifier (a persistent grip
+mark, an arrow, contrast, or shape) so the affordance is announced, not just
+present.
+
+## The Hover-Revealed Grip Pattern
+
+The hover-revealed grip is a recognised pattern: on hover over a panel edge or
+splitter, the cursor changes (commonly to col-resize or row-resize for
+splitters, or pointer for a clickable region) and a grip mark such as a row of
+dots or a thin handle appears. It is widely used for resizable split views and
+panes, and the CSS cursor property includes col-resize and row-resize precisely
+to signal horizontal and vertical resizing on these handles.
+
+Its discoverability limits are real and well documented:
+
+- Touch devices have no hover. NN/g and others note that touch interfaces
+  generally do not generate hover events, so any signifier that only appears on
+  hover is invisible to mobile and tablet users. On touch, "the first click
+  shows the hidden content and the second click leads you to it," meaning
+  hover-gated controls become a two-tap guessing exercise or are missed
+  entirely. A grip that only appears on hover does not exist for touch users.
+- First-time users may never trigger the hover. The reveal only fires if the
+  pointer lands on the exact edge. A user who never happens to move the cursor
+  over the thin border never sees the cursor change or the grip, so the control
+  stays undiscovered. The signifier is conditional on already suspecting the
+  control is there.
+- Cursor change is not a signifier at rest. cursor: pointer and col-resize only
+  communicate after the pointer is over the target, so they cannot do the job of
+  announcing the control before interaction.
+
+So the hover-revealed grip improves a border control for mouse users who explore
+the edge, but it does not solve discoverability for touch users or for users who
+never hover the precise spot. It is a reinforcement, not a substitute for an
+at-rest visible signifier.
+
+## Resize Handle / Hit-Target Guidance
+
+Even a discoverable handle fails if it is too small to hit reliably.
+
+- WCAG 2.2 Success Criterion 2.5.8, Target Size (Minimum), Level AA: pointer
+  targets must be at least 24 by 24 CSS pixels, or, if smaller, have enough
+  spacing that a 24px-diameter circle centred on each target does not intersect
+  another target. A 1px or 2px border is well under this and would fail unless
+  the hit area is padded out to 24px even when the visible line stays thin.
+- WCAG 2.2 Success Criterion 2.5.5, Target Size (Enhanced), Level AAA: 44 by 44
+  CSS pixels for important controls. Apple's Human Interface Guidelines also
+  recommend 44 by 44 points, and Google Material recommends 48 by 48 dp for
+  touch targets. For a primary collapse control these stricter sizes are the
+  better target, especially on touch.
+- Sash and splitter practice: editors render a thin visible divider but give it a
+  wider invisible hit zone, and combine it with a cursor change on hover. The
+  visible line can stay slim for aesthetics as long as the actual interactive
+  region meets the minimum hit size.
+
+Implication for #2437: if the panel border is to be clickable, pad its hit area
+to at least 24px (ideally 44px for the collapse action and for touch), keep the
+collapse affordance distinct from the resize sash so the two actions do not
+conflict on the same pixels, and ensure the visible signifier (grip or arrow) is
+large enough to both see and tap.
+
+## Sources
+
+- https://code.visualstudio.com/docs/getstarted/userinterface - VS Code UI:
+  Activity Bar, Primary and Secondary Side Bars, Panel, layout customization,
+  toggling and repositioning views.
+- https://code.visualstudio.com/docs/getstarted/tips-and-tricks - VS Code tips,
+  including Ctrl+B / Cmd+B toggle sidebar and related layout shortcuts.
+- https://bobbyhadz.com/blog/vscode-show-hide-sidebar - confirms Ctrl/Cmd+B and
+  the Activity Bar show/hide behaviour in VS Code.
+- https://forum.figma.com/suggest-a-feature-11/bring-back-independent-left-right-panel-collapsing-as-in-ui2-42703
+  - Figma users requesting independent left/right panel collapse; documents that
+  UI3 collapses both panels together and UI2 collapsed them independently.
+- https://forum.figma.com/suggest-a-feature-11/option-to-hide-the-right-panel-20448
+  - Figma forum thread on hiding the right panel and panel-toggle behaviour.
+- https://jnd.org/signifiers-not-affordances/ - Don Norman's primary essay
+  distinguishing affordances from signifiers; "what design must provide, are
+  signifiers"; affordances need not be perceivable to exist.
+- https://www.nngroup.com/articles/clickable-elements/ - NN/g "Beyond Blue
+  Links"; the minesweeping problem, "life is too short to click on things you
+  don't understand," and the flat-design loss of clickability signifiers.
+- https://www.nngroup.com/articles/timing-exposing-content/ - NN/g on exposing
+  hidden content and the hover problem on touch devices.
+- https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html - WCAG 2.2
+  SC 2.5.8 Target Size (Minimum), 24x24 CSS px, Level AA, with the spacing
+  exception.
+- https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html - WCAG
+  2.2 SC 2.5.5 Target Size (Enhanced), 44x44 CSS px, Level AAA.
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor -
+  MDN cursor property; col-resize and row-resize values for splitter handles and
+  the limits of cursor as a signifier on touch.

--- a/docs/research/2437-external.md
+++ b/docs/research/2437-external.md
@@ -1,155 +1,61 @@
 # Spike #2437 External Research
 
-Research question: can the collapse chevron on a side panel be replaced by a
-clickable panel border/edge without losing discoverability? This compares that
-against keeping a visible chevron or handle. Findings are drawn from VS Code and
-Figma behaviour, plus established UX guidance on signifiers and hit targets.
+Research question: can the collapse chevron on a side panel be replaced by a clickable panel border/edge without losing discoverability? This compares that against keeping a visible chevron or handle. Findings are drawn from VS Code and Figma behaviour, plus established UX guidance on signifiers and hit targets.
 
 ## Industry Practices
 
-The pattern across mature editors is layered controls, not a single hidden one.
-None of the editors surveyed rely on a bare clickable border as the only way to
-collapse a panel. Each pairs an always-visible control with a keyboard shortcut,
-and treats the draggable border as a resize affordance rather than the primary
-collapse control.
+The pattern across mature editors is layered controls, not a single hidden one. None of the editors surveyed rely on a bare clickable border as the only way to collapse a panel. Each pairs an always-visible control with a keyboard shortcut, and treats the draggable border as a resize affordance rather than the primary collapse control.
 
-- VS Code, Primary Side Bar: collapses with Ctrl+B (Cmd+B on Mac), the most
-  documented method. It also keeps a persistent Activity Bar on the edge whose
-  icons re-open a view, and a "Customize Layout" control plus View menu entries
-  that toggle visibility. The border between the side bar and editor is a
-  draggable sash for resizing, separate from collapsing. So VS Code keeps
-  multiple visible affordances (Activity Bar icons, menu items, layout control)
-  in addition to the keyboard shortcut. The draggable border is never the only
-  way in.
-- VS Code, Secondary Side Bar and Panel: same model. They are repositionable and
-  toggleable via menu commands and shortcuts, not via a hidden edge. The Panel
-  has a visible close affordance and shortcut (Ctrl+J).
-- Figma, left and right panels: in the current UI (UI3) the panels minimise and
-  expand with Shift+\ (both panels together). There is also a visible control in
-  the interface: a minimise-UI button and collapse arrows you can click, rather
-  than relying on the keyboard alone. Earlier UI (UI2) allowed independent
-  left/right collapse, and users have actively requested that independence back,
-  which shows the collapse control is something users look for and expect to be
-  reachable, not hidden.
+- VS Code, Primary Side Bar: collapses with Ctrl+B (Cmd+B on Mac), the most documented method. It also keeps a persistent Activity Bar on the edge whose icons re-open a view, and a "Customize Layout" control plus View menu entries that toggle visibility. The border between the side bar and editor is a draggable sash for resizing, separate from collapsing. So VS Code keeps multiple visible affordances (Activity Bar icons, menu items, layout control) in addition to the keyboard shortcut. The draggable border is never the only way in.
+- VS Code, Secondary Side Bar and Panel: same model. They are repositionable and toggleable via menu commands and shortcuts, not via a hidden edge. The Panel has a visible close affordance and shortcut (Ctrl+J).
+- Figma, left and right panels: in the current UI (UI3) the panels minimise and expand with Shift+\ (both panels together). There is also a visible control in the interface: a minimise-UI button and collapse arrows you can click, rather than relying on the keyboard alone. Earlier UI (UI2) allowed independent left/right collapse, and users have actively requested that independence back, which shows the collapse control is something users look for and expect to be reachable, not hidden.
 
-Takeaway for #2437: a clickable border can be one entry point, but the
-prevailing practice is to also keep at least one persistently visible affordance
-(an icon, an arrow, or a labelled control) and a keyboard shortcut. Replacing the
-chevron with a border alone would diverge from how VS Code and Figma ship.
+Takeaway for #2437: a clickable border can be one entry point, but the prevailing practice is to also keep at least one persistently visible affordance (an icon, an arrow, or a labelled control) and a keyboard shortcut. Replacing the chevron with a border alone would diverge from how VS Code and Figma ship.
 
 ## Hidden vs Visible Affordances
 
-The governing principle is Don Norman's distinction between affordances and
-signifiers. An affordance is a possible action an object permits. A signifier is
-the perceivable signal that tells a person the action exists and how to do it.
+The governing principle is Don Norman's distinction between affordances and signifiers. An affordance is a possible action an object permits. A signifier is the perceivable signal that tells a person the action exists and how to do it.
 
-Norman's core argument, from his essay "Signifiers, not affordances": affordances
-"did not have to be perceivable or even knowable, they simply existed," and
-because of that, "what people need, and what design must provide, are
-signifiers." His point is that an action that is genuinely possible is still
-useless if the user cannot detect that it is possible. A clickable panel border
-is an affordance with a missing or weak signifier: the click works, but nothing
-on screen tells a first-time user it is there.
+Norman's core argument, from his essay "Signifiers, not affordances": affordances "did not have to be perceivable or even knowable, they simply existed," and because of that, "what people need, and what design must provide, are signifiers." His point is that an action that is genuinely possible is still useless if the user cannot detect that it is possible. A clickable panel border is an affordance with a missing or weak signifier: the click works, but nothing on screen tells a first-time user it is there.
 
-Nielsen Norman Group reinforces this for screen interfaces. In "Beyond Blue
-Links: Making Clickable Elements Recognizable," NN/g notes that on a screen every
-pixel can be clicked even though most clicks do nothing, so users will not play a
-"minesweeping game" hunting for what is actionable. The article's blunt summary,
-"life is too short to click on things you don't understand," captures the cost of
-hidden controls. It explicitly warns that over-minimal flat design strips away
-the signals (borders, shape, contrast, depth) that tell users something is
-interactive, and that removing them "without substituting clear alternatives
-creates ambiguity about what's clickable." A border with no visible mark is
-exactly that ambiguity.
+Nielsen Norman Group reinforces this for screen interfaces. In "Beyond Blue Links: Making Clickable Elements Recognizable," NN/g notes that on a screen every pixel can be clicked even though most clicks do nothing, so users will not play a "minesweeping game" hunting for what is actionable. The article's blunt summary, "life is too short to click on things you don't understand," captures the cost of hidden controls. It explicitly warns that over-minimal flat design strips away the signals (borders, shape, contrast, depth) that tell users something is interactive, and that removing them "without substituting clear alternatives creates ambiguity about what's clickable." A border with no visible mark is exactly that ambiguity.
 
-Conclusion: a border-only collapse fails the signifier test. To keep it without
-losing discoverability you must add a perceptible signifier (a persistent grip
-mark, an arrow, contrast, or shape) so the affordance is announced, not just
-present.
+Conclusion: a border-only collapse fails the signifier test. To keep it without losing discoverability you must add a perceptible signifier (a persistent grip mark, an arrow, contrast, or shape) so the affordance is announced, not just present.
 
 ## The Hover-Revealed Grip Pattern
 
-The hover-revealed grip is a recognised pattern: on hover over a panel edge or
-splitter, the cursor changes (commonly to col-resize or row-resize for
-splitters, or pointer for a clickable region) and a grip mark such as a row of
-dots or a thin handle appears. It is widely used for resizable split views and
-panes, and the CSS cursor property includes col-resize and row-resize precisely
-to signal horizontal and vertical resizing on these handles.
+The hover-revealed grip is a recognised pattern: on hover over a panel edge or splitter, the cursor changes (commonly to col-resize or row-resize for splitters, or pointer for a clickable region) and a grip mark such as a row of dots or a thin handle appears. It is widely used for resizable split views and panes, and the CSS cursor property includes col-resize and row-resize precisely to signal horizontal and vertical resizing on these handles.
 
 Its discoverability limits are real and well documented:
 
-- Touch devices have no hover. NN/g and others note that touch interfaces
-  generally do not generate hover events, so any signifier that only appears on
-  hover is invisible to mobile and tablet users. On touch, "the first click
-  shows the hidden content and the second click leads you to it," meaning
-  hover-gated controls become a two-tap guessing exercise or are missed
-  entirely. A grip that only appears on hover does not exist for touch users.
-- First-time users may never trigger the hover. The reveal only fires if the
-  pointer lands on the exact edge. A user who never happens to move the cursor
-  over the thin border never sees the cursor change or the grip, so the control
-  stays undiscovered. The signifier is conditional on already suspecting the
-  control is there.
-- Cursor change is not a signifier at rest. cursor: pointer and col-resize only
-  communicate after the pointer is over the target, so they cannot do the job of
-  announcing the control before interaction.
+- Touch devices have no hover. NN/g and others note that touch interfaces generally do not generate hover events, so any signifier that only appears on hover is invisible to mobile and tablet users. On touch, "the first click shows the hidden content and the second click leads you to it," meaning hover-gated controls become a two-tap guessing exercise or are missed entirely. A grip that only appears on hover does not exist for touch users.
+- First-time users may never trigger the hover. The reveal only fires if the pointer lands on the exact edge. A user who never happens to move the cursor over the thin border never sees the cursor change or the grip, so the control stays undiscovered. The signifier is conditional on already suspecting the control is there.
+- Cursor change is not a signifier at rest. cursor: pointer and col-resize only communicate after the pointer is over the target, so they cannot do the job of announcing the control before interaction.
 
-So the hover-revealed grip improves a border control for mouse users who explore
-the edge, but it does not solve discoverability for touch users or for users who
-never hover the precise spot. It is a reinforcement, not a substitute for an
-at-rest visible signifier.
+So the hover-revealed grip improves a border control for mouse users who explore the edge, but it does not solve discoverability for touch users or for users who never hover the precise spot. It is a reinforcement, not a substitute for an at-rest visible signifier.
 
 ## Resize Handle / Hit-Target Guidance
 
 Even a discoverable handle fails if it is too small to hit reliably.
 
-- WCAG 2.2 Success Criterion 2.5.8, Target Size (Minimum), Level AA: pointer
-  targets must be at least 24 by 24 CSS pixels, or, if smaller, have enough
-  spacing that a 24px-diameter circle centred on each target does not intersect
-  another target. A 1px or 2px border is well under this and would fail unless
-  the hit area is padded out to 24px even when the visible line stays thin.
-- WCAG 2.2 Success Criterion 2.5.5, Target Size (Enhanced), Level AAA: 44 by 44
-  CSS pixels for important controls. Apple's Human Interface Guidelines also
-  recommend 44 by 44 points, and Google Material recommends 48 by 48 dp for
-  touch targets. For a primary collapse control these stricter sizes are the
-  better target, especially on touch.
-- Sash and splitter practice: editors render a thin visible divider but give it a
-  wider invisible hit zone, and combine it with a cursor change on hover. The
-  visible line can stay slim for aesthetics as long as the actual interactive
-  region meets the minimum hit size.
+- WCAG 2.2 Success Criterion 2.5.8, Target Size (Minimum), Level AA: pointer targets must be at least 24 by 24 CSS pixels, or, if smaller, have enough spacing that a 24px-diameter circle centred on each target does not intersect another target. A 1px or 2px border is well under this and would fail unless the hit area is padded out to 24px even when the visible line stays thin.
+- WCAG 2.2 Success Criterion 2.5.5, Target Size (Enhanced), Level AAA: 44 by 44 CSS pixels for important controls. Apple's Human Interface Guidelines also recommend 44 by 44 points, and Google Material recommends 48 by 48 dp for touch targets. For a primary collapse control these stricter sizes are the better target, especially on touch.
+- Sash and splitter practice: editors render a thin visible divider but give it a wider invisible hit zone, and combine it with a cursor change on hover. The visible line can stay slim for aesthetics as long as the actual interactive region meets the minimum hit size.
 
-Implication for #2437: if the panel border is to be clickable, pad its hit area
-to at least 24px (ideally 44px for the collapse action and for touch), keep the
-collapse affordance distinct from the resize sash so the two actions do not
-conflict on the same pixels, and ensure the visible signifier (grip or arrow) is
-large enough to both see and tap.
+Implication for #2437: if the panel border is to be clickable, pad its hit area to at least 24px (ideally 44px for the collapse action and for touch), keep the collapse affordance distinct from the resize sash so the two actions do not conflict on the same pixels, and ensure the visible signifier (grip or arrow) is large enough to both see and tap.
 
 ## Sources
 
-- https://code.visualstudio.com/docs/getstarted/userinterface - VS Code UI:
-  Activity Bar, Primary and Secondary Side Bars, Panel, layout customization,
-  toggling and repositioning views.
-- https://code.visualstudio.com/docs/getstarted/tips-and-tricks - VS Code tips,
-  including Ctrl+B / Cmd+B toggle sidebar and related layout shortcuts.
-- https://bobbyhadz.com/blog/vscode-show-hide-sidebar - confirms Ctrl/Cmd+B and
-  the Activity Bar show/hide behaviour in VS Code.
+- https://code.visualstudio.com/docs/getstarted/userinterface - VS Code UI: Activity Bar, Primary and Secondary Side Bars, Panel, layout customization, toggling and repositioning views.
+- https://code.visualstudio.com/docs/getstarted/tips-and-tricks - VS Code tips, including Ctrl+B / Cmd+B toggle sidebar and related layout shortcuts.
+- https://bobbyhadz.com/blog/vscode-show-hide-sidebar - confirms Ctrl/Cmd+B and the Activity Bar show/hide behaviour in VS Code.
 - https://forum.figma.com/suggest-a-feature-11/bring-back-independent-left-right-panel-collapsing-as-in-ui2-42703
-  - Figma users requesting independent left/right panel collapse; documents that
-  UI3 collapses both panels together and UI2 collapsed them independently.
+  - Figma users requesting independent left/right panel collapse; documents that UI3 collapses both panels together and UI2 collapsed them independently.
 - https://forum.figma.com/suggest-a-feature-11/option-to-hide-the-right-panel-20448
   - Figma forum thread on hiding the right panel and panel-toggle behaviour.
-- https://jnd.org/signifiers-not-affordances/ - Don Norman's primary essay
-  distinguishing affordances from signifiers; "what design must provide, are
-  signifiers"; affordances need not be perceivable to exist.
-- https://www.nngroup.com/articles/clickable-elements/ - NN/g "Beyond Blue
-  Links"; the minesweeping problem, "life is too short to click on things you
-  don't understand," and the flat-design loss of clickability signifiers.
-- https://www.nngroup.com/articles/timing-exposing-content/ - NN/g on exposing
-  hidden content and the hover problem on touch devices.
-- https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html - WCAG 2.2
-  SC 2.5.8 Target Size (Minimum), 24x24 CSS px, Level AA, with the spacing
-  exception.
-- https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html - WCAG
-  2.2 SC 2.5.5 Target Size (Enhanced), 44x44 CSS px, Level AAA.
-- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor -
-  MDN cursor property; col-resize and row-resize values for splitter handles and
-  the limits of cursor as a signifier on touch.
+- https://jnd.org/signifiers-not-affordances/ - Don Norman's primary essay distinguishing affordances from signifiers; "what design must provide, are signifiers"; affordances need not be perceivable to exist.
+- https://www.nngroup.com/articles/clickable-elements/ - NN/g "Beyond Blue Links"; the minesweeping problem, "life is too short to click on things you don't understand," and the flat-design loss of clickability signifiers.
+- https://www.nngroup.com/articles/timing-exposing-content/ - NN/g on exposing hidden content and the hover problem on touch devices.
+- https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html - WCAG 2.2 SC 2.5.8 Target Size (Minimum), 24x24 CSS px, Level AA, with the spacing exception.
+- https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html - WCAG 2.2 SC 2.5.5 Target Size (Enhanced), 44x44 CSS px, Level AAA.
+- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/cursor - MDN cursor property; col-resize and row-resize values for splitter handles and the limits of cursor as a signifier on touch.

--- a/docs/research/2437-patterns.md
+++ b/docs/research/2437-patterns.md
@@ -1,0 +1,87 @@
+# Spike #2437 Pattern Analysis
+
+Synthesis of the codebase findings (2437-codebase.md) and external research
+(2437-external.md) into a recommendation.
+
+## Key Insights
+
+- The reopen path is already solved. Collapsed, each panel is a 44px strip that
+  is one big labelled button. The spike is only about the COLLAPSE (close) path,
+  which today is a 44px chevron in the tab row.
+- A border-only collapse is an affordance with no at-rest signifier. Norman's
+  signifiers argument and NN/g's "minesweeping" warning both say a control the
+  user cannot see is, in practice, a control most users will not find.
+- The mature editors do not ship a bare clickable border as the only collapse
+  control. VS Code uses an Activity Bar, menu items, a layout control, and Ctrl+B;
+  its draggable border is a resize sash, not the collapse control. Figma keeps a
+  visible toggle plus Shift+\. The border is at most an extra entry point.
+- A hover-revealed grip helps mouse users who explore the edge, but it does
+  nothing for touch (no hover events) and nothing for users who never hover the
+  exact 1px edge. It reinforces; it does not announce.
+- Hit-target rules bite a thin border. WCAG 2.2 SC 2.5.8 (AA) wants 24x24px; the
+  enhanced SC 2.5.5 (AAA) and the existing project 44px touch standard want
+  44x44px. A 1-2px line must pad its hit area to clear this.
+- The existing chevron already satisfies all of the above: it is visible at rest,
+  44px, labelled, keyboard reachable, and identical in shape on both panels.
+
+## Implementation Approaches
+
+### Option A: REPLACE the chevron with a clickable border plus hover grip
+
+Remove `.sidebar-collapse-btn` and `.side-panel-collapse-btn`, add a
+`PanelEdgeGrip` on each panel's canvas-facing edge (prototype in
+docs/research/prototype-border-collapse-grip.svelte). Cleaner tab row, more
+canvas-like edge.
+
+Cost: loses the only at-rest signifier. Fails the Norman/NN/g discoverability
+test. The grip is invisible on touch. Diverges from VS Code and Figma. A thin
+border needs hit-area padding to meet WCAG 2.2 target size. Net: cleaner but
+measurably less discoverable, which is exactly the risk the spike names.
+
+### Option B: KEEP the chevron, change nothing
+
+Zero work, zero risk, fully discoverable, already shipped and tested. The only
+downside is the stated aesthetic one: the chevron is a small piece of chrome in
+the tab row.
+
+### Option C: HYBRID, border grip plus retained chevron
+
+Keep both existing chevrons exactly as they are (the at-rest signifier, the
+keyboard path, the touch path) and ADD a hover-revealed `PanelEdgeGrip` on each
+panel's canvas-facing edge as a power-user shortcut for mouse users who already
+expect a VS Code-style edge. This is how VS Code itself layers controls: a
+visible primary plus an edge affordance.
+
+Cost: a small, additive component on each panel (about 30 to 60 lines including
+shared styling), gated to non-mobile via the existing `viewportStore.isMobile`,
+wired to the existing `set*Collapsed(true)` handlers. No store change, no change
+to the reopen strip, no change to the chevron. Low risk because it is purely
+additive: if the grip is never discovered, nothing is lost.
+
+## Trade-offs
+
+| Concern                    | A: Replace | B: Keep | C: Hybrid |
+| -------------------------- | ---------- | ------- | --------- |
+| At-rest discoverability    | Poor       | Good    | Good      |
+| Touch support              | Poor       | Good    | Good      |
+| Matches VS Code / Figma    | No         | Partial | Yes       |
+| Aesthetic (clean tab row)  | Best       | Plain   | Plain     |
+| Build cost                 | Medium     | None    | Low       |
+| Regression risk            | Medium     | None    | Low       |
+| WCAG 2.2 target size       | Needs care | Met     | Met       |
+
+## Recommendation
+
+HYBRID (Option C), with a strong fallback to KEEP (Option B).
+
+The research answers the spike's literal question, "can the chevron be replaced
+without losing discoverability", with no: a clickable border alone is a hidden
+affordance and both the UX literature and the reference editors reject it as a
+sole control. So REPLACE is off the table.
+
+That leaves whether the border grip is worth adding at all. It is a genuine,
+additive nicety for mouse users that mirrors VS Code, costs little, and carries
+low risk because the chevron stays as the guaranteed-discoverable path. Ship it
+as HYBRID if the edge interaction is wanted. If the appetite is "don't add chrome
+for a marginal gain", KEEP is the honest default and the spike still closes with
+a clear no to the original replace question. Either way, the chevron stays.

--- a/docs/research/2437-patterns.md
+++ b/docs/research/2437-patterns.md
@@ -1,87 +1,50 @@
 # Spike #2437 Pattern Analysis
 
-Synthesis of the codebase findings (2437-codebase.md) and external research
-(2437-external.md) into a recommendation.
+Synthesis of the codebase findings (2437-codebase.md) and external research (2437-external.md) into a recommendation.
 
 ## Key Insights
 
-- The reopen path is already solved. Collapsed, each panel is a 44px strip that
-  is one big labelled button. The spike is only about the COLLAPSE (close) path,
-  which today is a 44px chevron in the tab row.
-- A border-only collapse is an affordance with no at-rest signifier. Norman's
-  signifiers argument and NN/g's "minesweeping" warning both say a control the
-  user cannot see is, in practice, a control most users will not find.
-- The mature editors do not ship a bare clickable border as the only collapse
-  control. VS Code uses an Activity Bar, menu items, a layout control, and Ctrl+B;
-  its draggable border is a resize sash, not the collapse control. Figma keeps a
-  visible toggle plus Shift+\. The border is at most an extra entry point.
-- A hover-revealed grip helps mouse users who explore the edge, but it does
-  nothing for touch (no hover events) and nothing for users who never hover the
-  exact 1px edge. It reinforces; it does not announce.
-- Hit-target rules bite a thin border. WCAG 2.2 SC 2.5.8 (AA) wants 24x24px; the
-  enhanced SC 2.5.5 (AAA) and the existing project 44px touch standard want
-  44x44px. A 1-2px line must pad its hit area to clear this.
-- The existing chevron already satisfies all of the above: it is visible at rest,
-  44px, labelled, keyboard reachable, and identical in shape on both panels.
+- The reopen path is already solved. Collapsed, each panel is a 44px strip that is one big labelled button. The spike is only about the COLLAPSE (close) path, which today is a 44px chevron in the tab row.
+- A border-only collapse is an affordance with no at-rest signifier. Norman's signifiers argument and NN/g's "minesweeping" warning both say a control the user cannot see is, in practice, a control most users will not find.
+- The mature editors do not ship a bare clickable border as the only collapse control. VS Code uses an Activity Bar, menu items, a layout control, and Ctrl+B; its draggable border is a resize sash, not the collapse control. Figma keeps a visible toggle plus Shift+\. The border is at most an extra entry point.
+- A hover-revealed grip helps mouse users who explore the edge, but it does nothing for touch (no hover events) and nothing for users who never hover the exact 1px edge. It reinforces; it does not announce.
+- Hit-target rules bite a thin border. WCAG 2.2 SC 2.5.8 (AA) wants 24x24px; the enhanced SC 2.5.5 (AAA) and the existing project 44px touch standard want 44x44px. A 1-2px line must pad its hit area to clear this.
+- The existing chevron already satisfies all of the above: it is visible at rest, 44px, labelled, keyboard reachable, and identical in shape on both panels.
 
 ## Implementation Approaches
 
 ### Option A: REPLACE the chevron with a clickable border plus hover grip
 
-Remove `.sidebar-collapse-btn` and `.side-panel-collapse-btn`, add a
-`PanelEdgeGrip` on each panel's canvas-facing edge (prototype in
-docs/research/prototype-border-collapse-grip.svelte). Cleaner tab row, more
-canvas-like edge.
+Remove `.sidebar-collapse-btn` and `.side-panel-collapse-btn`, add a `PanelEdgeGrip` on each panel's canvas-facing edge (prototype in docs/research/prototype-border-collapse-grip.svelte). Cleaner tab row, more canvas-like edge.
 
-Cost: loses the only at-rest signifier. Fails the Norman/NN/g discoverability
-test. The grip is invisible on touch. Diverges from VS Code and Figma. A thin
-border needs hit-area padding to meet WCAG 2.2 target size. Net: cleaner but
-measurably less discoverable, which is exactly the risk the spike names.
+Cost: loses the only at-rest signifier. Fails the Norman/NN/g discoverability test. The grip is invisible on touch. Diverges from VS Code and Figma. A thin border needs hit-area padding to meet WCAG 2.2 target size. Net: cleaner but measurably less discoverable, which is exactly the risk the spike names.
 
 ### Option B: KEEP the chevron, change nothing
 
-Zero work, zero risk, fully discoverable, already shipped and tested. The only
-downside is the stated aesthetic one: the chevron is a small piece of chrome in
-the tab row.
+Zero work, zero risk, fully discoverable, already shipped and tested. The only downside is the stated aesthetic one: the chevron is a small piece of chrome in the tab row.
 
 ### Option C: HYBRID, border grip plus retained chevron
 
-Keep both existing chevrons exactly as they are (the at-rest signifier, the
-keyboard path, the touch path) and ADD a hover-revealed `PanelEdgeGrip` on each
-panel's canvas-facing edge as a power-user shortcut for mouse users who already
-expect a VS Code-style edge. This is how VS Code itself layers controls: a
-visible primary plus an edge affordance.
+Keep both existing chevrons exactly as they are (the at-rest signifier, the keyboard path, the touch path) and ADD a hover-revealed `PanelEdgeGrip` on each panel's canvas-facing edge as a power-user shortcut for mouse users who already expect a VS Code-style edge. This is how VS Code itself layers controls: a visible primary plus an edge affordance.
 
-Cost: a small, additive component on each panel (about 30 to 60 lines including
-shared styling), gated to non-mobile via the existing `viewportStore.isMobile`,
-wired to the existing `set*Collapsed(true)` handlers. No store change, no change
-to the reopen strip, no change to the chevron. Low risk because it is purely
-additive: if the grip is never discovered, nothing is lost.
+Cost: a small, additive component on each panel (about 30 to 60 lines including shared styling), gated to non-mobile via the existing `viewportStore.isMobile`, wired to the existing `set*Collapsed(true)` handlers. No store change, no change to the reopen strip, no change to the chevron. Low risk because it is purely additive: if the grip is never discovered, nothing is lost.
 
 ## Trade-offs
 
-| Concern                    | A: Replace | B: Keep | C: Hybrid |
-| -------------------------- | ---------- | ------- | --------- |
-| At-rest discoverability    | Poor       | Good    | Good      |
-| Touch support              | Poor       | Good    | Good      |
-| Matches VS Code / Figma    | No         | Partial | Yes       |
-| Aesthetic (clean tab row)  | Best       | Plain   | Plain     |
-| Build cost                 | Medium     | None    | Low       |
-| Regression risk            | Medium     | None    | Low       |
-| WCAG 2.2 target size       | Needs care | Met     | Met       |
+| Concern                   | A: Replace | B: Keep | C: Hybrid |
+| ------------------------- | ---------- | ------- | --------- |
+| At-rest discoverability   | Poor       | Good    | Good      |
+| Touch support             | Poor       | Good    | Good      |
+| Matches VS Code / Figma   | No         | Partial | Yes       |
+| Aesthetic (clean tab row) | Best       | Plain   | Plain     |
+| Build cost                | Medium     | None    | Low       |
+| Regression risk           | Medium     | None    | Low       |
+| WCAG 2.2 target size      | Needs care | Met     | Met       |
 
 ## Recommendation
 
 HYBRID (Option C), with a strong fallback to KEEP (Option B).
 
-The research answers the spike's literal question, "can the chevron be replaced
-without losing discoverability", with no: a clickable border alone is a hidden
-affordance and both the UX literature and the reference editors reject it as a
-sole control. So REPLACE is off the table.
+The research answers the spike's literal question, "can the chevron be replaced without losing discoverability", with no: a clickable border alone is a hidden affordance and both the UX literature and the reference editors reject it as a sole control. So REPLACE is off the table.
 
-That leaves whether the border grip is worth adding at all. It is a genuine,
-additive nicety for mouse users that mirrors VS Code, costs little, and carries
-low risk because the chevron stays as the guaranteed-discoverable path. Ship it
-as HYBRID if the edge interaction is wanted. If the appetite is "don't add chrome
-for a marginal gain", KEEP is the honest default and the spike still closes with
-a clear no to the original replace question. Either way, the chevron stays.
+That leaves whether the border grip is worth adding at all. It is a genuine, additive nicety for mouse users that mirrors VS Code, costs little, and carries low risk because the chevron stays as the guaranteed-discoverable path. Ship it as HYBRID if the edge interaction is wanted. If the appetite is "don't add chrome for a marginal gain", KEEP is the honest default and the spike still closes with a clear no to the original replace question. Either way, the chevron stays.

--- a/docs/research/2437-spike.md
+++ b/docs/research/2437-spike.md
@@ -1,57 +1,30 @@
 # Spike #2437: Collapse Affordance for Side Panels (Clickable Border vs Chevron)
 
-Date: 2026-06-20
-Milestone: M014 -- Canvas UX Overhaul
-Epic: #2017
+Date: 2026-06-20 Milestone: M014 -- Canvas UX Overhaul Epic: #2017
 
 ## Research Question
 
-Can the collapse chevron on both side panels, the left device panel and the
-right edit panel, be replaced by a clickable panel border or edge without losing
-discoverability?
+Can the collapse chevron on both side panels, the left device panel and the right edit panel, be replaced by a clickable panel border or edge without losing discoverability?
 
 ## Recommendation
 
 HYBRID, with a clean fallback to KEEP.
 
-Do not replace the chevron with a clickable border alone. A border-only collapse
-is a hidden affordance: the click works but nothing on screen tells a first-time
-or touch user that it is there. Both the UX literature (Don Norman on signifiers,
-NN/g on clickability) and the reference editors (VS Code, Figma) reject a bare
-clickable border as the sole collapse control. The literal answer to the spike
-question is therefore no.
+Do not replace the chevron with a clickable border alone. A border-only collapse is a hidden affordance: the click works but nothing on screen tells a first-time or touch user that it is there. Both the UX literature (Don Norman on signifiers, NN/g on clickability) and the reference editors (VS Code, Figma) reject a bare clickable border as the sole collapse control. The literal answer to the spike question is therefore no.
 
-The retained chevron stays the primary, guaranteed-discoverable control on both
-panels. If an edge interaction is wanted, ADD a hover-revealed grip on each
-panel's canvas-facing edge as a power-user shortcut for mouse users, mirroring
-how VS Code layers a visible control plus an edge affordance. The grip is purely
-additive: if a user never finds it, nothing is lost because the chevron is still
-there. If the appetite is to avoid adding chrome for a marginal mouse-only gain,
-KEEP is the honest default and the spike still closes with a firm no to replace.
+The retained chevron stays the primary, guaranteed-discoverable control on both panels. If an edge interaction is wanted, ADD a hover-revealed grip on each panel's canvas-facing edge as a power-user shortcut for mouse users, mirroring how VS Code layers a visible control plus an edge affordance. The grip is purely additive: if a user never finds it, nothing is lost because the chevron is still there. If the appetite is to avoid adding chrome for a marginal mouse-only gain, KEEP is the honest default and the spike still closes with a firm no to replace.
 
 ## Executive Summary
 
-The reopen path is already solved: collapsed, each panel is a 44px strip that is
-one large labelled button. This spike concerns only the collapse (close) path,
-which today is a visible 44px chevron in each panel's tab row (`«` far-left on the
-device panel, `»` far-right on the edit panel).
+The reopen path is already solved: collapsed, each panel is a 44px strip that is one large labelled button. This spike concerns only the collapse (close) path, which today is a visible 44px chevron in each panel's tab row (`«` far-left on the device panel, `»` far-right on the edit panel).
 
-Replacing that chevron with a clickable border would trade a known-discoverable
-control for a hidden one. The evidence is consistent across three angles:
+Replacing that chevron with a clickable border would trade a known-discoverable control for a hidden one. The evidence is consistent across three angles:
 
-- Precedent: VS Code and Figma both keep a persistently visible collapse
-  affordance plus a keyboard shortcut. In VS Code the draggable border is a
-  resize sash, separate from collapsing, and never the only way in.
-- Principle: a clickable border is an affordance without a signifier. Norman's
-  rule is that design must provide perceptible signifiers, not just latent
-  affordances. NN/g warns that users will not play a "minesweeping game" to find
-  invisible clickable zones.
-- Accessibility: a hover-revealed grip is invisible on touch (no hover events)
-  and is missed by users who never hover the exact edge. A thin border also fails
-  WCAG 2.2 target-size guidance unless its hit area is padded to 24px or more.
+- Precedent: VS Code and Figma both keep a persistently visible collapse affordance plus a keyboard shortcut. In VS Code the draggable border is a resize sash, separate from collapsing, and never the only way in.
+- Principle: a clickable border is an affordance without a signifier. Norman's rule is that design must provide perceptible signifiers, not just latent affordances. NN/g warns that users will not play a "minesweeping game" to find invisible clickable zones.
+- Accessibility: a hover-revealed grip is invisible on touch (no hover events) and is missed by users who never hover the exact edge. A thin border also fails WCAG 2.2 target-size guidance unless its hit area is padded to 24px or more.
 
-A hybrid keeps the chevron as the at-rest signifier and adds the grip as an
-extra, low-risk entry point for mouse users.
+A hybrid keeps the chevron as the at-rest signifier and adds the grip as an extra, low-risk entry point for mouse users.
 
 ## Technical Findings (Codebase)
 
@@ -59,76 +32,42 @@ How the two panels collapse today, and where a border affordance would attach.
 
 Components:
 
-- `src/lib/components/SidePanel.svelte`: right-panel chrome. Switches between
-  `CollapsedPanelStrip` (collapsed) and `SidePanelContent` (expanded). Owns
-  expand/collapse focus management (#2076).
-- `src/lib/components/SidePanelContent.svelte`: tabbed Edit/View content; renders
-  the right panel's in-row collapse chevron `.side-panel-collapse-btn`
-  (IconChevronRight) at the far-right of the tab row.
-- `src/lib/components/SidebarTabs.svelte`: left-panel tab row; renders the left
-  panel's in-row collapse chevron `.sidebar-collapse-btn` (IconChevronLeft) at
-  the far-left of the tab row.
-- `src/lib/components/CollapsedPanelStrip.svelte`: the shared 44px collapsed strip
-  for both panels, mirrored via a `side` prop. The whole strip is the reopen
-  button.
-- `src/App.svelte` (around lines 561-603): composes the left panel as
-  `aside.sidebar-panel`; defines `handleCollapseSidebar` / `handleExpandSidebar`.
-- `src/lib/stores/ui.svelte.ts`: holds `sidebarCollapsed` / `sidePanelCollapsed`
-  `$state` with `setSidebarCollapsed`, `setSidePanelCollapsed` (and toggles),
-  persisted to localStorage.
-- `src/lib/utils/viewport.svelte.ts`: `getViewportStore().isMobile`, the existing
-  gate for desktop/tablet-only chrome.
+- `src/lib/components/SidePanel.svelte`: right-panel chrome. Switches between `CollapsedPanelStrip` (collapsed) and `SidePanelContent` (expanded). Owns expand/collapse focus management (#2076).
+- `src/lib/components/SidePanelContent.svelte`: tabbed Edit/View content; renders the right panel's in-row collapse chevron `.side-panel-collapse-btn` (IconChevronRight) at the far-right of the tab row.
+- `src/lib/components/SidebarTabs.svelte`: left-panel tab row; renders the left panel's in-row collapse chevron `.sidebar-collapse-btn` (IconChevronLeft) at the far-left of the tab row.
+- `src/lib/components/CollapsedPanelStrip.svelte`: the shared 44px collapsed strip for both panels, mirrored via a `side` prop. The whole strip is the reopen button.
+- `src/App.svelte` (around lines 561-603): composes the left panel as `aside.sidebar-panel`; defines `handleCollapseSidebar` / `handleExpandSidebar`.
+- `src/lib/stores/ui.svelte.ts`: holds `sidebarCollapsed` / `sidePanelCollapsed` `$state` with `setSidebarCollapsed`, `setSidePanelCollapsed` (and toggles), persisted to localStorage.
+- `src/lib/utils/viewport.svelte.ts`: `getViewportStore().isMobile`, the existing gate for desktop/tablet-only chrome.
 
-Tokens: `--colour-border`, `--colour-border-hover`, `--colour-surface-hover`,
-`--colour-selection`, `--side-panel-width: 320px`,
-`--panel-collapsed-strip-width: 44px`.
+Tokens: `--colour-border`, `--colour-border-hover`, `--colour-surface-hover`, `--colour-selection`, `--side-panel-width: 320px`, `--panel-collapsed-strip-width: 44px`.
 
 Where a grip attaches:
 
-- Right panel: the `border-left` edge of `aside.side-panel` in
-  `SidePanel.svelte`. A grip lives inside that aside, absolutely positioned on
-  the left (canvas-facing) edge.
-- Left panel: the inner (right, canvas-facing) edge of `aside.sidebar-panel` in
-  `App.svelte`. A grip lives inside that aside on the right edge.
-- Both call the existing `handleCollapse*` / `set*Collapsed(true)` handlers. No
-  store change is required. Both must be gated to non-mobile via
-  `viewportStore.isMobile`.
+- Right panel: the `border-left` edge of `aside.side-panel` in `SidePanel.svelte`. A grip lives inside that aside, absolutely positioned on the left (canvas-facing) edge.
+- Left panel: the inner (right, canvas-facing) edge of `aside.sidebar-panel` in `App.svelte`. A grip lives inside that aside on the right edge.
+- Both call the existing `handleCollapse*` / `set*Collapsed(true)` handlers. No store change is required. Both must be gated to non-mobile via `viewportStore.isMobile`.
 
 Constraints worth carrying into implementation:
 
 - Svelte 5 runes only.
-- Touch standard 44px; a border is far thinner, so it must not be the only
-  collapse path on touch and needs a padded hit area on pointer devices.
-- A11y focus management (#2076) must not be disrupted; a new grip should not
-  become a confusing second tab stop with an unclear label.
+- Touch standard 44px; a border is far thinner, so it must not be the only collapse path on touch and needs a padded hit area on pointer devices.
+- A11y focus management (#2076) must not be disrupted; a new grip should not become a confusing second tab stop with an unclear label.
 - `prefers-reduced-motion: reduce` must disable any reveal animation.
-- The 320px fixed width keeps fit-to-view stable; the grip collapses, it does not
-  drag-to-resize (resize is out of scope).
+- The 320px fixed width keeps fit-to-view stable; the grip collapses, it does not drag-to-resize (resize is out of scope).
 
 ## Prototype (Deliverable 1)
 
-A throwaway prototype is in
-`docs/research/prototype-border-collapse-grip.svelte`. It is a self-contained
-`PanelEdgeGrip` component, validated clean by the Svelte autofixer, not wired
-into the app. It demonstrates the hybrid shape: a full-height edge button that at
-rest reads as the 1px panel border, and on hover or focus widens the line,
-reveals a small grip handle, and shows a pointer cursor. It calls an `oncollapse`
-prop.
+A throwaway prototype is in `docs/research/prototype-border-collapse-grip.svelte`. It is a self-contained `PanelEdgeGrip` component, validated clean by the Svelte autofixer, not wired into the app. It demonstrates the hybrid shape: a full-height edge button that at rest reads as the 1px panel border, and on hover or focus widens the line, reveals a small grip handle, and shows a pointer cursor. It calls an `oncollapse` prop.
 
 Concrete wiring in the real components:
 
-- Right panel: place `<PanelEdgeGrip side="left" oncollapse={handleCollapse} />`
-  inside `aside.side-panel` (which is already `position: relative`) in
-  `SidePanel.svelte`.
-- Left panel: place
-  `<PanelEdgeGrip side="right" oncollapse={handleCollapseSidebar} />` inside
-  `aside.sidebar-panel` in `App.svelte`.
+- Right panel: place `<PanelEdgeGrip side="left" oncollapse={handleCollapse} />` inside `aside.side-panel` (which is already `position: relative`) in `SidePanel.svelte`.
+- Left panel: place `<PanelEdgeGrip side="right" oncollapse={handleCollapseSidebar} />` inside `aside.sidebar-panel` in `App.svelte`.
 - Gate both with `{#if !viewportStore.isMobile}`.
 - No change to the collapsed strip, the chevron, or the UI store.
 
-The hit area in the prototype is 10px wide for illustration; a production build
-should pad it to at least 24px (WCAG 2.2 SC 2.5.8) while keeping the visible line
-at 1 to 2px.
+The hit area in the prototype is 10px wide for illustration; a production build should pad it to at least 24px (WCAG 2.2 SC 2.5.8) while keeping the visible line at 1 to 2px.
 
 ## External Research (Deliverable 2: Discoverability Comparison)
 
@@ -136,78 +75,52 @@ Full notes and sources are in `docs/research/2437-external.md`. Key points:
 
 Precedent:
 
-- VS Code keeps multiple visible affordances for collapsing the Primary Side Bar:
-  Ctrl/Cmd+B, a persistent Activity Bar, View-menu items, and a layout control.
-  The draggable border between side bar and editor is a resize sash, distinct
-  from collapsing, and is never the only entry point.
-- Figma (UI3) minimises and expands panels with Shift+\ and via a visible
-  minimise-UI button and collapse arrows. Users have asked for the older
-  independent left/right collapse back, which shows the collapse control is
-  something users expect to find, not hunt for.
+- VS Code keeps multiple visible affordances for collapsing the Primary Side Bar: Ctrl/Cmd+B, a persistent Activity Bar, View-menu items, and a layout control. The draggable border between side bar and editor is a resize sash, distinct from collapsing, and is never the only entry point.
+- Figma (UI3) minimises and expands panels with Shift+\ and via a visible minimise-UI button and collapse arrows. Users have asked for the older independent left/right collapse back, which shows the collapse control is something users expect to find, not hunt for.
 
 Hidden vs visible affordance:
 
-- Don Norman, "Signifiers, not affordances": affordances need not be perceivable
-  to exist, so "what people need, and what design must provide, are signifiers."
-  A clickable border is an affordance with a missing signifier.
-- NN/g, "Beyond Blue Links": users will not play a "minesweeping game" hunting
-  for clickable zones, and over-minimal design that strips visible cues creates
-  exactly that ambiguity.
+- Don Norman, "Signifiers, not affordances": affordances need not be perceivable to exist, so "what people need, and what design must provide, are signifiers." A clickable border is an affordance with a missing signifier.
+- NN/g, "Beyond Blue Links": users will not play a "minesweeping game" hunting for clickable zones, and over-minimal design that strips visible cues creates exactly that ambiguity.
 
 Hover-revealed grip limits:
 
-- Touch devices generate no hover events, so a hover-gated grip is invisible to
-  mobile and tablet users.
-- First-time mouse users may never move the pointer onto the exact 1px edge, so
-  the reveal never fires. The cursor change only communicates after the pointer
-  is already over the target. The grip reinforces an at-rest signifier; it cannot
-  replace one.
+- Touch devices generate no hover events, so a hover-gated grip is invisible to mobile and tablet users.
+- First-time mouse users may never move the pointer onto the exact 1px edge, so the reveal never fires. The cursor change only communicates after the pointer is already over the target. The grip reinforces an at-rest signifier; it cannot replace one.
 
 Hit-target sizing:
 
 - WCAG 2.2 SC 2.5.8 (AA): 24x24 CSS px minimum, or equivalent spacing.
 - WCAG 2.2 SC 2.5.5 (AAA), Apple HIG, Material: 44 to 48 px for touch.
-- A 1 to 2px border must pad its hit area accordingly and stay distinct from any
-  resize sash.
+- A 1 to 2px border must pad its hit area accordingly and stay distinct from any resize sash.
 
 Discoverability comparison, current chevron vs border-collapse:
 
-| Attribute                 | Current chevron | Border-only | Border + hover grip |
-| ------------------------- | --------------- | ----------- | ------------------- |
-| Visible at rest           | Yes             | No          | No (grip on hover)  |
-| Works on touch            | Yes             | Marginal    | Marginal            |
-| Keyboard reachable        | Yes             | Needs work  | Needs work          |
-| Meets WCAG 2.2 target     | Yes (44px)      | No (1-2px)  | Needs padded area   |
-| Matches VS Code / Figma   | Partial         | No          | As a secondary only |
+| Attribute | Current chevron | Border-only | Border + hover grip |
+| --- | --- | --- | --- |
+| Visible at rest | Yes | No | No (grip on hover) |
+| Works on touch | Yes | Marginal | Marginal |
+| Keyboard reachable | Yes | Needs work | Needs work |
+| Meets WCAG 2.2 target | Yes (44px) | No (1-2px) | Needs padded area |
+| Matches VS Code / Figma | Partial | No | As a secondary only |
 
-The chevron wins on discoverability on every axis. A border, with or without a
-hover grip, is at best a secondary affordance.
+The chevron wins on discoverability on every axis. A border, with or without a hover grip, is at best a secondary affordance.
 
 ## Recommendation Detail (Deliverable 3)
 
-REPLACE: rejected. It removes the only at-rest signifier and the touch path, and
-diverges from both reference editors. This is precisely the discoverability loss
-the spike asked us to avoid.
+REPLACE: rejected. It removes the only at-rest signifier and the touch path, and diverges from both reference editors. This is precisely the discoverability loss the spike asked us to avoid.
 
-KEEP: the safe default. Zero work, zero risk, already shipped and tested. The
-only cost is the stated aesthetic one, a small chevron in each tab row.
+KEEP: the safe default. Zero work, zero risk, already shipped and tested. The only cost is the stated aesthetic one, a small chevron in each tab row.
 
-HYBRID: recommended if an edge interaction is wanted. Keep both chevrons exactly
-as they are and add the `PanelEdgeGrip` on each canvas-facing edge for mouse
-users. Low cost (about 30 to 60 lines including shared styling), low risk
-(purely additive, the chevron remains the guaranteed path), and it matches how
-VS Code layers controls. A follow-up implementation issue is filed for this.
+HYBRID: recommended if an edge interaction is wanted. Keep both chevrons exactly as they are and add the `PanelEdgeGrip` on each canvas-facing edge for mouse users. Low cost (about 30 to 60 lines including shared styling), low risk (purely additive, the chevron remains the guaranteed path), and it matches how VS Code layers controls. A follow-up implementation issue is filed for this.
 
 ## Follow-up Issue (Deliverable 4)
 
 Filed as the hybrid implementation task in milestone M014 -- Canvas UX Overhaul:
 
-- #2553: feat: add hover-revealed edge grip as a secondary panel collapse
-  affordance (hybrid). Keeps the chevron, adds the grip, gated to non-mobile,
-  hit area padded to WCAG 2.2 target size, no store change.
+- #2553: feat: add hover-revealed edge grip as a secondary panel collapse affordance (hybrid). Keeps the chevron, adds the grip, gated to non-mobile, hit area padded to WCAG 2.2 target size, no store change.
 
-If the team prefers KEEP over HYBRID, close #2553 as not-planned; the spike's
-core answer (do not replace the chevron with a bare border) holds either way.
+If the team prefers KEEP over HYBRID, close #2553 as not-planned; the spike's core answer (do not replace the chevron with a bare border) holds either way.
 
 ## Source Files
 

--- a/docs/research/2437-spike.md
+++ b/docs/research/2437-spike.md
@@ -1,0 +1,217 @@
+# Spike #2437: Collapse Affordance for Side Panels (Clickable Border vs Chevron)
+
+Date: 2026-06-20
+Milestone: M014 -- Canvas UX Overhaul
+Epic: #2017
+
+## Research Question
+
+Can the collapse chevron on both side panels, the left device panel and the
+right edit panel, be replaced by a clickable panel border or edge without losing
+discoverability?
+
+## Recommendation
+
+HYBRID, with a clean fallback to KEEP.
+
+Do not replace the chevron with a clickable border alone. A border-only collapse
+is a hidden affordance: the click works but nothing on screen tells a first-time
+or touch user that it is there. Both the UX literature (Don Norman on signifiers,
+NN/g on clickability) and the reference editors (VS Code, Figma) reject a bare
+clickable border as the sole collapse control. The literal answer to the spike
+question is therefore no.
+
+The retained chevron stays the primary, guaranteed-discoverable control on both
+panels. If an edge interaction is wanted, ADD a hover-revealed grip on each
+panel's canvas-facing edge as a power-user shortcut for mouse users, mirroring
+how VS Code layers a visible control plus an edge affordance. The grip is purely
+additive: if a user never finds it, nothing is lost because the chevron is still
+there. If the appetite is to avoid adding chrome for a marginal mouse-only gain,
+KEEP is the honest default and the spike still closes with a firm no to replace.
+
+## Executive Summary
+
+The reopen path is already solved: collapsed, each panel is a 44px strip that is
+one large labelled button. This spike concerns only the collapse (close) path,
+which today is a visible 44px chevron in each panel's tab row (`«` far-left on the
+device panel, `»` far-right on the edit panel).
+
+Replacing that chevron with a clickable border would trade a known-discoverable
+control for a hidden one. The evidence is consistent across three angles:
+
+- Precedent: VS Code and Figma both keep a persistently visible collapse
+  affordance plus a keyboard shortcut. In VS Code the draggable border is a
+  resize sash, separate from collapsing, and never the only way in.
+- Principle: a clickable border is an affordance without a signifier. Norman's
+  rule is that design must provide perceptible signifiers, not just latent
+  affordances. NN/g warns that users will not play a "minesweeping game" to find
+  invisible clickable zones.
+- Accessibility: a hover-revealed grip is invisible on touch (no hover events)
+  and is missed by users who never hover the exact edge. A thin border also fails
+  WCAG 2.2 target-size guidance unless its hit area is padded to 24px or more.
+
+A hybrid keeps the chevron as the at-rest signifier and adds the grip as an
+extra, low-risk entry point for mouse users.
+
+## Technical Findings (Codebase)
+
+How the two panels collapse today, and where a border affordance would attach.
+
+Components:
+
+- `src/lib/components/SidePanel.svelte`: right-panel chrome. Switches between
+  `CollapsedPanelStrip` (collapsed) and `SidePanelContent` (expanded). Owns
+  expand/collapse focus management (#2076).
+- `src/lib/components/SidePanelContent.svelte`: tabbed Edit/View content; renders
+  the right panel's in-row collapse chevron `.side-panel-collapse-btn`
+  (IconChevronRight) at the far-right of the tab row.
+- `src/lib/components/SidebarTabs.svelte`: left-panel tab row; renders the left
+  panel's in-row collapse chevron `.sidebar-collapse-btn` (IconChevronLeft) at
+  the far-left of the tab row.
+- `src/lib/components/CollapsedPanelStrip.svelte`: the shared 44px collapsed strip
+  for both panels, mirrored via a `side` prop. The whole strip is the reopen
+  button.
+- `src/App.svelte` (around lines 561-603): composes the left panel as
+  `aside.sidebar-panel`; defines `handleCollapseSidebar` / `handleExpandSidebar`.
+- `src/lib/stores/ui.svelte.ts`: holds `sidebarCollapsed` / `sidePanelCollapsed`
+  `$state` with `setSidebarCollapsed`, `setSidePanelCollapsed` (and toggles),
+  persisted to localStorage.
+- `src/lib/utils/viewport.svelte.ts`: `getViewportStore().isMobile`, the existing
+  gate for desktop/tablet-only chrome.
+
+Tokens: `--colour-border`, `--colour-border-hover`, `--colour-surface-hover`,
+`--colour-selection`, `--side-panel-width: 320px`,
+`--panel-collapsed-strip-width: 44px`.
+
+Where a grip attaches:
+
+- Right panel: the `border-left` edge of `aside.side-panel` in
+  `SidePanel.svelte`. A grip lives inside that aside, absolutely positioned on
+  the left (canvas-facing) edge.
+- Left panel: the inner (right, canvas-facing) edge of `aside.sidebar-panel` in
+  `App.svelte`. A grip lives inside that aside on the right edge.
+- Both call the existing `handleCollapse*` / `set*Collapsed(true)` handlers. No
+  store change is required. Both must be gated to non-mobile via
+  `viewportStore.isMobile`.
+
+Constraints worth carrying into implementation:
+
+- Svelte 5 runes only.
+- Touch standard 44px; a border is far thinner, so it must not be the only
+  collapse path on touch and needs a padded hit area on pointer devices.
+- A11y focus management (#2076) must not be disrupted; a new grip should not
+  become a confusing second tab stop with an unclear label.
+- `prefers-reduced-motion: reduce` must disable any reveal animation.
+- The 320px fixed width keeps fit-to-view stable; the grip collapses, it does not
+  drag-to-resize (resize is out of scope).
+
+## Prototype (Deliverable 1)
+
+A throwaway prototype is in
+`docs/research/prototype-border-collapse-grip.svelte`. It is a self-contained
+`PanelEdgeGrip` component, validated clean by the Svelte autofixer, not wired
+into the app. It demonstrates the hybrid shape: a full-height edge button that at
+rest reads as the 1px panel border, and on hover or focus widens the line,
+reveals a small grip handle, and shows a pointer cursor. It calls an `oncollapse`
+prop.
+
+Concrete wiring in the real components:
+
+- Right panel: place `<PanelEdgeGrip side="left" oncollapse={handleCollapse} />`
+  inside `aside.side-panel` (which is already `position: relative`) in
+  `SidePanel.svelte`.
+- Left panel: place
+  `<PanelEdgeGrip side="right" oncollapse={handleCollapseSidebar} />` inside
+  `aside.sidebar-panel` in `App.svelte`.
+- Gate both with `{#if !viewportStore.isMobile}`.
+- No change to the collapsed strip, the chevron, or the UI store.
+
+The hit area in the prototype is 10px wide for illustration; a production build
+should pad it to at least 24px (WCAG 2.2 SC 2.5.8) while keeping the visible line
+at 1 to 2px.
+
+## External Research (Deliverable 2: Discoverability Comparison)
+
+Full notes and sources are in `docs/research/2437-external.md`. Key points:
+
+Precedent:
+
+- VS Code keeps multiple visible affordances for collapsing the Primary Side Bar:
+  Ctrl/Cmd+B, a persistent Activity Bar, View-menu items, and a layout control.
+  The draggable border between side bar and editor is a resize sash, distinct
+  from collapsing, and is never the only entry point.
+- Figma (UI3) minimises and expands panels with Shift+\ and via a visible
+  minimise-UI button and collapse arrows. Users have asked for the older
+  independent left/right collapse back, which shows the collapse control is
+  something users expect to find, not hunt for.
+
+Hidden vs visible affordance:
+
+- Don Norman, "Signifiers, not affordances": affordances need not be perceivable
+  to exist, so "what people need, and what design must provide, are signifiers."
+  A clickable border is an affordance with a missing signifier.
+- NN/g, "Beyond Blue Links": users will not play a "minesweeping game" hunting
+  for clickable zones, and over-minimal design that strips visible cues creates
+  exactly that ambiguity.
+
+Hover-revealed grip limits:
+
+- Touch devices generate no hover events, so a hover-gated grip is invisible to
+  mobile and tablet users.
+- First-time mouse users may never move the pointer onto the exact 1px edge, so
+  the reveal never fires. The cursor change only communicates after the pointer
+  is already over the target. The grip reinforces an at-rest signifier; it cannot
+  replace one.
+
+Hit-target sizing:
+
+- WCAG 2.2 SC 2.5.8 (AA): 24x24 CSS px minimum, or equivalent spacing.
+- WCAG 2.2 SC 2.5.5 (AAA), Apple HIG, Material: 44 to 48 px for touch.
+- A 1 to 2px border must pad its hit area accordingly and stay distinct from any
+  resize sash.
+
+Discoverability comparison, current chevron vs border-collapse:
+
+| Attribute                 | Current chevron | Border-only | Border + hover grip |
+| ------------------------- | --------------- | ----------- | ------------------- |
+| Visible at rest           | Yes             | No          | No (grip on hover)  |
+| Works on touch            | Yes             | Marginal    | Marginal            |
+| Keyboard reachable        | Yes             | Needs work  | Needs work          |
+| Meets WCAG 2.2 target     | Yes (44px)      | No (1-2px)  | Needs padded area   |
+| Matches VS Code / Figma   | Partial         | No          | As a secondary only |
+
+The chevron wins on discoverability on every axis. A border, with or without a
+hover grip, is at best a secondary affordance.
+
+## Recommendation Detail (Deliverable 3)
+
+REPLACE: rejected. It removes the only at-rest signifier and the touch path, and
+diverges from both reference editors. This is precisely the discoverability loss
+the spike asked us to avoid.
+
+KEEP: the safe default. Zero work, zero risk, already shipped and tested. The
+only cost is the stated aesthetic one, a small chevron in each tab row.
+
+HYBRID: recommended if an edge interaction is wanted. Keep both chevrons exactly
+as they are and add the `PanelEdgeGrip` on each canvas-facing edge for mouse
+users. Low cost (about 30 to 60 lines including shared styling), low risk
+(purely additive, the chevron remains the guaranteed path), and it matches how
+VS Code layers controls. A follow-up implementation issue is filed for this.
+
+## Follow-up Issue (Deliverable 4)
+
+Filed as the hybrid implementation task in milestone M014 -- Canvas UX Overhaul:
+
+- #2553: feat: add hover-revealed edge grip as a secondary panel collapse
+  affordance (hybrid). Keeps the chevron, adds the grip, gated to non-mobile,
+  hit area padded to WCAG 2.2 target size, no store change.
+
+If the team prefers KEEP over HYBRID, close #2553 as not-planned; the spike's
+core answer (do not replace the chevron with a bare border) holds either way.
+
+## Source Files
+
+- `docs/research/2437-codebase.md`
+- `docs/research/2437-external.md`
+- `docs/research/2437-patterns.md`
+- `docs/research/prototype-border-collapse-grip.svelte`

--- a/docs/research/prototype-border-collapse-grip.svelte
+++ b/docs/research/prototype-border-collapse-grip.svelte
@@ -1,0 +1,120 @@
+<!--
+  THROWAWAY PROTOTYPE for spike #2437. Not wired into the app.
+
+  Demonstrates a clickable panel-edge collapse affordance with a hover-revealed
+  grip, sized so the hover/click hit area is comfortable while the resting visual
+  is just a 1px border. This is the HYBRID shape: the grip lives on the border AND
+  the existing in-row chevron is retained (the chevron is shown here as a sibling
+  for illustration; in the real components it already exists).
+
+  Wiring in the real components:
+  - Right panel: drop <PanelEdgeGrip side="left" oncollapse={handleCollapse} />
+    inside aside.side-panel in SidePanel.svelte, on the canvas-facing (left) edge.
+  - Left panel: drop <PanelEdgeGrip side="right" oncollapse={handleCollapseSidebar} />
+    inside aside.sidebar-panel in App.svelte, on the canvas-facing (right) edge.
+  Both call the existing set*Collapsed(true) handlers. No store change needed.
+  Gate to non-mobile (touch has no hover) with the existing viewportStore.isMobile.
+-->
+<script lang="ts">
+  interface Props {
+    /** Which edge of the panel the grip sits on (the canvas-facing edge). */
+    side: "left" | "right";
+    /** Collapse the panel. Wires to the existing set*Collapsed(true) handlers. */
+    oncollapse: () => void;
+  }
+
+  let { side, oncollapse }: Props = $props();
+</script>
+
+<!-- A full-height hit strip on the panel edge. At rest it reads as the existing
+     1px border; on hover it widens its visible band and reveals a grip plus a
+     col-resize-style cursor, the same way VS Code surfaces its sash. It is a real
+     button so keyboard and screen-reader users get a labelled, focusable control
+     in addition to the in-row chevron. -->
+<button
+  type="button"
+  class="edge-grip edge-grip--{side}"
+  aria-label="Collapse panel"
+  onclick={oncollapse}
+>
+  <span class="edge-grip-handle" aria-hidden="true"></span>
+</button>
+
+<style>
+  .edge-grip {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    /* Comfortable pointer hit area even though the resting visual is 1px. */
+    width: 10px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .edge-grip--left {
+    left: -5px;
+  }
+
+  .edge-grip--right {
+    right: -5px;
+  }
+
+  /* The resting hairline that reads as the panel border. */
+  .edge-grip::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--colour-border);
+    transition: background-color var(--duration-fast) var(--ease-out);
+  }
+
+  .edge-grip--left::before {
+    left: 5px;
+  }
+
+  .edge-grip--right::before {
+    right: 5px;
+  }
+
+  /* Hover and focus reveal the grip and brighten the border line. */
+  .edge-grip:hover::before,
+  .edge-grip:focus-visible::before {
+    background: var(--colour-selection);
+    width: 2px;
+  }
+
+  /* The revealed grip dots: hidden until hover/focus. */
+  .edge-grip-handle {
+    width: 4px;
+    height: 28px;
+    border-radius: 2px;
+    background: var(--colour-border-hover);
+    opacity: 0;
+    transition: opacity var(--duration-fast) var(--ease-out);
+  }
+
+  .edge-grip:hover .edge-grip-handle,
+  .edge-grip:focus-visible .edge-grip-handle {
+    opacity: 1;
+  }
+
+  .edge-grip:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: -2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .edge-grip::before,
+    .edge-grip-handle {
+      transition: none;
+    }
+  }
+</style>

--- a/docs/research/prototype-border-collapse-grip.svelte
+++ b/docs/research/prototype-border-collapse-grip.svelte
@@ -34,7 +34,7 @@
 <button
   type="button"
   class="edge-grip edge-grip--{side}"
-  aria-label="Collapse panel"
+  aria-label={`Collapse ${side} panel`}
   onclick={oncollapse}
 >
   <span class="edge-grip-handle" aria-hidden="true"></span>
@@ -45,12 +45,13 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    /* Comfortable pointer hit area even though the resting visual is 1px. */
-    width: 10px;
+    /* Comfortable pointer hit area even though the resting visual is 1px.
+       At least 24px wide to meet WCAG 2.2 target-size guidance. */
+    width: 24px;
     padding: 0;
     border: none;
     background: transparent;
-    cursor: pointer;
+    cursor: col-resize;
     z-index: 1;
     display: flex;
     align-items: center;
@@ -58,11 +59,11 @@
   }
 
   .edge-grip--left {
-    left: -5px;
+    left: -12px;
   }
 
   .edge-grip--right {
-    right: -5px;
+    right: -12px;
   }
 
   /* The resting hairline that reads as the panel border. */
@@ -77,11 +78,11 @@
   }
 
   .edge-grip--left::before {
-    left: 5px;
+    left: 12px;
   }
 
   .edge-grip--right::before {
-    right: 5px;
+    right: 12px;
   }
 
   /* Hover and focus reveal the grip and brighten the border line. */


### PR DESCRIPTION
## **User description**
Research deliverables for spike #2437: can the collapse chevron on both side panels be replaced by a clickable panel border without losing discoverability?

## Recommendation: HYBRID (fallback KEEP)

Do not replace the chevron with a bare clickable border. A border-only collapse is a hidden affordance that fails the signifier test (Don Norman), invites NN/g's "minesweeping" ambiguity, is invisible on touch (no hover), and diverges from VS Code and Figma (both keep a visible control plus a keyboard shortcut; VS Code's border is a resize sash, not the collapse control). A thin border also fails WCAG 2.2 target-size guidance unless padded.

Keep both chevrons as the primary, always-visible control. If an edge interaction is wanted, ADD a hover-revealed grip on each panel's canvas-facing edge for mouse users (the VS Code layering pattern). It is purely additive and low-risk.

## Deliverables

- docs/research/2437-spike.md: main findings, recommendation, discoverability comparison table, prototype wiring
- docs/research/2437-codebase.md: where collapse lives today, where a grip attaches (SidePanel.svelte, SidebarTabs.svelte, App.svelte, ui.svelte.ts)
- docs/research/2437-external.md: VS Code / Figma precedent, Norman signifiers, NN/g, WCAG 2.2 target size, with sources
- docs/research/2437-patterns.md: REPLACE vs KEEP vs HYBRID option analysis and trade-offs
- docs/research/prototype-border-collapse-grip.svelte: throwaway PanelEdgeGrip component, passes the Svelte autofixer, not wired into the app

## Follow-up

Implementation issue #2553 filed in M014 -- Canvas UX Overhaul for the HYBRID build.

Closes #2437

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Documented the recommended side panel collapse pattern and why a border-only control should not replace the chevron**

### What Changed
- Added research notes showing that a clickable border alone is harder to discover than the current visible chevron, especially on touch devices
- Compared the current chevron, a border-only control, and a hybrid border-plus-grip option, and recommended keeping the chevron as the primary collapse control
- Added codebase notes and a throwaway prototype for a hover-revealed edge grip that can be used as an optional secondary mouse-only affordance
- Filed the follow-up implementation issue for the hybrid option

### Impact
`✅ Clearer panel collapse guidance`
`✅ Fewer discoverability regressions`
`✅ Safer panel interaction decisions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
