### PR TITLE
test: align stale/flaky mobile e2e to shipped behaviour (#2680)

### DIFF
--- a/e2e/android-chrome.spec.ts
+++ b/e2e/android-chrome.spec.ts
@@ -97,12 +97,23 @@ test.describe("Devices Tab (Device Library)", () => {
     });
   }
 
-  test("Device library FAB is removed in desktop mode", async ({ page }) => {
+  test("mobile device-library affordances are removed in desktop mode", async ({
+    page,
+  }) => {
+    // Pixel Tablet is 1280px wide, above the 1024px MOBILE_BREAKPOINT, so the
+    // app renders its desktop layout: the mobile bottom nav (and its Devices
+    // tab) and the floating device-library button are gone.
     const device = androidDevices.find((d) => d.name === "Pixel Tablet")!;
     await setupMobileViewport(page, device);
 
+    // The mobile-only device-library affordances are absent in desktop mode.
     await expect(page.locator(locators.mobile.deviceLibraryFab)).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Devices" })).toHaveCount(0);
+    await expect(page.locator(locators.mobile.bottomNav)).toHaveCount(0);
+    await expect(page.getByTestId("nav-tab-devices")).toHaveCount(0);
+
+    // The desktop layout still exposes the device library, now through the
+    // sidebar's Devices tab (role="tab", not the mobile bottom-nav button).
+    await expect(page.getByRole("tab", { name: "Devices" })).toBeVisible();
   });
 });
 
@@ -355,48 +366,57 @@ test.describe("Touch Interactions", () => {
 });
 
 // ============================================================================
-// Long-Press Gesture Tests
+// Device Context Menu Tests
 // ============================================================================
 
