### PR TITLE
fix: decouple top-bar spacing from side-panel collapse state (#2583)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -578,8 +578,6 @@
     <Toolbar
       hasRacks={layoutStore.hasRack}
       {partyMode}
-      sidebarCollapsed={uiStore.sidebarCollapsed}
-      sidePanelCollapsed={uiStore.sidePanelCollapsed}
       onsave={maybeSave}
       onsaveas={maybeSaveAs}
       onload={handleLoad}

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -15,6 +15,9 @@
   View and history controls (zoom, fit, display mode, undo, redo) relocate to the
   canvas bottom-left in #2074 / #2458. File and settings commands live in the app
   menu behind the logo.
+  The lane widths are held at the expanded column widths in both states, so
+  collapsing a side panel never moves or resizes the search field or the tab
+  strip (#2583).
 -->
 <script lang="ts">
   import AppMenu from "./AppMenu.svelte";
@@ -33,10 +36,6 @@
   interface Props {
     hasRacks?: boolean;
     partyMode?: boolean;
-    /** Left sidebar collapsed: shrink the left lane to align with the strip. */
-    sidebarCollapsed?: boolean;
-    /** Right panel collapsed: shrink the right lane to align with the strip. */
-    sidePanelCollapsed?: boolean;
     onsave?: () => void;
     onsaveas?: () => void;
     onload?: () => void;
@@ -56,8 +55,6 @@
   let {
     hasRacks = false,
     partyMode = false,
-    sidebarCollapsed = false,
-    sidePanelCollapsed = false,
     onsave,
     onsaveas,
     onload,
@@ -108,11 +105,10 @@
 
 <header class="toolbar">
   <!-- Left: Logo (also the app menu) + command palette pill.
-       Width = --sidebar-width so it aligns with the column below; shrinks to
-       natural width when the sidebar is collapsed to its 44px strip (#2397). -->
+       Width = --sidebar-width so it aligns with the column below; held constant
+       across sidebar collapse so the pill never moves or resizes (#2583). -->
   <div
     class="toolbar-section toolbar-left"
-    class:toolbar-left--collapsed={sidebarCollapsed}
     class:toolbar-left--mobile={viewportStore.isMobile}
   >
     <AppMenu onaction={handleAppMenuAction} {hasRacks} {partyMode} />
@@ -157,12 +153,11 @@
        mobile the chip is the right zone (#2458): it replaces the old quick file
        actions, whose Save / Load / Export now live in the registry-driven app
        menu behind the logo. The Settings gear moved into the app menu (#2398)
-       and the side-panel collapse/expand chevron lives in the panel (#2397). -->
+       and the side-panel collapse/expand chevron lives in the panel (#2397).
+       Width = --side-panel-width, held constant across panel collapse so the
+       tab strip never moves (#2583). -->
   {#if !viewportStore.isMobile}
-    <div
-      class="toolbar-section toolbar-right"
-      class:toolbar-right--collapsed={sidePanelCollapsed}
-    >
+    <div class="toolbar-section toolbar-right">
       <StorageStatusChip />
     </div>
   {:else}
@@ -192,19 +187,15 @@
     height: 100%;
   }
 
-  /* Left lane: fixed to the sidebar column width so it aligns with the column
-     below. Left padding gives the logo ~8px from the edge. When the sidebar is
-     collapsed to its 44px strip, the lane shrinks to its natural width so it
-     does not overhang the strip (#2397). */
+  /* Left lane: fixed to the sidebar column width. Left padding gives the logo
+     ~8px from the edge. The width is held at the expanded column width in both
+     states so the search pill and the centre tab strip keep a constant size and
+     position regardless of whether the sidebar is collapsed (#2583). */
   .toolbar-left {
     flex: 0 0 var(--sidebar-width, 320px);
     padding-left: var(--space-2);
     padding-right: var(--space-2);
     min-width: 0;
-  }
-
-  .toolbar-left--collapsed {
-    flex: 0 0 auto;
   }
 
   /* Mobile left lane: there is no column to align with, so the lane shrinks to
@@ -226,11 +217,11 @@
     margin-left: var(--space-3);
   }
 
-  /* Right lane: fixed to side-panel width so it aligns with the panel column.
-     The storage chip is now the sole occupant and fills the lane as the status
-     zone for the panel beneath it (#2398). Shrinks to its natural width (pinned
-     to the right edge) when the panel is collapsed to its 44px strip, so the
-     chip never overhangs it (#2397). */
+  /* Right lane: fixed to side-panel width. The storage chip is the sole
+     occupant and fills the lane as the status zone (#2398). The width is held
+     at the expanded column width in both states so the centre tab strip keeps a
+     constant size and position regardless of whether the panel is collapsed
+     (#2583). */
   .toolbar-right {
     flex: 0 0 var(--side-panel-width, 320px);
     padding-left: var(--space-2);
@@ -244,17 +235,6 @@
   .toolbar-right :global(.storage-chip) {
     flex: 1 1 auto;
     justify-content: flex-start;
-  }
-
-  /* Collapsed: the lane shrinks to the chip's natural width and pins to the
-     right edge over the 44px strip, so it stays aligned and never overhangs. */
-  .toolbar-right--collapsed {
-    flex: 0 0 auto;
-    justify-content: flex-end;
-  }
-
-  .toolbar-right--collapsed :global(.storage-chip) {
-    flex: 0 0 auto;
   }
 
   /* Mobile centre lane: the current layout name as a plain centred label. It


### PR DESCRIPTION
## **User description**
Closes #2583

## Problem

Collapsing the left side panel changed the horizontal spacing of the search bar and the layout tab bar. The toolbar's three lanes tracked the side-panel column widths (`--sidebar-width`, `--side-panel-width`) and switched to a natural-width flex (`flex: 0 0 auto`) on collapse. When a side lane shrank, the centre `flex: 1 1 auto` tab lane absorbed the freed space and the search pill (which fills the left lane) shrank with it. So the top-bar geometry was coupled to panel collapse state.

## Fix

Hold both toolbar side lanes at the expanded column width in all states. The centre lane, the search pill, and the layout tab strip now keep a constant size and position regardless of whether either panel is collapsed. Only the columns below the toolbar move on collapse.

This removes:
- The collapse-driven width overrides (`.toolbar-left--collapsed`, `.toolbar-right--collapsed`).
- The now-unused `sidebarCollapsed` / `sidePanelCollapsed` props (and their App.svelte call-site bindings), per the no-dead-code policy.

The breathing room from dabe9250 (`.toolbar-tabs { margin-left: var(--space-3) }`) is unchanged.

## Acceptance criteria

- Collapsing or expanding the LEFT panel no longer moves or resizes the search bar or tab bar: lane widths are constant.
- Collapsing or expanding the RIGHT panel likewise has no effect on them.
- The top-bar region is driven by its own constant flex tracks, not coupled to side-panel column widths.

## Testing

Visual/layout fix; per project policy no brittle DOM/CSS unit tests added. Validated via `svelte-autofixer` (clean), `npm run lint` (clean), `npm run test:run`, `npm run build` (green), and the gating `visual regression` check on CI.


___

## **CodeAnt-AI Description**
**Keep the top bar from shifting when side panels collapse**

### What Changed
- Collapsing the left or right side panel no longer moves or resizes the search field or the layout tab bar
- The top bar now keeps the same left and right lane widths in both panel states
- Removed the panel-collapse behavior from the toolbar so the desktop header stays stable while only the side panels below it change

### Impact
`✅ Stable search bar position`
`✅ Steady tab bar layout`
`✅ Fewer top-bar shifts when panels collapse`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
