### PR TITLE
feat: registry-driven help tooltips on verb bar and canvas view controls

### DIFF
--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -518,6 +518,34 @@ export function getActionById(id: ActionId): ActionDefinition | undefined {
   return ACTION_REGISTRY.find((action) => action.id === id);
 }
 
+/** Tooltip content for a control bound to a registry action (#117). */
+export interface ActionTooltip {
+  /** The action's label, used as the tooltip text. */
+  label: string;
+  /**
+   * The platform-formatted primary shortcut, if the action has a keybinding.
+   * Omitted when the action has no shortcut so the tooltip shows the label
+   * alone rather than an empty badge.
+   */
+  shortcut?: string;
+}
+
+/**
+ * Resolve an action id to its tooltip content (label plus formatted shortcut).
+ * Lets a control source its tooltip from the registry rather than hand-authored
+ * copy, so the tooltip cannot drift from the keyboard handler or help overlay.
+ * Returns undefined for an unknown id so the caller can fall back to its own
+ * label.
+ */
+export function getActionTooltip(id: ActionId): ActionTooltip | undefined {
+  const action = getActionById(id);
+  if (!action) return undefined;
+  return {
+    label: action.label,
+    shortcut: formatMenuShortcut(action),
+  };
+}
+
 /**
  * Resolve a keyboard event to the action it should trigger. Returns the first
  * action whose any binding matches, or undefined if none do. Uses the same

--- a/src/lib/components/VerbBar.svelte
+++ b/src/lib/components/VerbBar.svelte
@@ -13,9 +13,11 @@
 -->
 <script lang="ts">
   import type { ActionId } from "$lib/actions/registry";
+  import { getActionTooltip } from "$lib/actions/registry";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import { nextRovingIndex } from "$lib/utils/roving-index";
   import type { Component } from "svelte";
+  import Tooltip from "./Tooltip.svelte";
   import {
     IconChevronUp,
     IconChevronDown,
@@ -90,20 +92,25 @@
   >
     {#each verbs as verb, index (verb.id)}
       {@const Icon = iconForVerb[verb.id]}
-      <button
-        bind:this={buttons[index]}
-        class="verb-button"
-        class:destructive={isDestructive(verb.id)}
-        type="button"
-        aria-label={verb.label}
-        title={verb.label}
-        tabindex={index === clampedActiveIndex ? 0 : -1}
-        onclick={() => ondispatch(verb.id)}
-      >
-        {#if Icon}
-          <Icon size={ICON_SIZE.md} />
-        {/if}
-      </button>
+      {@const tooltip = getActionTooltip(verb.id)}
+      <Tooltip text={tooltip?.label ?? verb.label} shortcut={tooltip?.shortcut}>
+        {#snippet triggerChild({ props })}
+          <button
+            {...props}
+            bind:this={buttons[index]}
+            class="verb-button"
+            class:destructive={isDestructive(verb.id)}
+            type="button"
+            aria-label={verb.label}
+            tabindex={index === clampedActiveIndex ? 0 : -1}
+            onclick={() => ondispatch(verb.id)}
+          >
+            {#if Icon}
+              <Icon size={ICON_SIZE.md} />
+            {/if}
+          </button>
+        {/snippet}
+      </Tooltip>
     {/each}
   </div>
 {/if}

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -10,6 +10,7 @@
 -->
 <script lang="ts">
   import { ICON_SIZE } from "$lib/constants/sizing";
+  import { getActionTooltip } from "$lib/actions/registry";
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
@@ -38,6 +39,14 @@
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
 
+  // Shortcuts come from the registry so they cannot drift from the keyboard
+  // handler or help overlay (#117). Zoom in/out have no registry action (they
+  // are canvas-only, not bound keys), so they keep a label-only tooltip.
+  const undoShortcut = getActionTooltip("undo")?.shortcut;
+  const redoShortcut = getActionTooltip("redo")?.shortcut;
+  const fitAllShortcut = getActionTooltip("fit-all")?.shortcut;
+  const displayModeShortcut = getActionTooltip("toggle-display-mode")?.shortcut;
+
   function handleUndo() {
     if (!layoutStore.canUndo) return;
     const desc = layoutStore.undoDescription?.replace("Undo: ", "") ?? "action";
@@ -57,7 +66,7 @@
   <div class="control-group" role="group" aria-label="History actions">
     <Tooltip
       text={layoutStore.undoDescription ?? "Undo"}
-      shortcut="Ctrl+Z"
+      shortcut={undoShortcut}
       position="top"
     >
       {#snippet triggerChild({ props })}
@@ -77,7 +86,7 @@
 
     <Tooltip
       text={layoutStore.redoDescription ?? "Redo"}
-      shortcut="Ctrl+Shift+Z"
+      shortcut={redoShortcut}
       position="top"
     >
       {#snippet triggerChild({ props })}
@@ -139,7 +148,7 @@
       {/snippet}
     </Tooltip>
 
-    <Tooltip text="Fit all" shortcut="F" position="top">
+    <Tooltip text="Fit all" shortcut={fitAllShortcut} position="top">
       {#snippet triggerChild({ props })}
         <button
           {...props}
@@ -156,7 +165,7 @@
 
     <Tooltip
       text={`Display: ${DISPLAY_MODE_LABELS[displayMode]}`}
-      shortcut="I"
+      shortcut={displayModeShortcut}
       position="top"
     >
       {#snippet triggerChild({ props })}

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   ACTION_REGISTRY,
   getActionById,
+  getActionTooltip,
   findActionForEvent,
   getHelpGroups,
   getAppMenuSections,
@@ -438,6 +439,40 @@ describe("actions registry", () => {
       expect(viewYaml?.enabledWhen).toBeDefined();
       expect(viewYaml?.enabledWhen?.({ ...base, hasRacks: true })).toBe(true);
       expect(viewYaml?.enabledWhen?.({ ...base, hasRacks: false })).toBe(false);
+    });
+  });
+
+  describe("getActionTooltip (registry-driven tooltip content)", () => {
+    it("returns the action label as the tooltip text", () => {
+      const tooltip = getActionTooltip("toggle-display-mode");
+      expect(tooltip?.label).toBe(getActionById("toggle-display-mode")?.label);
+    });
+
+    it("includes the primary key for an action with a bare-key binding", () => {
+      // toggle-display-mode binds the single key "i"; the badge shows it
+      // uppercased with no modifier.
+      const tooltip = getActionTooltip("toggle-display-mode");
+      expect(tooltip?.shortcut).toBe("I");
+    });
+
+    it("includes a modifier for an action with a chorded binding", () => {
+      // duplicate-selection binds mod+D; the formatted shortcut carries the
+      // platform modifier label and the key, joined as "<mod> + D".
+      const tooltip = getActionTooltip("duplicate-selection");
+      expect(tooltip?.shortcut).toMatch(/ \+ D$/);
+    });
+
+    it("omits the shortcut for an action with no binding", () => {
+      // flip-device-face has no keyboard binding, so the tooltip is label-only.
+      const flip = getActionById("flip-device-face");
+      expect(flip?.bindings.length).toBe(0);
+      const tooltip = getActionTooltip("flip-device-face");
+      expect(tooltip?.label).toBe(flip?.label);
+      expect(tooltip?.shortcut).toBeUndefined();
+    });
+
+    it("returns undefined for an unknown id", () => {
+      expect(getActionTooltip("not-a-real-command" as never)).toBeUndefined();
     });
   });
 

--- a/src/tests/helpers/TestVerbBarOverlay.svelte
+++ b/src/tests/helpers/TestVerbBarOverlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { Tooltip } from "bits-ui";
+  import VerbBarOverlay from "$lib/components/VerbBarOverlay.svelte";
+
+  interface Props {
+    canvasEl: HTMLElement | null;
+    ondelete?: () => void;
+    onrackfocus?: (rackIds: string[]) => void;
+    onrackexport?: (rackIds: string[]) => void;
+  }
+
+  let { canvasEl, ondelete, onrackfocus, onrackexport }: Props = $props();
+</script>
+
+<!-- VerbBar renders verb buttons that use Tooltip; the app supplies the
+     Tooltip.Provider context at the top level (App.svelte), so mount it the
+     same way here. -->
+<Tooltip.Provider>
+  <VerbBarOverlay {canvasEl} {ondelete} {onrackfocus} {onrackexport} />
+</Tooltip.Provider>

--- a/src/tests/verb-bar-overlay.test.ts
+++ b/src/tests/verb-bar-overlay.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, cleanup, fireEvent, screen } from "@testing-library/svelte";
-import VerbBarOverlay from "$lib/components/VerbBarOverlay.svelte";
+// Rendered through a thin wrapper that supplies the Tooltip.Provider context
+// the verb buttons' tooltips need (App.svelte provides it in the real app).
+import VerbBarOverlay from "./helpers/TestVerbBarOverlay.svelte";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import {
   getSelectionStore,


### PR DESCRIPTION
## **User description**
Closes #117

## What

Adds contextual help tooltips that render label plus keyboard shortcut sourced from the command registry (#2096), not hand-authored per-control copy.

New `getActionTooltip(id)` in `src/lib/actions/registry.ts` resolves an action id to `{ label, shortcut? }`, reusing the same shortcut formatting the app menu and help overlay already use. A control's tooltip therefore cannot drift from the keyboard handler.

## Surfaces wired

Both surfaces have a single focusable control per item, so bits-ui render delegation (`triggerChild`) opens the tooltip on hover AND keyboard focus without an axe `nested-interactive` violation:

- VerbBar icon buttons: styled registry tooltip (label + shortcut) replaces the bare native `title`. `aria-label` kept for AT. Maps each verb to its registry action by id.
- CanvasViewControls: undo / redo / fit-all / display-mode tooltips now source their shortcut from the registry (`undo`, `redo`, `fit-all`, `toggle-display-mode`) instead of hand-authored `Ctrl+Z` / `F` / `I` strings. Zoom in/out have no registry action, so they stay label-only.

The visible side effect is cosmetic: shortcut badges now read `Ctrl + Z` (spaced), matching the app menu and help overlay.

## Scope decision

The side-panel `ViewControls.svelte` composites (a `SegmentedControl` button group and a `Switch`) are left for a later pass. They have no single compliant focusable trigger host: the group container is not focusable, and anchoring on a non-focusable heading would give a hover-only tooltip that fails the keyboard-focus requirement. Their purpose is already shown by visible headings and helper text, and their shortcuts are discoverable in the help overlay and on the canonical on-canvas display-mode control.

## Depth

Label + shortcut only. No `description` field added to the registry, per the maintainer decision.

## Tests

- `getActionTooltip` resolver unit-tested in `src/tests/actions-registry.test.ts`: label text, bare-key shortcut, chorded shortcut, no-binding omits the shortcut, unknown id returns undefined.
- `VerbBarOverlay` test renders through a thin `TestVerbBarOverlay.svelte` wrapper that supplies the `Tooltip.Provider` context (mirrors the existing `TestDevicePalette` pattern).
- No new render-only tests, per the project TDD protocol.

## Verification

- `npm run lint` clean
- `npm run test:run` 2863 passed
- `npm run build` succeeds
- `npm run test:e2e:a11y` 15/15 axe scans pass, zero new WCAG 2.2 AA violations (including the canvas-with-selected-device scan that renders the VerbBar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rqNWAVCioj5VVNzWtGJ5b


___

## **CodeAnt-AI Description**
**Use registry-based labels and shortcuts in tooltips for toolbar and canvas controls**

### What Changed
- Verb bar buttons now show tooltips from the command registry, so the label and shortcut match the action behavior users actually trigger.
- Canvas undo, redo, fit all, and display mode controls now show registry-sourced shortcuts instead of manually written key hints; zoom in and zoom out keep label-only tooltips.
- The tooltip tests now mount the verb bar the same way the app does, and the registry tooltip resolver is covered for labeled actions, shortcut display, missing shortcuts, and unknown commands.

### Impact
`✅ Shortcut hints that match the real keyboard commands`
`✅ Fewer mismatched tooltip labels on toolbar actions`
`✅ More reliable tooltip coverage in tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
