### PR TITLE
ci: self-host header and build-env parity guard (#2032 self-host half)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Check compose parity
         run: bash scripts/check-compose-persist-parity.sh
 
+      - name: Check self-host header and build-env parity
+        run: bash scripts/check-header-parity.sh
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -90,6 +93,12 @@ jobs:
 
       - name: Run smoke E2E tests
         run: npm run test:e2e:smoke
+
+      # The smoke E2E webServer runs `npm run build`, so dist/ exists here. Scan
+      # the built HTML for inline <script> tags (must be none, so the CSP can
+      # stay script-src 'self').
+      - name: Scan dist for inline scripts
+        run: bash scripts/check-header-parity.sh --with-build
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/check-header-parity.sh
+++ b/scripts/check-header-parity.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# check-header-parity.sh - self-host header and build-env parity guard.
+#
+# Part of issue #2032 (self-host half). Verifies the self-host CSP/header files
+# and the Dockerfile VITE_* build args stay within their expected invariants so
+# an accidental change fails CI instead of shipping.
+#
+# Checks (self-host half):
+#   1. No analytics origins (cloudflareinsights, /cdn-cgi/) in either header file.
+#   2. CSP script-src is exactly 'self' (zero inline-script hashes, no analytics
+#      origins) and each CSP declares form-action 'self'.
+#   3. The VITE_* build args declared in deploy/Dockerfile match an explicit
+#      allowlist, so an accidental add/remove fails CI.
+#   5. (--with-build) dist inline-script scan: dist/index.html and
+#      dist/login.html must contain no inline <script> tags (every <script>
+#      must carry a src= attribute). Requires `npm run build` to have run first.
+#
+# DEFERRED to the CF half (#2029 prod _headers, #2134 dev _headers):
+#   - The prod/dev CF _headers script-src diff against the self-host files. Those
+#     CF surfaces do not exist yet, so there is nothing to compare against.
+#   - The wrangler-job VITE_* parity comparison (dev: VITE_ENV=development,
+#     analytics token absent in dev). The wrangler deploy jobs do not exist yet;
+#     add this comparison alongside the CF surfaces in #2029/#2134.
+#
+# Usage:
+#   scripts/check-header-parity.sh              # static checks (1-3)
+#   scripts/check-header-parity.sh --with-build # also run the dist scan (5)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+WITH_BUILD=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-build) WITH_BUILD=1; shift ;;
+    -h | --help) sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1 (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+SELFHOST_HEADERS=(
+  "deploy/security-headers.conf"
+  "deploy/lxc/security-headers.conf"
+)
+
+# Analytics origins that must never appear in the self-host header files.
+ANALYTICS_PATTERNS=(
+  "cloudflareinsights"
+  "/cdn-cgi/"
+)
+
+# VITE_* build args expected in deploy/Dockerfile. The self-host Docker build
+# pins exactly these; an add/remove here must be a deliberate edit to this list.
+EXPECTED_VITE_ARGS=(
+  "VITE_ENV"
+)
+
+FAILS=0
+fail() { echo "FAIL: $*" >&2; FAILS=$((FAILS + 1)); }
+pass() { echo "ok: $*"; }
+
+# --- check 1: no analytics origins in the self-host header files -------------
+for f in "${SELFHOST_HEADERS[@]}"; do
+  [[ -f "$f" ]] || { fail "missing header file: $f"; continue; }
+  for pat in "${ANALYTICS_PATTERNS[@]}"; do
+    if grep -F --quiet "$pat" "$f"; then
+      fail "analytics origin '$pat' found in $f (self-host must have none)"
+    fi
+  done
+done
+[[ $FAILS -eq 0 ]] && pass "no analytics origins in self-host header files"
+
+# --- check 2: CSP script-src invariant + form-action ------------------------
+# script-src must be exactly 'self': zero inline-script hashes, no extra origins.
+for f in "${SELFHOST_HEADERS[@]}"; do
+  [[ -f "$f" ]] || continue
+
+  csp_line="$(grep -F "Content-Security-Policy" "$f" || true)"
+  if [[ -z "$csp_line" ]]; then
+    fail "no Content-Security-Policy directive in $f"
+    continue
+  fi
+
+  # Pull out the script-src directive value (between 'script-src' and the next ';').
+  script_src="$(printf '%s' "$csp_line" | grep -oE "script-src[^;]*" || true)"
+  if [[ -z "$script_src" ]]; then
+    fail "no script-src directive in CSP of $f"
+    continue
+  fi
+
+  # Normalise surrounding whitespace for an exact-match compare.
+  script_src="$(printf '%s' "$script_src" | tr -s ' ' | sed 's/[[:space:]]*$//')"
+  if [[ "$script_src" != "script-src 'self'" ]]; then
+    fail "script-src in $f must be exactly \"script-src 'self'\" (got: \"$script_src\")"
+  fi
+
+  # Belt-and-braces: explicitly reject inline-script hashes even if the exact
+  # match above ever loosens.
+  if printf '%s' "$script_src" | grep -qE "'sha(256|384|512)-"; then
+    fail "script-src in $f contains an inline-script hash (must be zero hashes)"
+  fi
+
+  # form-action must be present and scoped to 'self'.
+  if ! printf '%s' "$csp_line" | grep -qE "form-action 'self'"; then
+    fail "CSP in $f must declare \"form-action 'self'\""
+  fi
+done
+[[ $FAILS -eq 0 ]] && pass "CSP script-src is 'self' with zero hashes; form-action 'self' present"
+
+# --- check 3: Dockerfile VITE_* build-arg allowlist -------------------------
+# DEFERRED: the full prod/dev parity comparison against the wrangler deploy jobs
+# is added with the CF half (#2029/#2134). Those jobs do not exist yet, so here
+# we only validate the self-host Dockerfile against the expected allowlist.
+DOCKERFILE="deploy/Dockerfile"
+if [[ ! -f "$DOCKERFILE" ]]; then
+  fail "missing $DOCKERFILE"
+else
+  declared_vite_args="$(grep -oE "^ARG[[:space:]]+VITE_[A-Z0-9_]+" "$DOCKERFILE" \
+    | awk '{print $2}' | sed 's/=.*//' | sort -u || true)"
+  expected_sorted="$(printf '%s\n' "${EXPECTED_VITE_ARGS[@]}" | sort -u)"
+  if [[ "$declared_vite_args" != "$expected_sorted" ]]; then
+    fail "VITE_* build args in $DOCKERFILE do not match the expected allowlist"
+    echo "  expected:" >&2; printf '    %s\n' $expected_sorted >&2
+    echo "  declared:" >&2; printf '    %s\n' ${declared_vite_args:-<none>} >&2
+  else
+    pass "Dockerfile VITE_* build args match the expected allowlist"
+  fi
+fi
+
+# --- check 5: dist inline-script scan (--with-build) ------------------------
+if [[ $WITH_BUILD -eq 1 ]]; then
+  dist_files=(
+    "dist/index.html"
+    "dist/login.html"
+  )
+  for f in "${dist_files[@]}"; do
+    if [[ ! -f "$f" ]]; then
+      fail "missing $f (run 'npm run build' before --with-build)"
+      continue
+    fi
+    # Flag any <script ...> opening tag that lacks a src= attribute. The bundle
+    # must emit only external scripts so the CSP can stay script-src 'self'.
+    if grep -oiE "<script\b[^>]*>" "$f" | grep -qivE "\bsrc="; then
+      fail "inline <script> (no src=) found in $f"
+      grep -oiE "<script\b[^>]*>" "$f" | grep -ivE "\bsrc=" | sed 's/^/    /' >&2
+    fi
+  done
+  [[ $FAILS -eq 0 ]] && pass "no inline <script> tags in dist/index.html or dist/login.html"
+fi
+
+echo
+if [[ $FAILS -eq 0 ]]; then
+  echo "Header and build-env parity check passed."
+  exit 0
+else
+  echo "Header and build-env parity check FAILED: $FAILS issue(s)." >&2
+  exit 1
+fi

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -488,6 +488,19 @@ smoke_checks() {
   _check "$id" "nginx active" "systemctl is-active --quiet nginx"
   _check "$id" "no API crash in journal" \
     "! journalctl -u rackula-api --no-pager 2>/dev/null | grep -qiE 'panic|segfault|MODULE_NOT_FOUND|cannot find module'"
+  # Security headers from deploy/lxc/security-headers.conf must reach the client.
+  # Header names are case-insensitive (grep -i); --max-time 5 caps the request.
+  _check "$id" "Content-Security-Policy header present" \
+    "curl -sfI --max-time 5 http://127.0.0.1/ | grep -qi '^Content-Security-Policy:'"
+  _check "$id" "X-Frame-Options header present" \
+    "curl -sfI --max-time 5 http://127.0.0.1/ | grep -qi '^X-Frame-Options:'"
+  # version.json is emitted at build time (vite.config.ts) and served statically.
+  # version must be a non-empty string and commit must be non-empty: the LXC build
+  # runs `npm run build` inside a full git checkout, so APP_COMMIT/commit is set.
+  _check "$id" "version.json reports a non-empty version" \
+    "curl -sf --max-time 5 http://127.0.0.1/version.json | grep -qE '\"version\"[[:space:]]*:[[:space:]]*\"[^\"]+\"'"
+  _check "$id" "version.json reports a non-empty commit" \
+    "curl -sf --max-time 5 http://127.0.0.1/version.json | grep -qE '\"commit\"[[:space:]]*:[[:space:]]*\"[^\"]+\"'"
 }
 
 # --- run --------------------------------------------------------------------


### PR DESCRIPTION
## **User description**
## Summary

Part of #2032 (self-host half). Adds the self-host-only parity checks from issue #2032: a header/build-env parity guard plus extended LXC smoke assertions. The Cloudflare `_headers` comparison is deferred (those surfaces do not exist yet, blocked on #2029 and #2134). This PR does not close #2032.

## Changes

- `scripts/check-header-parity.sh` (new): self-host parity guard
  - No analytics origins (`cloudflareinsights`, `/cdn-cgi/`) in `deploy/security-headers.conf` or `deploy/lxc/security-headers.conf`.
  - CSP `script-src` is exactly `'self'` (zero `'sha256-'`/`'sha384-'`/`'sha512-'` hashes), and each CSP declares `form-action 'self'`.
  - Dockerfile `VITE_*` build args match an explicit allowlist (`VITE_ENV`), so an accidental add/remove fails CI.
  - `--with-build`: scans `dist/index.html` and `dist/login.html` for inline `<script>` tags (any `<script>` without `src=` fails).
- `.github/workflows/test.yml`: run the static checks in the `validate` job next to `check-compose-persist-parity.sh`, and run the dist scan after the smoke E2E build.
- `scripts/lxc-smoke-test.sh`: add `curl -I` assertions that `Content-Security-Policy` and `X-Frame-Options` are present on the LXC frontend, plus `version.json` assertions for a non-empty version and a non-empty commit (the LXC build runs `npm run build` in a git checkout, so commit is populated).

## ACs implemented (self-host half)

- No analytics origins in the self-host header files (`cloudflareinsights`, `/cdn-cgi/`).
- CSP `script-src` invariant: exactly `'self'`, zero inline-script hashes, plus `form-action 'self'`, on both self-host header files.
- VITE build-arg allowlist check against `deploy/Dockerfile` (self-host-implementable portion).
- `lxc-smoke-test.sh` extended: CSP + X-Frame-Options header presence and a well-formed `version.json` with a non-empty commit.
- dist inline-script scan after `npm run build`.

## ACs deferred to the CF half (blocked on #2029 / #2134)

- The prod/dev CF `_headers` `script-src` diff against the self-host header files. The CF `_headers` surfaces do not exist yet (#2029 prod, #2134 dev), so there is nothing to compare against.
- The wrangler-job `VITE_*` parity comparison (dev: `VITE_ENV=development`, analytics token absent in dev). The wrangler deploy jobs do not exist yet; this comparison is added alongside the CF surfaces.

Both deferrals are noted in a header comment in `scripts/check-header-parity.sh`.

## Testing

- [x] `bash scripts/check-header-parity.sh` passes on the current tree.
- [x] `bash scripts/check-header-parity.sh --with-build` passes after `npm run build`.
- [x] Negative tests: injecting a `cloudflareinsights` origin, a `'sha256-...'` hash into `script-src`, an extra `VITE_*` arg, and an inline `<script>` into `dist/index.html` each made the guard FAIL; reverting restored PASS.
- [x] `npm run lint` and `npm run format:check` pass.
- [x] `bash -n` syntax check passes for both scripts.
- [ ] LXC smoke run against a live CT (requires a Proxmox host; not run here).

## Accessibility

Non-UI PR. Not applicable.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality (parity guard with verified negative tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148VTaTnT1JcYQp9YojPY6u

---
_Generated by [Claude Code](https://claude.ai/code/session_0148VTaTnT1JcYQp9YojPY6u)_


___

## **CodeAnt-AI Description**
**Add CI checks for self-host security headers and built HTML**

### What Changed
- CI now fails if self-host header files include analytics origins, loosen the script policy, or omit `form-action 'self'`
- CI now checks that the Docker build only uses the expected `VITE_*` build setting
- The smoke test now confirms the frontend returns security headers and exposes a non-empty version and commit in `version.json`
- After the smoke build, CI scans the built pages for inline scripts so the page can keep using a strict script policy

### Impact
`✅ Fewer security header regressions`
`✅ Safer builds with less chance of accidental config drift`
`✅ Clearer deployment checks for frontend version information`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
