### PR TITLE
fix(ci): clear leftover sparse-checkout in prod smoke-test job

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -95,6 +95,15 @@ jobs:
           [ "$fe" = "$VERSION" ] || { echo "::error::Live frontend version '${fe}' != '${VERSION}'"; exit 1; }
           echo "✓ Live frontend reports ${VERSION}"
 
+      # The deploy job runs a sparse checkout on this same self-hosted runner and
+      # leaves the shared workspace in sparse mode. actions/checkout does not clear
+      # an existing sparse cone when the sparse-checkout input is omitted, so the
+      # full tree (package-lock.json, e2e specs) would be missing here, breaking
+      # setup-node's npm cache and the npm ci that follows. Disable any leftover
+      # sparse-checkout before the full checkout below.
+      - name: Clear leftover sparse-checkout from the deploy job
+        run: git -C "$GITHUB_WORKSPACE" sparse-checkout disable 2>/dev/null || true
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag }}


### PR DESCRIPTION
## **User description**
## Fix prod smoke-test sparse-checkout leak

### Problem

The v26.6.4 release deploy succeeded and prod is live and verified at 26.6.4, but the `Promote to prod / smoke-test` job failed:

```
Error: Dependencies lock file is not found in /home/.../actions-runner/_work/Rackula/Rackula.
Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
```

### Root cause

The `deploy` and `smoke-test` jobs run on the same single self-hosted runner and share the workspace. `deploy` does a sparse checkout (`sparse-checkout: docker-compose.yml`). `actions/checkout` does not clear an existing sparse cone when the `sparse-checkout` input is omitted, so the `smoke-test` job's checkout left the tree sparse, missing `package-lock.json` and the e2e specs. That broke `setup-node`'s npm cache and the `npm ci` that follows.

### Fix

Disable any leftover sparse-checkout before the smoke-test's full checkout. Minimal and self-contained; no change to the gated-deploy design (no new triggers added).

Verified: YAML parses, prettier clean. Prod is already serving 26.6.4 (the live-frontend-version check passed); this prevents the smoke-test failure on future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent the post-deploy smoke test from inheriting a sparse checkout**

### What Changed
- The prod smoke-test job now clears any leftover sparse checkout before it checks out the full repository
- This restores missing files needed for dependency setup and end-to-end tests after deploy runs on the shared self-hosted runner
- The smoke test can now run from a complete workspace instead of failing because required files are absent

### Impact
`✅ Fewer post-deploy smoke-test failures`
`✅ Reliable dependency installs after deploy`
`✅ More dependable release verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
