### PR TITLE
fix: remove aria-required-children axe baseline via render delegation

### DIFF
--- a/e2e/helpers/a11y.ts
+++ b/e2e/helpers/a11y.ts
@@ -52,16 +52,7 @@ export function axeBuilder(page: Page): AxeBuilder {
  *   //   "color-contrast": "https://github.com/RackulaLives/Rackula/issues/NNNN",
  *   // } as const;
  */
-export const BASELINED_RULES: Record<string, string> = {
-  // Pre-existing violations found when the guard rail was first wired (#2099).
-  // A baselined rule is disabled for ALL scans, so the guard rail still fails on
-  // any non-baselined rule but will NOT catch a fresh violation of a baselined
-  // rule (even on a new surface). That is the accepted cost of the baseline:
-  // narrow the list, and remove each entry as soon as its issue closes so the
-  // rule is enforced again everywhere.
-  "aria-required-children":
-    "https://github.com/RackulaLives/Rackula/issues/2254",
-};
+export const BASELINED_RULES: Record<string, string> = {};
 
 /**
  * Run an axe scan on `selector` (a whole page or a single surface) and assert it

--- a/src/lib/components/LayoutContextMenu.svelte
+++ b/src/lib/components/LayoutContextMenu.svelte
@@ -31,8 +31,16 @@
     onexport?: () => void;
     /** Delete (close) layout callback */
     ondelete?: () => void;
-    /** Trigger element (the layout row) */
-    children: Snippet;
+    /**
+     * The trigger element, rendered via bits-ui render delegation. Spread the
+     * supplied `props` onto your own root element so the context-menu wiring
+     * (right-click handler, data attributes) lands on it directly, with no
+     * extra wrapper. The wrapper-free trigger keeps the parent role intact:
+     * the trigger sits inside a `tablist`/`list`, so a roleless, focusable
+     * wrapper between it and the `tab`/`listitem` would break
+     * aria-required-children (#2254).
+     */
+    trigger: Snippet<[Record<string, unknown>]>;
   }
 
   let {
@@ -43,7 +51,7 @@
     onduplicate,
     onexport,
     ondelete,
-    children,
+    trigger,
   }: Props = $props();
 
   function handleSelect(action?: () => void) {
@@ -61,7 +69,9 @@
 
 <ContextMenu.Root {open} onOpenChange={handleOpenChange}>
   <ContextMenu.Trigger>
-    {@render children()}
+    {#snippet child({ props })}
+      {@render trigger(props)}
+    {/snippet}
   </ContextMenu.Trigger>
 
   <ContextMenu.Portal>

--- a/src/lib/components/LayoutTabs.svelte
+++ b/src/lib/components/LayoutTabs.svelte
@@ -279,77 +279,93 @@
   }
 </script>
 
-<div
-  class="layout-tabs"
-  bind:this={stripEl}
-  role="tablist"
-  aria-label="Open layouts"
->
-  {#each visibleTabs as view (view.id)}
-    {@const selected = view.id === workspace.activeId}
-    <LayoutContextMenu
-      onrename={() => contextRename(view.id)}
-      onduplicate={() => contextDuplicate(view.id)}
-      onexport={onexport ? () => onexport(view.id) : undefined}
-      ondelete={showClose ? () => workspace.closeTab(view.id) : undefined}
-    >
-      {#if selected && isEditingName}
-        <input
-          bind:this={nameInputElement}
-          class="layout-tab-input"
-          type="text"
-          bind:value={editNameValue}
-          onkeydown={handleNameKeydown}
-          onblur={() => isEditingName && commitName()}
-          aria-label="Layout name"
-          data-testid="layout-name-input"
-        />
-      {:else}
-        <!--
-          The tab is a div with role="tab" so the close affordance can be a real
-          nested button without a button-in-button. The div carries roving
-          tabindex, aria-selected, click and key activation, drag, and the
-          double-click rename on the active tab.
-        -->
-        <div
-          id="layout-tab-{view.id}"
-          class="layout-tab"
-          class:active={selected}
-          class:drag-over={dragOverId === view.id &&
-            dragIndex !== tabIndex(view.id)}
-          role="tab"
-          aria-selected={selected}
-          tabindex={selected ? 0 : -1}
-          data-testid="layout-tab-{view.id}"
-          draggable="true"
-          onclick={() => workspace.switchTo(view.id)}
-          ondblclick={() => startEditingName(view.id)}
-          onkeydown={(e) => handleTabKeydown(e, view.id)}
-          ondragstart={(e) => handleDragStart(e, view.id)}
-          ondragover={(e) => handleDragOver(e, view.id)}
-          ondrop={(e) => handleDrop(e, view.id)}
-          ondragend={handleDragEnd}
-        >
-          {#if view.unbacked}
-            <span class="layout-tab-dot" aria-hidden="true"></span>
-            <span class="sr-only">{view.statusLabel}.</span>
-          {/if}
-          <span class="layout-tab-label">{view.name}</span>
-          {#if showClose}
-            <button
-              type="button"
-              class="layout-tab-close"
-              aria-label={`Close ${view.name}`}
-              data-testid="layout-tab-close-{view.id}"
-              onclick={(e) => handleClose(e, view.id)}
-            >
-              <IconClose size={ICON_SIZE.sm} />
-            </button>
-          {/if}
-        </div>
-      {/if}
-    </LayoutContextMenu>
-  {/each}
+<!--
+  The outer strip is a plain flex row, not the tablist, and is the width the
+  ResizeObserver measures: it holds the tabs AND the persistent "+"/overflow
+  controls, so the partition can reserve the controls' width from the full lane
+  (see partition below). role="tablist" sits on the inner element that owns only
+  the tabs, so the "+" and the overflow chevron (neither of which is a tab) are
+  siblings of the tablist rather than non-tab children of it
+  (aria-required-children, #2254).
+-->
+<div class="layout-tabs" bind:this={stripEl}>
+  <div class="layout-tablist" role="tablist" aria-label="Open layouts">
+    {#each visibleTabs as view (view.id)}
+      {@const selected = view.id === workspace.activeId}
+      <LayoutContextMenu
+        onrename={() => contextRename(view.id)}
+        onduplicate={() => contextDuplicate(view.id)}
+        onexport={onexport ? () => onexport(view.id) : undefined}
+        ondelete={showClose ? () => workspace.closeTab(view.id) : undefined}
+      >
+        {#snippet trigger(triggerProps)}
+          {@const editing = selected && isEditingName}
+          <!--
+            The tab is always a div with role="tab" so it stays a valid direct
+            child of the tablist in both states (aria-required-children, #2254);
+            rename swaps only the inner content to the input, never the tab root.
+            role="tab" also lets the close affordance be a real nested button
+            without a button-in-button. The div carries roving tabindex,
+            aria-selected, click and key activation, drag, and the double-click
+            rename on the active tab. The context-menu trigger props spread
+            directly onto it (render delegation), so there is no roleless wrapper
+            between the tablist and the tab.
+          -->
+          <div
+            {...triggerProps}
+            id="layout-tab-{view.id}"
+            class="layout-tab"
+            class:active={selected}
+            class:editing
+            class:drag-over={dragOverId === view.id &&
+              dragIndex !== tabIndex(view.id)}
+            role="tab"
+            aria-selected={selected}
+            tabindex={selected ? 0 : -1}
+            data-testid="layout-tab-{view.id}"
+            draggable={!editing}
+            onclick={() => !editing && workspace.switchTo(view.id)}
+            ondblclick={() => startEditingName(view.id)}
+            onkeydown={(e) => !editing && handleTabKeydown(e, view.id)}
+            ondragstart={(e) => handleDragStart(e, view.id)}
+            ondragover={(e) => handleDragOver(e, view.id)}
+            ondrop={(e) => handleDrop(e, view.id)}
+            ondragend={handleDragEnd}
+          >
+            {#if editing}
+              <input
+                bind:this={nameInputElement}
+                class="layout-tab-input"
+                type="text"
+                bind:value={editNameValue}
+                onkeydown={handleNameKeydown}
+                onblur={() => isEditingName && commitName()}
+                aria-label="Layout name"
+                data-testid="layout-name-input"
+              />
+            {:else}
+              {#if view.unbacked}
+                <span class="layout-tab-dot" aria-hidden="true"></span>
+                <span class="sr-only">{view.statusLabel}.</span>
+              {/if}
+              <span class="layout-tab-label">{view.name}</span>
+              {#if showClose}
+                <button
+                  type="button"
+                  class="layout-tab-close"
+                  aria-label={`Close ${view.name}`}
+                  data-testid="layout-tab-close-{view.id}"
+                  onclick={(e) => handleClose(e, view.id)}
+                >
+                  <IconClose size={ICON_SIZE.sm} />
+                </button>
+              {/if}
+            {/if}
+          </div>
+        {/snippet}
+      </LayoutContextMenu>
+    {/each}
+  </div>
 
   <button
     type="button"
@@ -403,7 +419,24 @@
 </div>
 
 <style>
+  /* The measured lane: holds the tabs plus the "+"/overflow controls. The
+     ResizeObserver reads this full width and the partition reserves the
+     controls' width from it, so the visible-tab count matches what fits beside
+     the controls. */
   .layout-tabs {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+  }
+
+  /* The tablist owns only the tabs and takes the space the "+"/overflow
+     controls (its flex siblings) leave. overflow: hidden clips tabs that exceed
+     that space; the partition keeps them from rendering, so they move behind the
+     overflow chevron instead of being cut off. */
+  .layout-tablist {
     display: flex;
     align-items: center;
     gap: var(--space-1);
@@ -441,6 +474,15 @@
     box-shadow:
       0 0 0 2px var(--colour-bg),
       0 0 0 4px var(--colour-focus-ring);
+  }
+
+  /* While renaming, the tab is just a host for the input: drop its own padding,
+     border and text cursor so the input fills the slot as before. The input
+     carries its own height, border and background. */
+  .layout-tab.editing {
+    padding: 0;
+    border: none;
+    cursor: text;
   }
 
   .layout-tab-label {

--- a/src/lib/components/LayoutsLibrary.svelte
+++ b/src/lib/components/LayoutsLibrary.svelte
@@ -354,72 +354,77 @@
         onexport={onexport ? () => exportLayout(row) : undefined}
         ondelete={() => initiateDelete(row)}
       >
-        <!-- The row is a role="listitem", not a role="option": an open row holds
-             an interactive close button, and an option may not contain focusable
-             descendants (nested-interactive, #2255). It stays a click/keyboard
-             focus stop for row selection, so the noninteractive-tabindex and
-             noninteractive-element-interactions warnings are expected here. -->
-        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-        <div
-          class="layout-item"
-          class:active={row.isActive}
-          class:closed={!row.isOpen}
-          onclick={() => activateRow(row)}
-          onkeydown={(e) => handleRowKeydown(e, row)}
-          role="listitem"
-          aria-current={row.isActive ? "true" : undefined}
-          tabindex={row.isActive ? 0 : -1}
-          data-testid="layout-item-{rowKey(row)}"
-        >
-          <span
-            class="layout-indicator"
-            class:is-active={row.isActive}
-            class:is-open={row.isOpen}
-            aria-hidden="true"
-          ></span>
-          <span class="layout-preview" aria-hidden="true">
-            {#if previewSvg}
-              <!-- eslint-disable-next-line svelte/no-at-html-tags -- Safe: SVG built by generateExportSVG via the DOM API; all user text is set with textContent and escaped by XMLSerializer, never raw-HTML injected. -->
-              {@html previewSvg}
-            {:else}
-              <span class="layout-preview-empty"></span>
-            {/if}
-          </span>
-          <span class="layout-info">
-            <span class="layout-name">{row.name}</span>
-            <span class="layout-meta">
-              <span class="layout-state">
-                {#if row.isActive}
-                  Active
-                {:else if row.isOpen}
-                  Open
-                {:else}
-                  Closed
-                {/if}
-              </span>
-              {#if row.isOpen}
-                <span aria-hidden="true">·</span>
-                {row.rackCount} rack{row.rackCount !== 1 ? "s" : ""} ·
-                {row.deviceCount} device{row.deviceCount !== 1 ? "s" : ""}
+        {#snippet trigger(triggerProps)}
+          <!-- The row is a role="listitem", not a role="option": an open row
+               holds an interactive close button, and an option may not contain
+               focusable descendants (nested-interactive, #2255). It stays a
+               click/keyboard focus stop for row selection, so the
+               noninteractive-tabindex warning is expected here. The context-menu
+               trigger props spread directly onto it (render delegation), so
+               there is no roleless wrapper between the list and the listitem
+               (aria-required-children, #2254). -->
+          <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+          <div
+            {...triggerProps}
+            class="layout-item"
+            class:active={row.isActive}
+            class:closed={!row.isOpen}
+            onclick={() => activateRow(row)}
+            onkeydown={(e) => handleRowKeydown(e, row)}
+            role="listitem"
+            aria-current={row.isActive ? "true" : undefined}
+            tabindex={row.isActive ? 0 : -1}
+            data-testid="layout-item-{rowKey(row)}"
+          >
+            <span
+              class="layout-indicator"
+              class:is-active={row.isActive}
+              class:is-open={row.isOpen}
+              aria-hidden="true"
+            ></span>
+            <span class="layout-preview" aria-hidden="true">
+              {#if previewSvg}
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -- Safe: SVG built by generateExportSVG via the DOM API; all user text is set with textContent and escaped by XMLSerializer, never raw-HTML injected. -->
+                {@html previewSvg}
+              {:else}
+                <span class="layout-preview-empty"></span>
               {/if}
             </span>
-          </span>
-          {#if row.isOpen}
-            <button
-              type="button"
-              class="layout-delete"
-              onclick={(e) => {
-                e.stopPropagation();
-                closeLayout(row);
-              }}
-              aria-label="Close {row.name}"
-              title="Close layout"
-            >
-              ✕
-            </button>
-          {/if}
-        </div>
+            <span class="layout-info">
+              <span class="layout-name">{row.name}</span>
+              <span class="layout-meta">
+                <span class="layout-state">
+                  {#if row.isActive}
+                    Active
+                  {:else if row.isOpen}
+                    Open
+                  {:else}
+                    Closed
+                  {/if}
+                </span>
+                {#if row.isOpen}
+                  <span aria-hidden="true">·</span>
+                  {row.rackCount} rack{row.rackCount !== 1 ? "s" : ""} ·
+                  {row.deviceCount} device{row.deviceCount !== 1 ? "s" : ""}
+                {/if}
+              </span>
+            </span>
+            {#if row.isOpen}
+              <button
+                type="button"
+                class="layout-delete"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  closeLayout(row);
+                }}
+                aria-label="Close {row.name}"
+                title="Close layout"
+              >
+                ✕
+              </button>
+            {/if}
+          </div>
+        {/snippet}
       </LayoutContextMenu>
     {/each}
 

--- a/src/lib/components/RackContextMenu.svelte
+++ b/src/lib/components/RackContextMenu.svelte
@@ -17,7 +17,7 @@
   import type { Snippet } from "svelte";
   import "$lib/styles/context-menus.css";
 
-  interface Props {
+  interface BaseProps {
     /** Whether the menu is open */
     open?: boolean;
     /** Callback when open state changes */
@@ -34,9 +34,25 @@
     onduplicate?: () => void;
     /** Delete rack callback */
     ondelete?: () => void;
-    /** Trigger element (the rack) */
-    children: Snippet;
   }
+
+  /**
+   * Exactly one trigger source. A discriminated union so passing both, or
+   * neither, is a compile-time error rather than a silently empty trigger.
+   * - `children`: the trigger content, wrapped in bits-ui's default trigger
+   *   div. Use for canvas triggers that are not inside a role that constrains
+   *   its children.
+   * - `trigger`: bits-ui render delegation. Receives the trigger `props` to
+   *   spread onto your own root element, with no wrapper. Use when the trigger
+   *   sits inside a `list` (the Racks panel rows), so a roleless, focusable
+   *   wrapper between the `list` and its `listitem` does not break
+   *   aria-required-children (#2254).
+   */
+  type TriggerProps =
+    | { children: Snippet; trigger?: never }
+    | { trigger: Snippet<[Record<string, unknown>]>; children?: never };
+
+  type Props = BaseProps & TriggerProps;
 
   let {
     open = $bindable(false),
@@ -48,6 +64,7 @@
     onduplicate,
     ondelete,
     children,
+    trigger,
   }: Props = $props();
 
   function handleSelect(action?: () => void) {
@@ -65,7 +82,15 @@
 
 <ContextMenu.Root {open} onOpenChange={handleOpenChange}>
   <ContextMenu.Trigger>
-    {@render children()}
+    {#snippet child({ props })}
+      {#if trigger}
+        {@render trigger(props)}
+      {:else}
+        <div {...props}>
+          {@render children?.()}
+        </div>
+      {/if}
+    {/snippet}
   </ContextMenu.Trigger>
 
   <ContextMenu.Portal>

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -283,73 +283,46 @@
   {onduplicate}
   {ondelete}
 >
-  <!-- The rack is a role="listitem" (it holds interactive device buttons, so it
-       cannot be a role="option", which forbids focusable descendants:
-       nested-interactive, #2255). It stays a click/keyboard focus stop for
-       rack-level selection, so the noninteractive-tabindex and
-       noninteractive-element-interactions warnings are expected here. -->
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <div
-    bind:this={containerElement}
-    class="rack-dual-view"
-    data-rack-id={rack.id}
-    class:selected
-    class:active={isActive}
-    class:long-press-active={longPressActive}
-    tabindex="0"
-    role="listitem"
-    aria-current={isActive ? "location" : undefined}
-    aria-label="{rack.name}, {rack.height}U rack, {rack.show_rear
-      ? 'front and rear view'
-      : 'front view only'}{isActive ? ', active' : ''}{selected
-      ? ', selected'
-      : ''}"
-    onclick={handleContainerClick}
-    onkeydown={handleKeyDown}
-    style:--long-press-progress={longPressProgress}
-  >
-    <!-- Rack name centered above both views -->
-    <div class="rack-dual-view-name">{rack.name}</div>
+  {#snippet trigger(triggerProps)}
+    <!-- The rack is a role="listitem" (it holds interactive device buttons, so
+         it cannot be a role="option", which forbids focusable descendants:
+         nested-interactive, #2255). It stays a click/keyboard focus stop for
+         rack-level selection, so the noninteractive-tabindex warning is expected
+         here. The context-menu trigger props spread directly onto it (render
+         delegation), so there is no roleless wrapper between the canvas list and
+         the listitem (aria-required-children, #2254). -->
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+    <div
+      {...triggerProps}
+      bind:this={containerElement}
+      class="rack-dual-view"
+      data-rack-id={rack.id}
+      class:selected
+      class:active={isActive}
+      class:long-press-active={longPressActive}
+      tabindex="0"
+      role="listitem"
+      aria-current={isActive ? "location" : undefined}
+      aria-label="{rack.name}, {rack.height}U rack, {rack.show_rear
+        ? 'front and rear view'
+        : 'front view only'}{isActive ? ', active' : ''}{selected
+        ? ', selected'
+        : ''}"
+      onclick={handleContainerClick}
+      onkeydown={handleKeyDown}
+      style:--long-press-progress={longPressProgress}
+    >
+      <!-- Rack name centered above both views -->
+      <div class="rack-dual-view-name">{rack.name}</div>
 
-    <div class="rack-dual-view-container" class:single-view={!rack.show_rear}>
-      <!-- Annotation column (left of front view) -->
-      {#if showAnnotations}
-        <AnnotationColumn {rack} {deviceLibrary} {annotationField} />
-      {/if}
-
-      <!-- Front view -->
-      <div class="rack-front" data-testid="rack-front" role="presentation">
-        <Rack
-          {rack}
-          {deviceLibrary}
-          selected={false}
-          selectable={false}
-          {selectedDeviceId}
-          {displayMode}
-          {showLabelsOnImages}
-          {partyMode}
-          faceFilter="front"
-          hideRackName={true}
-          viewLabel={rack.show_rear ? "FRONT" : undefined}
-          onselect={() => handleSelect()}
-          {ondeviceselect}
-          ondevicedrop={handleFrontDeviceDrop}
-          {ondevicemove}
-          {ondevicemoverack}
-          {onplacementtap}
-        />
-        <!-- Banana for scale (single view - front panel only) -->
-        {#if showBanana && !rack.show_rear}
-          <div class="banana-container" aria-hidden="true">
-            <BananaForScale />
-          </div>
+      <div class="rack-dual-view-container" class:single-view={!rack.show_rear}>
+        <!-- Annotation column (left of front view) -->
+        {#if showAnnotations}
+          <AnnotationColumn {rack} {deviceLibrary} {annotationField} />
         {/if}
-      </div>
 
-      <!-- Rear view (conditionally shown based on rack.show_rear) -->
-      {#if rack.show_rear}
-        <div class="rack-rear" data-testid="rack-rear" role="presentation">
+        <!-- Front view -->
+        <div class="rack-front" data-testid="rack-front" role="presentation">
           <Rack
             {rack}
             {deviceLibrary}
@@ -359,31 +332,62 @@
             {displayMode}
             {showLabelsOnImages}
             {partyMode}
-            faceFilter="rear"
+            faceFilter="front"
             hideRackName={true}
-            viewLabel="REAR"
+            viewLabel={rack.show_rear ? "FRONT" : undefined}
             onselect={() => handleSelect()}
             {ondeviceselect}
-            ondevicedrop={handleRearDeviceDrop}
+            ondevicedrop={handleFrontDeviceDrop}
             {ondevicemove}
             {ondevicemoverack}
             {onplacementtap}
           />
-          <!-- Banana for scale (dual view - rear panel) -->
-          {#if showBanana}
+          <!-- Banana for scale (single view - front panel only) -->
+          {#if showBanana && !rack.show_rear}
             <div class="banana-container" aria-hidden="true">
               <BananaForScale />
             </div>
           {/if}
         </div>
-      {/if}
 
-      <!-- Balancing spacer to keep rack centered when annotations are shown -->
-      {#if showAnnotations}
-        <div class="annotation-spacer" aria-hidden="true"></div>
-      {/if}
+        <!-- Rear view (conditionally shown based on rack.show_rear) -->
+        {#if rack.show_rear}
+          <div class="rack-rear" data-testid="rack-rear" role="presentation">
+            <Rack
+              {rack}
+              {deviceLibrary}
+              selected={false}
+              selectable={false}
+              {selectedDeviceId}
+              {displayMode}
+              {showLabelsOnImages}
+              {partyMode}
+              faceFilter="rear"
+              hideRackName={true}
+              viewLabel="REAR"
+              onselect={() => handleSelect()}
+              {ondeviceselect}
+              ondevicedrop={handleRearDeviceDrop}
+              {ondevicemove}
+              {ondevicemoverack}
+              {onplacementtap}
+            />
+            <!-- Banana for scale (dual view - rear panel) -->
+            {#if showBanana}
+              <div class="banana-container" aria-hidden="true">
+                <BananaForScale />
+              </div>
+            {/if}
+          </div>
+        {/if}
+
+        <!-- Balancing spacer to keep rack centered when annotations are shown -->
+        {#if showAnnotations}
+          <div class="annotation-spacer" aria-hidden="true"></div>
+        {/if}
+      </div>
     </div>
-  </div>
+  {/snippet}
 </RackContextMenu>
 
 <style>

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -210,6 +210,11 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
+    // Only act on keys aimed at the container itself. The listitem holds the
+    // rack's interactive device buttons; without this guard a bubbled Enter or
+    // Space from a focused device button is preventDefault'd here and selects
+    // the rack instead of activating the button.
+    if (event.target !== event.currentTarget) return;
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       handleSelect();

--- a/src/lib/components/RackList.svelte
+++ b/src/lib/components/RackList.svelte
@@ -233,48 +233,55 @@
         }}
         ondelete={() => initiateGroupDelete(group)}
       >
-        <!-- The row is a role="listitem", not a role="option": it holds an
-             interactive delete button, and an option may not contain focusable
-             descendants (nested-interactive, #2255). It stays a click/keyboard
-             focus stop for rack selection, so the noninteractive-tabindex and
-             noninteractive-element-interactions warnings are expected here. -->
-        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-        <div
-          class="rack-item"
-          class:active={isActive}
-          onclick={() => handleGroupClick(group.id)}
-          onkeydown={(e) => {
-            if (e.key === " ") e.preventDefault();
-            if (e.key === "Enter" || e.key === " ") handleGroupClick(group.id);
-          }}
-          role="listitem"
-          aria-current={isActive ? "true" : undefined}
-          tabindex="0"
-          data-testid="rack-item-group-{group.id}"
-        >
-          <span class="rack-indicator" aria-hidden="true">
-            {isActive ? "●" : "○"}
-          </span>
-          <span class="rack-info">
-            <span class="rack-name">{group.name ?? "Bayed Rack"}</span>
-            <span class="rack-meta"
-              >{firstRack?.height ?? "?"}U · {bayCount}-bay · {deviceCount} device{deviceCount !==
-              1
-                ? "s"
-                : ""}</span
-            >
-          </span>
-          <button
-            type="button"
-            class="rack-delete"
-            onclick={(e) => handleGroupDeleteClick(e, group)}
-            aria-label="Delete {group.name ?? 'bayed rack'}"
-            title="Delete bayed rack"
+        {#snippet trigger(triggerProps)}
+          <!-- The row is a role="listitem", not a role="option": it holds an
+               interactive delete button, and an option may not contain focusable
+               descendants (nested-interactive, #2255). It stays a click/keyboard
+               focus stop for rack selection, so the noninteractive-tabindex
+               warning is expected here. The context-menu trigger props spread
+               directly onto it (render delegation), so there is no roleless
+               wrapper between the list and the listitem
+               (aria-required-children, #2254). -->
+          <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+          <div
+            {...triggerProps}
+            class="rack-item"
+            class:active={isActive}
+            onclick={() => handleGroupClick(group.id)}
+            onkeydown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === " ") e.preventDefault();
+              if (e.key === "Enter" || e.key === " ")
+                handleGroupClick(group.id);
+            }}
+            role="listitem"
+            aria-current={isActive ? "true" : undefined}
+            tabindex="0"
+            data-testid="rack-item-group-{group.id}"
           >
-            ✕
-          </button>
-        </div>
+            <span class="rack-indicator" aria-hidden="true">
+              {isActive ? "●" : "○"}
+            </span>
+            <span class="rack-info">
+              <span class="rack-name">{group.name ?? "Bayed Rack"}</span>
+              <span class="rack-meta"
+                >{firstRack?.height ?? "?"}U · {bayCount}-bay · {deviceCount} device{deviceCount !==
+                1
+                  ? "s"
+                  : ""}</span
+              >
+            </span>
+            <button
+              type="button"
+              class="rack-delete"
+              onclick={(e) => handleGroupDeleteClick(e, group)}
+              aria-label="Delete {group.name ?? 'bayed rack'}"
+              title="Delete bayed rack"
+            >
+              ✕
+            </button>
+          </div>
+        {/snippet}
       </RackContextMenu>
     {/each}
 
@@ -290,48 +297,54 @@
         onduplicate={() => onduplicate?.(rack.id)}
         ondelete={() => initiateRackDelete({ id: rack.id, name: rack.name })}
       >
-        <!-- The row is a role="listitem", not a role="option": it holds an
-             interactive delete button, and an option may not contain focusable
-             descendants (nested-interactive, #2255). It stays a click/keyboard
-             focus stop for rack selection, so the noninteractive-tabindex and
-             noninteractive-element-interactions warnings are expected here. -->
-        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-        <div
-          class="rack-item"
-          class:active={isActive}
-          onclick={() => handleRackClick(rack.id)}
-          onkeydown={(e) => {
-            if (e.key === " ") e.preventDefault();
-            if (e.key === "Enter" || e.key === " ") handleRackClick(rack.id);
-          }}
-          role="listitem"
-          aria-current={isActive ? "true" : undefined}
-          tabindex="0"
-          data-testid="rack-item-{rack.id}"
-        >
-          <span class="rack-indicator" aria-hidden="true">
-            {isActive ? "●" : "○"}
-          </span>
-          <span class="rack-info">
-            <span class="rack-name">{rack.name}</span>
-            <span class="rack-meta"
-              >{rack.height}U · {deviceCount} device{deviceCount !== 1
-                ? "s"
-                : ""}</span
-            >
-          </span>
-          <button
-            type="button"
-            class="rack-delete"
-            onclick={(e) =>
-              handleDeleteClick(e, { id: rack.id, name: rack.name })}
-            aria-label="Delete {rack.name}"
-            title="Delete rack"
+        {#snippet trigger(triggerProps)}
+          <!-- The row is a role="listitem", not a role="option": it holds an
+               interactive delete button, and an option may not contain focusable
+               descendants (nested-interactive, #2255). It stays a click/keyboard
+               focus stop for rack selection, so the noninteractive-tabindex
+               warning is expected here. The context-menu trigger props spread
+               directly onto it (render delegation), so there is no roleless
+               wrapper between the list and the listitem
+               (aria-required-children, #2254). -->
+          <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+          <div
+            {...triggerProps}
+            class="rack-item"
+            class:active={isActive}
+            onclick={() => handleRackClick(rack.id)}
+            onkeydown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === " ") e.preventDefault();
+              if (e.key === "Enter" || e.key === " ") handleRackClick(rack.id);
+            }}
+            role="listitem"
+            aria-current={isActive ? "true" : undefined}
+            tabindex="0"
+            data-testid="rack-item-{rack.id}"
           >
-            ✕
-          </button>
-        </div>
+            <span class="rack-indicator" aria-hidden="true">
+              {isActive ? "●" : "○"}
+            </span>
+            <span class="rack-info">
+              <span class="rack-name">{rack.name}</span>
+              <span class="rack-meta"
+                >{rack.height}U · {deviceCount} device{deviceCount !== 1
+                  ? "s"
+                  : ""}</span
+              >
+            </span>
+            <button
+              type="button"
+              class="rack-delete"
+              onclick={(e) =>
+                handleDeleteClick(e, { id: rack.id, name: rack.name })}
+              aria-label="Delete {rack.name}"
+              title="Delete rack"
+            >
+              ✕
+            </button>
+          </div>
+        {/snippet}
       </RackContextMenu>
     {/each}
 


### PR DESCRIPTION
Closes #2254.

## Problem

The `aria-required-children` axe rule (WCAG 2.2 AA, critical) was baselined in `e2e/helpers/a11y.ts`. The sidebar lists, the layout tablist, and the canvas rack list each wrapped their rows in a bits-ui `<ContextMenu.Trigger>`, which renders a roleless, focusable `<div data-context-menu-trigger tabindex="-1">` between a `role="list"`/`role="tablist"` parent and its required `listitem`/`tab` child. That wrapper tripped the rule.

Exact violating nodes on main (with the rule re-enabled):

- `.rack-items` (RackList, `role="list"`): unallowed child `div[tabindex]`
- `.layout-items` (LayoutsLibrary, `role="list"`): unallowed child `div[tabindex]`
- `.layout-tabs` (LayoutTabs, `role="tablist"`): unallowed children `div[tabindex], button[aria-label]` (the context-menu wrapper AND the `+`/overflow buttons that were direct tablist children)
- `.racks-wrapper` (RackCanvasView canvas, `role="list"`): unallowed child `div[tabindex]` (the RackDualView rack listitem's context-menu wrapper)

## Fix: render delegation

Give `RackContextMenu` and `LayoutContextMenu` a render-delegation `trigger` snippet so the consumer's own element becomes the trigger with no wrapper, via the bits-ui Trigger `child` snippet. Consumers spread `{...triggerProps}` first, then set `role`/`tabindex`/handlers so the row's own values win.

- `RackContextMenu` keeps a `children` branch for canvas usage that is not inside a constrained role, via a discriminated union so passing both or neither is a compile error.
- `LayoutContextMenu` is delegation-only (both its consumers sit inside a constrained role).
- `RackList` and `LayoutsLibrary` rows render via the `trigger` snippet.
- `RackDualView` renders its canvas rack listitem via the `trigger` snippet (`bind:this` is compatible: bits-ui props are spreadable attributes, not a ref).
- `LayoutTabs` moves `role="tablist"` to an inner `.layout-tablist` so the `+` and overflow controls are siblings, not non-tab children; the tab stays a `role="tab"` div in both states and rename swaps only the inner content.

Two prior review findings addressed:

1. RackList row keydown is guarded with `if (e.target !== e.currentTarget) return;` so Space on the nested delete button is not `preventDefault`'d by the row.
2. `RackContextMenu` Props is a discriminated union (compile error on both/neither trigger source).

The now-dead `a11y_no_noninteractive_element_interactions` ignores are removed: the spread props make the Svelte compiler treat the row as interactive, so only the `a11y_no_noninteractive_tabindex` ignore is still needed (verified with svelte-check).

`aria-required-children` is removed from `BASELINED_RULES`; the a11y suite passes with the rule re-enabled.

## Verification

- `npm run test:e2e:a11y` (15/15 pass with the rule re-enabled)
- `npm run lint` clean, `npm run test:run` (2858 pass), `npm run build` OK
- Context-menu e2e (`rack-context-menu-focus`, `context-menu-position`) and LayoutTabs unit tests pass: right-click still opens the menu, Focus fires, rename/drag/switch all work.

## Scope

Behaviour-preserving. Does not redo #2255's nested-interactive work; only fixes `aria-required-children` plus the two findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rqNWAVCioj5VVNzWtGJ5b
