### PR TITLE
feat: mobile app-menu sheet rendering the registry projection (#2597)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -25,6 +25,7 @@
   import MobileViewSheet from "$lib/components/mobile/MobileViewSheet.svelte";
   import MobileLayoutsSheet from "$lib/components/mobile/MobileLayoutsSheet.svelte";
   import MobileRacksSheet from "$lib/components/mobile/MobileRacksSheet.svelte";
+  import MobileMenuSheet from "$lib/components/mobile/MobileMenuSheet.svelte";
   import DevicePalette from "$lib/components/DevicePalette.svelte";
   import LoadDialog from "$lib/components/LoadDialog.svelte";
   import CommandPalette from "$lib/components/CommandPalette.svelte";
@@ -62,6 +63,10 @@
 
   import { getSelectionVerbsWithState } from "$lib/actions/verb-bars";
   import type { ActionEnabledContext, ActionId } from "$lib/actions/registry";
+  import {
+    createActionDispatch,
+    type ActionDispatch,
+  } from "$lib/actions/dispatch";
   import {
     moveSelectedDeviceUp,
     moveSelectedDeviceDown,
@@ -117,6 +122,12 @@
   let layoutsSheetOpen = $derived(dialogStore.isSheetOpen("layouts"));
   let racksSheetOpen = $derived(dialogStore.isSheetOpen("racks"));
   let viewSheetOpen = $derived(dialogStore.isSheetOpen("view"));
+  let menuSheetOpen = $derived(dialogStore.isSheetOpen("menu"));
+
+  // Shared dispatch spine. The mobile app-menu sheet routes its chosen action
+  // here so a command runs identically from the sheet, the command palette, the
+  // keyboard, and the desktop dropdown (#2597).
+  const dispatch: ActionDispatch = createActionDispatch();
 
   // Aliases to dialogStore properties for template access
   let deleteTarget = $derived(dialogStore.deleteTarget);
@@ -706,6 +717,18 @@
     dialogStore.openSheet("deviceLibrary");
   }
 
+  // The mobile app-menu sheet replaces the desktop dropdown on touch (#2597).
+  // The hamburger trigger lives in the Toolbar and opens this sheet; choosing an
+  // item runs it through the shared dispatch spine, so the same command behaves
+  // identically across the dropdown, the palette, the keyboard, and the sheet.
+  function handleMenuSheetClose() {
+    dialogStore.closeSheet();
+  }
+
+  function handleMenuAction(id: ActionId) {
+    dispatch[id]?.();
+  }
+
   // The Layouts and Racks tabs open titled bottom sheets: Layouts switches the
   // active layout (#2460) and Racks lists racks and opens their properties
   // (#2461).
@@ -998,6 +1021,23 @@
       onfitall={handleFitAll}
       onresetzoom={() => canvasStore.resetZoom()}
       onclose={handleViewSheetActionClose}
+    />
+  </Dialog>
+{/if}
+
+<!-- Mobile app-menu sheet: the touch presentation of the desktop dropdown,
+     rendering the shared registry projection (#2597). -->
+{#if viewportStore.isMobile && menuSheetOpen}
+  <Dialog
+    open={menuSheetOpen}
+    title="Menu"
+    size="M"
+    onclose={handleMenuSheetClose}
+  >
+    <MobileMenuSheet
+      onaction={handleMenuAction}
+      hasRacks={layoutStore.hasRack}
+      onclose={handleMenuSheetClose}
     />
   </Dialog>
 {/if}

--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -24,7 +24,7 @@
   import StorageStatusChip from "./StorageStatusChip.svelte";
   import LayoutTabs from "./LayoutTabs.svelte";
   import type { ActionId } from "$lib/actions/registry";
-  import { IconSearch } from "./icons";
+  import { IconSearch, IconMenuBold } from "./icons";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { ICON_SIZE } from "$lib/constants/sizing";
@@ -101,17 +101,46 @@
   function handleAppMenuAction(id: ActionId) {
     appMenuDispatch[id]?.();
   }
+
+  // Mirrors the desktop dropdown's open-state on mobile so the hamburger reports
+  // aria-expanded correctly. The sheet itself lives in DialogOrchestrator.
+  const menuSheetOpen = $derived(dialogStore.isSheetOpen("menu"));
+
+  // Focus the trigger before opening so bits-ui captures it as the element to
+  // restore focus to when the sheet closes. Touch taps do not move keyboard
+  // focus on mobile by default, the same gap MobileBottomNav's handleTabClick
+  // handles for the bottom-nav buttons.
+  function handleMenuTriggerClick(event: MouseEvent) {
+    (event.currentTarget as HTMLElement).focus();
+    dialogStore.openSheet("menu");
+  }
 </script>
 
 <header class="toolbar">
-  <!-- Left: Logo (also the app menu) + command palette pill.
+  <!-- Left: app menu + command palette pill. On desktop the logo lockup is the
+       app-menu dropdown trigger; on mobile a hamburger button opens the same
+       menu as a bottom sheet, since a dropdown is awkward on touch (#2597).
        Width = --sidebar-width so it aligns with the column below; held constant
        across sidebar collapse so the pill never moves or resizes (#2583). -->
   <div
     class="toolbar-section toolbar-left"
     class:toolbar-left--mobile={viewportStore.isMobile}
   >
-    <AppMenu onaction={handleAppMenuAction} {hasRacks} {partyMode} />
+    {#if viewportStore.isMobile}
+      <button
+        class="menu-trigger"
+        type="button"
+        aria-label="App menu"
+        aria-haspopup="dialog"
+        aria-expanded={menuSheetOpen}
+        data-testid="btn-app-menu-mobile"
+        onclick={handleMenuTriggerClick}
+      >
+        <IconMenuBold size={ICON_SIZE.md} />
+      </button>
+    {:else}
+      <AppMenu onaction={handleAppMenuAction} {hasRacks} {partyMode} />
+    {/if}
     <button
       class="command-pill"
       class:command-pill--icon={viewportStore.isMobile}
@@ -264,6 +293,55 @@
     flex: 0 0 auto;
     padding-right: max(var(--space-2), env(safe-area-inset-right, 0px));
     justify-content: flex-end;
+  }
+
+  /* Mobile app-menu trigger: a hamburger button that opens the menu sheet. A
+     true 44px square hit area (WCAG 2.5.5) matching the compact search button
+     beside it, so the mobile left group reads as two equal icon buttons. */
+  .menu-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: var(--touch-target-min);
+    height: var(--touch-target-min);
+    min-width: var(--touch-target-min);
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--colour-text);
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      transform var(--duration-fast) var(--ease-out);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .menu-trigger:hover {
+    background: var(--colour-surface-hover);
+  }
+
+  .menu-trigger:active {
+    transform: scale(0.96);
+  }
+
+  .menu-trigger:focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--colour-bg),
+      0 0 0 4px var(--colour-focus-ring);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .menu-trigger {
+      transition: none;
+    }
+
+    .menu-trigger:active {
+      transform: none;
+    }
   }
 
   /* Command pill: the button is the hit target, a true 44px-tall layout box

--- a/src/lib/components/icons/IconMenuBold.svelte
+++ b/src/lib/components/icons/IconMenuBold.svelte
@@ -1,0 +1,22 @@
+<!--
+  List icon (Phosphor Bold) — the app-menu (hamburger) trigger on mobile.
+-->
+<script lang="ts">
+  interface Props {
+    size?: number;
+  }
+
+  let { size = 20 }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 256 256"
+  fill="currentColor"
+  aria-hidden="true"
+>
+  <path
+    d="M28,64a12,12,0,0,1,12-12H216a12,12,0,0,1,0,24H40A12,12,0,0,1,28,64Zm188,52H40a12,12,0,0,0,0,24H216a12,12,0,0,0,0-24Zm0,64H40a12,12,0,0,0,0,24H216a12,12,0,0,0,0-24Z"
+  />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -92,6 +92,7 @@ export { default as IconSunBold } from "./IconSunBold.svelte";
 export { default as IconMoonBold } from "./IconMoonBold.svelte";
 export { default as IconDownloadBold } from "./IconDownloadBold.svelte";
 export { default as IconFileDownloadBold } from "./IconFileDownloadBold.svelte";
+export { default as IconMenuBold } from "./IconMenuBold.svelte";
 export { default as IconShareBold } from "./IconShareBold.svelte";
 export { default as IconQuestionBold } from "./IconQuestionBold.svelte";
 export { default as IconServerBold } from "./IconServerBold.svelte";

--- a/src/lib/components/mobile/MobileMenuSheet.svelte
+++ b/src/lib/components/mobile/MobileMenuSheet.svelte
@@ -1,0 +1,201 @@
+<!--
+  MobileMenuSheet Component
+
+  Body of the mobile app-menu bottom sheet (#2597). It is the touch presentation
+  of the same app menu the desktop dropdown shows behind the logo: it renders the
+  shared registry projection (projectMobileMenuSections -> getAppMenuSections) so
+  no menu item set, ordering, label, or icon is duplicated here. Adding or
+  reordering a registry action updates this sheet with zero changes in this file.
+
+  Unlike the desktop dropdown (which renders bare separators), this view renders
+  the projection's section headings as visible titles, the pattern the headings
+  added in #2596 were built for. Each item resolves its icon from iconForAction
+  by action id; disabled items (from the projection's enabledWhen) render
+  aria-disabled and do not dispatch. Keyboard shortcuts are omitted on mobile.
+
+  The sheet chrome (scrim, focus trap, Escape, swipe-to-dismiss) is the shared
+  Dialog wrapper in DialogOrchestrator; this component is the body only, matching
+  MobileLayoutsSheet and MobileViewSheet.
+-->
+<script lang="ts">
+  import {
+    type ActionEnabledContext,
+    type ActionId,
+  } from "$lib/actions/registry";
+  import { projectMobileMenuSections } from "./mobile-menu-projection";
+  import { iconForAction } from "$lib/components/icons/action-icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+  import { getStorageMode, type StorageMode } from "$lib/storage";
+
+  interface Props {
+    /** Runs the chosen app-menu action; bound to the shared dispatch spine. */
+    onaction: (id: ActionId) => void;
+    /** Whether any rack exists; gates share and view-yaml (via the projection). */
+    hasRacks?: boolean;
+    /** Dismiss the sheet after an action runs. */
+    onclose?: () => void;
+  }
+
+  let { onaction, hasRacks = false, onclose }: Props = $props();
+
+  const mode: StorageMode = getStorageMode();
+
+  // Live context for the projection's enabledWhen predicates, mirroring the
+  // desktop AppMenu: only the rack-gated items (share, view-yaml) read hasRacks;
+  // the selection and history fields are reported as the neutral no-target state
+  // because no app-menu item consults them.
+  const enableContext: ActionEnabledContext = $derived({
+    hasSelection: false,
+    isDeviceSelected: false,
+    isRackSelected: false,
+    canUndo: false,
+    canRedo: false,
+    hasRacks,
+    mode,
+    canMoveDeviceSlot: false,
+  });
+
+  const sections = $derived(projectMobileMenuSections(mode, enableContext));
+
+  function runAction(id: ActionId, disabled: boolean) {
+    if (disabled) return;
+    onaction(id);
+    onclose?.();
+  }
+</script>
+
+<div class="mobile-menu-sheet">
+  {#each sections as section (section.group)}
+    <section
+      class="menu-section"
+      aria-labelledby="menu-heading-{section.group}"
+    >
+      <h3 class="section-heading" id="menu-heading-{section.group}">
+        {section.heading}
+      </h3>
+      <div class="menu-items">
+        {#each section.items as item (item.id)}
+          {@const Icon = iconForAction[item.id]}
+          {@const disabled = item.disabled ?? false}
+          <!-- aria-disabled, not the native disabled attribute: a natively
+               disabled button is removed from the tab order and the a11y tree,
+               so a screen-reader user could not reach it to learn why it is
+               unavailable. Matching the desktop dropdown (bits-ui keeps disabled
+               items focusable and aria-disabled), the row stays focusable and
+               runAction no-ops the activation. -->
+          <button
+            type="button"
+            class="menu-item"
+            aria-disabled={disabled}
+            data-testid="mobile-menu-{item.id}"
+            onclick={() => runAction(item.id, disabled)}
+          >
+            <span class="menu-icon" aria-hidden="true">
+              {#if Icon}
+                <Icon size={ICON_SIZE.md} />
+              {/if}
+            </span>
+            <span class="menu-label">{item.label}</span>
+          </button>
+        {/each}
+      </div>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .mobile-menu-sheet {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding: var(--space-1) var(--space-1) var(--space-4);
+  }
+
+  .menu-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .section-heading {
+    margin: 0 0 var(--space-1);
+    padding: 0 var(--space-1);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: var(--letter-spacing-wide);
+    text-transform: uppercase;
+    color: var(--colour-text-muted);
+  }
+
+  .menu-items {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    min-height: var(--touch-target-min);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--colour-text);
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    text-align: left;
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .menu-item:hover:not([aria-disabled="true"]) {
+    background: var(--colour-surface-hover);
+  }
+
+  .menu-item:active:not([aria-disabled="true"]) {
+    scale: 0.99;
+  }
+
+  .menu-item:focus-visible {
+    outline: 2px solid var(--colour-selection);
+    outline-offset: -2px;
+  }
+
+  .menu-item[aria-disabled="true"] {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  .menu-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: var(--colour-text-muted);
+  }
+
+  .menu-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .menu-item {
+      transition: none;
+    }
+
+    .menu-item:active:not([aria-disabled="true"]) {
+      scale: 1;
+    }
+  }
+</style>

--- a/src/lib/components/mobile/mobile-menu-projection.ts
+++ b/src/lib/components/mobile/mobile-menu-projection.ts
@@ -1,0 +1,29 @@
+/**
+ * Mobile app-menu projection (#2597).
+ *
+ * The mobile menu sheet is a touch presentation of the same app menu the
+ * desktop dropdown renders (#2596). To keep the sheet provably registry-driven,
+ * it binds to this thin pass-through rather than calling getAppMenuSections with
+ * its own arguments inline. There is exactly one source of truth (the registry
+ * projection) and one place the sheet reads it, so the sheet cannot hardcode an
+ * item set, ordering, label, or icon: adding or reordering a registry action
+ * updates the sheet with zero changes in the component.
+ *
+ * This is deliberately not a new projection. It forwards to getAppMenuSections
+ * unchanged; the indirection exists only so the contract (sheet renders exactly
+ * the projection, in both storage modes, disabled states included) is unit
+ * testable as behaviour without querying the rendered DOM.
+ */
+import {
+  getAppMenuSections,
+  type ActionEnabledContext,
+  type AppMenuSection,
+} from "$lib/actions/registry";
+import type { StorageMode } from "$lib/storage";
+
+export function projectMobileMenuSections(
+  mode: StorageMode,
+  context?: ActionEnabledContext,
+): AppMenuSection[] {
+  return getAppMenuSections(mode, context);
+}

--- a/src/lib/stores/dialogs.svelte.ts
+++ b/src/lib/stores/dialogs.svelte.ts
@@ -33,6 +33,7 @@ export type SheetId =
   | "layouts"
   | "racks"
   | "view"
+  | "menu"
   | "yamlEditor";
 
 export interface DeleteTarget {

--- a/src/tests/mobile-menu-sheet.test.ts
+++ b/src/tests/mobile-menu-sheet.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { getAppMenuSections } from "$lib/actions/registry";
+import { iconForAction } from "$lib/components/icons/action-icons";
+import { projectMobileMenuSections } from "$lib/components/mobile/mobile-menu-projection";
+
+/**
+ * The mobile menu sheet (#2597) is a touch presentation of the same app-menu
+ * projection the desktop dropdown renders (#2596). The contract that matters is
+ * that the sheet is registry-driven: it has no hardcoded item set, ordering,
+ * labels, or icons of its own. These tests pin that contract so adding or
+ * reordering a registry action updates the mobile sheet with zero changes here.
+ *
+ * They assert the data the sheet binds to (projectMobileMenuSections), not its
+ * DOM. The component renders exactly this projection, so the projection IS the
+ * sheet's behaviour.
+ */
+describe("mobile menu sheet projection", () => {
+  it("renders exactly the app-menu projection ids for each storage mode", () => {
+    for (const mode of ["browser", "server"] as const) {
+      const sheetIds = projectMobileMenuSections(mode).flatMap((s) =>
+        s.items.map((i) => i.id),
+      );
+      const registryIds = getAppMenuSections(mode).flatMap((s) =>
+        s.items.map((i) => i.id),
+      );
+      // The sheet never adds, drops, or reorders an item relative to the shared
+      // projection; it is a pass-through of getAppMenuSections.
+      expect(sheetIds).toEqual(registryIds);
+    }
+  });
+
+  it("renders sections in the same grouping and order as the projection", () => {
+    for (const mode of ["browser", "server"] as const) {
+      const sheetGroups = projectMobileMenuSections(mode).map((s) => s.group);
+      const registryGroups = getAppMenuSections(mode).map((s) => s.group);
+      expect(sheetGroups).toEqual(registryGroups);
+    }
+  });
+
+  it("carries a visible heading for every section it renders", () => {
+    // The sheet is the view that uses the headings #2596 added; a section
+    // without one would render a blank title.
+    for (const mode of ["browser", "server"] as const) {
+      for (const section of projectMobileMenuSections(mode)) {
+        expect(
+          section.heading,
+          `group "${section.group}" has no heading`,
+        ).toBeTruthy();
+      }
+    }
+  });
+
+  it("resolves an icon for every item it renders", () => {
+    // The sheet draws an icon per row from iconForAction; a missing icon would
+    // leave a broken-looking gap. Every projected item must resolve one.
+    for (const mode of ["browser", "server"] as const) {
+      for (const section of projectMobileMenuSections(mode)) {
+        for (const item of section.items) {
+          expect(
+            iconForAction[item.id],
+            `menu item "${item.id}" has no icon`,
+          ).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it("inherits disabled state from the projection's enabledWhen", () => {
+    // Rack-dependent items (share, view-yaml) are disabled when no rack exists.
+    // The sheet does not recompute this; it shows the projection's disabled flag.
+    const noRacks = {
+      hasSelection: false,
+      isDeviceSelected: false,
+      isRackSelected: false,
+      canUndo: false,
+      canRedo: false,
+      hasRacks: false,
+      mode: "browser" as const,
+      canMoveDeviceSlot: false,
+    };
+    const items = projectMobileMenuSections("browser", noRacks).flatMap(
+      (s) => s.items,
+    );
+    expect(items.find((i) => i.id === "share")?.disabled).toBe(true);
+    expect(items.find((i) => i.id === "view-yaml")?.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## **User description**
Closes #2597

## What

Reimplements the app menu (the desktop dropdown behind the logo) as a mobile bottom sheet, rendered entirely from the shared registry projection added in #2596. No menu data is duplicated in the mobile component.

## How

- `MobileMenuSheet.svelte`: the sheet body, rendered inside the shared `Dialog` wrapper (scrim, focus trap, Escape, swipe-to-dismiss) exactly like the other mobile sheets. It renders `getAppMenuSections(mode, context)`: each section's `heading` (the view that uses the headings #2596 added) and its items, resolving each item's icon via `iconForAction[item.id]`. Disabled items (from the projection's `enabledWhen`) render `aria-disabled` and no-op on activation. Shortcuts are omitted on mobile.
- `mobile-menu-projection.ts`: a thin, documented pass-through to `getAppMenuSections`. It is the single seam the sheet binds to, which makes the registry-driven contract unit-testable without querying the DOM.
- Wiring: a new `"menu"` sheet key in `dialogs.svelte.ts`; `DialogOrchestrator` renders the sheet and dispatches each chosen `ActionId` through the same `createActionDispatch()` spine the command palette and keyboard use, so a command behaves identically across the dropdown, the palette, the keyboard, and the sheet.
- Trigger: a hamburger button in the mobile top bar (the Toolbar's left lane), beside the search button per the mockup, with `aria-label`, `aria-haspopup="dialog"`, and `aria-expanded`. It uses the focus-before-open pattern so focus restores to it on close. On desktop the logo-lockup dropdown is unchanged.
- `IconMenuBold.svelte`: the hamburger glyph (Phosphor List, bold).

## Scope

Per the issue, this builds only the menu trigger and sheet. The mobile top bar already exists (the Toolbar renders on mobile with the search button, centred layout name, and storage chip); those items are left exactly as-is. The hamburger replaces the desktop dropdown on the mobile left lane only.

## Tests

`mobile-menu-sheet.test.ts` pins the registry-driven contract: the sheet's projected action ids, grouping, headings, icons, and disabled states equal `getAppMenuSections` for both storage modes. Adding or reordering a registry action requires zero changes in the sheet. No "renders without throwing" test, no DOM/class/length-literal assertions.

Gates: `npm run lint`, `npm run test:run` (2906 tests), `npm run build`, `npx prettier --check .` all pass.

## A11y

>=44px touch targets, focus restoration on close, ESC/scrim/swipe dismiss via the shared `Dialog`, labelled trigger, and disabled items kept focusable + `aria-disabled` (matching the desktop dropdown) so they stay screen-reader discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSN57q3mAc2c6CvdccBSkb


___

## **CodeAnt-AI Description**
**Add a mobile bottom-sheet app menu with shared actions**

### What Changed
- On mobile, the app menu now opens from a hamburger button in the top bar instead of the desktop-style dropdown.
- The mobile menu is shown as a bottom sheet with section headings, action icons, and disabled items where actions are unavailable.
- Choosing a menu item runs the same action flow used by the desktop menu, command palette, and keyboard shortcuts, so commands behave the same across all surfaces.
- The sheet and trigger include mobile-friendly touch targets, focus handling, and a visible open/closed state.
- Added tests to confirm the mobile menu matches the shared app-menu sections, keeps the same grouping and order, shows headings and icons, and reflects disabled states.

### Impact
`✅ Easier menu use on phones`
`✅ Consistent app actions across mobile and desktop`
`✅ Clearer unavailable menu items`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
