### PR TITLE
feat: add keyboard alternative for device placement (#106)

### DIFF
--- a/e2e/keyboard-placement.spec.ts
+++ b/e2e/keyboard-placement.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Keyboard-only device placement (#106).
+ *
+ * A keyboard user picks a device from the palette with Enter ("picks it up"),
+ * moves a U-slot cursor in the focused rack with the arrow keys, and places it
+ * with Enter. Escape cancels with no side effects. The flow is announced through
+ * an assertive live region for screen readers.
+ *
+ * These run under the desktop `chromium` project (mouse + keyboard, wide
+ * viewport) where the sidebar palette is visible, which is the desktop
+ * keyboard path this issue adds.
+ */
+import { test, expect } from "./helpers/base-test";
+import {
+  gotoWithRack,
+  SMALL_RACK_SHARE,
+  clickNewRack,
+  completeWizardWithClicks,
+  locators,
+} from "./helpers";
+
+const announcer = '[data-testid="placement-sr-announcer"]';
+const placementBanner = '[data-testid="rack-canvas"] [role="status"]';
+
+test.describe("Keyboard device placement (#106)", () => {
+  test.beforeEach(async ({ page }) => {
+    // SMALL_RACK_SHARE is an empty 12U rack; the Devices sidebar tab is the
+    // desktop default, so the palette is on screen.
+    await gotoWithRack(page, SMALL_RACK_SHARE);
+  });
+
+  test("pick up with Enter, move with arrows, place with Enter", async ({
+    page,
+  }) => {
+    const firstDevice = page.locator(locators.device.paletteItem).first();
+    await expect(firstDevice).toBeVisible();
+
+    const devicesBefore = await page.locator(locators.rack.device).count();
+
+    // Enter on a focused palette device picks it up (enters placement mode).
+    await firstDevice.focus();
+    await page.keyboard.press("Enter");
+
+    // Placement mode is announced: the "Placing:" banner appears and the
+    // assertive announcer names the mode, the seeded slot, and the controls.
+    await expect(
+      page.locator(placementBanner).filter({ hasText: "Placing:" }),
+    ).toBeVisible();
+    await expect(page.locator(announcer)).toContainText("Placing");
+    await expect(page.locator(announcer)).toContainText("arrows");
+
+    // A placement preview is shown on the rack.
+    await expect(page.locator(locators.rack.dropZone).first()).toBeVisible();
+
+    // Arrow keys move the U-slot cursor; the announcer reports the new slot.
+    await page.keyboard.press("ArrowUp");
+    await expect(page.locator(announcer)).toContainText(
+      /U\d+ of .+, available/,
+    );
+
+    // Enter confirms placement.
+    await page.keyboard.press("Enter");
+
+    // The device is placed (count increases) and placement mode exits.
+    await expect(async () => {
+      const devicesAfter = await page.locator(locators.rack.device).count();
+      expect(devicesAfter).toBeGreaterThan(devicesBefore);
+    }).toPass({ timeout: 5000 });
+    await expect(
+      page.locator(placementBanner).filter({ hasText: "Placing:" }),
+    ).not.toBeVisible();
+    await expect(page.locator(announcer)).toContainText("Placed");
+  });
+
+  test("Space confirms placement", async ({ page }) => {
+    const firstDevice = page.locator(locators.device.paletteItem).first();
+    await expect(firstDevice).toBeVisible();
+
+    const devicesBefore = await page.locator(locators.rack.device).count();
+
+    await firstDevice.focus();
+    await page.keyboard.press("Enter");
+    await expect(
+      page.locator(placementBanner).filter({ hasText: "Placing:" }),
+    ).toBeVisible();
+
+    // Space at the seeded slot places the device.
+    await page.keyboard.press("Space");
+
+    await expect(async () => {
+      const devicesAfter = await page.locator(locators.rack.device).count();
+      expect(devicesAfter).toBeGreaterThan(devicesBefore);
+    }).toPass({ timeout: 5000 });
+  });
+
+  test("Escape cancels placement with no side effects", async ({ page }) => {
+    const firstDevice = page.locator(locators.device.paletteItem).first();
+    await expect(firstDevice).toBeVisible();
+
+    const devicesBefore = await page.locator(locators.rack.device).count();
+
+    await firstDevice.focus();
+    await page.keyboard.press("Enter");
+    await expect(
+      page.locator(placementBanner).filter({ hasText: "Placing:" }),
+    ).toBeVisible();
+
+    // Move the cursor, then cancel.
+    await page.keyboard.press("ArrowUp");
+    await page.keyboard.press("Escape");
+
+    // Placement mode exits, the cancel is announced, and nothing was placed.
+    await expect(
+      page.locator(placementBanner).filter({ hasText: "Placing:" }),
+    ).not.toBeVisible();
+    await expect(page.locator(announcer)).toContainText("Placement cancelled");
+
+    const devicesAfter = await page.locator(locators.rack.device).count();
+    expect(devicesAfter).toBe(devicesBefore);
+  });
+
+  test("Tab switches the target rack during placement", async ({ page }) => {
+    // Add a second rack so there is somewhere to Tab to.
+    await clickNewRack(page);
+    await completeWizardWithClicks(page, { name: "Second Rack", height: 12 });
+    await expect(page.locator(locators.rackView.dualViewName)).toHaveCount(2);
+
+    // The wizard left the sidebar on the Racks tab; switch back to Devices so
+    // the palette is on screen.
+    await page.getByRole("tab", { name: "Devices" }).click();
+
+    const firstDevice = page.locator(locators.device.paletteItem).first();
+    await expect(firstDevice).toBeVisible();
+
+    await firstDevice.focus();
+    await page.keyboard.press("Enter");
+
+    // The cursor seeds in the active rack (the newly created Second Rack).
+    await expect(page.locator(announcer)).toContainText("Second Rack");
+
+    // Tab moves the cursor to the other rack; the announcer names it.
+    await page.keyboard.press("Tab");
+    await expect(page.locator(announcer)).toContainText(
+      /U\d+ of (?!Second Rack)/,
+    );
+
+    // Place there.
+    const devicesBefore = await page.locator(locators.rack.device).count();
+    await page.keyboard.press("Enter");
+    await expect(async () => {
+      const devicesAfter = await page.locator(locators.rack.device).count();
+      expect(devicesAfter).toBeGreaterThan(devicesBefore);
+    }).toPass({ timeout: 5000 });
+  });
+
+  test("placement survives undo (placed device can be undone)", async ({
+    page,
+  }) => {
+    const firstDevice = page.locator(locators.device.paletteItem).first();
+    await expect(firstDevice).toBeVisible();
+
+    const devicesBefore = await page.locator(locators.rack.device).count();
+
+    await firstDevice.focus();
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Enter"); // place at seeded slot
+
+    await expect(async () => {
+      const devicesAfter = await page.locator(locators.rack.device).count();
+      expect(devicesAfter).toBeGreaterThan(devicesBefore);
+    }).toPass({ timeout: 5000 });
+
+    // Keyboard placement goes through the recorded placeDevice path, so Ctrl+Z
+    // removes the device again (proves it is not a parallel, unrecorded path).
+    await page.keyboard.press("ControlOrMeta+z");
+    await expect(async () => {
+      const devicesAfter = await page.locator(locators.rack.device).count();
+      expect(devicesAfter).toBe(devicesBefore);
+    }).toPass({ timeout: 5000 });
+  });
+});

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -83,6 +83,11 @@
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
+  import {
+    primeKeyboardPlacement,
+    focusRackContainer,
+  } from "$lib/utils/placement-keyboard-controller";
+  import type { DeviceType } from "$lib/types";
   import { createKonamiDetector } from "$lib/utils/konami";
   import {
     formatDevBuildMessage,
@@ -527,6 +532,39 @@
   function handleRackContextRename(rackId: string) {
     handleRackContextEdit(rackId);
   }
+
+  // Desktop keyboard placement (#106): Enter (or click) on a palette device arms
+  // placement and seeds a keyboard cursor in the focused rack, so a keyboard-only
+  // user can pick a device then drive the U-slot with the arrow keys. Pointer
+  // placement (mobile tap-to-place) arms via a different handler and shows no
+  // cursor; this path is the desktop sidebar palette.
+  function handleDevicePaletteSelect(
+    event: CustomEvent<{ device: DeviceType }>,
+  ) {
+    if (uiStore.readOnly) return;
+    const { device } = event.detail;
+    placementStore.startPlacement(device);
+    primeKeyboardPlacement(
+      {
+        getRacks: () => layoutStore.racks,
+        getDeviceLibrary: () => layoutStore.device_types,
+        getActiveRackId: () => layoutStore.activeRackId,
+        getTargetFace: () => placementStore.targetFace,
+        setActiveRack: (id) => layoutStore.setActiveRack(id),
+        setCursor: (rackId, position) =>
+          placementStore.setCursor(rackId, position),
+        announce: (text) => placementStore.announcePosition(text),
+      },
+      device,
+    );
+    // Move focus off the palette item onto the rack the cursor is now in, so the
+    // palette item does not also handle the next Enter (which would re-arm the
+    // device) and so focus follows the placement context. Synchronous so an
+    // immediate second Enter (pick up, then place) lands on the rack.
+    if (placementStore.targetRackId) {
+      focusRackContainer(placementStore.targetRackId);
+    }
+  }
 </script>
 
 <svelte:window onkeydown={(e) => konamiDetector.handleKeyDown(e)} />
@@ -585,7 +623,10 @@
               />
               <div class="sidebar-content">
                 {#if uiStore.sidebarTab === "devices"}
-                  <DevicePalette oncreatedevice={handleAddDevice} />
+                  <DevicePalette
+                    ondeviceselect={handleDevicePaletteSelect}
+                    oncreatedevice={handleAddDevice}
+                  />
                 {:else if uiStore.sidebarTab === "racks"}
                   <RackList
                     onnewrack={handleNewRack}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -557,12 +557,15 @@
       },
       device,
     );
-    // Move focus off the palette item onto the rack the cursor is now in, so the
-    // palette item does not also handle the next Enter (which would re-arm the
-    // device) and so focus follows the placement context. Synchronous so an
-    // immediate second Enter (pick up, then place) lands on the rack.
-    if (placementStore.targetRackId) {
-      focusRackContainer(placementStore.targetRackId);
+    // Move focus off the palette item onto the active rack, so the palette item
+    // does not also handle the next Enter (which would re-arm the device) and so
+    // focus follows the placement context. Use the active rack (not the cursor's
+    // target) so focus still transfers when the rack is full and no cursor was
+    // seeded; the user can then Tab to a rack with space. Synchronous so an
+    // immediate second Enter lands on the rack.
+    const rackToFocus = placementStore.targetRackId ?? layoutStore.activeRackId;
+    if (rackToFocus) {
+      focusRackContainer(rackToFocus);
     }
   }
 </script>

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -99,6 +99,11 @@
   function handleKeyDown(event: KeyboardEvent) {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
+      // Stop the event reaching the global key handler: this same Enter arms
+      // keyboard placement (#106), and without this it would also bubble to the
+      // window where the placement handler would immediately place at the seeded
+      // slot, collapsing pick-up and place into one keystroke.
+      event.stopPropagation();
       onselect?.(new CustomEvent("select", { detail: { device } }));
     }
   }

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -11,9 +11,46 @@
   } from "$lib/actions/dispatch";
   import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
