### PR TITLE
fix: tighten dual-view e2e FRONT/REAR label selectors

### DIFF
--- a/e2e/dual-view.spec.ts
+++ b/e2e/dual-view.spec.ts
@@ -82,9 +82,11 @@ test.describe("Dual-View Rack Display", () => {
     await expect(page.locator(locators.rackView.rear)).toBeVisible();
 
     await expect(
-      page.getByTestId("rack-front").getByText("FRONT"),
+      page.getByTestId("rack-front").getByText("FRONT", { exact: true }),
     ).toBeVisible();
-    await expect(page.getByTestId("rack-rear").getByText("REAR")).toBeVisible();
+    await expect(
+      page.getByTestId("rack-rear").getByText("REAR", { exact: true }),
+    ).toBeVisible();
 
     await expect(page.locator(locators.rackView.frontSvg)).toBeVisible();
     await expect(page.locator(locators.rackView.rearSvg)).toBeVisible();


### PR DESCRIPTION
## **User description**
## Summary

Fixes one of the stale self-hosted e2e tests tracked in #2643: `e2e/dual-view.spec.ts:78` `dual-view renders correctly on page load`.

`page.getByTestId("rack-front").getByText("FRONT")` (and the `REAR` equivalent) used a non-exact, case-insensitive substring match. On page load the rack is empty, so each face also renders the empty-state hint:

- front: `No front-facing or full-depth devices`
- rear: `No rear-facing or full-depth devices`

"front-facing"/"rear-facing" contain "front"/"rear", so each `getByText` resolved to two elements (the `.rack-view-label` and the `.empty-face-hint`), causing a Playwright strict-mode violation.

## Change

Use exact matching so only the view label is asserted:

```diff
-page.getByTestId("rack-front").getByText("FRONT")
+page.getByTestId("rack-front").getByText("FRONT", { exact: true })
```

Same for `REAR`. Test-only; no app change.

## Verification

Ran locally against chromium:

```
✓ e2e/dual-view.spec.ts:78:3 › Dual-View Rack Display › dual-view renders correctly on page load (589ms)
1 passed
```

## Scope

Part of #2643. Does not close it: the responsive brand-logo and starter-library palette failures are still open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix dual-view page load test to match the FRONT and REAR labels exactly**

### What Changed
- The dual-view page load test now checks the FRONT and REAR face labels with exact text matching.
- This avoids the labels being confused with the empty-state hints shown when a rack face has no devices, so the test no longer fails on an empty rack.

### Impact
`✅ Fewer false e2e test failures`
`✅ More reliable dual-view page load checks`
`✅ Stable validation of FRONT and REAR labels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
