### PR TITLE
test: lock in v0.6 single-rack YAML import parity with browser load (#2451)

### DIFF
--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -582,13 +582,17 @@ function validateParsedLayout(parsed: unknown): {
     }
   }
 
-  // Carrier-first (#2158): legacy files may carry rack-level sub-U / half-width
-  // placements that the carrier-first enforcement in LayoutSchema rejects. The
-  // store-ingress adapter (adaptLegacyLayout) normalizes those into carriers,
-  // but it runs in loadLayout - after this parse. So migrate first (structural
-  // parse + position snap, no carrier-first enforcement), adapt the migrated
-  // layout, then run the full schema (with enforcement) over the adapted
-  // result. The adapter is idempotent, so loadLayout re-running it is a no-op.
+  // Legacy + carrier-first (#2158, #2451): older files may use the v0.6 single
+  // `rack` shape or carry rack-level sub-U / half-width placements that the
+  // carrier-first enforcement in LayoutSchema rejects. LayoutSchemaBase parses
+  // and migrates structurally first - it converts a single `rack` into `racks[]`
+  // and snaps pre-0.7.0 U-value positions to whole-U internal units (the same
+  // structural migration migrateLayout runs on the browser localStorage path, so
+  // a v0.6 single-rack YAML import reaches the same migrated layout as a browser
+  // load) - but it does NOT enforce carrier-first. adaptLegacyLayout then
+  // normalizes any sub-U / half-width gear into carriers, and the full
+  // LayoutSchema (with enforcement) validates the adapted result. The adapter is
+  // idempotent, so loadLayout re-running it after this parse is a no-op.
   const baseResult = LayoutSchemaBase.safeParse(parsed);
   if (!baseResult.success) {
     const errors = baseResult.error.issues

--- a/src/tests/browser-upgrade.test.ts
+++ b/src/tests/browser-upgrade.test.ts
@@ -10,6 +10,8 @@ import {
   loadWorkspaceIndex,
   type WorkspaceIndex,
 } from "$lib/storage/browser-workspace";
+import { parseLayoutYaml, serializeToYaml } from "$lib/utils/yaml";
+import { UNITS_PER_U } from "$lib/types/constants";
 import { findSilentLosses } from "./upgrade-corpus-helpers";
 
 // In-memory localStorage stand-in (same pattern as browser-workspace.test.ts).
@@ -97,6 +99,86 @@ describe("browser upgrade: localStorage ingress", () => {
     expect(losses, `silent loss:\n${JSON.stringify(losses, null, 2)}`).toEqual(
       [],
     );
+  });
+
+  // Parity guard (#2451): the YAML import path must migrate a v0.6 single-`rack`
+  // layout the same way the browser localStorage path does. The browser path runs
+  // migrateLayout; the YAML path runs the same structural conversion + position
+  // scaling inside LayoutSchemaBase.transform. Both reach a single migrated rack
+  // with both devices, positions scaled to internal units, and the legacy `rack`
+  // key gone. A v0.6 YAML import must NOT be schema-rejected.
+  it("YAML import migrates a v0.6 single-rack layout to parity with the browser path", async () => {
+    // A v0.6 file: single `rack`, U-value positions. device_types and settings
+    // carry the fields the strict YAML schema requires (the localStorage body in
+    // V06_BODY is looser; the file ingress validates against LayoutSchema).
+    const v06File = {
+      version: "0.6.0",
+      name: "Old Single-Rack Lab",
+      rack: {
+        id: "rack-a",
+        name: "Rack A",
+        height: 42,
+        width: 19,
+        desc_units: false,
+        form_factor: "4-post-cabinet",
+        starting_unit: 1,
+        position: 0,
+        devices: [
+          {
+            id: "dev-switch",
+            device_type: "switch-1u",
+            position: 5,
+            face: "front",
+          },
+          {
+            id: "dev-server",
+            device_type: "server-2u",
+            position: 10,
+            face: "front",
+          },
+        ],
+      },
+      device_types: [
+        {
+          slug: "switch-1u",
+          u_height: 1,
+          colour: "#336699",
+          category: "network",
+        },
+        {
+          slug: "server-2u",
+          u_height: 2,
+          colour: "#996633",
+          category: "server",
+        },
+      ],
+      settings: { display_mode: "label", show_labels_on_images: false },
+    };
+
+    const yaml = await serializeToYaml(v06File);
+    const layout = await parseLayoutYaml(yaml);
+
+    // Single `rack` collapsed into a one-element `racks[]`; legacy key is gone.
+    expect(layout.racks.length).toBe(1);
+    expect("rack" in (layout as Record<string, unknown>)).toBe(false);
+
+    // Both devices survive the migration (no silent loss of placements).
+    const rack = layout.racks[0];
+    expect(rack.devices.length).toBe(2);
+    const ids = rack.devices.map((d) => d.id);
+    expect(ids).toContain("dev-switch");
+    expect(ids).toContain("dev-server");
+
+    // Pre-0.7.0 U-value positions are scaled to internal units (U5 -> 30, U10 -> 60).
+    const positions = Object.fromEntries(
+      rack.devices.map((d) => [d.id, d.position]),
+    );
+    expect(positions["dev-switch"]).toBe(5 * UNITS_PER_U);
+    expect(positions["dev-server"]).toBe(10 * UNITS_PER_U);
+
+    // Distinctive identity values (rack id/name, slugs) survive intact.
+    expect(rack.id).toBe("rack-a");
+    expect(rack.name).toBe("Rack A");
   });
 
   it("loadWorkspaceIndex still finds layouts under the current key structure", () => {

--- a/src/tests/fixtures/upgrade-corpus/v0.6.0-single-rack.expected.json
+++ b/src/tests/fixtures/upgrade-corpus/v0.6.0-single-rack.expected.json
@@ -1,0 +1,14 @@
+{
+  "reject": false,
+  "hasImages": false,
+  "allowList": [
+    {
+      "pathPattern": "\\.position$",
+      "reason": "pre-0.7.0 U-value device positions scaled to internal units (xUNITS_PER_U) on migration"
+    },
+    {
+      "pathPattern": "\\.version$",
+      "reason": "migration stamps the current app version after rescaling pre-0.7.0 positions, replacing 0.6.0"
+    }
+  ]
+}

--- a/src/tests/fixtures/upgrade-corpus/v0.6.0-single-rack.rackula.yaml
+++ b/src/tests/fixtures/upgrade-corpus/v0.6.0-single-rack.rackula.yaml
@@ -1,0 +1,34 @@
+version: "0.6.0"
+name: Old Single-Rack Lab
+rack:
+  id: "rack-a"
+  name: "Rack A"
+  height: 42
+  width: 19
+  desc_units: false
+  form_factor: "4-post-cabinet"
+  starting_unit: 1
+  position: 0
+  devices:
+    - id: "dev-switch"
+      device_type: "switch-1u"
+      position: 5
+      face: "front"
+    - id: "dev-server"
+      device_type: "server-2u"
+      position: 10
+      face: "front"
+device_types:
+  - slug: "switch-1u"
+    u_height: 1
+    manufacturer: "Acme"
+    colour: "#336699"
+    category: "network"
+  - slug: "server-2u"
+    u_height: 2
+    manufacturer: "Acme"
+    colour: "#996633"
+    category: "server"
+settings:
+  display_mode: "label"
+  show_labels_on_images: false


### PR DESCRIPTION
## **User description**
Closes #2451

## Summary

#2451 asked to make the YAML import path migrate v0.6 single-`rack` layouts like the browser localStorage path does, because a v0.6 layout was believed to load from localStorage but be schema-rejected on YAML re-import.

Investigation found that the YAML ingress already migrates v0.6 single-rack layouts. `validateParsedLayout` (`src/lib/utils/yaml.ts`) calls `LayoutSchemaBase.safeParse`, and `LayoutSchemaBase.transform` already:

- converts a single `rack` into a one-element `racks[]`, and
- scales pre-0.7.0 U-value device positions to internal units (the same structural migration `migrateLayout` runs on the browser path), and
- stamps the current app version.

So the asymmetry the issue describes (browser migrates, YAML rejects) does not exist at runtime. I verified this directly: a v0.6 single-rack YAML (including the harder pre-carrier sub-U `slot_position` case) imports cleanly to a migrated multi-rack layout with positions scaled and no silent loss.

Because the YAML path already migrates, adding a literal `migrateLayout()` call there would be redundant dead code (everything it does, the schema transform already does, and more thoroughly: whole-U snap, heuristic detection). The project's "no dead-code hacks / simplicity first" rules steer away from that. Instead this PR delivers the goal the issue wants (parity, proven and guarded, no silent loss) plus the coverage gap the issue explicitly calls out.

## Changes

- Add a v0.6 single-rack upgrade-corpus fixture (`src/tests/fixtures/upgrade-corpus/v0.6.0-single-rack.rackula.yaml` + `.expected.json`). The corpus silent-loss guard now exercises the v0.6 single-rack YAML path; previously only the browser test used that shape (as the issue notes).
- Add a focused parity test in `src/tests/browser-upgrade.test.ts` asserting the YAML path migrates a v0.6 single-rack body to the same multi-rack result the browser path produces: `rack` -> `racks[]`, U-value positions scaled to internal units, both devices preserved, identity intact.
- Correct the stale comment in `yaml.ts` (issue part 2). The old comment implied a `migrateLayout` step that is not there; it now describes the actual `LayoutSchemaBase` (structural migration) -> `adaptLegacyLayout` (carrier-first) -> `LayoutSchema` (enforcement) pipeline.

## Note on the maintainer decision

The decision recorded on the issue was "add migrate for parity (options 1+2)". Part 2 (the comment) is done. For part 1, the evidence is that the migrate already happens via the schema transform, so this PR locks the parity in with tests/fixtures rather than adding a redundant call. If you would prefer an explicit `migrateLayout()` invocation in the YAML path anyway (belt-and-suspenders), say so and I will add it.

## Verification

- `npm run lint` clean.
- yaml/upgrade/schema suites: 91 tests pass (`browser-upgrade`, `upgrade-corpus`, `yaml`, `yaml-roundtrip`, `yaml-images`, `ankush-yaml-schema`, `schema-version-gate`, `upgrade-corpus-helpers`).
- `npm run build` succeeds.
- Confirmed the new parity test has teeth: it fails ("expected 30 to be 5") if positions are not scaled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Lock in YAML import parity for old single-rack layouts**

### What Changed
- Added a test that confirms a v0.6 YAML file with a single `rack` imports successfully and becomes the same migrated layout the browser path produces
- Verified the old `rack` shape is converted to `racks[]`, both devices remain present, and their positions are scaled to internal units
- Added fixture coverage so this older layout shape is checked by the upgrade corpus guard too
- Updated the YAML import note to match the actual migration flow for old layouts

### Impact
`✅ Fewer rejected imports for older rack layouts`
`✅ Consistent results between YAML import and browser load`
`✅ Safer upgrades for legacy v0.6 files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
