### PR TITLE
chore: release v26.6.4

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -96,6 +96,10 @@ To add yourself to this list, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Contributors who made merged pull requests in each release. For the full contributors table, see above.
 
+### v26.6.4
+
+- No external contributors in this release
+
 ### v26.6.2
 
 - @ilanKushnir: feat(kws): fix module widths/depths, drop U from names, add magnetic patch panels (#1912)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ A large usability release. The workspace is rebuilt around the canvas, and the s
 - New layouts open to a template picker instead of a blank canvas; the standalone StartScreen is gone, with entry routed through the sidebar and app menu (#2081, #2095)
 - Export-all renders every layout with per-mode framing in one pass (#2045)
 - Carrier device types host half-width and sub-U gear directly, replacing the fractional-rail model so sub-U placement is predictable (#2158, #2289, #2291, #2159)
-- Storage status chip in the toolbar shows save state at a glance, with the storage location inline and a last-save details popover on hover or tap; the first step toward a fuller storage status surface (#2035, #2446, #2640)
-- Server storage opt-in: dev sessions restore to server mode after running in browser mode, and switching a browser copy to the server prompts before overwriting an existing one (#2608)
+- Storage status chip in the toolbar shows save state at a glance, with the storage location inline and a last-save details popover on hover or tap (#2035, #2446, #2640)
+- Moving browser-stored layouts to server storage prompts before overwriting an existing server copy (#2608)
 - Pre-overwrite snapshots are taken server-side with conflict detection; the Load dialog lists and restores them (#2040, #2041, #2042)
 - Backup nudge tracks changes since the last export and warns before they are discarded, with a restore-from-file confirm step (#2034, #2038, #2039)
 - Custom device images embed as base64 in the YAML save, so one file round-trips with its images (#617)
@@ -64,7 +64,7 @@ A large usability release. The workspace is rebuilt around the canvas, and the s
 - Export download no longer races object-URL revocation (#2201)
 - Layout loads remap rack groups and container IDs in a two-pass load (#2155)
 - Placement images survive server reconciliation and YAML round-trips (#2220, #2225)
-- Layouts mark clean after a debounced auto-save, with corrected save-toast copy (#2057, #2058, #2061, #2084)
+- Layouts mark clean after a debounced auto-save (#2057, #2058, #2061, #2084)
 - Snapshot data loss closed with strictly monotonic updatedAt and a per-layout write lock (#2067, #2233)
 - Muted-text and QR-brand contrast raised to WCAG AA, nested-interactive controls flattened, and canvas racks given a listbox parent so axe WCAG AA passes (#2255, #2256)
 
@@ -73,7 +73,7 @@ A large usability release. The workspace is rebuilt around the canvas, and the s
 - CSV export escapes spreadsheet formula injection (#2200)
 - Patched libssl3 and libcrypto3 for CVE-2026-45447 (alerts #80-83)
 - Automated security-alert triage via Claude Code (#2357)
-- Pinned libexpat to >=2.8.1-r0 in the deploy image for CVE-2026-8823 (#2562)
+- Pinned libexpat to >=2.8.1-r0 in the deploy image for CVE-2026-45186 (#2562)
 
 ### Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,60 @@ A large usability release. The workspace is rebuilt around the canvas, and the s
 - Dev tooling hardened: cloud-safe superpowers bootstrap, worktree-aware main-edit guard, POSIX husky hooks, the /orchestrate-issues command, and pre-push gate fixes (#2102, #2288)
 - Dependency updates across the production, development, vitest, eslint, and api groups
 
+## [26.6.4] - 2026-06-27
+
+The rear of the rack is real now. Full-depth devices stop being front-only when you flip the view; they render, collide, and take up space on both faces the way they do in the physical rack. The app menu has been torn apart and put back together in an order that reflects what you actually do rather than what was convenient to build. And the storage layer grew a conscience: it asks before overwriting your server copy, it tells you exactly where your work lives, and server-mode saves now carry device images to disk instead of leaving them stranded in browser memory.
+
+### Added
+
+- Full-depth devices render and collide on both rack faces; a 4U NAS stored with `face: front` now appears on the rear too, occupying space correctly (#2337, PR #2641)
+- Storage chip shows the current storage location inline and opens a last-save details popover on hover or tap (#2446, #2035, PR #2640)
+- Server storage opt-in: dev environments restore to server mode after a browser-mode session; switching from browser to server prompts before overwriting an existing copy (#2608, PR #2604, #2638)
+- App menu reorganized by intent with the registry contract complete; group headings renamed for clarity (#2596, #2611, PR #2598, #2612)
+- Mobile app menu sheet renders the full registry projection (#2597, PR #2603)
+- API validates layout files against the JSON Schema before persisting them (#2449, PR #2586)
+- Hover-revealed edge grip on the panel seam as a secondary collapse affordance
+- Verb-bar and canvas-control tooltips now sourced from the command registry
+- Keyboard alternative for device placement (#106)
+- Device images show a load placeholder and fade in on load, with failure toasts and accessible alt text
+- flip-device-face verb uses the transition-right glyph (#2400)
+- Create-custom-device promoted to a labelled bottom button (#2556)
+- Server-mode saves write device images to disk with set-diff reconciliation
+
+### Changed
+
+- Edit/View tab strip unified with the sidebar's segmented control style (#2600, PR #2601)
+- App light theme (Alucard) removed (#2468, PR #2618)
+
+### Fixed
+
+- Toolbar search label simplified; magnifying glass centred (PR #2623)
+- Storage chip content centred in the toolbar status zone (PR #2614)
+- App menu group dividers render (#2602)
+- SPA entry document revalidated on deploy so stale caches do not serve the old build (PR #2599)
+- Top-bar height no longer shifts when the side panel collapses (#2583, PR #2590)
+- MikroTik CSS326-24G-2S+RM and CSS610-8G-2S+IN added (#1581, PR #2594)
+- Section tabs fit the 320px breakpoint without truncating (#2564)
+- Nested-interactive controls flattened; axe WCAG AA aria-required-children passes (#2255)
+- Muted-text and QR-brand contrast raised to WCAG AA (#2256)
+- Canvas racks given a listbox parent; aria-required-parent passes
+- Breathing room added between the search pill and the layout tab bar (#2574)
+- Panel edge grip floated to the seam; no longer reserves dead margin space
+- @testing-library/svelte pinned to 5.3.1; runes compatibility restored in the unit suite (#2587, PR #2592)
+
+### Security
+
+- Pinned libexpat to >=2.8.1-r0 in the deploy image to address CVE-2026-8823 (PR #2562)
+
+### Technical
+
+- Upgrade corpus exercises the loadLayout store path through the real parse pass with v0.6 YAML fixtures (#2450, #2451, PR #2593, #2582)
+- Vendor asset directories normalized; generic device library split from brand-specific packs (#2552)
+- RackList Space-keydown behaviour locked in; unblocked downstream test suite
+- DCO sign-off section added to CONTRIBUTING (#2559)
+- Research: depth model for M021 (PR #2634), Cloudflare Workers Static Assets for #2029 prep (PR #2621)
+- Dependency updates: svelte 5.56.4, hono 4.12.27, nanoid 5.1.16, better-auth 1.6.22, @types/node 26.0.1, and assorted dev and CI dep bumps
+
 ## [26.6.3] - 2026-06-08
 
 For a while, the way Rackula got released was: someone pushed a tag and hoped. Nobody deployed the LXC install on an actual container first. They just believed in it. That is how v26.6.2 shipped an install that could not start on an unprivileged container, which is the default. We found the guy who did that. It was me. @ggfevans.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,37 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Calendar Versioning](https://calver.org/).
 
-## [Unreleased]
+## [26.6.4] - 2026-06-27
 
 A large usability release. The workspace is rebuilt around the canvas, and the storage layer is rebuilt to stop silently losing work. The rest is targeted fixes and technical-debt paydown that make the app faster to work in and more reliable. You can trust it with your data now. Please. It would mean a lot.
 
 ### Added
 
-- Command palette (Ctrl+K) runs any action or finds any device from one search box, with recents, a selection-aware empty state, device search, and click-to-place on desktop (#2212, #2213, #2214, #2341, #2352)
+- Command palette is the search input for commands: one box runs any action or finds any device, opened from the toolbar search pill or with Ctrl+K, with recents, a selection-aware empty state, device search, and click-to-place on desktop (#2212, #2213, #2214, #2341, #2352)
 - Tabbed side panel replaces the single edit panel: Layouts, Racks, and Devices tabs, contextual properties on the Edit tab, display toggles on the View tab, collapsible (#2076, #2077, #2078, #2082)
 - Floating verb bars put context actions next to the selected device or rack, including a slot control for half-width devices (#2075, #2322, #2334, #2344)
 - Layouts library lists every saved layout with cached previews, opened and managed from the sidebar (#2082, #2083, #2325)
 - Open layouts persist as toolbar tabs and restore lazily on launch (#2079, #2080, #2324)
 - Top bar reduced to workspace chrome (logo, app menu, layout name, storage status, settings); view and history controls relocated to a floating cluster at the canvas bottom-left, where the cursor already is (#2072, #2073, #2074, #2187)
+- App menu behind the Rackula mark is now the main menu: reorganized by intent, with the menu-item registry contract completed, group headings renamed for clarity, dividers between groups, and a mobile sheet that renders the same projection (#2596, #2597, #2602, #2611)
 - Settings dialog consolidates Appearance, Behaviour, and Data options (#2093)
 - Device palette gains favourites, list virtualization for large libraries, and an image on/off toggle (#2094)
 - New layouts open to a template picker instead of a blank canvas; the standalone StartScreen is gone, with entry routed through the sidebar and app menu (#2081, #2095)
 - Export-all renders every layout with per-mode framing in one pass (#2045)
 - Carrier device types host half-width and sub-U gear directly, replacing the fractional-rail model so sub-U placement is predictable (#2158, #2289, #2291, #2159)
-- Storage status chip in the toolbar shows save state at a glance (#2035)
+- Storage status chip in the toolbar shows save state at a glance, with the storage location inline and a last-save details popover on hover or tap; the first step toward a fuller storage status surface (#2035, #2446, #2640)
+- Server storage opt-in: dev sessions restore to server mode after running in browser mode, and switching a browser copy to the server prompts before overwriting an existing one (#2608)
 - Pre-overwrite snapshots are taken server-side with conflict detection; the Load dialog lists and restores them (#2040, #2041, #2042)
 - Backup nudge tracks changes since the last export and warns before they are discarded, with a restore-from-file confirm step (#2034, #2038, #2039)
 - Custom device images embed as base64 in the YAML save, so one file round-trips with its images (#617)
 - Layout JSON Schema generated from the Zod schema for editor validation, under a documented versioning and compatibility policy (#1113, #2226)
+- Full-depth devices render and collide on both rack faces, so a device stored facing front also occupies and shows on the rear (#2337)
+- Keyboard alternative for placing devices, so a device can be added without a pointer (#106)
+- Device images show a load placeholder, fade in when ready, and raise a toast on failure, with accessible alt text
+- Create-custom-device promoted to a labelled button at the foot of the device palette (#2556)
+- Hover-revealed edge grip on the panel seam as a second way to collapse a side panel
+- Verb-bar and canvas-control tooltips are sourced from the command registry, so labels and shortcuts stay in step
+- MikroTik CSS326-24G-2S+RM and CSS610-8G-2S+IN switches added to the device library (#1581)
 
 ### Changed
 
@@ -38,6 +47,10 @@ A large usability release. The workspace is rebuilt around the canvas, and the s
 - Display-mode toggle icon redesigned for clarity (#2335)
 - Coffin-tapered mark adopted as the canonical logo (#2048)
 - Rack PDUs modelled as shallow power bars that render in rear view (#2337)
+- App light theme (Alucard) removed; Rackula is dark-only (#2468)
+- Edit and View tab strip unified with the sidebar's segmented-control style (#2600)
+- flip-device-face verb uses a transition-right glyph for clarity (#2400)
+- The API validates a layout against the JSON Schema before persisting it (#2449)
 
 ### Fixed
 
@@ -53,12 +66,14 @@ A large usability release. The workspace is rebuilt around the canvas, and the s
 - Placement images survive server reconciliation and YAML round-trips (#2220, #2225)
 - Layouts mark clean after a debounced auto-save, with corrected save-toast copy (#2057, #2058, #2061, #2084)
 - Snapshot data loss closed with strictly monotonic updatedAt and a per-layout write lock (#2067, #2233)
+- Muted-text and QR-brand contrast raised to WCAG AA, nested-interactive controls flattened, and canvas racks given a listbox parent so axe WCAG AA passes (#2255, #2256)
 
 ### Security
 
 - CSV export escapes spreadsheet formula injection (#2200)
 - Patched libssl3 and libcrypto3 for CVE-2026-45447 (alerts #80-83)
 - Automated security-alert triage via Claude Code (#2357)
+- Pinned libexpat to >=2.8.1-r0 in the deploy image for CVE-2026-8823 (#2562)
 
 ### Technical
 
@@ -69,61 +84,13 @@ A large usability release. The workspace is rebuilt around the canvas, and the s
 - Upgrade-safety net so a self-hosted deployment can take new images without losing saved data: prior-release layouts load through the real parse path in a self-discovering fixture corpus with silent-loss detection, plus a fail-closed release guard; the Docker upgrade smoke drives the compose stack from the previous released image to the new build against the same volume and confirms the saved layout survives byte-for-byte (#2448, #2515)
 - i18n deferred to M011; the orphaned Paraglide runtime removed (#2184)
 - Dev tooling hardened: cloud-safe superpowers bootstrap, worktree-aware main-edit guard, POSIX husky hooks, the /orchestrate-issues command, and pre-push gate fixes (#2102, #2288)
-- Dependency updates across the production, development, vitest, eslint, and api groups
-
-## [26.6.4] - 2026-06-27
-
-The rear of the rack is real now. Full-depth devices stop being front-only when you flip the view; they render, collide, and take up space on both faces the way they do in the physical rack. The app menu has been torn apart and put back together in an order that reflects what you actually do rather than what was convenient to build. And the storage layer grew a conscience: it asks before overwriting your server copy, it tells you exactly where your work lives, and server-mode saves now carry device images to disk instead of leaving them stranded in browser memory.
-
-### Added
-
-- Full-depth devices render and collide on both rack faces; a 4U NAS stored with `face: front` now appears on the rear too, occupying space correctly (#2337, PR #2641)
-- Storage chip shows the current storage location inline and opens a last-save details popover on hover or tap (#2446, #2035, PR #2640)
-- Server storage opt-in: dev environments restore to server mode after a browser-mode session; switching from browser to server prompts before overwriting an existing copy (#2608, PR #2604, #2638)
-- App menu reorganized by intent with the registry contract complete; group headings renamed for clarity (#2596, #2611, PR #2598, #2612)
-- Mobile app menu sheet renders the full registry projection (#2597, PR #2603)
-- API validates layout files against the JSON Schema before persisting them (#2449, PR #2586)
-- Hover-revealed edge grip on the panel seam as a secondary collapse affordance
-- Verb-bar and canvas-control tooltips now sourced from the command registry
-- Keyboard alternative for device placement (#106)
-- Device images show a load placeholder and fade in on load, with failure toasts and accessible alt text
-- flip-device-face verb uses the transition-right glyph (#2400)
-- Create-custom-device promoted to a labelled bottom button (#2556)
-- Server-mode saves write device images to disk with set-diff reconciliation
-
-### Changed
-
-- Edit/View tab strip unified with the sidebar's segmented control style (#2600, PR #2601)
-- App light theme (Alucard) removed (#2468, PR #2618)
-
-### Fixed
-
-- Toolbar search label simplified; magnifying glass centred (PR #2623)
-- Storage chip content centred in the toolbar status zone (PR #2614)
-- App menu group dividers render (#2602)
-- SPA entry document revalidated on deploy so stale caches do not serve the old build (PR #2599)
-- Top-bar height no longer shifts when the side panel collapses (#2583, PR #2590)
-- MikroTik CSS326-24G-2S+RM and CSS610-8G-2S+IN added (#1581, PR #2594)
-- Section tabs fit the 320px breakpoint without truncating (#2564)
-- Nested-interactive controls flattened; axe WCAG AA aria-required-children passes (#2255)
-- Muted-text and QR-brand contrast raised to WCAG AA (#2256)
-- Canvas racks given a listbox parent; aria-required-parent passes
-- Breathing room added between the search pill and the layout tab bar (#2574)
-- Panel edge grip floated to the seam; no longer reserves dead margin space
-- @testing-library/svelte pinned to 5.3.1; runes compatibility restored in the unit suite (#2587, PR #2592)
-
-### Security
-
-- Pinned libexpat to >=2.8.1-r0 in the deploy image to address CVE-2026-8823 (PR #2562)
-
-### Technical
-
-- Upgrade corpus exercises the loadLayout store path through the real parse pass with v0.6 YAML fixtures (#2450, #2451, PR #2593, #2582)
-- Vendor asset directories normalized; generic device library split from brand-specific packs (#2552)
-- RackList Space-keydown behaviour locked in; unblocked downstream test suite
+- Upgrade corpus exercises the loadLayout path with v0.6 single-rack YAML fixtures (#2450, #2451)
+- Vendor asset directories normalized and the generic device library split from brand packs (#2552)
+- @testing-library/svelte pinned to 5.3.1 to restore runes compatibility in the unit suite (#2587)
+- SPA entry document revalidated on deploy so a stale cache stops serving the old build (#2599)
 - DCO sign-off section added to CONTRIBUTING (#2559)
-- Research: depth model for M021 (PR #2634), Cloudflare Workers Static Assets for #2029 prep (PR #2621)
-- Dependency updates: svelte 5.56.4, hono 4.12.27, nanoid 5.1.16, better-auth 1.6.22, @types/node 26.0.1, and assorted dev and CI dep bumps
+- Research spikes: accurate depth model for M021 (#2622) and Cloudflare Workers Static Assets for #2029 prep (#2620)
+- Dependency updates across the production, development, vitest, eslint, and api groups
 
 ## [26.6.3] - 2026-06-08
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Rackula is currently in active development. Security updates are applied to the 
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| 26.6.3   | :white_check_mark: |
-| < 26.6.3 | :x:                |
+| 26.6.4   | :white_check_mark: |
+| < 26.6.4 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rackula/api",
-  "version": "26.6.3",
+  "version": "26.6.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rackula",
-  "version": "26.6.3",
+  "version": "26.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rackula",
-      "version": "26.6.3",
+      "version": "26.6.4",
       "license": "MIT",
       "dependencies": {
         "@lucide/svelte": "^1.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rackula",
-  "version": "26.6.3",
+  "version": "26.6.4",
   "description": "Drag and drop rack visualizer",
   "author": "ggfevans",
   "license": "MIT",


### PR DESCRIPTION
## **User description**
## Release v26.6.4

Cuts the v26.6.4 release. CHANGELOG.md is the source of truth; the GitHub release is generated from it.

### Contents

- Consolidated the `[Unreleased]` block into a single dated `## [26.6.4] - 2026-06-27` entry
- Detailed the headline UX work: command-palette search input, the app menu as the main menu, and the storage status chip
- Streamlined Fixed to drop cosmetic fixes to UI added this same release and dev-env-only fixes
- Corrected the libexpat CVE id to CVE-2026-45186 (matches the Dockerfile pin)
- Bumped version to 26.6.4 (`package.json`, `package-lock.json`, `api/package.json`)
- Updated SECURITY.md supported version and ACKNOWLEDGEMENTS.md

### Release step

After merge, tag `v26.6.4` on main triggers the production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Publish the v26.6.4 release notes and version update**

### What Changed
- Reworked the release notes into a dated v26.6.4 entry that highlights the main user-facing changes: the command palette as the search input, the app menu as the main menu, and the storage status chip
- Clarified a few release-note items to match the visible behavior users now get, including the overwrite prompt when moving browser-stored layouts to server storage and the storage chip’s location and save details
- Updated the app and API version numbers to v26.6.4
- Updated the supported version in the security policy and refreshed the acknowledgements for this release

### Impact
`✅ Clearer release notes`
`✅ Accurate version and support status`
`✅ Easier release tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
