### PR TITLE
test: align stale self-hosted e2e to shipped mobile top bar and device labels

### DIFF
--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -73,9 +73,13 @@ test.describe("Responsive Layout", () => {
       await expect(page.getByTestId("mobile-layout-name")).toBeVisible();
     });
 
-    test("brand logo is still visible", async ({ page }) => {
-      const logoMark = page.locator(locators.toolbar.brandLogoMark);
-      await expect(logoMark).toBeVisible();
+    test("app menu is reachable via the mobile hamburger", async ({ page }) => {
+      // Below the 1024px mobile breakpoint (viewport.svelte.ts) the desktop
+      // logo lockup (the AppMenu trigger with its .logo-mark) is not rendered.
+      // The restructured mobile top bar (#2458, #2597) exposes the same app
+      // menu through a hamburger button instead, so that is the affordance to
+      // assert here. The desktop .logo-mark is covered by the desktop suite.
+      await expect(page.getByTestId("btn-app-menu-mobile")).toBeVisible();
     });
 
     test("mobile bottom navigation is visible", async ({ page }) => {
@@ -102,14 +106,14 @@ test.describe("Responsive Layout", () => {
       await gotoWithRack(page);
     });
 
-    test("brand logo remains visible in toolbar", async ({ page }) => {
-      const logoMark = page.locator(locators.toolbar.brandLogoMark);
-      await expect(logoMark).toBeVisible();
-    });
-
-    test("logo mark is visible", async ({ page }) => {
-      const logo = page.locator(locators.toolbar.brandLogoMark);
-      await expect(logo).toBeVisible();
+    test("app menu hamburger is visible in the mobile top bar", async ({
+      page,
+    }) => {
+      // At 600px the app renders the mobile top bar (the 1024px mobile
+      // breakpoint in viewport.svelte.ts). The desktop logo lockup and its
+      // .logo-mark are not present; the hamburger button is the app-menu
+      // affordance on mobile (#2458, #2597).
+      await expect(page.getByTestId("btn-app-menu-mobile")).toBeVisible();
     });
 
     test("no horizontal scroll", async ({ page }) => {

--- a/e2e/starter-library.spec.ts
+++ b/e2e/starter-library.spec.ts
@@ -23,7 +23,11 @@ test.describe("Starter Library", () => {
   });
 
   test("all 12 categories are represented in the palette", async ({ page }) => {
-    // Aria-label format: "${model}, ${u_height}U, ${category}"
+    // Aria-label format: "${model}, ${u_height}U, ${category}", with a
+    // trailing ", half-depth" appended when the device sets is_full_depth:
+    // false (DevicePaletteItem.svelte builds the accessible name). Half-depth
+    // devices (patch panels, PDU, fan panel, blank panels, brush panel, cable
+    // manager) therefore carry that suffix, so their assertions match it.
 
     // Server category (3 items)
     await expect(
@@ -58,16 +62,16 @@ test.describe("Starter Library", () => {
       }),
     ).toBeVisible();
 
-    // Patch Panel category (2 items)
+    // Patch Panel category (both half-depth, so the name carries ", half-depth")
     await expect(
       page.getByRole("listitem", {
-        name: "Patch Panel (24-Port), 1U, patch-panel",
+        name: "Patch Panel (24-Port), 1U, patch-panel, half-depth",
         exact: true,
       }),
     ).toBeVisible();
     await expect(
       page.getByRole("listitem", {
-        name: "Patch Panel (48-Port), 2U, patch-panel",
+        name: "Patch Panel (48-Port), 2U, patch-panel, half-depth",
         exact: true,
       }),
     ).toBeVisible();
@@ -92,9 +96,12 @@ test.describe("Starter Library", () => {
       }),
     ).toBeVisible();
 
-    // Power category (3 items)
+    // Power category (3 items). The 1U PDU is half-depth.
     await expect(
-      page.getByRole("listitem", { name: "PDU, 1U, power", exact: true }),
+      page.getByRole("listitem", {
+        name: "PDU, 1U, power, half-depth",
+        exact: true,
+      }),
     ).toBeVisible();
     await expect(
       page.getByRole("listitem", { name: "UPS, 2U, power", exact: true }),
@@ -131,30 +138,30 @@ test.describe("Starter Library", () => {
       }),
     ).toBeVisible();
 
-    // Cooling category (1 item)
+    // Cooling category (1 item, half-depth)
     await expect(
       page.getByRole("listitem", {
-        name: "Fan Panel, 1U, cooling",
+        name: "Fan Panel, 1U, cooling, half-depth",
         exact: true,
       }),
     ).toBeVisible();
 
-    // Blank category (3 items)
+    // Blank category (3 items, all half-depth)
     await expect(
       page.getByRole("listitem", {
-        name: "Blank Panel, 0.5U, blank",
+        name: "Blank Panel, 0.5U, blank, half-depth",
         exact: true,
       }),
     ).toBeVisible();
     await expect(
       page.getByRole("listitem", {
-        name: "Blank Panel, 1U, blank",
+        name: "Blank Panel, 1U, blank, half-depth",
         exact: true,
       }),
     ).toBeVisible();
     await expect(
       page.getByRole("listitem", {
-        name: "Blank Panel, 2U, blank",
+        name: "Blank Panel, 2U, blank, half-depth",
         exact: true,
       }),
     ).toBeVisible();
@@ -167,16 +174,16 @@ test.describe("Starter Library", () => {
       page.getByRole("listitem", { name: "Shelf, 2U, shelf", exact: true }),
     ).toBeVisible();
 
-    // Cable Management category (2 items)
+    // Cable Management category (2 items, both half-depth)
     await expect(
       page.getByRole("listitem", {
-        name: "Brush Panel, 1U, cable-management",
+        name: "Brush Panel, 1U, cable-management, half-depth",
         exact: true,
       }),
     ).toBeVisible();
     await expect(
       page.getByRole("listitem", {
-        name: "Cable Manager, 1U, cable-management",
+        name: "Cable Manager, 1U, cable-management, half-depth",
         exact: true,
       }),
     ).toBeVisible();


### PR DESCRIPTION
## **User description**
## Summary

Two e2e specs fail on `main` independent of any PR. They are stale tests that drifted from shipped behaviour, not app regressions. This change is test-only: it aligns the assertions to the app's current behaviour and changes no app or source code.

Closes #2643

## Changes

- `e2e/responsive.spec.ts`
  - `viewport.svelte.ts` sets `MOBILE_BREAKPOINT = "(max-width: 1024px)"`, so at 900px and 600px the app renders the mobile top bar (restructured to hamburger-only in #2458, #2597). The desktop logo lockup and its `.logo-mark` are not rendered at those widths, so the three assertions on `locators.toolbar.brandLogoMark` could never pass.
  - Medium (900px): replaced `brand logo is still visible` with `app menu is reachable via the mobile hamburger`, asserting `btn-app-menu-mobile` is visible.
  - Small (600px): the two redundant logo-mark tests are merged into one `app menu hamburger is visible in the mobile top bar` test.
  - The Desktop (1200px) suite keeps its `.logo-mark` assertion, since the desktop logo is rendered there.
- `e2e/starter-library.spec.ts`
  - `DevicePaletteItem.svelte` builds the listitem accessible name as `"${model}, ${u_height}U, ${category}"` and appends `, half-depth` when a device sets `is_full_depth: false`. The patch panels, 1U PDU, fan panel, blank panels, brush panel, and cable manager are half-depth, so their exact-match names had drifted. Updated those assertions to the current accessible names (including the `, half-depth` suffix). The reported `Patch Panel (24-Port)` failure was one instance of this; the other half-depth entries were fixed in the same pass.

## Testing

The full Chromium browser suite cannot run in the dev environment (Chromium binary is not at Playwright's expected path), so the targeted e2e specs were validated by parse/list and by static checks. The self-hosted e2e CI job exercises the browsers.

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run check` introduces no new errors (the single pre-existing `src/lib/utils/share.ts` error is present on `main` and is unrelated to this change)
- [x] `npx playwright test ... --list` parses both edited specs across chromium and webkit
- [ ] Full E2E browser suite (runs in self-hosted CI)

## Screenshots

Not applicable. No UI changes; tests only.

## Accessibility

Not applicable. No UI changes. The new assertions reach the app-menu control through its `data-testid`, and the app already exposes the mobile hamburger with `aria-label="App menu"`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests updated to match shipped behaviour (test-only change)

Assumption: where it could be read either way, the tests were aligned to the shipped behaviour rather than changing the app. The mobile top bar is hamburger-only by design (#2458, #2597), so the brand logo intentionally does not appear at <= 1024px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJLT4DUCeWSbuWFpWaC8zn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJLT4DUCeWSbuWFpWaC8zn)_


___

## **CodeAnt-AI Description**
Align e2e checks with the current mobile top bar and starter library labels

### What Changed
- Mobile responsive tests now look for the hamburger app menu on small screens instead of a desktop logo that is no longer shown there
- The small-screen responsive checks were simplified by removing duplicate logo assertions
- Starter library tests now match the current device names for half-depth items, including patch panels, the 1U PDU, the fan panel, blank panels, the brush panel, and the cable manager

### Impact
`✅ Fewer false test failures on mobile layouts`
`✅ More stable starter library checks`
`✅ Clearer validation of current device labels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
