### PR TITLE
fix: prompt before overwriting an existing server copy on storage opt-in (#2608)

### DIFF
--- a/src/lib/components/ServerAvailableBanner.svelte
+++ b/src/lib/components/ServerAvailableBanner.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
-  import { switchToServerMode } from "$lib/storage";
+  import {
+    switchToServerMode,
+    confirmServerOverwrite,
+    adoptServerCopy,
+    type ServerCopyInfo,
+    type SwitchResult,
+  } from "$lib/storage";
 
   // Shown only when the parent determines a server is reachable in browser mode.
   let { onDismiss }: { onDismiss: () => void } = $props();
@@ -11,21 +17,54 @@
 
   let confirming = $state(false);
   let working = $state(false);
+  // Set when the server already holds a layout under this UUID; drives the
+  // replace-or-keep prompt instead of a blind overwrite (#2608).
+  let conflict = $state<ServerCopyInfo | null>(null);
 
   const layoutName = $derived(layoutStore.layout?.name ?? "your layout");
   const hasWork = $derived(layoutStore.hasRack);
 
-  async function confirmSwitch() {
-    working = true;
-    const result = await switchToServerMode();
+  // Route any switch outcome: reload on success, raise the conflict prompt, or
+  // toast the failure. Reload is synchronous so a debounced autosave never runs
+  // before the navigation (matters most for the keep-server path).
+  function handleResult(result: SwitchResult) {
     if (result.switched) {
-      // Boot cleanly in server mode; the override now resolves getStorageMode.
       window.location.reload();
       return;
     }
     working = false;
+    if (result.reason === "conflict") {
+      conflict = result.serverCopy;
+      return;
+    }
     confirming = false;
+    conflict = null;
     toastStore.showToast(result.message, "warning", 6000);
+  }
+
+  async function confirmSwitch() {
+    working = true;
+    handleResult(await switchToServerMode());
+  }
+
+  async function replaceServerCopy() {
+    if (!conflict) return;
+    working = true;
+    handleResult(await confirmServerOverwrite(conflict));
+  }
+
+  async function keepServerCopy() {
+    if (!conflict) return;
+    working = true;
+    handleResult(await adoptServerCopy(conflict));
+  }
+
+  function cancelConflict() {
+    // The probe already restored the clean browser baseline (override never set,
+    // apiAvailable dropped), so dismissing is purely local UI state.
+    conflict = null;
+    confirming = false;
+    working = false;
   }
 
   function startSwitch() {
@@ -35,30 +74,65 @@
       void confirmSwitch();
     }
   }
+
+  function formatUpdatedAt(isoString: string): string {
+    // toLocaleString already uses the locale's default hour cycle, so no explicit
+    // hour12 is needed.
+    return new Date(isoString).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  function formatCounts(rackCount: number, deviceCount: number): string {
+    const racks = rackCount === 1 ? "1 rack" : `${rackCount} racks`;
+    const devices = deviceCount === 1 ? "1 device" : `${deviceCount} devices`;
+    return `${racks}, ${devices}`;
+  }
 </script>
 
 <div class="server-banner" role="alert">
-  {#if !confirming}
+  {#if conflict}
     <div class="server-banner-body">
-      <p class="server-banner-title">A storage server is available</p>
+      <p class="server-banner-title">A copy already exists on the server</p>
       <p class="server-banner-text">
-        Your layouts are saving to this browser only. Switch to server mode to
-        save them on the server.
+        A layout with this ID is already saved on the server. Replace it with
+        your browser copy, or keep the server copy and switch to server mode
+        (find it in your Layouts list).
       </p>
-      <p class="server-banner-hint">
-        To make server mode the default for everyone, set
-        RACKULA_STORAGE_MODE=server.
+      <p class="server-banner-text">
+        Server copy "{conflict.name}": {formatCounts(
+          conflict.rackCount,
+          conflict.deviceCount,
+        )}, updated {formatUpdatedAt(conflict.updatedAt)}.
+      </p>
+      <p class="server-banner-text">
+        Your browser copy "{layoutName}": {formatCounts(
+          layoutStore.rackCount,
+          layoutStore.totalDeviceCount,
+        )}.
       </p>
     </div>
     <div class="server-banner-actions">
-      <button type="button" disabled={working} onclick={startSwitch}
-        >Switch to server mode</button
+      <button type="button" disabled={working} onclick={replaceServerCopy}>
+        {working ? "Working..." : "Replace server copy"}
+      </button>
+      <button type="button" disabled={working} onclick={keepServerCopy}>
+        {working ? "Working..." : "Keep server copy"}
+      </button>
+      <button
+        type="button"
+        class="server-banner-secondary"
+        disabled={working}
+        onclick={cancelConflict}
       >
-      <button type="button" class="server-banner-secondary" onclick={onDismiss}>
-        Stay in browser mode
+        Cancel
       </button>
     </div>
-  {:else}
+  {:else if confirming}
     <div class="server-banner-body">
       <p class="server-banner-title">Upload and switch?</p>
       <p class="server-banner-text">
@@ -77,6 +151,31 @@
         onclick={() => (confirming = false)}
       >
         Cancel
+      </button>
+    </div>
+  {:else}
+    <div class="server-banner-body">
+      <p class="server-banner-title">A storage server is available</p>
+      <p class="server-banner-text">
+        Your layouts are saving to this browser only. Switch to server mode to
+        save them on the server.
+      </p>
+      <p class="server-banner-hint">
+        To make server mode the default for everyone, set
+        RACKULA_STORAGE_MODE=server.
+      </p>
+    </div>
+    <div class="server-banner-actions">
+      <button type="button" disabled={working} onclick={startSwitch}
+        >Switch to server mode</button
+      >
+      <button
+        type="button"
+        class="server-banner-secondary"
+        disabled={working}
+        onclick={onDismiss}
+      >
+        Stay in browser mode
       </button>
     </div>
   {/if}
@@ -106,6 +205,7 @@
   }
   .server-banner-actions {
     display: flex;
+    flex-wrap: wrap;
     gap: var(--space-2);
   }
 </style>

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -113,5 +113,9 @@ export {
   isStorageModeFromOverride,
   clearStorageModeOverride,
 } from "./availability.svelte";
-export { switchToServerMode } from "./server-opt-in.svelte";
-export type { SwitchResult } from "./server-opt-in.svelte";
+export {
+  switchToServerMode,
+  confirmServerOverwrite,
+  adoptServerCopy,
+} from "./server-opt-in.svelte";
+export type { SwitchResult, ServerCopyInfo } from "./server-opt-in.svelte";

--- a/src/lib/storage/server-opt-in.svelte.ts
+++ b/src/lib/storage/server-opt-in.svelte.ts
@@ -4,75 +4,107 @@
  * active-layout scope; full multi-layout upload rides on the future tabs work),
  * then sets the upgrade-only override. The caller reloads on a true result so
  * the app boots cleanly in server mode. Browser localStorage is never deleted.
+ *
+ * When a server layout already exists under the active layout's UUID, the switch
+ * does not overwrite it blindly. switchToServerMode returns a "conflict" result
+ * carrying the server copy's metadata so the caller can ask the user to replace
+ * it (confirmServerOverwrite) or keep it (adoptServerCopy). See #2608.
  */
-import { checkApiHealth, saveLayoutToServer } from "./api";
+import { checkApiHealth, saveLayoutToServer, listSavedLayouts } from "./api";
 import {
   setApiAvailable,
   setStorageModeOverride,
   clearStorageModeOverride,
   getStorageModeOverride,
 } from "./availability.svelte";
+import { setServerBaseUpdatedAt } from "./server-base";
+import { clearSession } from "./working-copy";
 import { getLayoutStore } from "$lib/stores/layout.svelte";
 import { getImageStore } from "$lib/stores/images.svelte";
+
+/** Metadata of a server layout that already exists under the active layout's UUID. */
+export interface ServerCopyInfo {
+  id: string;
+  updatedAt: string;
+  name: string;
+  rackCount: number;
+  deviceCount: number;
+}
 
 /** Result of a browser-to-server storage opt-in attempt: success, or failure with a reason. */
 export type SwitchResult =
   | { switched: true }
   | {
       switched: false;
-      reason: "unreachable" | "upload-failed" | "override-failed";
+      reason:
+        | "unreachable"
+        | "upload-failed"
+        | "override-failed"
+        | "probe-failed";
       message: string;
-    };
+    }
+  | { switched: false; reason: "conflict"; serverCopy: ServerCopyInfo };
+
+const OVERRIDE_FAILED_MESSAGE =
+  "Could not save the server-mode preference in this browser. Check private browsing or storage settings.";
+
+const UNREACHABLE_MESSAGE = "The storage server is no longer reachable.";
+
+function overrideFailedResult(): SwitchResult {
+  return {
+    switched: false,
+    reason: "override-failed",
+    message: OVERRIDE_FAILED_MESSAGE,
+  };
+}
 
 /**
- * Switches the app from browser to server storage mode.
+ * Persist the server-mode override so getStorageMode resolves to "server" and
+ * saveLayoutToServer routes user images to the asset API (disk) instead of
+ * embedding them inline, which would blow the server's 1MB layout PUT cap.
  *
- * Re-checks server health, uploads the active layout (matching exportAllBrowser's
- * active-layout scope), sets the upgrade-only override, then returns switched: true.
- * The caller reloads on success so the app boots cleanly in server mode.
+ * apiAvailable is set BEFORE the override on purpose: while only apiAvailable is
+ * true the mode is still "browser" (manager Effect 2 guards on mode first), so
+ * setting the non-reactive override afterwards never wakes server autosave.
  *
- * Returns switched: false with a reason when any step fails:
- * - "unreachable": health check failed
- * - "override-failed": localStorage refused to persist the server-mode preference
- * - "upload-failed": the layout upload threw before completing
+ * Returns an override-failed result when localStorage refused the write (private
+ * browsing, quota); null on success.
  */
-export async function switchToServerMode(): Promise<SwitchResult> {
-  // Re-verify health so a server that dropped since the probe does not strand
-  // the user in a dead server mode.
-  const healthy = await checkApiHealth();
-  if (!healthy) {
-    return {
-      switched: false,
-      reason: "unreachable",
-      message: "The storage server is no longer reachable.",
-    };
-  }
-
-  // Mark the API available so saveLayoutToServer's guard passes, and set the
-  // override BEFORE the upload so saveLayoutToServer sees server mode and routes
-  // user images to the asset API (disk) instead of embedding them inline, which
-  // would blow the server's 1MB layout PUT cap for image-heavy layouts.
+function persistOverride(): SwitchResult | null {
   setApiAvailable(true);
   setStorageModeOverride();
-
-  // setStorageModeOverride swallows a localStorage write failure (private
-  // browsing, quota). If the override did not persist, the reload would land
-  // back in browser mode, so report failure instead of a false success.
+  // setStorageModeOverride swallows a localStorage write failure, so verify it
+  // actually stuck; otherwise the reload would land back in browser mode.
   if (getStorageModeOverride() !== "server") {
     setApiAvailable(false);
-    return {
-      switched: false,
-      reason: "override-failed",
-      message:
-        "Could not save the server-mode preference in this browser. Check private browsing or storage settings.",
-    };
+    return overrideFailedResult();
   }
+  return null;
+}
+
+/**
+ * Finish the switch: persist the override, then upload the active layout when
+ * there is one. `base` is the optimistic-concurrency base sent to the server:
+ * null for a fresh create (nothing to clobber), or the server's last-known
+ * updatedAt when replacing a copy we just probed.
+ */
+async function commitSwitch(base: string | null): Promise<SwitchResult> {
+  const failed = persistOverride();
+  if (failed) return failed;
 
   const layoutStore = getLayoutStore();
   if (layoutStore.hasRack) {
+    // Seed the server base before the upload so a server-autosave that races the
+    // (possibly slow, image-heavy) upload echoes this base rather than a null
+    // one, keeping the divergence-snapshot check honest mid-upload (#2608).
+    setServerBaseUpdatedAt(base);
     try {
-      const snapshot = structuredClone($state.snapshot(layoutStore.layout));
-      await saveLayoutToServer(snapshot, getImageStore().getUserImages(), null);
+      // $state.snapshot already returns a detached deep copy safe to hand off.
+      await saveLayoutToServer(
+        $state.snapshot(layoutStore.layout),
+        getImageStore().getUserImages(),
+        base,
+      );
     } catch (error) {
       // Revert the opt-in so a failed upload leaves the user honestly in browser
       // mode with their browser data intact, not stranded mid-switch.
@@ -89,5 +121,226 @@ export async function switchToServerMode(): Promise<SwitchResult> {
     }
   }
 
+  return { switched: true };
+}
+
+/**
+ * Find a server layout already stored under `uuid`, returning its display
+ * metadata or null when none exists. UUIDs are matched case-insensitively to
+ * mirror the server (a PUT with either casing hits the same stored layout), so
+ * the prompt fires whenever an overwrite would actually land. Throws when the
+ * server cannot be queried; the caller treats that as fail-closed.
+ */
+async function findServerCopy(uuid: string): Promise<ServerCopyInfo | null> {
+  const target = uuid.toLowerCase();
+  const items = await listSavedLayouts();
+  const match = items.find((it) => it.id.toLowerCase() === target);
+  if (!match) return null;
+  return {
+    id: match.id,
+    updatedAt: match.updatedAt,
+    name: match.name,
+    rackCount: match.rackCount,
+    deviceCount: match.deviceCount,
+  };
+}
+
+/**
+ * Guard the resolution helpers against a stale prompt: the conflict banner is
+ * non-blocking, so the active layout can change (a switch, a load) between the
+ * probe and the user's click. Only proceed when the active layout is still the
+ * one the prompt was about, matched case-insensitively to mirror the server.
+ */
+function activeLayoutMatches(serverCopy: ServerCopyInfo): boolean {
+  const uuid = getLayoutStore().layout?.metadata?.id;
+  return !!uuid && uuid.toLowerCase() === serverCopy.id.toLowerCase();
+}
+
+function staleResult(): SwitchResult {
+  return {
+    switched: false,
+    reason: "probe-failed",
+    message: "The active layout changed. Please try switching again.",
+  };
+}
+
+/**
+ * Switches the app from browser to server storage mode.
+ *
+ * Re-checks server health, then probes for an existing server layout under the
+ * active layout's UUID. If one exists, returns a "conflict" result instead of
+ * overwriting; otherwise uploads the active layout, sets the upgrade-only
+ * override, and returns switched: true. The caller reloads on success.
+ *
+ * Returns switched: false with a reason when a step fails or needs the user:
+ * - "unreachable": health check failed
+ * - "probe-failed": could not determine whether a server copy exists
+ * - "override-failed": localStorage refused to persist the server-mode preference
+ * - "upload-failed": the layout upload threw before completing
+ * - "conflict": a server copy already exists (carries its metadata)
+ */
+export async function switchToServerMode(): Promise<SwitchResult> {
+  // Re-verify health so a server that dropped since the probe does not strand
+  // the user in a dead server mode.
+  const healthy = await checkApiHealth();
+  if (!healthy) {
+    return {
+      switched: false,
+      reason: "unreachable",
+      message: UNREACHABLE_MESSAGE,
+    };
+  }
+
+  // Mark the API reachable so the probe (and any upload) can run. The override
+  // stays UNSET here, so getStorageMode is still "browser" and server autosave
+  // stays dormant: we can read server state without risking a stray PUT.
+  setApiAvailable(true);
+
+  const layoutStore = getLayoutStore();
+
+  // Empty workspace: there is nothing to upload, so the conflict prompt does not
+  // apply. Switch and clear the legacy session so a stale or emptied layout that
+  // shares a UUID with a server copy can never later autosave over it.
+  if (!layoutStore.hasRack) {
+    return switchEmptyWorkspace();
+  }
+
+  const uuid = layoutStore.layout?.metadata?.id;
+  // Only a stable UUID can collide with a server copy. Without one the upload
+  // path reports any save error itself (saveLayoutToServer requires a
+  // metadata.id), so there is nothing to probe for here.
+  if (uuid) {
+    let existing: ServerCopyInfo | null;
+    try {
+      existing = await findServerCopy(uuid);
+    } catch {
+      // Fail closed: if we cannot tell whether a server copy exists, do not
+      // risk a blind overwrite. Leave the user in browser mode to retry.
+      setApiAvailable(false);
+      return {
+        switched: false,
+        reason: "probe-failed",
+        message:
+          "Couldn't check the server for an existing copy. Please try again.",
+      };
+    }
+    // The active layout can change while findServerCopy is in flight (the app
+    // stays interactive). Re-validate before acting so a layout swapped in mid-
+    // probe is never prompted for or blind-uploaded against a stale probe. Match
+    // case-insensitively, like findServerCopy and the server.
+    const currentUuid = layoutStore.layout?.metadata?.id;
+    if (
+      currentUuid?.toLowerCase() !== uuid.toLowerCase() ||
+      !layoutStore.hasRack
+    ) {
+      setApiAvailable(false);
+      return staleResult();
+    }
+    if (existing) {
+      // Hand the decision back to the caller instead of overwriting. Restore
+      // the clean browser baseline (the override was never set; drop
+      // apiAvailable) so nothing is half-switched while the user decides; the
+      // resolution helpers re-establish availability.
+      setApiAvailable(false);
+      return { switched: false, reason: "conflict", serverCopy: existing };
+    }
+  }
+
+  // No existing server copy: switch and upload as a fresh create. No base is
+  // needed since there is nothing to clobber.
+  return await commitSwitch(null);
+}
+
+/**
+ * Switch an empty workspace (no racks) to server mode. Nothing is uploaded, and
+ * the legacy session is cleared so an empty or stale layout that happens to
+ * share a UUID with a server copy cannot later autosave over it; the reload
+ * boots cleanly to the server library. apiAvailable is left false so no autosave
+ * wakes before the reload.
+ */
+function switchEmptyWorkspace(): SwitchResult {
+  setApiAvailable(false);
+  setStorageModeOverride();
+  if (getStorageModeOverride() !== "server") {
+    return overrideFailedResult();
+  }
+  clearSession();
+  return { switched: true };
+}
+
+/**
+ * Replace the existing server copy with the browser copy after the user
+ * confirms. Bails out if the active layout changed since the prompt, so a stale
+ * probe never commits the wrong layout. Re-checks health first so a server that
+ * dropped while the user read the prompt yields a clean "unreachable" message
+ * rather than a raw upload error. Passing the server's last-known updatedAt as
+ * the base gives real optimistic concurrency: if the server copy changed between
+ * the prompt and this click, the server snapshots it before overwriting (the
+ * filesystem divergence check); otherwise it is a clean, user-consented
+ * overwrite. The caller reloads on success.
+ */
+export async function confirmServerOverwrite(
+  serverCopy: ServerCopyInfo,
+): Promise<SwitchResult> {
+  if (!activeLayoutMatches(serverCopy)) return staleResult();
+  const healthy = await checkApiHealth();
+  if (!healthy) {
+    return {
+      switched: false,
+      reason: "unreachable",
+      message: UNREACHABLE_MESSAGE,
+    };
+  }
+  // Re-validate after the await: the active layout can change while the health
+  // check is in flight. Require racks too, so a now-empty layout cannot report a
+  // false success without actually uploading anything.
+  if (!activeLayoutMatches(serverCopy) || !getLayoutStore().hasRack) {
+    return staleResult();
+  }
+  return await commitSwitch(serverCopy.updatedAt);
+}
+
+/**
+ * Keep the server's copy: switch to server mode WITHOUT uploading, so the
+ * browser fork can never clobber it. The legacy autosave slot is cleared so the
+ * reload boots cleanly in server mode with the kept layout available in the
+ * Layouts list; the browser fork stays in the browser workspace storage
+ * (recoverable by switching back). Nothing the fork could autosave is left in a
+ * server-mode session, so the kept copy is never at risk.
+ *
+ * Bails out if the active layout changed since the prompt. Re-checks health
+ * first because, unlike replace, there is no upload to surface a server that
+ * dropped while the user read the prompt. Forces apiAvailable off before setting
+ * the override: a true apiAvailable here would let server autosave (manager
+ * Effect 2) PUT the fork over the very copy we are keeping before the reload
+ * lands. This is done explicitly rather than assumed, so the exported function
+ * is safe regardless of caller state. App.svelte re-checks health on reload.
+ */
+export async function adoptServerCopy(
+  serverCopy: ServerCopyInfo,
+): Promise<SwitchResult> {
+  if (!activeLayoutMatches(serverCopy)) return staleResult();
+  const healthy = await checkApiHealth();
+  if (!healthy) {
+    return {
+      switched: false,
+      reason: "unreachable",
+      message: UNREACHABLE_MESSAGE,
+    };
+  }
+  // Re-validate after the await: the active layout can change while the health
+  // check is in flight, and "keep" must act on the layout the prompt was about.
+  if (!activeLayoutMatches(serverCopy)) return staleResult();
+
+  setApiAvailable(false);
+  setStorageModeOverride();
+  if (getStorageModeOverride() !== "server") {
+    return overrideFailedResult();
+  }
+
+  // Drop any legacy single-slot session so the server-mode reload does not
+  // restore a stale layout; the kept copy is opened from the Layouts list. The
+  // browser workspace (multi-layout) storage is untouched.
+  clearSession();
   return { switched: true };
 }

--- a/src/tests/server-opt-in.test.ts
+++ b/src/tests/server-opt-in.test.ts
@@ -1,13 +1,30 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { SavedLayoutItem } from "$lib/storage";
 
 const apiMocks = vi.hoisted(() => ({
   checkApiHealth: vi.fn(async () => true),
   saveLayoutToServer: vi.fn(async () => ({ id: "uuid-1", updatedAt: "t0" })),
+  listSavedLayouts: vi.fn(async () => [] as SavedLayoutItem[]),
 }));
 vi.mock("$lib/storage/api", () => ({
   checkApiHealth: apiMocks.checkApiHealth,
   saveLayoutToServer: apiMocks.saveLayoutToServer,
+  listSavedLayouts: apiMocks.listSavedLayouts,
 }));
+
+/** A server layout listing entry sharing the active layout's UUID by default. */
+function serverItem(overrides: Partial<SavedLayoutItem> = {}): SavedLayoutItem {
+  return {
+    id: "uuid-1",
+    name: "My Rack",
+    version: "1",
+    updatedAt: "t-server",
+    rackCount: 2,
+    deviceCount: 5,
+    valid: true,
+    ...overrides,
+  };
+}
 
 const storeMocks = vi.hoisted(() => ({
   hasRack: true,
@@ -28,7 +45,20 @@ vi.mock("$lib/stores/images.svelte", () => ({
   getImageStore: () => ({ getUserImages: () => storeMocks.images }),
 }));
 
-import { switchToServerMode } from "$lib/storage/server-opt-in.svelte";
+// Partial mock: spy on clearSession (adopt clears the legacy slot so the fork is
+// never left in a server-mode session) while keeping the real helpers.
+const wcMocks = vi.hoisted(() => ({ clearSession: vi.fn() }));
+vi.mock("$lib/storage/working-copy", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("$lib/storage/working-copy")>();
+  return { ...actual, clearSession: wcMocks.clearSession };
+});
+
+import {
+  switchToServerMode,
+  confirmServerOverwrite,
+  adoptServerCopy,
+} from "$lib/storage";
 import {
   getStorageModeOverride,
   clearStorageModeOverride,
@@ -47,6 +77,8 @@ describe("switchToServerMode", () => {
     apiMocks.saveLayoutToServer
       .mockClear()
       .mockResolvedValue({ id: "uuid-1", updatedAt: "t0" });
+    apiMocks.listSavedLayouts.mockClear().mockResolvedValue([]);
+    wcMocks.clearSession.mockClear();
     storeMocks.hasRack = true;
   });
 
@@ -90,13 +122,16 @@ describe("switchToServerMode", () => {
     expect(isApiAvailable()).toBe(false);
   });
 
-  it("switches without uploading when there is no layout to move", async () => {
+  it("switches an empty workspace without uploading and clears the legacy session", async () => {
     storeMocks.hasRack = false;
     const result = await switchToServerMode();
     expect(result.switched).toBe(true);
     expect(apiMocks.saveLayoutToServer).not.toHaveBeenCalled();
     expect(getStorageModeOverride()).toBe("server");
-    expect(isApiAvailable()).toBe(true);
+    // Clear the legacy session so a stale/empty layout cannot autosave over a
+    // server copy; leave the API unavailable in-session (no upload).
+    expect(wcMocks.clearSession).toHaveBeenCalled();
+    expect(isApiAvailable()).toBe(false);
   });
 
   it("does not switch when the override cannot be persisted", async () => {
@@ -114,5 +149,136 @@ describe("switchToServerMode", () => {
     } finally {
       setItemSpy.mockRestore();
     }
+  });
+
+  it("returns a conflict instead of overwriting when a server copy exists", async () => {
+    apiMocks.listSavedLayouts.mockResolvedValue([
+      serverItem({ updatedAt: "t-server", rackCount: 3, deviceCount: 7 }),
+    ]);
+    const result = await switchToServerMode();
+    expect(result.switched).toBe(false);
+    if (!result.switched && result.reason === "conflict") {
+      expect(result.serverCopy.id).toBe("uuid-1");
+      expect(result.serverCopy.name).toBe("My Rack");
+      expect(result.serverCopy.updatedAt).toBe("t-server");
+      expect(result.serverCopy.rackCount).toBe(3);
+      expect(result.serverCopy.deviceCount).toBe(7);
+    } else {
+      expect.unreachable("expected a conflict result");
+    }
+    // Must not overwrite, and must leave a clean browser baseline for the prompt.
+    expect(apiMocks.saveLayoutToServer).not.toHaveBeenCalled();
+    expect(wcMocks.clearSession).not.toHaveBeenCalled();
+    expect(getStorageModeOverride()).toBe(null);
+    expect(isApiAvailable()).toBe(false);
+  });
+
+  it("matches the server copy case-insensitively by UUID", async () => {
+    storeMocks.layout = { name: "My Rack", metadata: { id: "UUID-1" } };
+    apiMocks.listSavedLayouts.mockResolvedValue([serverItem({ id: "uuid-1" })]);
+    try {
+      const result = await switchToServerMode();
+      expect(result.switched).toBe(false);
+      if (!result.switched) expect(result.reason).toBe("conflict");
+      expect(apiMocks.saveLayoutToServer).not.toHaveBeenCalled();
+    } finally {
+      storeMocks.layout = { name: "My Rack", metadata: { id: "uuid-1" } };
+    }
+  });
+
+  it("confirmServerOverwrite uploads with the server's updatedAt as the base", async () => {
+    const result = await confirmServerOverwrite(
+      serverItem({ updatedAt: "t-server" }),
+    );
+    expect(result.switched).toBe(true);
+    expect(apiMocks.saveLayoutToServer).toHaveBeenCalledTimes(1);
+    // The probed updatedAt is threaded as the optimistic-concurrency base.
+    expect(apiMocks.saveLayoutToServer.mock.calls[0]?.[2]).toBe("t-server");
+    expect(getStorageModeOverride()).toBe("server");
+    expect(isApiAvailable()).toBe(true);
+  });
+
+  it("confirmServerOverwrite bails out when the active layout changed since the prompt", async () => {
+    const result = await confirmServerOverwrite(serverItem({ id: "other-id" }));
+    expect(result.switched).toBe(false);
+    if (!result.switched) expect(result.reason).toBe("probe-failed");
+    expect(apiMocks.saveLayoutToServer).not.toHaveBeenCalled();
+    expect(getStorageModeOverride()).toBe(null);
+    expect(isApiAvailable()).toBe(false);
+  });
+
+  it("confirmServerOverwrite does not overwrite when the server is no longer reachable", async () => {
+    apiMocks.checkApiHealth.mockResolvedValue(false);
+    const result = await confirmServerOverwrite(
+      serverItem({ updatedAt: "t-server" }),
+    );
+    expect(result.switched).toBe(false);
+    if (!result.switched) expect(result.reason).toBe("unreachable");
+    expect(apiMocks.saveLayoutToServer).not.toHaveBeenCalled();
+    expect(getStorageModeOverride()).toBe(null);
+    expect(isApiAvailable()).toBe(false);
+  });
+
+  it("confirmServerOverwrite bails out if the active layout changes during the health check", async () => {
+    // The layout swaps under us while checkApiHealth is in flight (TOCTOU).
+    apiMocks.checkApiHealth.mockImplementation(async () => {
+      storeMocks.layout = { name: "Other", metadata: { id: "changed-id" } };
+      return true;
+    });
+    try {
+      const result = await confirmServerOverwrite(serverItem());
+      expect(result.switched).toBe(false);
+      if (!result.switched) expect(result.reason).toBe("probe-failed");
+      expect(apiMocks.saveLayoutToServer).not.toHaveBeenCalled();
+      expect(getStorageModeOverride()).toBe(null);
+      expect(isApiAvailable()).toBe(false);
+    } finally {
+      storeMocks.layout = { name: "My Rack", metadata: { id: "uuid-1" } };
+    }
+  });
+
+  it("adoptServerCopy keeps the server copy: switches without uploading and clears the legacy slot", async () => {
+    const result = await adoptServerCopy(serverItem());
+    expect(result.switched).toBe(true);
+    expect(apiMocks.checkApiHealth).toHaveBeenCalled();
+    expect(apiMocks.saveLayoutToServer).not.toHaveBeenCalled();
+    expect(getStorageModeOverride()).toBe("server");
+    // Clearing the legacy session means the fork is never left in a server-mode
+    // session, so nothing can autosave it over the kept server copy.
+    expect(wcMocks.clearSession).toHaveBeenCalled();
+    // Deliberately unavailable in-session: avoids waking server autosave to PUT
+    // the fork over the server copy before the reload adopts it.
+    expect(isApiAvailable()).toBe(false);
+  });
+
+  it("adoptServerCopy bails out when the active layout changed since the prompt", async () => {
+    const result = await adoptServerCopy(serverItem({ id: "other-id" }));
+    expect(result.switched).toBe(false);
+    if (!result.switched) expect(result.reason).toBe("probe-failed");
+    expect(getStorageModeOverride()).toBe(null);
+    expect(isApiAvailable()).toBe(false);
+    expect(wcMocks.clearSession).not.toHaveBeenCalled();
+  });
+
+  it("adoptServerCopy does not switch when the server is no longer reachable", async () => {
+    apiMocks.checkApiHealth.mockResolvedValue(false);
+    const result = await adoptServerCopy(serverItem());
+    expect(result.switched).toBe(false);
+    if (!result.switched) expect(result.reason).toBe("unreachable");
+    expect(getStorageModeOverride()).toBe(null);
+    expect(isApiAvailable()).toBe(false);
+    expect(wcMocks.clearSession).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the server cannot be queried for an existing copy", async () => {
+    apiMocks.listSavedLayouts.mockRejectedValue(new Error("network"));
+    const result = await switchToServerMode();
+    expect(result.switched).toBe(false);
+    if (!result.switched) expect(result.reason).toBe("probe-failed");
+    // Never blind-overwrite when existence is unknown; stay cleanly in browser.
+    expect(apiMocks.saveLayoutToServer).not.toHaveBeenCalled();
+    expect(wcMocks.clearSession).not.toHaveBeenCalled();
+    expect(getStorageModeOverride()).toBe(null);
+    expect(isApiAvailable()).toBe(false);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

The browser-to-server opt-in (`switchToServerMode`, shipped in #2604) uploaded the active layout with `saveLayoutToServer(snapshot, images, null)`. The `null` base meant no `X-Rackula-Updated-At` header, so the server's optimistic-concurrency check was skipped and an existing server layout with the same UUID was overwritten with no recovery snapshot. A returning user (mode toggled before, or saved from another session) could irrecoverably clobber a newer server copy.

This probes the server before switching and, on a UUID collision, prompts the user instead of overwriting blind.

## Behaviour

`switchToServerMode` re-checks health, then probes `listSavedLayouts()` for the active layout's UUID:

- No collision: switches and uploads as today.
- Collision: returns a `conflict` result with the server copy's metadata (name, last-updated, rack/device counts). The banner shows an informed comparison with two choices:
  - Replace server copy: re-checks health, then uploads with the probed `updatedAt` as the optimistic-concurrency base. If the server copy changed between the prompt and the click, the server snapshots it before overwriting; otherwise it is a clean, user-consented overwrite.
  - Keep server copy: switches to server mode without uploading and clears the legacy session, so the browser fork is never left in a server-mode session and can never autosave over the kept copy. The kept layout is opened from the Layouts list; the browser fork stays in browser workspace storage (recoverable by switching back).
- Probe error: fails closed (stays in browser mode to retry) rather than risking a blind overwrite.

Both resolution paths bail out if the active layout changed since the prompt (the banner is non-blocking), and the keep path forces `apiAvailable` off before setting the override so server autosave cannot wake.

## Notes

- The server has no 412 path; its concurrency control is snapshot-on-divergence (`api/src/storage/filesystem.ts`). The fix works with that: passing the probed base engages the snapshot net exactly when the server changed under us.
- "Keep server copy" lands on the Layouts list rather than auto-opening the kept layout. This is deliberate: routing the adopt through the reload reconcile path was explored and rejected because it reintroduced data-loss edges (a server blip during the reload could let the fork autosave over the kept copy). Not writing any fork session makes the kept copy safe by construction.
- The post-switch "upload your local copy" prompt on the no-conflict and Replace paths is pre-existing #2604 boot behaviour and is not data-lossy; left as-is to keep this change scoped.

## Test Plan

- [x] `npm run test:run -- server-opt-in` (14 cases: conflict detect, replace-with-base, keep/clear-session, fail-closed probe, unreachable on both paths, stale-active-layout guard on both paths, case-insensitive match)
- [x] Neighbouring storage + App startup suites green (`reconcile`, `save-layout-to-server`, `session-storage`, `storage-mode`, `App.startScreen`, `App.cleanupPrompt`, `persistence-manager-autosave`)
- [x] `npm run lint`, `npm run check` (svelte-check), `npm run build` clean; banner validated with the Svelte MCP autofixer
- [ ] Manual (dev, server reachable in browser mode): create a layout and opt in (no prompt); switch back, edit, re-opt-in (conflict prompt with comparison); Replace updates the server copy; Keep boots into server mode with the copy in Layouts and the fork still in localStorage; stop the API mid-prompt then act (fails closed, stays in browser)

Closes #2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prompt before overwriting an existing server copy when switching from browser mode**

### What Changed
- Switching to server mode now checks whether a layout with the same ID already exists on the server and stops with a conflict prompt instead of overwriting it silently.
- When a conflict is found, the banner shows server copy details and gives two choices: replace the server copy or keep it and switch to server mode without uploading.
- Replacing now uses the server copy’s last update time so an intervening server change is preserved as a snapshot before overwrite.
- Keeping the server copy switches modes without uploading, clears the old browser session, and prevents autosave from clobbering the kept server layout.
- If the server cannot be checked, the switch fails closed and stays in browser mode.

### Impact
`✅ Fewer accidental server overwrites`
`✅ Safer browser-to-server switching`
`✅ Clearer conflict choices for existing layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
