### PR TITLE
chore: add ESLint regression guards for {@html} and raw web storage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -219,11 +219,15 @@ export default defineConfig(
   {
     // Storage access seam exemption: the helpers and the storage barrel are the
     // one place allowed to touch Web Storage directly. Tests are also exempt so
-    // they can seed, mock, and assert persistence against raw Web Storage.
+    // they can seed, mock, and assert persistence against raw Web Storage. This
+    // covers both the src/tests tree and co-located *.test.ts/*.spec.ts files
+    // (for example src/lib/utils/netbox-import.test.ts).
     files: [
       "src/lib/storage/**",
       "src/lib/utils/safe-storage.ts",
       "src/tests/**",
+      "**/*.test.ts",
+      "**/*.spec.ts",
     ],
     rules: {
       "no-restricted-properties": "off",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -88,6 +88,11 @@ export default defineConfig(
         svelteConfig,
       },
     },
+    rules: {
+      // Regression guard: block raw {@html} sinks. Every legitimate sink must
+      // carry an inline eslint-disable with provenance explaining why it is safe.
+      "svelte/no-at-html-tags": "error",
+    },
   },
   {
     files: ["**/*.test.ts", "**/*.spec.ts"],
@@ -160,6 +165,68 @@ export default defineConfig(
           ],
         },
       ],
+    },
+  },
+  {
+    // Storage access seam: block raw Web Storage member calls so reads/writes
+    // go through the safe-storage helpers, which swallow access failures
+    // (private mode, quota, disabled storage). The seam itself is exempted in
+    // the block below. no-restricted-properties has no per-rule path scoping in
+    // flat config, so scoping is expressed with files/ignores across two blocks.
+    files: ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+    rules: {
+      "no-restricted-properties": [
+        "error",
+        {
+          object: "localStorage",
+          property: "getItem",
+          message:
+            "Use safeGetItem from $lib/utils/safe-storage instead of localStorage.getItem.",
+        },
+        {
+          object: "localStorage",
+          property: "setItem",
+          message:
+            "Use safeSetItem from $lib/utils/safe-storage instead of localStorage.setItem.",
+        },
+        {
+          object: "localStorage",
+          property: "removeItem",
+          message:
+            "Use safeRemoveItem from $lib/utils/safe-storage instead of localStorage.removeItem.",
+        },
+        {
+          object: "sessionStorage",
+          property: "getItem",
+          message:
+            "Use safeGetItem(key, 'session') from $lib/utils/safe-storage instead of sessionStorage.getItem.",
+        },
+        {
+          object: "sessionStorage",
+          property: "setItem",
+          message:
+            "Use safeSetItem(key, value, 'session') from $lib/utils/safe-storage instead of sessionStorage.setItem.",
+        },
+        {
+          object: "sessionStorage",
+          property: "removeItem",
+          message:
+            "Use safeRemoveItem(key, 'session') from $lib/utils/safe-storage instead of sessionStorage.removeItem.",
+        },
+      ],
+    },
+  },
+  {
+    // Storage access seam exemption: the helpers and the storage barrel are the
+    // one place allowed to touch Web Storage directly. Tests are also exempt so
+    // they can seed, mock, and assert persistence against raw Web Storage.
+    files: [
+      "src/lib/storage/**",
+      "src/lib/utils/safe-storage.ts",
+      "src/tests/**",
+    ],
+    rules: {
+      "no-restricted-properties": "off",
     },
   },
   {


### PR DESCRIPTION
## **User description**
## Summary

Adds two cheap ESLint regression guards to prevent re-introduction of unsafe patterns:
- Raw `{@html}` sinks without a justified inline disable.
- Raw Web Storage access that bypasses the safe-storage seam.

## Changes

- Promote `svelte/no-at-html-tags` to `error` in the Svelte-files block. Every legitimate `{@html}` sink must carry an inline `eslint-disable-next-line svelte/no-at-html-tags` with provenance. The four existing sinks (MarkdownPreview, TemplatePicker, LayoutsLibrary, ExportDialog) already comply, so this is zero churn.
- Add a `no-restricted-properties` guard blocking `localStorage`/`sessionStorage` `getItem`/`setItem`/`removeItem` across `src/**`, with messages steering developers to `safeGetItem`/`safeSetItem`/`safeRemoveItem`. Flat config has no per-rule path scoping, so the rule is enabled in a `src`-wide block and turned off in a later block covering the storage seam (`src/lib/storage/**`, `src/lib/utils/safe-storage.ts`) and tests (`src/tests/**`).

No application code changed: all non-seam callers already use the safe-storage helpers, so the new rule passes with zero migrations or inline disables.

## Testing

Lint-only verification (config change):
- `npm run lint` passes.
- Deliberate-violation check: temporarily added a raw `localStorage.getItem` and an un-disabled `{@html}`; lint flagged both (`no-restricted-properties`, `svelte/no-at-html-tags`); reverted.
- `eslint --print-config` confirms seam files and tests resolve the rule to off while non-seam src files resolve it to error.
- `npm run build`, `npm run test:run` (2967 tests), and `npm run format:check` all pass.

## Screenshots

N/A

## Accessibility

N/A

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality (if applicable) - n/a, ESLint config change per repo TDD policy

Closes #2672

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUwpJvjFpgTY4WFoccEgJJ)_


___

## **CodeAnt-AI Description**
**Block unsafe HTML and direct browser storage access**

### What Changed
- Raw `{@html}` usage in Svelte files is now rejected unless it has an explicit inline exception with a reason.
- Direct `localStorage` and `sessionStorage` reads, writes, and deletes are now blocked in app code, steering usage to the safer storage helpers.
- The safe-storage files and tests are exempt, so the allowed storage access points still work as expected.

### Impact
`✅ Fewer unsafe HTML insertions`
`✅ Fewer broken storage reads and writes in private mode`
`✅ Safer persistence across the app`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
