### PR TITLE
fix: revalidate the SPA entry document so deploys propagate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,15 +534,15 @@ Two environments with different deployment triggers:
 
 | Environment | URL            | Trigger        | Infrastructure |
 | ----------- | -------------- | -------------- | -------------- |
-| **Dev**     | d.racku.la     | Push to `main` | GitHub Pages   |
+| **Dev**     | d.racku.la     | Push to `main` | VPS (Docker)   |
 | **Prod**    | count.racku.la | Git tag `v*`   | VPS (Docker)   |
 
 ### Dev Deployment
 
-Automatically deploys on code pushes to `main` (after lint/tests pass):
+Automatically deploys on code pushes to `main`. The Deploy Dev workflow builds and pushes the web and API Docker images, then deploys them via docker-compose to the self-hosted VPS. d.racku.la sits behind Cloudflare Access. Tests are not re-run here (they gate the PR before merge).
 
 ```bash
-git push origin main  # Triggers: lint → test → build → deploy to GitHub Pages
+git push origin main  # Triggers Deploy Dev: build and push Docker images, then deploy to the VPS
 ```
 
 The Deploy Dev workflow is path-filtered: it runs only when the push changes app inputs (`api/**`, `src/**`, `deploy/**`, `assets/**`, `static/**`, `login.html`, the lockfiles, build configs, `index.html`), and a trailing `!**/*.md` excludes markdown anywhere. Docs-only pushes (markdown-only, or paths outside that list such as `.claude/**`, `docs/**`, `.github/**`) do not trigger a deploy.

--- a/deploy/lxc/nginx.conf
+++ b/deploy/lxc/nginx.conf
@@ -141,6 +141,16 @@ server {
     # SPA fallback — all routes to index.html
     location / {
         try_files $uri $uri/ /index.html;
+
+        # The entry document must revalidate on every load: index.html references
+        # the fingerprinted /assets/ bundles by name, so a cached copy pins the
+        # browser to the previous deploy's JS. The bundles stay immutable (see
+        # location /assets/).
+        add_header Cache-Control "no-cache" always;
+
+        # nginx drops ALL server-level add_header directives when a location block
+        # defines its own; include shared security headers to avoid drift.
+        include /etc/nginx/snippets/security-headers.conf;
     }
 
     # Security headers (single source of truth: deploy/lxc/security-headers.conf)

--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -314,6 +314,16 @@ server {
         auth_request /_rackula_auth_check;
         error_page 401 = @auth_login_redirect;
         try_files $uri $uri/ /index.html;
+
+        # The entry document must revalidate on every load: index.html references
+        # the fingerprinted /assets/ bundles by name, so a cached copy pins the
+        # browser (and any edge cache) to the previous deploy's JS. The bundles
+        # themselves stay immutable (see location /assets/).
+        add_header Cache-Control "no-cache" always;
+
+        # nginx drops ALL server-level add_header directives when a location block
+        # defines its own; include shared security headers to avoid drift.
+        include /etc/nginx/snippets/security-headers.conf;
     }
 
     # Security headers (single source of truth: deploy/security-headers.conf)


### PR DESCRIPTION
## **User description**
## Problem

A merged and deployed change to the app menu was not visible on d.racku.la even after a hard reload was needed to see it. Investigation (over SSH to the dev VPS) confirmed the origin container was serving the correct new build (`version.json` commit matched, new bundle strings present), so the deploy itself was fine. The fault is caching of the entry document.

nginx serves `index.html` with only `ETag`/`Last-Modified` and no `Cache-Control`, while the fingerprinted `/assets/` bundles are `public, immutable`. An entry document without `no-cache` is heuristically cacheable, so a returning browser (or an edge cache) keeps handing back an old `index.html` that references the previous deploy's JS hashes, pinning users to the prior build until a forced reload. This affected every dev and prod deploy.

## Fix

Add `Cache-Control: no-cache` to the SPA-shell `location /` in both `deploy/nginx.conf.template` (Docker/VPS, dev + prod) and `deploy/lxc/nginx.conf` (LXC), re-including the shared `security-headers.conf` snippet. nginx drops inherited `add_header` directives once a location defines its own, so the re-include mirrors the existing mitigation already used by `location /assets/` and `location = /config.js`.

The immutable hashed assets are unchanged. Only the entry document revalidates, so future deploys show up on the next normal load instead of requiring a hard reload. Stable-named root files (favicon, og-image, version.json) also revalidate via cheap ETag 304s, which is correct for them too.

## Validation

Rendered the modified template inside the real `ghcr.io/rackulalives/rackula:main` image and ran `nginx -t`: `syntax is ok` / `test is successful`. The security-headers re-include resolves and the multiple `add_header` directives are accepted.

## Also

Corrects the stale CLAUDE.md deployment section: dev (d.racku.la) runs as Docker containers on the self-hosted VPS behind Cloudflare Access, not GitHub Pages, and Deploy Dev does not re-run tests (they gate the PR before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the app load the latest deploy without a hard refresh**

### What Changed
- The main app page now revalidates on every normal load, so users get the latest deployed version instead of a cached old entry page.
- This prevents the browser or edge cache from keeping users on stale JavaScript after a deploy.
- Deployment notes now match the real setup for dev, including Docker on the VPS and the fact that Deploy Dev does not rerun tests.

### Impact
`✅ Fewer stale app loads after deploys`
`✅ Less need for hard refreshes`
`✅ Clearer dev deployment instructions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