-test.describe("Long-Press Gesture", () => {
+test.describe("Device Context Menu", () => {
   const device = phoneDevices[0]; // Pixel 7
 
   test.beforeEach(async ({ page }) => {
     await setupMobileViewport(page, device);
   });
 
-  test("long-press opens the device context menu", async ({ page }) => {
+  test("contextmenu on a placed device opens the device context menu", async ({
+    page,
+  }) => {
     // Open bottom sheet to expose palette items on mobile
     await mobileDragDeviceToRack(page);
 
-    // Close the bottom sheet so the backdrop/sheet doesn't intercept the
-    // mouse-based long-press on the placed device. Escape is a no-op if the
-    // sheet already auto-closed after drag.
+    // Close the bottom sheet so the backdrop/sheet doesn't sit over the placed
+    // device. Escape is a no-op if the sheet already auto-closed after drag.
     await page.keyboard.press("Escape");
     await expect(page.locator(locators.mobile.bottomSheet)).toBeHidden();
 
     const rackDevice = page.locator(locators.rack.device).first();
     await expect(rackDevice).toBeVisible({ timeout: 5000 });
 
-    // Feature #1086: long-press on a placed device opens the app's device context menu.
-    // This confirms the gesture fires and the native browser context menu is suppressed
-    // in favour of the app's own menu (see RackDevice.svelte handleLongPress / useLongPress).
-    const contextMenu = page.locator('[role="menu"]');
+    // The app's device context menu opens from the contextmenu event
+    // (RackDevice.svelte oncontextmenu -> handleContextMenu -> oncontextmenuopen),
+    // wired unconditionally regardless of viewport. The previous long-press path
+    // exercised useLongPress, whose handler zooms the canvas to the device and
+    // never opens a menu, so the wait-for-menu assertion could not pass; #2680.
+    // Dispatching the event directly is deterministic across Chromium/WebKit and
+    // removes the timing-sensitive 500ms-hold flake.
+    const contextMenu = page.getByTestId("ctx-menu");
 
+    // Supply cursor coordinates so handleContextMenu anchors the menu over the
+    // device rather than falling back to (0,0); dispatchEvent builds a real
+    // MouseEvent from this init.
     const box = await rackDevice.boundingBox();
-    if (box) {
-      // Simulate long-press via mouse events (touchscreen.tap requires hasTouch).
-      // useLongPress fires its callback after 500ms while the pointer is still
-      // held, so wait for the menu to appear instead of sleeping a fixed 600ms.
-      const startPos = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
-      await page.mouse.move(startPos.x, startPos.y);
-      await page.mouse.down();
-      await expect(contextMenu).toBeVisible({ timeout: 3000 });
-      await page.mouse.up();
-    }
+    expect(box).toBeTruthy();
+    await rackDevice.dispatchEvent("contextmenu", {
+      clientX: box!.x + box!.width / 2,
+      clientY: box!.y + box!.height / 2,
+      button: 2,
+      bubbles: true,
+    });
 
-    // Menu stays open after pointer release
-    await expect(contextMenu).toBeVisible();
+    await expect(contextMenu).toBeVisible({ timeout: 5000 });
+    await expect(contextMenu).toHaveAttribute("role", "menu");
+
+    // Escape closes the menu.
+    await page.keyboard.press("Escape");
+    await expect(contextMenu).toBeHidden();
   });
 });
 

--- a/e2e/ios-safari.spec.ts
+++ b/e2e/ios-safari.spec.ts
@@ -89,7 +89,9 @@ test.describe("Devices Tab (Device Library)", () => {
     });
   }
 
-  test("Device library FAB is removed in desktop mode", async ({ page }) => {
+  test("mobile device-library affordances are removed in desktop mode", async ({
+    page,
+  }) => {
     // iPad Pro 12.9 at 1024px is at the mobile breakpoint (max-width: 1024px),
     // so it's still mobile. Use a wider viewport to test desktop mode.
     await page.setViewportSize({ width: 1280, height: 1366 });
@@ -102,8 +104,14 @@ test.describe("Devices Tab (Device Library)", () => {
       .first()
       .waitFor({ state: "visible" });
 
+    // The mobile-only device-library affordances are absent in desktop mode.
     await expect(page.locator(locators.mobile.deviceLibraryFab)).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Devices" })).toHaveCount(0);
+    await expect(page.locator(locators.mobile.bottomNav)).toHaveCount(0);
+    await expect(page.getByTestId("nav-tab-devices")).toHaveCount(0);
+
+    // The desktop layout still exposes the device library, now through the
+    // sidebar's Devices tab (role="tab", not the mobile bottom-nav button).
+    await expect(page.getByRole("tab", { name: "Devices" })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

Test-only fix for two self-hosted full-suite e2e tests that failed independent of any PR (tracked in #2680). Both were stale: they asserted behaviour the app does not ship. No app/source behaviour was changed. Same layout-drift class as #2643.

## Changes

- `e2e/android-chrome.spec.ts` and `e2e/ios-safari.spec.ts`, FAB-in-desktop-mode test: the old assertion `getByRole("button", { name: "Devices" }).toHaveCount(0)` was brittle. Playwright matches the accessible name as a case-insensitive substring, so at a 1280px (desktop) viewport it caught desktop "Devices" affordances that legitimately exist above the 1024px `MOBILE_BREAKPOINT` (the sidebar Devices tab, which is `role="tab"`, and the collapsed-strip "Expand Devices panel" button). Retargeted the test to assert that the mobile-only device-library affordances are removed: the mobile bottom nav (`mobile-bottom-nav`), its Devices tab (`nav-tab-devices`), and the floating device-library button. It also confirms the desktop layout still exposes the library through the sidebar Devices tab (`getByRole("tab", { name: "Devices" })`). Renamed to "mobile device-library affordances are removed in desktop mode".
- `e2e/android-chrome.spec.ts`, long-press context-menu test: the old test held a synthetic pointer for 500ms and waited up to 3s for `[role="menu"]`. That menu never appears from a long-press. `useLongPress` (`RackDevice.svelte` `handleLongPress`) zooms the canvas to the device; it does not open a menu. The device context menu opens from the `contextmenu` event (`oncontextmenu` -> `handleContextMenu` -> `oncontextmenuopen`), which `Rack.svelte` wires unconditionally regardless of viewport. Retargeted the test to dispatch the `contextmenu` event and assert the menu (`ctx-menu`, `role="menu"`) opens and dismisses on Escape. This is the app's real, viewport-independent affordance and removes the timing-sensitive hold-and-wait flake. Moved into a renamed "Device Context Menu" describe block.

## Testing

The full Playwright browser suite cannot run in this environment (the Chromium binary is not at the expected path), so validation was the gates below plus a spec parse check.

- [x] `npm run lint` clean
- [x] `npm run check` (svelte-check) clean for the changed files (one pre-existing, unrelated error remains in `src/lib/utils/share.ts`, untouched by this PR)
- [x] `npm run format:check` clean
- [x] `npx playwright test --config e2e/playwright.config.ts e2e/android-chrome.spec.ts e2e/ios-safari.spec.ts --list` parses; renamed tests appear across the android-chrome, android-tablet, ios-safari, and ipad profiles
- [ ] Unit tests pass (`npm run test:run`) - run in CI
- [ ] E2E tests pass (`npm run test:e2e`) - the self-hosted full suite is advisory and runs in CI

## Screenshots

Not applicable. Test-only change.

## Accessibility

Not applicable. No UI change; the assertions now match the shipped accessibility semantics (the sidebar Devices control is `role="tab"`; the device context menu is `role="menu"`).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality (if applicable) - n/a, existing tests realigned to shipped behaviour

### Assumptions

- Intended behaviour at >1024px is the desktop layout: the mobile bottom nav and floating device-library button are removed, and the device library is reached through the sidebar Devices tab. This matches the `MOBILE_BREAKPOINT` and the `viewportStore.isMobile`-guarded rendering of `MobileBottomNav`.
- Long-press is intentionally a zoom-to-device gesture, not a context-menu trigger; the context menu is opened by the `contextmenu` event on all viewports.

Closes #2680

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJLT4DUCeWSbuWFpWaC8zn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJLT4DUCeWSbuWFpWaC8zn)_


___

## **CodeAnt-AI Description**
**Align mobile e2e checks with the app's shipped behavior**

### What Changed
- The desktop-mode device library test now checks that the mobile bottom nav, Devices tab, and floating device-library button are gone, while still confirming the desktop sidebar shows the Devices tab.
- The device context menu test now opens the menu through the real context menu action instead of a long-press, and verifies it can be closed with Escape.
- Test names and comments were updated to match the actual mobile and desktop behavior the app presents.

### Impact
`✅ Fewer false test failures`
`✅ Stable mobile e2e checks`
`✅ Clearer desktop vs mobile layout checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
