### PR TITLE
fix: resolve prettier via node module resolution in pre-commit hook (#2639)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -22,11 +22,14 @@ if [ -n "$STAGED" ]; then
     echo "Error: prettier not found - run 'npm install' at the repo root" >&2
     exit 1
   fi
-  echo "$STAGED" | tr '\n' '\0' | xargs -0 node "$PRETTIER_BIN" --write --ignore-unknown || {
+  # Prefix each path with ./ so a filename starting with '-' is read as a path,
+  # not a CLI option (matching the vitest step below). Without this, prettier and
+  # git add could misparse such a staged file.
+  echo "$STAGED" | sed 's,^,./,' | tr '\n' '\0' | xargs -0 node "$PRETTIER_BIN" --write --ignore-unknown || {
     echo "Error: prettier formatting failed" >&2
     exit 1
   }
-  echo "$STAGED" | tr '\n' '\0' | xargs -0 git add || {
+  echo "$STAGED" | sed 's,^,./,' | tr '\n' '\0' | xargs -0 git add || {
     echo "Error: Failed to re-stage formatted files" >&2
     exit 1
   }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,8 +11,20 @@ fi
 
 STAGED=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(js|ts|svelte|json|md|css|html)$' || true)
 if [ -n "$STAGED" ]; then
-  echo "$STAGED" | tr '\n' '\0' | xargs -0 node node_modules/prettier/bin/prettier.cjs --write --ignore-unknown || {
-    echo "Warning: Prettier formatting failed for some files" >&2
+  # Resolve prettier through node's module resolution instead of a hard-coded
+  # ./node_modules path. Linked git worktrees have no local node_modules, but
+  # they nest under the primary checkout, so require.resolve walks up and finds
+  # its prettier (the same mechanism the vitest step below relies on). Fail
+  # closed if prettier is genuinely unavailable, so unformatted code can never
+  # slip past to CI's format:check.
+  PRETTIER_BIN=$(node -e "process.stdout.write(require.resolve('prettier/bin/prettier.cjs'))" 2>/dev/null)
+  if [ -z "$PRETTIER_BIN" ]; then
+    echo "Error: prettier not found - run 'npm install' at the repo root" >&2
+    exit 1
+  fi
+  echo "$STAGED" | tr '\n' '\0' | xargs -0 node "$PRETTIER_BIN" --write --ignore-unknown || {
+    echo "Error: prettier formatting failed" >&2
+    exit 1
   }
   echo "$STAGED" | tr '\n' '\0' | xargs -0 git add || {
     echo "Error: Failed to re-stage formatted files" >&2


### PR DESCRIPTION
## **User description**
## Summary

Fixes #2639: the pre-commit prettier step silently skipped formatting in git worktrees (and failed open), letting unformatted code reach CI's `format:check`.

## Root cause

The step ran `node node_modules/prettier/bin/prettier.cjs` (a hard-coded relative path) and swallowed failures with a warning. Linked worktrees have no local `node_modules`, so the path did not resolve, prettier no-opped, and the commit proceeded unformatted. (The vitest step works in worktrees because it uses `npx --no-install`, which goes through node's upward module resolution.)

## Fix

- Resolve prettier via `require.resolve('prettier/bin/prettier.cjs')` so node walks up to the primary checkout's `node_modules` from any nested worktree (the same mechanism the vitest-related step already relies on).
- Fail **closed**: block the commit if prettier can't be found or formatting errors, instead of warning and continuing.

## Verification

- A mis-formatted `.json` staged in a fresh worktree with no local `node_modules` is now reformatted by the hook (`{"a":1,  "b":2}` -> `{ "a": 1, "b": 2 }`), exit 0.
- Main-checkout behaviour unchanged (auto-format `--write` then re-stage).
- The package-lock sync check and the vitest-related step are untouched.

Closes #2639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep pre-commit formatting working in git worktrees and for tricky filenames**

### What Changed
- Pre-commit formatting now uses the repo’s shared Prettier install, so worktrees no longer skip formatting when they don’t have their own `node_modules`
- If Prettier cannot be found or formatting fails, the commit now stops with an error instead of letting unformatted files through
- Staged files that start with `-` are now handled safely as file paths, so they are not mistaken for command options
- Formatted files are still re-added automatically before the commit continues

### Impact
`✅ Fewer unformatted commits from worktrees`
`✅ Clearer pre-commit failures`
`✅ Safer commits for oddly named files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
