### PR TITLE
fix: raise muted-text and QR-brand contrast to WCAG AA (#2256)

### DIFF
--- a/docs/reference/BRAND.md
+++ b/docs/reference/BRAND.md
@@ -58,7 +58,7 @@ Rackula uses a **three-tier colour hierarchy**:
 | Token | Hex | Contrast | Usage |
 | --- | --- | --- | --- |
 | `--colour-text` | `#F8F8F2` | 11.6:1 | Primary text |
-| `--colour-text-muted` | `#BBBBBB` | 4.8:1 | Secondary text (WCAG AA) |
+| `--colour-text-muted` | `#BBBBBB` | 4.77:1 | Secondary text (WCAG AA) |
 | `--colour-text-disabled` | `#6272A4` | 3.3:1 | Disabled only (exempt from WCAG) |
 
 **Note:** Original Dracula comment (`#6272A4`) fails WCAG AA at 3.3:1. Use `#BBBBBB` for muted text that must be readable: it clears 4.5:1 on every dark surface, including the lightest (`#44475A`) at 4.77:1.

--- a/docs/reference/BRAND.md
+++ b/docs/reference/BRAND.md
@@ -58,10 +58,10 @@ Rackula uses a **three-tier colour hierarchy**:
 | Token | Hex | Contrast | Usage |
 | --- | --- | --- | --- |
 | `--colour-text` | `#F8F8F2` | 11.6:1 | Primary text |
-| `--colour-text-muted` | `#9A9A9A` | 5.1:1 | Secondary text (WCAG AA) |
+| `--colour-text-muted` | `#BBBBBB` | 4.8:1 | Secondary text (WCAG AA) |
 | `--colour-text-disabled` | `#6272A4` | 3.3:1 | Disabled only (exempt from WCAG) |
 
-**Note:** Original Dracula comment (`#6272A4`) fails WCAG AA at 3.3:1. Use `#9A9A9A` for muted text that must be readable.
+**Note:** Original Dracula comment (`#6272A4`) fails WCAG AA at 3.3:1. Use `#BBBBBB` for muted text that must be readable: it clears 4.5:1 on every dark surface, including the lightest (`#44475A`) at 4.77:1.
 
 ### Accent Colours (Small UI Only)
 

--- a/e2e/helpers/a11y.ts
+++ b/e2e/helpers/a11y.ts
@@ -63,7 +63,6 @@ export const BASELINED_RULES: Record<string, string> = {
   "aria-required-children":
     "https://github.com/RackulaLives/Rackula/issues/2254",
   "nested-interactive": "https://github.com/RackulaLives/Rackula/issues/2255",
-  "color-contrast": "https://github.com/RackulaLives/Rackula/issues/2256",
 };
 
 /**
@@ -84,6 +83,31 @@ export async function expectNoA11yViolations(
   page: Page,
   selector?: string,
 ): Promise<void> {
+  // Wait for any in-flight FINITE CSS animation or transition to finish before
+  // scanning. A surface mid-transition (a sheet sliding up, a backdrop fading)
+  // composites partially: axe then samples blended, anti-aliased pixels and
+  // reports a colour pair that does not match the element's resting style,
+  // producing flaky colour-contrast results under load. Settling first makes the
+  // scan sample resting pixels deterministically. Infinite/looping animations
+  // (the env-badge cylon, the logo gradient) never settle, so they are excluded
+  // here rather than blocking the scan for the full timeout.
+  await page
+    .waitForFunction(
+      () =>
+        document.getAnimations().every((animation) => {
+          if (animation.playState !== "running") return true;
+          const timing = animation.effect?.getComputedTiming();
+          const iterations = timing?.iterations ?? 1;
+          // Only wait on animations that will end on their own.
+          return iterations === Infinity;
+        }),
+      undefined,
+      { timeout: 5000 },
+    )
+    .catch(() => {
+      // Best-effort: never fail the scan because a settle wait timed out.
+    });
+
   let builder = axeBuilder(page);
 
   if (selector) {

--- a/src/app.css
+++ b/src/app.css
@@ -231,7 +231,7 @@ textarea {
 }
 
 .text-medium-contrast {
-  color: var(--colour-text-muted); /* 7:1+ on bg, meets 4.5:1 AA */
+  color: var(--colour-text-muted); /* 4.5:1+ on every surface, meets AA */
 }
 
 /* Use for decorative/non-essential text only */