+  import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getPlacementStore } from "$lib/stores/placement.svelte";
+  import { getCanvasStore } from "$lib/stores/canvas.svelte";
+  import {
+    createPlacementKeyboardController,
+    focusRackContainer,
+  } from "$lib/utils/placement-keyboard-controller";
 
   const workspace = getWorkspaceStore();
   const dispatch = createActionDispatch();
+
+  const layoutStore = getLayoutStore();
+  const placementStore = getPlacementStore();
+  const canvasStore = getCanvasStore();
+
+  // Keyboard placement (#106): while a device is armed, arrow / Tab / Enter /
+  // Escape drive a U-slot cursor and place via the same store path as
+  // tap-to-place. Reads live store values through getters so one controller
+  // instance stays correct as racks and the armed device change.
+  const placementKeyboard = createPlacementKeyboardController({
+    getRacks: () => layoutStore.racks,
+    getDeviceLibrary: () => layoutStore.device_types,
+    getActiveRackId: () => layoutStore.activeRackId,
+    isPlacing: () => placementStore.isPlacing,
+    getPendingDevice: () => placementStore.pendingDevice,
+    getTargetFace: () => placementStore.targetFace,
+    getCursorPosition: () => placementStore.cursorPosition,
+    setActiveRack: (id) => layoutStore.setActiveRack(id),
+    setCursor: (rackId, position) => placementStore.setCursor(rackId, position),
+    announce: (text) => placementStore.announcePosition(text),
+    cancelPlacement: () => placementStore.cancelPlacement(),
+    placeDevice: (rackId, slug, position, face) =>
+      layoutStore.placeDeviceSmart(rackId, slug, position, face),
+    completePlacement: (summary) => placementStore.completePlacement(summary),
+    onPlaced: () =>
+      canvasStore.fitAll(layoutStore.racks, layoutStore.rack_groups),
+    // Move focus to the newly focused rack so the visible focus ring follows the
+    // cursor across a Tab/arrow rack switch.
+    onFocusRack: (rackId) => focusRackContainer(rackId),
+  });
 
   /**
    * Alt+1-9 jumps to the Nth open layout tab. Keyed off event.code (Digit1..9)
@@ -53,6 +90,15 @@
 
     // Ignore if in input field
     if (shouldIgnoreKeyboard(event)) return;
+
+    // Keyboard placement (#106) owns arrow / Tab / Enter / Escape while a device
+    // is armed, so it runs before the action registry (which binds arrows to
+    // move-device and Escape to clear-selection). It only consumes keys while
+    // placing; otherwise it returns false and handling continues as normal.
+    if (placementKeyboard.handleKeyDown(event)) {
+      event.preventDefault();
+      return;
+    }
 
     // Workspace tab jumps (Alt+1-9) are dynamic, not fixed registry actions, so
     // they take precedence over the action registry.

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -40,6 +40,7 @@
   import { isChristmas } from "$lib/utils/christmas";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
+  import { validStartPositions } from "$lib/utils/placement-keyboard";
   import { SvelteSet, SvelteMap } from "svelte/reactivity";
   import { toHumanUnits } from "$lib/utils/position";
   import {
@@ -291,24 +292,55 @@
   const validPlacementSlots = $derived.by(() => {
     if (!isPlacementMode || !placementStore.pendingDevice)
       return new SvelteSet<number>();
-    const { u_height: deviceHeight } = placementStore.pendingDevice;
+    const device = placementStore.pendingDevice;
+    const deviceHeight = device.u_height;
+    // Reuse the keyboard cursor's valid-start scan so the highlight and the
+    // keyboard cursor agree by construction; expand each valid start into the
+    // U-slots the device would occupy.
     const validSlots = new SvelteSet<number>();
-    for (let startU = 1; startU <= rack.height - deviceHeight + 1; startU++) {
-      if (
-        getDropFeedback(
-          rack,
-          deviceLibrary,
-          deviceHeight,
-          startU,
-          undefined,
-          effectiveFaceFilter,
-        ) === "valid"
-      ) {
-        for (let u = startU; u < startU + deviceHeight; u++) validSlots.add(u);
-      }
+    for (const startU of validStartPositions(
+      rack,
+      deviceLibrary,
+      device,
+      effectiveFaceFilter,
+    )) {
+      for (let u = startU; u < startU + deviceHeight; u++) validSlots.add(u);
     }
     return validSlots;
   });
+
+  // Keyboard-placement cursor preview (#106). When the keyboard cursor is in
+  // this rack, surface it through the same drop-preview rectangle the drag/tap
+  // flow uses, so the keyboard preview is visually identical. The pointer
+  // `dropPreview` takes precedence while a drag is active; otherwise this drives
+  // the preview.
+  const keyboardCursorPreview = $derived.by<DropPreviewState | null>(() => {
+    if (!isPlacementMode || !placementStore.pendingDevice) return null;
+    if (placementStore.targetRackId !== rack.id) return null;
+    // Keyboard placement targets one face (placementStore.targetFace). In dual
+    // view the same rack renders a front and a rear Rack; only the face being
+    // placed onto should show the cursor, so the preview matches where the
+    // device actually lands.
+    if (effectiveFaceFilter !== placementStore.targetFace) return null;
+    const position = placementStore.cursorPosition;
+    if (position == null) return null;
+    const { u_height: deviceHeight } = placementStore.pendingDevice;
+    return {
+      position,
+      height: deviceHeight,
+      feedback: getDropFeedback(
+        rack,
+        deviceLibrary,
+        deviceHeight,
+        position,
+        undefined,
+        effectiveFaceFilter,
+      ),
+    };
+  });
+
+  // The active preview: a live pointer drag wins; otherwise the keyboard cursor.
+  const activePreview = $derived(dropPreview ?? keyboardCursorPreview);
 
   // --- Handler context for extracted interaction handlers ---
   const handlerCtx = $derived<RackHandlerContext>({
@@ -389,6 +421,9 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
+    // During keyboard placement the global handler owns Enter/Space (it places
+    // the armed device), so don't also select the rack from here.
+    if (placementStore.isPlacing) return;
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       onselect?.(new CustomEvent("select", { detail: { rackId: rack.id } }));
@@ -460,7 +495,7 @@
       nameYOffset={NAME_Y_OFFSET}
       {shiftKeyHeld}
       {blockedSlots}
-      {dropPreview}
+      dropPreview={activePreview}
       {isPlacementMode}
       {validPlacementSlots}
     />
@@ -513,12 +548,12 @@
       {/each}
     </g>
 
-    <!-- Layer 3: Drop preview -->
-    {#if dropPreview}
+    <!-- Layer 3: Drop preview (pointer drag or keyboard cursor) -->
+    {#if activePreview}
       <RackDropZone
-        position={dropPreview.position}
-        height={dropPreview.height}
-        feedback={dropPreview.feedback}
+        position={activePreview.position}
+        height={activePreview.height}
+        feedback={activePreview.feedback}
         railWidth={RAIL_WIDTH}
         {interiorWidth}
         uHeight={U_HEIGHT}

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -210,6 +210,10 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
+    // During keyboard placement the global handler owns Enter/Space (it places
+    // the armed device). Selecting the rack from its own handler here would
+    // race that, so defer while placing.
+    if (placementStore.isPlacing) return;
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       handleSelect();

--- a/src/lib/stores/placement.svelte.ts
+++ b/src/lib/stores/placement.svelte.ts
@@ -102,12 +102,17 @@ function setTargetFace(face: DeviceFace): void {
 /**
  * Move the keyboard cursor to a rack and U-slot. Setting the cursor does not
  * place anything; it only drives the preview and the position announcement.
+ * Passing `position: null` targets the rack with no slot (e.g. switching to a
+ * full rack), keeping `targetRackId` and `cursorPosition` consistent so the
+ * preview never shows on a stale rack.
  * @param rackId - Rack the cursor is in
- * @param position - Whole-U slot (1-indexed) within that rack
+ * @param position - Whole-U slot (1-indexed) within that rack, or null for none
  */
