### PR TITLE
fix: resolve share decode Data-to-string type error

### DIFF
--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -456,7 +456,8 @@ function inflateBounded(compressed: Uint8Array): string {
   let length = 0;
 
   inflator.onData = (chunk) => {
-    const text = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    const text =
+      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
     length += text.length;
     if (length > MAX_DECOMPRESSED_BYTES) {
       // Throw from the chunk callback to abort pako's inflate loop early, so a

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -456,7 +456,7 @@ function inflateBounded(compressed: Uint8Array): string {
   let length = 0;
 
   inflator.onData = (chunk) => {
-    const text = chunk as string;
+    const text = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
     length += text.length;
     if (length > MAX_DECOMPRESSED_BYTES) {
       // Throw from the chunk callback to abort pako's inflate loop early, so a


### PR DESCRIPTION
## **User description**
## Summary

Fixes a latent svelte-check type error in the share-link decode path. `npm run check` is not run in CI, so a type error slipped onto main via the merged share-decode PR (#2673). This PR resolves that single error in a type-safe, behavior-preserving way.

The error: `src/lib/utils/share.ts 459:18 "Conversion of type 'Data' to type 'string' may be a mistake..."`. Inside `inflateBounded`, pako's `Inflate` is built with `{ to: "string" }`, so each chunk is a string at runtime, but pako types `onData(chunk: Data)` where `Data = Uint8Array | string`, making the unconditional `as string` cast a type error.

## Changes

- `src/lib/utils/share.ts`: in `inflateBounded`'s `onData` callback, replace the unsafe `chunk as string` cast with a `typeof` narrow: `const text = typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);`. Identical behavior for the configured string mode; the decode branch keeps the function type-safe.

## Testing

- [x] `npm run check` (svelte-check) - share.ts:459 error gone; only the unrelated pre-existing device.ts:96 error remains (owned by #2665)
- [x] `npm run lint`
- [x] Targeted share decode/encode tests (`share.test.ts`, `adapt-legacy-layout.test.ts`) - 57 passing
- [x] `npm run build`
- [x] `npm run test:run` (full suite) - 2967 passing

## Screenshots

N/A (non-UI change)

## Accessibility

N/A (non-UI change)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality (if applicable) - n/a, type-only behavior-preserving fix covered by existing decode tests

Fixes the latent svelte-check error introduced by #2673.

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUwpJvjFpgTY4WFoccEgJJ)_


___

## **CodeAnt-AI Description**
**Fix share link decoding type handling**

### What Changed
- Share links now decode text safely even when the compressed data arrives as bytes instead of a string
- This removes a type-check failure in the share-link decode path without changing the visible result for users

### Impact
`✅ Fewer share-link decode errors`
`✅ Cleaner build checks`
`✅ Safer share-link handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