--- a/src/lib/components/ShareDialog.svelte
+++ b/src/lib/components/ShareDialog.svelte
@@ -326,7 +326,13 @@
   }
 
   .qr-scan-label .brand {
-    color: var(--dracula-purple);
+    /* The QR container is always white in both themes, so this brand text needs a
+       purple that clears WCAG AA on white. The Dracula dark-mode purple (#bd93f9)
+       only reaches 2.41:1 there; this is the Dracula light-mode (Alucard) purple,
+       which is on-brand and clears 4.5:1 at 6.24:1. Hardcoded rather than
+       var(--alucard-purple) because that token is only defined under
+       [data-theme="light"], and this label is white-backed in every theme. */
+    color: #644ac9;
     font-weight: var(--font-weight-semibold);
   }
 

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -201,7 +201,7 @@
 
   /* Text */
   --colour-text: var(--dracula-foreground);
-  --colour-text-muted: #9a9a9a; /* BRAND.md v0.6.0: improved contrast (5.1:1) */
+  --colour-text-muted: #bbbbbb; /* WCAG AA: clears 4.5:1 on every dark surface (4.77:1 on #44475a, the lightest) */
   --colour-text-disabled: var(--dracula-comment);
 
   /* Borders */
@@ -545,7 +545,7 @@
 
   /* Text */
   --colour-text: var(--alucard-foreground);
-  --colour-text-muted: var(--alucard-comment);
+  --colour-text-muted: #5c5647; /* WCAG AA (BRAND.md): darker Alucard olive, clears 4.5:1 on every light surface (4.74:1 on #cfcfde, the darkest) */
   --colour-text-disabled: var(--alucard-comment);
 
   /* Borders */

