### PR TITLE
fix: centre the storage chip content in the toolbar status zone

### DIFF
--- a/src/lib/components/Toolbar.svelte
+++ b/src/lib/components/Toolbar.svelte
@@ -260,10 +260,11 @@
   }
 
   /* The chip stretches to fill the right region so it reads as the panel's
-     status zone rather than a small pill pinned to the edge. */
+     status zone rather than a small pill pinned to the edge, with its icon and
+     label centred within that zone. */
   .toolbar-right :global(.storage-chip) {
     flex: 1 1 auto;
-    justify-content: flex-start;
+    justify-content: center;
   }
 
   /* Mobile centre lane: the current layout name as a plain centred label. It


### PR DESCRIPTION
## **User description**
On desktop the storage chip stretches to fill the fixed side-panel-width status zone but pinned its icon and label to the left edge. This centres the content within that zone.

Single change: `.toolbar-right :global(.storage-chip)` justify-content flex-start -> center in Toolbar.svelte. Mobile is unaffected (the chip is content-width and pinned to the right edge there).

Note: this shifts the desktop toolbar, so the visual regression baselines will need regenerating; I will update them on this branch if the check flags a diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Center the storage chip inside the toolbar status area**

### What Changed
- The storage chip on desktop now centers its icon and label within the right-side status area instead of lining up against the left edge
- Mobile layout is unchanged

### Impact
`✅ Centered toolbar status display`
`✅ Cleaner desktop header alignment`
`✅ Unchanged mobile layout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
