### PR TITLE
fix: validate NetBox-imported device types (closes #2655)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -853,6 +853,7 @@
 
 <ImportFromNetBoxDialog
   open={importFromNetBoxOpen}
+  existingSlugs={layoutStore.device_types.map((d) => d.slug)}
   onimport={handleNetBoxImport}
   oncancel={handleNetBoxImportCancel}
 />

--- a/src/lib/components/ImportFromNetBoxDialog.svelte
+++ b/src/lib/components/ImportFromNetBoxDialog.svelte
@@ -28,11 +28,13 @@
 
   interface Props {
     open: boolean;
+    /** Slugs already in the device library, so an import gets a unique slug. */
+    existingSlugs?: string[];
     onimport?: (result: ImportResult) => void;
     oncancel?: () => void;
   }
 
-  let { open, onimport, oncancel }: Props = $props();
+  let { open, existingSlugs = [], onimport, oncancel }: Props = $props();
 
   // Input mode
   type InputMode = "paste" | "upload";
@@ -194,6 +196,7 @@
       category: categoryOverride ?? undefined,
       colour: colourOverride ?? undefined,
       rack_widths: getRackWidths(),
+      existingSlugs,
     });
 
     if (!converted.success) {

--- a/src/lib/components/ImportFromNetBoxDialog.svelte
+++ b/src/lib/components/ImportFromNetBoxDialog.svelte
@@ -188,13 +188,20 @@
   function handleImport() {
     if (!parsedData) return;
 
-    const result = convertToDeviceType(parsedData, {
+    parseError = "";
+
+    const converted = convertToDeviceType(parsedData, {
       category: categoryOverride ?? undefined,
       colour: colourOverride ?? undefined,
       rack_widths: getRackWidths(),
     });
 
-    onimport?.(result);
+    if (!converted.success) {
+      parseError = converted.error;
+      return;
+    }
+
+    onimport?.(converted.result);
   }
 
   function handleCancel() {

--- a/src/lib/utils/netbox-import.test.ts
+++ b/src/lib/utils/netbox-import.test.ts
@@ -9,7 +9,10 @@ import {
   convertToDeviceType,
   importFromNetBoxYaml,
   type NetBoxDeviceType,
+  type ImportResult,
 } from "./netbox-import";
+import { parseLayoutObject } from "./yaml";
+import { createTestLayout } from "../../tests/factories";
 import { CATEGORY_COLOURS } from "$lib/types/constants";
 import { DeviceTypeSchema } from "$lib/schemas";
 
@@ -305,6 +308,18 @@ model: Some Device
   });
 
   describe("convertToDeviceType", () => {
+    // Unwrap a successful conversion. Fails the test if the conversion was
+    // refused, so the existing happy-path assertions can read .deviceType etc.
+    function convertOk(
+      ...args: Parameters<typeof convertToDeviceType>
+    ): ImportResult {
+      const converted = convertToDeviceType(...args);
+      if (!converted.success) {
+        throw new Error(`expected success, got error: ${converted.error}`);
+      }
+      return converted.result;
+    }
+
     it("converts basic NetBox device to Rackula DeviceType", () => {
       const netbox: NetBoxDeviceType = {
         manufacturer: "Ubiquiti",
@@ -314,7 +329,7 @@ model: Some Device
         is_full_depth: false,
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.slug).toBe("ubiquiti-usw-pro-24");
       expect(result.deviceType.manufacturer).toBe("Ubiquiti");
@@ -333,7 +348,7 @@ model: Some Device
         slug: "generic-unknown-device",
       };
 
-      const result = convertToDeviceType(netbox, { category: "server" });
+      const result = convertOk(netbox, { category: "server" });
 
       expect(result.deviceType.category).toBe("server");
       expect(result.deviceType.colour).toBe(CATEGORY_COLOURS.server);
@@ -346,7 +361,7 @@ model: Some Device
         slug: "ubiquiti-usw-pro-24",
       };
 
-      const result = convertToDeviceType(netbox, { colour: "#FF0000" });
+      const result = convertOk(netbox, { colour: "#FF0000" });
 
       expect(result.deviceType.colour).toBeTruthy(); // Color is set
     });
@@ -359,7 +374,7 @@ model: Some Device
         airflow: "front-to-rear",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.airflow).toBe("front-to-rear");
     });