--- a/src/lib/utils/contrast.ts
+++ b/src/lib/utils/contrast.ts
@@ -180,7 +180,7 @@ export const darkThemeColors = {
   surface: draculaColors.bgLight,
   surfaceRaised: draculaColors.bgLighter,
   text: draculaColors.foreground,
-  textMuted: "#9A9A9A", // BRAND.md v0.6.0: improved contrast (5.1:1)
+  textMuted: "#BBBBBB", // WCAG AA: clears 4.5:1 on every dark surface (4.77:1 on #44475A, the lightest)
   textDisabled: draculaColors.comment,
   selection: draculaColors.pink, // BRAND.md v0.6.0: pink (not purple)
   focusRing: draculaColors.pink, // BRAND.md v0.6.0: pink (not purple)
@@ -200,7 +200,7 @@ export const lightThemeColors = {
   surface: alucardColors.bgLight,
   surfaceRaised: alucardColors.bgLighter,
   text: alucardColors.foreground,
-  textMuted: alucardColors.comment, // Light theme already has good contrast (6.8:1)
+  textMuted: "#5C5647", // WCAG AA: darker Alucard olive, clears 4.5:1 on every light surface (4.74:1 on #CFCFDE, the darkest)
   textDisabled: alucardColors.comment,
   selection: alucardColors.pink, // BRAND.md v0.6.0: pink (not purple)
   focusRing: alucardColors.pink, // BRAND.md v0.6.0: pink (not purple)

--- a/src/tests/contrast.test.ts
+++ b/src/tests/contrast.test.ts
@@ -8,6 +8,8 @@ import {
   meetsUIComponentContrast,
   darkThemeColors,
   lightThemeColors,
+  draculaColors,
+  alucardColors,
 } from "$lib/utils/contrast";
 
 describe("Color Contrast Utilities", () => {
@@ -112,18 +114,20 @@ describe("Dark Theme Contrast (Dracula - WCAG AA)", () => {
     });
   });
 
-  describe("Muted text (BRAND.md v0.6.0 - improved accessibility)", () => {
-    // BRAND.md requires #8A8A9A (5.2:1) instead of #6272A4 (3.3:1)
-    // This improves readability for secondary/muted content
-    it("muted text meets 5:1 on background for WCAG AA compliance", () => {
-      const ratio = getContrastRatio(textMuted, bg);
-      expect(ratio).toBeGreaterThanOrEqual(5);
-    });
-
-    it("muted text on surface has acceptable contrast", () => {
-      // Surface (#343746) is lighter than bg, muted text should still be readable
-      const ratio = getContrastRatio(textMuted, surface);
-      expect(ratio).toBeGreaterThanOrEqual(4);
+  describe("Muted text meets WCAG AA (4.5:1) on every dark surface", () => {
+    // Muted text renders on the base, both raised surfaces, and the lightest
+    // surface of all (the selection primitive, behind active/hover rows). The
+    // lightest background is the worst case, so it is the one that must clear
+    // 4.5:1; an earlier value passed on the base background but failed here
+    // (issue #2256). Each surface is asserted so a regression names the surface.
+    it.each([
+      ["background", bg],
+      ["surface", surface],
+      ["surface-raised", draculaColors.bgLighter],
+      ["selection (lightest)", draculaColors.selection],
+    ])("muted text meets 4.5:1 on %s", (_label, background) => {
+      const ratio = getContrastRatio(textMuted, background);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
     });
   });
 
@@ -188,16 +192,17 @@ describe("Light Theme Contrast (Alucard - WCAG AA)", () => {
     });
   });
 
-  describe("Muted text (3:1 - secondary content)", () => {
-    // Alucard comment color is intentionally muted
-    it("muted text meets 3:1 on background", () => {
-      const ratio = getContrastRatio(textMuted, bg);
-      expect(ratio).toBeGreaterThanOrEqual(3);
-    });
-
-    it("muted text meets 3:1 on surface", () => {
-      const ratio = getContrastRatio(textMuted, surface);
-      expect(ratio).toBeGreaterThanOrEqual(3);
+  describe("Muted text meets WCAG AA (4.5:1) on every light surface", () => {
+    // Mirror of the dark-theme assertion: the selection primitive (#CFCFDE) is
+    // the darkest light surface and the worst case for muted text contrast.
+    it.each([
+      ["background", bg],
+      ["surface", surface],
+      ["surface-raised", alucardColors.bgLighter],
+      ["selection (darkest)", alucardColors.selection],
+    ])("muted text meets 4.5:1 on %s", (_label, background) => {
+      const ratio = getContrastRatio(textMuted, background);
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
     });
   });
 


### PR DESCRIPTION
## **User description**
## What

Fixes the `color-contrast` axe violations (WCAG 2.2 AA, serious) on muted text and the Share dialog QR brand label. Re-enables the `color-contrast` rule by removing it from `BASELINED_RULES`.

Closes #2256

## Root cause

The dark-theme muted-text token `--colour-text-muted: #9a9a9a` cleared 4.5:1 only on the darkest backgrounds. On the lighter Dracula surfaces it fell short, and muted text renders on all of them (sidebar metas, device-palette counts, command pill, share note). The light theme aliased muted text to `--alucard-comment`, which was also short on the `#dedccf` surface. The QR scan label used the dark-mode purple `#bd93f9` on the always-white QR container.

## Tokens changed

| Token / use | Old | New | Worst-case ratio (new) |
| --- | --- | --- | --- |
| `--colour-text-muted` (dark) | `#9a9a9a` | `#bbbbbb` | 4.77:1 on `#44475a` (lightest dark surface) |
| `--colour-text-muted` (light) | `#6c664b` (alias) | `#5c5647` | 4.74:1 on `#cfcfde` (darkest light surface) |
| QR `.brand` (ShareDialog) | `#bd93f9` | `#644ac9` | 6.24:1 on `#ffffff` |

The new values stay within the Dracula/Alucard palette. `#bbbbbb` is a neutral grey reading as muted; `#5c5647` is a darker shade of the existing Alucard olive; `#644ac9` is the official Dracula light-mode (Alucard) purple, the correct on-brand purple for a white surface. It is hardcoded in the component because `--alucard-purple` is only defined under `[data-theme="light"]` and the QR label is white-backed in every theme.

Old/new offending pairs (axe-reported), now resolved:

- `#9a9a9a` on `#343746` 4.19:1 -> `#bbbbbb` 6.14:1
- `#9a9a9a` on `#44475a` 3.25:1 -> `#bbbbbb` 4.77:1
- `#9a9a9a` on `#424450` 3.43:1 -> `#bbbbbb` 5.03:1
- `#bd93f9` on `#ffffff` 2.41:1 -> `#644ac9` 6.24:1

## Test-harness fix

The axe scan helper now waits for in-flight finite CSS transitions to settle before sampling. A bottom sheet mid-slide composites partially, so axe sampled blended pixels and reported an off-target pair (a flaky `#b0b0b0` on `#414456`) under parallel load. Infinite animations (the env-badge cylon, logo gradient) are excluded so they never block the scan.

The unit contrast tests now assert 4.5:1 on every surface muted text lands on, including the lightest (the `selection` primitive). That worst-case assertion is the gap that let the original violation through.

## Verification

- `npm run test:e2e:a11y`: 15/15 pass with `color-contrast` re-enabled
- `npm run lint`: clean
- `npm run test:run`: 2854 pass (contrast suite covers the new worst-case assertions)
- `npm run build`: succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rqNWAVCioj5VVNzWtGJ5b


___

## **CodeAnt-AI Description**
**Fix muted text and Share dialog contrast so all visible text meets WCAG AA**

### What Changed
- Muted text now uses darker theme-appropriate colors that stay readable on every dark and light surface.
- The Share dialog’s QR brand label now uses a purple that remains readable on its white background.
- Accessibility checks now wait for in-progress page transitions to finish before scanning, reducing false contrast failures during animations.
- Contrast tests now check the worst-case surfaces for both themes, and the contrast guidance in the design docs matches the new values.

### Impact
`✅ Fewer accessibility failures on dark and light surfaces`
`✅ Clearer secondary text in the app`
`✅ More reliable contrast checks during animated screen changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
