### PR TITLE
test: lock in RackList Space keydown behaviour + unblock test suite (#2570)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@playwright/test": "^1.61.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/svelte": "^5.4.1",
+        "@testing-library/svelte": "5.3.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/debug": "^4.1.13",
         "@types/js-yaml": "^4.0.9",
@@ -2175,14 +2175,14 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/svelte": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.4.1.tgz",
-      "integrity": "sha512-Ju8RZYx7AIAjv+Sc9KN/CbsWI/qjimz1hzGN4KGezw7vKivlDKjDwCXXpJxQrYu/xGx888dhApU+hPupQK6/PA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
+      "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@testing-library/dom": "9.x.x || 10.x.x",
-        "@testing-library/svelte-core": "1.1.2"
+        "@testing-library/svelte-core": "1.0.0"
       },
       "engines": {
         "node": ">= 10"
@@ -2202,9 +2202,9 @@
       }
     },
     "node_modules/@testing-library/svelte-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.1.2.tgz",
-      "integrity": "sha512-HiAsJfEiOtgqXLCAjKI5yZTbXqD0ByYBMhBxPLnw5wzMUZ050Ex3kvsxBgeXOboBUwgZWRDoRYanhp4j3z0AKQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
+      "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@playwright/test": "^1.61.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/svelte": "^5.4.1",
+    "@testing-library/svelte": "5.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/debug": "^4.1.13",
     "@types/js-yaml": "^4.0.9",

