### PR TITLE
feat: show storage location inline on the chip with a last-save details popover

### DIFF
--- a/docs/plans/2026-06-26-storage-chip-ux.md
+++ b/docs/plans/2026-06-26-storage-chip-ux.md
@@ -53,7 +53,7 @@
 
 - Produces: `BackupState` gains optional `lastExportedAt?: string | null`. The layout store gains a `lastExportedAt: string | null` getter, `markExported()` stamps it with the current ISO time, and `restoreBackupState(state)` restores it (coercing `undefined` to `null`).
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] Step 1: Write the failing tests
 
 Add to `src/tests/changes-since-export.test.ts` (inside the existing top-level `describe`):
 
@@ -84,11 +84,11 @@ it("restores lastExportedAt through restoreBackupState", () => {
 });
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [ ] Step 2: Run the tests to verify they fail
 
 Run: `npm run test:run -- src/tests/changes-since-export.test.ts` Expected: FAIL (`store.lastExportedAt` is `undefined`; `restoreBackupState` ignores the new field).
 
-- [ ] **Step 3: Add `lastExportedAt` to `BackupState`**
+- [ ] Step 3: Add `lastExportedAt` to `BackupState`
 
 In `src/lib/stores/layout/persistence.ts`, change the interface (currently lines 15-18):
 
@@ -102,7 +102,7 @@ export interface BackupState {
 }
 ```
 
-- [ ] **Step 4: Track, set, expose, restore, and reset the field in the store**
+- [ ] Step 4: Track, set, expose, restore, and reset the field in the store
 
 In `src/lib/stores/layout.svelte.ts`:
 
@@ -159,15 +159,15 @@ hasEverExported = false;
 lastExportedAt = null;
 ```
 
-- [ ] **Step 5: Run the tests to verify they pass**
+- [ ] Step 5: Run the tests to verify they pass
 
 Run: `npm run test:run -- src/tests/changes-since-export.test.ts` Expected: PASS (all tests, including the two new ones).
 
-- [ ] **Step 6: Type-check**
+- [ ] Step 6: Type-check
 
 Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no new errors from these files.
 
-- [ ] **Step 7: Commit**
+- [ ] Step 7: Commit
 
 ```bash
 git add src/lib/stores/layout/persistence.ts src/lib/stores/layout.svelte.ts src/tests/changes-since-export.test.ts
@@ -191,7 +191,7 @@ git commit -s -m "feat: track lastExportedAt in the layout store"
 - Consumes: `layoutStore.lastExportedAt` (Task 1).
 - Produces: `LibraryEntry` and `DurabilityInput` gain `lastExportedAt: string | null`. New export `getLayoutSavedAt(id: string): string | null` returns a layout's last localStorage write time (the library entry `updatedAt`, or null when absent or empty).
 
-- [ ] **Step 1: Write the failing test**
+- [ ] Step 1: Write the failing test
 
 Add to `src/tests/changes-since-export.test.ts`. It exercises the real persist+restore round-trip through the multi-tab schema for the active layout. Add the import at the top of the file if not present:
 
@@ -224,11 +224,11 @@ it("persists and reads back lastExportedAt via the workspace library", () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] Step 2: Run the test to verify it fails
 
 Run: `npm run test:run -- src/tests/changes-since-export.test.ts` Expected: FAIL (`DurabilityInput` has no `lastExportedAt`; `getLayoutSavedAt` is not exported).
 
-- [ ] **Step 3: Add the field to `LibraryEntry` and `DurabilityInput`, write it, and add the helper**
+- [ ] Step 3: Add the field to `LibraryEntry` and `DurabilityInput`, write it, and add the helper
 
 In `src/lib/storage/browser-workspace.ts`:
 
@@ -287,7 +287,7 @@ export function getLayoutSavedAt(id: string): string | null {
 }
 ```
 
-- [ ] **Step 4: Thread the field through the persist path**
+- [ ] Step 4: Thread the field through the persist path
 
 In `src/lib/storage/browser-workspace-persist.ts`:
 
@@ -343,7 +343,7 @@ library[tab.layoutId] = {
 };
 ```
 
-- [ ] **Step 5: Populate the field in the tab snapshot**
+- [ ] Step 5: Populate the field in the tab snapshot
 
 In `src/lib/components/PersistenceEffects.svelte`, the hydrated branch of `snapshotWorkspaceTabs` (lines 89-95):
 
@@ -358,7 +358,7 @@ tabs.push({
 });
 ```
 
-- [ ] **Step 6: Restore the field**
+- [ ] Step 6: Restore the field
 
 In `src/lib/stores/workspace.svelte.ts`, the restore block (lines 291-298):
 
@@ -374,13 +374,13 @@ if (entry) {
 }
 ```
 
-- [ ] **Step 7: Run the test and the type-check**
+- [ ] Step 7: Run the test and the type-check
 
 Run: `npm run test:run -- src/tests/changes-since-export.test.ts` Expected: PASS.
 
 Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no new errors. (If any other `LibraryEntry` literal is reported as missing `lastExportedAt`, add `lastExportedAt: null` there.)
 
-- [ ] **Step 8: Commit**
+- [ ] Step 8: Commit
 
 ```bash
 git add src/lib/storage/browser-workspace.ts src/lib/storage/browser-workspace-persist.ts src/lib/components/PersistenceEffects.svelte src/lib/stores/workspace.svelte.ts src/tests/changes-since-export.test.ts
@@ -400,7 +400,7 @@ git commit -s -m "feat: persist lastExportedAt in the browser workspace library"
 
 - Produces: `formatRelativeTime(iso: string | null, nowMs?: number): string | null` returning `null` for null/invalid input, `"just now"` under 45 seconds, else an "N units ago" string. Deterministic when `nowMs` is supplied.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] Step 1: Write the failing test
 
 Create `src/tests/relative-time.test.ts`:
 
@@ -430,11 +430,11 @@ describe("formatRelativeTime", () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] Step 2: Run the test to verify it fails
 
 Run: `npm run test:run -- src/tests/relative-time.test.ts` Expected: FAIL ("Cannot find module '$lib/utils/relative-time'").
 
-- [ ] **Step 3: Implement the util**
+- [ ] Step 3: Implement the util
 
 Create `src/lib/utils/relative-time.ts`:
 
@@ -470,11 +470,11 @@ export function formatRelativeTime(
 }
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [ ] Step 4: Run the test to verify it passes
 
 Run: `npm run test:run -- src/tests/relative-time.test.ts` Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] Step 5: Commit
 
 ```bash
 git add src/lib/utils/relative-time.ts src/tests/relative-time.test.ts
@@ -495,7 +495,7 @@ git commit -s -m "feat: add formatRelativeTime util for the storage chip"
 - Consumes: `layoutStore.lastExportedAt` (Task 1).
 - Produces: `computeLayoutStatus(...)` returns two extra fields: `shortLabel: string` (the inline state word) and `showLocation: boolean` (false for self-describing error states). `LayoutDurability` gains `shortLabel: string`, `showLocation: boolean`, and `lastExportedAt: string | null`.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] Step 1: Write the failing test
 
 Create `src/tests/durability-inline-labels.test.ts`. `computeLayoutStatus` is a pure exported function (signature: `(saveStatus, consecutiveSaveFailures, storageMode, apiAvailable, changesSinceExport, hasEverExported, apiEverReached)`):
 
@@ -542,11 +542,11 @@ describe("computeLayoutStatus inline fields", () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] Step 2: Run the test to verify it fails
 
 Run: `npm run test:run -- src/tests/durability-inline-labels.test.ts` Expected: FAIL (`shortLabel` / `showLocation` are undefined).
 
-- [ ] **Step 3: Add the fields to the `computeLayoutStatus` return type and every branch**
+- [ ] Step 3: Add the fields to the `computeLayoutStatus` return type and every branch
 
 In `src/lib/storage/durability.svelte.ts`, extend the return type annotation (lines 78-84):
 
@@ -668,7 +668,7 @@ return {
 };
 ```
 
-- [ ] **Step 4: Add the fields to `LayoutDurability` and the durability getters**
+- [ ] Step 4: Add the fields to `LayoutDurability` and the durability getters
 
 Extend the `LayoutDurability` interface (lines 42-58) by adding, after `label: string;`:
 
@@ -700,13 +700,13 @@ In `getLayoutDurability` (lines 226-256), add getters alongside the existing one
     },
 ```
 
-- [ ] **Step 5: Run the test and the type-check**
+- [ ] Step 5: Run the test and the type-check
 
 Run: `npm run test:run -- src/tests/durability-inline-labels.test.ts` Expected: PASS.
 
 Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no new errors.
 
-- [ ] **Step 6: Commit**
+- [ ] Step 6: Commit
 
 ```bash
 git add src/lib/storage/durability.svelte.ts src/tests/durability-inline-labels.test.ts
@@ -727,7 +727,7 @@ git commit -s -m "feat: add inline label, location flag, and export time to dura
 - Consumes: `durability.shortLabel`, `durability.showLocation`, `durability.status`, `durability.icon`, `durability.serverHint` (Task 4); `isServerMode` (already computed in the component).
 - Produces: the chip renders `[icon] [shortLabel] . [location]` with the status colour on the state word and a muted location. Accessible name is `Storage status: {label}` plus `, Browser` or `, Server` when `showLocation` is true.
 
-- [ ] **Step 1: Update the test for the new accessible name**
+- [ ] Step 1: Update the test for the new accessible name
 
 Replace the assertion in `src/tests/StorageStatusChip.test.ts` (the existing test expects `/storage status: unsaved changes/i`). A fresh browser-mode store is dirty, so:
 
@@ -741,11 +741,11 @@ it("exposes the current storage state and location in its accessible name", () =
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] Step 2: Run the test to verify it fails
 
 Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts` Expected: FAIL (current accessible name has no location).
 
-- [ ] **Step 3: Add a derived accessible name and split the inline text**
+- [ ] Step 3: Add a derived accessible name and split the inline text
 
 In `src/lib/components/StorageStatusChip.svelte`, add a derived value in the `<script>` (after the `durability` constant, near line 36):
 
@@ -784,7 +784,7 @@ Replace the chip markup (lines 99-133) so the label splits into a coloured state
 </div>
 ```
 
-- [ ] **Step 4: Make the location and separator muted**
+- [ ] Step 4: Make the location and separator muted
 
 In the `<style>` block, the status classes currently colour the whole chip; keep that (so the icon and state word inherit the status colour) and override the location and separator to muted. Add after the `.storage-chip-error` rule:
 
@@ -801,11 +801,11 @@ In the `<style>` block, the status classes currently colour the whole chip; keep
 }
 ```
 
-- [ ] **Step 5: Run the test to verify it passes**
+- [ ] Step 5: Run the test to verify it passes
 
 Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts` Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] Step 6: Commit
 
 ```bash
 git add src/lib/components/StorageStatusChip.svelte src/tests/StorageStatusChip.test.ts
@@ -827,7 +827,7 @@ git commit -s -m "feat: show storage location inline on the chip"
 - Consumes: `formatRelativeTime` (Task 3); `getLayoutSavedAt` (Task 2); `getServerBaseUpdatedAt` (existing, exported from `$lib/storage`); `durability.lastExportedAt`, `durability.label`, `durability.icon`, `durability.changesSinceExport` (Task 4).
 - Produces: `StorageDetailsPopover` renders mode-aware facts from plain props (so it is testable without opening a popover).
 
-- [ ] **Step 1: Write the failing test for the content component**
+- [ ] Step 1: Write the failing test for the content component
 
 Create `src/tests/storage-details-popover.test.ts`. It renders the content component directly with props and asserts on copy (text assertions are allowed):
 
@@ -904,11 +904,11 @@ describe("StorageDetailsPopover", () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [ ] Step 2: Run the test to verify it fails
 
 Run: `npm run test:run -- src/tests/storage-details-popover.test.ts` Expected: FAIL ("Cannot find module '.../StorageDetailsPopover.svelte'").
 
-- [ ] **Step 3: Create the content component**
+- [ ] Step 3: Create the content component
 
 Create `src/lib/components/StorageDetailsPopover.svelte`:
 
@@ -1066,18 +1066,18 @@ Create `src/lib/components/StorageDetailsPopover.svelte`:
 </style>
 ```
 
-- [ ] **Step 4: Run the content-component test to verify it passes**
+- [ ] Step 4: Run the content-component test to verify it passes
 
 Run: `npm run test:run -- src/tests/storage-details-popover.test.ts` Expected: PASS.
 
-- [ ] **Step 5: Commit the content component**
+- [ ] Step 5: Commit the content component
 
 ```bash
 git add src/lib/components/StorageDetailsPopover.svelte src/tests/storage-details-popover.test.ts
 git commit -s -m "feat: add StorageDetailsPopover content component"
 ```
 
-- [ ] **Step 6: Wire the popover into the chip with hover and tap**
+- [ ] Step 6: Wire the popover into the chip with hover and tap
 
 In `src/lib/components/StorageStatusChip.svelte`:
 
@@ -1187,7 +1187,7 @@ Replace the chip `<div>` (the block from Step 3 of Task 5) by wrapping it in a P
 
 Note: the chip is now a `<button>`, so the old `role="status"` / `aria-live="off"` move off it; the existing hidden `sr-only` live region (the `announced` span at the end of the file) stays and keeps announcing settled state. Leave the `ServerAvailableBanner` and the override `<button>` blocks unchanged.
 
-- [ ] **Step 7: Update the chip styles for the interactive trigger**
+- [ ] Step 7: Update the chip styles for the interactive trigger
 
 In the `<style>` block, replace the base `.storage-chip` rule so it is a borderless, interactive pill with a hover wash and a focus ring (the chip is a button now), and ensure the attention state still shows a border:
 
@@ -1229,7 +1229,7 @@ Add a popover surface rule (this targets the `Popover.Content` via its class):
 }
 ```
 
-- [ ] **Step 8: Validate the Svelte components**
+- [ ] Step 8: Validate the Svelte components
 
 Use the Svelte MCP `svelte-autofixer` on `StorageStatusChip.svelte` and `StorageDetailsPopover.svelte`; apply any fixes and re-run it until clean.
 
@@ -1237,7 +1237,7 @@ Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts src/tests/storage-
 
 Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no new errors.
 
-- [ ] **Step 9: Commit**
+- [ ] Step 9: Commit
 
 ```bash
 git add src/lib/components/StorageStatusChip.svelte
@@ -1250,17 +1250,17 @@ git commit -s -m "feat: reveal storage details on chip hover and tap"
 
 **Files:** none (verification only).
 
-- [ ] **Step 1: Run the full unit suite**
+- [ ] Step 1: Run the full unit suite
 
 Run: `npm run test:run` Expected: PASS. If any other `LibraryEntry` or `BackupState` literal site fails to compile, add `lastExportedAt: null` (entries) or omit it (optional on `BackupState`) and re-run.
 
-- [ ] **Step 2: Lint and type-check**
+- [ ] Step 2: Lint and type-check
 
 Run: `npm run lint` Expected: PASS (no `no-restricted-syntax` test violations, no querySelector/toHaveClass/colour assertions).
 
 Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no errors.
 
-- [ ] **Step 3: Manual smoke (dev server)**
+- [ ] Step 3: Manual smoke (dev server)
 
 Run: `npm run dev`, open the app, and confirm:
 
@@ -1268,7 +1268,7 @@ Run: `npm run dev`, open the app, and confirm:
 - The popover closes on Escape, on click-away, and on mouse-leave (after the short delay), and stays open while the pointer is inside it.
 - Keyboard: Tab to the chip, press Enter or Space to open, Escape to close; the focus ring shows.
 
-- [ ] **Step 4: Stop for review**
+- [ ] Step 4: Stop for review
 
 Stop here and hand back for review. Do not open a PR until the branch is reviewed per the project workflow (CodeRabbit + CodeAnt).
 

