### PR TITLE
fix: give canvas racks a listbox parent so aria-required-parent passes (#2253)

### DIFF
--- a/e2e/helpers/a11y.ts
+++ b/e2e/helpers/a11y.ts
@@ -59,7 +59,6 @@ export const BASELINED_RULES: Record<string, string> = {
   // rule (even on a new surface). That is the accepted cost of the baseline:
   // narrow the list, and remove each entry as soon as its issue closes so the
   // rule is enforced again everywhere.
-  "aria-required-parent": "https://github.com/RackulaLives/Rackula/issues/2253",
   "aria-required-children":
     "https://github.com/RackulaLives/Rackula/issues/2254",
   "nested-interactive": "https://github.com/RackulaLives/Rackula/issues/2255",

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -80,6 +80,11 @@
     rack: RackType;
     deviceLibrary: DeviceType[];
     selected: boolean;
+    /** Whether this rack is itself the selectable unit (role="option"). True for
+     *  standalone and bayed racks. False when an ancestor already carries the
+     *  selectable role (dual view wraps two faces under one role="option"), so
+     *  the face renders as presentation to avoid nesting option inside option. */
+    selectable?: boolean;
     selectedDeviceId?: string | null;
     displayMode?: DisplayMode;
     showLabelsOnImages?: boolean;
@@ -124,6 +129,7 @@
     rack,
     deviceLibrary,
     selected,
+    selectable = true,
     selectedDeviceId = null,
     displayMode = "label",
     showLabelsOnImages = false,
@@ -399,14 +405,18 @@
 
 <svelte:window onkeydown={handleShiftDown} onkeyup={handleShiftUp} />
 
+<!-- tabindex is only set alongside role="option" (interactive); the analyzer
+     cannot correlate the two dynamic values, so the noninteractive-tabindex
+     warning is a false positive here. -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
   class="rack-container"
   class:selected
   class:party-mode={partyMode}
   class:placement-mode={isPlacementMode}
-  tabindex="0"
-  aria-selected={selected}
-  role="option"
+  tabindex={selectable ? 0 : undefined}
+  aria-selected={selectable ? selected : undefined}
+  role={selectable ? "option" : "presentation"}
   onkeydown={handleKeyDown}
   onclick={handleClick}
 >

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -237,9 +237,13 @@
   }
 </script>
 
-<!-- Multi-rack mode: render racks with visual grouping -->
+<!-- Multi-rack mode: render racks with visual grouping. role="listbox" gives the
+     rack containers (role="option", see RackDualView) a valid required parent so
+     aria-selected is announced correctly; the racks are a single-select set. -->
 <div
   class="racks-wrapper"
+  role="listbox"
+  aria-label="Racks"
   class:swipe-next={swipeAnimationDirection === "next"}
   class:swipe-previous={swipeAnimationDirection === "previous"}
 >

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -318,6 +318,7 @@
           {rack}
           {deviceLibrary}
           selected={false}
+          selectable={false}
           {selectedDeviceId}
           {displayMode}
           {showLabelsOnImages}
@@ -347,6 +348,7 @@
             {rack}
             {deviceLibrary}
             selected={false}
+            selectable={false}
             {selectedDeviceId}
             {displayMode}
             {showLabelsOnImages}


### PR DESCRIPTION
## **User description**
## What

Re-enables the axe `aria-required-parent` rule (WCAG 2.2 AA, critical) and fixes the violation that kept it baselined.

Closes #2253

## Root cause

The issue title pointed at the device palette `role="listitem"` items, but those already sit under a valid `role="list"` ancestor and are not the violation. The real failure is in the canvas: `RackDualView` renders rack containers with `role="option"` (so `aria-selected` is announced on rack selection), but they have no `role="listbox"` or `role="group"` ancestor. axe flags every rack option.

There was also an invalid nesting: in dual view the outer `.rack-dual-view` is `role="option"`, and each of its two inner `Rack` faces was ALSO `role="option"`, so an option contained two more options.

## Fix

- `RackCanvasView.svelte`: add `role="listbox"` with `aria-label="Racks"` to `.racks-wrapper`, the common ancestor of every rack option. This matches the existing `listbox`/`option` pattern already used by `RackList`, `LayoutsLibrary` and `MobileLayoutsSheet`.
- `Rack.svelte`: add a `selectable` prop (default `true`, so standalone and bayed racks keep `role="option"`). When `false`, the container renders `role="presentation"` with no `tabindex`/`aria-selected`.
- `RackDualView.svelte`: pass `selectable={false}` to the two inner faces, since the outer `.rack-dual-view` owns selection. This removes the option-inside-option nesting and a pair of redundant focus stops per rack (selection and keyboard focus now live on the single outer container).
- `e2e/helpers/a11y.ts`: remove `aria-required-parent` from `BASELINED_RULES`.

## Verification

- `npm run test:e2e:a11y`: 15/15 pass with the rule enforced.
- `npm run test:run`: 2854/2854 pass.
- `npm run lint`, `npm run build`: pass.
- Dual-view rack selection e2e (the `aria-selected` assertion on `.rack-dual-view`) and the rack-select/context-menu webkit specs: pass.

## Note

The bayed-rack `role="option"` path (option under `role="presentation"` under `role="group"`) is valid per ARIA and is not affected by this change, but no axe scan renders a bayed group, so it ships unverified by the guard rail. A follow-up could add a bayed-group axe scan to `axe.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rqNWAVCioj5VVNzWtGJ5b


___

## **CodeAnt-AI Description**
Fix rack selection accessibility in the canvas view

### What Changed
- Rack groups in the canvas now have a proper listbox label, so selected racks are announced in a valid parent structure
- The two faces in dual-rack view no longer act like separate selectable items; only the outer rack is selectable, removing duplicate focus stops
- The a11y scan now checks the required-parent rule again instead of skipping it

### Impact
`✅ Fewer accessibility violations on rack selection`
`✅ Clearer screen reader output for canvas racks`
`✅ Fewer duplicate keyboard stops in dual-rack view`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