--- a/src/tests/RackList.delete-keydown.test.ts
+++ b/src/tests/RackList.delete-keydown.test.ts
@@ -9,11 +9,33 @@ import {
 import { resetHistoryStore } from "$lib/stores/history.svelte";
 import { resetToastStore } from "$lib/stores/toast.svelte";
 
-// Regression test for #2570: the rack row's keydown handler used to swallow
-// Space while the nested delete button was focused, suppressing the button's
-// native activation and selecting the row instead. The row handler now guards
-// on `e.target === e.currentTarget`, so a bubbled keydown from the delete
-// button no longer triggers row selection or preventDefault.
+// Regression test for #2570: each rack row is a focusable div whose onkeydown
+// preventDefaults Space and activates the row on Enter/Space. The row contains
+// a nested delete <button>. Because keydown bubbles, pressing Space while the
+// delete button was focused used to reach the row handler, which suppressed the
+// button's native activation and selected the row instead. Both row variants
+// are affected: grouped (handleGroupClick) and ungrouped (handleRackClick). The
+// handlers now guard on `e.target === e.currentTarget`, so a bubbled keydown
+// from the delete button no longer triggers row selection or preventDefault.
+
+// Both row variants render the same guarded handler, so cover both.
+const rowVariants = [
+  {
+    label: "ungrouped row (handleRackClick)",
+    setup: () => {
+      getLayoutStore().addRack("Edge", 42);
+    },
+    deleteButtonName: /Delete Edge/,
+  },
+  {
+    label: "grouped row (handleGroupClick)",
+    setup: () => {
+      getLayoutStore().addBayedRackGroup("Touring", 2, 42);
+    },
+    deleteButtonName: /Delete Touring/,
+  },
+];
+
 describe("RackList delete button keydown (#2570)", () => {
   beforeEach(() => {
     resetHistoryStore();
@@ -22,58 +44,66 @@ describe("RackList delete button keydown (#2570)", () => {
     resetToastStore();
   });
 
-  it("does not select the row when Space bubbles from the delete button", async () => {
-    const layout = getLayoutStore();
-    layout.addRack("Edge", 42);
+  for (const variant of rowVariants) {
+    describe(variant.label, () => {
+      it("does not select the row when Space bubbles from the delete button", async () => {
+        variant.setup();
+        const selection = getSelectionStore();
+        render(RackList);
 
-    const selection = getSelectionStore();
-    render(RackList);
+        const deleteButton = screen.getByRole("button", {
+          name: variant.deleteButtonName,
+        });
 
-    const deleteButton = screen.getByRole("button", { name: /Delete Edge/ });
+        // Space dispatched at the delete button bubbles to the row's keydown.
+        await fireEvent.keyDown(deleteButton, { key: " ", code: "Space" });
 
-    // Space dispatched at the delete button bubbles to the row's keydown.
-    await fireEvent.keyDown(deleteButton, { key: " ", code: "Space" });
+        // The row handler must ignore the bubbled event: no row selection.
+        expect(selection.isRackSelected).toBe(false);
+      });
 
-    // The row handler must ignore the bubbled event: no row selection.
-    expect(selection.isRackSelected).toBe(false);
-  });
+      it("does not preventDefault Space on the delete button, so native activation survives", () => {
+        variant.setup();
+        render(RackList);
 
-  it("does not preventDefault Space on the delete button, so native activation survives", async () => {
-    const layout = getLayoutStore();
-    layout.addRack("Edge", 42);
+        const deleteButton = screen.getByRole("button", {
+          name: variant.deleteButtonName,
+        });
 
-    render(RackList);
+        // The bug: the row handler called e.preventDefault() on the bubbled
+        // Space, which suppresses the button's native click activation. The
+        // guard must let the event through untouched so the browser still
+        // activates the button. happy-dom does not synthesize the native
+        // click from a keydown, so this asserts the precondition for native
+        // activation (the event reaches the button uncancelled); the click
+        // test below covers the resulting delete flow.
+        const spaceEvent = new KeyboardEvent("keydown", {
+          key: " ",
+          code: "Space",
+          bubbles: true,
+          cancelable: true,
+        });
+        deleteButton.dispatchEvent(spaceEvent);
 
-    const deleteButton = screen.getByRole("button", { name: /Delete Edge/ });
+        expect(spaceEvent.defaultPrevented).toBe(false);
+      });
 
-    // The bug: the row handler called e.preventDefault() on the bubbled Space,
-    // which suppresses the button's native click activation. The guard must let
-    // the event through untouched so the browser still activates the button.
-    const spaceEvent = new KeyboardEvent("keydown", {
-      key: " ",
-      code: "Space",
-      bubbles: true,
-      cancelable: true,
+      it("opens the delete confirmation when the delete button is activated", async () => {
+        variant.setup();
+        render(RackList);
+
+        const deleteButton = screen.getByRole("button", {
+          name: variant.deleteButtonName,
+        });
+
+        await fireEvent.click(deleteButton);
+
+        // The confirmation dialog's confirm button proves delete was initiated
+        // and the row handler did not intercept the action.
+        expect(
+          screen.getByRole("button", { name: /^Delete$/ }),
+        ).toBeInTheDocument();
+      });
     });
-    deleteButton.dispatchEvent(spaceEvent);
-
-    expect(spaceEvent.defaultPrevented).toBe(false);
-  });
-
-  it("opens the delete confirmation when the delete button is clicked", async () => {
-    const layout = getLayoutStore();
-    layout.addRack("Edge", 42);
-
-    render(RackList);
-
-    const deleteButton = screen.getByRole("button", { name: /Delete Edge/ });
-
-    await fireEvent.click(deleteButton);
-
-    // The confirmation dialog's confirm button proves delete was initiated and
-    // the row handler did not intercept the action.
-    expect(
-      screen.getByRole("button", { name: /^Delete$/ }),
-    ).toBeInTheDocument();
-  });
+  }
 });

--- a/src/tests/RackList.delete-keydown.test.ts
+++ b/src/tests/RackList.delete-keydown.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import RackList from "$lib/components/RackList.svelte";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getSelectionStore,
+  resetSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+
+// Regression test for #2570: the rack row's keydown handler used to swallow
+// Space while the nested delete button was focused, suppressing the button's
+// native activation and selecting the row instead. The row handler now guards
+// on `e.target === e.currentTarget`, so a bubbled keydown from the delete
+// button no longer triggers row selection or preventDefault.
+describe("RackList delete button keydown (#2570)", () => {
+  beforeEach(() => {
+    resetHistoryStore();
+    resetLayoutStore();
+    resetSelectionStore();
+    resetToastStore();
+  });
+
+  it("does not select the row when Space bubbles from the delete button", async () => {
+    const layout = getLayoutStore();
+    layout.addRack("Edge", 42);
+
+    const selection = getSelectionStore();
+    render(RackList);
+
+    const deleteButton = screen.getByRole("button", { name: /Delete Edge/ });
+
+    // Space dispatched at the delete button bubbles to the row's keydown.
+    await fireEvent.keyDown(deleteButton, { key: " ", code: "Space" });
+
+    // The row handler must ignore the bubbled event: no row selection.
+    expect(selection.isRackSelected).toBe(false);
+  });
+
+  it("does not preventDefault Space on the delete button, so native activation survives", async () => {
+    const layout = getLayoutStore();
+    layout.addRack("Edge", 42);
+
+    render(RackList);
+
+    const deleteButton = screen.getByRole("button", { name: /Delete Edge/ });
+
+    // The bug: the row handler called e.preventDefault() on the bubbled Space,
+    // which suppresses the button's native click activation. The guard must let
+    // the event through untouched so the browser still activates the button.
+    const spaceEvent = new KeyboardEvent("keydown", {
+      key: " ",
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    deleteButton.dispatchEvent(spaceEvent);
+
+    expect(spaceEvent.defaultPrevented).toBe(false);
+  });
+
+  it("opens the delete confirmation when the delete button is clicked", async () => {
+    const layout = getLayoutStore();
+    layout.addRack("Edge", 42);
+
+    render(RackList);
+
+    const deleteButton = screen.getByRole("button", { name: /Delete Edge/ });
+
+    await fireEvent.click(deleteButton);
+
+    // The confirmation dialog's confirm button proves delete was initiated and
+    // the row handler did not intercept the action.
+    expect(
+      screen.getByRole("button", { name: /^Delete$/ }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## **User description**
Closes #2570

## #2570: the fix already shipped, this adds the regression test

Issue #2570 asks for a row-keydown guard so that pressing Space while the nested delete button is focused activates delete instead of selecting the row. The proposed fix is `if (e.target !== e.currentTarget) return;` on each rack row's `onkeydown`.

That guard already exists on `main`. It landed via PR #2568 (commit `0abb521e`), which merged at `2026-06-22T10:32:41Z`, 19 minutes after this issue was filed (`2026-06-22T10:13:31Z`). PR #2568's render-delegation refactor re-wrapped both row handlers and added the exact guard to each (grouped `handleGroupClick` and ungrouped `handleRackClick` paths). So the production behaviour is already correct.

What was missing is a test locking it in. This adds `src/tests/RackList.delete-keydown.test.ts`:

- Space bubbling from the delete button does not select the row.
- The row handler does not `preventDefault` the bubbled Space, so the button's native activation survives.
- Clicking delete opens the confirmation dialog.

Red/green proof: with the guard reverted from both handlers, the two keydown tests fail (row gets selected; `defaultPrevented` is `true`); with it restored, all pass. No production code is changed by the test commit; `RackList.svelte` is byte-identical to `main`.

## Also: pin @testing-library/svelte to unblock CI

While validating, the `validate` (Test) job failed on this branch with every one of the 174 test files failing to compile:

```
CompileError: node_modules/@testing-library/svelte-core/src/wrapper-scaffold.svelte:2:2
Cannot use `export let` in runes mode - use `$props()` instead
```

Root cause: the dev-dependency bump in #2578 raised `@testing-library/svelte` to 5.4.1 on `main`, which pulls in `@testing-library/svelte-core@1.1.2`. That version's `wrapper-scaffold.svelte` uses legacy `export let`, invalid in Svelte runes mode. This is a repo-wide break: the same failure shows on the corpus-coverage branch and several dependabot branches, all branched from the affected `main`.

The second commit pins `@testing-library/svelte` to `5.3.1` (svelte-core 1.0.0, which ships no runes-incompatible scaffold), exact pin so Dependabot does not immediately re-bump into the broken release. This restores `npm ci` + `npm run test:run` to green.

## Gates (local, against a clean `npm ci`-equivalent install at the pinned version)

- `npm run lint`: clean.
- `npm run format:check`: clean.
- `npm run test:run`: 174 files, 2886 tests pass.
- `npm run build`: succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Keep RackList delete-button key presses working and restore the test suite**

### What Changed
- Added a regression test to ensure pressing Space on a rack row’s delete button does not select the row and still allows the delete action to run
- Covered both rack row layouts so the delete-button behavior stays consistent in each case
- Pinned the Svelte testing library to a working version so the test suite compiles and runs again

### Impact
`✅ Fewer accidental row selections`
`✅ Reliable delete-button keyboard behavior`
`✅ Test suite runs without compile failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