@@ -372,7 +387,7 @@ model: Some Device
         airflow: "unknown-airflow-type",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.airflow).toBeUndefined();
       expect(result.warnings).toContain(
@@ -391,7 +406,7 @@ model: Some Device
         ],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       // eslint-disable-next-line no-restricted-syntax -- Testing conversion (exactly 2 interfaces)
       expect(result.deviceType.interfaces).toHaveLength(2);
@@ -407,7 +422,7 @@ model: Some Device
         interfaces: [{ name: "Gi1/0/1", type: "1000base-lx" }],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.interfaces![0].type).toBe("other");
       expect(result.warnings).toContain(
@@ -423,7 +438,7 @@ model: Some Device
         interfaces: [{ name: "Te1/0/1", type: "10gbase-t" }],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.interfaces![0].type).toBe("10gbase-t");
       expect(result.warnings).toEqual([]);
@@ -444,7 +459,7 @@ model: Some Device
         ],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.interfaces![0].poe_mode).toBeUndefined();
       expect(result.deviceType.interfaces![0].poe_type).toBeUndefined();
@@ -468,7 +483,7 @@ model: Some Device
         ],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.interfaces![0].poe_mode).toBe("pse");
       expect(result.deviceType.interfaces![0].poe_type).toBe(
@@ -494,7 +509,7 @@ model: Some Device
         ],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(() => DeviceTypeSchema.parse(result.deviceType)).not.toThrow();
     });
@@ -508,7 +523,7 @@ model: Some Device
         power_outlets: [{ name: "Outlet 1", power_port: "Input" }],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       // eslint-disable-next-line no-restricted-syntax -- Testing conversion (exactly 1 power port)
       expect(result.deviceType.power_ports).toHaveLength(1);
@@ -524,7 +539,7 @@ model: Some Device
         slug: "generic-device",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.u_height).toBe(1);
     });
@@ -536,7 +551,7 @@ model: Some Device
         slug: "generic-device",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.is_full_depth).toBe(true);
     });
@@ -549,7 +564,7 @@ model: Some Device
         power_outlets: [{ name: "Outlet 1", feed_leg: "A" }],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.power_outlets![0].feed_leg).toBe("A");
       expect(result.warnings).toEqual([]);
@@ -563,7 +578,7 @@ model: Some Device
         power_outlets: [{ name: "Outlet 1", feed_leg: "N" }],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.power_outlets![0].feed_leg).toBeUndefined();
       expect(result.warnings).toContain("Unknown feed_leg value: N");
@@ -578,7 +593,7 @@ model: Some Device
         weight_unit: "lb",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.weight).toBe(21.9);
       expect(result.deviceType.weight_unit).toBe("lb");
@@ -593,7 +608,7 @@ model: Some Device
         weight: 21.9,
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.weight).toBe(21.9);
       expect(result.deviceType.weight_unit).toBe("kg");
@@ -609,7 +624,7 @@ model: Some Device
         weight_unit: "g",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.weight).toBeUndefined();
       expect(result.deviceType.weight_unit).toBeUndefined();
@@ -624,7 +639,7 @@ model: Some Device
         subdevice_role: "parent",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.subdevice_role).toBe("parent");
       expect(result.warnings).toEqual([]);
@@ -638,7 +653,7 @@ model: Some Device
         subdevice_role: "standalone",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.subdevice_role).toBeUndefined();
       expect(result.warnings).toContain(
@@ -653,7 +668,7 @@ model: Some Device
         slug: "generic-device",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.weight).toBeUndefined();
       expect(result.deviceType.weight_unit).toBeUndefined();
@@ -673,7 +688,7 @@ model: Some Device
         power_outlets: [{ name: "Outlet 1", feed_leg: "N" }],
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(() => DeviceTypeSchema.parse(result.deviceType)).not.toThrow();
       expect(result.warnings.length).toBeGreaterThan(0);
@@ -687,9 +702,91 @@ model: Some Device
         comments: "This is a test device",
       };
 
-      const result = convertToDeviceType(netbox);
+      const result = convertOk(netbox);
 
       expect(result.deviceType.notes).toBe("This is a test device");
