### PR TITLE
fix: add breathing room between search pill and layout tab bar

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -215,12 +215,15 @@
     padding-left: max(var(--space-2), env(safe-area-inset-left, 0px));
   }
 
-  /* Centre lane: fills the canvas gap between left and right fixed lanes. */
+  /* Centre lane: fills the canvas gap between left and right fixed lanes. The
+     left margin keeps the first tab clear of the search pill so the two do not
+     crowd at the lane boundary; it pairs with the pill's own margin-right. */
   .toolbar-tabs {
     flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
     justify-content: flex-start;
+    margin-left: var(--space-3);
   }
 
   /* Right lane: fixed to side-panel width so it aligns with the panel column.


### PR DESCRIPTION
## **User description**
## Summary

The command-pill search box in the toolbar's left lane and the first layout tab in the centre lane crowded each other at the lane boundary (reported after #2568). This adds `margin-left: var(--space-3)` (12px) to the `.toolbar-tabs` lane, pairing with the pill's existing `margin-right` for a clear, intentional gap.

## Changes

- `src/lib/components/Toolbar.svelte`: add `margin-left` to `.toolbar-tabs` plus an explanatory comment.

## Testing

- Prettier passes.
- Visual change only (CSS spacing); no logic affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012t6LFjizbKjdY1dWxkxRtR


___

## **CodeAnt-AI Description**
**Add spacing between the toolbar search pill and the first layout tab**

### What Changed
- Added a small gap before the tab bar so the search pill and first layout tab no longer touch at the lane boundary
- The toolbar keeps the same layout, but the center section now has clearer separation between controls

### Impact
`✅ Less crowded toolbar`
`✅ Clearer separation between search and tabs`
`✅ Fewer layout collisions at the toolbar boundary`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
