### PR TITLE
chore: unify the Edit/View tab strip with the sidebar's segmented style (#2600)

### DIFF
--- a/src/lib/components/SidePanelContent.svelte
+++ b/src/lib/components/SidePanelContent.svelte
@@ -25,7 +25,6 @@
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import type { SidePanelTab } from "$lib/stores/ui.svelte";
   import type { SelectedDeviceInfo } from "$lib/types";
-  import "$lib/styles/tabs.css";
 
   interface Props {
     /** Active tab. Controlled by the host (rail or sheet). */
@@ -285,10 +284,12 @@
     flex-shrink: 0;
   }
 
+  /* Connected segmented row: zero gap so adjacent segment borders collapse,
+     mirroring the left sidebar's Layouts/Racks/Devices control (#2600, #2435). */
   :global(.side-panel-tablist) {
     display: flex;
     flex: 1;
-    gap: var(--space-1);
+    gap: 0;
     min-width: 0;
   }
 
@@ -322,8 +323,10 @@
     outline-offset: -2px;
   }
 
-  /* Layout-only rules. The raised "layered sheet" look (background, colour, top
-     accent, rounded top corners, active merge) is shared via tabs.css. */
+  /* Connected segmented control matching the left sidebar's Layouts/Racks/Devices
+     row (#2600): square segments with collapsed borders and a filled active state,
+     rather than the raised tab sheets used by the top layout strip. Rounded
+     corners only on the row ends. */
   :global(.side-panel-tab) {
     flex: 1;
     display: flex;
@@ -331,18 +334,48 @@
     justify-content: center;
     /* 44px minimum touch target (mobile spike #2097 / a11y guard rail) */
     min-height: 44px;
-    padding: var(--space-2) var(--space-3);
+    min-width: 0;
+    padding: var(--space-2) var(--space-2);
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-medium);
+    background: transparent;
+    border: 1px solid var(--colour-border);
+    border-radius: 0;
+    color: var(--colour-text-muted);
     cursor: pointer;
+    /* Collapse adjacent borders so the row reads as one connected control. */
+    margin-left: -1px;
+    position: relative;
     transition:
-      background var(--duration-fast) var(--ease-out),
+      background-color var(--duration-fast) var(--ease-out),
       color var(--duration-fast) var(--ease-out);
