### PR TITLE
fix: pin @testing-library/svelte to 5.3.1 to restore runes compatibility (#2587)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,12 @@ updates:
     ignore:
       - dependency-name: "js-yaml"
         update-types: ["version-update:semver-major"]
+      # @testing-library/svelte 5.4.0+ pulls @testing-library/svelte-core 1.1.x,
+      # whose wrapper-scaffold.svelte uses `export let` and is rejected by Svelte
+      # runes mode (breaks the whole component-test suite). Hold at 5.3.x until
+      # upstream ships a runes-compatible svelte-core. See issue #2587.
+      - dependency-name: "@testing-library/svelte"
+        versions: [">=5.4.0"]
 
   # api workspace runs on Bun (api/bun.lock is the source of truth).
   # Dependabot supports bun for version updates (not security updates);

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@playwright/test": "^1.61.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/svelte": "^5.4.1",
+        "@testing-library/svelte": "5.3.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/debug": "^4.1.13",
         "@types/js-yaml": "^4.0.9",
@@ -2175,14 +2175,14 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/svelte": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.4.1.tgz",
-      "integrity": "sha512-Ju8RZYx7AIAjv+Sc9KN/CbsWI/qjimz1hzGN4KGezw7vKivlDKjDwCXXpJxQrYu/xGx888dhApU+hPupQK6/PA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
+      "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@testing-library/dom": "9.x.x || 10.x.x",
-        "@testing-library/svelte-core": "1.1.2"
+        "@testing-library/svelte-core": "1.0.0"
       },
       "engines": {
         "node": ">= 10"
@@ -2202,9 +2202,9 @@
       }
     },
     "node_modules/@testing-library/svelte-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.1.2.tgz",
-      "integrity": "sha512-HiAsJfEiOtgqXLCAjKI5yZTbXqD0ByYBMhBxPLnw5wzMUZ050Ex3kvsxBgeXOboBUwgZWRDoRYanhp4j3z0AKQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
+      "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@playwright/test": "^1.61.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/svelte": "^5.4.1",
+    "@testing-library/svelte": "5.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/debug": "^4.1.13",
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## **User description**
## Problem

`@testing-library/svelte` 5.4.0+ pulls `@testing-library/svelte-core` 1.1.x, whose vendored `wrapper-scaffold.svelte` uses `export let`. Svelte 5.56.3 rejects `export let` in runes mode, so all 174 component-test suites fail at compile time on a clean `npm ci`. This was introduced by Dependabot bump #2578 (`^5.2.6` -> `^5.4.1`) and currently breaks the `validate` check on every open PR.

## Fix

- Pin `@testing-library/svelte` to `5.3.1` (the last release on the runes-compatible `svelte-core@1.0.0` line).
- Add a Dependabot ignore for `@testing-library/svelte >= 5.4.0` so it cannot re-break until upstream ships a runes-compatible `svelte-core`.

## Verification

- Lockfile resolves `@testing-library/svelte@5.3.1` + `@testing-library/svelte-core@1.0.0`.
- Previously-failing suites (accordion, MobileBottomNav, DeviceDetails) now compile and pass.

Closes #2587.


___

## **CodeAnt-AI Description**
**Keep component tests working with Svelte runes mode**

### What Changed
- Locked `@testing-library/svelte` to 5.3.1 so component tests continue to run with Svelte 5 runes mode
- Kept Dependabot from upgrading `@testing-library/svelte` to 5.4.0 or newer, which was breaking the full component test suite

### Impact
`✅ Fewer component-test failures`
`✅ Stable Svelte 5 test runs`
`✅ Fewer broken dependency updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