+    });
+  });
+
+  describe("convertToDeviceType validation gate", () => {
+    const base: NetBoxDeviceType = {
+      manufacturer: "Generic",
+      model: "Device",
+      slug: "generic-device",
+    };
+
+    it.each([2.7, 0, -1, 99999])(
+      "refuses out-of-range u_height %p instead of producing a DeviceType",
+      (u_height) => {
+        const converted = convertToDeviceType({ ...base, u_height });
+
+        expect(converted.success).toBe(false);
+        if (!converted.success) {
+          expect(converted.error).toContain("u_height");
+        }
+      },
+    );
+
+    it("accepts an in-bounds half-U height", () => {
+      const converted = convertToDeviceType({ ...base, u_height: 1.5 });
+
+      expect(converted.success).toBe(true);
+      if (converted.success) {
+        expect(converted.result.deviceType.u_height).toBe(1.5);
+      }
+    });
+
+    it.each([
+      ["Weird Box", "weird-box"],
+      ["My Switch!", "my-switch"],
+      ["UPPER_CASE Name", "upper-case-name"],
+    ])(
+      "normalises an invalid slug %p to a SLUG_PATTERN-conforming slug",
+      (slug, expected) => {
+        const converted = convertToDeviceType({ ...base, slug });
+
+        expect(converted.success).toBe(true);
+        if (converted.success) {
+          expect(converted.result.deviceType.slug).toBe(expected);
+        }
+      },
+    );
+
+    it("falls back to manufacturer/model when the slug normalises to empty", () => {
+      const converted = convertToDeviceType({
+        manufacturer: "Acme",
+        model: "Rack Unit 1",
+        slug: "!!!",
+      });
+
+      expect(converted.success).toBe(true);
+      if (converted.success) {
+        expect(converted.result.deviceType.slug).toBe("acme-rack-unit-1");
+      }
+    });
+
+    it("round-trips an imported device through parseLayoutObject without rejection", () => {
+      const converted = convertToDeviceType({
+        manufacturer: "Ubiquiti",
+        model: "USW Pro 24",
+        slug: "Weird Box",
+        u_height: 1,
+      });
+
+      expect(converted.success).toBe(true);
+      if (!converted.success) return;
+
+      const layout = createTestLayout({
+        device_types: [converted.result.deviceType],
+      });
+
+      // Mirror the autosave path: JSON serialize, then parse back.
+      const roundTripped = parseLayoutObject(
+        JSON.parse(JSON.stringify(layout)),
+      );
+
+      expect(roundTripped).not.toBeNull();
+      expect(roundTripped?.device_types[0]?.slug).toBe("weird-box");
     });
   });
 

--- a/src/lib/utils/netbox-import.test.ts
+++ b/src/lib/utils/netbox-import.test.ts
@@ -12,7 +12,10 @@ import {
   type ImportResult,
 } from "./netbox-import";
 import { parseLayoutObject } from "./yaml";
-import { createTestLayout } from "../../tests/factories";
+import {
+  createTestLayout,
+  createTestNetBoxDeviceType,
+} from "../../tests/factories";
 import { CATEGORY_COLOURS } from "$lib/types/constants";
 import { DeviceTypeSchema } from "$lib/schemas";
 
