### PR TITLE
fix: add MikroTik CSS326-24G-2S+RM and CSS610-8G-2S+IN (#1581)

### DIFF
--- a/src/lib/data/brandPacks/mikrotik.ts
+++ b/src/lib/data/brandPacks/mikrotik.ts
@@ -616,6 +616,30 @@ export const mikrotikDevices: DeviceType[] = [
   },
 
   {
+    slug: "mikrotik-css326-24g-2s-plus-rm",
+    u_height: 1,
+    manufacturer: "MikroTik",
+    model: "CSS326-24G-2S+RM",
+    slot_width: 1,
+    is_full_depth: false,
+    airflow: "passive",
+    colour: CATEGORY_COLOURS.network,
+    category: "network",
+  },
+
+  {
+    slug: "mikrotik-css610-8g-2s-plus-in",
+    u_height: 1,
+    manufacturer: "MikroTik",
+    model: "CSS610-8G-2S+IN",
+    slot_width: 1,
+    is_full_depth: false,
+    airflow: "passive",
+    colour: CATEGORY_COLOURS.network,
+    category: "network",
+  },
+
+  {
     slug: "mikrotik-crs106-1c-5s",
     u_height: 1,
     manufacturer: "MikroTik",


### PR DESCRIPTION
## **User description**
Closes #1581

## What

Adds two MikroTik Cloud Smart Switches that were genuinely missing from the device library:

- CSS326-24G-2S+RM (1U rackmount, 24x GbE + 2x SFP+)
- CSS610-8G-2S+IN (8x GbE + 2x SFP+)

The third switch named in the issue, CSS318-16G-2S+IN, was already present in `mikrotik.ts`, so only these two were added.

## Details

These are network switches, so each entry uses `category: "network"`, `colour: CATEGORY_COLOURS.network`, `airflow: "passive"`, `is_full_depth: false`, and `u_height: 1`, matching the neighbouring `mikrotik-css318-16g-2s-plus-in` entry and the existing CRS-series rackmount switches.

Physical specs verified against the NetBox community devicetype-library source YAMLs:

- https://github.com/netbox-community/devicetype-library/blob/master/device-types/MikroTik/CSS326-24G-2S-Plus-RM.yaml
- https://github.com/netbox-community/devicetype-library/blob/master/device-types/MikroTik/CSS610-8G-2S-Plus-IN.yaml

No source images are available for these two models (the orphaned import branch did not include them), so they are added without image flags, consistent with most existing MikroTik switch entries.

## Testing

Static device data is validated by `DeviceTypeSchema` via `brandpacks.test.ts`; adding a device requires zero test changes per project policy. Lint, unit tests, and build all pass locally.


___

## **CodeAnt-AI Description**
**Add two missing MikroTik Cloud Smart Switch models**

### What Changed
- Added the MikroTik CSS326-24G-2S+RM to the device library as a 1U rackmount network switch
- Added the MikroTik CSS610-8G-2S+IN to the device library as a compact network switch
- Both switches now show the same network, size, and passive-cooling details as similar MikroTik models

### Impact
`✅ Fewer missing MikroTik switch entries`
`✅ Easier switch lookup in the device library`
`✅ More complete MikroTik hardware coverage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
