### PR TITLE
fix: ensure security triage never strands a fix without a PR

### DIFF
--- a/.github/prompts/security-triage.md
+++ b/.github/prompts/security-triage.md
@@ -60,11 +60,23 @@ If the finding is real:
 4. Commit, push the branch, and open a DRAFT PR against `main`. Title: `security: triage <rule-id> in <file> (alert #<number>)`.
 5. The PR body must include: the tool, severity, your confidence, the file, the alert URL, your triage reasoning, and the suggested fix (or the implemented fix if you made one).
 6. Label the PR `security` and `automated`.
+7. Verify the PR exists before moving on: run `gh pr view <branch> --json url -q .url`. If it returns nothing, `gh pr create` did not succeed: retry it. A real finding is not handled until its draft PR exists and you have its URL. Pushing the branch is not enough.
 
 ```bash
 gh pr create --draft --base main --head <branch> \
   --title "..." --body "..." --label security --label automated
 ```
+
+A workflow safety-net step opens a draft PR for any orphaned `fix/security-*` branch as a backstop, but do not rely on it: open and confirm the PR yourself.
+
+## Container image and OS-package findings (Trivy)
+
+Trivy `OsPackageVulnerability` findings live in a published container image, not in the source tree. The fix is usually a Dockerfile change in `deploy/Dockerfile` (app and persist images) or `api/Dockerfile` (API image): pin the patched package following the existing explicit-pin pattern (the `apk add --upgrade` line that pins libssl3/libcrypto3), or bump the base image.
+
+Two things to get right for these:
+
+- The apk package name Trivy reports is the name to pin (for example `libexpat`, which is built from the `expat` aport). Use `>=<fixed-version>` from the advisory.
+- Merging the Dockerfile fix does not clear the alert. The alert is bound to the published image, so it only clears after the rolling image is rebuilt and rescanned by the `Rebuild Images (OS patch)` workflow (`rebuild-images.yml`, run via `workflow_dispatch`). Say so in the PR body so the maintainer runs that workflow after merge. Often the rebuild alone clears the alert because the current base already ships the fix, and the pin just keeps future builds from regressing.
 
 ## Constraints
 
@@ -76,4 +88,4 @@ gh pr create --draft --base main --head <branch> \
 
 ## Report
 
-At the end, summarize what you did: how many net-new findings, how many dismissed as false positives, how many draft PRs opened (with their URLs), and how many skipped due to the cap.
+At the end, summarize what you did: how many net-new findings, how many dismissed as false positives, how many draft PRs opened (with their URLs), and how many skipped due to the cap. For every real finding, confirm its draft PR exists and include the URL. If you pushed a branch but could not open its PR, say so explicitly and loudly: that is a bug, not a completed triage.

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -249,7 +249,15 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -uo pipefail
-          git fetch origin main 'refs/heads/fix/security-*:refs/remotes/origin/fix/security-*' --quiet || true
+          # Fail loud, not silent: a swallowed fetch failure (network/auth) would
+          # leave the scan seeing no fix/security-* refs and report "opened 0",
+          # which looks like success while the backstop did nothing. A glob
+          # refspec that matches no branches still exits 0 (main is fetched), so
+          # this only fires on a genuine fetch failure.
+          if ! git fetch origin main 'refs/heads/fix/security-*:refs/remotes/origin/fix/security-*' --quiet; then
+            echo "::warning::Safety-net could not fetch fix/security-* branches from origin; the PR backstop did not run."
+            exit 1
+          fi
           opened=0
           for ref in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -E '^origin/fix/security-' || true); do
             branch="${ref#origin/}"

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -229,3 +229,48 @@ jobs:
           # not auto-install marketplace plugins (see docs/deployment/SECURITY-TRIAGE.md
           # and .claude/cloud-setup.sh), so --plugin-dir loads it deterministically.
           claude_args: '--plugin-dir .github/claude-plugins/secure-coding --allowedTools "Bash,Read,Write,Edit,Glob,Grep"'
