### PR TITLE
fix: skip no-op recorded colour/face updates so they do not clear the redo stack

### DIFF
--- a/src/lib/stores/layout/recorded-device-actions.ts
+++ b/src/lib/stores/layout/recorded-device-actions.ts
@@ -464,6 +464,10 @@ export function updateDeviceFaceRecorded(
   const targetFace: DeviceFace =
     deviceType && deviceType.is_full_depth !== false ? "both" : face;
 
+  // No-op edit: skip executing a command so the redo stack is preserved and no
+  // empty undo entry is recorded.
+  if (oldFace === targetFace) return;
+
   const history = ctx.getHistory();
   const adapter = getCommandStoreAdapter(ctx);
 
@@ -592,6 +596,11 @@ export function updateDeviceColourRecorded(
 
   const device = targetRack.devices[deviceIndex]!;
   const oldColour = device.colour_override;
+
+  // No-op edit: skip executing a command so the redo stack is preserved and no
+  // empty undo entry is recorded.
+  if (oldColour === colour) return;
+
   const layout = ctx.getLayout();
   const deviceType = findDeviceTypeInArray(
     layout.device_types,

--- a/src/tests/layout-undo-redo.test.ts
+++ b/src/tests/layout-undo-redo.test.ts
@@ -188,6 +188,56 @@ describe("Layout Store - Undo/Redo Integration", () => {
       store.undo();
       expect(store.rack?.devices[0]?.face).toBe("front");
     });
+
+    it("updateDeviceFaceRecorded is a no-op when the face is unchanged", () => {
+      // Half-depth device so the face can vary between front and rear.
+      const halfDepth = createTestDeviceType({
+        slug: "half-depth-srv",
+        u_height: 1,
+        is_full_depth: false,
+      });
+      store.addDeviceTypeRaw(halfDepth);
+      store.placeDeviceRecorded(rack.id, halfDepth.slug, 10);
+
+      // Create a pending redo chain: change the face, then undo it.
+      store.updateDeviceFaceRecorded(rack.id, 0, "rear");
+      store.undo();
+      expect(store.canRedo).toBe(true);
+
+      const currentFace = store.rack!.devices[0]!.face!;
+      const pendingRedo = store.redoDescription;
+      const pendingUndo = store.undoDescription;
+
+      // Re-emitting the current face must not execute a command, so the redo
+      // chain survives and no new undo entry is pushed.
+      store.updateDeviceFaceRecorded(rack.id, 0, currentFace);
+
+      expect(store.canRedo).toBe(true);
+      expect(store.redoDescription).toBe(pendingRedo);
+      expect(store.undoDescription).toBe(pendingUndo);
+    });
+
+    it("updateDeviceColourRecorded is a no-op when the colour is unchanged", () => {
+      const dt = store.device_types[0]!;
+      store.placeDeviceRecorded(rack.id, dt.slug, 10);
+
+      // Create a pending redo chain: set a colour, then undo it.
+      store.updateDeviceColourRecorded(rack.id, 0, "#abcdef");
+      store.undo();
+      expect(store.canRedo).toBe(true);
+
+      const currentColour = store.rack!.devices[0]!.colour_override;
+      const pendingRedo = store.redoDescription;
+      const pendingUndo = store.undoDescription;
+
+      // Re-emitting the current colour must not execute a command, so the redo
+      // chain survives and no new undo entry is pushed.
+      store.updateDeviceColourRecorded(rack.id, 0, currentColour);
+
+      expect(store.canRedo).toBe(true);
+      expect(store.redoDescription).toBe(pendingRedo);
+      expect(store.undoDescription).toBe(pendingUndo);
+    });
   });
 
   describe("Rack Operations", () => {


### PR DESCRIPTION
## **User description**
## Summary

Recorded colour and face update actions built and executed a command even when the new value equalled the current value. Because `history.execute()` unconditionally clears the redo stack, a no-op edit (re-selecting the already-current colour swatch or face) silently discarded a pending redo chain and inserted an empty undo entry. This adds a store-layer guard so a no-op edit never executes a command.

## Changes

- `updateDeviceColourRecorded` returns early when `oldColour === colour`, so no command is executed for a no-op.
- `updateDeviceFaceRecorded` returns early when `oldFace === targetFace` (compared after the full-depth coercion to "both"), so no command is executed for a no-op.
- The guards live at the store layer (`src/lib/stores/layout/recorded-device-actions.ts`) so any future caller re-emitting an unchanged value is protected.

## Testing

How was this tested?

- [x] Unit tests pass (`npm run test:run`) - 186 files, 2969 tests passing
- [ ] E2E tests pass (`npm run test:e2e`)
- [x] Manual testing completed - covered by added store/history tests

Added two store/history tests in `src/tests/layout-undo-redo.test.ts`: perform an undoable edit then undo it (so `canRedo` is true), invoke the recorded update with the device's current face/colour (a no-op), and assert `canRedo` is still true and the pending undo/redo descriptions are unchanged (no new undo entry). Assertions are on history state by reference, not on the DOM or colour literals.

## Accessibility

N/A - non-UI logic (store-layer history correctness).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality (if applicable)

Closes #2660

---
_Generated by [Claude Code](https://claude.ai/code/session_01RooRqS7eKzkgn3Yhczq43e)_


___

## **CodeAnt-AI Description**
**Skip no-op colour and face changes so undo/redo history stays intact**

### What Changed
- Re-selecting the same face or colour no longer creates an empty undo step
- Pending redo actions are preserved when a user repeats the current value
- Added tests that verify unchanged face and colour updates do not alter undo/redo history

### Impact
`✅ Fewer lost redo actions`
`✅ Cleaner undo history`
`✅ Fewer accidental empty edits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
