### PR TITLE
fix: flatten nested-interactive controls for axe WCAG AA (#2255)

### DIFF
--- a/e2e/dual-view.spec.ts
+++ b/e2e/dual-view.spec.ts
@@ -150,9 +150,12 @@ test.describe("Dual-View Rack Display", () => {
 
     await page.locator(locators.rackView.front).click();
 
+    // The rack is a role="listitem" (it holds interactive devices, so it cannot
+    // be a role="option", which forbids focusable descendants). Selection is
+    // announced through the accessible name, not aria-selected.
     await expect(page.locator(locators.rackView.dualView)).toHaveAttribute(
-      "aria-selected",
-      "true",
+      "aria-label",
+      /, selected$/,
     );
   });
 

--- a/e2e/helpers/a11y.ts
+++ b/e2e/helpers/a11y.ts
@@ -61,7 +61,6 @@ export const BASELINED_RULES: Record<string, string> = {
   // rule is enforced again everywhere.
   "aria-required-children":
     "https://github.com/RackulaLives/Rackula/issues/2254",
-  "nested-interactive": "https://github.com/RackulaLives/Rackula/issues/2255",
 };
 
 /**

--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -649,7 +649,7 @@
     outline: none !important;
   }
 
-  .bay-container :global(.rack-container[aria-selected="true"]) {
+  .bay-container :global(.rack-container[aria-current="true"]) {
     outline: none !important;
   }
 

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -294,31 +294,37 @@
     {/if}
   </span>
   <Tooltip text={isFavourite ? "Unpin device" : "Pin device"} position="left">
-    <button
-      type="button"
-      class="favourite-btn"
-      class:active={isFavourite}
-      onclick={handleFavouriteClick}
-      onkeydown={handleFavouriteKeyDown}
-      aria-label={favouriteLabel}
-      aria-pressed={isFavourite}
-      data-testid="favourite-device-btn"
-    >
-      <IconPin size={ICON_SIZE.sm} filled={isFavourite} />
-    </button>
+    {#snippet triggerChild({ props })}
+      <button
+        {...props}
+        type="button"
+        class="favourite-btn"
+        class:active={isFavourite}
+        onclick={handleFavouriteClick}
+        onkeydown={handleFavouriteKeyDown}
+        aria-label={favouriteLabel}
+        aria-pressed={isFavourite}
+        data-testid="favourite-device-btn"
+      >
+        <IconPin size={ICON_SIZE.sm} filled={isFavourite} />
+      </button>
+    {/snippet}
   </Tooltip>
   {#if canDelete}
     <Tooltip text="Delete unused device type" position="left">
-      <button
-        type="button"
-        class="delete-btn"
-        onclick={handleDeleteClick}
-        onkeydown={handleDeleteKeyDown}
-        aria-label="Delete {deviceName}"
-        data-testid="delete-device-type-btn"
-      >
-        <IconTrash size={ICON_SIZE.sm} />
-      </button>
+      {#snippet triggerChild({ props })}
+        <button
+          {...props}
+          type="button"
+          class="delete-btn"
+          onclick={handleDeleteClick}
+          onkeydown={handleDeleteKeyDown}
+          aria-label="Delete {deviceName}"
+          data-testid="delete-device-type-btn"
+        >
+          <IconTrash size={ICON_SIZE.sm} />
+        </button>
+      {/snippet}
     </Tooltip>
   {/if}
 </div>

--- a/src/lib/components/LayoutsLibrary.svelte
+++ b/src/lib/components/LayoutsLibrary.svelte
@@ -156,6 +156,10 @@
     // activation.
     if (event.target !== event.currentTarget) return;
 
+    // `.layout-item` is the row element. It serves both styling and this
+    // keyboard navigation; the rows are role="listitem" (not role="option",
+    // which forbids the focusable close button they contain), so we select by
+    // class rather than role here.
     const items = listEl
       ? Array.from(listEl.querySelectorAll<HTMLElement>(".layout-item"))
       : [];

--- a/src/lib/components/LayoutsLibrary.svelte
+++ b/src/lib/components/LayoutsLibrary.svelte
@@ -14,7 +14,7 @@
 
   Indicators are never colour-only (WCAG 1.4.1): each row pairs a state dot
   (filled for open, outline for closed) with a text label (Active / Open /
-  Closed) and, for open rows, an aria-selected state. The list is keyboard
+  Closed) and, for the active row, an aria-current state. The list is keyboard
   navigable (Up/Down to move, Home/End to jump, Enter to open).
 -->
 <script lang="ts">
@@ -157,7 +157,7 @@
     if (event.target !== event.currentTarget) return;
 
     const items = listEl
-      ? Array.from(listEl.querySelectorAll<HTMLElement>("[role='option']"))
+      ? Array.from(listEl.querySelectorAll<HTMLElement>(".layout-item"))
       : [];
     const index = items.findIndex((el) => el === event.currentTarget);
 
@@ -319,15 +319,18 @@
     </span>
     {#if onnewlayout}
       <Tooltip text="New Layout" position="bottom">
-        <button
-          type="button"
-          class="new-layout-btn"
-          onclick={onnewlayout}
-          aria-label="New Layout"
-          data-testid="btn-new-layout"
-        >
-          +
-        </button>
+        {#snippet triggerChild({ props })}
+          <button
+            {...props}
+            type="button"
+            class="new-layout-btn"
+            onclick={onnewlayout}
+            aria-label="New Layout"
+            data-testid="btn-new-layout"
+          >
+            +
+          </button>
+        {/snippet}
       </Tooltip>
     {/if}
   </div>
@@ -335,7 +338,7 @@
   <div
     bind:this={listEl}
     class="layout-items"
-    role="listbox"
+    role="list"
     aria-label="Layout library"
   >
     {#each rows as row (rowKey(row))}
@@ -347,14 +350,21 @@
         onexport={onexport ? () => exportLayout(row) : undefined}
         ondelete={() => initiateDelete(row)}
       >
+        <!-- The row is a role="listitem", not a role="option": an open row holds
+             an interactive close button, and an option may not contain focusable
+             descendants (nested-interactive, #2255). It stays a click/keyboard
+             focus stop for row selection, so the noninteractive-tabindex and
+             noninteractive-element-interactions warnings are expected here. -->
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <div
           class="layout-item"
           class:active={row.isActive}
           class:closed={!row.isOpen}
           onclick={() => activateRow(row)}
           onkeydown={(e) => handleRowKeydown(e, row)}
-          role="option"
-          aria-selected={row.isActive}
+          role="listitem"
+          aria-current={row.isActive ? "true" : undefined}
           tabindex={row.isActive ? 0 : -1}
           data-testid="layout-item-{rowKey(row)}"
         >

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -80,10 +80,10 @@
     rack: RackType;
     deviceLibrary: DeviceType[];
     selected: boolean;
-    /** Whether this rack is itself the selectable unit (role="option"). True for
-     *  standalone and bayed racks. False when an ancestor already carries the
-     *  selectable role (dual view wraps two faces under one role="option"), so
-     *  the face renders as presentation to avoid nesting option inside option. */
+    /** Whether this rack is itself the selectable unit (role="listitem"). True
+     *  for standalone and bayed racks. False when an ancestor already carries the
+     *  selectable role (dual view wraps two faces under one listitem), so the
+     *  face renders as presentation to avoid nesting one listitem inside another. */
     selectable?: boolean;
     selectedDeviceId?: string | null;
     displayMode?: DisplayMode;
@@ -405,9 +405,13 @@
 
 <svelte:window onkeydown={handleShiftDown} onkeyup={handleShiftUp} />
 
-<!-- tabindex is only set alongside role="option" (interactive); the analyzer
-     cannot correlate the two dynamic values, so the noninteractive-tabindex
-     warning is a false positive here. -->
+<!-- The rack is a list item that holds interactive devices, so it is a
+     non-interactive role="listitem" container, not an interactive role="option"
+     (an option may not contain focusable descendants: nested-interactive, #2255).
+     It stays a focus stop (tabindex) for rack-level selection, with the active
+     rack announced via aria-current. The analyzer cannot correlate the dynamic
+     tabindex with the role, so the noninteractive-tabindex warning is a false
+     positive here. -->
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
   class="rack-container"
@@ -415,8 +419,8 @@
   class:party-mode={partyMode}
   class:placement-mode={isPlacementMode}
   tabindex={selectable ? 0 : undefined}
-  aria-selected={selectable ? selected : undefined}
-  role={selectable ? "option" : "presentation"}
+  aria-current={selectable && selected ? "true" : undefined}
+  role={selectable ? "listitem" : "presentation"}
   onkeydown={handleKeyDown}
   onclick={handleClick}
 >
@@ -426,7 +430,7 @@
     width={RACK_WIDTH}
     height={viewBoxHeight + viewBoxYOffset}
     viewBox="0 -{viewBoxYOffset} {RACK_WIDTH} {viewBoxHeight + viewBoxYOffset}"
-    role="img"
+    role="group"
     aria-label="{rack.name}, {rack.height}U rack{selected ? ', selected' : ''}"
     ondragover={(e) => onDragOver(e, handlerCtx)}
     ondragenter={onDragEnter}
@@ -575,7 +579,7 @@
     outline-offset: 2px;
   }
 
-  .rack-container[aria-selected="true"],
+  .rack-container[aria-current="true"],
   .rack-container.selected {
     outline: 2px solid var(--colour-selection);
     outline-offset: 4px;

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -237,12 +237,15 @@
   }
 </script>
 
-<!-- Multi-rack mode: render racks with visual grouping. role="listbox" gives the
-     rack containers (role="option", see RackDualView) a valid required parent so
-     aria-selected is announced correctly; the racks are a single-select set. -->
+<!-- Multi-rack mode: render racks with visual grouping. role="list" gives the
+     rack containers (role="listitem", see RackDualView and Rack) a valid required
+     parent. The racks are listitems, not options, because each holds interactive
+     device buttons and an interactive option may not contain focusable
+     descendants (nested-interactive, #2255); the active rack is announced via
+     aria-current. -->
 <div
   class="racks-wrapper"
-  role="listbox"
+  role="list"
   aria-label="Racks"
   class:swipe-next={swipeAnimationDirection === "next"}
   class:swipe-previous={swipeAnimationDirection === "previous"}

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -283,6 +283,13 @@
   {onduplicate}
   {ondelete}
 >
+  <!-- The rack is a role="listitem" (it holds interactive device buttons, so it
+       cannot be a role="option", which forbids focusable descendants:
+       nested-interactive, #2255). It stays a click/keyboard focus stop for
+       rack-level selection, so the noninteractive-tabindex and
+       noninteractive-element-interactions warnings are expected here. -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
     bind:this={containerElement}
     class="rack-dual-view"
@@ -291,8 +298,7 @@
     class:active={isActive}
     class:long-press-active={longPressActive}
     tabindex="0"
-    role="option"
-    aria-selected={selected}
+    role="listitem"
     aria-current={isActive ? "location" : undefined}
     aria-label="{rack.name}, {rack.height}U rack, {rack.show_rear
       ? 'front and rear view'
@@ -398,7 +404,6 @@
     outline-offset: 2px;
   }
 
-  .rack-dual-view[aria-selected="true"],
   .rack-dual-view.selected {
     outline: 2px solid var(--colour-selection);
     outline-offset: 4px;

--- a/src/lib/components/RackList.svelte
+++ b/src/lib/components/RackList.svelte
@@ -193,20 +193,23 @@
     </span>
     {#if onnewrack}
       <Tooltip text="New Rack" position="bottom">
-        <button
-          type="button"
-          class="new-rack-btn"
-          onclick={onnewrack}
-          aria-label="New Rack"
-          data-testid="btn-new-rack"
-        >
-          +
-        </button>
+        {#snippet triggerChild({ props })}
+          <button
+            {...props}
+            type="button"
+            class="new-rack-btn"
+            onclick={onnewrack}
+            aria-label="New Rack"
+            data-testid="btn-new-rack"
+          >
+            +
+          </button>
+        {/snippet}
       </Tooltip>
     {/if}
   </div>
 
-  <div class="rack-items" role="listbox" aria-label="Rack list">
+  <div class="rack-items" role="list" aria-label="Rack list">
     <!-- Bayed rack groups as single entries -->
     {#each rackGroups as group (group.id)}
       {@const firstRack = getGroupFirstRack(group)}
@@ -230,6 +233,13 @@
         }}
         ondelete={() => initiateGroupDelete(group)}
       >
+        <!-- The row is a role="listitem", not a role="option": it holds an
+             interactive delete button, and an option may not contain focusable
+             descendants (nested-interactive, #2255). It stays a click/keyboard
+             focus stop for rack selection, so the noninteractive-tabindex and
+             noninteractive-element-interactions warnings are expected here. -->
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <div
           class="rack-item"
           class:active={isActive}
@@ -238,8 +248,8 @@
             if (e.key === " ") e.preventDefault();
             if (e.key === "Enter" || e.key === " ") handleGroupClick(group.id);
           }}
-          role="option"
-          aria-selected={isActive}
+          role="listitem"
+          aria-current={isActive ? "true" : undefined}
           tabindex="0"
           data-testid="rack-item-group-{group.id}"
         >
@@ -280,6 +290,13 @@
         onduplicate={() => onduplicate?.(rack.id)}
         ondelete={() => initiateRackDelete({ id: rack.id, name: rack.name })}
       >
+        <!-- The row is a role="listitem", not a role="option": it holds an
+             interactive delete button, and an option may not contain focusable
+             descendants (nested-interactive, #2255). It stays a click/keyboard
+             focus stop for rack selection, so the noninteractive-tabindex and
+             noninteractive-element-interactions warnings are expected here. -->
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <div
           class="rack-item"
           class:active={isActive}
@@ -288,8 +305,8 @@
             if (e.key === " ") e.preventDefault();
             if (e.key === "Enter" || e.key === " ") handleRackClick(rack.id);
           }}
-          role="option"
-          aria-selected={isActive}
+          role="listitem"
+          aria-current={isActive ? "true" : undefined}
           tabindex="0"
           data-testid="rack-item-{rack.id}"
         >

--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -7,29 +7,59 @@
   bits-ui tooltips are intentionally unsupported on touch devices because hover
   doesn't exist on touch. This is a deliberate UX decision - tooltip content
   should be non-essential information that can be discovered via other means.
+
+  Trigger markup
+  When the tooltip wraps content that is itself interactive (a button, a link),
+  pass a `triggerChild` snippet: it receives the trigger `props` and spreads
+  them onto that element so the element IS the trigger. That avoids nesting an
+  interactive element inside the default trigger button, which fails the axe
+  `nested-interactive` rule and confuses keyboard focus order (#2255). When the
+  content is static (an icon, a status glyph), use the default `children`
+  snippet and bits-ui renders its own trigger button.
 -->
 <script lang="ts">
   import type { Snippet } from "svelte";
   import { Tooltip } from "bits-ui";
 
   type Position = "top" | "bottom" | "left" | "right";
+  type TriggerProps = Record<string, unknown>;
 
   interface Props {
     text: string;
     shortcut?: string;
     position?: Position;
+    /** Static trigger content; bits-ui renders its own trigger button. */
     children?: Snippet;
+    /**
+     * Interactive trigger content. Receives the trigger `props` to spread onto
+     * your own element so it becomes the trigger (no wrapper button).
+     */
+    triggerChild?: Snippet<[{ props: TriggerProps }]>;
   }
 
-  let { text, shortcut, position = "top", children }: Props = $props();
+  let {
+    text,
+    shortcut,
+    position = "top",
+    children,
+    triggerChild,
+  }: Props = $props();
 </script>
 
 <Tooltip.Root>
-  <Tooltip.Trigger class="tooltip-trigger">
-    {#if children}
-      {@render children()}
-    {/if}
-  </Tooltip.Trigger>
+  {#if triggerChild}
+    <Tooltip.Trigger>
+      {#snippet child({ props })}
+        {@render triggerChild({ props })}
+      {/snippet}
+    </Tooltip.Trigger>
+  {:else}
+    <Tooltip.Trigger class="tooltip-trigger">
+      {#if children}
+        {@render children()}
+      {/if}
+    </Tooltip.Trigger>
+  {/if}
   <Tooltip.Portal>
     <Tooltip.Content
       class="tooltip-content"

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -66,7 +66,7 @@
           class="control-button"
           type="button"
           aria-label={layoutStore.undoDescription ?? "Undo"}
-          disabled={!layoutStore.canUndo}
+          aria-disabled={!layoutStore.canUndo}
           onclick={handleUndo}
           data-testid="btn-undo"
         >
@@ -86,7 +86,7 @@
           class="control-button"
           type="button"
           aria-label={layoutStore.redoDescription ?? "Redo"}
-          disabled={!layoutStore.canRedo}
+          aria-disabled={!layoutStore.canRedo}
           onclick={handleRedo}
           data-testid="btn-redo"
         >
@@ -104,7 +104,7 @@
           class="control-button"
           type="button"
           aria-label="Zoom out"
-          disabled={!canvasStore.canZoomOut}
+          aria-disabled={!canvasStore.canZoomOut}
           onclick={() => canvasStore.zoomOut()}
           data-testid="btn-zoom-out"
         >
@@ -130,7 +130,7 @@
           class="control-button"
           type="button"
           aria-label="Zoom in"
-          disabled={!canvasStore.canZoomIn}
+          aria-disabled={!canvasStore.canZoomIn}
           onclick={() => canvasStore.zoomIn()}
           data-testid="btn-zoom-in"
         >
@@ -229,12 +229,12 @@
     -webkit-tap-highlight-color: transparent;
   }
 
-  .control-button:hover:not(:disabled) {
+  .control-button:hover:not([aria-disabled="true"]) {
     background: var(--colour-overlay-hover);
     color: var(--colour-primary);
   }
 
-  .control-button:active:not(:disabled) {
+  .control-button:active:not([aria-disabled="true"]) {
     transform: scale(0.97);
   }
 
@@ -244,7 +244,11 @@
     color: var(--colour-primary);
   }
 
-  .control-button:disabled {
+  /* aria-disabled (not native disabled) keeps the control focusable and
+     hoverable so its tooltip and shortcut hint stay reachable while the action
+     is unavailable; the click/keyboard handlers and zoom store guard against
+     acting (#2255). */
+  .control-button[aria-disabled="true"] {
     opacity: 0.45;
     cursor: not-allowed;
   }

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -60,16 +60,19 @@
       shortcut="Ctrl+Z"
       position="top"
     >
-      <button
-        class="control-button"
-        type="button"
-        aria-label={layoutStore.undoDescription ?? "Undo"}
-        disabled={!layoutStore.canUndo}
-        onclick={handleUndo}
-        data-testid="btn-undo"
-      >
-        <IconUndoBold size={ICON_SIZE.md} />
-      </button>
+      {#snippet triggerChild({ props })}
+        <button
+          {...props}
+          class="control-button"
+          type="button"
+          aria-label={layoutStore.undoDescription ?? "Undo"}
+          disabled={!layoutStore.canUndo}
+          onclick={handleUndo}
+          data-testid="btn-undo"
+        >
+          <IconUndoBold size={ICON_SIZE.md} />
+        </button>
+      {/snippet}
     </Tooltip>
 
     <Tooltip
@@ -77,31 +80,37 @@
       shortcut="Ctrl+Shift+Z"
       position="top"
     >
-      <button
-        class="control-button"
-        type="button"
-        aria-label={layoutStore.redoDescription ?? "Redo"}
-        disabled={!layoutStore.canRedo}
-        onclick={handleRedo}
-        data-testid="btn-redo"
-      >
-        <IconRedoBold size={ICON_SIZE.md} />
-      </button>
+      {#snippet triggerChild({ props })}
+        <button
+          {...props}
+          class="control-button"
+          type="button"
+          aria-label={layoutStore.redoDescription ?? "Redo"}
+          disabled={!layoutStore.canRedo}
+          onclick={handleRedo}
+          data-testid="btn-redo"
+        >
+          <IconRedoBold size={ICON_SIZE.md} />
+        </button>
+      {/snippet}
     </Tooltip>
   </div>
 
   <div class="control-group" role="group" aria-label="View actions">
     <Tooltip text="Zoom out" position="top">
-      <button
-        class="control-button"
-        type="button"
-        aria-label="Zoom out"
-        disabled={!canvasStore.canZoomOut}
-        onclick={() => canvasStore.zoomOut()}
-        data-testid="btn-zoom-out"
-      >
-        <IconMinusBold size={ICON_SIZE.md} />
-      </button>
+      {#snippet triggerChild({ props })}
+        <button
+          {...props}
+          class="control-button"
+          type="button"
+          aria-label="Zoom out"
+          disabled={!canvasStore.canZoomOut}
+          onclick={() => canvasStore.zoomOut()}
+          data-testid="btn-zoom-out"
+        >
+          <IconMinusBold size={ICON_SIZE.md} />
+        </button>
+      {/snippet}
     </Tooltip>
 
     <span
@@ -115,28 +124,34 @@
     </span>
 
     <Tooltip text="Zoom in" position="top">
-      <button
-        class="control-button"
-        type="button"
-        aria-label="Zoom in"
-        disabled={!canvasStore.canZoomIn}
-        onclick={() => canvasStore.zoomIn()}
-        data-testid="btn-zoom-in"
-      >
-        <IconPlusBold size={ICON_SIZE.md} />
-      </button>
+      {#snippet triggerChild({ props })}
+        <button
+          {...props}
+          class="control-button"
+          type="button"
+          aria-label="Zoom in"
+          disabled={!canvasStore.canZoomIn}
+          onclick={() => canvasStore.zoomIn()}
+          data-testid="btn-zoom-in"
+        >
+          <IconPlusBold size={ICON_SIZE.md} />
+        </button>
+      {/snippet}
     </Tooltip>
 
     <Tooltip text="Fit all" shortcut="F" position="top">
-      <button
-        class="control-button"
-        type="button"
-        aria-label="Fit all"
-        onclick={() => onfitall?.()}
-        data-testid="btn-fit-all"
-      >
-        <IconFitAllBold size={ICON_SIZE.md} />
-      </button>
+      {#snippet triggerChild({ props })}
+        <button
+          {...props}
+          class="control-button"
+          type="button"
+          aria-label="Fit all"
+          onclick={() => onfitall?.()}
+          data-testid="btn-fit-all"
+        >
+          <IconFitAllBold size={ICON_SIZE.md} />
+        </button>
+      {/snippet}
     </Tooltip>
 
     <Tooltip
@@ -144,21 +159,24 @@
       shortcut="I"
       position="top"
     >
-      <button
-        class="control-button"
-        type="button"
-        aria-label="Toggle display mode"
-        onclick={() => ontoggledisplaymode?.()}
-        data-testid="btn-display-mode"
-      >
-        {#if displayMode === "label"}
-          <IconTextBold size={ICON_SIZE.md} />
-        {:else if displayMode === "image"}
-          <IconImageBold size={ICON_SIZE.md} />
-        {:else}
-          <IconImageLabel size={ICON_SIZE.md} />
-        {/if}
-      </button>
+      {#snippet triggerChild({ props })}
+        <button
+          {...props}
+          class="control-button"
+          type="button"
+          aria-label="Toggle display mode"
+          onclick={() => ontoggledisplaymode?.()}
+          data-testid="btn-display-mode"
+        >
+          {#if displayMode === "label"}
+            <IconTextBold size={ICON_SIZE.md} />
+          {:else if displayMode === "image"}
+            <IconImageBold size={ICON_SIZE.md} />
+          {:else}
+            <IconImageLabel size={ICON_SIZE.md} />
+          {/if}
+        </button>
+      {/snippet}
     </Tooltip>
   </div>
 </div>


### PR DESCRIPTION
## **User description**
Closes #2255

## Problem

axe `nested-interactive` (WCAG 2.2 AA, serious) fired wherever a focusable control was nested inside another interactive element, which confuses assistive tech and keyboard focus order. Three distinct nestings showed up across the canvas, the sidebar Devices/Racks/Layouts tabs, and toolbars.

## Root causes and fixes

Each was flattened so every interactive element stands alone, with behaviour and keyboard access preserved.

1. Tooltip-wrapped buttons. The bits-ui `Tooltip.Trigger` rendered its own `<button>` around the consumer's `<button>` (device palette favourite/delete toggles, RackList "New Rack", LayoutsLibrary "New Layout", and the six CanvasViewControls toolbar buttons). `Tooltip.svelte` now exposes a `triggerChild` snippet that forwards the bits-ui trigger `props` onto the consumer's element so that element is the trigger, with no wrapper button. Static-content tooltips (the saved-indicator glyphs) keep the default `children` path.

2. Sidebar rack and layout rows. Each row was `role="option"` with an inline delete/close `<button>`, and an option may not contain focusable descendants. The lists are now `role="list"` and the rows `role="listitem"` (matching the device palette pattern that already passes), with the active item announced via `aria-current` instead of `aria-selected`.

3. Canvas racks. The rack container was `role="option"` holding `role="button"` devices, and the rack SVG was `role="img"` holding those same device buttons. The rack is now a `role="listitem"` under the `role="list"` racks wrapper, and the rack SVG is a labelled `role="group"`. Both legitimately contain interactive devices, and the active rack is announced via `aria-current` and the accessible name.

## Verification

- Removed the `nested-interactive` entry from `BASELINED_RULES` in `e2e/helpers/a11y.ts`.
- `npm run test:e2e:a11y`: 15 passed with the rule re-enabled (was 5 failing on reproduce).
- `npm run lint`: clean. `npm run build`: clean (no Svelte a11y warnings). `npm run test:run`: 2858 passed.
- Functional e2e for the touched surfaces (dual-view, keyboard, basic-workflow, multi-rack, accessibility, rack-context-menu-focus, rack-select-editpanel): 84 passed.

## Accessibility checklist

- [x] WCAG 2.2 AA: no nested-interactive violations; aria-required-parent still holds (rack/layout listitems sit under list wrappers)
- [x] Keyboard: selection and roving focus preserved; selection announced via aria-current and accessible name
- [x] prefers-reduced-motion: unaffected
- [x] Visible focus: unchanged (focus styles retained on rows and buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rqNWAVCioj5VVNzWtGJ5b


___

## **CodeAnt-AI Description**
Fix nested interactive controls in racks, layouts, and toolbars

### What Changed
- Buttons inside tooltips now use the wrapped button itself as the trigger, so favorite, delete, undo, redo, zoom, fit, and display controls no longer end up inside an extra button
- Rack, bay, and layout rows now behave as list items instead of options, which lets them contain their own delete/close buttons without breaking keyboard or screen reader navigation
- The active rack and active layout are now announced with `aria-current`, and the selected rack label includes “selected” for clearer status
- The canvas rack list and rack view selection tests were updated to match the new accessibility behavior

### Impact
`✅ Fewer accessibility errors on main screens`
`✅ Clearer screen reader focus order`
`✅ Safer keyboard use for rows with inline actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