@@ -709,16 +712,12 @@ model: Some Device
   });
 
   describe("convertToDeviceType validation gate", () => {
-    const base: NetBoxDeviceType = {
-      manufacturer: "Generic",
-      model: "Device",
-      slug: "generic-device",
-    };
-
     it.each([2.7, 0, -1, 99999])(
       "refuses out-of-range u_height %p instead of producing a DeviceType",
       (u_height) => {
-        const converted = convertToDeviceType({ ...base, u_height });
+        const converted = convertToDeviceType(
+          createTestNetBoxDeviceType({ u_height }),
+        );
 
         expect(converted.success).toBe(false);
         if (!converted.success) {
@@ -727,8 +726,21 @@ model: Some Device
       },
     );
 
+    it.each([0.5, 50])("accepts boundary u_height %p", (u_height) => {
+      const converted = convertToDeviceType(
+        createTestNetBoxDeviceType({ u_height }),
+      );
+
+      expect(converted.success).toBe(true);
+      if (converted.success) {
+        expect(converted.result.deviceType.u_height).toBe(u_height);
+      }
+    });
+
     it("accepts an in-bounds half-U height", () => {
-      const converted = convertToDeviceType({ ...base, u_height: 1.5 });
+      const converted = convertToDeviceType(
+        createTestNetBoxDeviceType({ u_height: 1.5 }),
+      );
 
       expect(converted.success).toBe(true);
       if (converted.success) {
@@ -743,7 +755,9 @@ model: Some Device
     ])(
       "normalises an invalid slug %p to a SLUG_PATTERN-conforming slug",
       (slug, expected) => {
-        const converted = convertToDeviceType({ ...base, slug });
+        const converted = convertToDeviceType(
+          createTestNetBoxDeviceType({ slug }),
+        );
 
         expect(converted.success).toBe(true);
         if (converted.success) {
@@ -753,11 +767,13 @@ model: Some Device
     );
 
     it("falls back to manufacturer/model when the slug normalises to empty", () => {
-      const converted = convertToDeviceType({
-        manufacturer: "Acme",
-        model: "Rack Unit 1",
-        slug: "!!!",
-      });
+      const converted = convertToDeviceType(
+        createTestNetBoxDeviceType({
+          manufacturer: "Acme",
+          model: "Rack Unit 1",
+          slug: "!!!",
+        }),
+      );
 
       expect(converted.success).toBe(true);
       if (converted.success) {
@@ -765,13 +781,88 @@ model: Some Device
       }
     });
 
-    it("round-trips an imported device through parseLayoutObject without rejection", () => {
-      const converted = convertToDeviceType({
-        manufacturer: "Ubiquiti",
-        model: "USW Pro 24",
-        slug: "Weird Box",
-        u_height: 1,
+    it.each(["manufacturer", "model", "slug"] as const)(
+      "refuses a non-string %s instead of throwing",
+      (field) => {
+        // A non-string scalar (e.g. `slug: 123` in the YAML) passes the
+        // truthiness check in parseNetBoxYaml; the guard must return a clean
+        // failure rather than throwing a TypeError inside a string helper.
+        const converted = convertToDeviceType(
+          createTestNetBoxDeviceType({
+            [field]: 123,
+          } as unknown as Partial<NetBoxDeviceType>),
+        );
+
+        expect(converted.success).toBe(false);
+        if (!converted.success) {
+          expect(converted.error).toContain(field);
+        }
+      },
+    );
+
+    it("suffixes the slug when it collides with an existing library slug", () => {
+      // An existing "weird-box" plus an imported "Weird Box" both normalise to
+      // "weird-box"; the import must get a distinct slug, not a duplicate.
+      const converted = convertToDeviceType(
+        createTestNetBoxDeviceType({ slug: "Weird Box" }),
+        { existingSlugs: ["weird-box"] },
+      );
+
+      expect(converted.success).toBe(true);
+      if (converted.success) {
+        expect(converted.result.deviceType.slug).not.toBe("weird-box");
+        expect(converted.result.deviceType.slug).toBe("weird-box-2");
+      }
+    });
+
+    it("keeps the normalised slug when it does not collide", () => {
+      const converted = convertToDeviceType(
+        createTestNetBoxDeviceType({ slug: "Weird Box" }),
+        { existingSlugs: ["something-else"] },
+      );
+
+      expect(converted.success).toBe(true);
+      if (converted.success) {
+        expect(converted.result.deviceType.slug).toBe("weird-box");
+      }
+    });
+
+    it("round-trips a colliding import through parseLayoutObject without duplicate-slug rejection", () => {
+      const existing = convertToDeviceType(
+        createTestNetBoxDeviceType({ slug: "weird-box" }),
+      );
+      expect(existing.success).toBe(true);
+      if (!existing.success) return;
+
+      const imported = convertToDeviceType(
+        createTestNetBoxDeviceType({ model: "Other Box", slug: "Weird Box" }),
+        { existingSlugs: [existing.result.deviceType.slug] },
+      );
+      expect(imported.success).toBe(true);
+      if (!imported.success) return;
+
+      const layout = createTestLayout({
+        device_types: [existing.result.deviceType, imported.result.deviceType],
       });
+
+      // Mirror the autosave path: JSON serialize, then parse back. A duplicate
+      // slug would make validateSlugUniqueness reject the layout (null result).
+      const roundTripped = parseLayoutObject(
+        JSON.parse(JSON.stringify(layout)),
+      );
+
+      expect(roundTripped).not.toBeNull();
+    });
+
+    it("round-trips an imported device through parseLayoutObject without rejection", () => {
+      const converted = convertToDeviceType(
+        createTestNetBoxDeviceType({
+          manufacturer: "Ubiquiti",
+          model: "USW Pro 24",
+          slug: "Weird Box",
+          u_height: 1,
+        }),
+      );
 
       expect(converted.success).toBe(true);
       if (!converted.success) return;

--- a/src/lib/utils/netbox-import.ts
+++ b/src/lib/utils/netbox-import.ts
@@ -12,6 +12,7 @@ import type {
 } from "$lib/types";
 import { CATEGORY_COLOURS } from "$lib/types/constants";
 import {
+  DeviceTypeSchema,
   InterfaceTypeSchema,
   PoEModeSchema,
   PoETypeSchema,
@@ -20,6 +21,7 @@ import {
   WeightUnitSchema,
 } from "$lib/schemas";
 import { parseYaml } from "./yaml";
+import { generateDeviceSlug, slugify } from "./slug";
 
 const FeedLegSchema = PowerOutletSchema.shape.feed_leg;
 
@@ -114,7 +116,20 @@ export interface NetBoxParseError {
 export type NetBoxParseOutput = NetBoxParseResult | NetBoxParseError;
 
 /**
- * Result of converting to Rackula DeviceType
+ * Result of converting to Rackula DeviceType.
+ *
+ * `convertToDeviceType` returns either a success carrying the validated
+ * `DeviceType`, or a failure carrying a human-readable error. The failure
+ * branch never yields a `DeviceType`, so an out-of-range `u_height` or a
+ * non-conforming `slug` cannot enter the device library.
+ */
+export type ConvertResult =
+  | { success: true; result: ImportResult }
+  | { success: false; error: string };
+
+/**
+ * Successful conversion payload: the validated DeviceType plus the inferred
+ * category and any non-fatal warnings raised while mapping NetBox fields.
  */
 export interface ImportResult {
   deviceType: DeviceType;
@@ -393,7 +408,7 @@ export function convertToDeviceType(
     colour?: string;
     rack_widths?: RackWidth[];
   },
-): ImportResult {
+): ConvertResult {
   const warnings: string[] = [];
 
   // Infer category if not provided
@@ -403,9 +418,17 @@ export function convertToDeviceType(
   // Use provided colour or default for category
   const colour = options?.colour ?? CATEGORY_COLOURS[category];
 
+  // Normalise the slug through the same helper the JSON import path uses so the
+  // stored slug always matches SLUG_PATTERN. NetBox slugs are already lowercase
+  // hyphenated by convention, but a hand-edited paste ("My Switch!") would
+  // otherwise fail LayoutSchema on the next reload and discard the autosave.
+  const slug =
+    slugify(netbox.slug) ||
+    generateDeviceSlug(netbox.manufacturer, netbox.model);
+
   // Build the device type
   const deviceType: DeviceType = {
-    slug: netbox.slug,
+    slug,
     manufacturer: netbox.manufacturer,
     model: netbox.model,
     u_height: netbox.u_height ?? 1,
@@ -513,10 +536,27 @@ export function convertToDeviceType(
     }));
   }
 
+  // Validate the built DeviceType against the schema before it can enter the
+  // library. NetBox values pass through as-is, so an out-of-range u_height
+  // (2.7, 0, -1, 99999) or a slug that could not be normalised must be refused
+  // here rather than stored and silently discarded on the next reload.
+  const parsed = DeviceTypeSchema.safeParse(deviceType);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const field = first?.path.join(".") || "device";
+    return {
+      success: false,
+      error: `Invalid device type: ${field}: ${first?.message ?? "validation failed"}`,
+    };
+  }
+
   return {
-    deviceType,
-    inferredCategory,
-    warnings,
+    success: true,
+    result: {
+      deviceType: parsed.data,
+      inferredCategory,
+      warnings,
+    },
   };
 }
 
@@ -529,15 +569,12 @@ export async function importFromNetBoxYaml(
     category?: DeviceCategory;
     colour?: string;
   },
-): Promise<
-  { success: true; result: ImportResult } | { success: false; error: string }
-> {
+): Promise<ConvertResult> {
   const parseResult = await parseNetBoxYaml(yamlString);
 
   if (parseResult.success === false) {
     return { success: false, error: parseResult.error };
   }
 
-  const result = convertToDeviceType(parseResult.data, options);
-  return { success: true, result };
+  return convertToDeviceType(parseResult.data, options);
 }

--- a/src/lib/utils/netbox-import.ts
+++ b/src/lib/utils/netbox-import.ts
@@ -21,7 +21,7 @@ import {
   WeightUnitSchema,
 } from "$lib/schemas";
 import { parseYaml } from "./yaml";
-import { generateDeviceSlug, slugify } from "./slug";
+import { ensureUniqueSlug, generateDeviceSlug, slugify } from "./slug";
 
 const FeedLegSchema = PowerOutletSchema.shape.feed_leg;
 
@@ -407,9 +407,23 @@ export function convertToDeviceType(
     category?: DeviceCategory;
     colour?: string;
     rack_widths?: RackWidth[];
+    existingSlugs?: Iterable<string>;
   },
 ): ConvertResult {
   const warnings: string[] = [];
+
+  // Guard the identity fields before any string helper runs. A non-string
+  // scalar (e.g. `slug: 123` in the YAML) passes parseNetBoxYaml's truthiness
+  // check, so inferCategory/slugify would throw a TypeError before the schema
+  // could return a clean failure. Refuse it here with a readable message.
+  for (const field of ["manufacturer", "model", "slug"] as const) {
+    if (typeof netbox[field] !== "string") {
+      return {
+        success: false,
+        error: `Invalid device type: ${field} must be a string`,
+      };
+    }
+  }
 
   // Infer category if not provided
   const inferredCategory = inferCategory(netbox);
@@ -422,9 +436,18 @@ export function convertToDeviceType(
   // stored slug always matches SLUG_PATTERN. NetBox slugs are already lowercase
   // hyphenated by convention, but a hand-edited paste ("My Switch!") would
   // otherwise fail LayoutSchema on the next reload and discard the autosave.
-  const slug =
+  const normalisedSlug =
     slugify(netbox.slug) ||
     generateDeviceSlug(netbox.manufacturer, netbox.model);
+
+  // Suffix the slug if it collides with an existing device-type slug. Two
+  // imports can normalise to the same slug (an existing "weird-box" plus an
+  // imported "Weird Box"); a duplicate would make LayoutSchema reject the whole
+  // layout on the next reload and discard the autosave, the failure this guards.
+  const slug = ensureUniqueSlug(
+    normalisedSlug,
+    new Set(options?.existingSlugs ?? []),
+  );
 
   // Build the device type
   const deviceType: DeviceType = {
@@ -568,6 +591,7 @@ export async function importFromNetBoxYaml(
   options?: {
     category?: DeviceCategory;
     colour?: string;
+    existingSlugs?: Iterable<string>;
   },
 ): Promise<ConvertResult> {
   const parseResult = await parseNetBoxYaml(yamlString);

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -27,6 +27,7 @@ import type {
   SlotWidth,
 } from "$lib/types";
 import type { CreateDeviceTypeInput } from "$lib/stores/layout-helpers";
+import type { NetBoxDeviceType } from "$lib/utils/netbox-import";
 import type { Command, CommandType } from "$lib/stores/commands/types";
 import { toInternalUnits } from "$lib/utils/position";
 import { CATEGORY_COLOURS } from "$lib/types/constants";
@@ -144,6 +145,24 @@ export function createTestDeviceTypeInput(
     u_height: 1,
     category: "server",
     colour: "#4A90D9",
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a NetBoxDeviceType with the three required identity fields filled in.
+ * Use this in netbox-import tests and override only the field under test.
+ *
+ * @example
+ * const netbox = createTestNetBoxDeviceType({ slug: "Weird Box" });
+ */
+export function createTestNetBoxDeviceType(
+  overrides: Partial<NetBoxDeviceType> = {},
+): NetBoxDeviceType {
+  return {
+    manufacturer: "Generic",
+    model: "Device",
+    slug: "generic-device",
     ...overrides,
   };
 }


### PR DESCRIPTION
## **User description**
## Summary

The in-app "Import from NetBox" path copied `u_height` and `slug` verbatim into the device library without running `DeviceTypeSchema`. An out-of-range `u_height` (2.7, 0, -1, 99999) or a non-conforming `slug` ("My Switch!") produced a device type that failed `LayoutSchema` on the next reload, silently discarding the entire autosaved layout. NetBox was the only device-type ingress that skipped the validation and re-slugify the JSON import path already performs.

This change validates and normalises NetBox-imported device types at the conversion boundary so a bad value is refused up front instead of being stored and discarded on reload. Import-side only: it does not change how prior-release saved layouts are read, so no upgrade-corpus fixture is needed.

## Changes

- `convertToDeviceType` now returns a discriminated `ConvertResult` (`{ success: true, result } | { success: false, error }`) and runs `DeviceTypeSchema.safeParse` on the built `DeviceType` before returning success. On failure it returns a human-readable error instead of a `DeviceType`, so an invalid type can never enter the library.
- The NetBox `slug` is normalised through the same slug helper the JSON import path uses (`slugify`, falling back to `generateDeviceSlug(manufacturer, model)`), so the stored slug always matches `SLUG_PATTERN`.
- `u_height` is validated against the schema bounds (0.5 to 50, multiple of 0.5) via the same `safeParse`; out-of-range values are refused.
- `importFromNetBoxYaml` now returns `ConvertResult` (shape-identical to its previous inline union) and delegates refusal to `convertToDeviceType`.
- `ImportFromNetBoxDialog.handleImport` checks `converted.success` and surfaces `converted.error` in the dialog (clearing any stale error first) instead of importing.

## Acceptance criteria coverage

- `DeviceTypeSchema.safeParse` runs on the built `DeviceType` before it enters the library; on failure the import is refused and a parse error is surfaced in the dialog instead of calling `addDeviceTypeRaw`.
- `netbox.slug` is normalised through the same slug helper the JSON import path uses, so the stored slug always matches `SLUG_PATTERN`.
- `u_height` is validated against the schema bounds before storage.
- A NetBox import carrying an out-of-range `u_height` or an invalid slug no longer corrupts the library; a round-trip test proves a subsequent reload of the autosave succeeds (the layout is not discarded).
- Validation gates only the NetBox import entry point and does not retroactively reject already-loaded valid device types.

## Testing

- [x] Unit tests pass (`npm run test:run`) - 2949 passed across 186 files
- [ ] E2E tests pass (`npm run test:e2e`) - not run in this environment
- [x] `npm run lint` clean
- [x] `npm run build` succeeds

New tests in `src/lib/utils/netbox-import.test.ts` (added TDD-first, confirmed failing against the old implementation):

- `convertToDeviceType` refuses out-of-range `u_height` (2.7, 0, -1, 99999) rather than producing a `DeviceType`.
- Accepts an in-bounds half-U height (1.5).
- Normalises invalid slugs ("Weird Box", "My Switch!", "UPPER_CASE Name") to a `SLUG_PATTERN`-conforming slug.
- Falls back to manufacturer/model when the slug normalises to empty.
- Round-trips an imported device through `parseLayoutObject` (via the JSON autosave path) and asserts the result is non-null.

Existing `convertToDeviceType` tests were updated to unwrap the new `ConvertResult` via a small `convertOk` helper; behaviour assertions are unchanged.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2655

---
_Generated by [Claude Code](https://claude.ai/code/session_01RooRqS7eKzkgn3Yhczq43e)_


___

## **CodeAnt-AI Description**
**Reject invalid NetBox imports before they are saved**

### What Changed
- NetBox imports now refuse device types with invalid rack height values instead of saving data that breaks on the next reload
- Imported slugs are cleaned up before saving, so pasted names like “My Switch!” become valid slugs and do not disappear after reload
- The import dialog now shows the validation error directly and stops the import when the device type is not usable
- Added coverage for invalid heights, slug cleanup, and round-tripping imported layouts without rejection

### Impact
`✅ Fewer lost autosaved layouts`
`✅ Clearer NetBox import errors`
`✅ Safer device imports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NetBox import handling so invalid data is rejected with a clear error instead of partially importing.
  * Normalised imported slugs and added a fallback when no valid slug is available.
  * Refined import validation for device height and other schema checks to prevent bad records from getting through.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->