-function setCursor(rackId: string, position: number): void {
+function setCursor(rackId: string, position: number | null): void {
   targetRackId = rackId;
-  cursorPosition = position;
+  // Rail positions are whole-U integers (carrier-first model); reject a
+  // fractional slot rather than carry it into placement.
+  cursorPosition = position == null ? null : Math.round(position);
 }
 
 /**

--- a/src/lib/stores/placement.svelte.ts
+++ b/src/lib/stores/placement.svelte.ts
@@ -1,7 +1,8 @@
 /**
  * Placement Store
- * Manages tap-to-place workflow state for mobile editing.
- * Tracks the pending device being placed and target face.
+ * Manages tap-to-place and keyboard-place workflow state.
+ * Tracks the pending device being placed, the target face, and (for the
+ * keyboard flow) a U-slot cursor within a target rack.
  */
 
 import type { DeviceType, DeviceFace } from "$lib/types";
@@ -12,9 +13,19 @@ let pendingDevice = $state<DeviceType | null>(null);
 let targetFace = $state<DeviceFace>("front");
 
 /**
+ * Keyboard placement cursor.
+ * `targetRackId` is the rack the cursor is currently in; `cursorPosition` is the
+ * highlighted whole-U slot (1-indexed) within that rack. Both are null while no
+ * keyboard cursor is active (e.g. pure pointer tap-to-place never sets them).
+ */
+let targetRackId = $state<string | null>(null);
+let cursorPosition = $state<number | null>(null);
+
+/**
  * Screen-reader announcement for placement state transitions.
- * Set on cancel and complete so assistive technologies can announce the outcome.
- * Cleared on the next startPlacement so stale text is never re-read.
+ * Set on pick-up, slot change, cancel, and complete so assistive technologies
+ * can announce the mode and position. Cleared on the next startPlacement so
+ * stale text is never re-read.
  */
 let placementAnnouncement = $state<string | null>(null);
 
@@ -28,6 +39,8 @@ function startPlacement(device: DeviceType, face: DeviceFace = "front"): void {
   isPlacing = true;
   pendingDevice = device;
   targetFace = face;
+  targetRackId = null;
+  cursorPosition = null;
 }
 
 /**
@@ -38,6 +51,8 @@ function resetState(): void {
   isPlacing = false;
   pendingDevice = null;
   targetFace = "front";
+  targetRackId = null;
+  cursorPosition = null;
 }
 
 /**
@@ -65,11 +80,13 @@ function abandonPlacement(): void {
 
 /**
  * Complete placement mode after successfully placing the device.
+ * `summary` overrides the announcement (the keyboard flow passes a rich
+ * "Placed X at U12 of Rack 1" string); without it the default names the device.
  */
-function completePlacement(): void {
+function completePlacement(summary?: string): void {
   if (isPlacing) {
     const deviceName = pendingDevice?.model ?? pendingDevice?.slug ?? "Device";
-    placementAnnouncement = `${deviceName} placed`;
+    placementAnnouncement = summary ?? `${deviceName} placed`;
   }
   resetState();
 }
@@ -80,6 +97,26 @@ function completePlacement(): void {
  */
 function setTargetFace(face: DeviceFace): void {
   targetFace = face;
+}
+
+/**
+ * Move the keyboard cursor to a rack and U-slot. Setting the cursor does not
+ * place anything; it only drives the preview and the position announcement.
+ * @param rackId - Rack the cursor is in
+ * @param position - Whole-U slot (1-indexed) within that rack
+ */
+function setCursor(rackId: string, position: number): void {
+  targetRackId = rackId;
+  cursorPosition = position;
+}
+
+/**
+ * Set the live position announcement (e.g. "U12 of Rack 1, available").
+ * Kept separate from completePlacement so slot changes announce without ending
+ * placement.
+ */
+function announcePosition(text: string): void {
+  placementAnnouncement = text;
 }
 
 /**
@@ -105,11 +142,19 @@ export function getPlacementStore() {
     get targetFace() {
       return targetFace;
     },
+    /** Rack the keyboard cursor is in, or null when no keyboard cursor is active. */
+    get targetRackId() {
+      return targetRackId;
+    },
+    /** Highlighted whole-U slot (1-indexed) of the keyboard cursor, or null. */
+    get cursorPosition() {
+      return cursorPosition;
+    },
     /**
      * Screen-reader announcement text for the most recent placement state
-     * transition (placed or cancelled). Null while idle or during active
-     * placement. Rendered in an assertive aria-live region so screen readers
-     * announce the outcome immediately.
+     * transition (mode entered, position changed, placed, or cancelled). Null
+     * while idle. Rendered in an assertive aria-live region so screen readers
+     * announce it immediately.
      */
     get placementAnnouncement() {
       return placementAnnouncement;
@@ -119,5 +164,7 @@ export function getPlacementStore() {
     abandonPlacement,
     completePlacement,
     setTargetFace,
+    setCursor,
+    announcePosition,
   };
 }

--- a/src/lib/utils/placement-keyboard-controller.ts
+++ b/src/lib/utils/placement-keyboard-controller.ts
@@ -27,6 +27,7 @@ import {
   positionAnnouncement,
   noSpaceAnnouncement,
   singleRackAnnouncement,
+  noRacksAnnouncement,
   placedAnnouncement,
 } from "./placement-keyboard";
 
@@ -44,7 +45,7 @@ export interface PlacementKeyboardDeps {
   getCursorPosition: () => number | null;
   /** Placement store actions. */
   setActiveRack: (id: string) => void;
-  setCursor: (rackId: string, position: number) => void;
+  setCursor: (rackId: string, position: number | null) => void;
   announce: (text: string) => void;
   cancelPlacement: () => void;
   /** Place the armed device. Returns true on success. */
@@ -71,9 +72,13 @@ function resolveFace(face: DeviceFace): DeviceFace {
  * palette pick-up (so the next Enter places on the rack, not the palette item)
  * and the Tab rack-switch (so the focus ring follows the cursor). The rack
  * element is already in the DOM, so this runs synchronously. No-op if not found.
+ * `CSS.escape` guards against ids that carry selector-special characters (e.g.
+ * imported or legacy layouts), which would otherwise throw in querySelector.
  */
 export function focusRackContainer(rackId: string): void {
-  document.querySelector<HTMLElement>(`[data-rack-id="${rackId}"]`)?.focus();
+  document
+    .querySelector<HTMLElement>(`[data-rack-id="${CSS.escape(rackId)}"]`)
+    ?.focus();
 }
 
 /** Deps needed to prime the keyboard cursor (a subset of the controller deps). */
@@ -118,7 +123,11 @@ export function primeKeyboardPlacement(
   device: DeviceType,
 ): void {
   const rack = resolveActiveRack(deps);
-  if (!rack) return;
+  if (!rack) {
+    // Armed with no rack to place into: say so rather than fall silent.
+    deps.announce(noRacksAnnouncement(device));
+    return;
+  }
   deps.setActiveRack(rack.id);
   const positions = validFor(deps, rack, device);
   const start = initialCursorPosition(positions);
@@ -165,7 +174,11 @@ export function createPlacementKeyboardController(deps: PlacementKeyboardDeps) {
   /** Switch the focused rack by `step` (+1 next, -1 previous), wrapping. */
   function switchRack(device: DeviceType, step: 1 | -1): void {
     const racks = deps.getRacks();
-    if (racks.length <= 1) {
+    if (racks.length === 0) {
+      deps.announce(noRacksAnnouncement(device));
+      return;
+    }
+    if (racks.length === 1) {
       // Tab is consumed during placement (so focus stays on the canvas), so a
       // single-rack layout would otherwise swallow it silently. Announce instead.
       deps.announce(singleRackAnnouncement());
@@ -181,12 +194,15 @@ export function createPlacementKeyboardController(deps: PlacementKeyboardDeps) {
     // Keep the cursor near the same height across the switch.
     const positions = validFor(deps, nextRack, device);
     const start = initialCursorPosition(positions, deps.getCursorPosition());
-    if (start == null) {
-      deps.announce(noSpaceAnnouncement(nextRack.name));
-      return;
-    }
+    // Point the cursor at the new rack either way (start may be null for a full
+    // rack) so targetRackId and cursorPosition stay consistent with the active
+    // rack; a null cursor shows no preview and the user can Tab on to find space.
     deps.setCursor(nextRack.id, start);
-    deps.announce(positionAnnouncement(nextRack.name, start));
+    deps.announce(
+      start == null
+        ? noSpaceAnnouncement(nextRack.name)
+        : positionAnnouncement(nextRack.name, start),
+    );
   }
 
   function place(device: DeviceType): void {

--- a/src/lib/utils/placement-keyboard-controller.ts
+++ b/src/lib/utils/placement-keyboard-controller.ts
@@ -1,0 +1,277 @@
+/**
+ * Keyboard-placement controller (#106).
+ *
+ * Wires the keyboard placement flow over the placement store and the layout
+ * store. While a device is armed (placement mode) it owns the arrow / Tab /
+ * Enter / Escape keys:
+ *
+ *   - Up / Down       move the U-slot cursor within the focused rack
+ *   - Tab / Shift+Tab move between racks (Left / Right are aliases)
+ *   - Enter / Space   place the armed device at the cursor
+ *   - Escape          cancel placement with no side effects
+ *
+ * The cursor only lands on a valid (placeable) slot, mirroring how the drag
+ * preview snaps. The controller drives the placement store's cursor and
+ * announcements; the rack preview and the SR announcer read that store, so this
+ * module never touches the DOM. The navigation maths lives in the pure
+ * `placement-keyboard` helpers so it stays unit-testable.
+ */
+
+import type { Rack, DeviceType, DeviceFace } from "$lib/types";
+import {
+  validStartPositions,
+  initialCursorPosition,
+  nextCursorPosition,
+  pickUpAnnouncement,
+  pickUpNoSpaceAnnouncement,
+  positionAnnouncement,
+  noSpaceAnnouncement,
+  singleRackAnnouncement,
+  placedAnnouncement,
+} from "./placement-keyboard";
+
+export interface PlacementKeyboardDeps {
+  /** All racks in canvas order. */
+  getRacks: () => Rack[];
+  /** Device library for collision lookups. */
+  getDeviceLibrary: () => DeviceType[];
+  /** The currently focused rack id (drives which rack the cursor lives in). */
+  getActiveRackId: () => string | null;
+  /** Placement store state. */
+  isPlacing: () => boolean;
+  getPendingDevice: () => DeviceType | null;
+  getTargetFace: () => DeviceFace;
+  getCursorPosition: () => number | null;
+  /** Placement store actions. */
+  setActiveRack: (id: string) => void;
+  setCursor: (rackId: string, position: number) => void;
+  announce: (text: string) => void;
+  cancelPlacement: () => void;
+  /** Place the armed device. Returns true on success. */
+  placeDevice: (
+    rackId: string,
+    slug: string,
+    position: number,
+    face: DeviceFace,
+  ) => boolean;
+  completePlacement: (summary: string) => void;
+  /** Called after a successful placement (e.g. to re-fit the canvas). */
+  onPlaced?: () => void;
+  /** Called when the focused rack changes, so focus can follow it (e.g. on Tab). */
+  onFocusRack?: (rackId: string) => void;
+}
+
+/** Collapse the rack's view filter to a placement face (front/rear). */
+function resolveFace(face: DeviceFace): DeviceFace {
+  return face === "rear" ? "rear" : "front";
+}
+
+/**
+ * Move keyboard focus to a rack container by its `data-rack-id`. Used by the
+ * palette pick-up (so the next Enter places on the rack, not the palette item)
+ * and the Tab rack-switch (so the focus ring follows the cursor). The rack
+ * element is already in the DOM, so this runs synchronously. No-op if not found.
+ */
+export function focusRackContainer(rackId: string): void {
+  document.querySelector<HTMLElement>(`[data-rack-id="${rackId}"]`)?.focus();
+}
+
+/** Deps needed to prime the keyboard cursor (a subset of the controller deps). */
+export type PlacementPrimeDeps = Pick<
+  PlacementKeyboardDeps,
+  | "getRacks"
+  | "getDeviceLibrary"
+  | "getActiveRackId"
+  | "getTargetFace"
+  | "setActiveRack"
+  | "setCursor"
+  | "announce"
+>;
+
+function resolveActiveRack(deps: PlacementPrimeDeps): Rack | null {
+  const id = deps.getActiveRackId();
+  if (!id) return deps.getRacks()[0] ?? null;
+  return deps.getRacks().find((r) => r.id === id) ?? null;
+}
+
+function validFor(
+  deps: PlacementPrimeDeps,
+  rack: Rack,
+  device: DeviceType,
+): number[] {
+  return validStartPositions(
+    rack,
+    deps.getDeviceLibrary(),
+    device,
+    resolveFace(deps.getTargetFace()),
+  );
+}
+
+/**
+ * Seed the keyboard cursor when placement begins. Sets the focused rack as the
+ * target, picks its first valid slot, and announces both the pick-up
+ * instructions and the initial position. Shared by the controller and the
+ * desktop palette pick-up so both arm an identical, navigable cursor.
+ */
+export function primeKeyboardPlacement(
+  deps: PlacementPrimeDeps,
+  device: DeviceType,
+): void {
+  const rack = resolveActiveRack(deps);
+  if (!rack) return;
+  deps.setActiveRack(rack.id);
+  const positions = validFor(deps, rack, device);
+  const start = initialCursorPosition(positions);
+  if (start == null) {
+    deps.announce(pickUpNoSpaceAnnouncement(device, rack.name));
+    return;
+  }
+  deps.setCursor(rack.id, start);
+  // One combined utterance: mode + instructions + seeded slot. A separate
+  // instructions-then-position pair would be collapsed by the live region.
+  deps.announce(pickUpAnnouncement(device, rack.name, start));
+}
+
+export function createPlacementKeyboardController(deps: PlacementKeyboardDeps) {
+  function activeRack(): Rack | null {
+    return resolveActiveRack(deps);
+  }
+
+  function primeCursor(device: DeviceType): void {
+    primeKeyboardPlacement(deps, device);
+  }
+
+  function moveCursor(device: DeviceType, direction: 1 | -1): void {
+    const rack = activeRack();
+    if (!rack) return;
+    const positions = validFor(deps, rack, device);
+    const current = deps.getCursorPosition();
+    const next = nextCursorPosition(positions, current, direction);
+    if (next == null) {
+      deps.announce(noSpaceAnnouncement(rack.name));
+      return;
+    }
+    deps.setCursor(rack.id, next);
+    // At a boundary nextCursorPosition returns the same slot. Announce a
+    // distinct "no further slots" cue so the live region text changes (an
+    // identical string would not be re-read) and the user knows they hit an end.
+    deps.announce(
+      next === current
+        ? positionAnnouncement(rack.name, next, true)
+        : positionAnnouncement(rack.name, next),
+    );
+  }
+
+  /** Switch the focused rack by `step` (+1 next, -1 previous), wrapping. */
+  function switchRack(device: DeviceType, step: 1 | -1): void {
+    const racks = deps.getRacks();
+    if (racks.length <= 1) {
+      // Tab is consumed during placement (so focus stays on the canvas), so a
+      // single-rack layout would otherwise swallow it silently. Announce instead.
+      deps.announce(singleRackAnnouncement());
+      return;
+    }
+    const currentId = deps.getActiveRackId() ?? racks[0]?.id;
+    const currentIndex = racks.findIndex((r) => r.id === currentId);
+    const nextIndex = (currentIndex + step + racks.length) % racks.length;
+    const nextRack = racks[nextIndex];
+    if (!nextRack) return;
+    deps.setActiveRack(nextRack.id);
+    deps.onFocusRack?.(nextRack.id);
+    // Keep the cursor near the same height across the switch.
+    const positions = validFor(deps, nextRack, device);
+    const start = initialCursorPosition(positions, deps.getCursorPosition());
+    if (start == null) {
+      deps.announce(noSpaceAnnouncement(nextRack.name));
+      return;
+    }
+    deps.setCursor(nextRack.id, start);
+    deps.announce(positionAnnouncement(nextRack.name, start));
+  }
+
+  function place(device: DeviceType): void {
+    const rack = activeRack();
+    const position = deps.getCursorPosition();
+    if (!rack) return;
+    if (position == null) {
+      // No valid slot in this rack (e.g. it is full). Tell the user rather than
+      // letting Enter silently do nothing.
+      deps.announce(noSpaceAnnouncement(rack.name));
+      return;
+    }
+    const face = resolveFace(deps.getTargetFace());
+    const success = deps.placeDevice(rack.id, device.slug, position, face);
+    if (!success) {
+      deps.announce(noSpaceAnnouncement(rack.name));
+      return;
+    }
+    deps.completePlacement(placedAnnouncement(device, rack.name, position));
+    deps.onPlaced?.();
+  }
+
+  /**
+   * Handle a keydown while placement is armed. Returns true when the event was
+   * consumed (the caller should stop further handling and preventDefault).
+   */
+  function handleKeyDown(event: KeyboardEvent): boolean {
+    if (!deps.isPlacing()) return false;
+    const device = deps.getPendingDevice();
+    if (!device) return false;
+
+    // Escape always cancels, even before the cursor is primed.
+    if (event.key === "Escape") {
+      deps.cancelPlacement();
+      return true;
+    }
+
+    const navOrPlaceKeys = [
+      "ArrowUp",
+      "ArrowDown",
+      "ArrowLeft",
+      "ArrowRight",
+      "Tab",
+      "Enter",
+      " ",
+    ];
+
+    // The cursor is primed on a keyboard pick-up. A pointer pick-up (mobile
+    // tap-to-place) leaves it null and shows no preview, and we don't hijack its
+    // keys unless one of ours arrives. A device armed via the command palette is
+    // also null until the first key. On that first key, prime the cursor: an
+    // up/down arrow's only job is then to establish it (priming already
+    // announced the seeded slot, so don't also step away from a slot the user
+    // has not heard yet); Tab / Left / Right / Enter fall through to act, so a
+    // full active rack can still be Tabbed away from.
+    if (deps.getCursorPosition() == null) {
+      if (!navOrPlaceKeys.includes(event.key)) return false;
+      primeCursor(device);
+      if (event.key === "ArrowUp" || event.key === "ArrowDown") return true;
+    }
+
+    switch (event.key) {
+      case "ArrowUp":
+        moveCursor(device, 1);
+        return true;
+      case "ArrowDown":
+        moveCursor(device, -1);
+        return true;
+      case "ArrowRight":
+        switchRack(device, 1);
+        return true;
+      case "ArrowLeft":
+        switchRack(device, -1);
+        return true;
+      case "Tab":
+        switchRack(device, event.shiftKey ? -1 : 1);
+        return true;
+      case "Enter":
+      case " ":
+        place(device);
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  return { handleKeyDown };
+}

--- a/src/lib/utils/placement-keyboard.ts
+++ b/src/lib/utils/placement-keyboard.ts
@@ -1,0 +1,159 @@
+/**
+ * Pure helpers for keyboard-driven device placement (#106).
+ *
+ * The keyboard flow arms a device (placement mode), then moves a U-slot cursor
+ * within the focused rack with Up/Down and switches racks with Tab / Left-Right.
+ * These helpers compute the valid cursor positions and the next cursor when a
+ * key is pressed, plus the screen-reader copy. They take plain data (no stores,
+ * no DOM) so the navigation maths is unit-testable.
+ *
+ * "Valid start positions" are the whole-U slots (1-indexed, human units) where
+ * the device's bottom can mount without colliding or going out of bounds. The
+ * cursor only ever lands on a valid slot, mirroring how the drag preview snaps
+ * to a placeable position rather than letting the user hover an occupied slot.
+ */
+
+import type { Rack, DeviceType, DeviceFace } from "$lib/types";
+import { getDropFeedback } from "./dragdrop";
+
+/**
+ * Whole-U start positions (1-indexed, human units, ascending) where `device`
+ * can be placed on `face` in `rack`. Uses the same `getDropFeedback` check the
+ * tap-to-place valid-slot highlight uses, so the keyboard cursor and the
+ * highlight always agree.
+ */
+export function validStartPositions(
+  rack: Rack,
+  deviceLibrary: DeviceType[],
+  device: DeviceType,
+  face: DeviceFace = "front",
+): number[] {
+  const positions: number[] = [];
+  const deviceHeight = device.u_height;
+  const lastStart = rack.height - deviceHeight + 1;
+  for (let startU = 1; startU <= lastStart; startU++) {
+    if (
+      getDropFeedback(
+        rack,
+        deviceLibrary,
+        deviceHeight,
+        startU,
+        undefined,
+        face,
+      ) === "valid"
+    ) {
+      positions.push(startU);
+    }
+  }
+  return positions;
+}
+
+/**
+ * Pick the cursor's starting slot when the cursor first enters a rack.
+ * Prefers the valid slot at or nearest below `preferred` (so switching racks
+ * keeps the cursor near the same height), else the lowest valid slot. Returns
+ * null when the rack has no room for the device.
+ */
+export function initialCursorPosition(
+  validPositions: number[],
+  preferred?: number | null,
+): number | null {
+  if (validPositions.length === 0) return null;
+  if (preferred == null) return validPositions[0] ?? null;
+  // Nearest valid slot to `preferred` (ties pick the lower slot).
+  let best = validPositions[0] ?? null;
+  let bestDistance = Infinity;
+  for (const p of validPositions) {
+    const distance = Math.abs(p - preferred);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = p;
+    }
+  }
+  return best;
+}
+
+/**
+ * Move the cursor one valid slot in `direction` (+1 = up the rack toward higher
+ * U, -1 = down). Stays put at the ends rather than wrapping, so a screen-reader
+ * user is not silently teleported across the rack. Returns the current position
+ * unchanged when it is already at the relevant end, or null when there are no
+ * valid slots.
+ */
+export function nextCursorPosition(
+  validPositions: number[],
+  current: number | null,
+  direction: 1 | -1,
+): number | null {
+  if (validPositions.length === 0) return null;
+  if (current == null) return validPositions[0] ?? null;
+  const index = validPositions.indexOf(current);
+  if (index === -1) {
+    // Cursor drifted off a now-invalid slot (e.g. layout changed): snap to the
+    // nearest valid slot instead of moving from a stale index.
+    return initialCursorPosition(validPositions, current);
+  }
+  const nextIndex = index + direction;
+  if (nextIndex < 0 || nextIndex >= validPositions.length) return current;
+  return validPositions[nextIndex] ?? current;
+}
+
+/**
+ * Combined pick-up announcement: names the mode, the instructions, and the
+ * initial slot in one assertive utterance. A separate instructions-then-position
+ * pair would be collapsed by the live region (the second overwrites the first in
+ * the same tick), so the seeded position is folded in here.
+ */
+export function pickUpAnnouncement(
+  device: DeviceType,
+  rackName: string,
+  position: number,
+): string {
+  const name = device.model ?? device.slug;
+  return `Placing ${name} at U${position} of ${rackName}. Use up and down arrows to choose a slot, Tab to switch racks, Enter to place, Escape to cancel.`;
+}
+
+/** Instructions announced when the armed rack has no room for the device. */
+export function pickUpNoSpaceAnnouncement(
+  device: DeviceType,
+  rackName: string,
+): string {
+  const name = device.model ?? device.slug;
+  return `Placing ${name}. No space in ${rackName}. Tab to switch racks, Escape to cancel.`;
+}
+
+/**
+ * Position copy announced as the cursor moves (e.g. "U12 of Rack 1, available").
+ * When `atEdge` is set the cursor could not move further in the chosen
+ * direction, so a "no further slots" cue is appended; this also changes the
+ * string so an assertive live region re-reads it instead of staying silent on
+ * an identical repeat.
+ */
+export function positionAnnouncement(
+  rackName: string,
+  position: number,
+  atEdge = false,
+): string {
+  const base = `U${position} of ${rackName}, available`;
+  return atEdge ? `${base}, no further slots this way` : base;
+}
+
+/** Copy announced when a rack has no room for the armed device. */
+export function noSpaceAnnouncement(rackName: string): string {
+  return `No space for this device in ${rackName}`;
+}
+
+/** Copy announced when the user tries to switch racks but there is only one. */
+export function singleRackAnnouncement(): string {
+  return "Only one rack";
+}
+
+/** Outcome copy announced after a successful keyboard placement. */
+export function placedAnnouncement(
+  device: DeviceType,
+  rackName: string,
+  position: number,
+): string {
+  const name = device.model ?? device.slug;
+  return `Placed ${name} at U${position} of ${rackName}`;
+}

--- a/src/lib/utils/placement-keyboard.ts
+++ b/src/lib/utils/placement-keyboard.ts
@@ -148,6 +148,12 @@ export function singleRackAnnouncement(): string {
   return "Only one rack";
 }
 
+/** Copy announced when a device is armed but the layout has no racks. */
+export function noRacksAnnouncement(device: DeviceType): string {
+  const name = device.model ?? device.slug;
+  return `Placing ${name}. Add a rack first.`;
+}
+
 /** Outcome copy announced after a successful keyboard placement. */
 export function placedAnnouncement(
   device: DeviceType,

--- a/src/tests/placement-keyboard.test.ts
+++ b/src/tests/placement-keyboard.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the keyboard-placement cursor maths (#106).
+ * These cover the navigation edge cases: collision-aware valid slots,
+ * clamping at the rack ends, preferred-slot snapping when switching racks,
+ * and recovery when the cursor drifts off a now-invalid slot.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  validStartPositions,
+  initialCursorPosition,
+  nextCursorPosition,
+} from "$lib/utils/placement-keyboard";
+import {
+  createTestRack,
+  createTestDeviceType,
+  createTestDevice,
+} from "./factories";
+
+const oneU = createTestDeviceType({ slug: "switch", u_height: 1 });
+const twoU = createTestDeviceType({ slug: "server", u_height: 2 });
+
+describe("validStartPositions", () => {
+  it("lists every whole-U slot in an empty rack for a 1U device", () => {
+    const rack = createTestRack({ height: 5, devices: [] });
+    expect(validStartPositions(rack, [oneU], oneU, "front")).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+  });
+
+  it("excludes slots where a taller device would overrun the top", () => {
+    const rack = createTestRack({ height: 5, devices: [] });
+    // A 2U device can start at U1..U4 but not U5 (would need U5 and U6).
+    expect(validStartPositions(rack, [twoU], twoU, "front")).toEqual([
+      1, 2, 3, 4,
+    ]);
+  });
+
+  it("omits slots occupied by an existing device on the same face", () => {
+    const rack = createTestRack({
+      height: 5,
+      devices: [
+        createTestDevice({ device_type: "server", position: 2, face: "front" }),
+      ],
+    });
+    // The 2U server sits at U2-U3, so a 1U device cannot start at U2 or U3.
+    expect(validStartPositions(rack, [twoU, oneU], oneU, "front")).toEqual([
+      1, 4, 5,
+    ]);
+  });
+
+  it("treats the opposite face as free (face-aware collisions)", () => {
+    const rack = createTestRack({
+      height: 5,
+      devices: [
+        createTestDevice({ device_type: "server", position: 2, face: "rear" }),
+      ],
+    });
+    // The rear-mounted server does not block the front face.
+    expect(validStartPositions(rack, [twoU, oneU], oneU, "front")).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+  });
+
+  it("returns an empty list when the device cannot fit at all", () => {
+    const rack = createTestRack({ height: 1, devices: [] });
+    expect(validStartPositions(rack, [twoU], twoU, "front")).toEqual([]);
+  });
+});
+
+describe("initialCursorPosition", () => {
+  it("returns the lowest valid slot with no preference", () => {
+    expect(initialCursorPosition([2, 4, 6])).toBe(2);
+  });
+
+  it("snaps to the nearest valid slot to the preferred position", () => {
+    expect(initialCursorPosition([1, 4, 8], 5)).toBe(4);
+  });
+
+  it("picks the lower slot when two are equidistant from the preference", () => {
+    expect(initialCursorPosition([2, 4], 3)).toBe(2);
+  });
+
+  it("returns null when there are no valid slots", () => {
+    expect(initialCursorPosition([], 3)).toBeNull();
+  });
+});
+
+describe("nextCursorPosition", () => {
+  const valid = [1, 3, 5, 7];
+
+  it("moves up to the next valid slot", () => {
+    expect(nextCursorPosition(valid, 3, 1)).toBe(5);
+  });
+
+  it("moves down to the previous valid slot", () => {
+    expect(nextCursorPosition(valid, 5, -1)).toBe(3);
+  });
+
+  it("stays at the top slot rather than wrapping", () => {
+    expect(nextCursorPosition(valid, 7, 1)).toBe(7);
+  });
+
+  it("stays at the bottom slot rather than wrapping", () => {
+    expect(nextCursorPosition(valid, 1, -1)).toBe(1);
+  });
+
+  it("enters at the lowest slot when no cursor is set yet", () => {
+    expect(nextCursorPosition(valid, null, 1)).toBe(1);
+  });
+
+  it("snaps to the nearest valid slot when the cursor drifted off one", () => {
+    // 4 is not in the valid list (e.g. a device was placed there): snap, not
+    // index-from-stale.
+    expect(nextCursorPosition(valid, 4, 1)).toBe(3);
+  });
+
+  it("returns null when there are no valid slots", () => {
+    expect(nextCursorPosition([], 3, 1)).toBeNull();
+  });
+});

--- a/src/tests/placement-store.test.ts
+++ b/src/tests/placement-store.test.ts
@@ -183,16 +183,53 @@ describe("placement store", () => {
     });
   });
 
+  describe("setCursor() (keyboard placement)", () => {
+    it("records the target rack and slot for the keyboard cursor", () => {
+      const store = getPlacementStore();
+      store.startPlacement(mockDevice);
+      store.setCursor("rack-1", 5);
+      expect(store.targetRackId).toBe("rack-1");
+      expect(store.cursorPosition).toBe(5);
+    });
+
+    it("rounds a fractional slot to a whole U (rail invariant)", () => {
+      const store = getPlacementStore();
+      store.startPlacement(mockDevice);
+      store.setCursor("rack-1", 4.6);
+      expect(store.cursorPosition).toBe(5);
+    });
+
+    it("targets a rack with no slot when position is null (full rack)", () => {
+      const store = getPlacementStore();
+      store.startPlacement(mockDevice);
+      store.setCursor("rack-2", null);
+      expect(store.targetRackId).toBe("rack-2");
+      expect(store.cursorPosition).toBeNull();
+    });
+
+    it("clears the cursor on startPlacement so a new pick-up starts fresh", () => {
+      const store = getPlacementStore();
+      store.startPlacement(mockDevice);
+      store.setCursor("rack-1", 5);
+      store.startPlacement(mockDevice);
+      expect(store.targetRackId).toBeNull();
+      expect(store.cursorPosition).toBeNull();
+    });
+  });
+
   describe("resetPlacementStore()", () => {
     it("resets all state to defaults", () => {
       const store = getPlacementStore();
       store.startPlacement(mockDevice, "rear");
+      store.setCursor("rack-1", 5);
 
       resetPlacementStore();
 
       expect(store.isPlacing).toBe(false);
       expect(store.pendingDevice).toBeNull();
       expect(store.targetFace).toBe("front");
+      expect(store.targetRackId).toBeNull();
+      expect(store.cursorPosition).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## **User description**
Closes #106

## What

Keyboard-only users can now place devices without drag-and-drop.

- Enter on a focused palette device picks it up (placement mode).
- Up/Down move a U-slot cursor within the focused rack.
- Tab (or Left/Right) switches between racks.
- Enter or Space places the device.
- Escape cancels with no side effects.
- A placement preview rectangle shows the target slot, reusing the existing drag/tap drop-zone visuals.
- An assertive aria-live region announces the mode, the controls, each position change, and the outcome.

## How

Placement runs through the same recorded `placeDeviceSmart` path as drag-and-drop and tap-to-place, so undo/redo works and there is no parallel placement path. The cursor state (`targetRackId`, `cursorPosition`) lives on the existing placement store, alongside the existing tap-to-place state, and is read by the rack preview and the SR announcer.

Cursor navigation maths and the announcement copy are pure, unit-tested helpers (`placement-keyboard.ts`); a controller (`placement-keyboard-controller.ts`) wires them over the placement and layout stores and is driven from the global `KeyboardHandler`. The placement handler runs before the action registry so it can own arrow/Tab/Enter/Escape while a device is armed, and yields all keys when not placing.

The rack valid-slot highlight and the keyboard cursor now share one valid-start scan, so they cannot drift.

## Tests

- `e2e/keyboard-placement.spec.ts`: full keyboard flow (pick up, move, place), Space-to-place, Escape-cancels-no-side-effects, Tab-switches-rack, and undo-after-place.
- `src/tests/placement-keyboard.test.ts`: cursor maths edge cases (collision-aware valid slots, end-of-rack clamping, nearest-slot snapping, drift recovery).
- Existing keyboard, mobile tap-to-place, command-palette, and multi-rack e2e suites pass unchanged.
- `npm run lint`, `npm run test:run` (2874 unit tests), `npm run build`, and `npm run test:e2e:a11y` (axe, no new WCAG violations) all green.

## Notes for review

- The desktop sidebar palette previously had no `ondeviceselect` handler; this PR wires it to arm keyboard placement. Mobile tap-to-place and the command-palette "Add device" path are unchanged (they still arm via `startPlacement`; the keyboard cursor lazily primes on the first nav key for the command-palette path).
- `DevicePaletteItem` now stops propagation of Enter/Space so the same keystroke does not both arm and place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rqNWAVCioj5VVNzWtGJ5b


___

## **CodeAnt-AI Description**
**Add keyboard-based device placement and matching screen-reader feedback**

### What Changed
- Keyboard users can now pick a device from the palette, move a placement cursor with the arrow keys, switch racks with Tab, and place or cancel with Enter, Space, or Escape
- The placement preview now follows the keyboard cursor, using the same slot highlight as drag-and-drop so the on-screen target matches the final placement
- Screen readers now announce pickup, current position, successful placement, and cancellation during the keyboard flow
- Undo still works after keyboard placement, and the rack no longer reacts to Enter or Space while a device is armed
- Added unit and end-to-end coverage for cursor movement, rack switching, cancellation, placement, and undo

### Impact
`✅ Keyboard-only device placement`
`✅ Clearer placement feedback for screen-reader users`
`✅ Fewer accidental rack selections during placement`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
