### PR TITLE
fix: count one rack face in migration/duplicate-id e2e tests

### DIFF
--- a/e2e/duplicate-device-ids.spec.ts
+++ b/e2e/duplicate-device-ids.spec.ts
@@ -105,7 +105,7 @@ test.describe("Duplicate Device ID Handling (#1363)", () => {
     await expect(page.locator(locators.rack.device).first()).toBeVisible({
       timeout: 5000,
     });
-    const devices = await page.locator(locators.rack.device).count();
+    const devices = await page.locator(locators.rackView.frontDevice).count();
     expect(devices).toBe(3);
 
     // No each_key_duplicate errors

--- a/e2e/migration.spec.ts
+++ b/e2e/migration.spec.ts
@@ -47,7 +47,7 @@ test.describe("Position Migration", () => {
     // The server at U10 should now be at internal position 60
     // The switch at U1 should now be at internal position 6
     // Visual verification: both devices should be visible in the rack
-    const devices = await page.locator(locators.rack.device).count();
+    const devices = await page.locator(locators.rackView.frontDevice).count();
     expect(devices).toBe(2);
   });
 
@@ -112,7 +112,7 @@ test.describe("Position Migration", () => {
     });
 
     // Verify devices are still in correct positions (not double-migrated)
-    const devices = await page.locator(locators.rack.device).count();
+    const devices = await page.locator(locators.rackView.frontDevice).count();
     expect(devices).toBe(2);
 
     // Verify the rack name is preserved


### PR DESCRIPTION
## **User description**
## Summary

Fixes two more stale self-hosted e2e tests tracked in #2643:

- `e2e/migration.spec.ts:23` `loads legacy layout and migrates positions correctly`
- `e2e/migration.spec.ts:81` `reload after save does not double-migrate`
- `e2e/duplicate-device-ids.spec.ts:82` `loads layout with duplicate device IDs without crashing`

## Root cause

These assertions counted `locators.rack.device` (`[data-testid="rack-device"]`), which is not face-scoped, while the rack renders in dual-view (front + rear). Since full-depth rear-view (#2641) now renders full-depth / `face=both` devices on both the front and rear SVGs, each device was counted twice:

- migration: expected 2, received 4
- duplicate-id: expected 3, received 6

This is correct app behaviour with stale tests, not a migration or duplicate-id regression. The migration path itself runs fine; the test counted both faces.

## Change

Scope the counts to the front face so each logical device is counted once:

```diff
-const devices = await page.locator(locators.rack.device).count();
+const devices = await page.locator(locators.rackView.frontDevice).count();
```

Test-only; no app change.

## Verification

Ran locally against chromium (both spec files, plus carlton-migration picked up by the glob):

```
7 passed (6.6s)
✓ migration.spec.ts:23 loads legacy layout and migrates positions correctly
✓ migration.spec.ts:81 reload after save does not double-migrate
✓ duplicate-device-ids.spec.ts:82 loads layout with duplicate device IDs without crashing
```

## Scope

Part of #2643. Does not close it: the responsive brand-logo tests (900px / 600px) and `starter-library.spec.ts:25` remain, and the responsive ones need a product decision on whether a brand mark shows on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep dual-view device count tests from double-counting rack devices**

### What Changed
- Migration and duplicate-device-ID tests now count devices on the front face only, so each device is counted once in dual-view racks
- The tests still verify that legacy layouts load, saved layouts keep the migrated positions, and duplicate IDs load without crashing

### Impact
`✅ Fewer false test failures in rack loading`
`✅ Reliable checks for migrated device positions`
`✅ Reliable checks for duplicate-device-ID imports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
