### PR TITLE
docs: spike #2622 accurate depth model research (M021)

### DIFF
--- a/docs/research/2622-codebase.md
+++ b/docs/research/2622-codebase.md
@@ -1,0 +1,61 @@
+# Spike #2622: Codebase Map of Current Depth Model
+
+Source: Explore agent sweep of the Rackula codebase, 2026-06-26. Captures the current (categorical) depth model so the spike can plan the move to accurate physical depth.
+
+## Files Examined
+
+- `src/lib/schemas/index.ts:472-558` (`DeviceTypeSchema`), `:645-703` (rack schema): device + rack schema.
+- `src/lib/types/index.ts:558-627` (`PlacedDevice`), `:74-82` (`DisplayMode`): placement + display types.
+- `src/lib/stores/layout/device-actions.ts:~95` : default-face assignment on placement.
+- `src/lib/utils/collision.ts:95-106` (`doFacesCollide`): face-based collision.
+- `src/lib/utils/blocked-slots.ts:34-70` : opposite-face hatching for half-depth devices.
+- `src/lib/components/Rack.svelte`, `RackDevice.svelte:118`, `RackDualView.svelte`: SVG rendering.
+- `src/lib/components/ViewControls.svelte`, `EditPanelRack.svelte`: per-rack `show_rear` control.
+- `src/lib/data/starterLibrary.ts:35-189`: actual device data.
+- `src/lib/types/constants.ts`: `UNITS_PER_U = 6`.
+- `docs/reference/SPEC.md:77-96` (Mounting Model), `:132-139` (face-authoritative principle).
+
+## Existing Patterns
+
+### Depth is categorical, not measured
+- `is_full_depth?: boolean` on `DeviceTypeSchema` (`schemas/index.ts:472`). `undefined`/`true` = full-depth; `false` = half-depth. No `depth_mm` / numeric depth anywhere.
+- Width is also categorical: `slot_width: 1 | 2`. The entire physical model is half/full on two axes.
+
+### Face is authoritative for collision; is_full_depth only sets the default
+- `PlacedDevice.face: "front" | "rear" | "both"` (`types/index.ts:558`) drives collision.
+- Default-face logic (`device-actions.ts:95`): `face ?? (is_full_depth !== false ? "both" : (device.face ?? "front"))`.
+- `doFacesCollide` (`collision.ts:95`): `both` collides with everything; same face collides; opposite faces (front/rear) never collide.
+- SPEC `:132-139`: explicit `face` overrides `is_full_depth`; `is_full_depth` only determines the default face.
+
+### Rack has no depth dimension
+- Rack fields: `height` (U), `width: 10 | 19 | 21 | 23` (enum inches), `show_rear: boolean` (default true). No depth.
+- `show_rear` toggles dual front/rear rendering, not a physical depth.
+
+### Rendering is 2D elevation only
+- Front elevation standalone; `RackDualView.svelte` renders front + rear side-by-side. No side, top, or isometric view.
+- `DisplayMode = "label" | "image" | "image-label"` (the `I` key) controls device artwork, unrelated to depth.
+- `blocked-slots.ts:34-70`: half-depth devices already render hatching on the opposite face. Full-depth (`is_full_depth !== false`) are skipped (visible from both sides). This is the existing visual vocabulary for depth occupancy.
+
+### Carrier-first mounting
+- SPEC `:77-96`: sub-U-height, non-integer height, or sub-width devices mount inside a carrier, not on the rails. Full-width integer-U devices mount on rails.
+- Positions stored in internal units (`UNITS_PER_U = 6`); depth/face are categorical, not position-based.
+
+### Starter library uses half/full only
+- `is_full_depth: false` on `1u-pdu`, `2u-pdu`, `1u-fiber-patch-panel`, `1u-fan-panel`, `1u-cantilever-shelf`; omitted (full) on `1u-server`, `1u-switch`. No mm values anywhere.
+
+## Integration Points (where M021 lands)
+
+- `schemas/index.ts`: add device `depth_mm` and rack `depth_mm` (+ datum semantics). Zod 4.
+- `device-actions.ts:95`: depth is additive to existing `face` datum (front grows rearward, rear grows frontward, both spans).
+- `collision.ts:95`: refine the front/rear branch to an mm middle-collision (front extent + rear extent > rack usable depth).
+- `blocked-slots.ts:34`: extend the existing hatching into a front-elevation overhang / "exceeds depth" cue.
+- `RackDualView.svelte` + sibling: home for a new side/top depth view.
+- `starterLibrary.ts`: seed real per-device depth values.
+- `src/tests/fixtures/upgrade-corpus/`: migration fixture for prior-release layouts.
+
+## Constraints
+
+- Backward compatibility is a tested, first-class requirement (upgrade-safety harness). Any schema change is backward-compatible or ships a migration + a new upgrade-corpus fixture.
+- Rail positions stay whole-U integers; never reintroduce fractional rail positions.
+- Categorical -> mm is lossy on magnitude (cannot reconstruct 350mm from "full"), but direction is preserved by `face`. Migration must default magnitude without raising false warnings on previously-valid layouts.
+- Mixed units: `depth_mm` would be the first continuous physical measurement in a model where width is an enum of inches. Decide the unit policy deliberately.

