### PR TITLE
fix: storage popover z-index, verb bar dual-view anchoring, bottom-center toasts (#2645, #2646, #2637)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -674,6 +674,9 @@
               onfitall={handleFitAll}
               ontoggledisplaymode={handleToggleDisplayMode}
             />
+
+            <!-- Toasts anchor to the bottom-center of the canvas region (#2637). -->
+            <ToastContainer />
           </div>
 
           <SidePanel />
@@ -718,6 +721,11 @@
           onrackdelete={handleRackContextDelete}
           ondelete={handleDelete}
         />
+
+        <!-- Mobile has no canvas-region wrapper; anchor toasts to .app-main, which
+             spans the full mobile width (no side panels) and is bottom-center over
+             the canvas (#2637). -->
+        <ToastContainer />
       {/if}
     </main>
 
@@ -731,8 +739,6 @@
 
     <!-- Global SVG gradient definitions for animations -->
     <AnimationDefs />
-
-    <ToastContainer />
 
     <!-- Port tooltip for network interface hover -->
     <PortTooltip />

--- a/src/lib/actions/selection-actions.ts
+++ b/src/lib/actions/selection-actions.ts
@@ -178,9 +178,12 @@ export function duplicateSelection(): void {
     if (result.error) {
       toastStore.showToast(result.error, "error");
     } else if (result.device) {
+      // Keep the verb bar anchored to the same view the original was selected in
+      // (#2646); the duplicate shares the original's face.
       selectionStore.selectDevice(
         selectionStore.selectedRackId,
         result.device.id,
+        selectionStore.selectedDeviceFace ?? undefined,
       );
       toastStore.showToast("Device duplicated", "success");
     }

--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -60,6 +60,7 @@
         deviceId?: string;
         slug: string;
         position: number;
+        face: "front" | "rear";
       }>,
     ) => void;
     ondevicedrop?: (
@@ -324,7 +325,12 @@
   // Handle device select - inject the correct rackId into the event
   function handleDeviceSelect(
     rackId: string,
-    event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+    event: CustomEvent<{
+      deviceId?: string;
+      slug: string;
+      position: number;
+      face: "front" | "rear";
+    }>,
   ) {
     ondeviceselect?.(
       new CustomEvent("deviceselect", {
@@ -333,6 +339,7 @@
           deviceId: event.detail.deviceId,
           slug: event.detail.slug,
           position: event.detail.position,
+          face: event.detail.face,
         },
       }),
     );

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -54,7 +54,12 @@
     ontoggledisplaymode?: () => void;
     onrackselect?: (event: CustomEvent<{ rackId: string }>) => void;
     ondeviceselect?: (
-      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+      event: CustomEvent<{
+        deviceId?: string;
+        slug: string;
+        position: number;
+        face: "front" | "rear";
+      }>,
     ) => void;
     ondevicedrop?: (
       event: CustomEvent<{

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -97,7 +97,12 @@
     partyMode?: boolean;
     onselect?: (event: CustomEvent<{ rackId: string }>) => void;
     ondeviceselect?: (
-      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+      event: CustomEvent<{
+        deviceId?: string;
+        slug: string;
+        position: number;
+        face: "front" | "rear";
+      }>,
     ) => void;
     ondevicedrop?: (
       event: CustomEvent<{

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -26,7 +26,12 @@
     swipeAnimationDirection?: RackSwipeDirection | null;
     onrackselect?: (event: CustomEvent<{ rackId: string }>) => void;
     ondeviceselect?: (
-      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+      event: CustomEvent<{
+        deviceId?: string;
+        slug: string;
+        position: number;
+        face: "front" | "rear";
+      }>,
     ) => void;
     ondevicedrop?: (
       event: CustomEvent<{
@@ -160,7 +165,12 @@
 
   function handleDeviceSelect(
     rackId: string,
-    event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+    event: CustomEvent<{
+      deviceId?: string;
+      slug: string;
+      position: number;
+      face: "front" | "rear";
+    }>,
   ) {
     // Resolve the placed device by its UUID when available. The legacy
     // (slug, position) fallback is ambiguous for two half-width devices sharing
@@ -171,7 +181,10 @@
       const device = resolveSelectedDevice(targetRack, event.detail);
       if (device) {
         layoutStore.setActiveRack(rackId);
-        selectionStore.selectDevice(rackId, device.id);
+        // Pass the clicked face so view-relative UI (the verb bar, #2646) anchors
+        // to the copy that was clicked: a full-depth device renders in both the
+        // front and rear views under one UUID.
+        selectionStore.selectDevice(rackId, device.id, event.detail.face);
       }
     }
     ondeviceselect?.(event);

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -84,7 +84,12 @@
     /** Whether the current drag target slot is valid for the dragged device */
     isDragTargetValid?: boolean;
     onselect?: (
-      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+      event: CustomEvent<{
+        deviceId?: string;
+        slug: string;
+        position: number;
+        face: "front" | "rear";
+      }>,
     ) => void;
     ondragstart?: (
       event: CustomEvent<{ rackId: string; deviceIndex: number }>,
@@ -360,7 +365,12 @@
       event.stopPropagation();
       onselect?.(
         new CustomEvent("select", {
-          detail: { deviceId: placedDeviceId, slug: device.slug, position },
+          detail: {
+            deviceId: placedDeviceId,
+            slug: device.slug,
+            position,
+            face: currentFace,
+          },
         }),
       );
     }
@@ -479,7 +489,12 @@
       }
       onselect?.(
         new CustomEvent("select", {
-          detail: { deviceId: placedDeviceId, slug: device.slug, position },
+          detail: {
+            deviceId: placedDeviceId,
+            slug: device.slug,
+            position,
+            face: currentFace,
+          },
         }),
       );
     } else if (pointerState === "dragging") {
@@ -599,6 +614,7 @@
   bind:this={groupElement}
   data-device-id={device.slug}
   data-device-uuid={placedDeviceId}
+  data-device-face={currentFace}
   data-device-position={position}
   data-testid="rack-device"
   transform="translate({RAIL_WIDTH + slotXOffset}, {yPosition})"

--- a/src/lib/components/RackDualView.svelte
+++ b/src/lib/components/RackDualView.svelte
@@ -44,7 +44,12 @@
     enableLongPress?: boolean;
     onselect?: (event: CustomEvent<{ rackId: string }>) => void;
     ondeviceselect?: (
-      event: CustomEvent<{ deviceId?: string; slug: string; position: number }>,
+      event: CustomEvent<{
+        deviceId?: string;
+        slug: string;
+        position: number;
+        face: "front" | "rear";
+      }>,
     ) => void;
     ondevicedrop?: (
       event: CustomEvent<{

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -93,25 +93,26 @@
     animation: slideIn 0.2s ease-out;
   }
 
+  /* Bottom-center stack (#2637): rise in from below and sink back out. */
   @keyframes slideIn {
     from {
       opacity: 0;
-      transform: translateX(100%);
+      transform: translateY(0.5rem);
     }
     to {
       opacity: 1;
-      transform: translateX(0);
+      transform: translateY(0);
     }
   }
 
   @keyframes slideOut {
     from {
       opacity: 1;
-      transform: translateX(0);
+      transform: translateY(0);
     }
     to {
       opacity: 0;
-      transform: translateX(100%);
+      transform: translateY(0.5rem);
     }
   }
 

--- a/src/lib/components/ToastContainer.svelte
+++ b/src/lib/components/ToastContainer.svelte
@@ -16,20 +16,21 @@
 </div>
 
 <style>
-  /* Anchored top-right, beneath the top bar / storage chip. The stack grows
-	   downward: newest sits just under the chip and older toasts push down
-	   (column-reverse keeps the latest closest to its source, #2405). The right
-	   offset matches the storage chip's right edge (the toolbar right lane's
-	   --space-2 padding) so cause and effect line up vertically. */
+  /* Anchored to the bottom-center of the canvas region (#2637): the conventional,
+	   least-occluding spot for transient system feedback. Positioned absolutely
+	   within the canvas region (its nearest positioned ancestor) so it centers over
+	   the canvas, clear of the side panels and the bottom-left view controls. The
+	   stack is bottom-anchored and grows upward: the newest toast sits at the bottom
+	   (closest to its source) and older toasts push up as they accumulate. */
   .toast-container {
-    position: fixed;
-    top: calc(
-      var(--toolbar-height) + var(--space-3) + env(safe-area-inset-top, 0px)
-    );
-    right: calc(var(--space-2) + env(safe-area-inset-right, 0px));
+    position: absolute;
+    bottom: var(--space-3);
+    left: 50%;
+    transform: translateX(-50%);
     z-index: var(--z-toast);
     display: flex;
-    flex-direction: column-reverse;
+    flex-direction: column;
+    align-items: center;
     gap: 0.75rem;
     pointer-events: none;
   }
@@ -38,20 +39,19 @@
     pointer-events: auto;
   }
 
-  /* Responsive positioning: span the width beneath the top bar on small
-	   screens so messages stay readable, still stacking downward from the top. */
-  @media (max-width: 480px) {
+  /* Mobile (matches the layout breakpoint, viewport <= 1024px): lift the stack
+	   above the fixed bottom nav and the safe-area inset so it is never hidden
+	   behind the nav. */
+  @media (max-width: 1024px) {
     .toast-container {
-      left: calc(var(--space-4) + env(safe-area-inset-left, 0px));
-      right: calc(var(--space-4) + env(safe-area-inset-right, 0px));
-      top: calc(
-        var(--toolbar-height) + var(--space-2) + env(safe-area-inset-top, 0px)
+      bottom: calc(
+        var(--bottom-nav-height) + var(--space-3) +
+          env(safe-area-inset-bottom, 0px)
       );
     }
 
     .toast-container :global(.toast) {
-      min-width: 0;
-      max-width: none;
+      max-width: min(420px, calc(100vw - 2 * var(--space-4)));
     }
   }
 </style>

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -114,9 +114,19 @@
     if (!canvasEl) return null;
 
     if (selection.isDeviceSelected && selection.selectedDeviceId) {
-      return canvasEl.querySelector(
-        `[data-device-uuid="${CSS.escape(selection.selectedDeviceId)}"]`,
-      );
+      const uuid = CSS.escape(selection.selectedDeviceId);
+      // A full-depth device renders in both the front and rear views under one
+      // UUID, so a bare UUID selector always resolves to the first (front) copy.
+      // Anchor to the copy in the view the device was clicked (#2646); fall back
+      // to the first match when the face is unknown (keyboard/palette selection).
+      const face = selection.selectedDeviceFace;
+      if (face === "front" || face === "rear") {
+        const inFace = canvasEl.querySelector(
+          `[data-device-uuid="${uuid}"][data-device-face="${face}"]`,
+        );
+        if (inFace) return inFace;
+      }
+      return canvasEl.querySelector(`[data-device-uuid="${uuid}"]`);
     }
 
     if (selection.isRackSelected && selection.selectedRackId) {

--- a/src/lib/stores/selection.svelte.ts
+++ b/src/lib/stores/selection.svelte.ts
@@ -7,7 +7,7 @@
  * - Selection remains valid after device additions/deletions
  */
 
-import type { PlacedDevice } from "$lib/types";
+import type { DeviceFace, PlacedDevice } from "$lib/types";
 import { selectionDebug } from "$lib/utils/debug";
 
 // Selection types
@@ -18,6 +18,11 @@ let selectedType = $state<SelectionType>(null);
 let selectedRackId = $state<string | null>(null);
 let selectedGroupId = $state<string | null>(null);
 let selectedDeviceId = $state<string | null>(null);
+// The view a device was selected in (front or rear). A full-depth device
+// renders in both views under one UUID, so callers that position UI against the
+// selected element (the floating verb bar, #2646) need to know which copy was
+// clicked. Null when unknown (e.g. keyboard or palette selection).
+let selectedDeviceFace = $state<DeviceFace | null>(null);
 
 // Derived values (using $derived rune)
 const hasSelection = $derived(selectedType !== null);
@@ -33,6 +38,7 @@ export function resetSelectionStore(): void {
   selectedRackId = null;
   selectedGroupId = null;
   selectedDeviceId = null;
+  selectedDeviceFace = null;
 }
 
 /**
@@ -53,6 +59,9 @@ export function getSelectionStore() {
     },
     get selectedDeviceId() {
       return selectedDeviceId;
+    },
+    get selectedDeviceFace() {
+      return selectedDeviceFace;
     },
 
     // Derived getters
@@ -95,6 +104,7 @@ function selectRack(rackId: string): void {
   selectedRackId = rackId;
   selectedGroupId = null;
   selectedDeviceId = null;
+  selectedDeviceFace = null;
 }
 
 /**
@@ -114,18 +124,27 @@ function selectGroup(groupId: string, activeRackId?: string): void {
   selectedRackId = activeRackId ?? null;
   selectedGroupId = groupId;
   selectedDeviceId = null;
+  selectedDeviceFace = null;
 }
 
 /**
  * Select a device within a rack
  * @param rackId - ID of the rack containing the device
  * @param deviceId - Unique ID of the placed device (UUID)
+ * @param face - View the device was clicked in (front or rear); used to anchor
+ *   view-relative UI to the correct copy of a full-depth device (#2646).
+ *   Omit when the view is unknown (keyboard, palette, programmatic selection).
  */
-function selectDevice(rackId: string, deviceId: string): void {
+function selectDevice(
+  rackId: string,
+  deviceId: string,
+  face?: DeviceFace,
+): void {
   selectionDebug.state(
-    "selectDevice: %s in rack %s (prev: %s/%s)",
+    "selectDevice: %s in rack %s face %s (prev: %s/%s)",
     deviceId,
     rackId,
+    face,
     selectedType,
     selectedDeviceId,
   );
@@ -133,6 +152,7 @@ function selectDevice(rackId: string, deviceId: string): void {
   selectedRackId = rackId;
   selectedGroupId = null;
   selectedDeviceId = deviceId;
+  selectedDeviceFace = face ?? null;
 }
 
 /**
@@ -150,6 +170,7 @@ function clearSelection(): void {
   selectedRackId = null;
   selectedGroupId = null;
   selectedDeviceId = null;
+  selectedDeviceFace = null;
 }
 
 /**

--- a/src/lib/stores/selection.svelte.ts
+++ b/src/lib/stores/selection.svelte.ts
@@ -13,6 +13,10 @@ import { selectionDebug } from "$lib/utils/debug";
 // Selection types
 type SelectionType = "rack" | "group" | "device" | null;
 
+// The face a device can be selected in is always a concrete rendered view; a
+// full-depth device's "both" is never a clickable copy, so it is excluded here.
+type SelectedDeviceFace = Exclude<DeviceFace, "both">;
+
 // Module-level state (using $state rune)
 let selectedType = $state<SelectionType>(null);
 let selectedRackId = $state<string | null>(null);
@@ -22,7 +26,7 @@ let selectedDeviceId = $state<string | null>(null);
 // renders in both views under one UUID, so callers that position UI against the
 // selected element (the floating verb bar, #2646) need to know which copy was
 // clicked. Null when unknown (e.g. keyboard or palette selection).
-let selectedDeviceFace = $state<DeviceFace | null>(null);
+let selectedDeviceFace = $state<SelectedDeviceFace | null>(null);
 
 // Derived values (using $derived rune)
 const hasSelection = $derived(selectedType !== null);
@@ -138,7 +142,7 @@ function selectGroup(groupId: string, activeRackId?: string): void {
 function selectDevice(
   rackId: string,
   deviceId: string,
-  face?: DeviceFace,
+  face?: SelectedDeviceFace,
 ): void {
   selectionDebug.state(
     "selectDevice: %s in rack %s face %s (prev: %s/%s)",

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -369,6 +369,11 @@
   /* Side panels: persistent chrome that flanks the canvas. Above the canvas
      overlays, below the drawer/modal/dropdown layers. */
   --z-sidebar: 60;
+  /* Toolbar popovers (e.g. the storage chip details popover) portal to the body
+     and must sit above the side panels so a panel never occludes them (#2645).
+     Below the drawer/modal layers, which the passive chip popover never coexists
+     with. */
+  --z-popover: 70;
   --z-drawer-backdrop: 99;
   --z-drawer: 100;
   --z-fab: 100;

--- a/src/tests/selection-store.test.ts
+++ b/src/tests/selection-store.test.ts
@@ -110,6 +110,37 @@ describe("Selection Store", () => {
     });
   });
 
+  // The clicked face anchors view-relative UI (the floating verb bar) to the
+  // correct copy of a full-depth device, which renders in both the front and
+  // rear views under one UUID (#2646).
+  describe("selectedDeviceFace", () => {
+    it("records the face a device was selected in", () => {
+      const store = getSelectionStore();
+      store.selectDevice("rack-1", "device-uuid-123", "rear");
+      expect(store.selectedDeviceFace).toBe("rear");
+    });
+
+    it("is null when the face is not given (keyboard/palette selection)", () => {
+      const store = getSelectionStore();
+      store.selectDevice("rack-1", "device-uuid-123");
+      expect(store.selectedDeviceFace).toBeNull();
+    });
+
+    it("clears when a rack is selected", () => {
+      const store = getSelectionStore();
+      store.selectDevice("rack-1", "device-uuid-123", "rear");
+      store.selectRack("rack-2");
+      expect(store.selectedDeviceFace).toBeNull();
+    });
+
+    it("clears when the selection is cleared", () => {
+      const store = getSelectionStore();
+      store.selectDevice("rack-1", "device-uuid-123", "front");
+      store.clearSelection();
+      expect(store.selectedDeviceFace).toBeNull();
+    });
+  });
+
   describe("clearSelection", () => {
     it("resets all selection state", () => {
       const store = getSelectionStore();


### PR DESCRIPTION
## **User description**
## Summary

Fixes three canvas/panel UI bugs:

- #2645: the storage chip details popover rendered behind the right panel.
- #2646: the verb bar appeared over the front view when a rear-view device was clicked.
- #2637: relocate toasts from the top-right to the bottom-center of the canvas.

## Changes

- #2645 (`tokens.css`): `StorageStatusChip` set the popover to `z-index: var(--z-popover, 50)`, but `--z-popover` was never defined, so it fell back to `50`: below the side panel's `--z-sidebar` (60). The popover portals to the body, so the panel occluded it. Define `--z-popover: 70` so toolbar popovers sit above the side panels and below the drawer/modal layers.
- #2646 (selection store, rack/device components, verb bar): a full-depth device renders in both the front and rear views under one `data-device-uuid`, so the verb bar's `findTarget()` `querySelector` always matched the first (front) copy. Thread the clicked face through the device-select event into `selectedDeviceFace`, tag each rendered device with `data-device-face`, and scope `findTarget()` to the copy in the selected view (falling back to the first match when the face is unknown, e.g. keyboard or palette selection). The duplicate flow preserves the face so the bar stays put after Ctrl+D.
- #2637 (`ToastContainer`, `Toast`, `App.svelte`): move the toast stack to the bottom-center of the canvas region, bottom-anchored and growing upward, rising in from below instead of sliding in from the right. Mounted in both the desktop canvas-region and the mobile branch (no canvas-region there, so it anchors to `.app-main`); on mobile the stack clears the bottom nav and the safe-area inset. The container keeps its `.toast-container` class and `--z-toast`, so `neutralizeToasts` and the visual baselines are unaffected.

## Testing

- [x] Unit tests pass (`npm run test:run`): 186 files / 2943 tests green, including new `selectedDeviceFace` tracking tests.
- [x] `svelte-check` clean (0 errors, 0 warnings); ESLint clean; `prettier --check` clean.
- [ ] E2E tests pass (`npm run test:e2e`) - to run in CI.
- [ ] Manual testing: verify the popover sits above the right panel, the verb bar anchors to the clicked view in dual view, and toasts appear bottom-center (desktop and mobile). The issues' test requirements are visual.

## Screenshots

Not captured in this environment; the issues call for manual/visual verification.

## Accessibility

- [x] Meets WCAG 2.2 AA: no change to roles, names, or contrast; toasts keep their `aria-live` region and roles.
- [x] Interactive controls on mobile surfaces are at least 44x44 CSS pixels: unchanged.
- [x] `prefers-reduced-motion` respected: toast animation direction changed only (no new motion category); existing handling unchanged.
- [x] Every interactive element has a visible focus state: unchanged.
- [x] Focus is managed on open and close of panels, dialogs, and sheets: unchanged.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality (selection-store face tracking)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJLT4DUCeWSbuWFpWaC8zn)_


___

## **CodeAnt-AI Description**
Make popovers and toasts stack in the right place, and keep the verb bar attached to the device view you clicked

### What Changed
- Storage chip details now appear above the side panel instead of hiding behind it
- Toasts move to the bottom-center of the canvas, rise in from below, and stay clear of the bottom nav on smaller screens
- Clicking a full-depth device now keeps the floating verb bar anchored to the same front or rear view, including after duplicate actions
- Device selection now remembers which view was clicked and clears that view info when selection changes

### Impact
`✅ Clearer popovers`
`✅ Fewer toast overlaps`
`✅ Correct verb bar placement` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
