### PR TITLE
fix: bound share-link decode size (closes #2658)

### DIFF
--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -423,6 +423,58 @@ export interface DecodeResult {
 }
 
 /**
+ * Maximum length of an encoded `?l=` value accepted by decodeLayout, in
+ * characters. Checked before any base64 decode or decompression so a crafted
+ * link cannot spend CPU/memory inflating before being rejected.
+ *
+ * Kept small on purpose: lz-string (the primary format) has no streaming decode,
+ * so it fully materializes its output before we can measure it. Capping the
+ * input is the only way to bound that transient, and lz-string's ratio against
+ * crafted repetitive input climbs past 2000:1. 64 KB stays well above the
+ * largest realistic layout (an extreme 100-rack/4200-device layout encodes to
+ * ~35 KB; normal links are a few KB) while keeping the worst-case lz-string
+ * transient far below the unbounded status quo.
+ */
+export const MAX_ENCODED_LENGTH = 64 * 1024;
+
+/**
+ * Maximum number of decompressed bytes accepted by decodeLayout. Bounds the
+ * decompression-bomb surface: inflation aborts once output exceeds this. Chosen
+ * comfortably above any real layout (which serialize to well under 1 MB).
+ */
+export const MAX_DECOMPRESSED_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Inflate a pako/gzip payload to a string, aborting if output exceeds
+ * MAX_DECOMPRESSED_BYTES. Uses an incremental Inflate instance so a high-ratio
+ * payload cannot buffer its entire output before the cap is enforced.
+ * Throws on malformed input or when the size ceiling is exceeded.
+ */
+function inflateBounded(compressed: Uint8Array): string {
+  const inflator = new pako.Inflate({ to: "string" });
+  let result = "";
+  let length = 0;
+
+  inflator.onData = (chunk) => {
+    const text = chunk as string;
+    length += text.length;
+    if (length > MAX_DECOMPRESSED_BYTES) {
+      // Throw from the chunk callback to abort pako's inflate loop early, so a
+      // high-ratio payload cannot finish inflating its full output.
+      throw new Error("Decompressed share link exceeds size limit");
+    }
+    result += text;
+  };
+
+  inflator.push(compressed, true);
+
+  if (inflator.err) {
+    throw new Error(inflator.msg || "Failed to inflate share link");
+  }
+  return result;
+}
+
+/**
  * Decode URL-safe compressed string to Layout
  * Supports both v1 (single rack) and v2 (multi-rack) formats.
  * Detects version by field presence: `r` = v1, `rs` = v2.
@@ -430,13 +482,25 @@ export interface DecodeResult {
  */
 export function decodeLayout(encoded: string): DecodeResult {
   try {
+    // Reject over-length input before any base64 decode or decompression so a
+    // crafted link cannot spend CPU/memory inflating before being rejected.
+    if (encoded.length > MAX_ENCODED_LENGTH) {
+      return { layout: null, error: "Share link is too large" };
+    }
+
     // Try lz-string first (new format); returns null for legacy pako-encoded URLs
     let json = LZString.decompressFromEncodedURIComponent(encoded);
 
-    if (!json) {
-      // Fall back to pako for URLs encoded before the lz-string migration
+    if (json) {
+      // Guard the lz-string output too: it is also attacker-controlled.
+      if (json.length > MAX_DECOMPRESSED_BYTES) {
+        return { layout: null, error: "Share link is too large" };
+      }
+    } else {
+      // Fall back to pako for URLs encoded before the lz-string migration.
+      // inflateBounded aborts if output exceeds the decompressed ceiling.
       const compressed = base64UrlDecode(encoded);
-      json = pako.inflate(compressed, { to: "string" });
+      json = inflateBounded(compressed);
     }
     const parsed = JSON.parse(json);
 

--- a/src/tests/share.test.ts
+++ b/src/tests/share.test.ts
@@ -14,6 +14,8 @@ import {
   getShareParam,
   clearShareParam,
   base64UrlEncode,
+  MAX_ENCODED_LENGTH,
+  MAX_DECOMPRESSED_BYTES,
 } from "$lib/utils/share";
 import {
   createTestLayout,
@@ -353,6 +355,40 @@ describe("decodeLayout", () => {
     const decoded = requireDecoded(encoded);
 
     expect(decoded.racks[0].devices[0].name).toBe("My Custom Name");
+  });
+
+  it("rejects an over-length encoded input before decompressing", () => {
+    // Spy on the inflate paths to confirm the size guard short-circuits before
+    // any decompression runs. decodeLayout uses pako.Inflate (class) for the
+    // legacy path; pako.inflate (function) is covered too for completeness.
+    const inflateSpy = vi.spyOn(pako, "inflate");
+    const InflateSpy = vi.spyOn(pako, "Inflate");
+    const oversized = "A".repeat(MAX_ENCODED_LENGTH + 1);
+
+    const result = decodeLayout(oversized);
+
+    expect(result.layout).toBeNull();
+    expect(result.error).toBeDefined();
+    expect(inflateSpy).not.toHaveBeenCalled();
+    expect(InflateSpy).not.toHaveBeenCalled();
+    inflateSpy.mockRestore();
+    InflateSpy.mockRestore();
+  });
+
+  it("aborts decompression when output exceeds the decompressed ceiling", () => {
+    // A small, highly compressible payload that inflates past the ceiling.
+    // Stays well under MAX_ENCODED_LENGTH so the input-size guard passes and
+    // the decompressed-size ceiling is the thing under test.
+    const huge = "a".repeat(MAX_DECOMPRESSED_BYTES + 1024);
+    const compressed = pako.deflate(huge);
+    const encoded = base64UrlEncode(compressed);
+
+    expect(encoded.length).toBeLessThanOrEqual(MAX_ENCODED_LENGTH);
+
+    const result = decodeLayout(encoded);
+
+    expect(result.layout).toBeNull();
+    expect(result.error).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

`decodeLayout` decompressed a fully attacker-controlled `?l=` URL parameter with no input-size or decompressed-size cap. A crafted share link could inflate to hundreds of MB on the main thread and freeze or OOM-crash the victim tab on page load, with the victim only clicking a link (threat model TM-004). This PR bounds the decode cost on every path.

## Changes

- Reject an over-length encoded input (`MAX_ENCODED_LENGTH`, 64 KB) before any base64 decode or decompression, returning a decode error. The cap is kept tight because lz-string (the primary format) has no streaming decode and fully materializes its output before it can be measured, so bounding the input is the only way to bound that transient. lz-string's ratio against crafted repetitive input climbs past 2000:1; 64 KB still sits well above the largest realistic layout (an extreme 100-rack / 4200-device layout encodes to ~35 KB, normal links are a few KB).
- Bound the legacy pako path with a streamed `pako.Inflate()` instance (`inflateBounded`) that aborts once output exceeds `MAX_DECOMPRESSED_BYTES` (8 MB), instead of buffering the whole output via `{ to: "string" }`. The abort throws from the chunk callback, which pako propagates synchronously, so a high-ratio payload never finishes inflating.
- Guard the lz-string result length against the same 8 MB ceiling before `JSON.parse`.

## AC coverage

- decodeLayout rejects an over-length encoded input before any base64 decode or decompression: done (`encoded.length > MAX_ENCODED_LENGTH` short-circuit).
- The pako path is bounded and aborts past a sane ceiling instead of buffering the whole output: done (`inflateBounded` streams and aborts at `MAX_DECOMPRESSED_BYTES`).
- A crafted oversized payload returns a decode error instead of hanging or crashing the tab: done (both the over-length input and the high-ratio payload return the decode-error path).
- Existing valid share links, including the pre-migration pako/v1 links, still decode: done (the v1 and pako-v2 fixtures in `share.test.ts` still pass; real layouts are a few KB, far under both caps).

## Testing

How was this tested?

- [x] Unit tests pass (`npm run test:run`) - 2941 passed across 186 files
- [ ] E2E tests pass (`npm run test:e2e`) - not run in this environment
- [x] Manual testing completed - empirically verified pako abort propagation, malformed-input handling, lz-string expansion ratios, and legacy-fixture round-trips

Added unit tests in `src/tests/share.test.ts`:
- an over-length encoded input returns the decode-error path and never calls inflate (`pako.inflate` and `pako.Inflate` both asserted not-called)
- a high-ratio payload that exceeds the decompressed ceiling returns an error rather than completing
- existing valid v1/pako and v2 fixtures still decode (unchanged, kept green)

Lint clean, full unit suite green, production build succeeds.

## Accessibility

Non-UI change; not applicable. The only user-facing surface is an error-toast string ("Share link is too large") with no em dashes or smart quotes.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2658

---
_Generated by [Claude Code](https://claude.ai/code/session_01RooRqS7eKzkgn3Yhczq43e)_


___

## **CodeAnt-AI Description**
**Reject oversized share links before they can freeze the page**

### What Changed
- Share links that are too large are now rejected up front instead of being decompressed first
- Legacy share links are also capped while expanding, so crafted payloads stop with an error instead of hanging or crashing the tab
- Normal share links still decode as before

### Impact
`✅ Fewer tab freezes from shared links`
`✅ Lower chance of browser crashes on page load`
`✅ Clearer errors for oversized share URLs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