--- a/docs/research/2622-external.md
+++ b/docs/research/2622-external.md
@@ -1,0 +1,299 @@
+# 2622 External Research: Accurate Depth Model and Visualization
+
+Industry and standards research for Rackula spike #2622 (move device depth from categorical half/full to accurate physical mm, and give racks a depth dimension).
+
+- Access date for all sources: 2026-06-26
+- NetBox source pinned to commit `4f4e97f1a67b2f46df9a7ccf8f74a7e28b3f88ce` (develop branch, fetched 2026-06-26)
+- "unverified" = could not confirm an exact figure against a primary source; treat as directional only.
+
+---
+
+## 1. NetBox Depth Model (Primary Reference)
+
+NetBox is the dominant open-source DCIM. The headline, schema-changing finding for this spike:
+
+> **NetBox device types have NO numeric depth field.** Device depth is modelled solely as a boolean `is_full_depth`. Rack depth is captured as `mounting_depth` (always millimetres) plus optional `outer_depth`, but NetBox does **not** validate device depth against rack depth, because there is no device depth to compare. `mounting_depth` is informational metadata only.
+
+This is confirmed three independent ways: the model source, the device-type-library JSON schema, and real device YAMLs (below). A feature request to add per-device depth (issue #14176) was **closed as "not planned."**
+
+### 1a. DeviceType fields (verbatim from `netbox/dcim/models/devices.py`)
+
+```python
+u_height = models.DecimalField(
+    max_digits=4, decimal_places=1, default=1.0,
+    verbose_name=_('height (U)')
+)
+is_full_depth = models.BooleanField(
+    default=True,
+    verbose_name=_('is full depth'),
+    help_text=_('Device consumes both front and rear rack faces.')
+)
+subdevice_role = models.CharField(
+    max_length=50, choices=SubdeviceRoleChoices, blank=True, null=True,
+    verbose_name=_('parent/child status'),
+    help_text=_('Parent devices house child devices in device bays. Leave blank '
+                'if this device type is neither a parent nor a child.')
+)
+airflow = models.CharField(
+    max_length=50, choices=DeviceAirflowChoices, blank=True, null=True,
+    verbose_name=_('airflow')
+)
+exclude_from_utilization = models.BooleanField(
+    default=False,
+    verbose_name=_('exclude from utilization'),
+    help_text=_('Devices of this type are excluded when calculating rack utilization.')
+)
+# weight + weight_unit are inherited from WeightMixin (no depth field anywhere)
+```
+
+- `u_height`: decimal, 0.5-step (max 4 digits, 1 decimal place), default 1.0.
+- `is_full_depth`: boolean, **default True**. Semantics: a full-depth device occupies BOTH the front and rear rack faces in its U-span; a non-full-depth device occupies only the face it is mounted on, leaving the opposite face free for another device.
+- `subdevice_role`: `SubdeviceRoleChoices` = `parent` / `child` (parent houses children in device bays). Blank = neither. This is NetBox's chassis/blade model, orthogonal to depth.
+- `airflow` (`DeviceAirflowChoices`): `front-to-rear`, `rear-to-front`, `left-to-right`, `right-to-left`, `side-to-rear`, `rear-to-side`, `bottom-to-top`, `top-to-bottom`, `passive`, `mixed`.
+- **No depth/length/mm field exists on DeviceType.** The only physical dimensions are `u_height` (RU) and `weight`.
+
+### 1b. How `is_full_depth` drives front/rear mounting (from `racks.py`)
+
+`Rack.get_rack_units()` selects which devices appear on a given face with:
+
+```python
+.filter(Q(face=face) | Q(device_type__is_full_depth=True))
+```
+
+So a device shows on a face if it is mounted on that face OR it is full-depth (full-depth = shows on both). `Device.face` (front/rear) plus `is_full_depth` is the entire depth model. There is no millimetre comparison anywhere in placement or validation logic.
+
+### 1c. Rack / RackType fields (verbatim from `netbox/dcim/models/racks.py`)
+
+`RackType` and `Rack` share a `RackBase(WeightMixin, PrimaryModel)` abstract base:
+
+```python
+width = models.PositiveSmallIntegerField(
+    choices=RackWidthChoices, default=RackWidthChoices.WIDTH_19IN,
+    verbose_name=_('width'), help_text=_('Rail-to-rail width')
+)
+u_height = models.PositiveSmallIntegerField(
+    default=RACK_U_HEIGHT_DEFAULT, verbose_name=_('height (U)'),
+    help_text=_('Height in rack units')
+)
+starting_unit = models.PositiveSmallIntegerField(
+    default=RACK_STARTING_UNIT_DEFAULT, verbose_name=_('starting unit'),
+    help_text=_('Starting unit for rack')
+)
+desc_units = models.BooleanField(
+    default=False, verbose_name=_('descending units'),
+    help_text=_('Units are numbered top-to-bottom')
+)
+outer_width  = PositiveSmallIntegerField(null=True, help_text='Outer dimension of rack (width)')
+outer_height = PositiveSmallIntegerField(null=True, help_text='Outer dimension of rack (height)')
+outer_depth  = PositiveSmallIntegerField(null=True, help_text='Outer dimension of rack (depth)')
+outer_unit = models.CharField(
+    max_length=50, choices=RackDimensionUnitChoices, blank=True, null=True
+)
+mounting_depth = models.PositiveSmallIntegerField(
+    verbose_name=_('mounting depth'), blank=True, null=True,
+    help_text=_('Maximum depth of a mounted device, in millimeters. For four-post '
+                'racks, this is the distance between the front and rear rails.')
+)
+max_weight = models.PositiveIntegerField(null=True, help_text='Maximum load capacity for the rack')
+# weight, weight_unit from WeightMixin
+```
+
+`RackType` adds `form_factor` (required); `Rack` adds `form_factor` (optional), `rack_type` FK, and an `airflow` field (`RackAirflowChoices`: `front-to-rear`, `rear-to-front`).
+
+Choice enums (from `netbox/dcim/choices.py`):
+
+- **`RackFormFactorChoices`**: `2-post-frame`, `4-post-frame`, `4-post-cabinet`, `wall-frame`, `wall-frame-vertical`, `wall-cabinet`, `wall-cabinet-vertical`.
+- **`RackWidthChoices`**: `10`, `19`, `21`, `23` (inches).
+- **`RackDimensionUnitChoices`**: `mm`, `in`. (Applies to `outer_*` only.)
+- **`RackAirflowChoices`**: `front-to-rear`, `rear-to-front`.
+
+### 1d. Critical: units and validation
+
+- `outer_width/height/depth` accept **mm or in** via `outer_unit`. Validation: setting any outer dimension requires `outer_unit` ("Must specify a unit when setting an outer dimension").
+- **`mounting_depth` is hard-coded to millimetres** (no unit selector). This inconsistency is the subject of open feature request #20942 ("allow rack type mounting depth to be either inches or millimeters") and display request #21178.
+- **NetBox performs NO "device deeper than rack" validation.** The `Rack.clean()` checks are: rack tall enough for installed devices, starting unit valid, outer dims require a unit, max_weight requires a unit, location/site consistency. Nothing compares any device dimension to `mounting_depth`. Because device depth is not modelled, `mounting_depth` is purely human-readable capacity info.
+- Issue #14176 ("Add Depth as Device Property") proposed deriving full-depth status dynamically from a device depth vs rack depth. **Closed as not planned.** So the categorical `is_full_depth` is, by deliberate NetBox design choice, the substitute for real depth.
+
+### 1e. devicetype-library YAML (what real device data actually contains)
+
+`netbox-community/devicetype-library` `schema/devicetype.json` top-level properties: `manufacturer, model, slug, part_number, u_height, is_full_depth, airflow, weight, weight_unit, front_image, rear_image, subdevice_role, is_powered, console-ports, console-server-ports, power-ports, power-outlets, interfaces, front-ports, rear-ports, module-bays, device-bays, inventory-items, description, comments`.
+
+> There is **no `depth`, `length`, or mm-dimension property** in the schema. The only physical dimensions a community device-type carries are `u_height` (RU) and `weight` + `weight_unit`.
+
+Example, `device-types/Dell/PowerEdge-R740.yaml`: `u_height: 2`, `is_full_depth: true`, `weight: 28.6`, `weight_unit: kg`, `airflow: front-to-rear`. No depth field. Confirms the corpus Rackula would import from has no depth data; depth would have to be sourced separately.
+
+**Implication for Rackula:** if Rackula adds a numeric `depth_mm` to devices, it goes beyond NetBox's data model and cannot be auto-populated from the NetBox device-type-library. Defaults must be seeded from vendor datasheets (Section 2) or inferred from `is_full_depth` + a per-category heuristic.
+
+---
+
+## 2. Real-World Device Depth Ranges (per category, cited examples)
+
+All depths are chassis depth (body), millimetres. Bezels, handles, PSU bulges and cable-management arms add to the in-rack footprint beyond these figures.
+
+### Rack servers
+- **Mainstream 2U (deep):** Dell PowerEdge R740 = **678.8 mm** without bezel, **715.5 mm** with bezel (Dell tech specs).
+- **Short-depth / edge 1U:** Supermicro SYS-510T-ML "Mini-1U short-depth" = 437 x 43 x **368 mm** (W x H x D) (Supermicro datasheet).
+- **Deep 4U GPU:** Supermicro AS-4125GS-TNRT = 17.2"W x 7"H x 29"D = **~737 mm** deep (Supermicro / eStore).
+- **Defensible range:** short-depth/edge **300-400 mm**; mainstream 1-2U **650-780 mm**; deep GPU/storage **750-900 mm** (verified to 737 mm; >800 mm class such as dense storage JBODs and DGX-class GPU systems exists but exact figure unverified here).
+
+### Network switches and routers
+- **Shallow access switch:** Ubiquiti USW-Pro-48 = 44.0 x 28.5 x 4.3 cm → depth **285 mm** (Ubiquiti tech specs).
+- **Deep PoE access switch:** Cisco Catalyst 9300-M = depth **449 mm** (C9300-24T-M) up to **564 mm** (high-PoE 48-port) (Cisco Meraki datasheet).
+- **Defensible range:** shallow access **200-300 mm**; deep PoE / fixed-config **450-600 mm**; modular chassis (Catalyst 9400/9600 class) deeper still (unverified, ~600-900 mm).
+
+### Patch panels
+- 1U 24-port copper panel body ≈ **44-50 mm** projection (e.g. 19"L x 1.97"W x 1.75"H; the ~2" "width" is the front-to-back body depth). Keystone variants ~65 mm.
+- **Defensible range:** **25-70 mm**. Essentially face-plane hardware; depth is negligible for collision but they still occupy a U.
+
+### PDUs
+- **0U vertical (most common in cabinets):** APC AP8853 Metered ZeroU = 1791 x 56 x **44 mm** (H x W x D). Mounts in the rear/side mounting channel, **outside the U-space**; its 44 mm depth is essentially irrelevant to U-depth planning but matters for rear-door clearance.
+- **Horizontal 1U/2U PDU:** shallow body, typically **<100-150 mm** deep but plugs/cords project rearward (figure unverified; varies widely by outlet count).
+- **Modelling note:** treat 0U vertical PDUs as a side-channel mount, not a depth-consuming U device.
+
+### UPS
+- APC Smart-UPS SMT2200RM2U (2U) = max depth **683 mm**, max width 480 mm, 2U (Schneider/APC datasheet). Heavy (battery mass) and among the deepest rack items.
+- **Defensible range:** small rack UPS **400-500 mm**; mid/large **600-750 mm+**. Always treat as deep + heavy.
+
+### Rack shelves (cantilever vs full-depth)
+- StarTech cantilever shelves: 1U/2U from **254 mm (10")** to **559 mm (22")** deep; cantilever = front-rail mount only.
+- Adjustable 4-post shelf: up to **~700 mm (27.5")** deep with 19.5-38" adjustable mounting depth.
+- **Defensible range:** cantilever **250-400 mm** typical; full-depth 4-post shelves **500-750 mm**.
+
+### AV gear (amps, processors)
+- QSC GX5 power amp: min chassis depth **257 mm (10.1")** (QSC).
+- QSC PL380 power amp: **~406 mm (~16")** deep (QSC).
+- **Defensible range:** AV amps/processors **250-560 mm** (touring power amps run deepest; small DSP/processors shallow). Relevant to Rackula's AV/touring/studio audience.
+
+---
+
+## 3. Enclosure / Cabinet Depth
+
+### Common outer depths and vendor examples
+- **APC NetShelter SX** (Schneider) AR3100 = **1991H x 600W x 1070D mm**; SX family ships in common outer depths of **600, 1070, 1200 mm**.
+- **Tripp Lite (Eaton) SmartRack 42U:** standard-depth **1070 mm (42")** vs deep **SR42UBDP = 1200 mm (47.25")**.
+- **StarTech 42U 4-post open frame:** **1016 mm (40")** adjustable mounting depth.
+- **Homelab 10-inch mini-rack:** DeskPi RackMate T1 (10", 8U) usable depth **~200 mm** (GeeekPi 10" shelves are 7.87"/200 mm deep); RackMate T2 Plus ~260 mm for NAS. The IKEA "Lack rack" (table legs ~50 cm apart) is a 19"-ish DIY frame with ~500 mm usable depth (unverified exact figure).
+- **Common cabinet outer-depth ladder:** **600, 800, 1000, 1070, 1200 mm**.
+
+### Outer depth vs usable mounting depth (the delta)
+- Mounting posts are **adjustable front-to-back** in 4-post cabinets, so usable rail-to-rail depth is set at install, not by the SKU. NetBox's `mounting_depth` = this rail-to-rail figure.
+- Front door + rear door + cable space typically consume **~100-150 mm+** of the outer depth; rear clearance of **4-6" (100-150 mm)** is recommended for cabling/airflow. So a 1070 mm cabinet commonly yields ~**800-900 mm** usable mounting depth (directional; depends on door/PDU choices).
+
+### CRITICAL standards point (verified)
+> **EIA-310-D (and IEC 60297) standardize rack WIDTH, the rack unit (1U = 1.75"), and hole spacing - NOT depth.** Depth, mounting depth, hole type, front/rear space, and obstructions between front and rear rails are explicitly **not** part of EIA-310-D and are vendor-defined / rail-adjustable.
+
+- NavePoint and RackSolutions confirm EIA-310-D standardizes: rack unit = 1.75", 19" panel/flange width, horizontal hole spacing (18.312" / 465 mm flange-to-flange family), the 0.625" repeating vertical hole pattern, and a minimum rack opening of ~450 mm. Depth is absent.
+- RackSolutions / Intel's "Server Rack Cabinet Compatibility Guide" state characteristics such as "hole type, mounting depth, front and rear space, and obstructions between front and rear rails" are **not standardized** in EIA-310-D.
+- Consequence for Rackula: rack depth must be a free numeric field (with sensible presets), not derived from a width/form-factor standard. There is no canonical depth per rack class.
+
+---
+
+## 4. Clearance Behind / Around Devices ("what depth planning is for")
+
+- **Rear service/cabling clearance:** minimum **4-6 inches (≈100-150 mm)** behind equipment for cabling and ventilation; more with rear-mounted PDUs or cable managers (serverrackcabinets.com guide).
+- **Cable minimum bend radius (TIA/EIA-568):**
+  - Copper UTP (Cat5e/6/6A): **4x cable outer diameter** installed. Example: Cat6A ~0.57" OD → **~2.28" (58 mm)** min bend radius.
+  - Fibre: **10x diameter** static/installed, **20x diameter** dynamic/under pulling tension. Example: duplex fibre ~0.19" OD → **~1.9" (48 mm)** installed.
+  - Implication: even "shallow" gear needs rear room for the cable to turn; bend radius sets a practical rear-clearance floor.
+- **Cable-management-arm (CMA) depth penalty:** CMAs extend roughly **28.5-33"** when articulated and consume rear depth; conversely some tool-free rail+CMA kits add ~5" of required install depth. Plan CMA depth into cabinet depth separately from device depth.
+- **Blanking panels and airflow:** empty U allows hot exhaust to recirculate to intakes (bypass airflow). Filling unused U with blanking panels prevents front/rear air mixing - quantified in Schneider Electric White Paper 44, "Improving Rack Cooling Performance Using Airflow Management Blanking Panels." Depth-relevant because the front/rear air separation that blanking enforces is the same plane that `is_full_depth` / depth modelling represents.
+- **Front clearance:** needed for install/removal and door swing; rear clearance for cabling/service. Depth planning exists to guarantee (a) the device physically fits rail-to-rail, (b) cables can turn within bend radius behind it, and (c) doors close.
+
+---
+
+## 5. 2-Post / 4-Post / Open-Frame / Wall-Mount Depth Semantics
+
+- **4-post frame/cabinet:** front AND rear rails. Rails are adjustable front-to-back; the device must fit between them plus cabling/airflow. **Usable depth = front-rail-to-rear-rail distance** - exactly NetBox's `mounting_depth` definition ("for four-post racks, this is the distance between the front and rear rails"). This is the case where "device deeper than rack" is a real, enforceable constraint.
+- **2-post (telco/relay) frame:** only two posts; equipment is **cantilever-mounted** via center-mount or flush-mount brackets. There is no rear rail, so depth is **largely unconstrained by the rack** - the limiting factor is tipping/weight, and the manufacturer specifies a max mounting depth for stability. **Center mount** balances weight over the post line; **flush mount** aligns the face to the front (cantilever, needs floor-bolting). For Rackula: a 2-post rack should not hard-fail on device depth; depth is advisory, not a fit constraint.
+- **Open-frame 4-post:** rails define depth, no doors/side panels, so outer depth ≈ mounting depth + minor overhang. Cleanest case where outer_depth ≈ mounting_depth.
+- **Wall-mount (NetBox `wall-frame` / `wall-cabinet`, plus vertical variants):** shallow by design; limited rear depth (wall behind). Depth constraint is tight and the binding factor. Vertical wall variants rotate the U-axis.
+
+Mapping to NetBox `form_factor`: `2-post-frame`, `4-post-frame`, `4-post-cabinet`, `wall-frame`, `wall-frame-vertical`, `wall-cabinet`, `wall-cabinet-vertical`. A Rackula depth model should let `mounting_depth` be a hard constraint for 4-post/cabinet, advisory for 2-post, and tight for wall-mount.
+
+---
+
+## 6. Competitor / Other Tools Depth Modelling
+
+- **rackbuilder.io** (Universal 19" Rack Planning Tool; touring, studio, server): models device depth and validates depth conflicts. Per the spike brief and the site's own description, it plans "with real RU space and depth constraints, maintaining aligned front/rear/side views while blocking depth conflicts before bad placements occur": a single device `depth_mm` is checked against a single rack `depth_mm`, it renders a side/depth-profile view, and warns "device exceeds rack depth." **Strength:** depth-aware side profile plus a concrete exceed-depth warning - the closest competitor to spike #2622's goal, and a strong UX precedent. **Limit:** a single scalar rack depth (no per-rail, door, or front/rear-offset modelling); front vs rear mounting offset not represented. (Note: the site is a client-rendered SPA and could not be deep-fetched on 2026-06-26; behaviour corroborated by the search-result description and the project brief.)
+- **RackTables** (open-source DCIM/asset management): rack-mountable objects can carry height and depth attributes in the object model, but RackTables is primarily an asset/space database with elevation views rather than a depth-validating visual planner. **Strength:** depth is a first-class stored attribute. **Limit:** little/no visual depth-collision feedback; depth is documentation, not an enforced placement constraint (similar in spirit to NetBox's informational `mounting_depth`).
+- **NetBox** (for contrast): `is_full_depth` boolean on the device + informational `mounting_depth` (mm) on the rack; **no per-device mm depth and no depth-vs-rack validation** (Section 1). The dominant tool deliberately stops at categorical depth - so Rackula's mm model would be a differentiator, but cannot be back-filled from NetBox data.
+
+---
+
+## Key Figures Table (seedable mm ranges)
+
+| Category | Min (mm) | Typical (mm) | Max (mm) | Cited anchor |
+| --- | --- | --- | --- | --- |
+| Server, short-depth / edge 1U | 300 | 370 | 450 | Supermicro SYS-510T-ML = 368 |
+| Server, mainstream 1-2U | 600 | 700 | 780 | Dell R740 = 678.8 / 715.5 |
+| Server, deep GPU / storage 4U | 700 | 800 | 900 | Supermicro AS-4125GS-TNRT = 737 (>800 unverified) |
+| Switch, shallow access | 200 | 280 | 350 | Ubiquiti USW-Pro-48 = 285 |
+| Switch, deep PoE / fixed | 450 | 520 | 600 | Cisco Catalyst 9300-M = 449-564 |
+| Switch/router, modular chassis | 600 | 750 | 900 | unverified |
+| Patch panel | 25 | 45 | 70 | 1U 24-port body ~44-50 |
+| PDU, 0U vertical (side-channel) | 40 | 50 | 70 | APC AP8853 = 44 (excluded from U-depth) |
+| PDU, horizontal 1U/2U | 60 | 120 | 200 | unverified (varies by outlet count) |
+| UPS, rack | 400 | 600 | 750 | APC SMT2200RM2U = 683 |
+| Shelf, cantilever | 250 | 350 | 450 | StarTech 254-559 |
+| Shelf, full-depth 4-post | 500 | 650 | 750 | StarTech adjustable to ~700 |
+| AV amp / processor | 250 | 400 | 560 | QSC GX5 = 257, PL380 ~406 |
+| Cabinet outer depth (rack) | 600 | 1000 | 1200 | APC AR3100 = 1070; Tripp Lite 1070/1200 |
+| Cabinet usable mounting depth | 450 | 800 | 1016 | StarTech open frame = 1016; outer minus ~150-250 |
+| Mini-rack (10") usable depth | 180 | 220 | 300 | DeskPi RackMate = ~200-260 |
+
+Defaults guidance: seed device `depth_mm` per category from "Typical"; if a device's NetBox import says `is_full_depth: true`, bias toward the deeper end. Rear clearance budget ~100-150 mm should be added to device depth (not stored on the device) when checking fit against rack `mounting_depth`.
+
+---
+
+## Sources
+
+NetBox (primary):
+- DeviceType model source: https://github.com/netbox-community/netbox/blob/4f4e97f1a67b2f46df9a7ccf8f74a7e28b3f88ce/netbox/dcim/models/devices.py
+- Rack / RackType model source: https://github.com/netbox-community/netbox/blob/4f4e97f1a67b2f46df9a7ccf8f74a7e28b3f88ce/netbox/dcim/models/racks.py
+- DCIM choices source: https://github.com/netbox-community/netbox/blob/4f4e97f1a67b2f46df9a7ccf8f74a7e28b3f88ce/netbox/dcim/choices.py
+- DeviceType docs: https://netboxlabs.com/docs/netbox/models/dcim/devicetype/
+- RackType docs: https://netboxlabs.com/docs/netbox/models/dcim/racktype/
+- Rack docs: https://netboxlabs.com/docs/netbox/en/stable/models/dcim/rack/
+- devicetype-library schema: https://github.com/netbox-community/devicetype-library/blob/master/schema/devicetype.json
+- Example device YAML (Dell R740): https://github.com/netbox-community/devicetype-library/blob/master/device-types/Dell/PowerEdge-R740.yaml
+- Issue #14176 "Add Depth as Device Property" (closed, not planned): https://github.com/netbox-community/netbox/issues/14176
+- Issue #20942 (mounting depth unit selector request): https://github.com/netbox-community/netbox/issues/20942
+- Issue #21178 (mounting depth display consistency): https://github.com/netbox-community/netbox/issues/21178
+
+Device datasheets (Section 2):
+- Dell PowerEdge R740 dimensions: https://www.dell.com/support/manuals/en-us/poweredge-r740/per740_techspecs_pub/system-dimensions
+- Supermicro SYS-510T-ML (short-depth 1U): https://www.supermicro.com/en/products/system/datasheet/SYS-510T-ML
+- Supermicro AS-4125GS-TNRT (4U GPU): https://www.supermicro.com/en/products/system/gpu/4u/as-4125gs-tnrt
+- Cisco Catalyst 9300-M datasheet: https://documentation.meraki.com/Switching/Cloud_Management_with_IOS_XE/Product_Information/Overviews_and_Datasheets/Catalyst_9300-M_Datasheet
+- Ubiquiti UniFi Pro 48 tech specs: https://techspecs.ui.com/unifi/switching/usw-pro-48-poe
+- 1U 24-port patch panel (dimensions): https://navepoint.com/navepoint-24-port-cat6-utp-patch-panel-1u-with-keystones-black/
+- APC AP8853 0U PDU specs: https://www.se.com/us/en/download/document/990-3439_EN/
+- APC Smart-UPS SMT2200RM2U specs: https://www.se.com/us/en/product/SMT2200RM2U/
+- StarTech rack shelves (cantilever/adjustable): https://www.startech.com/en-us/server-management/shelf-1u-12-fixed-v
+- QSC GX5 power amp: https://www.qscaudio.com/solutions-products/power-amplifiers/portable/2-channel/gx-series/gx5/
+- QSC PL380 dimensions: https://www.guitarchalk.com/qsc-pl380-2500-watt-2-channel-power-amp-dimensions/
+
+Cabinets / standards (Section 3):
+- APC NetShelter SX AR3100 (1991H x 600W x 1070D): https://www.apc.com/us/en/product/AR3100/
+- Tripp Lite SmartRack 42U deep (SR42UBDP, 1200 mm): https://www.cdw.com/product/tripp-lite-42u-rack-enclosure-server-cabinet-doors-sides/2110388
+- StarTech 42U 4-post open frame (40"/1016 mm mounting depth): https://www.amazon.com/Tripp-Lite-Equipment-Capacity-SR4POST/dp/B000FAKFNC
+- DeskPi RackMate (10" mini-rack, homelab): https://wiki.deskpi.com/rackmate/
+- GeeekPi 10" shelf (7.87"/200 mm depth): https://www.amazon.com/GeeekPi-Cabinet-Equipment-RackMate-Rackmount/dp/B0CSCWVTQ7
+- EIA-310-D explainer (NavePoint): https://navepoint.com/blog/what-is-eia310d/
+- EIA-310 (RackSolutions, depth not standardized): https://www.racksolutions.com/news/data-center-optimization/eia-310-definition/
+- Intel Server Rack Cabinet Compatibility Guide (mounting depth not standardized): https://cdrdv2-public.intel.com/840778/server_rack_cabinet_compatibility_guide_24.pdf
+
+Clearance / cabling (Section 4):
+- Cable bend radius (copper 4x, fibre 10x/20x): https://www.comms-express.com/infozone/article/bend-radius/
+- Minimum bend radius TIA/EIA-568 reference: https://www.elliottelectric.com/StaticPages/ElectricalReferences/DataComm/minimum_bending.aspx
+- Rack depth / rear clearance + CMA guide: https://www.serverrackcabinets.com/blogs/recent-blog/how-deep-should-my-server-rack-cabinet-be-a-complete-guide
+- Schneider White Paper 44 (blanking panels / airflow): https://www.se.com/us/en/download/document/SPD_SADE-5TPLKQ_EN/
+
+Mounting types (Section 5):
+- 2-post vs 4-post (mounting depth, cantilever): https://www.racksolutions.com/news/data-center-trends/how-to-mount-server-2-post-rack/
+- What is rack mounting depth: https://www.racksolutions.com/news/blog/what-is-rack-mounting-depth/
+- Enconnex 2-post vs 4-post: https://blog.enconnex.com/differences-between-2-post-vs-4-post-racks
+
+Competitors (Section 6):
+- rackbuilder.io: https://www.rackbuilder.io/
+- RackTables (project + wiki): http://www.racktables.org/ , https://wiki.racktables.org/index.php/FeatureWishlist

--- a/docs/research/2622-patterns.md
+++ b/docs/research/2622-patterns.md
@@ -1,0 +1,207 @@
+# Spike #2622: Patterns Analysis — Accurate Depth Model and Visualization
+
+Source: synthesis of `2622-codebase.md` (current categorical model) and `2622-external.md` (NetBox / rackbuilder / standards research), 2026-06-26. This doc drives the schema-design decision and the issue decomposition for moving device depth from categorical half/full to accurate physical millimetres.
+
+## Key Insights
+
+**1. NetBox stops at categorical depth by deliberate design, and that choice does not bind Rackula.** NetBox models device depth as a single boolean `is_full_depth` and explicitly closed the per-device depth request (#14176) as "not planned." Its only depth number, rack `mounting_depth` (mm), is informational and never validated against any device. So the dominant DCIM has consciously decided depth magnitude is out of scope. Rackula should diverge for two grounded reasons:
+
+- **The milestone headline case is inexpressible in NetBox's model.** "A device longer than the full depth of the rack" requires a device magnitude and a rack magnitude to compare. `is_full_depth` is a direction flag with no length, so it can never *exceed* anything. The headline feature is structurally impossible without `depth_mm`.
+- **Rackula already has the harder half of the model that rackbuilder lacks.** rackbuilder.io validates one device `depth_mm` against one rack `depth_mm` from a single front-anchored scalar; it cannot represent a rear-mounted device growing *frontward* meeting a front-mounted device growing *rearward*. Rackula's `face` field already encodes mount direction, so `depth_mm` + `face` yields a genuine two-sided middle-collision that neither NetBox (no magnitude) nor rackbuilder (no rear anchor) can express. That two-sided collision is the differentiator.
+
+**2. Face is already a mount datum; depth is additive, not a replacement (the load-bearing reframe).** The authoritative collision field is `PlacedDevice.face` ("front" | "rear" | "both"); `is_full_depth` only sets the *default* face. `face` therefore already tells us *where a device is anchored and which way it grows*: front devices grow rearward from the front rail, rear devices grow frontward from the rear rail, "both" spans. A naive port of rackbuilder would add a redundant "mounting offset" field. Rackula does not need one — it adds a scalar `depth_mm` (a length) on top of the direction it already stores. Every depth computation reads `face` for direction and `depth_mm` for magnitude. The categorical model is the magnitude-unknown degenerate case of the mm model, which is why migration is safe.
+
+**3. Unit asymmetry (depth continuous, width enum-inches) is principled, not sloppy.** `depth_mm` is the first continuous physical measurement in a model where width is an enum (`10 | 19 | 21 | 23`). This asymmetry is correct and should be kept deliberately: EIA-310-D / IEC 60297 standardize rack *width*, the rack unit, and hole spacing, but explicitly **not depth** (verified, external doc Section 3). Width is genuinely a four-value enum because only those flange widths exist; depth is genuinely a free scalar because it is vendor-defined and rail-adjustable with no canonical value per rack class. Store width as an enum, depth as `mm`. Do not "fix" the asymmetry by making either match the other.
+
+**4. Categorical -> mm is lossy on magnitude but lossless on direction.** You cannot reconstruct 678 mm from "full," but `face` survives intact. This single fact dictates the migration policy (Fork A): synthesize nothing for user data, because any synthesized magnitude risks flipping a previously-valid saved layout into a false "exceeds depth" warning, and prior-release load is a tested first-class invariant.
+
+## Data model design
+
+### Device type (`DeviceTypeSchema`, `schemas/index.ts:472`)
+
+```ts
+depth_mm: z.number().positive().optional()   // chassis in-rack projection, measured from the mount rail plane rearward
+```
+
+- Optional. `undefined` = depth unknown (the migrated / un-authored state). Keep `is_full_depth` as-is; it continues to set the default `face`. `depth_mm` and `is_full_depth` are orthogonal: direction vs magnitude.
+- **Front-overhang field: not needed in v1.** Bezels, handles, and front-projecting trim sit *in front of* the front rail and never contend for rail-to-rail space, so they cannot cause the collisions this spike targets. Define `depth_mm` as the dimension that consumes mounting depth (rail plane rearward), seeded from chassis depth without bezel (external doc gives both figures for the R740: use 678.8, not 715.5). A `front_overhang_mm` can be added later for door-clearance polish; it is YAGNI for the headline case. Do not add it now.
+
+### Rack (`schemas/index.ts:645`)
+
+```ts
+mounting_depth_mm: z.number().positive().optional()   // usable rail-to-rail depth — the collision datum
+outer_depth_mm:    z.number().positive().optional()   // outer cabinet depth — visual/cabinet-shell only, never used for collision
+mount_type:        z.enum(["4-post", "2-post", "open-frame", "wall"]).optional()   // keys hard vs advisory enforcement (Fork B / Section 4)
+```
+
+- **`mounting_depth_mm` is the single authoritative depth datum**, mapped 1:1 to NetBox `mounting_depth`: "Maximum depth of a mounted device... for four-post racks, the distance between the front and rear rails." This is what `depth_mm` is checked against.
+- **`outer_depth_mm` maps to NetBox `outer_depth`** and is informational only — it draws the cabinet shell around the rails in the depth view. Never derive `mounting_depth_mm` from it automatically (door/PDU/clearance delta is 100-250 mm and install-specific, external doc Section 3); if only outer is known, prompt for mounting depth rather than computing it.
+- Deliberately do **not** replicate NetBox's `outer_unit` dual mm/in storage — that inconsistency is the subject of NetBox's own open bugs #20942/#21178. One canonical unit (mm), optional display-only conversion (Fork B).
+
+### How depth composes with `face`
+
+Define occupancy as an interval along the depth axis, origin at the front rail, `usable = rack.mounting_depth_mm`:
+
+| `face` | front_extent (from front rail) | rear_extent (from rear rail) | interval |
+| --- | --- | --- | --- |
+| `front` | `depth_mm` | 0 | `[0, depth_mm]` |
+| `rear` | 0 | `depth_mm` | `[usable - depth_mm, usable]` |
+| `both` | `usable` | `usable` | `[0, usable]` (full span; `depth_mm` informational + drives exceeds-depth badge) |
+
+`face=both` keeps its current "blocks everything" semantics by occupying the whole span regardless of `depth_mm`. This is what makes the mm model a strict superset of today's categorical model: existing full-depth devices stay full-span blockers, existing half-depth front/rear devices stay non-colliding *until* a real magnitude says otherwise.
+
+### Composition through carriers
+
+Carrier-first mounting is preserved: collision is computed only on **rail-mounted entities** (full-width integer-U devices and carriers). A carrier carries its own `depth_mm` (tray depth) and is the entity checked against `mounting_depth_mm`. A child device's `depth_mm` is checked only against its *carrier's* depth (does it fit the tray — a soft, local check), never directly against the rack. This keeps rail positions whole-U integers and means the rack-level middle-collision logic never has to reason about sub-U children.
+
+## The three forks
+
+### Fork A — migration default-magnitude policy
+
+| Option | Mechanism | Tradeoff |
+| --- | --- | --- |
+| A1. Per-category default table | Map each device to "Typical" mm (external doc figures table) by inferred category | Realistic seeds, but requires classification and **risks false warnings**: a synthesized 700 mm "typical server" placed in a previously-valid shallow rack would newly fail the exceeds-depth check on data the user never entered. Violates the tested upgrade invariant. |
+| A2. Conservative single value = `usable` | Synthesize `depth_mm = rack.mounting_depth_mm` so nothing newly fails | Guarantees no overflow, but is a lie about magnitude that pollutes the signature view and the middle-collision math (every device looks full-depth). |
+| A3. Null / unset, fit-check suppressed | Migrate `depth_mm` as `undefined`; suppress exceeds-depth and middle-collision whenever magnitude is unknown | Zero false warnings by construction (you cannot fail a check that does not run); direction preserved via `face`, so categorical collision is byte-identical to today. No magnitude delivered for legacy data until the user fills it. |
+
+**Recommendation: A3 (null on migration), plus seed magnitudes only where it is authoring, not migrating.**
+
+- **User data**: migrate to `depth_mm: undefined`. Synthesize nothing. This is the only option that satisfies the tested prior-release-load invariant — a previously-valid layout must load with zero new warnings, and the upgrade corpus will assert exactly that.
+- **Starter library** (`starterLibrary.ts`): author real `depth_mm` values from external doc Section 2 (e.g. `1u-server` ~700, `1u-switch` ~280, `1u-fiber-patch-panel` ~45, PDUs as side-channel). This is new authored data, not migrated user data, so realistic values are safe and desirable.
+- **Per-category table**: use it as authoring guidance and behind an explicit, non-destructive "estimate depths" affordance that fills *only* nulls on user request — never auto-applied. The user opts into the guess.
+
+### Fork B — rack depth datum + unit policy
+
+| Datum option | Maps to | Use |
+| --- | --- | --- |
+| B1. `mounting_depth_mm` (rail-to-rail usable) | NetBox `mounting_depth` | The collision constraint. Authoritative. |
+| B2. `outer_depth_mm` (outer cabinet) | NetBox `outer_depth` | Visual cabinet shell only. Needs an install-specific clearance subtraction to become usable, so not directly checkable. |
+| B3. Both, derive mounting from outer | — | Convenient but the delta is 100-250 mm and install-specific; auto-derivation manufactures fake precision. |
+
+**Recommendation: B1 as the authoritative collision datum, B2 optional for visualization, never B3's auto-derivation.** `mounting_depth_mm` is what `depth_mm` is compared against, matching NetBox semantics exactly. `outer_depth_mm` is optional decoration for the depth view.
+
+**Unit policy:**
+- **mm canonical for every depth field** (device and rack). Single stored unit.
+- **Width stays enum-inches** (`10 | 19 | 21 | 23`) — principled per Key Insight 3 (width is standardized, depth is not).
+- **Imperial: display-only, never stored.** Offer an optional read-only mm->inch render in the inspector/ruler; do not store inches and do not add a per-field unit selector. This sidesteps NetBox's own dual-unit bug class.
+
+**Recommended `mounting_depth_mm` presets** (from external doc cabinet ladder, Section 3):
+
+| Preset | mounting_depth_mm |
+| --- | --- |
+| Mini-rack (10") | 200 |
+| Wall / shallow | 300 |
+| Comms / half-depth | 450 |
+| Standard server cabinet | 800 |
+| Deep server cabinet | 1000 |
+| Open frame (4-post) | 1016 |
+| Custom | numeric entry |
+
+### Fork C — signature visualization
+
+**Candidate 1 — front-elevation at-a-glance cue (extend `blocked-slots.ts:34` hatching).** Always-on, lives in the existing front view; reuses the established opposite-face hatch vocabulary, adds an exceeds-depth badge. Shows occupancy/overflow, not magnitude.
+
+```
+Front face            Rear face
++------------------+  +------------------+
+| 1U server        |  |//////////////////|   // hatch = rear blocked by front depth
+| deep UPS    [!]  |  |//////////////////|   [!] = exceeds rack depth
++------------------+  +------------------+
+```
+
+**Candidate 2 — side depth-profile ruler (rackbuilder precedent).** A side view with a depth axis; each device is a horizontal bar from its rail. Shows magnitude vs rack depth well, but is front-anchored single-sided — it is exactly rackbuilder's model and cannot show front+rear meeting.
+
+```
+        0mm    300    600    900   (mounting_depth = 800)
+        |------|------|------|----:----
+U10 srv [#####################]        678  ok
+U9  ups [##############################]>   900  EXCEEDS
+U8  pdu [##] 44  ok
+        front rail               rear rail
+```
+
+**Candidate 3 — top-down per-U plan section.** For a U (or scrollable per-U strip), a horizontal cross-section: front device grows from the top edge, rear device grows from the bottom edge, with the remaining centre gap (or overlap) drawn between them.
+
+```
+U10  front |==front 600==>          <==rear 350==| rear
+            [ server         ] gap  [   switch   ]
+            |<-------- usable 800mm -------->|
+
+U7   front |==front 500==>===rear 400===| rear
+            [ shelf       ][!OVERLAP 100!][ ups ]   // two-sided middle collision
+```
+
+**Recommendation: signature view = Candidate 3 (top-down per-U plan section); always-on cue = Candidate 1.**
+
+- Candidate 3 is the **only** view that renders Rackula's differentiator — two devices growing toward the centre and the remaining centre gap/overlap. It is the visual proof of the two-sided collision that NetBox and rackbuilder cannot express. The depth axis from Candidate 2 (the ruler) is absorbed into Candidate 3's horizontal scale, so the side-profile's one virtue is kept without a second view.
+- Candidate 1 is the always-on cue because it costs almost nothing (extends existing hatching) and surfaces the depth signal in the default front elevation without making the user open the signature view.
+- Constraints: dark "coffin" tokens for the new section; respect reduced-motion (no animated growth/scrub on the depth axis); visible focus on the per-U selector; the overlap band and `[!]` badge must not rely on colour alone (use hatch + label, consistent with existing accessibility floor).
+
+## Collision and validation rule
+
+Extend `collision.ts:95` (`doFacesCollide`). Current behaviour: `both` collides with everything; same face collides; opposite faces (front/rear) never collide. Keep all three; refine only the opposite-face branch and add a per-device exceeds check.
+
+**Middle-collision (pairwise, same U-span, opposite faces):** let `usable = rack.mounting_depth_mm`, `d_front` / `d_rear` the two devices' `depth_mm`.
+
+```
+if (usable == null || d_front == null || d_rear == null)
+    -> fall back to current behaviour: opposite faces DO NOT collide, NO new warning
+else
+    -> collide  iff  d_front + d_rear > usable        // they meet/overlap in the middle
+```
+
+**Exceeds-depth (single device, independent of any pair):**
+
+```
+if (device.depth_mm != null && rack.mounting_depth_mm != null && device.depth_mm > rack.mounting_depth_mm)
+    -> "exceeds depth" warning on that device     // the milestone headline case
+```
+
+`face=both` is treated as full-span `[0, usable]` and keeps its current "collides with everything" semantics unchanged.
+
+**Unknown-depth behaviour:** any time `mounting_depth_mm` or a participating `depth_mm` is unknown, the system **falls back to today's categorical face collision and raises no depth warning**. This is the gate that makes Fork A (null migration) safe: legacy layouts run the exact old logic.
+
+**Hard block vs soft warning, keyed by mounting type** (external doc Section 5; NetBox `mounting_depth` is rail-to-rail "for four-post racks"):
+
+| `mount_type` | Depth semantics | Enforcement |
+| --- | --- | --- |
+| `4-post`, `open-frame` | Real rail-to-rail constraint | Hard (blocking severity) once `mount_type` and both magnitudes are known |
+| `wall` | Tight, wall behind | Hard, small depth |
+| `2-post` | Cantilever, no rear rail; depth limited by tipping, not the rack | Advisory (soft) only, never blocks |
+| unset | Unknown | Advisory (soft) |
+
+**Shipping recommendation:** default everything to **advisory (soft, non-blocking)** in the first release, even on 4-post, and escalate to hard-block only once `mount_type` is an explicit, user-set field. Rationale: a prior layout that newly overflows after the user enters real depths must still be loadable and editable; a hard block on legacy-derived data would regress the backward-compat invariant. Hard enforcement is a later, opt-in refinement keyed by `mount_type`.
+
+## Recommended phased plan
+
+The milestone's headline case ("a device longer than the full depth of the rack") is delivered in **Phase 2**, before any new view. The signature visualization (Phase 3) is the leapfrog, not the headline.
+
+### Phase 1 — Data foundation (schema + migration + corpus)
+
+- Add `depth_mm?` to `DeviceTypeSchema`; add `mounting_depth_mm?`, `outer_depth_mm?`, `mount_type?` to the rack schema (Zod 4).
+- Migration: existing device types and saved layouts -> `depth_mm` stays `undefined`; `face` untouched. Synthesize no magnitude (Fork A3).
+- Upgrade-corpus fixture (`src/tests/fixtures/upgrade-corpus/`): a prior-release layout with half/full devices that loads clean, depths unknown, **zero new warnings** — the regression guard for the whole spike.
+- Seed `starterLibrary.ts` device types with real `depth_mm` from external doc Section 2.
+- Plumb rack-depth presets (Fork B table) into the schema/defaults. No UI warnings yet.
+- Dependencies: none. Gates Phases 2 and 3.
+
+### Phase 2 — Headline value (inspector field + front cue + exceeds-depth warning)
+
+- Inspector: editable device `depth_mm`; editable rack `mounting_depth_mm` with presets + optional display-only inch readout.
+- Front-elevation always-on cue (Candidate 1): extend `blocked-slots.ts` hatching + `[!]` exceeds-depth badge.
+- Exceeds-depth validation: single device `depth_mm > mounting_depth_mm` -> advisory warning. **This is the milestone headline case.**
+- Severity advisory/soft; suppressed whenever a magnitude is unknown.
+- Dependencies: Phase 1. **Delivers the milestone headline with no new view.**
+
+### Phase 3 — Leapfrog (mm middle-collision + signature view)
+
+- `collision.ts`: implement the two-sided middle-collision rule (`d_front + d_rear > usable`) — the differentiator competitors cannot express.
+- Signature top-down per-U depth-profile view (Candidate 3): front/rear growth toward centre, centre gap/overlap band, coffin tokens, reduced-motion, visible focus.
+- `mount_type` -> hard/advisory enforcement keying (Section 4); opt-in hard-block for 4-post/open-frame/wall.
+- Dependencies: Phase 2 (depth fields populated and the warning vocabulary established).
+
+### Issue-decomposition notes
+
+- Keep the schema additions (Phase 1) as one slice so migration + corpus fixture land together; never merge a schema change without its upgrade-corpus fixture.
+- Phase 2's three pieces (inspector field, front cue, exceeds warning) can be parallel children once Phase 1 lands.
+- Phase 3's collision rule and signature view are separable: the mm collision can ship and be asserted via unit tests on `collision.ts` before the view exists; the view is the visual layer on top.

--- a/docs/research/spike-2622-depth-model.md
+++ b/docs/research/spike-2622-depth-model.md
@@ -1,0 +1,107 @@
+# Spike #2622: Accurate Depth Model and Visualization
+
+Date: 2026-06-26. Milestone: M021. Parent epic: none (milestone-level spike).
+Status: research complete; three forks settled by maintainer 2026-06-26 (null-on-migration, usable rail-to-rail mm, top-down per-U signature view); ready for issue decomposition.
+
+Detail docs: [`2622-codebase.md`](2622-codebase.md) (current model), [`2622-external.md`](2622-external.md) (NetBox / standards / device data), [`2622-patterns.md`](2622-patterns.md) (options and recommendations).
+
+---
+
+## Executive Summary
+
+M021 moves device depth from categorical (half/full) to accurate millimetres, so Rackula can answer the four questions a user makes with real gear in hand: does this device fit this cabinet, will cabling fit behind it, do front- and rear-mounted devices collide in the middle, and can the door close. The milestone's headline case is "a device longer than the full depth of the rack."
+
+The research produced one load-bearing reframe and one premise challenge that together make the work smaller and sharper than a naive port of the competitor:
+
+1. Reframe: Rackula's `PlacedDevice.face` ("front" | "rear" | "both") is already a mount datum. Front devices grow rearward from the front rail, rear devices grow frontward from the rear rail, "both" spans. So depth is an additive scalar (`depth_mm`) on top of a direction the model already stores, not a new positioning subsystem. The categorical model is the magnitude-unknown degenerate case of the mm model, which is what makes migration safe.
+
+2. Premise challenge (NetBox): NetBox, the dominant DCIM, deliberately models device depth as a boolean only and closed the per-device-depth request as "not planned." Its single depth number (rack `mounting_depth`, mm) is informational and never validated. So adding device mm depth must be justified, not assumed. It is justified, on two grounds: the headline case is structurally inexpressible with a boolean (a direction flag has no length to exceed anything), and Rackula's `face` lets `depth_mm` produce a genuine two-sided middle-collision that neither NetBox (no magnitude) nor rackbuilder.io (single front-anchored scalar) can express. That two-sided collision is the differentiator.
+
+Recommended sequencing delivers the milestone headline in Phase 2, before any new view. The signature depth visualization is Phase 3: the leapfrog, not the headline.
+
+## Why millimetres despite NetBox
+
+| Tool | Device depth | Rack depth | Validates fit? | Two-sided (front+rear) collision? |
+| --- | --- | --- | --- | --- |
+| NetBox | `is_full_depth` boolean only | `mounting_depth` mm (informational) | No | No (no magnitude) |
+| rackbuilder.io | `depth_mm` (single, front-anchored) | `depth_mm` (single) | Yes (exceeds-depth) | No (no rear anchor) |
+| Rackula (proposed) | `depth_mm` + existing `face` direction | `mounting_depth_mm` | Yes | Yes (the differentiator) |
+
+EIA-310-D / IEC 60297 standardize rack width, the rack unit, and hole spacing, but explicitly not depth. Depth is vendor-defined and rail-adjustable. So rack depth must be a free numeric field with presets, and the unit asymmetry (depth continuous mm, width a `10|19|21|23` enum) is principled, not sloppy.
+
+## Proposed data model
+
+Device type (`DeviceTypeSchema`, `schemas/index.ts:472`):
+
+```ts
+depth_mm: z.number().positive().optional()   // in-rack projection from the mount rail plane rearward
+```
+
+`depth_mm` (magnitude) and `is_full_depth` (default-face direction) are orthogonal and both kept. No `front_overhang_mm` in v1 (bezels and handles sit in front of the rail and never contend for rail-to-rail space; YAGNI for the headline case).
+
+Rack (`schemas/index.ts:645`):
+
+```ts
+mounting_depth_mm: z.number().positive().optional()  // usable rail-to-rail; the collision datum (NetBox mounting_depth)
+outer_depth_mm:    z.number().positive().optional()  // outer cabinet shell; visual only, never collision (NetBox outer_depth)
+mount_type:        z.enum(["4-post","2-post","open-frame","wall"]).optional()  // keys hard vs advisory enforcement
+```
+
+Occupancy as a depth interval, origin at the front rail, `usable = mounting_depth_mm`:
+
+| `face` | interval |
+| --- | --- |
+| `front` | `[0, depth_mm]` |
+| `rear` | `[usable - depth_mm, usable]` |
+| `both` | `[0, usable]` (full span; keeps current "blocks everything" semantics) |
+
+Carrier-first is preserved: rack-level collision runs only on rail-mounted entities (full-width integer-U devices and carriers). A carrier carries its own `depth_mm`; a child's depth is checked against its carrier (does it fit the tray), never directly against the rack. Rail positions stay whole-U integers.
+
+## The three forks (recommendations; pending sign-off)
+
+### Fork A: migration default-magnitude policy
+
+Recommendation: null on migration. Existing device types and saved layouts migrate to `depth_mm: undefined`; the fit-check and middle-collision are suppressed whenever a magnitude is unknown, so a previously-valid layout loads with zero new warnings (the tested prior-release-load invariant). Seed real `depth_mm` only in the starter library (authoring, not migrating). Offer a non-destructive, opt-in "estimate depths" affordance that fills only nulls on request, using the per-category table; never auto-applied.
+
+Rejected: per-category auto-fill (risks flipping valid layouts into false warnings) and conservative `= usable` (lies about magnitude, pollutes the view and the collision math).
+
+### Fork B: rack depth datum + unit policy
+
+Recommendation: `mounting_depth_mm` (usable rail-to-rail) is the sole authoritative collision datum, matching NetBox semantics; `outer_depth_mm` is optional and visual-only; never auto-derive usable from outer (the delta is 100-250 mm and install-specific). mm canonical for all depth; width stays the inches enum; imperial is display-only, never stored (sidesteps NetBox's own dual-unit bug class). Presets: 200 (mini-rack 10"), 300 (wall/shallow), 450 (comms/half-depth), 800 (standard server), 1000 (deep server), 1016 (open frame), plus custom.
+
+### Fork C: signature visualization
+
+Recommendation: signature view is a top-down per-U plan section (front device grows from one edge, rear from the other, with the centre gap or overlap drawn between them) because it is the only view that renders the two-sided collision. The always-on cue is the front-elevation hatch (extending `blocked-slots.ts:34`) plus an exceeds-depth `[!]` badge, so the depth signal shows in the default front view without opening anything. The side-profile ruler (rackbuilder's model) is single-sided and is absorbed into the top-down view's horizontal scale, so it is not built separately. New section uses coffin tokens, respects reduced-motion, keeps visible focus, and never encodes overflow by colour alone.
+
+## Collision and validation rule
+
+Extend `collision.ts:95` (`doFacesCollide`). Keep all current behaviour (`both` collides with everything; same face collides); refine only the opposite-face branch and add a per-device exceeds-check. `usable = rack.mounting_depth_mm`:
+
+```
+middle-collision (opposite faces, same U-span):
+  if (usable == null || d_front == null || d_rear == null)  -> no collision, no warning (categorical fallback)
+  else                                                      -> collide iff d_front + d_rear > usable
+
+exceeds-depth (single device):
+  if (depth_mm != null && usable != null && depth_mm > usable) -> "exceeds depth" warning   // headline case
+```
+
+Unknown-depth always falls back to today's categorical face collision with no new warning. This is the gate that makes null migration (Fork A) safe. Severity defaults to advisory/soft for the first release even on 4-post, escalating to hard-block only once `mount_type` is an explicit user-set field (a hard block on legacy-derived data would regress backward compatibility). Enforcement keying: 4-post / open-frame / wall = hard once known; 2-post = advisory only (cantilever, depth limited by tipping not the rack); unset = advisory.
+
+## Recommended phased plan
+
+Phase 1, data foundation: add the schema fields (Zod 4); migrate `depth_mm` to `undefined` with `face` untouched; add an upgrade-corpus fixture (a prior-release half/full layout that loads clean with zero new warnings, the regression guard for the whole spike); seed `starterLibrary.ts` with real depths; plumb the rack-depth presets. No UI warnings yet. Gates Phases 2 and 3.
+
+Phase 2, headline value: inspector fields for device `depth_mm` and rack `mounting_depth_mm` (with presets and optional inch readout); the always-on front cue; the exceeds-depth advisory warning. Delivers the milestone headline case with no new view.
+
+Phase 3, leapfrog: the two-sided middle-collision in `collision.ts` (unit-testable before any UI); the signature top-down per-U depth view; `mount_type`-keyed hard/advisory enforcement. The collision rule and the view are separable slices.
+
+Decomposition notes: keep the schema additions plus migration plus corpus fixture as one slice (never merge a schema change without its fixture); Phase 2's three pieces are parallelisable once Phase 1 lands; Phase 3's collision rule ships and is asserted independently of the view.
+
+## Decisions (settled 2026-06-26)
+
+- Fork A: null on migration. Existing data migrates to `depth_mm: undefined`; seed magnitudes only in the starter library; opt-in non-destructive "estimate depths" fills nulls on request.
+- Fork B: `mounting_depth_mm` (usable rail-to-rail) is the sole collision datum; `outer_depth_mm` optional/visual; mm canonical, width stays the inches enum, imperial display-only; presets 200/300/450/800/1000/1016 + custom.
+- Fork C: signature view is the top-down per-U plan section; the always-on cue is the extended front-elevation hatch plus an exceeds-depth `[!]` badge.
+
+Issue decomposition below follows from these.


### PR DESCRIPTION
## **User description**
Research spike for **M021 - accurate depth measurements & visualization** (#2622).

## Deliverables
- `docs/research/spike-2622-depth-model.md` - synthesized findings, decisions, phased plan
- `docs/research/2622-codebase.md` - current categorical model map
- `docs/research/2622-external.md` - NetBox schema, EIA-310 standards, real device depth ranges
- `docs/research/2622-patterns.md` - options and recommendations

## Headline findings
- **`face` is already a mount datum.** Front devices grow rearward, rear grow frontward, "both" spans. So `depth_mm` is an additive scalar, not a new positioning subsystem; the categorical model is the magnitude-unknown case of the mm model, which makes migration safe.
- **NetBox deliberately has no per-device depth** (request closed "not planned"); only an informational rack `mounting_depth`. The milestone headline ("a device longer than the rack") is structurally inexpressible with a boolean, which justifies mm depth. With `face`, `depth_mm` yields a two-sided front-meets-rear collision that neither NetBox nor rackbuilder.io can express - the differentiator.
- **EIA-310 / IEC 60297 standardize width, not depth**, so depth is a free numeric field with presets and the unit asymmetry (depth mm, width inches enum) is principled.

## Decisions (settled with maintainer)
- Migration: null-on-migration (zero false warnings on previously-valid layouts).
- Rack depth: `mounting_depth_mm` (usable rail-to-rail) as sole collision datum; mm canonical, width stays inches enum, imperial display-only.
- Visualization: top-down per-U signature view + always-on front-elevation cue.

## Implementation issues
Phase 1 (foundation): #2627, #2628
Phase 2 (headline value): #2629, #2630
Phase 3 (leapfrog): #2631, #2632, #2633

Spine: #2627 -> {#2628, #2629, #2630, #2631} -> #2632 ; #2631 -> #2633. The M021 headline case lands in #2630, before any new view.

Closes #2622

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document the depth-model research and rollout plan for rack and device fit checks**

### What Changed
- Added a research summary covering the move from categorical half/full depth to millimetre-based device depth and rack depth
- Recorded the current codebase behavior, including face-based placement, existing depth visuals, and where the new model will fit
- Added external findings on NetBox, rack standards, real device depth ranges, and depth-related clearance needs
- Captured the agreed migration and visualization plan, including null-on-migration, depth presets, and the top-down signature view

### Impact
`✅ Clearer implementation plan for depth-aware racks`
`✅ Safer upgrade path for existing layouts`
`✅ Faster handoff for follow-up depth work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
