### PR TITLE
docs: spike #2620 Workers Static Assets research (#2029 prep)

### DIFF
--- a/docs/research/2620-codebase.md
+++ b/docs/research/2620-codebase.md
@@ -16,13 +16,13 @@ This documents the exact behaviour the current VPS/nginx prod deploy provides, s
 
 Current prod CSP (no script hashes — #2028 removed the only inline script, so `script-src 'self'` suffices; **there are no pinned hashes to carry across**, contrary to the spike issue's assumption):
 
-```
+```text
 Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';
 ```
 
 Plus, on every response (`deploy/security-headers.conf:11-22`):
 
-```
+```text
 X-Frame-Options: SAMEORIGIN
 X-Content-Type-Options: nosniff
 Strict-Transport-Security: max-age=31536000; includeSubDomains   # prod only (TLS terminated)

--- a/docs/research/2620-codebase.md
+++ b/docs/research/2620-codebase.md
@@ -1,0 +1,60 @@
+# Spike #2620 — Codebase context: what the CF Static Assets config must reproduce
+
+**Date:** 2026-06-26. Migrate-from contract for the `count.racku.la` prod cutover (#2029).
+
+This documents the exact behaviour the current VPS/nginx prod deploy provides, so the Cloudflare Workers Static Assets config reproduces it byte-for-byte. Source of truth files cited inline.
+
+## Files examined
+
+- `deploy/security-headers.conf` — Docker/prod security headers + CSP (single source of truth).
+- `deploy/lxc/security-headers.conf` — LXC variant (same CSP, no HSTS since LXC serves HTTP).
+- `deploy/nginx.conf.template` — prod nginx routing, caching, SPA fallback, API proxy (API proxy is **not** used by public prod).
+- `e2e/playwright.smoke.config.ts` — post-deploy smoke harness (`SMOKE_TEST_URL`, optional CF Access service-token headers).
+- `vite.config.ts` — static SPA build to `dist/`, emits `version.json` and `config.js`; inputs `index.html` + `login.html`.
+
+## The header contract (must be reproduced on CF)
+
+Current prod CSP (no script hashes — #2028 removed the only inline script, so `script-src 'self'` suffices; **there are no pinned hashes to carry across**, contrary to the spike issue's assumption):
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';
+```
+
+Plus, on every response (`deploy/security-headers.conf:11-22`):
+
+```
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+Strict-Transport-Security: max-age=31536000; includeSubDomains   # prod only (TLS terminated)
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: geolocation=(), microphone=(), camera=()
+```
+
+The CF config must emit all of these by value. The C4 parity guard (#2032) asserts CSP/X-Frame-Options by value across prod CF headers, dev CF headers, and the two `security-headers.conf` files — so whatever mechanism CF uses (`_headers` file or a headers Worker, TBD by the external research) must produce an identical CSP string.
+
+## The cache contract (critical for deploy verification)
+
+From `deploy/nginx.conf.template`:
+
+- `/assets/*` (Vite-fingerprinted): `Cache-Control: public, immutable`, `expires 1y` (lines 85-92).
+- `index.html` / SPA shell (`location /`): `Cache-Control: no-cache` (lines 313-327). The shell must revalidate every load because it references the fingerprinted bundles by name; a cached shell pins the browser to the previous deploy's JS.
+
+This shell-no-cache / assets-immutable split is the single most important behaviour to preserve on CF, otherwise `wrangler versions deploy` would not be picked up by returning clients. The external research must confirm CF can express it.
+
+## SPA fallback
+
+nginx: `try_files $uri $uri/ /index.html` (line 316). CF equivalent: `assets.not_found_handling: "single-page-application"` (to be confirmed by external research). `/login.html` is a second build input but is **not** served on public prod (it is gated to local-auth mode only, `nginx.conf.template:305-310`); the robots.txt decision (#2029) is to `Disallow: /login` on prod only.
+
+## Prod is frontend-only (the #2029 "phantom AC" check)
+
+`deploy/nginx.conf.template` contains extensive `/api/` proxy + `auth_request` logic, but the **public prod** deploy runs with no API sidecar and `RACKULA_AUTH_MODE=none` — count.racku.la serves the static SPA only and has no server persistence. This confirms #2029's "user-data disposition at cutover" AC is trivially satisfied for prod: there is no server-saved data on count.racku.la. The only server data in the system is dev's `/opt/rackula/rackula-dev/data` (archived by #2134/#1986).
+
+Cross-ref to confirm at cutover: whether count.racku.la currently sits behind Cloudflare Access (Phase-1a scaffolding per `docs/superpowers/specs/2026-06-17-hosted-cloud-sync-auth-design.md`). If so, the prod smoke also needs CF Access service-token headers (the smoke config already supports them).
+
+## Smoke harness (reuse, do not rebuild)
+
+`e2e/playwright.smoke.config.ts`: when `SMOKE_TEST_URL` is set it runs the read-only `deploy-smoke.spec.ts` set (boot, render, `version.json` shape) against the live URL, and applies `CF-Access-Client-Id`/`CF-Access-Client-Secret` headers when present. This is the harness to point at the `wrangler versions` preview URL during the cutover smoke, and to schedule on a cron against count.racku.la during the #1986 soak window.
+
+## Implication for the deploy job
+
+The prod CF deploy replaces `.github/workflows/deploy-prod.yml` (currently: tag `v*` -> sync `docker-compose.yml` to VPS -> `docker compose up`). The new job: build the SPA (`npm ci && npm run build` -> `dist/`), then `wrangler versions upload` -> smoke the version preview URL -> `wrangler versions deploy`. `version.json` (emitted by `vite.config.ts`) is the smoke's deploy-identity check.

--- a/docs/research/2620-external.md
+++ b/docs/research/2620-external.md
@@ -92,7 +92,7 @@ For a typical SPA the default `html_handling` is fine; the SPA behaviour is driv
 
 **Path matching:** `*` (splat) greedily matches all characters; `:placeholder_name` matches all characters except the path delimiter; absolute URLs are supported (HTTPS only, no port) (<https://developers.cloudflare.com/workers/static-assets/headers/>).
 
-**Precedence / combining:** "An incoming request which matches multiple rules' URL patterns will inherit all rules' headers." A header can be removed by prefixing its name with `! `. "If a header is applied twice in the `_headers` file, the values are joined with a comma separator." (<https://developers.cloudflare.com/workers/static-assets/headers/>).
+**Precedence / combining:** "An incoming request which matches multiple rules' URL patterns will inherit all rules' headers." A header can be removed by prefixing its name with `!` (e.g. `! X-Frame-Options`). "If a header is applied twice in the `_headers` file, the values are joined with a comma separator." (<https://developers.cloudflare.com/workers/static-assets/headers/>).
 
 **Limits** (<https://developers.cloudflare.com/workers/platform/limits/> and the headers page):
 
@@ -213,15 +213,15 @@ This template is sufficient for `wrangler deploy`, `wrangler versions upload`, a
 
 By default both the HTML shell and hashed assets get the same conservative `max-age=0, must-revalidate`, so clients always revalidate. That default already makes deploy verification safe: a new shell is picked up on the next request because the browser revalidates.
 
-**Yes — you can split caching (immutable `/assets/*` + revalidated `index.html`) via `_headers`** (<https://developers.cloudflare.com/workers/static-assets/headers/>). Vite emits content-hashed filenames under `assets/`, which are safe to cache immutably; the HTML shell should revalidate so a new deploy is seen immediately:
+**Yes — you can split caching (immutable `/assets/*` + revalidated `index.html`) via `_headers`** (<https://developers.cloudflare.com/workers/static-assets/headers/>). Vite emits content-hashed filenames under `assets/`, which are safe to cache immutably; the HTML shell should revalidate so a new deploy is seen immediately. The shell entries below use `Cache-Control: no-cache` to match the current nginx SPA-shell directive (`deploy/nginx.conf.template`, `location /`) exactly; CF's default `public, max-age=0, must-revalidate` is semantically equivalent (both force revalidation) but is not byte-identical:
 
 ```text
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 /index.html
-  Cache-Control: public, max-age=0, must-revalidate
+  Cache-Control: no-cache
 /
-  Cache-Control: public, max-age=0, must-revalidate
+  Cache-Control: no-cache
 ```
 
 This gives long-lived caching for fingerprinted bundles while guaranteeing the SPA shell (and root path) is re-fetched/revalidated on every deploy, so Playwright smoke tests and real clients always pick up the new version. The default behaviour (everything `max-age=0, must-revalidate`) is already smoke-test-friendly; the `_headers` override above is the performance optimization for repeat visitors (<https://developers.cloudflare.com/workers/static-assets/headers/>).
@@ -248,7 +248,7 @@ This gives long-lived caching for fingerprinted bundles while guaranteeing the S
 
 ```text
 /*
-  X-Frame-Options: DENY
+  X-Frame-Options: SAMEORIGIN
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: ...
@@ -256,7 +256,7 @@ This gives long-lived caching for fingerprinted bundles while guaranteeing the S
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 /index.html
-  Cache-Control: public, max-age=0, must-revalidate
+  Cache-Control: no-cache
 ```
 
 CI deploy (items 5 + 6): token = "Edit Cloudflare Workers" template scoped to the one account + `racku.la` zone; flow = `wrangler versions upload` -> Playwright against the version preview URL -> `wrangler versions deploy` -> `wrangler rollback` on failure.

--- a/docs/research/2620-external.md
+++ b/docs/research/2620-external.md
@@ -1,0 +1,280 @@
+# Cloudflare Workers Static Assets — External Research (Issue #2620)
+
+Accessed 2026-06-26. All figures verified against official Cloudflare developer docs (`developers.cloudflare.com`). Every factual claim is inline-cited with the source URL. Where a fact could not be confirmed from official docs, it is flagged explicitly rather than guessed.
+
+Goal: gather everything needed to author a production `wrangler` config and a GitHub Actions deploy job for hosting a pure static Vite SPA (`dist/`, no SSR, no prod Worker logic) at the custom domain `count.racku.la`, on the **Workers Static Assets** product (not Pages).
+
+---
+
+## 1. Assets-only Worker config (`wrangler.jsonc`)
+
+**Worker script is optional for assets-only projects.** The `assets` configuration reference states plainly: "The `main` key is optional for assets-only Workers." (<https://developers.cloudflare.com/workers/wrangler/configuration/>). The Static Assets overview corroborates the runtime behaviour: if a request does not match an asset and no Worker script is present, a `404 Not Found` response is returned (<https://developers.cloudflare.com/workers/static-assets/>). So you can deploy with **no `main` entry at all** for a pure SPA.
+
+`assets` block fields (from <https://developers.cloudflare.com/workers/wrangler/configuration/> and <https://developers.cloudflare.com/workers/static-assets/binding/>):
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `directory` | yes (for non-Vite) | "The folder of static assets to be served. For many frameworks, this is the `./public/`, `./dist/`, or `./build/` folder." (<https://developers.cloudflare.com/workers/static-assets/binding/>) |
+| `binding` | no | Programmatic access via `env.ASSETS.fetch()`. "Optional, and only useful when a Worker script is set with `main`." For assets-only you can omit it. (<https://developers.cloudflare.com/workers/wrangler/configuration/>) |
+| `html_handling` | no | Default `"auto-trailing-slash"`. See item 2. |
+| `not_found_handling` | no | Default `"none"`. See item 2. |
+| `run_worker_first` | no | Default `false`. Not needed for assets-only. |
+
+`compatibility_date` is a required top-level field; the docs advise setting it to today's date (<https://developers.cloudflare.com/workers/static-assets/>).
+
+**Concrete minimal config for a Vite `dist/` SPA, assets-only (no `main`):**
+
+```jsonc
+{
+  "name": "rackula",
+  "compatibility_date": "2026-06-26",
+  "assets": {
+    "directory": "./dist",
+  },
+}
+```
+
+Deploy with `npx wrangler deploy` (single-step; see item 5 for the two-step versioned workflow). Note: `binding`/`ASSETS` is intentionally omitted because there is no Worker script to call `env.ASSETS.fetch()`.
+
+---
+
+## 2. SPA fallback routing (deep links)
+
+To serve `index.html` for unknown paths (client-side routes / deep links), set `not_found_handling` to `"single-page-application"`. Documented behaviour: "When an incoming request does not match a file in the `assets.directory`, Workers will serve the contents of the `/index.html` file with a `200 OK` status." (<https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/>).
+
+**`not_found_handling` values** (default `"none"`) (<https://developers.cloudflare.com/workers/wrangler/configuration/>):
+
+- `"single-page-application"` — unmatched request returns `200 OK` with `/index.html`. Use this for the SPA.
+- `"404-page"` — serves a custom `404.html` for unmatched requests (looks up the nearest `404.html` up the path tree). This is the option that wires up a custom 404 page; it is mutually exclusive with the SPA fallback.
+- `"none"` (default) — returns a bare `404` with no body.
+
+**`html_handling` values** (default `"auto-trailing-slash"`), which control redirects/rewrites of HTML requests (<https://developers.cloudflare.com/workers/wrangler/configuration/>):
+
+- `"auto-trailing-slash"` (default)
+- `"force-trailing-slash"`
+- `"drop-trailing-slash"`
+- `"none"`
+
+For a typical SPA the default `html_handling` is fine; the SPA behaviour is driven entirely by `not_found_handling`.
+
+**Exact SPA config:**
+
+```jsonc
+{
+  "name": "rackula",
+  "compatibility_date": "2026-06-26",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+  },
+}
+```
+
+**Interaction with a custom `404.html`:** the SPA mode does not serve `404.html`; it always returns `index.html` with `200`. If you instead want a real 404 page, use `not_found_handling: "404-page"` (you cannot have both). For an SPA that owns its own routing/error UI, `"single-page-application"` is correct (<https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/>).
+
+**Note on navigation requests (minor):** with compatibility date `2025-04-01`+ (or the `assets_navigation_prefers_asset_serving` flag), navigation requests bypass any Worker script and are served assets directly, which "reduces billable invocations of your Worker script" (<https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/>). For an assets-only deploy there is no Worker, so this is moot, but it is the current behaviour and worth knowing if a Worker is ever added.
+
+---
+
+## 3. Custom HTTP headers (`_headers` file)
+
+**Yes — Workers Static Assets natively supports a Pages-style `_headers` file.** "`_headers` and `_redirects` files are supported natively in Workers with static assets." The file is "a plain text file called `_headers` without a file extension, in the static asset directory of your project" (i.e. inside `dist/`). "This file will not itself be served as a static asset, but will instead be parsed by Workers and its rules will be applied to static asset responses." (<https://developers.cloudflare.com/workers/static-assets/headers/>).
+
+**Syntax** (<https://developers.cloudflare.com/workers/static-assets/headers/>): multi-line blocks; the first line is a URL or URL pattern, followed by indented `Name: Value` lines:
+
+```text
+/secure/page
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+/static/*
+  Access-Control-Allow-Origin: *
+```
+
+**Path matching:** `*` (splat) greedily matches all characters; `:placeholder_name` matches all characters except the path delimiter; absolute URLs are supported (HTTPS only, no port) (<https://developers.cloudflare.com/workers/static-assets/headers/>).
+
+**Precedence / combining:** "An incoming request which matches multiple rules' URL patterns will inherit all rules' headers." A header can be removed by prefixing its name with `! `. "If a header is applied twice in the `_headers` file, the values are joined with a comma separator." (<https://developers.cloudflare.com/workers/static-assets/headers/>).
+
+**Limits** (<https://developers.cloudflare.com/workers/platform/limits/> and the headers page):
+
+- Maximum **100** `_headers` rules (also listed as "`_headers` rules: 100" in Platform Limits).
+- Each line in `_headers` has a **2,000-character** limit.
+- (For reference, `_redirects` allows 2,000 static redirects, 100 dynamic redirects, 1,000 characters per rule.)
+
+**Security headers — confirmed settable on served HTML:** Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy can all be set via `_headers` and are applied to static asset responses (including the HTML shell) (<https://developers.cloudflare.com/workers/static-assets/headers/>).
+
+**Important limitation (does not affect this assets-only project):** "Custom headers defined in the `_headers` file are not applied to responses generated by your Worker code, even if the request URL matches a rule." If you use an SSR framework, `run_worker_first`, or any Worker script, you must set those headers in the Worker code instead (<https://developers.cloudflare.com/workers/static-assets/headers/>). Since `count.racku.la` is assets-only, the `_headers` file is sufficient — no Worker script is required to set CSP and friends.
+
+So for Rackula: drop a `_headers` file into `dist/` (or have Vite emit it to the build output) and you get CSP/X-Frame-Options/etc. without writing any Worker. This is the recommended path; the Worker-script alternative (`run_worker_first` + a fetch handler) is unnecessary here.
+
+---
+
+## 4. Custom domain attach (`count.racku.la`)
+
+Use a **Custom Domain** (not a Route). Custom Domains "point all paths of a domain or subdomain to your Worker," and are the recommended option when the Worker is the application's origin/server for the whole hostname (<https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>). Routes, by contrast, attach a Worker to specific path patterns (`example.com/*`) on an existing record and are for finer-grained control.
+
+**Declared in `wrangler.jsonc`** with `custom_domain: true` (<https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>):
+
+```jsonc
+{
+  "name": "rackula",
+  "compatibility_date": "2026-06-26",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+  },
+  "routes": [{ "pattern": "count.racku.la", "custom_domain": true }],
+}
+```
+
+Running `npx wrangler deploy` creates the Custom Domain.
+
+**DNS + TLS handled automatically:** "Cloudflare will create DNS records and issue necessary certificates on your behalf." Creating a Custom Domain "will also generate an Advanced Certificate on your target zone for your target hostname" with default settings. You do not edit DNS or manage certs manually (<https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>).
+
+**Same-account requirement (satisfied — `racku.la` is on this account):** "You cannot create a Custom Domain on a hostname with an existing CNAME DNS record or on a zone you do not own." Practical implication: there must not be a pre-existing `count.racku.la` CNAME in the zone, or the create will fail (<https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>).
+
+**Proxied / orange-cloud:** the docs state the auto-created record routes traffic to the Worker, but they do **not** explicitly use the "proxied / orange-cloud" label for the Custom Domain record. By design, Custom Domain traffic flows through Cloudflare's edge to the Worker (it is a Cloudflare-managed record, not a user-editable DNS-only entry), so it is effectively proxied. I could not find an official sentence that uses the orange-cloud terminology for Custom Domains — flagging this as not explicitly documented (<https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>).
+
+**Propagation/activation:** the Custom Domains page does not state an activation time; it only notes certificate provisioning happens automatically. There is typically a short delay for cert issuance, but no official figure is documented — do not assume an SLA. Flagging as not documented (<https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>).
+
+**Cleanup caveat:** deleting a Custom Domain does **not** auto-delete its Advanced Certificate; remove it manually from the dashboard (<https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>).
+
+---
+
+## 5. Versioned deploys + rollback model
+
+**Two-step workflow** (<https://developers.cloudflare.com/workers/configuration/versions-and-deployments/>):
+
+1. `wrangler versions upload` — "creates a version without immediate deployment." It "uploads a new version of your Worker and returns a preview URL for each version uploaded" (<https://developers.cloudflare.com/workers/configuration/previews/>).
+2. `wrangler versions deploy` — deploys a previously-uploaded version, "all at once or gradually" (interactive prompt for split percentages) (<https://developers.cloudflare.com/workers/configuration/versions-and-deployments/>).
+
+**`wrangler deploy` differs:** it is the single-step path — "a new version that is automatically deployed to 100% of traffic" in one operation (<https://developers.cloudflare.com/workers/configuration/versions-and-deployments/>).
+
+**Preview URLs** (<https://developers.cloudflare.com/workers/configuration/previews/>):
+
+- Format: `<VERSION_PREFIX>-<WORKER_NAME>.<SUBDOMAIN>.workers.dev`.
+- "Every time you create a new version of your Worker, a unique static version preview URL is generated automatically" — so each version's preview URL is **stable and unique per version**, which makes it directly smoke-testable with Playwright before promoting.
+- Enabled by default when `workers_dev` is enabled; controllable via `"preview_urls": true|false` in `wrangler.jsonc`.
+- Optional **aliased preview URLs** (`--preview-alias`) give a persistent human-readable alias to a version.
+- Caveat: preview URLs are only available for versions uploaded after 2024-09-25.
+
+**Versions include static assets — confirmed.** A version "tracks historical changes to bundled code, static assets and changes to configuration like bindings and compatibility date and compatibility flags over time" (<https://developers.cloudflare.com/workers/configuration/versions-and-deployments/>). This is the key fact: an assets-only deploy still produces a normal Worker _version_, so the upload -> preview-URL -> deploy -> rollback machinery applies.
+
+**Assets-only caveat — flagged.** The docs confirm static assets are part of a version, but they do **not** publish an explicit "assets-only project" example for `wrangler versions upload`/preview URLs. The only documented restriction on versioned uploads is "Service worker syntax is not supported for versions that are uploaded through `wrangler versions upload`" — that constraint is about Worker _code format_ and does not apply to an assets-only project that ships no code (<https://developers.cloudflare.com/workers/configuration/versions-and-deployments/>). Practical read: versioned uploads + preview URLs should work for assets-only, but because there is no official assets-only worked example, treat the preview-URL smoke test as something to verify hands-on during the spike rather than as a documented guarantee. (Also note item 7: preview URLs depend on `workers_dev`/`preview_urls` being enabled.)
+
+**Rollback** (<https://developers.cloudflare.com/workers/configuration/versions-and-deployments/rollbacks/>):
+
+- `wrangler rollback` (optionally with a version ID) — "Rolling back to a previous version of your Worker will immediately create a new deployment ... [and] become the active deployment across all your deployed routes and domains." Rollback is **instant** (all-at-once), not gradual.
+- You can roll back to "the 100 most recently published versions." In interactive mode you pick from up to 100 recent versions; for older ones, "specify the version ID directly on the command line."
+- You can equivalently re-deploy any prior version with `wrangler versions deploy <version-id>`.
+- Caveat: rollback does **not** revert connected resources (KV/D1/R2 bindings, data structures). Not relevant for an assets-only SPA with no bindings.
+
+For Rackula CI, the clean model is: `wrangler versions upload` -> Playwright smoke test against the version preview URL -> `wrangler versions deploy` (promote 100%) -> on failure, `wrangler rollback` to the prior version.
+
+---
+
+## 6. Minimal API token permissions
+
+The official Cloudflare GitHub Actions guide directs you to the **"Edit Cloudflare Workers"** custom token template and to scope it to only the target account (and zone) (<https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/>).
+
+**"Edit Cloudflare Workers" template contents** (<https://developers.cloudflare.com/fundamentals/api/reference/template/>):
+
+- Account-level: **Workers Scripts Write**, **Workers KV Storage Write**, **Workers R2 Storage Write**, **Account Settings Read**, **User Details Read**, **User Memberships Read**.
+- Zone-level: **Workers Routes Write**, **Workers Tail Read**.
+
+This template is sufficient for `wrangler deploy`, `wrangler versions upload`, and `wrangler versions deploy`, and the zone-level **Workers Routes Write** covers attaching the Custom Domain (`routes` + `custom_domain: true`). For a truly minimal set you could prune to roughly: **Workers Scripts: Edit** (account) + **Account Settings: Read** (account) + **Workers Routes: Edit** (zone) + **Zone: Read** (zone, to resolve the zone for the custom domain). The docs do not publish a hand-tuned minimal list, so the safe, officially documented choice is the "Edit Cloudflare Workers" template scoped to the one account/zone (<https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/>).
+
+**"Workers Scripts" is account-wide — confirmed.** The permissions reference categorizes "Workers Scripts Read" and "Workers Scripts Edit" under **Account permissions** (scope `com.cloudflare.api.account`); they grant access to Workers scripts at the account level and **cannot be restricted to individual zones or specific resources** (i.e. not to a single Worker) (<https://developers.cloudflare.com/fundamentals/api/reference/permissions/>). The practical consequence: the deploy token can edit _every_ Worker in the selected account; the tightest scoping available is account selection, not per-Worker.
+
+**Custom-domain DNS/SSL token permissions — partially documented.** Cloudflare creates the DNS record and Advanced Certificate "on your behalf" when a Custom Domain is created (item 4), and the official GitHub Actions path uses only the "Edit Cloudflare Workers" template (whose zone permission is Workers Routes Write) to deploy Workers with custom domains. The docs do **not** explicitly state that a separate DNS:Edit or SSL/Certificates permission must be added to the token for custom-domain creation. Flagging as not definitively documented: if a custom-domain create fails with a permissions error in CI, add **Zone: Read** and, if needed, **DNS: Edit** / **SSL and Certificates: Edit** for the `racku.la` zone (<https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/>, <https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>).
+
+---
+
+## 7. Free-tier limits / headroom
+
+**Static asset requests are free and unmetered — they do NOT count against the 100,000 Workers requests/day free limit.** "Requests to static assets are free and unlimited. Requests to the Worker script (for example, in the case of SSR content) are billed according to Workers pricing." There is "no additional cost for storing Assets." (<https://developers.cloudflare.com/workers/static-assets/billing-and-limitations/>). The 100,000 requests/day Free-plan ceiling applies to Worker-script invocations (<https://developers.cloudflare.com/workers/platform/limits/>) — for an assets-only SPA there are none, so the daily limit is effectively not a concern. (The only way to hit it is to introduce `run_worker_first` patterns, which then count and can return `429` once exhausted (<https://developers.cloudflare.com/workers/static-assets/billing-and-limitations/>).)
+
+**Asset count and size limits** (<https://developers.cloudflare.com/workers/platform/limits/>, increase announced <https://developers.cloudflare.com/changelog/2025-09-02-increased-static-asset-limits/>):
+
+- Max assets per Worker version: **20,000 (Free plan)** / **100,000 (Paid plan)**.
+- Max individual asset size: **25 MiB** (both plans).
+- Total deployment / aggregate-size cap: **not documented** as a single number on the limits page (the governing limits are the per-version file count and the 25 MiB per-file size). Flagging as not stated.
+- Max file path length: **not documented** in the consulted pages. Flagging as not stated.
+
+**Headroom verdict:** a low-traffic public Vite SPA fits the Free tier comfortably. A typical Vite `dist/` is well under a few hundred files and far below 20,000; no individual bundle approaches 25 MiB; and static-asset request volume is free/unmetered regardless of traffic. The only Free-plan request ceiling (100k/day) does not apply because there is no Worker script (<https://developers.cloudflare.com/workers/static-assets/billing-and-limitations/>, <https://developers.cloudflare.com/workers/platform/limits/>).
+
+---
+
+## 8. Smoke-testability + caching
+
+**Default headers Workers attaches to static assets** (<https://developers.cloudflare.com/workers/static-assets/headers/>):
+
+- `Cache-Control: public, max-age=0, must-revalidate` (applied when the request has no `Authorization` or `Range` header). This tells the browser it may cache but must revalidate freshness every time before use.
+- An `ETag` (a hash of the file), so revalidation uses `If-None-Match` / `304` without re-downloading unchanged assets.
+
+By default both the HTML shell and hashed assets get the same conservative `max-age=0, must-revalidate`, so clients always revalidate. That default already makes deploy verification safe: a new shell is picked up on the next request because the browser revalidates.
+
+**Yes — you can split caching (immutable `/assets/*` + revalidated `index.html`) via `_headers`** (<https://developers.cloudflare.com/workers/static-assets/headers/>). Vite emits content-hashed filenames under `assets/`, which are safe to cache immutably; the HTML shell should revalidate so a new deploy is seen immediately:
+
+```text
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+/
+  Cache-Control: public, max-age=0, must-revalidate
+```
+
+This gives long-lived caching for fingerprinted bundles while guaranteeing the SPA shell (and root path) is re-fetched/revalidated on every deploy, so Playwright smoke tests and real clients always pick up the new version. The default behaviour (everything `max-age=0, must-revalidate`) is already smoke-test-friendly; the `_headers` override above is the performance optimization for repeat visitors (<https://developers.cloudflare.com/workers/static-assets/headers/>).
+
+---
+
+## Appendix: production config skeleton (synthesis)
+
+`wrangler.jsonc` for `count.racku.la` (assets-only SPA), combining items 1, 2, 4:
+
+```jsonc
+{
+  "name": "rackula",
+  "compatibility_date": "2026-06-26",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+  },
+  "routes": [{ "pattern": "count.racku.la", "custom_domain": true }],
+}
+```
+
+`dist/_headers` (Vite must emit this into the build output; items 3 + 8):
+
+```text
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: ...
+  Content-Security-Policy: ...
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+```
+
+CI deploy (items 5 + 6): token = "Edit Cloudflare Workers" template scoped to the one account + `racku.la` zone; flow = `wrangler versions upload` -> Playwright against the version preview URL -> `wrangler versions deploy` -> `wrangler rollback` on failure.
+
+### Sources
+
+- <https://developers.cloudflare.com/workers/static-assets/>
+- <https://developers.cloudflare.com/workers/static-assets/binding/>
+- <https://developers.cloudflare.com/workers/static-assets/routing/single-page-application/>
+- <https://developers.cloudflare.com/workers/static-assets/headers/>
+- <https://developers.cloudflare.com/workers/static-assets/billing-and-limitations/>
+- <https://developers.cloudflare.com/workers/wrangler/configuration/>
+- <https://developers.cloudflare.com/workers/configuration/routing/custom-domains/>
+- <https://developers.cloudflare.com/workers/configuration/versions-and-deployments/>
+- <https://developers.cloudflare.com/workers/configuration/versions-and-deployments/rollbacks/>
+- <https://developers.cloudflare.com/workers/configuration/previews/>
+- <https://developers.cloudflare.com/workers/platform/limits/>
+- <https://developers.cloudflare.com/changelog/2025-09-02-increased-static-asset-limits/>
+- <https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/>
+- <https://developers.cloudflare.com/fundamentals/api/reference/template/>
+- <https://developers.cloudflare.com/fundamentals/api/reference/permissions/>

--- a/docs/research/spike-2620-static-assets.md
+++ b/docs/research/spike-2620-static-assets.md
@@ -44,7 +44,7 @@ No `main` / Worker entry. (`preview_urls: true` is needed for the versioned-depl
 
 Reproduces `deploy/security-headers.conf` by value (asserted by the #2032 parity guard) and the cache split from `deploy/nginx.conf.template`:
 
-```
+```text
 /*
   Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';
   X-Frame-Options: SAMEORIGIN
@@ -68,7 +68,7 @@ Notes:
 
 Per the #2029 robots decision. Inject/select the prod variant at the wrangler build step (self-host keeps allow-all):
 
-```
+```text
 User-agent: *
 Disallow: /login
 ```

--- a/docs/research/spike-2620-static-assets.md
+++ b/docs/research/spike-2620-static-assets.md
@@ -1,0 +1,120 @@
+# Spike #2620: Workers Static Assets for prod SPA cutover
+
+**Date:** 2026-06-26 **Parent epic:** #1984 (Cloudflare frontend hosting). **Prep for:** #2029 (C1b prod cutover). **Milestone:** M018. **Component research:** [`2620-external.md`](2620-external.md) (Cloudflare docs, cited) · [`2620-codebase.md`](2620-codebase.md) (migrate-from contract).
+
+---
+
+## Executive summary
+
+Green light. Hosting `count.racku.la` on Cloudflare Workers Static Assets is a clean fit for our static Vite SPA, and every #2029 acceptance criterion is answerable from official docs:
+
+- **No Worker script needed.** Assets-only deploy is first-class (`main` is optional). Security headers come from a native `_headers` file in `dist/`; SPA routing comes from `assets.not_found_handling`.
+- **The header + cache contract is reproducible** exactly (CSP, X-Frame-Options, etc., plus the `/assets/*` immutable + shell no-cache split that makes new deploys land for returning clients).
+- **Versioned deploy + instant rollback** (`wrangler versions upload` -> smoke the per-version preview URL -> `wrangler versions deploy` -> `wrangler rollback`) covers the release runbook in #2029's AC.
+- **Free tier fits** with large headroom (static-asset requests are unmetered).
+- **One unavoidable security fact** confirmed: the CF API token's Workers Scripts permission is account-wide and cannot be scoped to a single Worker. This is exactly why we chose **one account + hardened gate** (GitHub Environment protection + minimal-perm token) rather than per-Worker isolation.
+
+Three things to verify hands-on during #2029 (none are blockers; all are quick): the preview-URL smoke for an assets-only project, custom-domain propagation/orange-cloud behaviour, and `_headers` duplicate-`Cache-Control` precedence between `/*` and `/assets/*`.
+
+---
+
+## Recommended deploy configuration
+
+### `wrangler.jsonc` (assets-only, prod)
+
+```jsonc
+{
+  "name": "rackula-prod",
+  "compatibility_date": "2026-06-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application", // unknown paths -> index.html (200) for client routing
+  },
+  "routes": [
+    { "pattern": "count.racku.la", "custom_domain": true }, // auto-creates the proxied DNS record + cert on the racku.la account
+  ],
+  "workers_dev": false,
+  "preview_urls": true, // required so `wrangler versions upload` yields a smoke-able per-version preview URL
+}
+```
+
+No `main` / Worker entry. (`preview_urls: true` is needed for the versioned-deploy smoke; confirm it does not expose a publicly-guessable prod-data URL — moot here since assets-only prod has no data.)
+
+### `public/_headers` (shipped into `dist/` by Vite)
+
+Reproduces `deploy/security-headers.conf` by value (asserted by the #2032 parity guard) and the cache split from `deploy/nginx.conf.template`:
+
+```
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Cache-Control: no-cache
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+```
+
+Notes:
+
+- Default `/*` is `no-cache` so every SPA route (all served as the shell) revalidates; `/assets/*` (Vite-fingerprinted) overrides to immutable. **Verify** during #2029 that the more-specific `/assets/*` rule overrides rather than appends the `Cache-Control` from `/*`; if CF combines duplicate headers, drop `Cache-Control` from `/*` and instead set it only on the shell entry. CF's default is already `public, max-age=0, must-revalidate` + ETag (smoke-safe), so even an imperfect split fails safe.
+- `Strict-Transport-Security` can alternatively be enabled at the CF edge (SSL/TLS -> Edge Certificates -> HSTS). Keeping it in `_headers` keeps the parity guard's by-value comparison simple. There is no script hash to carry: #2028 left `script-src 'self'` hash-free.
+- **#2030 (analytics) will need a CSP edit** here: the CF Web Analytics beacon loads from `static.cloudflareinsights.com` and posts to `cloudflareinsights.com`, both blocked by the current `script-src 'self'`/`connect-src 'self'`. That CSP relaxation is owned by #2030, not the cutover.
+
+### `public/robots.txt` (prod-only `Disallow: /login`)
+
+Per the #2029 robots decision. Inject/select the prod variant at the wrangler build step (self-host keeps allow-all):
+
+```
+User-agent: *
+Disallow: /login
+```
+
+### Deploy-job shape (replaces `deploy-prod.yml`)
+
+`ubuntu-latest`, no self-hosted runner: `npm ci && npm run build` (-> `dist/` with `_headers`, `robots.txt`, `version.json`) then:
+
+1. `wrangler versions upload` -> capture the version preview URL.
+2. `SMOKE_TEST_URL=<preview-url> npm run test:e2e:smoke` (full fail-closed `deploy-smoke.spec.ts`).
+3. On green: `wrangler versions deploy` (promote behind the GitHub Environment protection rule).
+4. Light re-check of `https://count.racku.la` (`version.json` matches the built commit).
+5. Rollback path: `wrangler rollback` or `wrangler versions deploy <previous-id>` (instant; up to 100 prior versions retained).
+
+---
+
+## Verdict on each #2029-prep acceptance criterion
+
+| # | Question | Verdict |
+| --- | --- | --- |
+| 1 | Assets-only `wrangler.jsonc` | Confirmed. `main` optional; minimal config above. |
+| 2 | SPA fallback | `assets.not_found_handling: "single-page-application"` returns `index.html` with 200 for unknown paths. |
+| 3 | `_headers` for CSP/security | Natively supported on Static Assets; applies to served HTML. 100 rules / 2000 chars per line (our CSP fits). No Worker needed. |
+| 4 | Custom-domain attach | `routes` + `custom_domain: true`; CF auto-creates proxied DNS + Advanced Cert on the same account as the `racku.la` zone. Remove any stale `count.racku.la` record first. |
+| 5 | Versions + rollback | `wrangler versions upload` -> stable per-version preview URL -> `wrangler versions deploy`; `wrangler rollback` is instant. Versions track static assets. Verify the preview-URL smoke hands-on (no official assets-only worked example). |
+| 6 | Minimal token perms | "Edit Cloudflare Workers" template scoped to the one account + `racku.la` zone. Workers Scripts is account-wide (cannot narrow). Add Zone:Read / DNS:Edit if custom-domain creation errors in CI. |
+| 7 | Free-tier headroom | Static-asset requests are free/unmetered (do not count against 100k/day Workers limit). 20,000 files/version, 25 MiB/file. A low-traffic SPA fits comfortably. |
+| 8 | Caching / smoke-safety | Default `public, max-age=0, must-revalidate` + ETag. Split via `_headers` for `/assets/*` immutable + shell revalidate so new shells are picked up immediately. |
+
+---
+
+## Items to verify hands-on during #2029 (quick, not blockers)
+
+1. **Preview-URL smoke for assets-only.** Run `wrangler versions upload` once and confirm the preview URL serves the SPA and is reachable by Playwright (needs `preview_urls: true`). This is the only versions-model uncertainty.
+2. **Custom-domain propagation + orange-cloud.** Not documented precisely; observe activation time and proxied state when binding `count.racku.la`.
+3. **`_headers` duplicate `Cache-Control` precedence** between `/*` and `/assets/*` (see note above).
+4. **Aggregate deployment-size cap / max file-path length** were not found in official docs; our `dist/` is small, so this is informational only.
+5. **CF Access on prod?** Confirm whether `count.racku.la` sits behind Cloudflare Access at cutover (Phase-1a scaffolding). If so, the prod smoke also needs the CF Access service-token headers the smoke config already supports.
+
+---
+
+## Decisions reinforced by this research
+
+- **One account + hardened gate** (vs separate accounts): the account-wide Workers Scripts permission is now confirmed from the token docs, so per-Worker token isolation was never available; the GitHub Environment protection rule on the deploy step is the real control.
+- **No Worker for prod:** keeps the cutover to static assets + `_headers` + `wrangler`, with no `nodejs_compat`/argon2/pino concerns (those belong to the dev Worker, #2133).
+
+## Decomposition
+
+No new implementation issues. This spike feeds the existing #2029 (cutover), #2032 (parity guard reads the same `_headers` CSP), and #2030 (owns the analytics CSP relaxation). #2029 is now research-ready; remaining unknowns are hands-on verifications listed above, not open design questions.


### PR DESCRIPTION
## **User description**
## Summary

Research spike #2620, de-risking the prod cutover (#2029) to Cloudflare Workers Static Assets. Verdict: green light, assets-only, no Worker script needed.

## Deliverables

- `docs/research/spike-2620-static-assets.md`: synthesized findings with a concrete `wrangler.jsonc` + `_headers` + deploy-job shape, a per-AC verdict table, and hands-on items.
- `docs/research/2620-external.md`: Cloudflare docs research, every claim inline-cited.
- `docs/research/2620-codebase.md`: the migrate-from header/cache contract the CF config must reproduce.

## Key findings

- `_headers` is native on Workers Static Assets and reproduces the CSP/security headers by value (feeds the #2032 parity guard). No Worker needed for prod.
- SPA deep links via `assets.not_found_handling: "single-page-application"`.
- `wrangler versions upload` -> preview-URL smoke -> `wrangler versions deploy` -> `wrangler rollback` covers the #2029 release runbook.
- Static-asset requests are free/unmetered; free tier fits with headroom.
- The Workers Scripts token permission is account-wide and cannot be narrowed, reinforcing the one-account + hardened-gate decision.

## Hands-on items for #2029 (not blockers)

Preview-URL smoke for an assets-only project, custom-domain propagation/orange-cloud behaviour, `_headers` duplicate-`Cache-Control` precedence, and whether `count.racku.la` sits behind CF Access at cutover.

Closes #2620. Prep for #2029. Part of M018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Document the Cloudflare Workers Static Assets cutover plan for the prod SPA

### What Changed
- Added a research summary showing that `count.racku.la` can be served as an assets-only Cloudflare deployment with no Worker script
- Documented the exact SPA routing, security headers, cache split, custom domain setup, rollback flow, and token permissions needed for the cutover
- Recorded the existing production header and caching behavior the new Cloudflare setup must match, plus the smoke test harness to reuse during deployment
- Noted the remaining items to verify during the cutover, including preview URL smoke testing, custom-domain activation, and header precedence

### Impact
`✅ Clearer cutover plan`
`✅ Safer production migration`
`✅ Fewer deployment unknowns`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
