### PR TITLE
feat(api): validate layouts against schema before persisting (#2449)

### DIFF
--- a/api/src/routes/layouts.test.ts
+++ b/api/src/routes/layouts.test.ts
@@ -8,6 +8,13 @@
  * - Invalid YAML (rejected 400, not silently skipped)
  * - Body without metadata (accepted, no guard applies)
  * - Save target derives from URL uuid, not metadata.id
+ *
+ * PUT /layouts/:uuid schema validation tests (#2449)
+ *
+ * Covers defense-in-depth schema validation before persisting:
+ * - A device missing its required structural fields is rejected 400
+ *   (the prior minimal schema accepted any object as a device)
+ * - A structurally valid prior-release layout still saves unchanged
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm, readdir } from "node:fs/promises";
@@ -142,5 +149,54 @@ describe("PUT /layouts/:uuid save target derives from URL uuid", () => {
       e.toLowerCase().includes(OTHER_UUID.toLowerCase()),
     );
     expect(otherFolder).toBeUndefined();
+  });
+});
+
+describe("PUT /layouts/:uuid schema validation (#2449)", () => {
+  it("rejects a layout whose device is missing required fields", async () => {
+    // The device object has no id/device_type/position/face. The prior minimal
+    // schema typed devices as z.unknown() and accepted this, persisting a body
+    // that only fails later in the frontend load.
+    const body = [
+      'version: "1.0.0"',
+      "name: Garbage Device",
+      "racks:",
+      "  - devices:",
+      "      - notadevice: true",
+    ].join("\n");
+
+    const res = await putLayout(URL_UUID, body);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Invalid layout");
+
+    // The malformed body must not have been written to disk.
+    const entries = await readdir(testDir);
+    expect(
+      entries.find((e) => e.toLowerCase().includes(URL_UUID.toLowerCase())),
+    ).toBeUndefined();
+  });
+
+  it("accepts a structurally valid prior-release layout", async () => {
+    // Shape mirrors src/tests/fixtures/upgrade-corpus: a device carries
+    // id/device_type/position/face plus a legacy passthrough field. Valid
+    // layouts must continue to save unchanged.
+    const body = [
+      'version: "1.0"',
+      "name: Representative Lab",
+      "racks:",
+      '  - id: "rack-a"',
+      "    devices:",
+      '      - id: "dev-switch"',
+      '        device_type: "switch-1u"',
+      "        position: 240",
+      '        face: "front"',
+      '        slot_position: "left"',
+    ].join("\n");
+
+    const res = await putLayout(URL_UUID, body);
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.id).toBe(URL_UUID);
   });
 });

--- a/api/src/schemas/layout.ts
+++ b/api/src/schemas/layout.ts
@@ -124,8 +124,30 @@ export const LayoutYamlMetadataSchema = z
   })
   .passthrough();
 
-// Minimal schema for extracting layout info (we don't need full validation here)
-// The full schema validation happens in the SPA
+/**
+ * Structural shape of a placed device, validated server-side before persisting
+ * (#2449). This is the minimal-but-meaningful subset that every valid device
+ * across shipped releases carries; the full device validation (positions,
+ * containers, port instances) happens in the SPA against the richer
+ * src/lib/schemas LayoutSchema.
+ *
+ * `.passthrough()` keeps unknown and legacy fields (e.g. slot_position) so a
+ * prior-release layout still validates and saves unchanged. The point of this
+ * gate is defense-in-depth: reject a body where a device is clearly not a
+ * device (missing its identifying fields), not to re-enforce the SPA's rules.
+ */
+export const PlacedDeviceFileSchema = z
+  .object({
+    id: z.string().min(1, "Device id is required"),
+    device_type: z.string().min(1, "Device device_type is required"),
+    position: z.number(),
+    face: z.string().min(1, "Device face is required"),
+  })
+  .passthrough();
+
+// Minimal schema for extracting layout info and rejecting clearly malformed
+// bodies before they are persisted (#2449). The full schema validation happens
+// in the SPA against the richer src/lib/schemas LayoutSchema.
 export const LayoutFileSchema = z.object({
   version: z.string(),
   name: z.string().min(1, "Layout name is required"),
@@ -133,9 +155,11 @@ export const LayoutFileSchema = z.object({
   metadata: LayoutYamlMetadataSchema.optional(),
   racks: z
     .array(
-      z.object({
-        devices: z.array(z.unknown()).optional().default([]),
-      }),
+      z
+        .object({
+          devices: z.array(PlacedDeviceFileSchema).optional().default([]),
+        })
+        .passthrough(),
     )
     .optional()
     .default([]),

--- a/api/src/storage/filesystem.test.ts
+++ b/api/src/storage/filesystem.test.ts
@@ -56,7 +56,9 @@ interface LayoutYamlOptions {
 }
 
 /**
- * Create valid layout YAML for testing
+ * Create valid layout YAML for testing. Devices carry the structural fields
+ * every real saved device has (id/device_type/position/face), so fixtures match
+ * what the persistence layer now validates before writing (#2449).
  */
 function createLayoutYaml(options: LayoutYamlOptions): string {
   const { name, racks = [] } = options;
@@ -70,7 +72,10 @@ function createLayoutYaml(options: LayoutYamlOptions): string {
               return "  - devices: []";
             }
             const devicesYaml = rack.devices
-              .map((d) => `      - id: ${d.id}`)
+              .map(
+                (d) =>
+                  `      - id: ${d.id}\n        device_type: server-1u\n        position: 1\n        face: front`,
+              )
               .join("\n");
             return `  - devices:\n${devicesYaml}`;
           })
@@ -274,6 +279,22 @@ describe("saveLayout and getLayout", () => {
       "utf-8",
     );
     expect(restoredAsset).toBe("asset-data");
+  });
+
+  it("rejects a schema-invalid legacy migration with the route-mapped prefix", async () => {
+    // A legacy flat file whose body fails the schema must reject before being
+    // migrated, and use the same "Invalid layout metadata:" prefix the route
+    // maps to 400 (rather than the old "Invalid layout:" prefix that fell
+    // through to a 500). #2449.
+    const slug = "broken-legacy";
+    const brokenYaml =
+      'version: "1.0.0"\nname: Broken\nracks:\n  - devices:\n      - notadevice: true';
+    // A legacy flat file must exist so saveLayout takes the migration path.
+    await writeFile(join(testDir, `${slug}.yaml`), brokenYaml);
+
+    await expect(saveLayout(brokenYaml, slug)).rejects.toThrow(
+      /^Invalid layout metadata:/,
+    );
   });
 });
 

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -641,7 +641,8 @@ async function migrateLegacyLayout(
     const issues = layout.error.issues
       .map((i) => `${i.path.join(".")}: ${i.message}`)
       .join("; ");
-    throw new Error(`Invalid layout: ${issues}`);
+    // Same prefix as the non-migration save path so the route maps both to 400.
+    throw new Error(`Invalid layout metadata: ${issues}`);
   }
 
   // Generate UUID (use metadata.id if valid, else generate new)


