### PR TITLE
test: exercise loadLayout store pass in upgrade corpus (#2450)

### DIFF
--- a/src/tests/fixtures/upgrade-corpus/README.md
+++ b/src/tests/fixtures/upgrade-corpus/README.md
@@ -4,6 +4,8 @@ Each entry is a pair: a `.rackula.yaml` layout exactly as some past version wrot
 
 `src/tests/upgrade-corpus.test.ts` runs every YAML fixture through the real `parseLayoutYaml` and fails if any leaf value disappears that is not declared in the sidecar allow-list. Browser-mode localStorage cases live in `src/tests/browser-upgrade.test.ts`.
 
+The real UI ingress does not stop at `parseLayoutYaml`: it continues into `layoutStore.loadLayout` (`src/lib/stores/layout/layout-lifecycle.ts`), a second pass that re-runs `adaptLegacyLayout` and applies per-rack ID regeneration/dedup plus defensive position defaulting. `src/tests/upgrade-corpus-loadlayout.test.ts` drives a representative fixture one layer deeper, through that store pass, and asserts the same no-silent-loss property so an ID-remap or position-defaulting regression that drops a value is caught (#2450).
+
 ## Sidecar format
 
 ```json

--- a/src/tests/upgrade-corpus-loadlayout.test.ts
+++ b/src/tests/upgrade-corpus-loadlayout.test.ts
@@ -22,9 +22,7 @@ import { findSilentLosses } from "./upgrade-corpus-helpers";
 // slug, and colour must survive the store pass verbatim. This is the same
 // fixture the YAML corpus exercises; here we drive it one layer deeper.
 const representativeYaml = (
-  await import(
-    "./fixtures/upgrade-corpus/v26.5.0-representative.rackula.yaml?raw"
-  )
+  await import("./fixtures/upgrade-corpus/v26.5.0-representative.rackula.yaml?raw")
 ).default as string;
 
 describe("upgrade corpus: store ingress via loadLayout", () => {

--- a/src/tests/upgrade-corpus-loadlayout.test.ts
+++ b/src/tests/upgrade-corpus-loadlayout.test.ts
@@ -1,0 +1,69 @@
+// src/tests/upgrade-corpus-loadlayout.test.ts
+// The YAML corpus (upgrade-corpus.test.ts) stops at parseLayoutYaml. The real UI
+// ingress continues into layoutStore.loadLayout (layout-lifecycle.ts), which runs
+// a SECOND pass: a re-adaptLegacyLayout, per-rack ID regeneration/dedup, and
+// defensive position/view defaulting. ID remapping that drops a value is exactly
+// the silent change the harness exists to catch, and it lives one layer below
+// where the corpus stops (#2450).
+//
+// This file routes a corpus fixture through the real store ingress
+// (parseLayoutYaml -> getLayoutStore().loadLayout) and asserts the loadLayout pass
+// preserves every distinctive value. It compares the parsed Layout (loadLayout's
+// input) against the loaded store layout (loadLayout's output) using the same
+// value-based findSilentLosses detector the corpus uses, so it is robust to
+// legitimate restructuring and only fails when a value actually disappears.
+import { describe, it, expect, beforeEach } from "vitest";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { parseLayoutYaml } from "$lib/utils/yaml";
+import { findSilentLosses } from "./upgrade-corpus-helpers";
+
+// A representative fixture with distinct, stable ids (dev-switch, dev-server,
+// rack-a) so loadLayout's dedup/regeneration does NOT fire: every id, name,
+// slug, and colour must survive the store pass verbatim. This is the same
+// fixture the YAML corpus exercises; here we drive it one layer deeper.
+const representativeYaml = (
+  await import(
+    "./fixtures/upgrade-corpus/v26.5.0-representative.rackula.yaml?raw"
+  )
+).default as string;
+
+describe("upgrade corpus: store ingress via loadLayout", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+  });
+
+  it("loadLayout preserves every distinctive value from a parsed fixture", async () => {
+    // Step one: the YAML ingress the corpus already covers.
+    const parsed = await parseLayoutYaml(representativeYaml);
+
+    // Step two: the store pass the corpus does NOT cover. Compare loadLayout's
+    // input against its output: any distinctive value (id, name, slug, colour)
+    // that vanishes here is an uncaught silent loss in the second pass.
+    const store = getLayoutStore();
+    store.loadLayout(parsed);
+
+    const losses = findSilentLosses(parsed, store.layout, []);
+    expect(
+      losses,
+      `silent data loss in loadLayout pass:\n${JSON.stringify(losses, null, 2)}`,
+    ).toEqual([]);
+  });
+
+  it("loadLayout preserves device and rack counts from a parsed fixture", async () => {
+    const parsed = await parseLayoutYaml(representativeYaml);
+    const parsedDeviceCount = parsed.racks.reduce(
+      (sum, r) => sum + r.devices.length,
+      0,
+    );
+
+    const store = getLayoutStore();
+    store.loadLayout(parsed);
+
+    const loadedDeviceCount = store.layout.racks.reduce(
+      (sum, r) => sum + r.devices.length,
+      0,
+    );
+    expect(store.layout.racks.length).toBe(parsed.racks.length);
+    expect(loadedDeviceCount).toBe(parsedDeviceCount);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Closes #2450.

The upgrade corpus (PR #2448) drives fixtures through `parseLayoutYaml`, but the real UI ingress continues into `layoutStore.loadLayout` (`src/lib/stores/layout/layout-lifecycle.ts`), which runs a second pass: a re-`adaptLegacyLayout`, per-rack ID regeneration/dedup, and defensive position/view defaulting. The corpus did not exercise that second pass, so a future loadLayout ID-remap or position-defaulting regression that drops a value would slip through.

This takes acceptance option (a): route a representative fixture through the real store ingress and assert no silent loss in the loadLayout pass.

## What changed

- New `src/tests/upgrade-corpus-loadlayout.test.ts`: parses the `v26.5.0-representative` fixture via `parseLayoutYaml` (the ingress the corpus already covers), then drives the parsed `Layout` through `getLayoutStore().loadLayout()` (the second pass the corpus did not), and asserts:
  - every distinctive value survives, using the same value-based `findSilentLosses` detector the corpus uses (so it is robust to legitimate restructuring and only fails when a value actually disappears), and
  - device and rack counts are preserved.
- README note in `src/tests/fixtures/upgrade-corpus/README.md` pointing at the new store-pass test.

## Why this fixture

`v26.5.0-representative` has distinct, stable ids (`rack-a`, `dev-switch`, `dev-server`), so loadLayout's dedup/regeneration does not fire and `adaptLegacyLayout` is idempotent on the already-parsed layout. That makes the empty allow-list correct: nothing is legitimately dropped, so any loss is a real regression.

## Teeth verified

During TDD I temporarily injected an ID-drop regression into `loadLayout` and confirmed the test went red (it reported `dev-switch` and `dev-server` ids vanishing), then reverted. The production path (`layout-lifecycle.ts`) is unchanged by this PR.

## Gates

- `npm run lint` clean
- `npm run test:run` green (2885 tests)
- `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Add coverage for layout loading after YAML parsing**

### What Changed
- Added a test that sends a representative saved layout through the full layout loading path, not just YAML parsing
- Verifies that no device, rack, name, slug, or color values disappear during the load step
- Verifies that rack and device counts stay the same after loading
- Updated the upgrade corpus README to point to the new store-level coverage

### Impact
`✅ Fewer lost layout values after upgrade`
`✅ Safer layout loading from saved files`
`✅ Earlier detection of layout regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
