### PR TITLE
feat: storage driver interface + per-request DI seam (#2624)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,4 +1,4 @@
-import { Hono, type Context } from "hono";
+import { Hono, type Context, type Env } from "hono";
 import { cors } from "hono/cors";
 import { logger as honoLogger } from "hono/logger";
 import { bodyLimit } from "hono/body-limit";
@@ -38,6 +38,8 @@ import {
 } from "./local-auth";
 import pkg from "../package.json";
 import { logger } from "./logger";
+import type { StorageDriver, StorageVariables } from "./storage/driver";
+import { createFilesystemDriver } from "./storage/filesystem-driver";
 
 const DEFAULT_MAX_ASSET_SIZE = 5 * 1024 * 1024; // 5MB
 const DEFAULT_MAX_LAYOUT_SIZE = 1 * 1024 * 1024; // 1MB
@@ -77,11 +79,17 @@ export function resolveVersionInfo(env: EnvMap = process.env): VersionInfo {
 }
 
 type AppEnv = {
-  Variables: {
+  Variables: StorageVariables & {
     authSubject: string;
     authClaims: AuthSessionClaims | undefined;
   };
 };
+
+/** Optional dependency overrides for {@link createApp}. */
+export interface CreateAppDeps {
+  /** Storage backend; defaults to the filesystem driver (self-host / Bun). */
+  storage?: StorageDriver;
+}
 
 type BetterAuthSessionLike = {
   session: {
@@ -279,8 +287,20 @@ function validateFallbackSessionClaims(
  */
 export async function createApp(
   env: EnvMap = process.env,
+  deps: CreateAppDeps = {},
 ): Promise<Hono<AppEnv>> {
   const app = new Hono<AppEnv>();
+
+  // Storage driver seam (#2624): resolve the backend once and inject it per
+  // request. Defaults to the filesystem driver (self-host / Bun); the Workers
+  // entry (#2626) passes an R2-backed driver instead. Route handlers read it
+  // from the context rather than importing the filesystem free functions.
+  const storage = deps.storage ?? createFilesystemDriver();
+  app.use("*", async (c, next) => {
+    c.set("storage", storage);
+    await next();
+  });
+
   const securityConfig = resolveApiSecurityConfig(env);
   configureAuthLogHashKey(securityConfig.authLogHashKey);
 
@@ -886,7 +906,10 @@ export async function createApp(
   // at the /api/* alias for direct access. Using a helper keeps the two
   // mounts adjacent so a new router can't be added at one path and silently
   // missed at the other.
-  const mountWithAlias = (path: `/${string}`, router: Hono) => {
+  const mountWithAlias = <E extends Env>(
+    path: `/${string}`,
+    router: Hono<E>,
+  ) => {
     app.route(path, router);
     app.route(`/api${path}`, router);
   };

--- a/api/src/routes/layouts.test.ts
+++ b/api/src/routes/layouts.test.ts
@@ -22,6 +22,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createApp } from "../app";
 import type { EnvMap } from "../security";
+import type { StorageDriver } from "../storage/driver";
 
 type App = Awaited<ReturnType<typeof createApp>>;
 
@@ -198,5 +199,100 @@ describe("PUT /layouts/:uuid schema validation (#2449)", () => {
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.id).toBe(URL_UUID);
+  });
+});
+
+describe("createApp storage driver injection (#2624)", () => {
+  it("routes resolve the storage driver provided via deps, not the filesystem", async () => {
+    // A stub driver records which methods the routes call and returns a
+    // sentinel updatedAt. If the routes still imported the filesystem free
+    // functions directly, this driver would be ignored and the sentinel would
+    // never surface — so the assertions below prove the per-request seam.
+    const calls: string[] = [];
+    const sentinelUpdatedAt = "2030-01-01T00:00:00.000Z";
+    const stub: StorageDriver = {
+      async listLayouts() {
+        calls.push("listLayouts");
+        return [];
+      },
+      async getLayout() {
+        calls.push("getLayout");
+        return null;
+      },
+      async saveLayout() {
+        calls.push("saveLayout");
+        return { id: URL_UUID, isNew: true, updatedAt: sentinelUpdatedAt };
+      },
+      async deleteLayout() {
+        calls.push("deleteLayout");
+        return false;
+      },
+      async listSnapshots() {
+        calls.push("listSnapshots");
+        return null;
+      },
+      async getSnapshot() {
+        calls.push("getSnapshot");
+        return null;
+      },
+      async saveSnapshot() {
+        calls.push("saveSnapshot");
+        return null;
+      },
+      async getPreCarrierBackup() {
+        calls.push("getPreCarrierBackup");
+        return null;
+      },
+    };
+
+    const stubApp = await createApp(
+      {
+        NODE_ENV: "test",
+        DATA_DIR: testDir,
+        RACKULA_RATE_LIMIT_ENABLED: "false",
+      } satisfies EnvMap,
+      { storage: stub },
+    );
+
+    // Exercise every layout route so each one is proven to resolve the driver
+    // from context. A route reverting to a direct filesystem import (the bypass
+    // class this seam removes) would not record a call on the stub.
+    const snapshotFilename = "injected~20260101-000000.yaml";
+    await stubApp.request("/layouts");
+    await stubApp.request(`/layouts/${URL_UUID}`);
+    const putRes = await stubApp.request(`/layouts/${URL_UUID}`, {
+      method: "PUT",
+      headers: { "Content-Type": "text/yaml" },
+      body: layoutYaml("Injected", URL_UUID),
+    });
+    await stubApp.request(`/layouts/${URL_UUID}`, { method: "DELETE" });
+    await stubApp.request(`/layouts/${URL_UUID}/snapshots`);
+    await stubApp.request(`/layouts/${URL_UUID}/snapshots/${snapshotFilename}`);
+    await stubApp.request(`/layouts/${URL_UUID}/snapshots`, {
+      method: "POST",
+      headers: { "Content-Type": "text/yaml" },
+      body: "version: '1'\nname: Snap\nracks: []",
+    });
+    await stubApp.request(`/layouts/${URL_UUID}/pre-carrier-backup`);
+
+    // The PUT return value flows back through the route, proving the injected
+    // driver's result (not the filesystem's) is what the handler returns.
+    expect(putRes.status).toBe(201);
+    expect(putRes.headers.get("X-Rackula-Updated-At")).toBe(sentinelUpdatedAt);
+
+    // Every driver method backing a layout route was invoked via the context.
+    const expectedDriverCalls = [
+      "listLayouts",
+      "getLayout",
+      "saveLayout",
+      "deleteLayout",
+      "listSnapshots",
+      "getSnapshot",
+      "saveSnapshot",
+      "getPreCarrierBackup",
+    ];
+    for (const method of expectedDriverCalls) {
+      expect(calls).toContain(method);
+    }
   });
 });

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -21,17 +21,8 @@
 import { Hono } from "hono";
 import * as yaml from "js-yaml";
 import { UuidSchema, LayoutFileSchema } from "../schemas/layout";
-import {
-  listLayouts,
-  getLayout,
-  saveLayout,
-  deleteLayout,
-  listSnapshots,
-  getSnapshot,
-  saveSnapshot,
-  getPreCarrierBackup,
-  SNAPSHOT_NAME_PATTERN,
-} from "../storage/filesystem";
+import type { StorageVariables } from "../storage/driver";
+import { SNAPSHOT_NAME_PATTERN } from "../storage/snapshot-name";
 import { deleteLayoutAssets } from "../storage/assets";
 import { logger } from "../logger";
 
@@ -66,12 +57,12 @@ function isValidSnapshotFilenameParam(filename: string): boolean {
   return SNAPSHOT_NAME_PATTERN.test(filename);
 }
 
-const layouts = new Hono();
+const layouts = new Hono<{ Variables: StorageVariables }>();
 
 // List all layouts
 layouts.get("/", async (c) => {
   try {
-    const items = await listLayouts();
+    const items = await c.get("storage").listLayouts();
     return c.json({ layouts: items });
   } catch (error) {
     logger.error({ err: error }, "Failed to list layouts");
@@ -89,7 +80,7 @@ layouts.get("/:uuid", async (c) => {
   }
 
   try {
-    const layout = await getLayout(uuidResult.data);
+    const layout = await c.get("storage").getLayout(uuidResult.data);
     if (!layout) {
       return c.json({ error: "Layout not found" }, 404);
     }
@@ -160,14 +151,17 @@ layouts.put("/:uuid", async (c) => {
       }
     }
 
-    const result = await saveLayout(
-      yamlContent,
-      uuidResult.data,
-      c.req.header(UPDATED_AT_HEADER),
-      {
-        preCarrierMigration: c.req.header(PRE_CARRIER_MIGRATION_HEADER) === "1",
-      },
-    );
+    const result = await c
+      .get("storage")
+      .saveLayout(
+        yamlContent,
+        uuidResult.data,
+        c.req.header(UPDATED_AT_HEADER),
+        {
+          preCarrierMigration:
+            c.req.header(PRE_CARRIER_MIGRATION_HEADER) === "1",
+        },
+      );
 
     c.header(UPDATED_AT_HEADER, result.updatedAt);
     return c.json(
@@ -205,7 +199,7 @@ layouts.delete("/:uuid", async (c) => {
   }
 
   try {
-    const deleted = await deleteLayout(uuidResult.data);
+    const deleted = await c.get("storage").deleteLayout(uuidResult.data);
     if (!deleted) {
       return c.json({ error: "Layout not found" }, 404);
     }
@@ -239,7 +233,7 @@ layouts.get("/:uuid/snapshots", async (c) => {
   }
 
   try {
-    const snapshots = await listSnapshots(uuidResult.data);
+    const snapshots = await c.get("storage").listSnapshots(uuidResult.data);
     if (snapshots === null) {
       return c.json({ error: "Layout not found" }, 404);
     }
@@ -269,7 +263,9 @@ layouts.get("/:uuid/snapshots/:filename", async (c) => {
   }
 
   try {
-    const content = await getSnapshot(uuidResult.data, filename);
+    const content = await c
+      .get("storage")
+      .getSnapshot(uuidResult.data, filename);
     if (content === null) {
       return c.json({ error: "Snapshot not found" }, 404);
     }
@@ -307,7 +303,9 @@ layouts.post("/:uuid/snapshots", async (c) => {
       return c.json({ error: `Invalid YAML: ${message}` }, 400);
     }
 
-    const result = await saveSnapshot(uuidResult.data, yamlContent);
+    const result = await c
+      .get("storage")
+      .saveSnapshot(uuidResult.data, yamlContent);
     if (!result) {
       return c.json({ error: "Layout not found" }, 404);
     }
@@ -335,7 +333,7 @@ layouts.get("/:uuid/pre-carrier-backup", async (c) => {
   }
 
   try {
-    const content = await getPreCarrierBackup(uuidResult.data);
+    const content = await c.get("storage").getPreCarrierBackup(uuidResult.data);
     if (content === null) {
       return c.json({ error: "Pre-carrier backup not found" }, 404);
     }

--- a/api/src/storage/driver.ts
+++ b/api/src/storage/driver.ts
@@ -1,0 +1,57 @@
+/**
+ * Storage driver interface (#2624, slice 1 of #2133).
+ *
+ * The seam that lets the API serve layouts from different backends: the
+ * filesystem (self-host / Bun) today, Cloudflare R2 (#2625) next. Routes resolve
+ * the driver per-request from the Hono context instead of importing the
+ * filesystem free functions directly, so the backend is selected once at the
+ * edge (createApp / the future Workers entry) rather than baked into every
+ * handler. The R2 driver implements this same interface and is proven against
+ * the shared storage contract (#2091).
+ */
+import type { LayoutListItem } from "../schemas/layout";
+import type { SnapshotListItem } from "./filesystem";
+
+export interface StorageDriver {
+  /** List all stored layouts. */
+  listLayouts(): Promise<LayoutListItem[]>;
+  /** Read a layout by UUID, or null if it does not exist. */
+  getLayout(
+    uuid: string,
+  ): Promise<{ content: string; updatedAt: string } | null>;
+  /**
+   * Create or update a layout. `echoedUpdatedAt` is the updatedAt the client
+   * last received; a mismatch with the stored copy snapshots the diverged copy
+   * before overwriting it. Returns the stored copy's new updatedAt.
+   *
+   * Argument order is (yamlContent, existingId, ...), matching the filesystem
+   * free function. The #2091 contract harness (StorageContractDriver) takes
+   * (id, yamlContent, ...), so its adapter swaps the two; keep that swap when
+   * wiring a new driver into the contract. Slice 2 (#2625) aligns the orders.
+   */
+  saveLayout(
+    yamlContent: string,
+    existingId?: string,
+    echoedUpdatedAt?: string,
+    options?: { preCarrierMigration?: boolean },
+  ): Promise<{ id: string; isNew: boolean; updatedAt: string }>;
+  /** Delete a layout by UUID. Returns false if it did not exist. */
+  deleteLayout(uuid: string): Promise<boolean>;
+  /** List a layout's pre-overwrite snapshots, or null if the layout is missing. */
+  listSnapshots(uuid: string): Promise<SnapshotListItem[] | null>;
+  /** Read a single snapshot's YAML content, or null if not found. */
+  getSnapshot(uuid: string, filename: string): Promise<string | null>;
+  /**
+   * Persist a losing local copy as a snapshot, or null if the layout is
+   * missing.
+   */
+  saveSnapshot(
+    uuid: string,
+    yamlContent: string,
+  ): Promise<{ filename: string } | null>;
+  /** Read the durable pre-carrier-migration backup, or null if absent. */
+  getPreCarrierBackup(uuid: string): Promise<string | null>;
+}
+
+/** Hono context Variables carrying the per-request storage driver. */
+export type StorageVariables = { storage: StorageDriver };

--- a/api/src/storage/filesystem-contract.test.ts
+++ b/api/src/storage/filesystem-contract.test.ts
@@ -21,7 +21,8 @@ async function makeFilesystemDriver(): Promise<{
   const previousDataDir = process.env.DATA_DIR;
   process.env.DATA_DIR = dataDir;
 
-  const { saveLayout, getLayout } = await import("./filesystem");
+  const { createFilesystemDriver } = await import("./filesystem-driver");
+  const fsDriver = createFilesystemDriver();
 
   async function snapshotContents(id: string): Promise<string[]> {
     const entries = await readdir(dataDir, { withFileTypes: true });
@@ -47,11 +48,15 @@ async function makeFilesystemDriver(): Promise<{
 
   const driver: StorageContractDriver = {
     async saveLayout(id, yamlContent, echoedUpdatedAt) {
-      const result = await saveLayout(yamlContent, id, echoedUpdatedAt);
+      const result = await fsDriver.saveLayout(
+        yamlContent,
+        id,
+        echoedUpdatedAt,
+      );
       return { updatedAt: result.updatedAt };
     },
     getLayout(id) {
-      return getLayout(id);
+      return fsDriver.getLayout(id);
     },
     getSnapshotContents(id) {
       return snapshotContents(id);

--- a/api/src/storage/filesystem-driver.ts
+++ b/api/src/storage/filesystem-driver.ts
@@ -1,0 +1,34 @@
+/**
+ * Filesystem-backed StorageDriver (#2624).
+ *
+ * A thin adapter over the api/src/storage/filesystem.ts free functions;
+ * behaviour is unchanged (per-layout write locks, atomic snapshot-on-mismatch,
+ * monotonic updatedAt all live in filesystem.ts). This is the default driver
+ * for the self-host / Bun runtime; the Workers runtime binds an R2 driver
+ * (#2625) behind the same interface.
+ */
+import type { StorageDriver } from "./driver";
+import {
+  listLayouts,
+  getLayout,
+  saveLayout,
+  deleteLayout,
+  listSnapshots,
+  getSnapshot,
+  saveSnapshot,
+  getPreCarrierBackup,
+} from "./filesystem";
+
+/** Construct the filesystem storage driver. */
+export function createFilesystemDriver(): StorageDriver {
+  return {
+    listLayouts,
+    getLayout,
+    saveLayout,
+    deleteLayout,
+    listSnapshots,
+    getSnapshot,
+    saveSnapshot,
+    getPreCarrierBackup,
+  };
+}

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs/promises";
 import { join } from "node:path";
 import * as yaml from "js-yaml";
+import { SNAPSHOT_NAME_PATTERN } from "./snapshot-name";
 import {
   LayoutFileSchema,
   isUuid,
@@ -159,8 +160,6 @@ function formatSnapshotTimestamp(date: Date): string {
     `-${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`
   );
 }
-
-export const SNAPSHOT_NAME_PATTERN = /~(\d{8}-\d{6})(?:-(\d+))?\.yaml$/;
 
 // Control characters (ASCII 0x00-0x1F and 0x7F) are never valid in a snapshot
 // filename and must be rejected before any filesystem access.

--- a/api/src/storage/snapshot-name.ts
+++ b/api/src/storage/snapshot-name.ts
@@ -1,0 +1,9 @@
+/**
+ * Snapshot filename pattern, shared by the filesystem storage layer and the
+ * layout routes' input validation. Extracted from filesystem.ts (#2624) so the
+ * routes can validate snapshot filenames without importing the filesystem
+ * storage module.
+ */
+
+/** Matches a snapshot suffix: {base}~YYYYMMDD-HHMMSS[-N].yaml */
+export const SNAPSHOT_NAME_PATTERN = /~(\d{8}-\d{6})(?:-(\d+))?\.yaml$/;


### PR DESCRIPTION
## **User description**
## Summary

Slice 1 of #2133 (move dev to Cloudflare Workers). Introduces the storage-driver seam the dev Worker needs: a `StorageDriver` interface, a filesystem implementation behind it, and per-request injection via Hono context. Pure refactor; behaviour on the self-host / Bun path is unchanged.

## What changed

- New `api/src/storage/driver.ts`: `StorageDriver` interface (the layout + snapshot operations the routes use) + `StorageVariables` context type.
- New `api/src/storage/filesystem-driver.ts`: `createFilesystemDriver()`, a thin wrapper over the existing filesystem free functions. Per-layout write locks, atomic snapshot-on-mismatch, and monotonic updatedAt all stay in `filesystem.ts`.
- `createApp(env, deps?)` resolves the driver once and injects it per request via a `c.set("storage", ...)` middleware; the Workers entry (#2626) will pass an R2 driver instead.
- `routes/layouts.ts` resolves `c.get("storage")` instead of importing filesystem free functions.
- `SNAPSHOT_NAME_PATTERN` moves to `storage/snapshot-name.ts` so the routes validate snapshot filenames without importing the filesystem module.
- `AppEnv.Variables` composes `StorageVariables` (single source for the storage context-key type).

## Scope (deferred to later slices)

- The storage-quota middleware stays filesystem-coupled here; its abstraction pairs with the R2 quota (prefix count) in slice 2 (#2625), and forcing it now would only churn its standalone test for no functional gain.
- Asset storage stays filesystem-only (`deleteLayoutAssets` in the DELETE handler is FS-coupled by design, per the #2133 scope); asset abstraction is future work.
- `StorageDriver.saveLayout` arg order is `(yamlContent, id, ...)` to match the filesystem function, while the #2091 contract harness uses `(id, yamlContent, ...)` and its adapter swaps them. A doc warning is in place; slice 2 aligns the two when it makes the harness runner-agnostic.

## Review

An xhigh multi-agent review ran pre-push. Addressed: extended the injection test to exercise all eight layout routes (was two), removed a dead `layoutExists` interface method, and composed `AppEnv` from `StorageVariables`. The deferrals above are the verified-but-out-of-scope findings.

## Test plan

- [x] `cd api && bun run typecheck` clean
- [x] `cd api && bun test`: 337 pass / 0 fail, including the shared storage contract run through `createFilesystemDriver` and a new injection test asserting all eight routes resolve the context-provided driver (a stub's sentinel updatedAt surfaces through PUT)
- [x] prettier clean

Closes #2624. Part of #2133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prepare layout routes to use interchangeable storage backends**

### What Changed
- Layout routes now read storage operations from a per-request backend instead of calling the filesystem directly
- The default filesystem storage path still behaves the same, including layout reads, saves, deletes, snapshots, and backup access
- Snapshot filename validation now shares one rule between storage and route checks
- Added a route test that verifies the app uses the storage backend it is given

### Impact
`✅ Ready for Cloudflare Workers storage`
`✅ Easier backend swapping without changing routes`
`✅ Fewer regressions when adding new storage backends`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