+
+      # Safety net for a failure mode seen in practice: the triage step can
+      # commit and push a fix/security-<alert> branch but end its turn before
+      # running `gh pr create`, stranding the fix on an orphan branch with no PR.
+      # The alert then stays open and nothing surfaces for review. This step
+      # opens a draft PR for any fix/security-* branch that is ahead of main and
+      # has never had a PR, so a drafted fix can never be silently lost. Runs even
+      # if the triage step failed (always()), so a crash mid-run is still caught.
+      #
+      # Caveat: PRs opened with GITHUB_TOKEN do not trigger pull_request CI
+      # workflows (GitHub's recursion guard). CodeRabbit and CodeAnt still review
+      # via their own app webhooks. A maintainer marks the draft ready, or pushes
+      # a commit, to run CI before merge.
+      - name: Ensure a PR exists for every drafted security fix
+        if: always() && steps.gate.outputs.has_alerts == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          git fetch origin main 'refs/heads/fix/security-*:refs/remotes/origin/fix/security-*' --quiet || true
+          opened=0
+          for ref in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin | grep -E '^origin/fix/security-' || true); do
+            branch="${ref#origin/}"
+            # Skip if this branch ever had a PR (open, closed, or merged): a
+            # closed/merged PR means a human already handled it; do not reopen.
+            if [ -n "$(gh pr list --head "$branch" --state all --json number --jq '.[].number' 2>/dev/null)" ]; then
+              continue
+            fi
+            # Only branches with a real commit ahead of main.
+            if [ "$(git rev-list --count "origin/main..$ref" 2>/dev/null || echo 0)" -eq 0 ]; then
+              continue
+            fi
+            alert="${branch#fix/security-}"
+            echo "::warning::Triage left ${branch} without a PR; opening a draft PR as a safety net."
+            if gh pr create --draft --base main --head "$branch" \
+              --title "security: triage finding (alert #${alert})" \
+              --body "Automated safety-net PR. The triage run pushed \`${branch}\` but did not open a PR; this step opened one so the drafted fix is not lost. See alert #${alert} at https://github.com/${REPO}/security/code-scanning/${alert} for details. CI (pull_request workflows) does not run on PRs opened by GITHUB_TOKEN, so a maintainer should mark this PR ready, or push a commit, to trigger CI before merge." \
+              --label security --label automated; then
+              opened=$((opened + 1))
+            else
+              echo "::warning::Failed to open a safety-net PR for ${branch}."
+            fi
+          done
+          echo "Safety-net opened ${opened} PR(s)."


### PR DESCRIPTION
## **User description**
## Summary

Hardens the Security Triage automation against the failure mode found while investigating Code Scanning alert #85.

The triage run on 2026-06-21 ([27917039430](https://github.com/RackulaLives/Rackula/actions/runs/27917039430)) correctly dismissed 3 false positives and committed a correct fix for the libexpat CVE to `fix/security-85`, but its turn ended before running `gh pr create`. The branch was left orphaned with no PR, so the fix was invisible for review and the alert stayed open. (That fix is now finished in #2562.)

## Changes

`.github/workflows/security-triage.yml`
- New step `Ensure a PR exists for every drafted security fix`. After the Claude step (and on `always()`, so a mid-run crash is still caught), it opens a draft PR for any `fix/security-*` branch that is ahead of `main` and has never had a PR. A drafted fix can no longer be silently lost.
- Skips branches that already had any PR (open, closed, or merged) so it never reopens something a human handled.

`.github/prompts/security-triage.md`
- Step 4b: require confirming the PR actually exists (`gh pr view <branch>`); pushing the branch is not enough.
- New section on Trivy image / OS-package CVEs: the fix goes in `deploy/Dockerfile` or `api/Dockerfile`, the apk package name Trivy reports is the one to pin, and merging does not clear the alert: the image must be rebuilt and rescanned via `rebuild-images.yml`.
- Report step: explicitly flag any branch pushed without a PR as a bug.

## Known limitation (documented in the step)

PRs opened with `GITHUB_TOKEN` do not trigger `pull_request` CI workflows (GitHub's recursion guard). CodeRabbit and CodeAnt still review via their app webhooks. A maintainer marks the safety-net draft ready, or pushes a commit, to run CI before merge. The goal here is visibility, not auto-merge.

## Verification

- `actionlint` passes on the modified workflow (it caught and I fixed a YAML block-scalar / shell-quote bug in the first draft).
- Dry-ran the safety-net branch logic against the live repo: `fix/security-85` is correctly skipped because PR #2562 exists; no PRs would be opened.

## Test Plan

- [x] `actionlint .github/workflows/security-triage.yml` clean
- [x] Safety-net loop dry-run skips branches that already have a PR
- [ ] Next scheduled/dispatched triage run: confirm the step runs and opens nothing when no orphan branches exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDCBUDa6ozjMxJ3kickMLh


___

## **CodeAnt-AI Description**
**Keep security triage fixes from getting stranded without a PR**

### What Changed
- Security triage now opens a draft PR for any pushed `fix/security-*` branch that has new commits but no PR yet, so a completed fix is still visible for review even if the triage run stops early.
- The triage instructions now require confirming the PR exists before moving on, instead of treating a pushed branch as complete.
- The triage guide now explains how container image vulnerability fixes work: the Dockerfile change must be followed by rebuilding and rescanning the image before the alert clears.

### Impact
`✅ Fewer orphaned security fixes`
`✅ Clearer triage completion`
`✅ Fewer missed image vulnerability follow-ups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
