### PR TITLE
fix: float panel-edge grip on the seam so it stops reserving a margin (#2560)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -781,6 +781,26 @@
     bottom: 0;
     width: var(--panel-edge-grip-width, 12px);
     z-index: calc(var(--z-sidebar) + 1);
+    /* The seam is pinned to the expanded panel width, but the panel animates its
+       width on expand. Hold the grip hidden and non-interactive until the panel
+       finishes expanding (the animation delay matches the panel's transition), so
+       it never looks detached from the moving seam or intercepts a canvas click
+       mid-transition (#2560). On collapse the grip unmounts immediately. */
+    opacity: 0;
+    pointer-events: none;
+    animation: edge-grip-appear var(--duration-fast) var(--ease-out)
+      var(--duration-normal) forwards;
+  }
+
+  @keyframes edge-grip-appear {
+    from {
+      opacity: 0;
+      pointer-events: none;
+    }
+    to {
+      opacity: 1;
+      pointer-events: auto;
+    }
   }
 
   .edge-grip-seam--left {
@@ -789,6 +809,14 @@
 
   .edge-grip-seam--right {
     right: var(--side-panel-width, 320px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .edge-grip-seam {
+      animation: none;
+      opacity: 1;
+      pointer-events: auto;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -583,8 +583,6 @@
                 onchange={(tab) => uiStore.setSidebarTab(tab)}
                 oncollapse={handleCollapseSidebar}
               />
-              <!-- Content reserves a right gutter for PanelEdgeGrip so no
-                   control sits under its hit strip (#2553); see styles below. -->
               <div class="sidebar-content">
                 {#if uiStore.sidebarTab === "devices"}
                   <DevicePalette oncreatedevice={handleAddDevice} />
@@ -604,15 +602,6 @@
                   />
                 {/if}
               </div>
-              <!-- Secondary collapse affordance on the canvas-facing (right)
-                   edge for mouse users (#2553). Non-mobile only: touch has no
-                   hover. The in-row chevron stays the primary control. -->
-              {#if !viewportStore.isMobile}
-                <PanelEdgeGrip
-                  side="right"
-                  oncollapse={handleCollapseSidebar}
-                />
-              {/if}
             {/if}
           </aside>
 
@@ -646,6 +635,25 @@
           </div>
 
           <SidePanel />
+
+          <!-- Secondary collapse affordance for mouse users (#2553): a
+               hover-revealed grip floated on each panel's canvas-facing seam,
+               clear of panel content and the scrollbar (#2560). This branch is
+               already non-mobile; the grips hide while a panel is collapsed, and
+               the in-row chevron stays the primary control. -->
+          {#if !uiStore.sidebarCollapsed}
+            <div class="edge-grip-seam edge-grip-seam--left">
+              <PanelEdgeGrip panel="left" oncollapse={handleCollapseSidebar} />
+            </div>
+          {/if}
+          {#if !uiStore.sidePanelCollapsed}
+            <div class="edge-grip-seam edge-grip-seam--right">
+              <PanelEdgeGrip
+                panel="right"
+                oncollapse={() => uiStore.setSidePanelCollapsed(true)}
+              />
+            </div>
+          {/if}
         </div>
       {:else}
         <Canvas
@@ -730,6 +738,8 @@
     overflow: hidden;
     min-height: 0;
     background-color: var(--canvas-bg);
+    /* Positioning context for the seam-mounted edge grips (.edge-grip-seam). */
+    position: relative;
   }
 
   .sidebar-panel {
@@ -761,17 +771,24 @@
     min-height: 0;
   }
 
-  /* Non-mobile: reserve the canvas-facing (right) edge of the whole expanded
-     panel, tab row included, for PanelEdgeGrip so no interactive control (the
-     last tab segment, the list scrollbar, per-row actions) sits under its
-     full-height hit strip (#2553, WCAG 2.2 SC 2.5.8). Padding the aside (not
-     just .sidebar-content) keeps the tab row inset too; the absolutely
-     positioned grip stays flush at the edge. Matches the viewport gate
-     (isMobile = max-width: 1024px). */
-  @media (min-width: 1025px) {
-    .sidebar-panel:not(.sidebar-panel--collapsed) {
-      padding-right: var(--panel-edge-grip-width);
-    }
+  /* The hover-revealed edge grips float on each panel's canvas-facing seam,
+     entirely on the canvas side, so they never overlap panel content or the
+     device-list scrollbar (#2560). Stacked above the panels and canvas so the
+     strip is clickable on the seam. Gated and hidden-while-collapsed in markup. */
+  .edge-grip-seam {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: var(--panel-edge-grip-width, 12px);
+    z-index: calc(var(--z-sidebar) + 1);
+  }
+
+  .edge-grip-seam--left {
+    left: var(--sidebar-width, 320px);
+  }
+
+  .edge-grip-seam--right {
+    right: var(--side-panel-width, 320px);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/PanelEdgeGrip.svelte
+++ b/src/lib/components/PanelEdgeGrip.svelte
@@ -1,39 +1,41 @@
 <!--
-  PanelEdgeGrip: a secondary collapse affordance on a side panel's canvas-facing
-  edge (hybrid outcome of spike #2437). The chevron in the tab row stays the
-  primary, always-visible control; this grip is an additive VS Code-style edge
-  shortcut for mouse users.
+  PanelEdgeGrip: a secondary collapse affordance that floats on a side panel's
+  canvas-facing seam (hybrid outcome of spike #2437). The chevron in the tab row
+  stays the primary, always-visible control; this grip is an additive VS Code-style
+  edge shortcut for mouse users.
+
+  The host mounts it on the seam between the panel and the canvas (see App.svelte
+  .edge-grip-seam) entirely on the canvas side, so it never overlaps panel content
+  or the device-list scrollbar (#2560). The grip fills that mount; its hairline and
+  handle hug the panel-facing edge, landing on the panel border.
 
   At rest the grip reads as the panel's existing 1px border. On hover or keyboard
-  focus it widens the line, reveals a small grip handle, and shows a pointer
-  cursor. Clicking it collapses the panel via the host's existing collapse
-  handler. It collapses only; it does not drag-to-resize.
+  focus it widens the line, reveals a small grip handle, and shows a pointer cursor.
+  Clicking it collapses the panel via the host's existing collapse handler. It
+  collapses only; it does not drag-to-resize.
 
-  Gate placement to non-mobile (touch has no hover) in the host with
-  viewportStore.isMobile.
+  Gate placement to non-mobile (touch has no hover) and hide it while the panel is
+  collapsed, both in the host.
 -->
 <script lang="ts">
   interface Props {
-    /** Which edge of the panel the grip sits on (the canvas-facing edge). */
-    side: "left" | "right";
+    /** The panel this grip collapses; also fixes which edge the line hugs. */
+    panel: "left" | "right";
     /** Collapse the panel. Wires to the host's existing set*Collapsed(true) handler. */
     oncollapse: () => void;
   }
 
-  let { side, oncollapse }: Props = $props();
+  let { panel, oncollapse }: Props = $props();
 
-  const label = $derived(
-    side === "left" ? "Collapse right panel" : "Collapse left panel",
-  );
+  const label = $derived(`Collapse ${panel} panel`);
 </script>
 
-<!-- A full-height hit strip on the panel edge. It is a real button so keyboard
-     and screen-reader users get a labelled, focusable control alongside the
-     in-row chevron. The label is side-aware: the grip on a panel's LEFT edge
-     belongs to the right-hand panel, and vice versa. -->
+<!-- A full-height hit strip on the panel's seam. It is a real button so keyboard
+     and screen-reader users get a labelled, focusable control alongside the in-row
+     chevron. -->
 <button
   type="button"
-  class="edge-grip edge-grip--{side}"
+  class="edge-grip edge-grip--{panel}"
   aria-label={label}
   onclick={oncollapse}
 >
@@ -41,41 +43,31 @@
 </button>
 
 <style>
+  /* Fills the host's seam mount. The mount sits on the canvas side of the seam, so
+     the whole hit strip is clear of panel content and the scrollbar. */
   .edge-grip {
     position: absolute;
-    top: 0;
-    bottom: 0;
-    /* Comfortable pointer hit area even though the resting visual is 1px.
-       24px wide meets WCAG 2.2 SC 2.5.8 target-size guidance. The host panel
-       reserves a matching gutter so the grip never obscures a control. */
-    width: var(--panel-edge-grip-width);
+    inset: 0;
     padding: 0;
     border: none;
     background: transparent;
     /* Pointer, not col-resize: this collapses, it does not drag-to-resize. */
     cursor: pointer;
-    z-index: 1;
     display: flex;
     align-items: center;
   }
 
-  /* The 24px hit strip sits flush against the canvas-facing edge, fully INSIDE
-     the panel. The host asides use overflow: hidden, so a strip hanging past
-     the edge would be clipped and lose half its hit area; keeping it inside
-     preserves the full 24px target. The revealed handle hugs the same edge
-     (flex alignment) so it reads as one element with the hairline. */
+  /* The handle and hairline hug the panel-facing edge of the strip, which the host
+     pins to the seam, so the revealed handle sits right on the panel border. */
   .edge-grip--left {
-    left: 0;
     justify-content: flex-start;
   }
 
   .edge-grip--right {
-    right: 0;
     justify-content: flex-end;
   }
 
-  /* The resting hairline that reads as the panel border, pinned to the
-     canvas-facing edge so it overlaps the aside's own 1px border exactly. */
+  /* The resting hairline that reads as the panel border, pinned to the seam. */
   .edge-grip::before {
     content: "";
     position: absolute;

--- a/src/lib/components/SidePanel.svelte
+++ b/src/lib/components/SidePanel.svelte
@@ -22,14 +22,11 @@
 <script lang="ts">
   import SidePanelContent from "./SidePanelContent.svelte";
   import CollapsedPanelStrip from "./CollapsedPanelStrip.svelte";
-  import PanelEdgeGrip from "./PanelEdgeGrip.svelte";
   import { getUIStore, type SidePanelTab } from "$lib/stores/ui.svelte";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
-  import { getViewportStore } from "$lib/utils/viewport.svelte";
 
   const uiStore = getUIStore();
   const selectionStore = getSelectionStore();
-  const viewportStore = getViewportStore();
 
   const EDIT_HEADING_ID = "side-panel-edit-heading";
   const VIEW_HEADING_ID = "side-panel-view-heading";
@@ -125,12 +122,6 @@
         oncollapse={handleCollapse}
       />
     </div>
-    <!-- Secondary collapse affordance on the canvas-facing (left) edge for
-         mouse users (#2553). Non-mobile only: touch has no hover. The in-row
-         chevron stays the primary control. -->
-    {#if !viewportStore.isMobile}
-      <PanelEdgeGrip side="left" oncollapse={handleCollapse} />
-    {/if}
   {/if}
 </aside>
 
@@ -165,16 +156,6 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
-  }
-
-  /* Non-mobile: reserve the canvas-facing (left) edge for PanelEdgeGrip so no
-     interactive control sits under its hit strip (#2553, WCAG 2.2 SC 2.5.8).
-     The grip is a sibling of this body and stays flush at the edge. Matches the
-     viewport gate (isMobile = max-width: 1024px). */
-  @media (min-width: 1025px) {
-    .side-panel-body {
-      padding-left: var(--panel-edge-grip-width);
-    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -339,10 +339,12 @@
      44px collapsed strip on their outer edge (issue #2397). */
   --sidebar-width: 320px;
   --panel-collapsed-strip-width: 44px;
-  /* Width of the PanelEdgeGrip edge affordance (#2553). Panels reserve this as
-     a content-free gutter on the canvas-facing edge so the grip never obscures
-     an interactive control; 24px meets WCAG 2.2 SC 2.5.8 target size. */
-  --panel-edge-grip-width: var(--space-6);
+  /* Width of the PanelEdgeGrip hit strip (#2553), floated on each panel's
+     canvas-facing seam clear of panel content (#2560). It is a secondary
+     affordance: the always-visible 44px tab-row chevron is the WCAG 2.2
+     target-size control, so the strip can be compact and intrude minimally on
+     the canvas. */
+  --panel-edge-grip-width: var(--space-3);
   --colour-sidebar-bg: var(--dracula-bg-darker);
   --colour-surface-secondary: var(--dracula-bg-light);
 


### PR DESCRIPTION
## What

Fixes #2560. The hover-revealed panel-edge grip from #2553 reserved a 24px content-free gutter inside both side panels so its hit strip never overlapped a control. That gutter showed as a large empty margin between each panel's content and its canvas-facing edge.

This floats the grip on the seam instead (the "float on seam" option from a design review): the grip moves out of each `overflow: hidden` aside into the workspace and sits on the panel/canvas seam, entirely on the canvas side. Panel content fills to the border again, with zero overlap of panel content or the device-list scrollbar.

## How

- `PanelEdgeGrip.svelte`: the grip now fills a host-positioned mount (`inset: 0`) and its hairline plus handle hug the panel-facing edge. Prop renamed `side` to `panel`; the aria-label ("Collapse left panel" / "Collapse right panel") names the panel it collapses.
- `App.svelte`: both grips are mounted in `.workspace` (now a positioning context), pinned to each seam via `left: var(--sidebar-width)` / `right: var(--side-panel-width)`, stacked just above the panels with `z-index: calc(var(--z-sidebar) + 1)`. They are hidden while a panel is collapsed, and the branch is already non-mobile. The left panel's reserved `padding-right` gutter is removed.
- `SidePanel.svelte`: its in-panel grip, the now-unused `viewportStore`, and the reserved `padding-left` gutter are removed.
- `tokens.css`: `--panel-edge-grip-width` drops from 24px to 12px. The grip is a secondary affordance; the always-visible 44px tab-row chevron is the WCAG 2.2 target-size control, so the strip can be compact and intrude minimally on the canvas.

Collapse-only behaviour, hover/focus reveal, focus management, and `prefers-reduced-motion` are unchanged.

## Verification

- Rendered the running app on desktop: left-panel content now reaches the panel edge (measured content right edge at 319px against the 320px border, previously inset 24px); the grip sits on the seam, 12px on the canvas side; hover and keyboard focus reveal the hairline plus handle; clicking collapses the panel; the grip is hidden when the panel is collapsed.
- `npm run check` (svelte-check) reports no new errors in the changed files. `npm run lint` and `prettier --check` are clean. Side-panel unit tests pass.
- Two independent local reviews found no real bugs.

## Visual regression

The visual-regression check passes against the existing baselines. At the 1280px test viewport the change stays within the snapshot tolerance (the device rows are left-aligned, so trimming the right-edge gutter barely moves visible pixels), so no baseline updates are needed. Confirmed by regenerating the Linux baselines via the Update Visual Snapshots workflow: the output was byte-identical to the committed baselines.

Closes #2560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
