### PR TITLE
feat: rename app-menu group headings for clarity (#2611)

### DIFF
--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -707,11 +707,11 @@ const APP_MENU_GROUP_ORDER: AppMenuGroup[] = [
  */
 const APP_MENU_GROUP_HEADINGS: Record<AppMenuGroup, string> = {
   layout: "Layout",
-  output: "Share",
-  "layout-data": "Backups",
+  output: "Export & Share",
+  "layout-data": "Data",
   devices: "Devices",
   workspace: "Workspace",
-  app: "About",
+  app: "App",
 };
 
 /** A single projected app-menu item. */


### PR DESCRIPTION
## **User description**
## What

Renames three app-menu group headings whose names did not cover their group's contents:

| Group | Items | Before | After |
| --- | --- | --- | --- |
| `output` | Export image, Share | Share | Export & Share |
| `layout-data` | Export layout (.zip), Save As (ZIP), Restore from backup (.zip), View YAML | Backups | Data |
| `app` | About and shortcuts, Settings | About | App |

Layout, Devices, and Workspace are unchanged.

## Why

These headings are rendered as visible section titles by the mobile app-menu sheet (#2597), so the old names ("Share", "Backups", "About") were live, misleading copy on mobile. The desktop dropdown renders dividers instead and is unaffected.

## Scope

One constant: `APP_MENU_GROUP_HEADINGS` in `src/lib/actions/registry.ts`. The registry test that asserts every group has a non-empty heading still passes (it checks existence, not values), so no test changes are needed.

## Verification

- `npx prettier --check` clean
- `npx eslint` clean
- `actions-registry.test.ts` + `mobile-menu-sheet.test.ts`: 63 passed

Closes #2611

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Rename app-menu section headings to match their contents**

### What Changed
- The mobile app menu now shows clearer section titles for grouped actions:
  - “Share” becomes “Export & Share”
  - “Backups” becomes “Data”
  - “About” becomes “App”
- The other section headings stay the same.

### Impact
`✅ Clearer app-menu labels`
`✅ Less confusion on mobile`
`✅ Easier to find export, backup, and settings actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
