### PR TITLE
fix: pin @testing-library/svelte to 5.3.1 to unbreak the validate suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@playwright/test": "^1.61.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/svelte": "^5.4.1",
+        "@testing-library/svelte": "5.3.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/debug": "^4.1.13",
         "@types/js-yaml": "^4.0.9",
@@ -2175,14 +2175,14 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/svelte": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.4.1.tgz",
-      "integrity": "sha512-Ju8RZYx7AIAjv+Sc9KN/CbsWI/qjimz1hzGN4KGezw7vKivlDKjDwCXXpJxQrYu/xGx888dhApU+hPupQK6/PA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
+      "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@testing-library/dom": "9.x.x || 10.x.x",
-        "@testing-library/svelte-core": "1.1.2"
+        "@testing-library/svelte-core": "1.0.0"
       },
       "engines": {
         "node": ">= 10"
@@ -2202,9 +2202,9 @@
       }
     },
     "node_modules/@testing-library/svelte-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.1.2.tgz",
-      "integrity": "sha512-HiAsJfEiOtgqXLCAjKI5yZTbXqD0ByYBMhBxPLnw5wzMUZ050Ex3kvsxBgeXOboBUwgZWRDoRYanhp4j3z0AKQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
+      "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@playwright/test": "^1.61.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/svelte": "^5.4.1",
+    "@testing-library/svelte": "5.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/debug": "^4.1.13",
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## **User description**
## Problem

The gating `validate` check is red on `main`. Dependabot #2578 bumped `@testing-library/svelte` 5.3.1 -> 5.4.1, which pulls `@testing-library/svelte-core@1.1.2`. That version ships `wrapper-scaffold.svelte` using `export let`, incompatible with the project's Svelte runes mode:

```
CompileError: node_modules/@testing-library/svelte-core/src/wrapper-scaffold.svelte:2:2
Cannot use `export let` in runes mode — use `$props()` instead
```

Every SPA vitest file fails to compile (173/173), so `npm run test:run` fails. #2578 was auto-merged by Dependabot with `validate` already red, so this is currently blocking every open PR (they all run `npm ci` + `npm run test:run`).

## Fix

Pin `@testing-library/svelte` back to `5.3.1` (resolves `svelte-core@1.0.0`, which is runes-compatible) and refresh the lockfile. `5.4.1` is the latest published release; there is no newer one that fixes the scaffold, so a pin is the only current option. Revisit when a fixed `svelte-core` ships.

## Verification

With the pin, the previously-failing vitest files compile and pass again locally (`svelte-core` back to `1.0.0`, the `export let` CompileError is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Pin the Svelte testing library to restore failing validation checks**

### What Changed
- Reverts `@testing-library/svelte` to a compatible version so the test suite compiles again in Svelte runes mode
- Restores the working testing dependency set used by the locked install file

### Impact
`✅ Fewer broken validate runs`
`✅ Tests compile again in Svelte runes mode`
`✅ Less CI blocking on open PRs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
