### PR TITLE
fix(api): align hono override to clear CVE-2026-54290

### DIFF
--- a/api/bun.lock
+++ b/api/bun.lock
@@ -23,7 +23,7 @@
   "overrides": {
     "@hono/node-server": "^1.19.10",
     "defu": "^6.1.5",
-    "hono": "^4.12.19",
+    "hono": "^4.12.27",
   },
   "packages": {
     "@better-auth/core": ["@better-auth/core@1.6.22", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.7", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-aFH/5nzmR501jAJPKjJfiVg4BrkcjVCqq9WS9JnhTruE/2PIWopv1QGMiRIRqxXaPbHczri7cqRdhep3Lg5PMw=="],
@@ -124,7 +124,7 @@
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 

--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "overrides": {
-    "hono": "^4.12.19",
+    "hono": "^4.12.27",
     "@hono/node-server": "^1.19.10",
     "defu": "^6.1.5"
   },


### PR DESCRIPTION
## **User description**
## Clear CVE-2026-54290 (hono) by aligning the stale override

### Triage

Trivy on main flagged hono `4.12.23` (CVE-2026-54290, HIGH, fixed in 4.12.25) in three places: the app and api filesystem scans and the api image.

- **Exploitability: none on this codebase.** The CVE only triggers with credentialed CORS; `api/src/app.ts` configures `cors()` without `credentials: true`. This is why the alert was dismissed as a false positive.
- **Root cause of the recurring finding:** `overrides.hono: "^4.12.19"` (added in #1691 to patch an older hono CVE) takes precedence over `dependencies.hono: "^4.12.27"`, so Dependabot's bump never reached `bun.lock` and hono stayed pinned at the vulnerable 4.12.23.

### Fix

Align the override to `^4.12.27` and regenerate `bun.lock`. hono now resolves to 4.12.27 (above the 4.12.25 fix), staying above the older #1691 CVE floor too. This clears the finding for real instead of relying on the false-positive rationale.

### Verification

- `bun install` -> hono 4.12.27 in `bun.lock`
- `bun test` -> 336 pass, 0 fail
- Minimal diff: override line + lockfile entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep the API on the fixed Hono release**

### What Changed
- Updated the API dependency override so Hono now resolves to the newer fixed version
- This removes the older pin that was preventing the security update from taking effect

### Impact
`✅ Cleared a vulnerable Hono version from API installs`
`✅ Fewer security scan findings in the API image`
`✅ Reduced risk of missed dependency updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