--- a/docs/plans/2026-06-26-storage-chip-ux.md
+++ b/docs/plans/2026-06-26-storage-chip-ux.md
@@ -19,6 +19,16 @@
 - Commits: `type: description`; sign off with `-s` (DCO) and include `Co-Authored-By`.
 - The chip carries no actions; export/restore actions stay in the app menu (#2446).
 
+## Post-review refinements
+
+The following deltas were applied during PR review and are reflected in the snippets below:
+
+- Failed-write guard in `getLayoutSavedAt`: returns null when the entry's `writeFailed` flag is set, so the chip never shows a fresh autosave time after a failed write.
+- Explicit-null clear in `saveLayoutBody`: `lastExportedAt` uses a `!== undefined` check rather than nullish coalescing, so an intentional null (layout reset or load) clears the stored timestamp rather than preserving a stale one.
+- `formatRelativeTime` renamed to `formatTimeAgo`; absolute-elapsed (`const abs = Math.abs(elapsed)`) replaces the raw elapsed check so future timestamps (small clock skew or genuinely future) format as "in X ..." rather than returning unexpected values.
+- `StorageDetailsPopover` gained a `kind: DurabilityKind` prop; `neverReached` and `degraded` derive from `kind` (not `icon === "error"`), and the server-not-found state shows honest copy ("This layout has not been saved to the server") rather than falling into the "Last saved" row.
+- Popover-open integration test: the test cases for `StorageDetailsPopover` include a `kind` prop on every render call.
+
 ## File structure
 
 - `src/lib/stores/layout/persistence.ts` (modify): add `lastExportedAt` to `BackupState`.
@@ -27,7 +37,7 @@
 - `src/lib/storage/browser-workspace-persist.ts` (modify): carry `lastExportedAt` through `PersistTab` and the shell/paused entry writes.
 - `src/lib/components/PersistenceEffects.svelte` (modify): include `lastExportedAt` in the tab snapshot.
 - `src/lib/stores/workspace.svelte.ts` (modify): restore `lastExportedAt`.
-- `src/lib/utils/relative-time.ts` (create): `formatRelativeTime`.
+- `src/lib/utils/relative-time.ts` (create): `formatTimeAgo`.
 - `src/lib/storage/durability.svelte.ts` (modify): add `shortLabel`, `showLocation`, `lastExportedAt` to the durability source.
 - `src/lib/components/StorageStatusChip.svelte` (modify): two-tone inline rendering; become a popover trigger; wire hover/tap.
 - `src/lib/components/StorageDetailsPopover.svelte` (create): prop-driven popover content.
@@ -263,11 +273,18 @@ Update the index entry write inside `saveLayoutBody` (lines 250-258) to carry th
 ```typescript
 index.library[id] = {
   name: layout.name,
-  updatedAt: savedAt,
+  updatedAt: wrote ? savedAt : (previous?.updatedAt ?? ""),
   changesSinceExport: durability.changesSinceExport,
   hasEverExported:
     durability.hasEverExported ?? previous?.hasEverExported ?? false,
-  lastExportedAt: durability.lastExportedAt ?? previous?.lastExportedAt ?? null,
+  // Distinguish an explicit null (clear, e.g. after a layout reset/load) from
+  // an omitted value (undefined, preserve the prior timestamp). Nullish
+  // coalescing alone would treat the intentional null as "keep previous" and
+  // leave a stale "Last exported" time in the entry.
+  lastExportedAt:
+    durability.lastExportedAt !== undefined
+      ? durability.lastExportedAt
+      : (previous?.lastExportedAt ?? null),
   writeFailed: durability.writeFailed ?? !wrote,
   storageMode: previous?.storageMode ?? "browser",
 };
@@ -278,12 +295,16 @@ Add the read helper (place it after `saveLayoutBody`, before `deleteLayoutBody` 
 ```typescript
 /**
  * The last time a layout's working copy was written to localStorage, as an ISO
- * timestamp, or null when the layout has no library entry or has never been
- * written (an empty updatedAt). Surfaces the "Auto-saved" time in the chip popover.
+ * timestamp, or null when the layout has no library entry, has never been
+ * written (an empty updatedAt), or the last write failed. Surfaces the
+ * "Auto-saved" time in the chip popover; excludes failed writes so the chip
+ * never reports a fresh autosave time after a failed write.
  */
 export function getLayoutSavedAt(id: string): string | null {
-  const updatedAt = loadWorkspaceIndex()?.library[id]?.updatedAt;
-  return updatedAt ? updatedAt : null;
+  const entry = loadWorkspaceIndex()?.library[id];
+  return entry && !entry.writeFailed && entry.updatedAt
+    ? entry.updatedAt
+    : null;
 }
 ```
 
@@ -398,7 +419,7 @@ git commit -s -m "feat: persist lastExportedAt in the browser workspace library"
 
 **Interfaces:**
 
-- Produces: `formatRelativeTime(iso: string | null, nowMs?: number): string | null` returning `null` for null/invalid input, `"just now"` under 45 seconds, else an "N units ago" string. Deterministic when `nowMs` is supplied.
+- Produces: `formatTimeAgo(iso: string | null, nowMs?: number): string | null` returning `null` for null/invalid input, `"just now"` under 45 seconds (or small future skew), else a relative-time string. Deterministic when `nowMs` is supplied.
 
 - [ ] Step 1: Write the failing test
 
@@ -406,18 +427,18 @@ Create `src/tests/relative-time.test.ts`:
 
 ```typescript
 import { describe, it, expect } from "vitest";
-import { formatRelativeTime } from "$lib/utils/relative-time";
+import { formatTimeAgo } from "$lib/utils/relative-time";
 
 const NOW = Date.parse("2026-06-26T12:00:00.000Z");
-const at = (iso: string) => formatRelativeTime(iso, NOW);
+const at = (iso: string) => formatTimeAgo(iso, NOW);
 
-describe("formatRelativeTime", () => {
+describe("formatTimeAgo", () => {
   it("returns null for null or unparseable input", () => {
-    expect(formatRelativeTime(null, NOW)).toBeNull();
-    expect(formatRelativeTime("not-a-date", NOW)).toBeNull();
+    expect(formatTimeAgo(null, NOW)).toBeNull();
+    expect(formatTimeAgo("not-a-date", NOW)).toBeNull();
   });
 
-  it("says 'just now' under 45 seconds, including small clock skew", () => {
+  it("says 'just now' under 45 seconds, including small future skew", () => {
     expect(at("2026-06-26T11:59:30.000Z")).toBe("just now");
     expect(at("2026-06-26T12:00:10.000Z")).toBe("just now");
   });
@@ -451,9 +472,9 @@ const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 
-const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" });
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "always" });
 
-export function formatRelativeTime(
+export function formatTimeAgo(
   iso: string | null,
   nowMs: number = Date.now(),
 ): string | null {
@@ -462,10 +483,10 @@ export function formatRelativeTime(
   if (Number.isNaN(then)) return null;
 
   const elapsed = nowMs - then;
-  if (elapsed < 45 * SECOND) return "just now";
-  if (elapsed < HOUR)
-    return rtf.format(-Math.round(elapsed / MINUTE), "minute");
-  if (elapsed < DAY) return rtf.format(-Math.round(elapsed / HOUR), "hour");
+  const abs = Math.abs(elapsed);
+  if (abs < 45 * SECOND) return "just now";
+  if (abs < HOUR) return rtf.format(-Math.round(elapsed / MINUTE), "minute");
+  if (abs < DAY) return rtf.format(-Math.round(elapsed / HOUR), "hour");
   return rtf.format(-Math.round(elapsed / DAY), "day");
 }
 ```
@@ -478,7 +499,7 @@ Run: `npm run test:run -- src/tests/relative-time.test.ts` Expected: PASS.
 
 ```bash
 git add src/lib/utils/relative-time.ts src/tests/relative-time.test.ts
-git commit -s -m "feat: add formatRelativeTime util for the storage chip"
+git commit -s -m "feat: add formatTimeAgo util for the storage chip"
 ```
 
 ---
@@ -824,7 +845,7 @@ git commit -s -m "feat: show storage location inline on the chip"
 
 **Interfaces:**
 
-- Consumes: `formatRelativeTime` (Task 3); `getLayoutSavedAt` (Task 2); `getServerBaseUpdatedAt` (existing, exported from `$lib/storage`); `durability.lastExportedAt`, `durability.label`, `durability.icon`, `durability.changesSinceExport` (Task 4).
+- Consumes: `formatTimeAgo` (Task 3); `getLayoutSavedAt` (Task 2); `getServerBaseUpdatedAt` (existing, exported from `$lib/storage`); `durability.lastExportedAt`, `durability.label`, `durability.icon`, `durability.changesSinceExport` (Task 4).
 - Produces: `StorageDetailsPopover` renders mode-aware facts from plain props (so it is testable without opening a popover).
 
 - [ ] Step 1: Write the failing test for the content component
@@ -842,6 +863,7 @@ describe("StorageDetailsPopover", () => {
   it("browser mode shows both timestamps and 'Never exported' when null", () => {
     render(StorageDetailsPopover, {
       mode: "browser",
+      kind: "pending",
       headline: "Unsaved changes",
       icon: "pending",
       changesSinceExport: 3,
@@ -860,6 +882,7 @@ describe("StorageDetailsPopover", () => {
   it("browser mode formats a real export time", () => {
     render(StorageDetailsPopover, {
       mode: "browser",
+      kind: "saved",
       headline: "Saved",
       icon: "saved",
       changesSinceExport: 0,
@@ -875,6 +898,7 @@ describe("StorageDetailsPopover", () => {
   it("server mode shows the last server save and storage location", () => {
     render(StorageDetailsPopover, {
       mode: "server",
+      kind: "saved",
       headline: "Saved",
       icon: "saved",
       changesSinceExport: 0,
@@ -891,6 +915,7 @@ describe("StorageDetailsPopover", () => {
   it("server mode error reframes the time as last reached", () => {
     render(StorageDetailsPopover, {
       mode: "server",
+      kind: "offline",
       headline: "Offline",
       icon: "error",
       changesSinceExport: 0,
@@ -925,10 +950,12 @@ Create `src/lib/components/StorageDetailsPopover.svelte`:
 <script lang="ts">
   import { IconCheck, IconClock, IconWarningTriangle } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
-  import { formatRelativeTime } from "$lib/utils/relative-time";
+  import { formatTimeAgo } from "$lib/utils/relative-time";
+  import type { DurabilityKind } from "$lib/storage";
 
   interface Props {
     mode: "browser" | "server";
+    kind: DurabilityKind;
     headline: string;
     icon: "saved" | "pending" | "error";
     changesSinceExport: number;
@@ -940,6 +967,7 @@ Create `src/lib/components/StorageDetailsPopover.svelte`:
 
   let {
     mode,
+    kind,
     headline,
     icon,
     changesSinceExport,
@@ -949,10 +977,11 @@ Create `src/lib/components/StorageDetailsPopover.svelte`:
     nowMs,
   }: Props = $props();
 
-  const autosaveRel = $derived(formatRelativeTime(autosaveAt, nowMs));
-  const exportRel = $derived(formatRelativeTime(lastExportedAt, nowMs));
-  const serverRel = $derived(formatRelativeTime(serverSavedAt, nowMs));
-  const isDegraded = $derived(icon === "error");
+  const autosaveRel = $derived(formatTimeAgo(autosaveAt, nowMs));
+  const exportRel = $derived(formatTimeAgo(lastExportedAt, nowMs));
+  const serverRel = $derived(formatTimeAgo(serverSavedAt, nowMs));
+  const neverReached = $derived(kind === "server-not-found");
+  const degraded = $derived(kind === "offline");
 </script>
 
 <div class="storage-details">
@@ -992,19 +1021,21 @@ Create `src/lib/components/StorageDetailsPopover.svelte`:
       </p>
     {/if}
     <p class="storage-details-foot">Stored in this browser only</p>
+  {:else if neverReached}
+    <p class="storage-details-note storage-details-warn">
+      This layout has not been saved to the server.
+    </p>
+    <p class="storage-details-foot">Not saved to the server</p>
   {:else}
     <div class="storage-details-row">
       <span class="storage-details-label">
-        {isDegraded ? "Last reached server" : "Last saved"}
+        {degraded ? "Last reached server" : "Last saved"}
       </span>
-      <span
-        class="storage-details-value"
-        class:storage-details-warn={isDegraded}
-      >
+      <span class="storage-details-value" class:storage-details-warn={degraded}>
         {serverRel ?? "Not yet saved"}
       </span>
     </div>
-    {#if isDegraded}
+    {#if degraded}
       <p class="storage-details-note storage-details-warn">
         Your most recent edits may not be saved.
       </p>
@@ -1172,6 +1203,7 @@ Replace the chip `<div>` (the block from Step 3 of Task 5) by wrapping it in a P
     >
       <StorageDetailsPopover
         mode={isServerMode ? "server" : "browser"}
+        kind={durability.kind}
         headline={durability.label}
         icon={durability.icon}
         changesSinceExport={durability.changesSinceExport}
@@ -1288,4 +1320,4 @@ Deviations recorded: server-mode working-copy path is not threaded (server never
 
 Placeholder scan: every code step shows complete code; no TBD/TODO; test code is concrete.
 
-Type consistency: `lastExportedAt: string | null` is consistent across `BackupState` (optional), `LibraryEntry`, `DurabilityInput`, the layout store getter, and `LayoutDurability`. `getLayoutSavedAt(id: string): string | null` and `formatRelativeTime(iso, nowMs?)` signatures match their call sites. `StorageDetailsPopover` props match the test and the chip's usage.
+Type consistency: `lastExportedAt: string | null` is consistent across `BackupState` (optional), `LibraryEntry`, `DurabilityInput`, the layout store getter, and `LayoutDurability`. `getLayoutSavedAt(id: string): string | null` and `formatTimeAgo(iso, nowMs?)` signatures match their call sites. `StorageDetailsPopover` props match the test and the chip's usage.

--- a/docs/superpowers/plans/2026-06-26-storage-chip-ux.md
+++ b/docs/superpowers/plans/2026-06-26-storage-chip-ux.md
@@ -1,0 +1,1212 @@
+# Storage chip UX redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the workspace storage chip show save state and storage location inline, with a hover/tap popover carrying honest, mode-aware last-save facts.
+
+**Architecture:** Add one new field (`lastExportedAt`) to the layout store and thread it through the live browser multi-tab persistence schema. Extend the existing single durability source (`getLayoutDurability`) with an inline short label, a location-visibility flag, and the export timestamp. Render a two-tone inline chip (status colour + muted location) that becomes a bits-ui Popover trigger; the popover content is a small, prop-driven component formatting timestamps with a new relative-time util.
+
+**Tech Stack:** Svelte 5 runes, TypeScript strict, Vitest + @testing-library/svelte, bits-ui Popover, CSS custom properties (tokens.css).
+
+## Global Constraints
+
+- Svelte 5 runes only (`$state`, `$derived`, `$effect`); no Svelte 4 stores.
+- TypeScript strict mode; no `any`.
+- User-facing copy: no em dashes, en dashes, or smart quotes; no emoji; be succinct.
+- Tests must follow the project testing rules: assert behaviour and text content, never DOM nodes (`querySelector`), class names (`toHaveClass`), exact data-array lengths (`toHaveLength(literal)`), or hardcoded colours. ESLint hard-blocks these.
+- Accessibility (#2064): chip state is never colour-only; the accessible name includes the current state; the settled state is announced via the existing debounced live region.
+- Storage mode is fixed for the session (read once via `getStorageMode()`); switching reloads the page.
+- Commits: `type: description`; sign off with `-s` (DCO) and include `Co-Authored-By`.
+- The chip carries no actions; export/restore actions stay in the app menu (#2446).
+
+## File structure
+
+- `src/lib/stores/layout/persistence.ts` (modify): add `lastExportedAt` to `BackupState`.
+- `src/lib/stores/layout.svelte.ts` (modify): track, set, expose, restore, and reset `lastExportedAt`.
+- `src/lib/storage/browser-workspace.ts` (modify): add `lastExportedAt` to `LibraryEntry` and `DurabilityInput`; write it in the index entry; add a `getLayoutSavedAt` read helper.
+- `src/lib/storage/browser-workspace-persist.ts` (modify): carry `lastExportedAt` through `PersistTab` and the shell/paused entry writes.
+- `src/lib/components/PersistenceEffects.svelte` (modify): include `lastExportedAt` in the tab snapshot.
+- `src/lib/stores/workspace.svelte.ts` (modify): restore `lastExportedAt`.
+- `src/lib/utils/relative-time.ts` (create): `formatRelativeTime`.
+- `src/lib/storage/durability.svelte.ts` (modify): add `shortLabel`, `showLocation`, `lastExportedAt` to the durability source.
+- `src/lib/components/StorageStatusChip.svelte` (modify): two-tone inline rendering; become a popover trigger; wire hover/tap.
+- `src/lib/components/StorageDetailsPopover.svelte` (create): prop-driven popover content.
+- Tests: extend `src/tests/changes-since-export.test.ts`, `src/tests/StorageStatusChip.test.ts`; create `src/tests/relative-time.test.ts`, `src/tests/durability-inline-labels.test.ts`, `src/tests/storage-details-popover.test.ts`.
+
+## Scoping decisions (carry into implementation)
+
+- Server mode never displays "Last exported", so `lastExportedAt` is threaded only through the browser multi-tab schema, not the legacy `working-copy.ts` session path.
+- The existing `ServerAvailableBanner` and the "Switch back to browser mode" button stay exactly as they are. The popover does not duplicate the #2063 server-reachable hint; the amber attention chip plus the existing banner already cover it. This is a deliberate deviation from the spec mock to avoid a redundant second surface.
+- Export-age colour: the popover "Last exported" value renders in the warning colour whenever `changesSinceExport > 0`, not on a wall-clock age threshold.
+
+---
+
+### Task 1: Track `lastExportedAt` in the layout store
+
+**Files:**
+- Modify: `src/lib/stores/layout/persistence.ts:15-18`
+- Modify: `src/lib/stores/layout.svelte.ts` (state ~140-142, getters ~233-238, `markExported` ~836-839, `restoreBackupState` ~845-847, resets ~170-173 and ~212-215)
+- Test: `src/tests/changes-since-export.test.ts`
+
+**Interfaces:**
+- Produces: `BackupState` gains optional `lastExportedAt?: string | null`. The layout store gains a `lastExportedAt: string | null` getter, `markExported()` stamps it with the current ISO time, and `restoreBackupState(state)` restores it (coercing `undefined` to `null`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/tests/changes-since-export.test.ts` (inside the existing top-level `describe`):
+
+```typescript
+  it("stamps lastExportedAt on markExported and clears it on load", () => {
+    const store = getLayoutStore();
+    expect(store.lastExportedAt).toBeNull();
+
+    store.markExported();
+    expect(store.lastExportedAt).not.toBeNull();
+    expect(() => new Date(store.lastExportedAt as string)).not.toThrow();
+
+    store.loadLayout(store.layout);
+    expect(store.lastExportedAt).toBeNull();
+  });
+
+  it("restores lastExportedAt through restoreBackupState", () => {
+    const store = getLayoutStore();
+    const stamp = "2026-06-26T12:00:00.000Z";
+    store.restoreBackupState({
+      changesSinceExport: 4,
+      hasEverExported: true,
+      lastExportedAt: stamp,
+    });
+    expect(store.lastExportedAt).toBe(stamp);
+    expect(store.changesSinceExport).toBe(4);
+    expect(store.hasEverExported).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npm run test:run -- src/tests/changes-since-export.test.ts`
+Expected: FAIL (`store.lastExportedAt` is `undefined`; `restoreBackupState` ignores the new field).
+
+- [ ] **Step 3: Add `lastExportedAt` to `BackupState`**
+
+In `src/lib/stores/layout/persistence.ts`, change the interface (currently lines 15-18):
+
+```typescript
+/** Backup state tracked alongside the layout for the storage chip. */
+export interface BackupState {
+  changesSinceExport: number;
+  hasEverExported: boolean;
+  /** ISO timestamp of the last successful export to a file; null if never exported. */
+  lastExportedAt?: string | null;
+}
+```
+
+- [ ] **Step 4: Track, set, expose, restore, and reset the field in the store**
+
+In `src/lib/stores/layout.svelte.ts`:
+
+Add the state declaration next to the others (after line 142):
+
+```typescript
+  let lastExportedAt = $state<string | null>(null);
+```
+
+Add a getter in the returned store object, after the `hasEverExported` getter (after line 238):
+
+```typescript
+    get lastExportedAt() {
+      return lastExportedAt;
+    },
+```
+
+Update `markExported()` (currently lines 836-839) to stamp the time:
+
+```typescript
+  function markExported(): void {
+    changesSinceExport = 0;
+    hasEverExported = true;
+    lastExportedAt = new Date().toISOString();
+  }
+```
+
+Update `restoreBackupState()` (currently lines 845-847) to restore it (undefined coerces to null):
+
+```typescript
+  function restoreBackupState(state: BackupState): void {
+    changesSinceExport = state.changesSinceExport;
+    hasEverExported = state.hasEverExported;
+    lastExportedAt = state.lastExportedAt ?? null;
+  }
+```
+
+In `resetBackupTracking` (the object method around lines 170-173), add the reset:
+
+```typescript
+    resetBackupTracking: () => {
+      isDirty = false;
+      changesSinceExport = 0;
+      hasEverExported = false;
+      lastExportedAt = null;
+    },
+```
+
+In `resetLayout` (around lines 212-215), add the reset after `hasEverExported = false;`:
+
+```typescript
+    changesSinceExport = 0;
+    hasEverExported = false;
+    lastExportedAt = null;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm run test:run -- src/tests/changes-since-export.test.ts`
+Expected: PASS (all tests, including the two new ones).
+
+- [ ] **Step 6: Type-check**
+
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
+Expected: no new errors from these files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/stores/layout/persistence.ts src/lib/stores/layout.svelte.ts src/tests/changes-since-export.test.ts
+git commit -s -m "feat: track lastExportedAt in the layout store"
+```
+
+---
+
+### Task 2: Persist `lastExportedAt` across reload (browser multi-tab schema)
+
+**Files:**
+- Modify: `src/lib/storage/browser-workspace.ts` (`LibraryEntry` ~45-52, `DurabilityInput` ~69-73, index write ~250-258, add helper near other exports)
+- Modify: `src/lib/storage/browser-workspace-persist.ts` (`PersistTab` ~25-38, `saveLayoutBody` call ~82-85, paused/shell entries ~113-130)
+- Modify: `src/lib/components/PersistenceEffects.svelte` (snapshot ~88-95)
+- Modify: `src/lib/stores/workspace.svelte.ts` (restore ~291-298)
+- Test: `src/tests/changes-since-export.test.ts`
+
+**Interfaces:**
+- Consumes: `layoutStore.lastExportedAt` (Task 1).
+- Produces: `LibraryEntry` and `DurabilityInput` gain `lastExportedAt: string | null`. New export `getLayoutSavedAt(id: string): string | null` returns a layout's last localStorage write time (the library entry `updatedAt`, or null when absent or empty).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/tests/changes-since-export.test.ts`. It exercises the real persist+restore round-trip through the multi-tab schema for the active layout. Add the import at the top of the file if not present:
+
+```typescript
+import {
+  saveLayoutBody,
+  getLayoutSavedAt,
+  loadWorkspaceIndex,
+} from "$lib/storage/browser-workspace";
+```
+
+Then add the test:
+
+```typescript
+  it("persists and reads back lastExportedAt via the workspace library", () => {
+    const id = "test-layout-id";
+    const stamp = "2026-06-26T12:00:00.000Z";
+    const layout = getLayoutStore().layout;
+
+    saveLayoutBody(id, layout, {
+      changesSinceExport: 2,
+      hasEverExported: true,
+      lastExportedAt: stamp,
+    });
+
+    const index = loadWorkspaceIndex();
+    expect(index?.library[id]?.lastExportedAt).toBe(stamp);
+    // updatedAt is the autosave write time, exposed for the "Auto-saved" line.
+    expect(getLayoutSavedAt(id)).toBe(index?.library[id]?.updatedAt);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:run -- src/tests/changes-since-export.test.ts`
+Expected: FAIL (`DurabilityInput` has no `lastExportedAt`; `getLayoutSavedAt` is not exported).
+
+- [ ] **Step 3: Add the field to `LibraryEntry` and `DurabilityInput`, write it, and add the helper**
+
+In `src/lib/storage/browser-workspace.ts`:
+
+Extend `LibraryEntry` (lines 45-52):
+
+```typescript
+export interface LibraryEntry {
+  name: string;
+  updatedAt: string;
+  changesSinceExport: number;
+  hasEverExported: boolean;
+  /** ISO timestamp of the last export to a file; null if never exported. */
+  lastExportedAt: string | null;
+  writeFailed: boolean;
+  storageMode: StorageMode;
+}
+```
+
+Extend `DurabilityInput` (lines 69-73):
+
+```typescript
+export interface DurabilityInput {
+  changesSinceExport: number;
+  hasEverExported?: boolean;
+  lastExportedAt?: string | null;
+  writeFailed?: boolean;
+}
+```
+
+Update the index entry write inside `saveLayoutBody` (lines 250-258) to carry the field, preserving a prior value when the caller omits it:
+
+```typescript
+  index.library[id] = {
+    name: layout.name,
+    updatedAt: savedAt,
+    changesSinceExport: durability.changesSinceExport,
+    hasEverExported:
+      durability.hasEverExported ?? previous?.hasEverExported ?? false,
+    lastExportedAt:
+      durability.lastExportedAt ?? previous?.lastExportedAt ?? null,
+    writeFailed: durability.writeFailed ?? !wrote,
+    storageMode: previous?.storageMode ?? "browser",
+  };
+```
+
+Add the read helper (place it after `saveLayoutBody`, before `deleteLayoutBody` near line 264):
+
+```typescript
+/**
+ * The last time a layout's working copy was written to localStorage, as an ISO
+ * timestamp, or null when the layout has no library entry or has never been
+ * written (an empty updatedAt). Surfaces the "Auto-saved" time in the chip popover.
+ */
+export function getLayoutSavedAt(id: string): string | null {
+  const updatedAt = loadWorkspaceIndex()?.library[id]?.updatedAt;
+  return updatedAt ? updatedAt : null;
+}
+```
+
+- [ ] **Step 4: Thread the field through the persist path**
+
+In `src/lib/storage/browser-workspace-persist.ts`:
+
+Extend the hydrated `PersistTab` variant (lines 26-32):
+
+```typescript
+  | {
+      layoutId: string;
+      hydrated: true;
+      layout: Layout;
+      changesSinceExport: number;
+      hasEverExported: boolean;
+      lastExportedAt: string | null;
+    }
+```
+
+Pass it into the body write (lines 81-85):
+
+```typescript
+      const write = () =>
+        saveLayoutBody(tab.layoutId, tab.layout, {
+          changesSinceExport: tab.changesSinceExport,
+          hasEverExported: tab.hasEverExported,
+          lastExportedAt: tab.lastExportedAt,
+        });
+```
+
+Add it to the paused-hydrated entry (lines 113-120):
+
+```typescript
+      library[tab.layoutId] = {
+        name: tab.layout.name,
+        updatedAt: "",
+        changesSinceExport: tab.changesSinceExport,
+        hasEverExported: tab.hasEverExported,
+        lastExportedAt: tab.lastExportedAt,
+        writeFailed: false,
+        storageMode: "browser",
+      };
+```
+
+Add it to the shell entry (lines 123-130), carrying forward any prior value:
+
+```typescript
+    library[tab.layoutId] = {
+      name: tab.name,
+      updatedAt: previous?.updatedAt ?? "",
+      changesSinceExport: previous?.changesSinceExport ?? 0,
+      hasEverExported: previous?.hasEverExported ?? false,
+      lastExportedAt: previous?.lastExportedAt ?? null,
+      writeFailed: previous?.writeFailed ?? false,
+      storageMode: previous?.storageMode ?? "browser",
+    };
+```
+
+- [ ] **Step 5: Populate the field in the tab snapshot**
+
+In `src/lib/components/PersistenceEffects.svelte`, the hydrated branch of `snapshotWorkspaceTabs` (lines 89-95):
+
+```typescript
+        tabs.push({
+          layoutId,
+          hydrated: true,
+          layout: $state.snapshot(tab.store.layout),
+          changesSinceExport: tab.store.changesSinceExport,
+          hasEverExported: tab.store.hasEverExported,
+          lastExportedAt: tab.store.lastExportedAt,
+        });
+```
+
+- [ ] **Step 6: Restore the field**
+
+In `src/lib/stores/workspace.svelte.ts`, the restore block (lines 291-298):
+
+```typescript
+    const entry = tab.layoutId ? restoreLibrary[tab.layoutId] : undefined;
+    if (entry) {
+      tab.store.markDirty();
+      tab.store.restoreBackupState({
+        changesSinceExport: entry.changesSinceExport,
+        hasEverExported: entry.hasEverExported,
+        lastExportedAt: entry.lastExportedAt,
+      });
+    }
+```
+
+- [ ] **Step 7: Run the test and the type-check**
+
+Run: `npm run test:run -- src/tests/changes-since-export.test.ts`
+Expected: PASS.
+
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
+Expected: no new errors. (If any other `LibraryEntry` literal is reported as missing `lastExportedAt`, add `lastExportedAt: null` there.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/storage/browser-workspace.ts src/lib/storage/browser-workspace-persist.ts src/lib/components/PersistenceEffects.svelte src/lib/stores/workspace.svelte.ts src/tests/changes-since-export.test.ts
+git commit -s -m "feat: persist lastExportedAt in the browser workspace library"
+```
+
+---
+
+### Task 3: Relative-time util
+
+**Files:**
+- Create: `src/lib/utils/relative-time.ts`
+- Test: `src/tests/relative-time.test.ts`
+
+**Interfaces:**
+- Produces: `formatRelativeTime(iso: string | null, nowMs?: number): string | null` returning `null` for null/invalid input, `"just now"` under 45 seconds, else an "N units ago" string. Deterministic when `nowMs` is supplied.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/relative-time.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { formatRelativeTime } from "$lib/utils/relative-time";
+
+const NOW = Date.parse("2026-06-26T12:00:00.000Z");
+const at = (iso: string) => formatRelativeTime(iso, NOW);
+
+describe("formatRelativeTime", () => {
+  it("returns null for null or unparseable input", () => {
+    expect(formatRelativeTime(null, NOW)).toBeNull();
+    expect(formatRelativeTime("not-a-date", NOW)).toBeNull();
+  });
+
+  it("says 'just now' under 45 seconds, including small clock skew", () => {
+    expect(at("2026-06-26T11:59:30.000Z")).toBe("just now");
+    expect(at("2026-06-26T12:00:10.000Z")).toBe("just now");
+  });
+
+  it("formats minutes, hours, and days as elapsed time", () => {
+    expect(at("2026-06-26T11:58:00.000Z")).toBe("2 minutes ago");
+    expect(at("2026-06-26T09:00:00.000Z")).toBe("3 hours ago");
+    expect(at("2026-06-23T12:00:00.000Z")).toBe("3 days ago");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:run -- src/tests/relative-time.test.ts`
+Expected: FAIL ("Cannot find module '$lib/utils/relative-time'").
+
+- [ ] **Step 3: Implement the util**
+
+Create `src/lib/utils/relative-time.ts`:
+
+```typescript
+/**
+ * Format an ISO timestamp as elapsed time relative to now, for the storage chip
+ * popover. Returns null for null or unparseable input so the caller can choose
+ * its own copy (for example "Never exported"). Under 45 seconds (including small
+ * negative skew) it returns "just now". `nowMs` is injectable for deterministic
+ * tests.
+ */
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" });
+
+export function formatRelativeTime(
+  iso: string | null,
+  nowMs: number = Date.now(),
+): string | null {
+  if (!iso) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return null;
+
+  const elapsed = nowMs - then;
+  if (elapsed < 45 * SECOND) return "just now";
+  if (elapsed < HOUR) return rtf.format(-Math.round(elapsed / MINUTE), "minute");
+  if (elapsed < DAY) return rtf.format(-Math.round(elapsed / HOUR), "hour");
+  return rtf.format(-Math.round(elapsed / DAY), "day");
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test:run -- src/tests/relative-time.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/utils/relative-time.ts src/tests/relative-time.test.ts
+git commit -s -m "feat: add formatRelativeTime util for the storage chip"
+```
+
+---
+
+### Task 4: Extend the durability source with inline label, location flag, and export time
+
+**Files:**
+- Modify: `src/lib/storage/durability.svelte.ts` (`LayoutDurability` ~42-58, `computeLayoutStatus` return type ~78-84 and all return branches ~90-187, `getLayoutDurability` getters ~226-256)
+- Test: `src/tests/durability-inline-labels.test.ts`
+
+**Interfaces:**
+- Consumes: `layoutStore.lastExportedAt` (Task 1).
+- Produces: `computeLayoutStatus(...)` returns two extra fields: `shortLabel: string` (the inline state word) and `showLocation: boolean` (false for self-describing error states). `LayoutDurability` gains `shortLabel: string`, `showLocation: boolean`, and `lastExportedAt: string | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/durability-inline-labels.test.ts`. `computeLayoutStatus` is a pure exported function (signature: `(saveStatus, consecutiveSaveFailures, storageMode, apiAvailable, changesSinceExport, hasEverExported, apiEverReached)`):
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { computeLayoutStatus } from "$lib/storage/durability.svelte";
+
+describe("computeLayoutStatus inline fields", () => {
+  it("browser clean: short 'Saved', location shown", () => {
+    const r = computeLayoutStatus("idle", 0, "browser", null, 0, true, false);
+    expect(r.shortLabel).toBe("Saved");
+    expect(r.showLocation).toBe(true);
+  });
+
+  it("browser dirty: short 'Unsaved', location shown", () => {
+    const r = computeLayoutStatus("idle", 0, "browser", null, 3, false, false);
+    expect(r.shortLabel).toBe("Unsaved");
+    expect(r.showLocation).toBe(true);
+  });
+
+  it("server saved: short 'Saved', location shown", () => {
+    const r = computeLayoutStatus("saved", 0, "server", true, 0, true, true);
+    expect(r.shortLabel).toBe("Saved");
+    expect(r.showLocation).toBe(true);
+  });
+
+  it("server checking: short 'Connecting', location shown", () => {
+    const r = computeLayoutStatus("idle", 0, "server", null, 0, true, false);
+    expect(r.shortLabel).toBe("Connecting");
+    expect(r.showLocation).toBe(true);
+  });
+
+  it("server never reached: 'Server not found' stands alone", () => {
+    const r = computeLayoutStatus("idle", 0, "server", false, 0, true, false);
+    expect(r.shortLabel).toBe("Server not found");
+    expect(r.showLocation).toBe(false);
+  });
+
+  it("server breaker open: 'Server unavailable' stands alone", () => {
+    const r = computeLayoutStatus("error", 3, "server", true, 0, true, true);
+    expect(r.shortLabel).toBe("Server unavailable");
+    expect(r.showLocation).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:run -- src/tests/durability-inline-labels.test.ts`
+Expected: FAIL (`shortLabel` / `showLocation` are undefined).
+
+- [ ] **Step 3: Add the fields to the `computeLayoutStatus` return type and every branch**
+
+In `src/lib/storage/durability.svelte.ts`, extend the return type annotation (lines 78-84):
+
+```typescript
+): {
+  status: DurabilityStatus;
+  kind: DurabilityKind;
+  label: string;
+  shortLabel: string;
+  showLocation: boolean;
+  detail: string;
+  icon: DurabilityStatus;
+} {
+```
+
+Then add `shortLabel` and `showLocation` to each of the eight return objects. Use these exact values (insert the two new properties into each existing object; keep the existing comments):
+
+```typescript
+// browser, durable (line ~91)
+    return { status: "saved", kind: "saved", label: "Saved", shortLabel: "Saved", showLocation: true, detail: "Stored in this browser", icon: "saved" };
+// browser, pending (line ~99)
+    return { status: "pending", kind: "pending", label: "Unsaved changes", shortLabel: "Unsaved", showLocation: true, detail: "Stored in this browser", icon: "pending" };
+// server, breaker open (line ~113)
+    return { status: "error", kind: "offline", label: "Server unavailable", shortLabel: "Server unavailable", showLocation: false, detail: "Working from your browser; reload to retry.", icon: "error" };
+// server, checking (line ~122)
+    return { status: "pending", kind: "pending", label: "Checking connection", shortLabel: "Connecting", showLocation: true, detail: "Looking for the server.", icon: "pending" };
+// server, reached-then-lost (line ~137)
+    return { status: "error", kind: "offline", label: "Offline", shortLabel: "Offline", showLocation: true, detail: "Working from your browser; reload to retry.", icon: "error" };
+// server, never-reached (line ~145)
+    return { status: "error", kind: "server-not-found", label: "Server not found", shortLabel: "Server not found", showLocation: false, detail: "Check that the API container is running and RACKULA_STORAGE_MODE matches the deployment.", icon: "error" };
+// server, save error (line ~155)
+    return { status: "error", kind: "offline", label: "Save error", shortLabel: "Save error", showLocation: true, detail: "The last save did not go through.", icon: "error" };
+// server, saving (line ~164)
+    return { status: "pending", kind: "pending", label: "Saving", shortLabel: "Saving", showLocation: true, detail: "Saving to server.", icon: "pending" };
+// server, saved (line ~173)
+    return { status: "saved", kind: "saved", label: "Saved", shortLabel: "Saved", showLocation: true, detail: "Saved to server", icon: "saved" };
+// server, fallback pending (line ~181)
+    return { status: "pending", kind: "pending", label: "Pending save", shortLabel: "Pending", showLocation: true, detail: "Saving to server.", icon: "pending" };
+```
+
+- [ ] **Step 4: Add the fields to `LayoutDurability` and the durability getters**
+
+Extend the `LayoutDurability` interface (lines 42-58) by adding, after `label: string;`:
+
+```typescript
+  shortLabel: string;
+  showLocation: boolean;
+```
+
+and, after `hasEverExported: boolean;`:
+
+```typescript
+  lastExportedAt: string | null;
+```
+
+In `getLayoutDurability` (lines 226-256), add getters alongside the existing ones (after the `label` getter and after the `hasEverExported` getter respectively):
+
+```typescript
+    get shortLabel(): string {
+      return compute().shortLabel;
+    },
+    get showLocation(): boolean {
+      return compute().showLocation;
+    },
+```
+
+```typescript
+    get lastExportedAt(): string | null {
+      return layoutStore.lastExportedAt;
+    },
+```
+
+- [ ] **Step 5: Run the test and the type-check**
+
+Run: `npm run test:run -- src/tests/durability-inline-labels.test.ts`
+Expected: PASS.
+
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
+Expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/storage/durability.svelte.ts src/tests/durability-inline-labels.test.ts
+git commit -s -m "feat: add inline label, location flag, and export time to durability"
+```
+
+---
+
+### Task 5: Two-tone inline chip and accessible name
+
+**Files:**
+- Modify: `src/lib/components/StorageStatusChip.svelte` (markup ~99-133, styles ~135-191)
+- Test: `src/tests/StorageStatusChip.test.ts`
+
+**Interfaces:**
+- Consumes: `durability.shortLabel`, `durability.showLocation`, `durability.status`, `durability.icon`, `durability.serverHint` (Task 4); `isServerMode` (already computed in the component).
+- Produces: the chip renders `[icon] [shortLabel] . [location]` with the status colour on the state word and a muted location. Accessible name is `Storage status: {label}` plus `, Browser` or `, Server` when `showLocation` is true.
+
+- [ ] **Step 1: Update the test for the new accessible name**
+
+Replace the assertion in `src/tests/StorageStatusChip.test.ts` (the existing test expects `/storage status: unsaved changes/i`). A fresh browser-mode store is dirty, so:
+
+```typescript
+  it("exposes the current storage state and location in its accessible name", () => {
+    render(StorageStatusChip);
+    const chip = screen.getByTestId("storage-status-chip");
+    expect(chip).toHaveAccessibleName(/storage status: unsaved changes, browser/i);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts`
+Expected: FAIL (current accessible name has no location).
+
+- [ ] **Step 3: Add a derived accessible name and split the inline text**
+
+In `src/lib/components/StorageStatusChip.svelte`, add a derived value in the `<script>` (after the `durability` constant, near line 36):
+
+```typescript
+  const locationWord = $derived(isServerMode ? "Server" : "Browser");
+  const accessibleName = $derived(
+    durability.showLocation
+      ? `Storage status: ${durability.label}, ${locationWord}`
+      : `Storage status: ${durability.label}`,
+  );
+```
+
+Replace the chip markup (lines 99-133) so the label splits into a coloured state word and a muted location, and the `aria-label` uses the derived name:
+
+```svelte
+<div
+  class="storage-chip storage-chip-{durability.status}"
+  class:storage-chip--attention={durability.serverHint}
+  role="status"
+  aria-live="off"
+  aria-label={accessibleName}
+  data-testid="storage-status-chip"
+>
+  {#if durability.icon === "saved"}
+    <IconCheck size={ICON_SIZE.sm} />
+  {:else if durability.icon === "pending"}
+    <IconClock size={ICON_SIZE.sm} />
+  {:else}
+    <IconWarningTriangle size={ICON_SIZE.sm} />
+  {/if}
+  <span class="storage-chip-state">{durability.shortLabel}</span>
+  {#if durability.showLocation}
+    <span class="storage-chip-sep" aria-hidden="true">.</span>
+    <span class="storage-chip-loc">{locationWord}</span>
+  {/if}
+</div>
+```
+
+- [ ] **Step 4: Make the location and separator muted**
+
+In the `<style>` block, the status classes currently colour the whole chip; keep that (so the icon and state word inherit the status colour) and override the location and separator to muted. Add after the `.storage-chip-error` rule:
+
+```css
+  .storage-chip-state {
+    font-weight: 600;
+  }
+
+  /* Location is secondary: muted so the coloured state word leads. */
+  .storage-chip-sep,
+  .storage-chip-loc {
+    color: var(--colour-text-muted);
+    font-weight: 500;
+  }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/components/StorageStatusChip.svelte src/tests/StorageStatusChip.test.ts
+git commit -s -m "feat: show storage location inline on the chip"
+```
+
+---
+
+### Task 6: Details popover (content component + hover/tap wiring)
+
+**Files:**
+- Create: `src/lib/components/StorageDetailsPopover.svelte`
+- Modify: `src/lib/components/StorageStatusChip.svelte` (wrap the chip in a Popover; add hover/tap and the refresh timer)
+- Test: `src/tests/storage-details-popover.test.ts`
+
+**Interfaces:**
+- Consumes: `formatRelativeTime` (Task 3); `getLayoutSavedAt` (Task 2); `getServerBaseUpdatedAt` (existing, exported from `$lib/storage`); `durability.lastExportedAt`, `durability.label`, `durability.icon`, `durability.changesSinceExport` (Task 4).
+- Produces: `StorageDetailsPopover` renders mode-aware facts from plain props (so it is testable without opening a popover).
+
+- [ ] **Step 1: Write the failing test for the content component**
+
+Create `src/tests/storage-details-popover.test.ts`. It renders the content component directly with props and asserts on copy (text assertions are allowed):
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import StorageDetailsPopover from "$lib/components/StorageDetailsPopover.svelte";
+
+const NOW = Date.parse("2026-06-26T12:00:00.000Z");
+
+describe("StorageDetailsPopover", () => {
+  it("browser mode shows both timestamps and 'Never exported' when null", () => {
+    render(StorageDetailsPopover, {
+      mode: "browser",
+      headline: "Unsaved changes",
+      icon: "pending",
+      changesSinceExport: 3,
+      lastExportedAt: null,
+      autosaveAt: "2026-06-26T11:59:50.000Z",
+      serverSavedAt: null,
+      nowMs: NOW,
+    });
+    expect(screen.getByText(/auto-saved/i)).toBeInTheDocument();
+    expect(screen.getByText(/never exported/i)).toBeInTheDocument();
+    expect(screen.getByText(/stored in this browser only/i)).toBeInTheDocument();
+  });
+
+  it("browser mode formats a real export time", () => {
+    render(StorageDetailsPopover, {
+      mode: "browser",
+      headline: "Saved",
+      icon: "saved",
+      changesSinceExport: 0,
+      lastExportedAt: "2026-06-23T12:00:00.000Z",
+      autosaveAt: "2026-06-26T11:59:50.000Z",
+      serverSavedAt: null,
+      nowMs: NOW,
+    });
+    expect(screen.getByText(/last exported/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 days ago/i)).toBeInTheDocument();
+  });
+
+  it("server mode shows the last server save and storage location", () => {
+    render(StorageDetailsPopover, {
+      mode: "server",
+      headline: "Saved",
+      icon: "saved",
+      changesSinceExport: 0,
+      lastExportedAt: null,
+      autosaveAt: null,
+      serverSavedAt: "2026-06-26T11:58:00.000Z",
+      nowMs: NOW,
+    });
+    expect(screen.getByText(/last saved/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 minutes ago/i)).toBeInTheDocument();
+    expect(screen.getByText(/stored on the server/i)).toBeInTheDocument();
+  });
+
+  it("server mode error reframes the time as last reached", () => {
+    render(StorageDetailsPopover, {
+      mode: "server",
+      headline: "Offline",
+      icon: "error",
+      changesSinceExport: 0,
+      lastExportedAt: null,
+      autosaveAt: null,
+      serverSavedAt: "2026-06-26T11:52:00.000Z",
+      nowMs: NOW,
+    });
+    expect(screen.getByText(/last reached server/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:run -- src/tests/storage-details-popover.test.ts`
+Expected: FAIL ("Cannot find module '.../StorageDetailsPopover.svelte'").
+
+- [ ] **Step 3: Create the content component**
+
+Create `src/lib/components/StorageDetailsPopover.svelte`:
+
+```svelte
+<!--
+  StorageDetailsPopover
+  Read-only facts for the storage chip popover. Prop-driven so it renders the
+  same way from the chip and from a unit test. Facts only: no actions (those
+  live in the app menu, #2446). Browser mode shows the autosave time and the
+  last-export time, labelled, so a recent autosave never reads as a durable
+  backup. Server mode shows the last server save, reframed as "last reached"
+  when the connection is degraded.
+-->
+<script lang="ts">
+  import { IconCheck, IconClock, IconWarningTriangle } from "./icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+  import { formatRelativeTime } from "$lib/utils/relative-time";
+
+  interface Props {
+    mode: "browser" | "server";
+    headline: string;
+    icon: "saved" | "pending" | "error";
+    changesSinceExport: number;
+    lastExportedAt: string | null;
+    autosaveAt: string | null;
+    serverSavedAt: string | null;
+    nowMs: number;
+  }
+
+  let {
+    mode,
+    headline,
+    icon,
+    changesSinceExport,
+    lastExportedAt,
+    autosaveAt,
+    serverSavedAt,
+    nowMs,
+  }: Props = $props();
+
+  const autosaveRel = $derived(formatRelativeTime(autosaveAt, nowMs));
+  const exportRel = $derived(formatRelativeTime(lastExportedAt, nowMs));
+  const serverRel = $derived(formatRelativeTime(serverSavedAt, nowMs));
+  const isDegraded = $derived(icon === "error");
+</script>
+
+<div class="storage-details">
+  <div class="storage-details-head storage-details-{icon}">
+    {#if icon === "saved"}
+      <IconCheck size={ICON_SIZE.sm} />
+    {:else if icon === "pending"}
+      <IconClock size={ICON_SIZE.sm} />
+    {:else}
+      <IconWarningTriangle size={ICON_SIZE.sm} />
+    {/if}
+    <span>{headline}</span>
+  </div>
+
+  <div class="storage-details-divider"></div>
+
+  {#if mode === "browser"}
+    {#if autosaveRel}
+      <div class="storage-details-row">
+        <span class="storage-details-label">Auto-saved</span>
+        <span class="storage-details-value">{autosaveRel}</span>
+      </div>
+    {/if}
+    <div class="storage-details-row">
+      <span class="storage-details-label">Last exported</span>
+      <span
+        class="storage-details-value"
+        class:storage-details-warn={changesSinceExport > 0}
+      >
+        {exportRel ?? "Never exported"}
+      </span>
+    </div>
+    {#if changesSinceExport > 0}
+      <p class="storage-details-note storage-details-warn">
+        {changesSinceExport}
+        {changesSinceExport === 1 ? "change" : "changes"} since last export
+      </p>
+    {/if}
+    <p class="storage-details-foot">Stored in this browser only</p>
+  {:else}
+    <div class="storage-details-row">
+      <span class="storage-details-label">
+        {isDegraded ? "Last reached server" : "Last saved"}
+      </span>
+      <span
+        class="storage-details-value"
+        class:storage-details-warn={isDegraded}
+      >
+        {serverRel ?? "Not yet saved"}
+      </span>
+    </div>
+    {#if isDegraded}
+      <p class="storage-details-note storage-details-warn">
+        Your most recent edits may not be saved.
+      </p>
+    {/if}
+    <p class="storage-details-foot">Stored on the server</p>
+  {/if}
+</div>
+
+<style>
+  .storage-details {
+    min-width: 224px;
+    padding: var(--space-3);
+    font-size: var(--font-size-xs);
+    color: var(--colour-text);
+  }
+  .storage-details-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-weight: 600;
+  }
+  .storage-details-saved {
+    color: var(--colour-success);
+  }
+  .storage-details-pending {
+    color: var(--colour-warning);
+  }
+  .storage-details-error {
+    color: var(--colour-error);
+  }
+  .storage-details-divider {
+    height: 1px;
+    background: var(--colour-border);
+    margin: var(--space-2) calc(-1 * var(--space-3));
+  }
+  .storage-details-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: 2px 0;
+  }
+  .storage-details-label {
+    color: var(--colour-text-muted);
+  }
+  .storage-details-value {
+    font-variant-numeric: tabular-nums;
+  }
+  .storage-details-warn {
+    color: var(--colour-warning);
+  }
+  .storage-details-note {
+    margin: var(--space-1) 0 0;
+    font-size: var(--font-size-xs);
+  }
+  .storage-details-foot {
+    margin: var(--space-2) 0 0;
+    color: var(--colour-text-muted);
+  }
+</style>
+```
+
+- [ ] **Step 4: Run the content-component test to verify it passes**
+
+Run: `npm run test:run -- src/tests/storage-details-popover.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit the content component**
+
+```bash
+git add src/lib/components/StorageDetailsPopover.svelte src/tests/storage-details-popover.test.ts
+git commit -s -m "feat: add StorageDetailsPopover content component"
+```
+
+- [ ] **Step 6: Wire the popover into the chip with hover and tap**
+
+In `src/lib/components/StorageStatusChip.svelte`:
+
+Add imports (with the existing imports):
+
+```typescript
+  import { Popover } from "$lib/components/ui/Popover";
+  import StorageDetailsPopover from "./StorageDetailsPopover.svelte";
+  import { getServerBaseUpdatedAt } from "$lib/storage";
+  import { getLayoutSavedAt } from "$lib/storage/browser-workspace";
+```
+
+Add the open state, the relative-time refresh, and the hover handlers in the `<script>`:
+
+```typescript
+  let open = $state(false);
+  let nowMs = $state(Date.now());
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Recompute the popover's relative times only while it is open.
+  $effect(() => {
+    if (!open) return;
+    nowMs = Date.now();
+    const id = setInterval(() => {
+      nowMs = Date.now();
+    }, 30_000);
+    return () => clearInterval(id);
+  });
+
+  function hoverOpen(event: PointerEvent) {
+    if (event.pointerType === "touch") return; // touch uses tap
+    clearTimeout(closeTimer);
+    open = true;
+  }
+  function hoverClose(event: PointerEvent) {
+    if (event.pointerType === "touch") return;
+    clearTimeout(closeTimer);
+    closeTimer = setTimeout(() => {
+      open = false;
+    }, 150);
+  }
+
+  // Timestamp sources for the popover, read on open. Browser: the layout's last
+  // localStorage write (autosave) plus its last export. Server: the last server save.
+  const layoutId = $derived(layoutStore.layout.metadata?.id ?? null);
+  const autosaveAt = $derived(
+    open && !isServerMode && layoutId ? getLayoutSavedAt(layoutId) : null,
+  );
+  const serverSavedAt = $derived(
+    open && isServerMode ? getServerBaseUpdatedAt() : null,
+  );
+```
+
+Replace the chip `<div>` (the block from Step 3 of Task 5) by wrapping it in a Popover, turning the chip into the trigger button via the `child` snippet (mirroring `Tooltip.svelte`):
+
+```svelte
+<Popover.Root bind:open>
+  <Popover.Trigger>
+    {#snippet child({ props })}
+      <button
+        {...props}
+        type="button"
+        class="storage-chip storage-chip-{durability.status}"
+        class:storage-chip--attention={durability.serverHint}
+        aria-label={accessibleName}
+        data-testid="storage-status-chip"
+        onpointerenter={hoverOpen}
+        onpointerleave={hoverClose}
+      >
+        {#if durability.icon === "saved"}
+          <IconCheck size={ICON_SIZE.sm} />
+        {:else if durability.icon === "pending"}
+          <IconClock size={ICON_SIZE.sm} />
+        {:else}
+          <IconWarningTriangle size={ICON_SIZE.sm} />
+        {/if}
+        <span class="storage-chip-state">{durability.shortLabel}</span>
+        {#if durability.showLocation}
+          <span class="storage-chip-sep" aria-hidden="true">.</span>
+          <span class="storage-chip-loc">{locationWord}</span>
+        {/if}
+      </button>
+    {/snippet}
+  </Popover.Trigger>
+  <Popover.Portal>
+    <Popover.Content
+      class="storage-chip-popover"
+      side="bottom"
+      sideOffset={8}
+      onpointerenter={() => clearTimeout(closeTimer)}
+      onpointerleave={hoverClose}
+    >
+      <StorageDetailsPopover
+        mode={isServerMode ? "server" : "browser"}
+        headline={durability.label}
+        icon={durability.icon}
+        changesSinceExport={durability.changesSinceExport}
+        lastExportedAt={durability.lastExportedAt}
+        {autosaveAt}
+        {serverSavedAt}
+        {nowMs}
+      />
+    </Popover.Content>
+  </Popover.Portal>
+</Popover.Root>
+```
+
+Note: the chip is now a `<button>`, so the old `role="status"` / `aria-live="off"` move off it; the existing hidden `sr-only` live region (the `announced` span at the end of the file) stays and keeps announcing settled state. Leave the `ServerAvailableBanner` and the override `<button>` blocks unchanged.
+
+- [ ] **Step 7: Update the chip styles for the interactive trigger**
+
+In the `<style>` block, replace the base `.storage-chip` rule so it is a borderless, interactive pill with a hover wash and a focus ring (the chip is a button now), and ensure the attention state still shows a border:
+
+```css
+  .storage-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    height: 28px;
+    padding: 0 var(--space-2);
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--colour-text);
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .storage-chip:hover,
+  .storage-chip[data-state="open"] {
+    background: var(--colour-surface-hover);
+  }
+  .storage-chip:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring-glow);
+  }
+```
+
+Add a popover surface rule (this targets the `Popover.Content` via its class):
+
+```css
+  :global(.storage-chip-popover) {
+    background: var(--colour-bg);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg, 0 12px 30px rgba(0, 0, 0, 0.45));
+    z-index: var(--z-popover, 50);
+  }
+```
+
+- [ ] **Step 8: Validate the Svelte components**
+
+Use the Svelte MCP `svelte-autofixer` on `StorageStatusChip.svelte` and `StorageDetailsPopover.svelte`; apply any fixes and re-run it until clean.
+
+Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts src/tests/storage-details-popover.test.ts`
+Expected: PASS.
+
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
+Expected: no new errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/components/StorageStatusChip.svelte
+git commit -s -m "feat: reveal storage details on chip hover and tap"
+```
+
+---
+
+### Task 7: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `npm run test:run`
+Expected: PASS. If any other `LibraryEntry` or `BackupState` literal site fails to compile, add `lastExportedAt: null` (entries) or omit it (optional on `BackupState`) and re-run.
+
+- [ ] **Step 2: Lint and type-check**
+
+Run: `npm run lint`
+Expected: PASS (no `no-restricted-syntax` test violations, no querySelector/toHaveClass/colour assertions).
+
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
+Expected: no errors.
+
+- [ ] **Step 3: Manual smoke (dev server)**
+
+Run: `npm run dev`, open the app, and confirm:
+- Browser mode: chip reads `Unsaved . Browser` then `Saved . Browser` after an export; hovering (mouse) and tapping (touch) both open the popover; the popover shows "Auto-saved", "Last exported" (or "Never exported"), and "Stored in this browser only".
+- The popover closes on Escape, on click-away, and on mouse-leave (after the short delay), and stays open while the pointer is inside it.
+- Keyboard: Tab to the chip, press Enter or Space to open, Escape to close; the focus ring shows.
+
+- [ ] **Step 4: Stop for review**
+
+Stop here and hand back for review. Do not open a PR until the branch is reviewed per the project workflow (CodeRabbit + CodeAnt).
+
+## Self-review
+
+Spec coverage:
+- Inline two-tone state + location: Task 5 (rendering), Task 4 (`shortLabel`, `showLocation`).
+- De-dup rule for self-describing errors: Task 4 (`showLocation: false` for "Server not found" and "Server unavailable").
+- Popover facts, mode-aware: Task 6 (`StorageDetailsPopover`), with browser "show both, labelled" and server "last saved" / degraded "last reached".
+- Data model `lastExportedAt`: Task 1 (store) and Task 2 (persistence), threaded through the live multi-tab schema.
+- Relative time computed on open, refreshed only while open: Task 6 (`$effect` gated on `open`).
+- Interaction and a11y: Task 6 (button trigger, hybrid hover/tap, focus ring); the existing debounced live region is preserved.
+- Default decisions: export-age amber tied to `changesSinceExport > 0` (Task 6 content component); "Connecting"/"Unsaved"/"Pending" wording (Task 4); calm clock for "Saving" (unchanged icons).
+
+Deviations recorded: server-mode working-copy path is not threaded (server never shows "Last exported"); the #2063 server hint stays in the existing `ServerAvailableBanner` rather than being duplicated in the popover.
+
+Placeholder scan: every code step shows complete code; no TBD/TODO; test code is concrete.
+
+Type consistency: `lastExportedAt: string | null` is consistent across `BackupState` (optional), `LibraryEntry`, `DurabilityInput`, the layout store getter, and `LayoutDurability`. `getLayoutSavedAt(id: string): string | null` and `formatRelativeTime(iso, nowMs?)` signatures match their call sites. `StorageDetailsPopover` props match the test and the chip's usage.

--- a/docs/superpowers/plans/2026-06-26-storage-chip-ux.md
+++ b/docs/superpowers/plans/2026-06-26-storage-chip-ux.md
@@ -44,11 +44,13 @@
 ### Task 1: Track `lastExportedAt` in the layout store
 
 **Files:**
+
 - Modify: `src/lib/stores/layout/persistence.ts:15-18`
 - Modify: `src/lib/stores/layout.svelte.ts` (state ~140-142, getters ~233-238, `markExported` ~836-839, `restoreBackupState` ~845-847, resets ~170-173 and ~212-215)
 - Test: `src/tests/changes-since-export.test.ts`
 
 **Interfaces:**
+
 - Produces: `BackupState` gains optional `lastExportedAt?: string | null`. The layout store gains a `lastExportedAt: string | null` getter, `markExported()` stamps it with the current ISO time, and `restoreBackupState(state)` restores it (coercing `undefined` to `null`).
 
 - [ ] **Step 1: Write the failing tests**
@@ -56,36 +58,35 @@
 Add to `src/tests/changes-since-export.test.ts` (inside the existing top-level `describe`):
 
 ```typescript
-  it("stamps lastExportedAt on markExported and clears it on load", () => {
-    const store = getLayoutStore();
-    expect(store.lastExportedAt).toBeNull();
+it("stamps lastExportedAt on markExported and clears it on load", () => {
+  const store = getLayoutStore();
+  expect(store.lastExportedAt).toBeNull();
 
-    store.markExported();
-    expect(store.lastExportedAt).not.toBeNull();
-    expect(() => new Date(store.lastExportedAt as string)).not.toThrow();
+  store.markExported();
+  expect(store.lastExportedAt).not.toBeNull();
+  expect(() => new Date(store.lastExportedAt as string)).not.toThrow();
 
-    store.loadLayout(store.layout);
-    expect(store.lastExportedAt).toBeNull();
+  store.loadLayout(store.layout);
+  expect(store.lastExportedAt).toBeNull();
+});
+
+it("restores lastExportedAt through restoreBackupState", () => {
+  const store = getLayoutStore();
+  const stamp = "2026-06-26T12:00:00.000Z";
+  store.restoreBackupState({
+    changesSinceExport: 4,
+    hasEverExported: true,
+    lastExportedAt: stamp,
   });
-
-  it("restores lastExportedAt through restoreBackupState", () => {
-    const store = getLayoutStore();
-    const stamp = "2026-06-26T12:00:00.000Z";
-    store.restoreBackupState({
-      changesSinceExport: 4,
-      hasEverExported: true,
-      lastExportedAt: stamp,
-    });
-    expect(store.lastExportedAt).toBe(stamp);
-    expect(store.changesSinceExport).toBe(4);
-    expect(store.hasEverExported).toBe(true);
-  });
+  expect(store.lastExportedAt).toBe(stamp);
+  expect(store.changesSinceExport).toBe(4);
+  expect(store.hasEverExported).toBe(true);
+});
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `npm run test:run -- src/tests/changes-since-export.test.ts`
-Expected: FAIL (`store.lastExportedAt` is `undefined`; `restoreBackupState` ignores the new field).
+Run: `npm run test:run -- src/tests/changes-since-export.test.ts` Expected: FAIL (`store.lastExportedAt` is `undefined`; `restoreBackupState` ignores the new field).
 
 - [ ] **Step 3: Add `lastExportedAt` to `BackupState`**
 
@@ -108,7 +109,7 @@ In `src/lib/stores/layout.svelte.ts`:
 Add the state declaration next to the others (after line 142):
 
 ```typescript
-  let lastExportedAt = $state<string | null>(null);
+let lastExportedAt = $state<string | null>(null);
 ```
 
 Add a getter in the returned store object, after the `hasEverExported` getter (after line 238):
@@ -122,21 +123,21 @@ Add a getter in the returned store object, after the `hasEverExported` getter (a
 Update `markExported()` (currently lines 836-839) to stamp the time:
 
 ```typescript
-  function markExported(): void {
-    changesSinceExport = 0;
-    hasEverExported = true;
-    lastExportedAt = new Date().toISOString();
-  }
+function markExported(): void {
+  changesSinceExport = 0;
+  hasEverExported = true;
+  lastExportedAt = new Date().toISOString();
+}
 ```
 
 Update `restoreBackupState()` (currently lines 845-847) to restore it (undefined coerces to null):
 
 ```typescript
-  function restoreBackupState(state: BackupState): void {
-    changesSinceExport = state.changesSinceExport;
-    hasEverExported = state.hasEverExported;
-    lastExportedAt = state.lastExportedAt ?? null;
-  }
+function restoreBackupState(state: BackupState): void {
+  changesSinceExport = state.changesSinceExport;
+  hasEverExported = state.hasEverExported;
+  lastExportedAt = state.lastExportedAt ?? null;
+}
 ```
 
 In `resetBackupTracking` (the object method around lines 170-173), add the reset:
@@ -153,20 +154,18 @@ In `resetBackupTracking` (the object method around lines 170-173), add the reset
 In `resetLayout` (around lines 212-215), add the reset after `hasEverExported = false;`:
 
 ```typescript
-    changesSinceExport = 0;
-    hasEverExported = false;
-    lastExportedAt = null;
+changesSinceExport = 0;
+hasEverExported = false;
+lastExportedAt = null;
 ```
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
-Run: `npm run test:run -- src/tests/changes-since-export.test.ts`
-Expected: PASS (all tests, including the two new ones).
+Run: `npm run test:run -- src/tests/changes-since-export.test.ts` Expected: PASS (all tests, including the two new ones).
 
 - [ ] **Step 6: Type-check**
 
-Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
-Expected: no new errors from these files.
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no new errors from these files.
 
 - [ ] **Step 7: Commit**
 
@@ -180,6 +179,7 @@ git commit -s -m "feat: track lastExportedAt in the layout store"
 ### Task 2: Persist `lastExportedAt` across reload (browser multi-tab schema)
 
 **Files:**
+
 - Modify: `src/lib/storage/browser-workspace.ts` (`LibraryEntry` ~45-52, `DurabilityInput` ~69-73, index write ~250-258, add helper near other exports)
 - Modify: `src/lib/storage/browser-workspace-persist.ts` (`PersistTab` ~25-38, `saveLayoutBody` call ~82-85, paused/shell entries ~113-130)
 - Modify: `src/lib/components/PersistenceEffects.svelte` (snapshot ~88-95)
@@ -187,6 +187,7 @@ git commit -s -m "feat: track lastExportedAt in the layout store"
 - Test: `src/tests/changes-since-export.test.ts`
 
 **Interfaces:**
+
 - Consumes: `layoutStore.lastExportedAt` (Task 1).
 - Produces: `LibraryEntry` and `DurabilityInput` gain `lastExportedAt: string | null`. New export `getLayoutSavedAt(id: string): string | null` returns a layout's last localStorage write time (the library entry `updatedAt`, or null when absent or empty).
 
@@ -205,28 +206,27 @@ import {
 Then add the test:
 
 ```typescript
-  it("persists and reads back lastExportedAt via the workspace library", () => {
-    const id = "test-layout-id";
-    const stamp = "2026-06-26T12:00:00.000Z";
-    const layout = getLayoutStore().layout;
+it("persists and reads back lastExportedAt via the workspace library", () => {
+  const id = "test-layout-id";
+  const stamp = "2026-06-26T12:00:00.000Z";
+  const layout = getLayoutStore().layout;
 
-    saveLayoutBody(id, layout, {
-      changesSinceExport: 2,
-      hasEverExported: true,
-      lastExportedAt: stamp,
-    });
-
-    const index = loadWorkspaceIndex();
-    expect(index?.library[id]?.lastExportedAt).toBe(stamp);
-    // updatedAt is the autosave write time, exposed for the "Auto-saved" line.
-    expect(getLayoutSavedAt(id)).toBe(index?.library[id]?.updatedAt);
+  saveLayoutBody(id, layout, {
+    changesSinceExport: 2,
+    hasEverExported: true,
+    lastExportedAt: stamp,
   });
+
+  const index = loadWorkspaceIndex();
+  expect(index?.library[id]?.lastExportedAt).toBe(stamp);
+  // updatedAt is the autosave write time, exposed for the "Auto-saved" line.
+  expect(getLayoutSavedAt(id)).toBe(index?.library[id]?.updatedAt);
+});
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm run test:run -- src/tests/changes-since-export.test.ts`
-Expected: FAIL (`DurabilityInput` has no `lastExportedAt`; `getLayoutSavedAt` is not exported).
+Run: `npm run test:run -- src/tests/changes-since-export.test.ts` Expected: FAIL (`DurabilityInput` has no `lastExportedAt`; `getLayoutSavedAt` is not exported).
 
 - [ ] **Step 3: Add the field to `LibraryEntry` and `DurabilityInput`, write it, and add the helper**
 
@@ -261,17 +261,16 @@ export interface DurabilityInput {
 Update the index entry write inside `saveLayoutBody` (lines 250-258) to carry the field, preserving a prior value when the caller omits it:
 
 ```typescript
-  index.library[id] = {
-    name: layout.name,
-    updatedAt: savedAt,
-    changesSinceExport: durability.changesSinceExport,
-    hasEverExported:
-      durability.hasEverExported ?? previous?.hasEverExported ?? false,
-    lastExportedAt:
-      durability.lastExportedAt ?? previous?.lastExportedAt ?? null,
-    writeFailed: durability.writeFailed ?? !wrote,
-    storageMode: previous?.storageMode ?? "browser",
-  };
+index.library[id] = {
+  name: layout.name,
+  updatedAt: savedAt,
+  changesSinceExport: durability.changesSinceExport,
+  hasEverExported:
+    durability.hasEverExported ?? previous?.hasEverExported ?? false,
+  lastExportedAt: durability.lastExportedAt ?? previous?.lastExportedAt ?? null,
+  writeFailed: durability.writeFailed ?? !wrote,
+  storageMode: previous?.storageMode ?? "browser",
+};
 ```
 
 Add the read helper (place it after `saveLayoutBody`, before `deleteLayoutBody` near line 264):
@@ -308,40 +307,40 @@ Extend the hydrated `PersistTab` variant (lines 26-32):
 Pass it into the body write (lines 81-85):
 
 ```typescript
-      const write = () =>
-        saveLayoutBody(tab.layoutId, tab.layout, {
-          changesSinceExport: tab.changesSinceExport,
-          hasEverExported: tab.hasEverExported,
-          lastExportedAt: tab.lastExportedAt,
-        });
+const write = () =>
+  saveLayoutBody(tab.layoutId, tab.layout, {
+    changesSinceExport: tab.changesSinceExport,
+    hasEverExported: tab.hasEverExported,
+    lastExportedAt: tab.lastExportedAt,
+  });
 ```
 
 Add it to the paused-hydrated entry (lines 113-120):
 
 ```typescript
-      library[tab.layoutId] = {
-        name: tab.layout.name,
-        updatedAt: "",
-        changesSinceExport: tab.changesSinceExport,
-        hasEverExported: tab.hasEverExported,
-        lastExportedAt: tab.lastExportedAt,
-        writeFailed: false,
-        storageMode: "browser",
-      };
+library[tab.layoutId] = {
+  name: tab.layout.name,
+  updatedAt: "",
+  changesSinceExport: tab.changesSinceExport,
+  hasEverExported: tab.hasEverExported,
+  lastExportedAt: tab.lastExportedAt,
+  writeFailed: false,
+  storageMode: "browser",
+};
 ```
 
 Add it to the shell entry (lines 123-130), carrying forward any prior value:
 
 ```typescript
-    library[tab.layoutId] = {
-      name: tab.name,
-      updatedAt: previous?.updatedAt ?? "",
-      changesSinceExport: previous?.changesSinceExport ?? 0,
-      hasEverExported: previous?.hasEverExported ?? false,
-      lastExportedAt: previous?.lastExportedAt ?? null,
-      writeFailed: previous?.writeFailed ?? false,
-      storageMode: previous?.storageMode ?? "browser",
-    };
+library[tab.layoutId] = {
+  name: tab.name,
+  updatedAt: previous?.updatedAt ?? "",
+  changesSinceExport: previous?.changesSinceExport ?? 0,
+  hasEverExported: previous?.hasEverExported ?? false,
+  lastExportedAt: previous?.lastExportedAt ?? null,
+  writeFailed: previous?.writeFailed ?? false,
+  storageMode: previous?.storageMode ?? "browser",
+};
 ```
 
 - [ ] **Step 5: Populate the field in the tab snapshot**
@@ -349,14 +348,14 @@ Add it to the shell entry (lines 123-130), carrying forward any prior value:
 In `src/lib/components/PersistenceEffects.svelte`, the hydrated branch of `snapshotWorkspaceTabs` (lines 89-95):
 
 ```typescript
-        tabs.push({
-          layoutId,
-          hydrated: true,
-          layout: $state.snapshot(tab.store.layout),
-          changesSinceExport: tab.store.changesSinceExport,
-          hasEverExported: tab.store.hasEverExported,
-          lastExportedAt: tab.store.lastExportedAt,
-        });
+tabs.push({
+  layoutId,
+  hydrated: true,
+  layout: $state.snapshot(tab.store.layout),
+  changesSinceExport: tab.store.changesSinceExport,
+  hasEverExported: tab.store.hasEverExported,
+  lastExportedAt: tab.store.lastExportedAt,
+});
 ```
 
 - [ ] **Step 6: Restore the field**
@@ -364,24 +363,22 @@ In `src/lib/components/PersistenceEffects.svelte`, the hydrated branch of `snaps
 In `src/lib/stores/workspace.svelte.ts`, the restore block (lines 291-298):
 
 ```typescript
-    const entry = tab.layoutId ? restoreLibrary[tab.layoutId] : undefined;
-    if (entry) {
-      tab.store.markDirty();
-      tab.store.restoreBackupState({
-        changesSinceExport: entry.changesSinceExport,
-        hasEverExported: entry.hasEverExported,
-        lastExportedAt: entry.lastExportedAt,
-      });
-    }
+const entry = tab.layoutId ? restoreLibrary[tab.layoutId] : undefined;
+if (entry) {
+  tab.store.markDirty();
+  tab.store.restoreBackupState({
+    changesSinceExport: entry.changesSinceExport,
+    hasEverExported: entry.hasEverExported,
+    lastExportedAt: entry.lastExportedAt,
+  });
+}
 ```
 
 - [ ] **Step 7: Run the test and the type-check**
 
-Run: `npm run test:run -- src/tests/changes-since-export.test.ts`
-Expected: PASS.
+Run: `npm run test:run -- src/tests/changes-since-export.test.ts` Expected: PASS.
 
-Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
-Expected: no new errors. (If any other `LibraryEntry` literal is reported as missing `lastExportedAt`, add `lastExportedAt: null` there.)
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no new errors. (If any other `LibraryEntry` literal is reported as missing `lastExportedAt`, add `lastExportedAt: null` there.)
 
 - [ ] **Step 8: Commit**
 
@@ -395,10 +392,12 @@ git commit -s -m "feat: persist lastExportedAt in the browser workspace library"
 ### Task 3: Relative-time util
 
 **Files:**
+
 - Create: `src/lib/utils/relative-time.ts`
 - Test: `src/tests/relative-time.test.ts`
 
 **Interfaces:**
+
 - Produces: `formatRelativeTime(iso: string | null, nowMs?: number): string | null` returning `null` for null/invalid input, `"just now"` under 45 seconds, else an "N units ago" string. Deterministic when `nowMs` is supplied.
 
 - [ ] **Step 1: Write the failing test**
@@ -433,8 +432,7 @@ describe("formatRelativeTime", () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm run test:run -- src/tests/relative-time.test.ts`
-Expected: FAIL ("Cannot find module '$lib/utils/relative-time'").
+Run: `npm run test:run -- src/tests/relative-time.test.ts` Expected: FAIL ("Cannot find module '$lib/utils/relative-time'").
 
 - [ ] **Step 3: Implement the util**
 
@@ -465,7 +463,8 @@ export function formatRelativeTime(
 
   const elapsed = nowMs - then;
   if (elapsed < 45 * SECOND) return "just now";
-  if (elapsed < HOUR) return rtf.format(-Math.round(elapsed / MINUTE), "minute");
+  if (elapsed < HOUR)
+    return rtf.format(-Math.round(elapsed / MINUTE), "minute");
   if (elapsed < DAY) return rtf.format(-Math.round(elapsed / HOUR), "hour");
   return rtf.format(-Math.round(elapsed / DAY), "day");
 }
@@ -473,8 +472,7 @@ export function formatRelativeTime(
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `npm run test:run -- src/tests/relative-time.test.ts`
-Expected: PASS.
+Run: `npm run test:run -- src/tests/relative-time.test.ts` Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -488,10 +486,12 @@ git commit -s -m "feat: add formatRelativeTime util for the storage chip"
 ### Task 4: Extend the durability source with inline label, location flag, and export time
 
 **Files:**
+
 - Modify: `src/lib/storage/durability.svelte.ts` (`LayoutDurability` ~42-58, `computeLayoutStatus` return type ~78-84 and all return branches ~90-187, `getLayoutDurability` getters ~226-256)
 - Test: `src/tests/durability-inline-labels.test.ts`
 
 **Interfaces:**
+
 - Consumes: `layoutStore.lastExportedAt` (Task 1).
 - Produces: `computeLayoutStatus(...)` returns two extra fields: `shortLabel: string` (the inline state word) and `showLocation: boolean` (false for self-describing error states). `LayoutDurability` gains `shortLabel: string`, `showLocation: boolean`, and `lastExportedAt: string | null`.
 
@@ -544,8 +544,7 @@ describe("computeLayoutStatus inline fields", () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm run test:run -- src/tests/durability-inline-labels.test.ts`
-Expected: FAIL (`shortLabel` / `showLocation` are undefined).
+Run: `npm run test:run -- src/tests/durability-inline-labels.test.ts` Expected: FAIL (`shortLabel` / `showLocation` are undefined).
 
 - [ ] **Step 3: Add the fields to the `computeLayoutStatus` return type and every branch**
 
@@ -567,25 +566,106 @@ Then add `shortLabel` and `showLocation` to each of the eight return objects. Us
 
 ```typescript
 // browser, durable (line ~91)
-    return { status: "saved", kind: "saved", label: "Saved", shortLabel: "Saved", showLocation: true, detail: "Stored in this browser", icon: "saved" };
+return {
+  status: "saved",
+  kind: "saved",
+  label: "Saved",
+  shortLabel: "Saved",
+  showLocation: true,
+  detail: "Stored in this browser",
+  icon: "saved",
+};
 // browser, pending (line ~99)
-    return { status: "pending", kind: "pending", label: "Unsaved changes", shortLabel: "Unsaved", showLocation: true, detail: "Stored in this browser", icon: "pending" };
+return {
+  status: "pending",
+  kind: "pending",
+  label: "Unsaved changes",
+  shortLabel: "Unsaved",
+  showLocation: true,
+  detail: "Stored in this browser",
+  icon: "pending",
+};
 // server, breaker open (line ~113)
-    return { status: "error", kind: "offline", label: "Server unavailable", shortLabel: "Server unavailable", showLocation: false, detail: "Working from your browser; reload to retry.", icon: "error" };
+return {
+  status: "error",
+  kind: "offline",
+  label: "Server unavailable",
+  shortLabel: "Server unavailable",
+  showLocation: false,
+  detail: "Working from your browser; reload to retry.",
+  icon: "error",
+};
 // server, checking (line ~122)
-    return { status: "pending", kind: "pending", label: "Checking connection", shortLabel: "Connecting", showLocation: true, detail: "Looking for the server.", icon: "pending" };
+return {
+  status: "pending",
+  kind: "pending",
+  label: "Checking connection",
+  shortLabel: "Connecting",
+  showLocation: true,
+  detail: "Looking for the server.",
+  icon: "pending",
+};
 // server, reached-then-lost (line ~137)
-    return { status: "error", kind: "offline", label: "Offline", shortLabel: "Offline", showLocation: true, detail: "Working from your browser; reload to retry.", icon: "error" };
+return {
+  status: "error",
+  kind: "offline",
+  label: "Offline",
+  shortLabel: "Offline",
+  showLocation: true,
+  detail: "Working from your browser; reload to retry.",
+  icon: "error",
+};
 // server, never-reached (line ~145)
-    return { status: "error", kind: "server-not-found", label: "Server not found", shortLabel: "Server not found", showLocation: false, detail: "Check that the API container is running and RACKULA_STORAGE_MODE matches the deployment.", icon: "error" };
+return {
+  status: "error",
+  kind: "server-not-found",
+  label: "Server not found",
+  shortLabel: "Server not found",
+  showLocation: false,
+  detail:
+    "Check that the API container is running and RACKULA_STORAGE_MODE matches the deployment.",
+  icon: "error",
+};
 // server, save error (line ~155)
-    return { status: "error", kind: "offline", label: "Save error", shortLabel: "Save error", showLocation: true, detail: "The last save did not go through.", icon: "error" };
+return {
+  status: "error",
+  kind: "offline",
+  label: "Save error",
+  shortLabel: "Save error",
+  showLocation: true,
+  detail: "The last save did not go through.",
+  icon: "error",
+};
 // server, saving (line ~164)
-    return { status: "pending", kind: "pending", label: "Saving", shortLabel: "Saving", showLocation: true, detail: "Saving to server.", icon: "pending" };
+return {
+  status: "pending",
+  kind: "pending",
+  label: "Saving",
+  shortLabel: "Saving",
+  showLocation: true,
+  detail: "Saving to server.",
+  icon: "pending",
+};
 // server, saved (line ~173)
-    return { status: "saved", kind: "saved", label: "Saved", shortLabel: "Saved", showLocation: true, detail: "Saved to server", icon: "saved" };
+return {
+  status: "saved",
+  kind: "saved",
+  label: "Saved",
+  shortLabel: "Saved",
+  showLocation: true,
+  detail: "Saved to server",
+  icon: "saved",
+};
 // server, fallback pending (line ~181)
-    return { status: "pending", kind: "pending", label: "Pending save", shortLabel: "Pending", showLocation: true, detail: "Saving to server.", icon: "pending" };
+return {
+  status: "pending",
+  kind: "pending",
+  label: "Pending save",
+  shortLabel: "Pending",
+  showLocation: true,
+  detail: "Saving to server.",
+  icon: "pending",
+};
 ```
 
 - [ ] **Step 4: Add the fields to `LayoutDurability` and the durability getters**
@@ -593,14 +673,14 @@ Then add `shortLabel` and `showLocation` to each of the eight return objects. Us
 Extend the `LayoutDurability` interface (lines 42-58) by adding, after `label: string;`:
 
 ```typescript
-  shortLabel: string;
-  showLocation: boolean;
+shortLabel: string;
+showLocation: boolean;
 ```
 
 and, after `hasEverExported: boolean;`:
 
 ```typescript
-  lastExportedAt: string | null;
+lastExportedAt: string | null;
 ```
 
 In `getLayoutDurability` (lines 226-256), add getters alongside the existing ones (after the `label` getter and after the `hasEverExported` getter respectively):
@@ -622,11 +702,9 @@ In `getLayoutDurability` (lines 226-256), add getters alongside the existing one
 
 - [ ] **Step 5: Run the test and the type-check**
 
-Run: `npm run test:run -- src/tests/durability-inline-labels.test.ts`
-Expected: PASS.
+Run: `npm run test:run -- src/tests/durability-inline-labels.test.ts` Expected: PASS.
 
-Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
-Expected: no new errors.
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no new errors.
 
 - [ ] **Step 6: Commit**
 
@@ -640,10 +718,12 @@ git commit -s -m "feat: add inline label, location flag, and export time to dura
 ### Task 5: Two-tone inline chip and accessible name
 
 **Files:**
+
 - Modify: `src/lib/components/StorageStatusChip.svelte` (markup ~99-133, styles ~135-191)
 - Test: `src/tests/StorageStatusChip.test.ts`
 
 **Interfaces:**
+
 - Consumes: `durability.shortLabel`, `durability.showLocation`, `durability.status`, `durability.icon`, `durability.serverHint` (Task 4); `isServerMode` (already computed in the component).
 - Produces: the chip renders `[icon] [shortLabel] . [location]` with the status colour on the state word and a muted location. Accessible name is `Storage status: {label}` plus `, Browser` or `, Server` when `showLocation` is true.
 
@@ -652,29 +732,30 @@ git commit -s -m "feat: add inline label, location flag, and export time to dura
 Replace the assertion in `src/tests/StorageStatusChip.test.ts` (the existing test expects `/storage status: unsaved changes/i`). A fresh browser-mode store is dirty, so:
 
 ```typescript
-  it("exposes the current storage state and location in its accessible name", () => {
-    render(StorageStatusChip);
-    const chip = screen.getByTestId("storage-status-chip");
-    expect(chip).toHaveAccessibleName(/storage status: unsaved changes, browser/i);
-  });
+it("exposes the current storage state and location in its accessible name", () => {
+  render(StorageStatusChip);
+  const chip = screen.getByTestId("storage-status-chip");
+  expect(chip).toHaveAccessibleName(
+    /storage status: unsaved changes, browser/i,
+  );
+});
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts`
-Expected: FAIL (current accessible name has no location).
+Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts` Expected: FAIL (current accessible name has no location).
 
 - [ ] **Step 3: Add a derived accessible name and split the inline text**
 
 In `src/lib/components/StorageStatusChip.svelte`, add a derived value in the `<script>` (after the `durability` constant, near line 36):
 
 ```typescript
-  const locationWord = $derived(isServerMode ? "Server" : "Browser");
-  const accessibleName = $derived(
-    durability.showLocation
-      ? `Storage status: ${durability.label}, ${locationWord}`
-      : `Storage status: ${durability.label}`,
-  );
+const locationWord = $derived(isServerMode ? "Server" : "Browser");
+const accessibleName = $derived(
+  durability.showLocation
+    ? `Storage status: ${durability.label}, ${locationWord}`
+    : `Storage status: ${durability.label}`,
+);
 ```
 
 Replace the chip markup (lines 99-133) so the label splits into a coloured state word and a muted location, and the `aria-label` uses the derived name:
@@ -708,22 +789,21 @@ Replace the chip markup (lines 99-133) so the label splits into a coloured state
 In the `<style>` block, the status classes currently colour the whole chip; keep that (so the icon and state word inherit the status colour) and override the location and separator to muted. Add after the `.storage-chip-error` rule:
 
 ```css
-  .storage-chip-state {
-    font-weight: 600;
-  }
+.storage-chip-state {
+  font-weight: 600;
+}
 
-  /* Location is secondary: muted so the coloured state word leads. */
-  .storage-chip-sep,
-  .storage-chip-loc {
-    color: var(--colour-text-muted);
-    font-weight: 500;
-  }
+/* Location is secondary: muted so the coloured state word leads. */
+.storage-chip-sep,
+.storage-chip-loc {
+  color: var(--colour-text-muted);
+  font-weight: 500;
+}
 ```
 
 - [ ] **Step 5: Run the test to verify it passes**
 
-Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts`
-Expected: PASS.
+Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts` Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
@@ -737,11 +817,13 @@ git commit -s -m "feat: show storage location inline on the chip"
 ### Task 6: Details popover (content component + hover/tap wiring)
 
 **Files:**
+
 - Create: `src/lib/components/StorageDetailsPopover.svelte`
 - Modify: `src/lib/components/StorageStatusChip.svelte` (wrap the chip in a Popover; add hover/tap and the refresh timer)
 - Test: `src/tests/storage-details-popover.test.ts`
 
 **Interfaces:**
+
 - Consumes: `formatRelativeTime` (Task 3); `getLayoutSavedAt` (Task 2); `getServerBaseUpdatedAt` (existing, exported from `$lib/storage`); `durability.lastExportedAt`, `durability.label`, `durability.icon`, `durability.changesSinceExport` (Task 4).
 - Produces: `StorageDetailsPopover` renders mode-aware facts from plain props (so it is testable without opening a popover).
 
@@ -770,7 +852,9 @@ describe("StorageDetailsPopover", () => {
     });
     expect(screen.getByText(/auto-saved/i)).toBeInTheDocument();
     expect(screen.getByText(/never exported/i)).toBeInTheDocument();
-    expect(screen.getByText(/stored in this browser only/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/stored in this browser only/i),
+    ).toBeInTheDocument();
   });
 
   it("browser mode formats a real export time", () => {
@@ -822,8 +906,7 @@ describe("StorageDetailsPopover", () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `npm run test:run -- src/tests/storage-details-popover.test.ts`
-Expected: FAIL ("Cannot find module '.../StorageDetailsPopover.svelte'").
+Run: `npm run test:run -- src/tests/storage-details-popover.test.ts` Expected: FAIL ("Cannot find module '.../StorageDetailsPopover.svelte'").
 
 - [ ] **Step 3: Create the content component**
 
@@ -985,8 +1068,7 @@ Create `src/lib/components/StorageDetailsPopover.svelte`:
 
 - [ ] **Step 4: Run the content-component test to verify it passes**
 
-Run: `npm run test:run -- src/tests/storage-details-popover.test.ts`
-Expected: PASS.
+Run: `npm run test:run -- src/tests/storage-details-popover.test.ts` Expected: PASS.
 
 - [ ] **Step 5: Commit the content component**
 
@@ -1002,51 +1084,51 @@ In `src/lib/components/StorageStatusChip.svelte`:
 Add imports (with the existing imports):
 
 ```typescript
-  import { Popover } from "$lib/components/ui/Popover";
-  import StorageDetailsPopover from "./StorageDetailsPopover.svelte";
-  import { getServerBaseUpdatedAt } from "$lib/storage";
-  import { getLayoutSavedAt } from "$lib/storage/browser-workspace";
+import { Popover } from "$lib/components/ui/Popover";
+import StorageDetailsPopover from "./StorageDetailsPopover.svelte";
+import { getServerBaseUpdatedAt } from "$lib/storage";
+import { getLayoutSavedAt } from "$lib/storage/browser-workspace";
 ```
 
 Add the open state, the relative-time refresh, and the hover handlers in the `<script>`:
 
 ```typescript
-  let open = $state(false);
-  let nowMs = $state(Date.now());
-  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+let open = $state(false);
+let nowMs = $state(Date.now());
+let closeTimer: ReturnType<typeof setTimeout> | undefined;
 
-  // Recompute the popover's relative times only while it is open.
-  $effect(() => {
-    if (!open) return;
+// Recompute the popover's relative times only while it is open.
+$effect(() => {
+  if (!open) return;
+  nowMs = Date.now();
+  const id = setInterval(() => {
     nowMs = Date.now();
-    const id = setInterval(() => {
-      nowMs = Date.now();
-    }, 30_000);
-    return () => clearInterval(id);
-  });
+  }, 30_000);
+  return () => clearInterval(id);
+});
 
-  function hoverOpen(event: PointerEvent) {
-    if (event.pointerType === "touch") return; // touch uses tap
-    clearTimeout(closeTimer);
-    open = true;
-  }
-  function hoverClose(event: PointerEvent) {
-    if (event.pointerType === "touch") return;
-    clearTimeout(closeTimer);
-    closeTimer = setTimeout(() => {
-      open = false;
-    }, 150);
-  }
+function hoverOpen(event: PointerEvent) {
+  if (event.pointerType === "touch") return; // touch uses tap
+  clearTimeout(closeTimer);
+  open = true;
+}
+function hoverClose(event: PointerEvent) {
+  if (event.pointerType === "touch") return;
+  clearTimeout(closeTimer);
+  closeTimer = setTimeout(() => {
+    open = false;
+  }, 150);
+}
 
-  // Timestamp sources for the popover, read on open. Browser: the layout's last
-  // localStorage write (autosave) plus its last export. Server: the last server save.
-  const layoutId = $derived(layoutStore.layout.metadata?.id ?? null);
-  const autosaveAt = $derived(
-    open && !isServerMode && layoutId ? getLayoutSavedAt(layoutId) : null,
-  );
-  const serverSavedAt = $derived(
-    open && isServerMode ? getServerBaseUpdatedAt() : null,
-  );
+// Timestamp sources for the popover, read on open. Browser: the layout's last
+// localStorage write (autosave) plus its last export. Server: the last server save.
+const layoutId = $derived(layoutStore.layout.metadata?.id ?? null);
+const autosaveAt = $derived(
+  open && !isServerMode && layoutId ? getLayoutSavedAt(layoutId) : null,
+);
+const serverSavedAt = $derived(
+  open && isServerMode ? getServerBaseUpdatedAt() : null,
+);
 ```
 
 Replace the chip `<div>` (the block from Step 3 of Task 5) by wrapping it in a Popover, turning the chip into the trigger button via the `child` snippet (mirroring `Tooltip.svelte`):
@@ -1110,52 +1192,50 @@ Note: the chip is now a `<button>`, so the old `role="status"` / `aria-live="off
 In the `<style>` block, replace the base `.storage-chip` rule so it is a borderless, interactive pill with a hover wash and a focus ring (the chip is a button now), and ensure the attention state still shows a border:
 
 ```css
-  .storage-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    height: 28px;
-    padding: 0 var(--space-2);
-    border: 1px solid transparent;
-    border-radius: var(--radius-md);
-    background: transparent;
-    color: var(--colour-text);
-    font-size: var(--font-size-xs);
-    font-weight: 500;
-    font-family: inherit;
-    cursor: pointer;
-  }
-  .storage-chip:hover,
-  .storage-chip[data-state="open"] {
-    background: var(--colour-surface-hover);
-  }
-  .storage-chip:focus-visible {
-    outline: none;
-    box-shadow: var(--focus-ring-glow);
-  }
+.storage-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 28px;
+  padding: 0 var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--colour-text);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+}
+.storage-chip:hover,
+.storage-chip[data-state="open"] {
+  background: var(--colour-surface-hover);
+}
+.storage-chip:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-glow);
+}
 ```
 
 Add a popover surface rule (this targets the `Popover.Content` via its class):
 
 ```css
-  :global(.storage-chip-popover) {
-    background: var(--colour-bg);
-    border: 1px solid var(--colour-border);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-lg, 0 12px 30px rgba(0, 0, 0, 0.45));
-    z-index: var(--z-popover, 50);
-  }
+:global(.storage-chip-popover) {
+  background: var(--colour-bg);
+  border: 1px solid var(--colour-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg, 0 12px 30px rgba(0, 0, 0, 0.45));
+  z-index: var(--z-popover, 50);
+}
 ```
 
 - [ ] **Step 8: Validate the Svelte components**
 
 Use the Svelte MCP `svelte-autofixer` on `StorageStatusChip.svelte` and `StorageDetailsPopover.svelte`; apply any fixes and re-run it until clean.
 
-Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts src/tests/storage-details-popover.test.ts`
-Expected: PASS.
+Run: `npm run test:run -- src/tests/StorageStatusChip.test.ts src/tests/storage-details-popover.test.ts` Expected: PASS.
 
-Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
-Expected: no new errors.
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no new errors.
 
 - [ ] **Step 9: Commit**
 
@@ -1172,20 +1252,18 @@ git commit -s -m "feat: reveal storage details on chip hover and tap"
 
 - [ ] **Step 1: Run the full unit suite**
 
-Run: `npm run test:run`
-Expected: PASS. If any other `LibraryEntry` or `BackupState` literal site fails to compile, add `lastExportedAt: null` (entries) or omit it (optional on `BackupState`) and re-run.
+Run: `npm run test:run` Expected: PASS. If any other `LibraryEntry` or `BackupState` literal site fails to compile, add `lastExportedAt: null` (entries) or omit it (optional on `BackupState`) and re-run.
 
 - [ ] **Step 2: Lint and type-check**
 
-Run: `npm run lint`
-Expected: PASS (no `no-restricted-syntax` test violations, no querySelector/toHaveClass/colour assertions).
+Run: `npm run lint` Expected: PASS (no `no-restricted-syntax` test violations, no querySelector/toHaveClass/colour assertions).
 
-Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5`
-Expected: no errors.
+Run: `npx svelte-check --tsconfig ./tsconfig.json --threshold error 2>&1 | tail -5` Expected: no errors.
 
 - [ ] **Step 3: Manual smoke (dev server)**
 
 Run: `npm run dev`, open the app, and confirm:
+
 - Browser mode: chip reads `Unsaved . Browser` then `Saved . Browser` after an export; hovering (mouse) and tapping (touch) both open the popover; the popover shows "Auto-saved", "Last exported" (or "Never exported"), and "Stored in this browser only".
 - The popover closes on Escape, on click-away, and on mouse-leave (after the short delay), and stays open while the pointer is inside it.
 - Keyboard: Tab to the chip, press Enter or Space to open, Escape to close; the focus ring shows.
@@ -1197,6 +1275,7 @@ Stop here and hand back for review. Do not open a PR until the branch is reviewe
 ## Self-review
 
 Spec coverage:
+
 - Inline two-tone state + location: Task 5 (rendering), Task 4 (`shortLabel`, `showLocation`).
 - De-dup rule for self-describing errors: Task 4 (`showLocation: false` for "Server not found" and "Server unavailable").
 - Popover facts, mode-aware: Task 6 (`StorageDetailsPopover`), with browser "show both, labelled" and server "last saved" / degraded "last reached".

--- a/docs/superpowers/specs/2026-06-26-storage-chip-ux-design.md
+++ b/docs/superpowers/specs/2026-06-26-storage-chip-ux-design.md
@@ -1,8 +1,6 @@
 # Storage chip UX redesign
 
-Date: 2026-06-26
-Status: design (awaiting plan)
-Topic: surface storage location and last-save facts on the workspace storage chip
+Date: 2026-06-26 Status: design (awaiting plan) Topic: surface storage location and last-save facts on the workspace storage chip
 
 ## Summary
 

--- a/docs/superpowers/specs/2026-06-26-storage-chip-ux-design.md
+++ b/docs/superpowers/specs/2026-06-26-storage-chip-ux-design.md
@@ -1,0 +1,155 @@
+# Storage chip UX redesign
+
+Date: 2026-06-26
+Status: design (awaiting plan)
+Topic: surface storage location and last-save facts on the workspace storage chip
+
+## Summary
+
+The storage status chip currently shows only a save state (one of "Saved", "Unsaved changes", "Saving", "Offline", "Server not found"). Two pieces of designed intent never shipped: the storage location word (#2446 wanted "Saved . Server" / "Unsaved . Browser"), and the last-save / last-export facts that #2035 reserved a popover for. This design completes both: a two-tone inline chip that always shows state and location, plus a hover/tap details popover carrying honest, mode-aware timestamps. No save or export mechanics change.
+
+## Problem
+
+- The chip computes the storage mode but never renders it. A user cannot tell at a glance whether their work lands in this browser only or on the server. For server deployments and for the misconfiguration cases in #2063, that distinction is exactly what the chip exists to make honest.
+- There is no surface for "when was my work last saved". The underlying timestamps already exist (`savedAt` working-copy write, server `updatedAt`) but are used only internally for conflict detection.
+- The chip is a passive `role="status"` div with no details affordance, so there is nowhere to put facts without widening the inline footprint.
+
+## Goals
+
+- Always show storage location (Browser or Server) inline, paired with the save state.
+- Reveal last-save facts on demand without cluttering the toolbar or jittering with a live-ticking clock.
+- Keep the chip honest: never imply durability the storage mode does not provide.
+- Preserve the accessibility guarantees from #2064 (never colour-only, accessible name includes state, debounced live-region announcement).
+
+## Non-goals
+
+- No new actions on the chip. Export and restore actions stay in the file menu (#2446 decision stands).
+- No change to save, autosave, or export mechanics.
+- No new toasts (#2063 messaging decision stands; facts are popover-only).
+- No inline relative-time that ticks. Relative time lives inside the popover only.
+
+## Background
+
+Current implementation, confirmed by code:
+
+- `src/lib/components/StorageStatusChip.svelte`: passive `role="status"` div, renders an icon (check / clock / warning) plus a single state label. Inline extras are the server-reachable hint banner and an override "switch back to browser mode" button.
+- `src/lib/storage/durability.svelte.ts`: `computeLayoutStatus` derives the chip state from layout state, persistence state, and API reachability. This is the single chip data source.
+- `src/lib/storage/availability.svelte.ts`: `getStorageMode()` resolves browser vs server once at startup from `window.__RACKULA_CONFIG__.storage` plus a local opt-in override.
+- `src/lib/stores/layout.svelte.ts`: holds `isDirty`, `changesSinceExport`, `hasEverExported`; `markDirty()` increments the counter, `markExported()` zeroes it and sets `hasEverExported`.
+- Working-copy session blob carries `savedAt` (ISO 8601) for the localStorage autosave; the persistence manager echoes server `updatedAt`. Neither is surfaced to the user.
+
+Prior intent: #2035 (chip with states plus a facts/actions popover), #2034 (`changesSinceExport` counter), #2446 (status-only chip showing save state and storage target, actions moved to file menu), #2063 (surface storage-mode misconfiguration in the popover), #2064 (accessibility requirements).
+
+## Design
+
+### Inline chip (always visible)
+
+Format: `[icon] [State] . [Location]`.
+
+- State word carries the status colour (green success, amber warning, red error).
+- The separator dot and the location word use `--colour-text-muted`. Only the part that carries meaning is coloured, so colour stays semantic and the eye lands on state first, location second.
+- Icons stay distinct line glyphs (check, clock, warning triangle) so state is encoded without colour (WCAG 1.4.1). No bare colour-only dot.
+
+De-duplication rule: self-describing error states ("Server not found", "Server unavailable") stand alone with no `. Server` suffix. Normal states ("Saved", "Unsaved", "Saving", "Connecting") take the location suffix.
+
+The #2063 attention treatment (browser mode, server reachable) keeps its amber border and 10 percent amber background wash on the inline chip, and adds the explanatory hint line to the popover footer.
+
+### State and copy reference
+
+| Mode | Condition | Icon | Inline text |
+| --- | --- | --- | --- |
+| Browser | `changesSinceExport === 0 && hasEverExported` | check | Saved . Browser |
+| Browser | otherwise | clock | Unsaved . Browser |
+| Server | `saveStatus === "saved"` | check | Saved . Server |
+| Server | `saveStatus === "saving"` | clock | Saving . Server |
+| Server | `apiAvailable === null` (not yet checked) | clock | Connecting . Server |
+| Server | reached then lost (`apiEverReached && !apiAvailable`) | warning | Offline . Server |
+| Server | never reached (`!apiEverReached && !apiAvailable`) | warning | Server not found |
+| Server | circuit breaker open (3+ failures) | warning | Server unavailable |
+
+Inline shortening: the full phrase "Unsaved changes" shortens to "Unsaved" inline to fit the location suffix; the popover headline keeps the full phrase. "Checking connection" shortens to "Connecting".
+
+### Details popover (hover / tap)
+
+Facts only. No actions. Content is mode-aware.
+
+Browser mode:
+
+```
+[icon] [State headline]
+----------------------------
+Auto-saved        10s ago      (working-copy savedAt; omit line if never autosaved)
+Last exported     3 days ago   (lastExportedAt; "Never exported" when null)
+N changes since last export    (changesSinceExport, only when > 0)
+Stored in this browser only
+[server-reachable hint, only when a server answers /api/health]
+```
+
+Server mode:
+
+```
+[icon] [State headline]
+----------------------------
+Last saved        2m ago       (server updatedAt)
+Stored on the server
+[recovery hint, only in not-found / offline / unavailable states]
+```
+
+Degraded server states reframe the time line to carry the risk, for example a headline of "Offline" with "Last reached server 8 minutes ago" and a note that the most recent edits are not yet saved. This is the case where time-since-save drives a decision.
+
+Relative-time strings (for example "just now", "10 seconds ago", "2 minutes ago", "3 days ago") are computed when the popover opens and refreshed by a timer only while it is open. No timer runs while the popover is closed.
+
+### Data model
+
+One new field. Everything else already exists.
+
+- Add `lastExportedAt: string | null` to `layout.svelte.ts`. Set it to the current ISO timestamp inside the existing `markExported()`. Persist it in the session blob next to `changesSinceExport` (see `session-storage.ts`), and load and reset it on the same paths. Default `null` (never exported).
+
+The popover is a new read-only view derived from `getLayoutDurability()`, which already aggregates layout state, persistence state, and reachability. No new data plumbing beyond the one timestamp.
+
+### Interaction and accessibility
+
+- The chip becomes a `<button>` rather than a passive `role="status"` div. Its accessible name still includes the current state.
+- Reveal is hybrid: a bits-ui Popover is the base (tap, click, Enter, Space; persistent; dismiss with Escape or click-away). On fine-pointer devices, add hover-open with a short hover-intent delay and hover-out close. Coarse-pointer (touch) uses tap only. Hover is an enhancement; all facts are reachable by keyboard and tap, never hover-only.
+- Keep the existing settled-state live-region announcement, debounced about 500ms, so save churn does not spam assistive tech (#2064).
+- Mobile touch target is at least 44 by 44 px (the #2100 standard) even though the visual pill is 28 px tall.
+- Validate the component with the Svelte MCP `svelte-autofixer` and follow the existing `src/lib/components/ui/` wrapper patterns for the bits-ui Popover.
+
+### Visual
+
+- Chip: keep the borderless 28 px pill. Because it is now interactive, add a subtle background wash on hover and focus and a token-based focus ring, signalling it can be opened.
+- Hierarchy: state word at full weight in its status colour; separator and location muted.
+- Popover: Dracula surface from existing tokens, about 248 px wide, caption-size type, timestamps laid out as a tight two-column definition list with right-aligned tabular-numeric values, one hairline divider under the headline, the "Stored in ..." footer most muted. In browser mode the "Last exported" value renders in the warning colour while there are unexported changes, to flag backup drift.
+- Motion: popover fade and scale about 120 ms, gated by `prefers-reduced-motion`. The "Saving" state keeps the calm clock icon rather than an animated spinner, to avoid motion noise.
+
+## Default decisions
+
+These were raised during brainstorming and resolved as defaults; flag any during spec review to change.
+
+- Export-age warning colour: the "Last exported" value renders amber whenever there are unexported changes (`changesSinceExport > 0`), not on a time threshold. Simpler and tied to actual drift rather than wall-clock age.
+- State label wording: "Connecting . Server" (shortened from "Checking connection") and inline "Unsaved" (full "Unsaved changes" in the popover headline).
+- "Saving" icon: the calm clock, no animated spinner.
+
+## Testing
+
+Follow the project testing policy: test behaviour, not data or DOM structure. Candidate behavioural tests:
+
+- `lastExportedAt` is set by `markExported()`, persisted in and restored from the session blob, and reset on load, matching the existing `changesSinceExport` lifecycle.
+- The chip's accessible name includes both the state and, where applicable, the location, across browser and server states (extend the existing `StorageStatusChip.test.ts` accessible-name assertions; assert on text content, not classes or nodes).
+- Mode-aware popover copy: browser mode shows both autosave and last-export lines (with "Never exported" when null); server mode shows the single last-saved line; degraded server states surface the reframed "last reached" line.
+- The relative-time refresh timer runs only while the popover is open and is torn down on close.
+
+No exact-length, colour-value, class-name, or render-only assertions (ESLint enforces this).
+
+## Risks and devil's-advocate notes
+
+- Browser-mode honesty: the autosave timestamp is always recent and is not a durable backup. The popover labels it "Auto-saved (working copy in this browser)" and pairs it with "Last exported", so a recent autosave never reads as "you are backed up". This is the core honesty guard.
+- Server happy-path time is low-value on its own; it earns its place mainly in degraded states. The design keeps it one click away rather than inline, and reframes it under failure headlines.
+- Hybrid hover plus tap has the most edge cases (hover intent, pointer-type detection, focus management). Building on a real Popover rather than a tooltip keeps the tap and keyboard paths correct; hover is layered on as an enhancement.
+- Re-introducing an interactive surface must not regress #2446: the popover carries facts only, never actions.
+
+## References
+
+- Issues: #2035 (chip), #2034 (change counter), #2446 (status-only redesign), #2063 (misconfiguration), #2064 (accessibility).
+- Spike and plan: `docs/research/spike-2019-storage-model-data-safety.md`, `docs/plans/2026-06-12-m015-storage-data-safety-plan.md`.
+- Code: `src/lib/components/StorageStatusChip.svelte`, `src/lib/storage/durability.svelte.ts`, `src/lib/storage/availability.svelte.ts`, `src/lib/stores/layout.svelte.ts`, working-copy and persistence-manager modules, `src/lib/styles/tokens.css`, `src/lib/components/Toolbar.svelte`.

--- a/docs/superpowers/specs/2026-06-26-storage-chip-ux-design.md
+++ b/docs/superpowers/specs/2026-06-26-storage-chip-ux-design.md
@@ -73,7 +73,7 @@ Facts only. No actions. Content is mode-aware.
 
 Browser mode:
 
-```
+```text
 [icon] [State headline]
 ----------------------------
 Auto-saved        10s ago      (working-copy savedAt; omit line if never autosaved)
@@ -85,7 +85,7 @@ Stored in this browser only
 
 Server mode:
 
-```
+```text
 [icon] [State headline]
 ----------------------------
 Last saved        2m ago       (server updatedAt)
@@ -101,7 +101,7 @@ Relative-time strings (for example "just now", "10 seconds ago", "2 minutes ago"
 
 One new field. Everything else already exists.
 
-- Add `lastExportedAt: string | null` to `layout.svelte.ts`. Set it to the current ISO timestamp inside the existing `markExported()`. Persist it in the session blob next to `changesSinceExport` (see `session-storage.ts`), and load and reset it on the same paths. Default `null` (never exported).
+- Add `lastExportedAt: string | null` to `layout.svelte.ts`. Set it to the current ISO timestamp inside the existing `markExported()`. Persist it in the browser multi-tab workspace library (`LibraryEntry` in `browser-workspace.ts`), alongside `changesSinceExport`, restored on workspace load; server mode does not display it. Default `null` (never exported).
 
 The popover is a new read-only view derived from `getLayoutDurability()`, which already aggregates layout state, persistence state, and reachability. No new data plumbing beyond the one timestamp.
 

--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -92,6 +92,7 @@
           layout: $state.snapshot(tab.store.layout),
           changesSinceExport: tab.store.changesSinceExport,
           hasEverExported: tab.store.hasEverExported,
+          lastExportedAt: tab.store.lastExportedAt,
         });
       } else {
         tabs.push({

--- a/src/lib/components/StorageDetailsPopover.svelte
+++ b/src/lib/components/StorageDetailsPopover.svelte
@@ -5,15 +5,18 @@
   live in the app menu, #2446). Browser mode shows the autosave time and the
   last-export time, labelled, so a recent autosave never reads as a durable
   backup. Server mode shows the last server save, reframed as "last reached"
-  when the connection is degraded.
+  when the connection is degraded. Server-not-found shows an honest note that
+  the layout has not been saved to the server.
 -->
 <script lang="ts">
   import { IconCheck, IconClock, IconWarningTriangle } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
-  import { formatRelativeTime } from "$lib/utils/relative-time";
+  import { formatTimeAgo } from "$lib/utils/relative-time";
+  import type { DurabilityKind } from "$lib/storage";
 
   interface Props {
     mode: "browser" | "server";
+    kind: DurabilityKind;
     headline: string;
     icon: "saved" | "pending" | "error";
     changesSinceExport: number;
@@ -25,6 +28,7 @@
 
   let {
     mode,
+    kind,
     headline,
     icon,
     changesSinceExport,
@@ -34,10 +38,11 @@
     nowMs,
   }: Props = $props();
 
-  const autosaveRel = $derived(formatRelativeTime(autosaveAt, nowMs));
-  const exportRel = $derived(formatRelativeTime(lastExportedAt, nowMs));
-  const serverRel = $derived(formatRelativeTime(serverSavedAt, nowMs));
-  const isDegraded = $derived(icon === "error");
+  const autosaveRel = $derived(formatTimeAgo(autosaveAt, nowMs));
+  const exportRel = $derived(formatTimeAgo(lastExportedAt, nowMs));
+  const serverRel = $derived(formatTimeAgo(serverSavedAt, nowMs));
+  const neverReached = $derived(kind === "server-not-found");
+  const degraded = $derived(kind === "offline");
 </script>
 
 <div class="storage-details">
@@ -77,19 +82,21 @@
       </p>
     {/if}
     <p class="storage-details-foot">Stored in this browser only</p>
+  {:else if neverReached}
+    <p class="storage-details-note storage-details-warn">
+      This layout has not been saved to the server.
+    </p>
+    <p class="storage-details-foot">Not saved to the server</p>
   {:else}
     <div class="storage-details-row">
       <span class="storage-details-label">
-        {isDegraded ? "Last reached server" : "Last saved"}
+        {degraded ? "Last reached server" : "Last saved"}
       </span>
-      <span
-        class="storage-details-value"
-        class:storage-details-warn={isDegraded}
-      >
+      <span class="storage-details-value" class:storage-details-warn={degraded}>
         {serverRel ?? "Not yet saved"}
       </span>
     </div>
-    {#if isDegraded}
+    {#if degraded}
       <p class="storage-details-note storage-details-warn">
         Your most recent edits may not be saved.
       </p>

--- a/src/lib/components/StorageDetailsPopover.svelte
+++ b/src/lib/components/StorageDetailsPopover.svelte
@@ -1,0 +1,151 @@
+<!--
+  StorageDetailsPopover
+  Read-only facts for the storage chip popover. Prop-driven so it renders the
+  same way from the chip and from a unit test. Facts only: no actions (those
+  live in the app menu, #2446). Browser mode shows the autosave time and the
+  last-export time, labelled, so a recent autosave never reads as a durable
+  backup. Server mode shows the last server save, reframed as "last reached"
+  when the connection is degraded.
+-->
+<script lang="ts">
+  import { IconCheck, IconClock, IconWarningTriangle } from "./icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+  import { formatRelativeTime } from "$lib/utils/relative-time";
+
+  interface Props {
+    mode: "browser" | "server";
+    headline: string;
+    icon: "saved" | "pending" | "error";
+    changesSinceExport: number;
+    lastExportedAt: string | null;
+    autosaveAt: string | null;
+    serverSavedAt: string | null;
+    nowMs: number;
+  }
+
+  let {
+    mode,
+    headline,
+    icon,
+    changesSinceExport,
+    lastExportedAt,
+    autosaveAt,
+    serverSavedAt,
+    nowMs,
+  }: Props = $props();
+
+  const autosaveRel = $derived(formatRelativeTime(autosaveAt, nowMs));
+  const exportRel = $derived(formatRelativeTime(lastExportedAt, nowMs));
+  const serverRel = $derived(formatRelativeTime(serverSavedAt, nowMs));
+  const isDegraded = $derived(icon === "error");
+</script>
+
+<div class="storage-details">
+  <div class="storage-details-head storage-details-{icon}">
+    {#if icon === "saved"}
+      <IconCheck size={ICON_SIZE.sm} />
+    {:else if icon === "pending"}
+      <IconClock size={ICON_SIZE.sm} />
+    {:else}
+      <IconWarningTriangle size={ICON_SIZE.sm} />
+    {/if}
+    <span>{headline}</span>
+  </div>
+
+  <div class="storage-details-divider"></div>
+
+  {#if mode === "browser"}
+    {#if autosaveRel}
+      <div class="storage-details-row">
+        <span class="storage-details-label">Auto-saved</span>
+        <span class="storage-details-value">{autosaveRel}</span>
+      </div>
+    {/if}
+    <div class="storage-details-row">
+      <span class="storage-details-label">Last exported</span>
+      <span
+        class="storage-details-value"
+        class:storage-details-warn={changesSinceExport > 0}
+      >
+        {exportRel ?? "Never exported"}
+      </span>
+    </div>
+    {#if changesSinceExport > 0}
+      <p class="storage-details-note storage-details-warn">
+        {changesSinceExport}
+        {changesSinceExport === 1 ? "change" : "changes"} since last export
+      </p>
+    {/if}
+    <p class="storage-details-foot">Stored in this browser only</p>
+  {:else}
+    <div class="storage-details-row">
+      <span class="storage-details-label">
+        {isDegraded ? "Last reached server" : "Last saved"}
+      </span>
+      <span
+        class="storage-details-value"
+        class:storage-details-warn={isDegraded}
+      >
+        {serverRel ?? "Not yet saved"}
+      </span>
+    </div>
+    {#if isDegraded}
+      <p class="storage-details-note storage-details-warn">
+        Your most recent edits may not be saved.
+      </p>
+    {/if}
+    <p class="storage-details-foot">Stored on the server</p>
+  {/if}
+</div>
+
+<style>
+  .storage-details {
+    min-width: 224px;
+    padding: var(--space-3);
+    font-size: var(--font-size-xs);
+    color: var(--colour-text);
+  }
+  .storage-details-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-weight: 600;
+  }
+  .storage-details-saved {
+    color: var(--colour-success);
+  }
+  .storage-details-pending {
+    color: var(--colour-warning);
+  }
+  .storage-details-error {
+    color: var(--colour-error);
+  }
+  .storage-details-divider {
+    height: 1px;
+    background: var(--colour-border);
+    margin: var(--space-2) calc(-1 * var(--space-3));
+  }
+  .storage-details-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: 2px 0;
+  }
+  .storage-details-label {
+    color: var(--colour-text-muted);
+  }
+  .storage-details-value {
+    font-variant-numeric: tabular-nums;
+  }
+  .storage-details-warn {
+    color: var(--colour-warning);
+  }
+  .storage-details-note {
+    margin: var(--space-1) 0 0;
+    font-size: var(--font-size-xs);
+  }
+  .storage-details-foot {
+    margin: var(--space-2) 0 0;
+    color: var(--colour-text-muted);
+  }
+</style>

--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -137,12 +137,15 @@
 
   // Timestamp sources for the popover, read on open. Browser: the layout's last
   // localStorage write (autosave) plus its last export. Server: the last server save.
+  // Reading durability.status ensures these re-run when save state changes while open.
   const layoutId = $derived(layoutStore.layout.metadata?.id ?? null);
   const autosaveAt = $derived(
-    open && !isServerMode && layoutId ? getLayoutSavedAt(layoutId) : null,
+    open && !isServerMode && layoutId
+      ? (durability.status, getLayoutSavedAt(layoutId))
+      : null,
   );
   const serverSavedAt = $derived(
-    open && isServerMode ? getServerBaseUpdatedAt() : null,
+    open && isServerMode ? (durability.status, getServerBaseUpdatedAt()) : null,
   );
 </script>
 
@@ -184,6 +187,7 @@
     >
       <StorageDetailsPopover
         mode={isServerMode ? "server" : "browser"}
+        kind={durability.kind}
         headline={durability.label}
         icon={durability.icon}
         changesSinceExport={durability.changesSinceExport}

--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -23,11 +23,15 @@
     getStorageMode,
     isStorageModeFromOverride,
     clearStorageModeOverride,
+    getServerBaseUpdatedAt,
   } from "$lib/storage";
+  import { getLayoutSavedAt } from "$lib/storage/browser-workspace";
   import { maybeSaveAs } from "$lib/utils/app-actions";
   import { evaluateBackupNudge, NUDGE_MESSAGE } from "$lib/utils/backup-nudge";
   import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
   import ServerAvailableBanner from "./ServerAvailableBanner.svelte";
+  import { Popover } from "$lib/components/ui/Popover";
+  import StorageDetailsPopover from "./StorageDetailsPopover.svelte";
 
   const layoutStore = getLayoutStore();
   const durability = getLayoutDurability(layoutStore);
@@ -101,29 +105,94 @@
     }, 500);
     return () => clearTimeout(timer);
   });
+
+  let open = $state(false);
+  let nowMs = $state(Date.now());
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Recompute the popover's relative times only while it is open.
+  $effect(() => {
+    if (!open) return;
+    nowMs = Date.now();
+    const id = setInterval(() => {
+      nowMs = Date.now();
+    }, 30_000);
+    return () => clearInterval(id);
+  });
+
+  function hoverOpen(event: PointerEvent) {
+    if (event.pointerType === "touch") return; // touch uses tap
+    clearTimeout(closeTimer);
+    open = true;
+  }
+  function hoverClose(event: PointerEvent) {
+    if (event.pointerType === "touch") return;
+    clearTimeout(closeTimer);
+    closeTimer = setTimeout(() => {
+      open = false;
+    }, 150);
+  }
+
+  // Timestamp sources for the popover, read on open. Browser: the layout's last
+  // localStorage write (autosave) plus its last export. Server: the last server save.
+  const layoutId = $derived(layoutStore.layout.metadata?.id ?? null);
+  const autosaveAt = $derived(
+    open && !isServerMode && layoutId ? getLayoutSavedAt(layoutId) : null,
+  );
+  const serverSavedAt = $derived(
+    open && isServerMode ? getServerBaseUpdatedAt() : null,
+  );
 </script>
 
-<div
-  class="storage-chip storage-chip-{durability.status}"
-  class:storage-chip--attention={durability.serverHint}
-  role="status"
-  aria-live="off"
-  aria-label={accessibleName}
-  data-testid="storage-status-chip"
->
-  {#if durability.icon === "saved"}
-    <IconCheck size={ICON_SIZE.sm} />
-  {:else if durability.icon === "pending"}
-    <IconClock size={ICON_SIZE.sm} />
-  {:else}
-    <IconWarningTriangle size={ICON_SIZE.sm} />
-  {/if}
-  <span class="storage-chip-state">{durability.shortLabel}</span>
-  {#if durability.showLocation}
-    <span class="storage-chip-sep" aria-hidden="true">.</span>
-    <span class="storage-chip-loc">{locationWord}</span>
-  {/if}
-</div>
+<Popover.Root bind:open>
+  <Popover.Trigger>
+    {#snippet child({ props })}
+      <button
+        {...props}
+        type="button"
+        class="storage-chip storage-chip-{durability.status}"
+        class:storage-chip--attention={durability.serverHint}
+        aria-label={accessibleName}
+        data-testid="storage-status-chip"
+        onpointerenter={hoverOpen}
+        onpointerleave={hoverClose}
+      >
+        {#if durability.icon === "saved"}
+          <IconCheck size={ICON_SIZE.sm} />
+        {:else if durability.icon === "pending"}
+          <IconClock size={ICON_SIZE.sm} />
+        {:else}
+          <IconWarningTriangle size={ICON_SIZE.sm} />
+        {/if}
+        <span class="storage-chip-state">{durability.shortLabel}</span>
+        {#if durability.showLocation}
+          <span class="storage-chip-sep" aria-hidden="true">.</span>
+          <span class="storage-chip-loc">{locationWord}</span>
+        {/if}
+      </button>
+    {/snippet}
+  </Popover.Trigger>
+  <Popover.Portal>
+    <Popover.Content
+      class="storage-chip-popover"
+      side="bottom"
+      sideOffset={8}
+      onpointerenter={() => clearTimeout(closeTimer)}
+      onpointerleave={hoverClose}
+    >
+      <StorageDetailsPopover
+        mode={isServerMode ? "server" : "browser"}
+        headline={durability.label}
+        icon={durability.icon}
+        changesSinceExport={durability.changesSinceExport}
+        lastExportedAt={durability.lastExportedAt}
+        {autosaveAt}
+        {serverSavedAt}
+        {nowMs}
+      />
+    </Popover.Content>
+  </Popover.Portal>
+</Popover.Root>
 
 {#if showServerBanner}
   <ServerAvailableBanner onDismiss={dismissBanner} />
@@ -150,12 +219,29 @@
     gap: var(--space-1);
     height: 28px;
     padding: 0 var(--space-2);
-    border: 1px solid var(--colour-border);
+    border: 1px solid transparent;
     border-radius: var(--radius-md);
     background: transparent;
     color: var(--colour-text);
     font-size: var(--font-size-xs);
     font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .storage-chip:hover,
+  .storage-chip[data-state="open"] {
+    background: var(--colour-surface-hover);
+  }
+  .storage-chip:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring-glow);
+  }
+  :global(.storage-chip-popover) {
+    background: var(--colour-bg);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg, 0 12px 30px rgba(0, 0, 0, 0.45));
+    z-index: var(--z-popover, 50);
   }
 
   /* Colour reinforces, never replaces, the icon + text. */

--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -7,11 +7,10 @@
   app menu's file section, projected from the actions registry (#2446).
 
   Accessibility (#2064): state is conveyed by icon + text, never colour alone
-  (WCAG 1.4.1). The visible chip is a labelled but non-live status indicator
-  (role="status" with aria-live="off"), so it is not announced on every change.
-  The save->saved debounce cascade produces several intermediate statuses in
-  quick succession; a single hidden live region announces only the settled
-  state (debounced), so a screen reader is not spammed with intermediate ones.
+  (WCAG 1.4.1). The visible chip is a <button> with an aria-label that carries
+  the current storage state and location. Live announcements come from a
+  separate hidden sr-only span (role="status" aria-live="polite") that is
+  debounced so a screen reader is not spammed with intermediate save states.
 -->
 <script lang="ts">
   import { IconCheck, IconClock, IconWarningTriangle } from "./icons";
@@ -24,8 +23,8 @@
     isStorageModeFromOverride,
     clearStorageModeOverride,
     getServerBaseUpdatedAt,
+    getLayoutSavedAt,
   } from "$lib/storage";
-  import { getLayoutSavedAt } from "$lib/storage/browser-workspace";
   import { maybeSaveAs } from "$lib/utils/app-actions";
   import { evaluateBackupNudge, NUDGE_MESSAGE } from "$lib/utils/backup-nudge";
   import { safeGetItem, safeSetItem } from "$lib/utils/safe-storage";
@@ -40,7 +39,7 @@
   // Storage mode is fixed for the session (read once; mode switches reload the page).
   const isServerMode = getStorageMode() === "server";
 
-  const locationWord = $derived(isServerMode ? "Server" : "Browser");
+  const locationWord = isServerMode ? "Server" : "Browser";
   const accessibleName = $derived(
     durability.showLocation
       ? `Storage status: ${durability.label}, ${locationWord}`
@@ -109,6 +108,9 @@
   let open = $state(false);
   let nowMs = $state(Date.now());
   let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Clear a pending close timer if the component is destroyed while hovering.
+  $effect(() => () => clearTimeout(closeTimer));
 
   // Recompute the popover's relative times only while it is open.
   $effect(() => {

--- a/src/lib/components/StorageStatusChip.svelte
+++ b/src/lib/components/StorageStatusChip.svelte
@@ -36,6 +36,13 @@
   // Storage mode is fixed for the session (read once; mode switches reload the page).
   const isServerMode = getStorageMode() === "server";
 
+  const locationWord = $derived(isServerMode ? "Server" : "Browser");
+  const accessibleName = $derived(
+    durability.showLocation
+      ? `Storage status: ${durability.label}, ${locationWord}`
+      : `Storage status: ${durability.label}`,
+  );
+
   const DISMISS_KEY = "Rackula:server-hint-dismissed";
 
   let dismissed = $state(safeGetItem(DISMISS_KEY) === "1");
@@ -101,7 +108,7 @@
   class:storage-chip--attention={durability.serverHint}
   role="status"
   aria-live="off"
-  aria-label={`Storage status: ${durability.label}`}
+  aria-label={accessibleName}
   data-testid="storage-status-chip"
 >
   {#if durability.icon === "saved"}
@@ -111,7 +118,11 @@
   {:else}
     <IconWarningTriangle size={ICON_SIZE.sm} />
   {/if}
-  <span class="storage-chip-text">{durability.label}</span>
+  <span class="storage-chip-state">{durability.shortLabel}</span>
+  {#if durability.showLocation}
+    <span class="storage-chip-sep" aria-hidden="true">.</span>
+    <span class="storage-chip-loc">{locationWord}</span>
+  {/if}
 </div>
 
 {#if showServerBanner}
@@ -160,8 +171,16 @@
     color: var(--colour-error);
   }
 
-  .storage-chip-text {
+  .storage-chip-state {
+    font-weight: 600;
     white-space: nowrap;
+  }
+
+  /* Location is secondary: muted so the coloured state word leads. */
+  .storage-chip-sep,
+  .storage-chip-loc {
+    color: var(--colour-text-muted);
+    font-weight: 500;
   }
 
   /* Draws attention when a server is reachable in browser mode. */

--- a/src/lib/storage/browser-workspace-persist.ts
+++ b/src/lib/storage/browser-workspace-persist.ts
@@ -29,6 +29,7 @@ export type PersistTab =
       layout: Layout;
       changesSinceExport: number;
       hasEverExported: boolean;
+      lastExportedAt: string | null;
     }
   | {
       layoutId: string;
@@ -82,6 +83,7 @@ export async function persistBrowserWorkspace(
         saveLayoutBody(tab.layoutId, tab.layout, {
           changesSinceExport: tab.changesSinceExport,
           hasEverExported: tab.hasEverExported,
+          lastExportedAt: tab.lastExportedAt,
         });
       if (withLayoutLock) {
         await withLayoutLock(tab.layoutId, write);
@@ -115,6 +117,7 @@ export async function persistBrowserWorkspace(
         updatedAt: "",
         changesSinceExport: tab.changesSinceExport,
         hasEverExported: tab.hasEverExported,
+        lastExportedAt: tab.lastExportedAt,
         writeFailed: false,
         storageMode: "browser",
       };
@@ -125,6 +128,7 @@ export async function persistBrowserWorkspace(
       updatedAt: previous?.updatedAt ?? "",
       changesSinceExport: previous?.changesSinceExport ?? 0,
       hasEverExported: previous?.hasEverExported ?? false,
+      lastExportedAt: previous?.lastExportedAt ?? null,
       writeFailed: previous?.writeFailed ?? false,
       storageMode: previous?.storageMode ?? "browser",
     };

--- a/src/lib/storage/browser-workspace.ts
+++ b/src/lib/storage/browser-workspace.ts
@@ -254,7 +254,7 @@ export function saveLayoutBody(
   const previous = index.library[id];
   index.library[id] = {
     name: layout.name,
-    updatedAt: savedAt,
+    updatedAt: wrote ? savedAt : (previous?.updatedAt ?? ""),
     changesSinceExport: durability.changesSinceExport,
     hasEverExported:
       durability.hasEverExported ?? previous?.hasEverExported ?? false,
@@ -271,12 +271,16 @@ export function saveLayoutBody(
 
 /**
  * The last time a layout's working copy was written to localStorage, as an ISO
- * timestamp, or null when the layout has no library entry or has never been
- * written (an empty updatedAt). Surfaces the "Auto-saved" time in the chip popover.
+ * timestamp, or null when the layout has no library entry, has never been
+ * written (an empty updatedAt), or the last write failed. Surfaces the
+ * "Auto-saved" time in the chip popover; excludes failed writes so the chip
+ * never reports a fresh autosave time after a failed write.
  */
 export function getLayoutSavedAt(id: string): string | null {
-  const updatedAt = loadWorkspaceIndex()?.library[id]?.updatedAt;
-  return updatedAt ? updatedAt : null;
+  const entry = loadWorkspaceIndex()?.library[id];
+  return entry && !entry.writeFailed && entry.updatedAt
+    ? entry.updatedAt
+    : null;
 }
 
 /** Remove a layout body and drop its library entry. Open set is left to the caller. */

--- a/src/lib/storage/browser-workspace.ts
+++ b/src/lib/storage/browser-workspace.ts
@@ -258,8 +258,14 @@ export function saveLayoutBody(
     changesSinceExport: durability.changesSinceExport,
     hasEverExported:
       durability.hasEverExported ?? previous?.hasEverExported ?? false,
+    // Distinguish an explicit null (clear, e.g. after a layout reset/load) from
+    // an omitted value (undefined, preserve the prior timestamp). Nullish
+    // coalescing alone would treat the intentional null as "keep previous" and
+    // leave a stale "Last exported" time in the entry.
     lastExportedAt:
-      durability.lastExportedAt ?? previous?.lastExportedAt ?? null,
+      durability.lastExportedAt !== undefined
+        ? durability.lastExportedAt
+        : (previous?.lastExportedAt ?? null),
     writeFailed: durability.writeFailed ?? !wrote,
     storageMode: previous?.storageMode ?? "browser",
   };

--- a/src/lib/storage/browser-workspace.ts
+++ b/src/lib/storage/browser-workspace.ts
@@ -47,6 +47,8 @@ export interface LibraryEntry {
   updatedAt: string;
   changesSinceExport: number;
   hasEverExported: boolean;
+  /** ISO timestamp of the last export to a file; null if never exported. */
+  lastExportedAt: string | null;
   writeFailed: boolean;
   storageMode: StorageMode;
 }
@@ -69,6 +71,7 @@ export type LayoutBodyResult = { ok: true; layout: Layout } | { ok: false };
 export interface DurabilityInput {
   changesSinceExport: number;
   hasEverExported?: boolean;
+  lastExportedAt?: string | null;
   writeFailed?: boolean;
 }
 
@@ -104,6 +107,8 @@ function coerceLibraryEntry(
         ? changes
         : 0,
     hasEverExported: obj.hasEverExported === true,
+    lastExportedAt:
+      typeof obj.lastExportedAt === "string" ? obj.lastExportedAt : null,
     writeFailed: obj.writeFailed === true,
     storageMode: coerceStorageMode(obj.storageMode),
   };
@@ -253,6 +258,8 @@ export function saveLayoutBody(
     changesSinceExport: durability.changesSinceExport,
     hasEverExported:
       durability.hasEverExported ?? previous?.hasEverExported ?? false,
+    lastExportedAt:
+      durability.lastExportedAt ?? previous?.lastExportedAt ?? null,
     writeFailed: durability.writeFailed ?? !wrote,
     storageMode: previous?.storageMode ?? "browser",
   };
@@ -260,6 +267,16 @@ export function saveLayoutBody(
   saveWorkspaceIndex(index);
 
   return wrote;
+}
+
+/**
+ * The last time a layout's working copy was written to localStorage, as an ISO
+ * timestamp, or null when the layout has no library entry or has never been
+ * written (an empty updatedAt). Surfaces the "Auto-saved" time in the chip popover.
+ */
+export function getLayoutSavedAt(id: string): string | null {
+  const updatedAt = loadWorkspaceIndex()?.library[id]?.updatedAt;
+  return updatedAt ? updatedAt : null;
 }
 
 /** Remove a layout body and drop its library entry. Open set is left to the caller. */
@@ -326,6 +343,7 @@ export function adoptLegacyAutosave(): WorkspaceIndex | null {
     updatedAt: session.savedAt ?? new Date().toISOString(),
     changesSinceExport: session.changesSinceExport,
     hasEverExported: session.hasEverExported,
+    lastExportedAt: null,
     writeFailed: false,
     storageMode: session.storageMode,
   };

--- a/src/lib/storage/durability.svelte.ts
+++ b/src/lib/storage/durability.svelte.ts
@@ -328,7 +328,7 @@ export function rollupDurabilities(
       detail: "",
       icon: "saved",
       serverHint: false,
-      lastExportedAt: null,
+      lastExportedAt: null, // no single export timestamp across multiple layouts
     };
   }
   return worst;

--- a/src/lib/storage/durability.svelte.ts
+++ b/src/lib/storage/durability.svelte.ts
@@ -47,6 +47,8 @@ export interface LayoutDurability {
   hasEverExported: boolean;
   isHealthy: boolean;
   label: string;
+  shortLabel: string;
+  showLocation: boolean;
   detail: string;
   icon: DurabilityStatus;
   /**
@@ -55,6 +57,7 @@ export interface LayoutDurability {
    * only, never a toast, and never changes the status/label/kind.
    */
   serverHint: boolean;
+  lastExportedAt: string | null;
 }
 
 /**
@@ -79,6 +82,8 @@ export function computeLayoutStatus(
   status: DurabilityStatus;
   kind: DurabilityKind;
   label: string;
+  shortLabel: string;
+  showLocation: boolean;
   detail: string;
   icon: DurabilityStatus;
 } {
@@ -92,6 +97,8 @@ export function computeLayoutStatus(
         status: "saved",
         kind: "saved",
         label: "Saved",
+        shortLabel: "Saved",
+        showLocation: true,
         detail: "Stored in this browser",
         icon: "saved",
       };
@@ -100,6 +107,8 @@ export function computeLayoutStatus(
       status: "pending",
       kind: "pending",
       label: "Unsaved changes",
+      shortLabel: "Unsaved",
+      showLocation: true,
       detail: "Stored in this browser",
       icon: "pending",
     };
@@ -114,6 +123,8 @@ export function computeLayoutStatus(
       status: "error",
       kind: "offline",
       label: "Server unavailable",
+      shortLabel: "Server unavailable",
+      showLocation: false,
       detail: "Working from your browser; reload to retry.",
       icon: "error",
     };
@@ -123,6 +134,8 @@ export function computeLayoutStatus(
       status: "pending",
       kind: "pending",
       label: "Checking connection",
+      shortLabel: "Connecting",
+      showLocation: true,
       detail: "Looking for the server.",
       icon: "pending",
     };
@@ -138,6 +151,8 @@ export function computeLayoutStatus(
         status: "error",
         kind: "offline",
         label: "Offline",
+        shortLabel: "Offline",
+        showLocation: true,
         detail: "Working from your browser; reload to retry.",
         icon: "error",
       };
@@ -146,6 +161,8 @@ export function computeLayoutStatus(
       status: "error",
       kind: "server-not-found",
       label: "Server not found",
+      shortLabel: "Server not found",
+      showLocation: false,
       detail:
         "Check that the API container is running and RACKULA_STORAGE_MODE matches the deployment.",
       icon: "error",
@@ -156,6 +173,8 @@ export function computeLayoutStatus(
       status: "error",
       kind: "offline",
       label: "Save error",
+      shortLabel: "Save error",
+      showLocation: true,
       detail: "The last save did not go through.",
       icon: "error",
     };
@@ -165,6 +184,8 @@ export function computeLayoutStatus(
       status: "pending",
       kind: "pending",
       label: "Saving",
+      shortLabel: "Saving",
+      showLocation: true,
       detail: "Saving to server.",
       icon: "pending",
     };
@@ -174,6 +195,8 @@ export function computeLayoutStatus(
       status: "saved",
       kind: "saved",
       label: "Saved",
+      shortLabel: "Saved",
+      showLocation: true,
       detail: "Saved to server",
       icon: "saved",
     };
@@ -182,6 +205,8 @@ export function computeLayoutStatus(
     status: "pending",
     kind: "pending",
     label: "Pending save",
+    shortLabel: "Pending",
+    showLocation: true,
     detail: "Saving to server.",
     icon: "pending",
   };
@@ -237,6 +262,9 @@ export function getLayoutDurability(
     get hasEverExported(): boolean {
       return layoutStore.hasEverExported;
     },
+    get lastExportedAt(): string | null {
+      return layoutStore.lastExportedAt;
+    },
     get status(): DurabilityStatus {
       return compute().status;
     },
@@ -248,6 +276,12 @@ export function getLayoutDurability(
     },
     get label(): string {
       return compute().label;
+    },
+    get shortLabel(): string {
+      return compute().shortLabel;
+    },
+    get showLocation(): boolean {
+      return compute().showLocation;
     },
     get detail(): string {
       return compute().detail;
@@ -289,9 +323,12 @@ export function rollupDurabilities(
       hasEverExported: false,
       isHealthy: true,
       label: "All saved",
+      shortLabel: "Saved",
+      showLocation: true,
       detail: "",
       icon: "saved",
       serverHint: false,
+      lastExportedAt: null,
     };
   }
   return worst;

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -79,6 +79,7 @@ export {
   hasEverHadLayouts,
   markEverHadLayouts,
   adoptLegacyAutosave,
+  getLayoutSavedAt,
   type WorkspaceIndex,
   type LibraryEntry,
   type LayoutBodyResult,

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -842,6 +842,7 @@ export function createLayoutStore(
   function markExported(): void {
     changesSinceExport = 0;
     hasEverExported = true;
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- transient ISO timestamp, not a stored reactive Date
     lastExportedAt = new Date().toISOString();
   }
 

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -140,6 +140,7 @@ export function createLayoutStore(
   let isDirty = $state(false);
   let changesSinceExport = $state(0);
   let hasEverExported = $state(false);
+  let lastExportedAt = $state<string | null>(null);
   let hasStarted = $state(loadHasStarted());
   let activeRackId = $state<string | null>(null);
 
@@ -171,6 +172,7 @@ export function createLayoutStore(
       isDirty = false;
       changesSinceExport = 0;
       hasEverExported = false;
+      lastExportedAt = null;
     },
     getRackGroups: () => rack_groups,
     findRack: (id: string) => layout.racks.find((r) => r.id === id),
@@ -213,6 +215,7 @@ export function createLayoutStore(
     isDirty = false;
     changesSinceExport = 0;
     hasEverExported = false;
+    lastExportedAt = null;
     activeRackId = null;
     history.clear();
     if (clearStarted) {
@@ -235,6 +238,9 @@ export function createLayoutStore(
     },
     get hasEverExported() {
       return hasEverExported;
+    },
+    get lastExportedAt() {
+      return lastExportedAt;
     },
     get rack() {
       return rack;
@@ -836,6 +842,7 @@ export function createLayoutStore(
   function markExported(): void {
     changesSinceExport = 0;
     hasEverExported = true;
+    lastExportedAt = new Date().toISOString();
   }
 
   /**
@@ -845,6 +852,7 @@ export function createLayoutStore(
   function restoreBackupState(state: BackupState): void {
     changesSinceExport = state.changesSinceExport;
     hasEverExported = state.hasEverExported;
+    lastExportedAt = state.lastExportedAt ?? null;
   }
 
   function markStarted(): void {

--- a/src/lib/stores/layout/persistence.ts
+++ b/src/lib/stores/layout/persistence.ts
@@ -15,6 +15,8 @@ import {
 export interface BackupState {
   changesSinceExport: number;
   hasEverExported: boolean;
+  /** ISO timestamp of the last successful export to a file; null if never exported. */
+  lastExportedAt?: string | null;
 }
 
 /** localStorage key for tracking if user has started (created/loaded a rack) */

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -65,6 +65,7 @@ export interface RestoreLibraryEntry {
   name: string;
   changesSinceExport: number;
   hasEverExported: boolean;
+  lastExportedAt: string | null;
 }
 
 /** The minimal index shape lazy restore needs (from spike #2179). */
@@ -294,6 +295,7 @@ export function createWorkspaceStore() {
       tab.store.restoreBackupState({
         changesSinceExport: entry.changesSinceExport,
         hasEverExported: entry.hasEverExported,
+        lastExportedAt: entry.lastExportedAt,
       });
     }
     tab.hydrated = true;

--- a/src/lib/utils/relative-time.ts
+++ b/src/lib/utils/relative-time.ts
@@ -1,0 +1,28 @@
+/**
+ * Format an ISO timestamp as elapsed time relative to now, for the storage chip
+ * popover. Returns null for null or unparseable input so the caller can choose
+ * its own copy (for example "Never exported"). Under 45 seconds (including small
+ * negative skew) it returns "just now". `nowMs` is injectable for deterministic
+ * tests.
+ */
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" });
+
+export function formatRelativeTime(
+  iso: string | null,
+  nowMs: number = Date.now(),
+): string | null {
+  if (!iso) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return null;
+
+  const elapsed = nowMs - then;
+  if (elapsed < 45 * SECOND) return "just now";
+  if (elapsed < HOUR) return rtf.format(-Math.round(elapsed / MINUTE), "minute");
+  if (elapsed < DAY) return rtf.format(-Math.round(elapsed / HOUR), "hour");
+  return rtf.format(-Math.round(elapsed / DAY), "day");
+}

--- a/src/lib/utils/relative-time.ts
+++ b/src/lib/utils/relative-time.ts
@@ -10,7 +10,7 @@ const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 
-const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" });
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "always" });
 
 export function formatRelativeTime(
   iso: string | null,

--- a/src/lib/utils/relative-time.ts
+++ b/src/lib/utils/relative-time.ts
@@ -22,7 +22,8 @@ export function formatRelativeTime(
 
   const elapsed = nowMs - then;
   if (elapsed < 45 * SECOND) return "just now";
-  if (elapsed < HOUR) return rtf.format(-Math.round(elapsed / MINUTE), "minute");
+  if (elapsed < HOUR)
+    return rtf.format(-Math.round(elapsed / MINUTE), "minute");
   if (elapsed < DAY) return rtf.format(-Math.round(elapsed / HOUR), "hour");
   return rtf.format(-Math.round(elapsed / DAY), "day");
 }

--- a/src/lib/utils/relative-time.ts
+++ b/src/lib/utils/relative-time.ts
@@ -2,7 +2,7 @@
  * Format an ISO timestamp as elapsed time relative to now, for the storage chip
  * popover. Returns null for null or unparseable input so the caller can choose
  * its own copy (for example "Never exported"). Under 45 seconds (including small
- * negative skew) it returns "just now". `nowMs` is injectable for deterministic
+ * future skew) it returns "just now". `nowMs` is injectable for deterministic
  * tests.
  */
 const SECOND = 1000;
@@ -12,7 +12,7 @@ const DAY = 24 * HOUR;
 
 const rtf = new Intl.RelativeTimeFormat("en", { numeric: "always" });
 
-export function formatRelativeTime(
+export function formatTimeAgo(
   iso: string | null,
   nowMs: number = Date.now(),
 ): string | null {
@@ -21,9 +21,9 @@ export function formatRelativeTime(
   if (Number.isNaN(then)) return null;
 
   const elapsed = nowMs - then;
-  if (elapsed < 45 * SECOND) return "just now";
-  if (elapsed < HOUR)
-    return rtf.format(-Math.round(elapsed / MINUTE), "minute");
-  if (elapsed < DAY) return rtf.format(-Math.round(elapsed / HOUR), "hour");
+  const abs = Math.abs(elapsed);
+  if (abs < 45 * SECOND) return "just now";
+  if (abs < HOUR) return rtf.format(-Math.round(elapsed / MINUTE), "minute");
+  if (abs < DAY) return rtf.format(-Math.round(elapsed / HOUR), "hour");
   return rtf.format(-Math.round(elapsed / DAY), "day");
 }

--- a/src/tests/StorageStatusChip.test.ts
+++ b/src/tests/StorageStatusChip.test.ts
@@ -19,4 +19,13 @@ describe("StorageStatusChip", () => {
       /storage status: unsaved changes, browser/i,
     );
   });
+
+  it("trigger exposes aria-haspopup and aria-expanded for the popover", () => {
+    // bits-ui Popover renders the trigger with aria-haspopup and aria-expanded,
+    // confirming the popover integration is wired correctly in happy-dom.
+    render(StorageStatusChip);
+    const chip = screen.getByTestId("storage-status-chip");
+    expect(chip).toHaveAttribute("aria-haspopup");
+    expect(chip).toHaveAttribute("aria-expanded");
+  });
 });

--- a/src/tests/StorageStatusChip.test.ts
+++ b/src/tests/StorageStatusChip.test.ts
@@ -15,6 +15,8 @@ describe("StorageStatusChip", () => {
   it("exposes the current storage state and location in its accessible name", () => {
     render(StorageStatusChip);
     const chip = screen.getByTestId("storage-status-chip");
-    expect(chip).toHaveAccessibleName(/storage status: unsaved changes, browser/i);
+    expect(chip).toHaveAccessibleName(
+      /storage status: unsaved changes, browser/i,
+    );
   });
 });

--- a/src/tests/StorageStatusChip.test.ts
+++ b/src/tests/StorageStatusChip.test.ts
@@ -12,9 +12,9 @@ import StorageStatusChip from "$lib/components/StorageStatusChip.svelte";
  * accessible name reflects the pending "Unsaved changes" state.
  */
 describe("StorageStatusChip", () => {
-  it("exposes the current storage state in its accessible name", () => {
+  it("exposes the current storage state and location in its accessible name", () => {
     render(StorageStatusChip);
     const chip = screen.getByTestId("storage-status-chip");
-    expect(chip).toHaveAccessibleName(/storage status: unsaved changes/i);
+    expect(chip).toHaveAccessibleName(/storage status: unsaved changes, browser/i);
   });
 });

--- a/src/tests/browser-workspace.test.ts
+++ b/src/tests/browser-workspace.test.ts
@@ -62,6 +62,7 @@ function makeIndex(over: Partial<WorkspaceIndex> = {}): WorkspaceIndex {
         updatedAt: "2026-06-14T09:00:00.000Z",
         changesSinceExport: 0,
         hasEverExported: true,
+        lastExportedAt: null,
         writeFailed: false,
         storageMode: "browser",
       },

--- a/src/tests/changes-since-export.test.ts
+++ b/src/tests/changes-since-export.test.ts
@@ -9,6 +9,11 @@ import {
   loadSessionWithTimestamp,
   clearSession,
 } from "$lib/storage/working-copy";
+import {
+  saveLayoutBody,
+  getLayoutSavedAt,
+  loadWorkspaceIndex,
+} from "$lib/storage/browser-workspace";
 import { resetToastStore } from "$lib/stores/toast.svelte";
 import { downloadYamlFile } from "$lib/utils/archive";
 
@@ -132,5 +137,22 @@ describe("changesSinceExport", () => {
     expect(store.lastExportedAt).toBe(stamp);
     expect(store.changesSinceExport).toBe(4);
     expect(store.hasEverExported).toBe(true);
+  });
+
+  it("persists and reads back lastExportedAt via the workspace library", () => {
+    const id = "test-layout-id";
+    const stamp = "2026-06-26T12:00:00.000Z";
+    const layout = getLayoutStore().layout;
+
+    saveLayoutBody(id, layout, {
+      changesSinceExport: 2,
+      hasEverExported: true,
+      lastExportedAt: stamp,
+    });
+
+    const index = loadWorkspaceIndex();
+    expect(index?.library[id]?.lastExportedAt).toBe(stamp);
+    // updatedAt is the autosave write time, exposed for the "Auto-saved" line.
+    expect(getLayoutSavedAt(id)).toBe(index?.library[id]?.updatedAt);
   });
 });

--- a/src/tests/changes-since-export.test.ts
+++ b/src/tests/changes-since-export.test.ts
@@ -120,7 +120,9 @@ describe("changesSinceExport", () => {
 
     store.markExported();
     expect(store.lastExportedAt).not.toBeNull();
-    expect(() => new Date(store.lastExportedAt as string)).not.toThrow();
+    expect(Number.isNaN(Date.parse(store.lastExportedAt as string))).toBe(
+      false,
+    );
 
     store.loadLayout(store.layout);
     expect(store.lastExportedAt).toBeNull();

--- a/src/tests/changes-since-export.test.ts
+++ b/src/tests/changes-since-export.test.ts
@@ -108,4 +108,29 @@ describe("changesSinceExport", () => {
     expect(chip.saveStatus).toBeDefined();
     expect(chip.consecutiveSaveFailures).toBe(0);
   });
+
+  it("stamps lastExportedAt on markExported and clears it on load", () => {
+    const store = getLayoutStore();
+    expect(store.lastExportedAt).toBeNull();
+
+    store.markExported();
+    expect(store.lastExportedAt).not.toBeNull();
+    expect(() => new Date(store.lastExportedAt as string)).not.toThrow();
+
+    store.loadLayout(store.layout);
+    expect(store.lastExportedAt).toBeNull();
+  });
+
+  it("restores lastExportedAt through restoreBackupState", () => {
+    const store = getLayoutStore();
+    const stamp = "2026-06-26T12:00:00.000Z";
+    store.restoreBackupState({
+      changesSinceExport: 4,
+      hasEverExported: true,
+      lastExportedAt: stamp,
+    });
+    expect(store.lastExportedAt).toBe(stamp);
+    expect(store.changesSinceExport).toBe(4);
+    expect(store.hasEverExported).toBe(true);
+  });
 });

--- a/src/tests/changes-since-export.test.ts
+++ b/src/tests/changes-since-export.test.ts
@@ -157,4 +157,27 @@ describe("changesSinceExport", () => {
     // updatedAt is the autosave write time, exposed for the "Auto-saved" line.
     expect(getLayoutSavedAt(id)).toBe(index?.library[id]?.updatedAt);
   });
+
+  it("clears lastExportedAt when an explicit null is persisted (reset/load)", () => {
+    const id = "clear-export-id";
+    const layout = getLayoutStore().layout;
+
+    saveLayoutBody(id, layout, {
+      changesSinceExport: 0,
+      hasEverExported: true,
+      lastExportedAt: "2026-06-26T12:00:00.000Z",
+    });
+    expect(loadWorkspaceIndex()?.library[id]?.lastExportedAt).toBe(
+      "2026-06-26T12:00:00.000Z",
+    );
+
+    // An explicit null (the store after a reset/load) must overwrite the prior
+    // timestamp, not be coalesced back to it.
+    saveLayoutBody(id, layout, {
+      changesSinceExport: 0,
+      hasEverExported: false,
+      lastExportedAt: null,
+    });
+    expect(loadWorkspaceIndex()?.library[id]?.lastExportedAt).toBeNull();
+  });
 });

--- a/src/tests/durability-inline-labels.test.ts
+++ b/src/tests/durability-inline-labels.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { computeLayoutStatus } from "$lib/storage/durability.svelte";
+
+describe("computeLayoutStatus inline fields", () => {
+  it("browser clean: short 'Saved', location shown", () => {
+    const r = computeLayoutStatus("idle", 0, "browser", null, 0, true, false);
+    expect(r.shortLabel).toBe("Saved");
+    expect(r.showLocation).toBe(true);
+  });
+
+  it("browser dirty: short 'Unsaved', location shown", () => {
+    const r = computeLayoutStatus("idle", 0, "browser", null, 3, false, false);
+    expect(r.shortLabel).toBe("Unsaved");
+    expect(r.showLocation).toBe(true);
+  });
+
+  it("server saved: short 'Saved', location shown", () => {
+    const r = computeLayoutStatus("saved", 0, "server", true, 0, true, true);
+    expect(r.shortLabel).toBe("Saved");
+    expect(r.showLocation).toBe(true);
+  });
+
+  it("server checking: short 'Connecting', location shown", () => {
+    const r = computeLayoutStatus("idle", 0, "server", null, 0, true, false);
+    expect(r.shortLabel).toBe("Connecting");
+    expect(r.showLocation).toBe(true);
+  });
+
+  it("server never reached: 'Server not found' stands alone", () => {
+    const r = computeLayoutStatus("idle", 0, "server", false, 0, true, false);
+    expect(r.shortLabel).toBe("Server not found");
+    expect(r.showLocation).toBe(false);
+  });
+
+  it("server breaker open: 'Server unavailable' stands alone", () => {
+    const r = computeLayoutStatus("error", 3, "server", true, 0, true, true);
+    expect(r.shortLabel).toBe("Server unavailable");
+    expect(r.showLocation).toBe(false);
+  });
+});

--- a/src/tests/relative-time.test.ts
+++ b/src/tests/relative-time.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { formatRelativeTime } from "$lib/utils/relative-time";
+
+const NOW = Date.parse("2026-06-26T12:00:00.000Z");
+const at = (iso: string) => formatRelativeTime(iso, NOW);
+
+describe("formatRelativeTime", () => {
+  it("returns null for null or unparseable input", () => {
+    expect(formatRelativeTime(null, NOW)).toBeNull();
+    expect(formatRelativeTime("not-a-date", NOW)).toBeNull();
+  });
+
+  it("says 'just now' under 45 seconds, including small clock skew", () => {
+    expect(at("2026-06-26T11:59:30.000Z")).toBe("just now");
+    expect(at("2026-06-26T12:00:10.000Z")).toBe("just now");
+  });
+
+  it("formats minutes, hours, and days as elapsed time", () => {
+    expect(at("2026-06-26T11:58:00.000Z")).toBe("2 minutes ago");
+    expect(at("2026-06-26T09:00:00.000Z")).toBe("3 hours ago");
+    expect(at("2026-06-23T12:00:00.000Z")).toBe("3 days ago");
+  });
+});

--- a/src/tests/relative-time.test.ts
+++ b/src/tests/relative-time.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { formatRelativeTime } from "$lib/utils/relative-time";
+import { formatTimeAgo } from "$lib/utils/relative-time";
 
 const NOW = Date.parse("2026-06-26T12:00:00.000Z");
-const at = (iso: string) => formatRelativeTime(iso, NOW);
+const at = (iso: string) => formatTimeAgo(iso, NOW);
 
-describe("formatRelativeTime", () => {
+describe("formatTimeAgo", () => {
   it("returns null for null or unparseable input", () => {
-    expect(formatRelativeTime(null, NOW)).toBeNull();
-    expect(formatRelativeTime("not-a-date", NOW)).toBeNull();
+    expect(formatTimeAgo(null, NOW)).toBeNull();
+    expect(formatTimeAgo("not-a-date", NOW)).toBeNull();
   });
 
   it("says 'just now' under 45 seconds, including small clock skew", () => {
@@ -19,5 +19,13 @@ describe("formatRelativeTime", () => {
     expect(at("2026-06-26T11:58:00.000Z")).toBe("2 minutes ago");
     expect(at("2026-06-26T09:00:00.000Z")).toBe("3 hours ago");
     expect(at("2026-06-23T12:00:00.000Z")).toBe("3 days ago");
+  });
+
+  it("returns 'in 2 minutes' for a timestamp ~2 minutes in the future", () => {
+    expect(at("2026-06-26T12:02:00.000Z")).toBe("in 2 minutes");
+  });
+
+  it("returns 'just now' for a timestamp ~10 seconds in the future", () => {
+    expect(at("2026-06-26T12:00:10.000Z")).toBe("just now");
   });
 });

--- a/src/tests/storage-details-popover.test.ts
+++ b/src/tests/storage-details-popover.test.ts
@@ -18,7 +18,9 @@ describe("StorageDetailsPopover", () => {
     });
     expect(screen.getByText(/auto-saved/i)).toBeInTheDocument();
     expect(screen.getByText(/never exported/i)).toBeInTheDocument();
-    expect(screen.getByText(/stored in this browser only/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/stored in this browser only/i),
+    ).toBeInTheDocument();
   });
 
   it("browser mode formats a real export time", () => {

--- a/src/tests/storage-details-popover.test.ts
+++ b/src/tests/storage-details-popover.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import StorageDetailsPopover from "$lib/components/StorageDetailsPopover.svelte";
+
+const NOW = Date.parse("2026-06-26T12:00:00.000Z");
+
+describe("StorageDetailsPopover", () => {
+  it("browser mode shows both timestamps and 'Never exported' when null", () => {
+    render(StorageDetailsPopover, {
+      mode: "browser",
+      headline: "Unsaved changes",
+      icon: "pending",
+      changesSinceExport: 3,
+      lastExportedAt: null,
+      autosaveAt: "2026-06-26T11:59:50.000Z",
+      serverSavedAt: null,
+      nowMs: NOW,
+    });
+    expect(screen.getByText(/auto-saved/i)).toBeInTheDocument();
+    expect(screen.getByText(/never exported/i)).toBeInTheDocument();
+    expect(screen.getByText(/stored in this browser only/i)).toBeInTheDocument();
+  });
+
+  it("browser mode formats a real export time", () => {
+    render(StorageDetailsPopover, {
+      mode: "browser",
+      headline: "Saved",
+      icon: "saved",
+      changesSinceExport: 0,
+      lastExportedAt: "2026-06-23T12:00:00.000Z",
+      autosaveAt: "2026-06-26T11:59:50.000Z",
+      serverSavedAt: null,
+      nowMs: NOW,
+    });
+    expect(screen.getByText(/last exported/i)).toBeInTheDocument();
+    expect(screen.getByText(/3 days ago/i)).toBeInTheDocument();
+  });
+
+  it("server mode shows the last server save and storage location", () => {
+    render(StorageDetailsPopover, {
+      mode: "server",
+      headline: "Saved",
+      icon: "saved",
+      changesSinceExport: 0,
+      lastExportedAt: null,
+      autosaveAt: null,
+      serverSavedAt: "2026-06-26T11:58:00.000Z",
+      nowMs: NOW,
+    });
+    expect(screen.getByText(/last saved/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 minutes ago/i)).toBeInTheDocument();
+    expect(screen.getByText(/stored on the server/i)).toBeInTheDocument();
+  });
+
+  it("server mode error reframes the time as last reached", () => {
+    render(StorageDetailsPopover, {
+      mode: "server",
+      headline: "Offline",
+      icon: "error",
+      changesSinceExport: 0,
+      lastExportedAt: null,
+      autosaveAt: null,
+      serverSavedAt: "2026-06-26T11:52:00.000Z",
+      nowMs: NOW,
+    });
+    expect(screen.getByText(/last reached server/i)).toBeInTheDocument();
+  });
+});

--- a/src/tests/storage-details-popover.test.ts
+++ b/src/tests/storage-details-popover.test.ts
@@ -8,6 +8,7 @@ describe("StorageDetailsPopover", () => {
   it("browser mode shows both timestamps and 'Never exported' when null", () => {
     render(StorageDetailsPopover, {
       mode: "browser",
+      kind: "pending",
       headline: "Unsaved changes",
       icon: "pending",
       changesSinceExport: 3,
@@ -29,6 +30,7 @@ describe("StorageDetailsPopover", () => {
   it("browser mode formats a real export time", () => {
     render(StorageDetailsPopover, {
       mode: "browser",
+      kind: "saved",
       headline: "Saved",
       icon: "saved",
       changesSinceExport: 0,
@@ -44,6 +46,7 @@ describe("StorageDetailsPopover", () => {
   it("server mode shows the last server save and storage location", () => {
     render(StorageDetailsPopover, {
       mode: "server",
+      kind: "saved",
       headline: "Saved",
       icon: "saved",
       changesSinceExport: 0,
@@ -60,6 +63,7 @@ describe("StorageDetailsPopover", () => {
   it("server mode error reframes the time as last reached", () => {
     render(StorageDetailsPopover, {
       mode: "server",
+      kind: "offline",
       headline: "Offline",
       icon: "error",
       changesSinceExport: 0,
@@ -69,5 +73,24 @@ describe("StorageDetailsPopover", () => {
       nowMs: NOW,
     });
     expect(screen.getByText(/last reached server/i)).toBeInTheDocument();
+  });
+
+  it("server-not-found: does not claim stored on server, shows honest note", () => {
+    render(StorageDetailsPopover, {
+      mode: "server",
+      kind: "server-not-found",
+      headline: "Server not found",
+      icon: "error",
+      changesSinceExport: 0,
+      lastExportedAt: null,
+      autosaveAt: null,
+      serverSavedAt: null,
+      nowMs: NOW,
+    });
+    expect(screen.queryByText(/stored on the server/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/this layout has not been saved to the server/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/not saved to the server/i)).toBeInTheDocument();
   });
 });

--- a/src/tests/storage-details-popover.test.ts
+++ b/src/tests/storage-details-popover.test.ts
@@ -19,6 +19,9 @@ describe("StorageDetailsPopover", () => {
     expect(screen.getByText(/auto-saved/i)).toBeInTheDocument();
     expect(screen.getByText(/never exported/i)).toBeInTheDocument();
     expect(
+      screen.getByText(/3 changes since last export/i),
+    ).toBeInTheDocument();
+    expect(
       screen.getByText(/stored in this browser only/i),
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
## **User description**
## Summary

Completes unshipped design intent from #2446 (storage location in the chip) and #2035 (last-save facts popover). The storage status chip now shows save state and storage location inline, and reveals honest, mode-aware last-save facts on hover or tap.

## What changed

- Inline two-tone label: the chip renders `[state] . [location]`, for example "Saved . Server" or "Unsaved . Browser". The state word carries the status colour; the separator and location are muted. Self-describing error states ("Server not found", "Server unavailable") stand alone with no location suffix.
- Details popover (hover on desktop, tap or keyboard on touch): facts only, no actions (export/restore stay in the app menu, per #2446).
  - Browser mode shows the autosave time and the last-export time as separate labelled rows, so a recent autosave never reads as a durable backup, plus "Stored in this browser only".
  - Server mode shows the last server save, reframed as "Last reached server" when the connection is degraded, plus "Stored on the server".
- New `lastExportedAt` timestamp, stamped on export and threaded through the live browser multi-tab persistence schema so it survives a reload. Server mode never displays it, so the legacy session path is untouched. Old persisted data without the field coerces to null (no false "exported" state).
- New `formatRelativeTime` util (pinned to English to match the app's hardcoded copy) and a new prop-driven `StorageDetailsPopover.svelte` component. Relative times refresh only while the popover is open.

## Design and process

- Spec: `docs/superpowers/specs/2026-06-26-storage-chip-ux-design.md`
- Plan: `docs/superpowers/plans/2026-06-26-storage-chip-ux.md`
- Built task by task with TDD, a per-task review, a whole-branch review, and a fix pass.

The chip stays in the toolbar. Relocating toast notifications to the canvas bottom-center is tracked separately in #2637.

## Accessibility

- The chip is a button whose accessible name includes the current state and, where applicable, the location. The existing debounced live-region announcement is preserved. State is never colour-only (icon plus text). Touch target is at least 44 by 44 px.

## Testing

- 2904 unit tests pass; lint and svelte-check are clean.
- New tests cover the relative-time util, the durability inline fields, the `lastExportedAt` store and persistence round-trip, the popover copy per mode, and the chip's accessible name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show storage location inline and reveal save details on demand**

### What Changed
- The storage chip now shows both the save state and where the layout is stored, such as Browser or Server.
- The chip opens a popover with last-save details: browser mode shows auto-save and last export times, while server mode shows the last server save and a clear note when the server was never reached or is unavailable.
- The chip’s accessible name now includes the storage location when it applies, and the chip can be opened by hover, tap, or keyboard.
- The app now remembers the last export time across reloads and resets it correctly when a layout is cleared or reloaded.

### Impact
`✅ Clearer storage status at a glance`
`✅ Fewer mistakes about whether work is stored in the browser or on the server`
`✅ More useful backup details without adding toolbar clutter`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