### PR DESCRIPTION
## **User description**
Closes #2449

## What

The persistence API saved layout YAML after a YAML syntax check and a minimal metadata check only. Its `LayoutFileSchema` typed each rack's `devices` as `z.array(z.unknown())`, so a body whose device is clearly not a device (missing `id`/`device_type`/`position`/`face`) was accepted and written to the `/data` volume, only failing later in the frontend load.

This tightens the API schema so a placed device must carry its identifying structural fields before the layout is persisted:

```ts
export const PlacedDeviceFileSchema = z
  .object({
    id: z.string().min(1),
    device_type: z.string().min(1),
    position: z.number(),
    face: z.string().min(1),
  })
  .passthrough();
```

`PUT /layouts/:uuid` now rejects such a body with a 400 and a field-scoped message (`Invalid layout metadata: racks.0.devices.0.id: Device id is required`), via the existing route catch. Valid layouts continue to save unchanged.

This is the defense-in-depth fast-follow deferred from the upgrade-safety harness (Component 5, out of scope in PR #2448). It is not the silent-loss fix.

## Backward compatibility

`.passthrough()` on the device and the rack keeps unknown and legacy fields (e.g. `slot_position`, `ports`, `container_id`), so prior-release layouts still validate and save unchanged. Verified against every fixture in `src/tests/fixtures/upgrade-corpus/`: each real device across shipped releases carries the four required fields, and `position` is always a number. The constraint is strictly looser than the frontend's own `PlacedDeviceSchema`, so no data the SPA accepts is rejected here.

## Also fixed

The legacy-migration path threw `Invalid layout:` (a prefix the route did not map), so a schema-invalid legacy-migration body returned 500 instead of 400. It now throws the same `Invalid layout metadata:` prefix the route maps to 400, so every schema-invalid PUT body returns a consistent 4xx.

## Tests

- `PUT /layouts/:uuid` rejects a device missing required fields (400, nothing written to disk)
- `PUT /layouts/:uuid` accepts a structurally valid prior-release layout (with a legacy passthrough field)
- `saveLayout` rejects a schema-invalid legacy migration with the route-mapped `Invalid layout metadata:` prefix
- The `createLayoutYaml` test helper now emits realistic devices so fixtures match what the persistence layer validates

All 336 api tests pass (`bun test`), api typecheck clean, root lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Reject malformed layouts before they are saved**

### What Changed
- Layout uploads now fail fast when a device is missing required fields, instead of saving a broken layout that only fails later when opened.
- Legacy migration now returns the same 400-style error for invalid layout data, instead of surfacing as a server error.
- Valid older layouts still save unchanged, including legacy fields that are not part of the new check.
- Added coverage for rejecting malformed layouts and for accepting a valid prior-release layout.

### Impact
`✅ Fewer broken layouts saved`
`✅ Clearer layout upload errors`
`✅ Fewer server errors during legacy imports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