+  }
+
+  :global(.side-panel-tab:first-child) {
+    margin-left: 0;
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  }
+
+  :global(.side-panel-tab:last-child) {
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  }
+
+  :global(.side-panel-tab:hover:not([data-state="active"])) {
+    background: var(--colour-surface-hover);
+    color: var(--colour-text);
+  }
+
+  :global(.side-panel-tab[data-state="active"]) {
+    background: color-mix(in srgb, var(--colour-selection) 20%, transparent);
+    border-color: var(--colour-selection);
+    color: var(--colour-text);
+    z-index: 1;
   }
 
   :global(.side-panel-tab:focus-visible) {
     outline: 2px solid var(--colour-selection);
-    outline-offset: -2px;
+    outline-offset: 2px;
+    z-index: 2;
   }
 
   :global(.side-panel-tabpanel) {

--- a/src/lib/styles/tabs.css
+++ b/src/lib/styles/tabs.css
@@ -1,68 +1,46 @@
 /**
- * Shared "raised layered-sheet" tab treatment (issue #2396).
+ * Raised "layered-sheet" tab treatment for the open-layout strip (issue #2396).
  *
- * One snippet drives all three tab rows so they stay in sync:
- *   - LayoutTabs        .layout-tab            (open-layout strip, top bar)
- *   - SidebarTabs        .tab-btn               (Layouts / Racks / Devices)
- *   - SidePanelContent   .side-panel-tab        (Edit / View)
+ * Drives the LayoutTabs row (.layout-tab) in the top bar. The active tab reads as
+ * the top sheet in a stack of sheets: it lifts to the content surface, rounds its
+ * top corners, and carries a purple top accent with a soft downward shadow.
+ * Inactive tabs sit recessed and muted.
  *
- * The active tab reads as the top sheet in a stack of sheets: it lifts to the
- * content surface below it (--colour-tab-active-bg), rounds its top corners,
- * and carries a purple top accent with a soft downward shadow. The sidebar and
- * side-panel rows also drop the active tab's bottom edge so it merges into the
- * panel below; the layout strip floats in the top bar and keeps the lifted read
- * from the accent and shadow alone. Inactive tabs sit recessed and muted.
+ * The sidebar (Layouts / Racks / Devices, #2435) and the side panel (Edit / View,
+ * #2600) intentionally use the connected segmented-control style instead, so they
+ * are not styled here; each keeps its own segment rules.
  *
- * All three rows are imported as plain stylesheets, so these selectors are
- * global; each component keeps only its own layout (flex sizing, row padding).
- * Tokens only, theme-aware (see --colour-tab-* in tokens.css).
+ * Imported as a plain stylesheet, so these selectors are global; LayoutTabs keeps
+ * only its own layout (flex sizing, row padding). Tokens only, theme-aware
+ * (see --colour-tab-* in tokens.css).
  */
 
-/* Inactive (resting) state, shared by all three rows. The bits-ui rows expose
-   the active state via [data-state="active"]; the layout strip uses .active. */
-.layout-tab,
-.tab-btn,
-.side-panel-tab {
+/* Inactive (resting) state. */
+.layout-tab {
   border-radius: var(--tab-radius) var(--tab-radius) 0 0;
   background: var(--colour-tab-inactive-bg);
   color: var(--colour-text-muted);
   /* Two inset lines keep the inactive and active box-model identical (no shift
-     on activation): a transparent top accent slot, and a subtle bottom
-     separator so the recessed tabs stay legible where their fill matches the
-     row behind them. */
+     on activation): a transparent top accent slot, and a subtle bottom separator
+     so the recessed tab stays legible where its fill matches the row behind it. */
   box-shadow:
     inset 0 var(--tab-accent-height) 0 0 transparent,
     inset 0 -1px 0 0 var(--colour-border);
 }
 
-.layout-tab:hover,
-.tab-btn:hover,
-.side-panel-tab:hover {
+.layout-tab:hover {
   background: var(--colour-surface-hover);
   color: var(--colour-text);
 }
 
-/* Active (raised sheet) state. */
-.layout-tab.active,
-.tab-btn[data-state="active"],
-.side-panel-tab[data-state="active"] {
-  /* Lift to the content surface below the row. */
+/* Active (raised sheet) state. The layout strip floats in the top bar with the
+   canvas further below, so it keeps the lifted-sheet read from the accent and
+   shadow alone (no edge-merge into a panel below). */
+.layout-tab.active {
   background: var(--colour-tab-active-bg);
   color: var(--colour-text);
   font-weight: var(--font-weight-semibold);
-  /* Purple top accent + soft downward shadow so the sheet sits above the row. */
   box-shadow:
     inset 0 var(--tab-accent-height) 0 0 var(--colour-tab-accent),
     var(--shadow-tab-active);
-}
-
-/* The sidebar and side-panel rows sit directly atop their content panel, so the
-   active tab drops its bottom edge: it overlaps the row's 1px bottom border and
-   merges into the panel it owns (no seam between tab and content). The layout
-   strip floats in the top bar with the canvas further below, so it keeps the
-   lifted-sheet read from the accent and shadow without a literal edge-merge. */
-.tab-btn[data-state="active"],
-.side-panel-tab[data-state="active"] {
-  margin-bottom: -1px;
-  padding-bottom: 1px;
 }


### PR DESCRIPTION
## **User description**
## Summary

The two side panels read as different UI languages. The left sidebar (Layouts / Racks / Devices) uses a connected segmented control, while the right panel (Edit / View) used raised "folder" tab sheets. This unifies them: Edit / View now uses the sidebar's segmented style, so both side panels match.

Direction chosen with the maintainer after rendering both options: aligning the right panel to the left preserves the tightest visual relationship in the UI, the sidebar's tab strip sitting directly above its Brand / Category / A-Z segmented filter, while pulling the right panel into the same vocabulary. The alternative (making the left panel raised) would have put raised tabs directly on top of that segmented filter.

## Changes

- `SidePanelContent.svelte`: restyle `.side-panel-tab` from raised sheets to the sidebar's segmented vocabulary (square connected segments, collapsed borders via `margin-left: -1px`, filled active state using the selection token, outset focus ring). Set the tablist `gap` to 0 so segment borders collapse. Drop the now-unused `tabs.css` import.
- `tabs.css`: the raised-sheet treatment now drives only the top-bar layout strip (`.layout-tab`). Removed the dead `.tab-btn` selectors (unused since #2435 moved the sidebar to segments) and the `.side-panel-tab` rules (now segmented). Updated the doc comment.

The left sidebar (`SidebarTabs.svelte`) is untouched, so the reference style cannot regress.

## Before / after

Right panel header, `Edit / View`:

- Before: raised folder tabs (purple top accent on the active tab, underline baseline on the inactive one).
- After: connected segmented boxes with a filled active segment, matching the left sidebar.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] `npm run test:run` (175 files, 2901 tests) pass
- [x] Svelte autofixer reports no issues
- [x] CodeRabbit local review: 0 findings
- [x] Rendered in the running app at 1280-wide and verified both side panels match
- [ ] CI visual-regression job (the 4 full-page baselines include the right panel in frame; if the diff exceeds the 1% tolerance, the Linux baselines will be regenerated via the Update Visual Snapshots workflow and committed)

Closes #2600

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the Edit/View panel tabs match the sidebar’s segmented style**

### What Changed
- The Edit/View tabs in the side panel now use the same connected segmented look as the left sidebar instead of raised tab sheets
- The active tab now appears as a filled segment with a clear selection border, and the row ends are rounded only at the edges
- Hover and focus states were updated to fit the segmented control, while the top layout tabs keep the older raised-sheet style

### Impact
`✅ Consistent side-panel tabs`
`✅ Clearer active tab selection`
`✅ Fewer mixed-style UI elements`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
