### PR TITLE
fix: clamp over-rack rail device positions on load to keep layouts within bounds

### DIFF
--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -6,6 +6,7 @@
 import { z } from "../zod";
 import { nanoid } from "nanoid";
 import { UNITS_PER_U } from "$lib/types/constants";
+import { heightToInternalUnits } from "$lib/utils/position";
 import { VERSION } from "$lib/version";
 
 /**
@@ -925,6 +926,55 @@ function migrateDevicePositions<
 }
 
 /**
+ * Clamp rail-mounted device positions that extend above the rack (#2661).
+ *
+ * LayoutSchema enforces the whole-U and carrier-first rules but never bounded a
+ * rail position against rack.height, so a hand-edited or prior-release layout
+ * with an over-rack position loaded and rendered outside the rack. This clamps
+ * an overflowing rail device down to the highest within-rack whole-U position,
+ * mirroring the maxValidTop check in canPlaceDevice (src/lib/utils/collision.ts).
+ * Clamping (not hard-rejecting) keeps prior-release loading working, per the
+ * project's supported-prior-data policy.
+ *
+ * Runs on every load, not only legacy migration: a modern layout stores positions
+ * in internal units already, so its over-rack values never pass through
+ * migrateDevicePositions. Container children (container_id set) use container-
+ * relative positions and are left untouched.
+ *
+ * @param devices - Rack devices, positions already in internal units.
+ * @param rackHeight - Rack height in whole U.
+ * @param uHeightBySlug - Device-type u_height keyed by slug, for the fit math.
+ */
+function clampOverRackPositions<
+  T extends { position: number; device_type: string; container_id?: string },
+>(devices: T[], rackHeight: number, uHeightBySlug: Map<string, number>): T[] {
+  // Mirror canPlaceDevice: a device at P with height H occupies P..P+H*UPU-1,
+  // and the highest valid top is UN's top = rackHeight*UPU + (UPU - 1).
+  const maxValidTop = rackHeight * UNITS_PER_U + (UNITS_PER_U - 1);
+  return devices.map((device) => {
+    // Container children use container-relative positions; not rail-bounded.
+    if (device.container_id !== undefined) {
+      return device;
+    }
+    // Default to 1U when the type is unknown so the clamp still bounds the top.
+    const uHeight = uHeightBySlug.get(device.device_type) ?? 1;
+    const heightInternal = heightToInternalUnits(uHeight);
+    const topPosition = device.position + heightInternal - 1;
+    if (topPosition <= maxValidTop) {
+      return device;
+    }
+    // Highest bottom position that keeps the top within the rack, snapped down
+    // to a whole-U rail boundary and never below U1.
+    const maxBottom = maxValidTop - heightInternal + 1;
+    const clampedWholeU = Math.max(1, Math.floor(maxBottom / UNITS_PER_U));
+    return {
+      ...device,
+      position: clampedWholeU * UNITS_PER_U,
+    } as T;
+  });
+}
+
+/**
  * Complete layout schema (base, with migration transform)
  * Uses racks array for multi-rack support
  * Transform handles:
@@ -953,6 +1003,12 @@ export const LayoutSchemaBase = LayoutSchemaInput.transform((data) => {
   // Check if positions need migration (pre-0.7.0 format)
   const migratePositions = needsPositionMigration(data.version, allDevices);
 
+  // Resolve device-type u_height for the over-rack clamp (#2661). Built once per
+  // load; an unknown slug falls back to 1U inside clampOverRackPositions.
+  const uHeightBySlug = new Map(
+    data.device_types.map((t) => [t.slug, t.u_height]),
+  );
+
   // Generate IDs for racks missing them, deduplicate device IDs, and migrate positions if needed.
   const racksWithIds = racks.map((rack) => {
     // Deduplicate device IDs to prevent Svelte each_key_duplicate errors (#1363)
@@ -977,12 +1033,20 @@ export const LayoutSchemaBase = LayoutSchemaInput.transform((data) => {
         : { ...d, id: nextId, container_id: nextContainerId };
     });
 
+    const migratedDevices = migratePositions
+      ? migrateDevicePositions(deduplicatedDevices)
+      : deduplicatedDevices;
+
     return {
       ...rack,
       id: rack.id ?? nanoid(),
-      devices: migratePositions
-        ? migrateDevicePositions(deduplicatedDevices)
-        : deduplicatedDevices,
+      // Positions are in internal units here; clamp any rail device whose top
+      // extends above the rack down to the highest within-rack whole-U (#2661).
+      devices: clampOverRackPositions(
+        migratedDevices,
+        rack.height,
+        uHeightBySlug,
+      ),
     };
   });
 

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -953,7 +953,9 @@ function clampOverRackPositions<
   const maxValidTop = rackHeight * UNITS_PER_U + (UNITS_PER_U - 1);
   return devices.map((device) => {
     // Container children use container-relative positions; not rail-bounded.
-    if (device.container_id !== undefined) {
+    // A falsy container_id (undefined or "") is rack-level here, matching how
+    // PlacedDeviceSchema and the carrier-first refine distinguish the two.
+    if (device.container_id) {
       return device;
     }
     // Default to 1U when the type is unknown so the clamp still bounds the top.

--- a/src/tests/fixtures/upgrade-corpus/over-rack-rail-position.expected.json
+++ b/src/tests/fixtures/upgrade-corpus/over-rack-rail-position.expected.json
@@ -1,0 +1,10 @@
+{
+  "reject": false,
+  "hasImages": false,
+  "allowList": [
+    {
+      "pathPattern": "\\.position$",
+      "reason": "rail device top exceeds rack.height; position clamped to the highest within-rack whole-U on load (#2661)"
+    }
+  ]
+}

--- a/src/tests/fixtures/upgrade-corpus/over-rack-rail-position.rackula.yaml
+++ b/src/tests/fixtures/upgrade-corpus/over-rack-rail-position.rackula.yaml
@@ -1,0 +1,26 @@
+version: "26.5.0"
+name: Over-Rack Rail Position
+racks:
+  - id: "rack-a"
+    name: "Rack A"
+    height: 10
+    width: 19
+    desc_units: false
+    show_rear: true
+    form_factor: "4-post-cabinet"
+    starting_unit: 1
+    position: 0
+    devices:
+      - id: "dev-over"
+        device_type: "switch-1u"
+        position: 66
+        face: "front"
+device_types:
+  - slug: "switch-1u"
+    u_height: 1
+    manufacturer: "Acme"
+    colour: "#336699"
+    category: "network"
+settings:
+  display_mode: "label"
+  show_labels_on_images: false

--- a/src/tests/schemas.test.ts
+++ b/src/tests/schemas.test.ts
@@ -1017,6 +1017,40 @@ describe("LayoutSchema", () => {
       }
     });
 
+    it("clamps an over-rack rail device whose container_id is an empty string", () => {
+      // The rest of the schema treats a falsy/empty container_id as rack-level
+      // (PlacedDeviceSchema uses `!data.container_id`; the carrier-first refine
+      // uses `if (!device.container_id)`). A malformed rail device with
+      // container_id "" and no slot_id must be clamped like any other rail
+      // device, not skipped as if it were a container child (#2661 follow-up).
+      const layout = {
+        ...validLayout,
+        version: "26.5.0",
+        racks: [
+          {
+            ...tenURack,
+            devices: [
+              {
+                id: "dev-empty-cid",
+                device_type: "switch-1u",
+                position: 66,
+                face: "front" as const,
+                container_id: "",
+              },
+            ],
+          },
+        ],
+        device_types: [oneUType],
+      };
+      const result = LayoutSchema.safeParse(layout);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const placed = result.data.racks[0]!.devices[0]!;
+        expect(placed.position).toBe(60);
+        expect(placed.position % 6).toBe(0);
+      }
+    });
+
     it("leaves an in-bounds rail position unchanged", () => {
       const layout = {
         ...validLayout,

--- a/src/tests/schemas.test.ts
+++ b/src/tests/schemas.test.ts
@@ -893,6 +893,156 @@ describe("LayoutSchema", () => {
       expect(LayoutSchema.safeParse(layout).success).toBe(false);
     });
   });
+
+  // === Over-rack rail position clamping (#2661) ===
+  // A hand-edited or prior-release layout can carry a rail position whose top
+  // extends past rack.height. LayoutSchema enforces whole-U and carrier-first
+  // but never bounded the top, so the device rendered outside the rack. On load
+  // we clamp such a position to the highest within-rack whole-U position rather
+  // than hard-rejecting (prior-release loading must still succeed).
+  describe("over-rack rail position clamping", () => {
+    // 10U rack: UNITS_PER_U = 6, so the highest whole-U bottom position for a
+    // 1U device is U10 = 60 internal units (top 65 = rack.height*6 + 5).
+    const tenURack = {
+      id: "rack-1",
+      name: "Small Rack",
+      height: 10,
+      width: 19 as const,
+      desc_units: false,
+      form_factor: "4-post-cabinet" as const,
+      starting_unit: 1,
+      position: 0,
+      devices: [],
+    };
+    const oneUType = {
+      slug: "switch-1u",
+      u_height: 1,
+      colour: "#4A90D9",
+      category: "network" as const,
+    };
+
+    it("clamps a 1U rail device whose top exceeds the rack to the highest whole-U position", () => {
+      // Modern layout: position 66 is internal units (U11), one U above a 10U rack.
+      const layout = {
+        ...validLayout,
+        version: "26.5.0",
+        racks: [
+          {
+            ...tenURack,
+            devices: [
+              {
+                id: "dev-over",
+                device_type: "switch-1u",
+                position: 66,
+                face: "front" as const,
+              },
+            ],
+          },
+        ],
+        device_types: [oneUType],
+      };
+      const result = LayoutSchema.safeParse(layout);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const placed = result.data.racks[0]!.devices[0]!;
+        // Clamped to U10 = 60 internal units, a whole-U rail position.
+        expect(placed.position).toBe(60);
+        expect(placed.position % 6).toBe(0);
+      }
+    });
+
+    it("clamps a legacy U-value over-rack position (U999) to within the rack", () => {
+      // Legacy layout (< 0.7.0): position 999 is a U-value, migrated to internal
+      // units would be 5994; without an upper clamp it sits far above a 10U rack.
+      const layout = {
+        ...validLayout,
+        version: "0.6.0",
+        racks: [
+          {
+            ...tenURack,
+            devices: [
+              {
+                id: "dev-legacy",
+                device_type: "switch-1u",
+                position: 999,
+                face: "front" as const,
+              },
+            ],
+          },
+        ],
+        device_types: [oneUType],
+      };
+      const result = LayoutSchema.safeParse(layout);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const placed = result.data.racks[0]!.devices[0]!;
+        expect(placed.position).toBe(60);
+        expect(placed.position % 6).toBe(0);
+      }
+    });
+
+    it("clamps a 2U rail device so the whole device fits within the rack", () => {
+      const layout = {
+        ...validLayout,
+        version: "26.5.0",
+        racks: [
+          {
+            ...tenURack,
+            devices: [
+              {
+                id: "dev-2u",
+                device_type: "server-2u",
+                position: 66,
+                face: "front" as const,
+              },
+            ],
+          },
+        ],
+        device_types: [
+          {
+            slug: "server-2u",
+            u_height: 2,
+            colour: "#996633",
+            category: "server" as const,
+          },
+        ],
+      };
+      const result = LayoutSchema.safeParse(layout);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const placed = result.data.racks[0]!.devices[0]!;
+        // A 2U device fits with its bottom at U9 = 54 (top U10 = 65).
+        expect(placed.position).toBe(54);
+        expect(placed.position % 6).toBe(0);
+      }
+    });
+
+    it("leaves an in-bounds rail position unchanged", () => {
+      const layout = {
+        ...validLayout,
+        version: "26.5.0",
+        racks: [
+          {
+            ...tenURack,
+            devices: [
+              {
+                id: "dev-ok",
+                device_type: "switch-1u",
+                position: 30,
+                face: "front" as const,
+              },
+            ],
+          },
+        ],
+        device_types: [oneUType],
+      };
+      const result = LayoutSchema.safeParse(layout);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.racks[0]!.devices[0]!.position).toBe(30);
+      }
+    });
+  });
 });
 
 // ============================================================================

--- a/src/tests/upgrade-corpus.test.ts
+++ b/src/tests/upgrade-corpus.test.ts
@@ -75,3 +75,22 @@ describe("upgrade corpus: YAML ingress via parseLayoutYaml", () => {
     });
   }
 });
+
+// === Over-rack rail position is clamped on load, not rejected (#2661) ===
+// The corpus check above only proves no silent data loss; here we pin the actual
+// clamped value the load produces so a regression that stops clamping (or that
+// hard-rejects an over-rack layout, breaking prior-release loading) fails.
+const overRackYaml = (
+  await import("./fixtures/upgrade-corpus/over-rack-rail-position.rackula.yaml?raw")
+).default as string;
+
+describe("upgrade corpus: over-rack rail clamp (#2661)", () => {
+  it("clamps a rail device above a 10U rack to the highest whole-U, loading does not fail", async () => {
+    const layout = await parseLayoutYaml(overRackYaml);
+    const device = layout.racks[0]!.devices[0]!;
+    // UNITS_PER_U = 6; raw position 66 (U11) clamps to U10 = 60 in a 10U rack.
+    expect(device.position).toBe(60);
+    // Invariant: a rail position is always a whole U (no fractional rails).
+    expect(device.position % 6).toBe(0);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

`LayoutSchema` validated the rail whole-U and carrier-first rules but never checked that a rail-mounted device fits within `rack.height`. A hand-edited or prior-release layout with an over-rack position was accepted and rendered outside the rack, with no on-load bound check. `migrateDevicePositions` did `Math.max(1, round)` with no upper clamp, and a modern (internal-unit) layout skipped that path entirely, so an over-rack value flowed straight to the render layer.

This clamps an overflowing rail device down to the highest within-rack whole-U position on load, mirroring the `maxValidTop` check in `canPlaceDevice` (`src/lib/utils/collision.ts`). Clamping is preferred over a hard `superRefine` reject so existing prior-release and hand-edited layouts still load, per the project's supported-prior-data policy.

## Changes

- Add `clampOverRackPositions` in `src/lib/schemas/index.ts`: for each rail device (no `container_id`), if `position + heightToInternalUnits(u_height) - 1 > rack.height * UNITS_PER_U + (UNITS_PER_U - 1)`, clamp the bottom position down to the highest whole-U rail boundary that keeps the device within the rack (never below U1). Container children are untouched.
- Wire the clamp into the `LayoutSchemaBase` transform for every rack, regardless of legacy migration. A `u_height`-by-slug map resolves device heights from `device_types`; an unknown slug falls back to 1U so the top is still bounded.
- The clamped value is always a multiple of `UNITS_PER_U`, preserving the whole-U rail invariant (no fractional rail positions).

## Testing

How was this tested?

- [x] Unit tests pass (`npm run test:run`) - 186 files, 2970 tests pass
- [ ] E2E tests pass (`npm run test:e2e`) - not run (non-UI data-schema change)
- [x] Manual testing completed - covered by new unit and corpus tests
- `npm run lint` clean; `npm run build` succeeds.
- New tests in `src/tests/schemas.test.ts` assert the clamped whole-U position for a modern over-rack layout, a legacy U-value over-rack position (U999), a 2U device, and that an in-bounds position is unchanged.
- New upgrade-corpus fixture `over-rack-rail-position.{rackula.yaml,expected.json}` (10U rack, rail device at position 66) loads without failure; `src/tests/upgrade-corpus.test.ts` pins the clamped result (60 = U10) and the no-silent-loss harness covers backward-compat with a `\.position$` allow-list entry.

## Screenshots

N/A - non-UI data-schema change.

## Accessibility

N/A - non-UI change (load-time schema validation).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2661

---
_Generated by [Claude Code](https://claude.ai/code/session_01RooRqS7eKzkgn3Yhczq43e)_


___

## **CodeAnt-AI Description**
**Clamp over-rack rail devices to fit inside the rack on load**

### What Changed
- Rail-mounted devices that would extend past the top of a rack are now moved down to the highest valid whole-U position instead of loading outside the rack
- Existing layouts still load successfully, including hand-edited and older layouts with out-of-bounds rail positions
- Devices already inside the rack stay unchanged, and container children are left as they are
- Added coverage for modern and legacy layouts so over-rack positions are clamped consistently on load

### Impact
`✅ Fewer layouts rendering outside the rack`
`✅ Safer loading of older saved layouts`
`✅ Consistent rail positions after import`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
