### PR TITLE
security: triage CVE-2026-45186 (libexpat) in deploy/Dockerfile (alert #85)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -29,16 +29,16 @@ RUN npm run build
 # Production stage - non-root nginx
 FROM nginxinc/nginx-unprivileged:alpine
 # Patch system packages to resolve known CVEs (e.g. libpng, libxml2 CVE-2026-6732,
-# libssl3/libcrypto3 CVE-2026-45447). APK_CACHEBUST is fed a per-build value
-# (release version / date) so this layer's buildcache is invalidated each build
-# and apk upgrade re-fetches current Alpine secfixes instead of reusing a stale
-# cached layer. The openssl libs are named explicitly so the fix for the tracked
-# CVE-2026-45447 alerts is force-applied even if a future base ships them pinned.
+# libssl3/libcrypto3 CVE-2026-45447, libexpat CVE-2026-45186). APK_CACHEBUST is
+# fed a per-build value (release version / date) so this layer's buildcache is
+# invalidated each build and apk upgrade re-fetches current Alpine secfixes instead
+# of reusing a stale cached layer. Packages are pinned explicitly so tracked CVE
+# fixes are force-applied even if a future base ships them pinned to older versions.
 ARG APK_CACHEBUST=0
 USER root
 RUN echo "apk-cachebust=${APK_CACHEBUST}" && \
     apk upgrade --no-cache && \
-    apk add --no-cache --upgrade "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0"
+    apk add --no-cache --upgrade "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0" "libexpat>=2.8.1-r0"
 USER nginx
 
 # OCI labels


### PR DESCRIPTION
## **User description**
## Summary

Resolves Code Scanning alert [#85](https://github.com/RackulaLives/Rackula/security/code-scanning/85): Trivy, HIGH, `CVE-2026-45186` (libexpat DoS via crafted XML) on the `rackula-persist` image.

Pins `libexpat>=2.8.1-r0` in the `deploy/Dockerfile` production-stage `apk add --upgrade`, matching the existing explicit-pin pattern for `libssl3`/`libcrypto3`. The generic `apk upgrade --no-cache` already covers it, but the explicit pin documents the tracked CVE and force-applies the floor on every build.

## Provenance

This is the fix the Security Triage workflow drafted on the 2026-06-21 scheduled scan but never opened a PR for. The triage run ([27917039430](https://github.com/RackulaLives/Rackula/actions/runs/27917039430)) correctly judged the finding real, created `fix/security-85`, and committed the fix, but its turn ended before running `gh pr create`, leaving the branch orphaned. This PR finishes that work (re-authored with a DCO sign-off, which the bot commit lacked).

## Verification

Ran the exact build command against the real base image `nginxinc/nginx-unprivileged:alpine` (Alpine 3.23.4):

- The apk package is named `libexpat` (not `expat`), so the pin syntax is correct and will not break the build.
- `apk add --no-cache --upgrade "libexpat>=2.8.1-r0"` resolves cleanly (`OK`).
- The current base already ships `libexpat-2.8.1-r0`, i.e. the fixed version.

## How the alert actually clears

Merging this changes source only. The alert is against the published `ghcr.io/rackulalives/rackula:persist` image, so it clears when that image is rebuilt and rescanned. The `Rebuild Images (OS patch)` workflow (`rebuild-images.yml`, `workflow_dispatch`) rebuilds the rolling tags with a busted apk cache and rescans. Because the current Alpine base already carries `2.8.1-r0`, that rebuild clears alert #85 today even independently of this pin; the pin keeps future builds pinned if a base ever regresses.

## Test Plan

- [x] `apk add --no-cache --upgrade "libexpat>=2.8.1-r0"` succeeds on the real base image (Alpine 3.23.4)
- [x] Confirmed apk package name is `libexpat`
- [ ] Post-merge: run `rebuild-images.yml` and confirm the Trivy rescan closes alert #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDCBUDa6ozjMxJ3kickMLh


___

## **CodeAnt-AI Description**
**Pin the fixed libexpat version in the production image**

### What Changed
- The production Docker image now upgrades `libexpat` to a fixed version during build, closing the known XML denial-of-service security issue
- The existing package update step still refreshes other Alpine security fixes, and the new pin makes the `libexpat` fix apply on every build

### Impact
`✅ Fewer vulnerable production images`
`✅ Lower risk of XML-based crashes`
`✅ Clearer security compliance for container builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
