### PR TITLE
fix: add runtime whole-U rail integer guard at place/move chokepoints

### DIFF
--- a/src/lib/utils/collision.ts
+++ b/src/lib/utils/collision.ts
@@ -133,6 +133,13 @@ export function canPlaceDevice(
     return false;
   }
 
+  // Rail-mounted devices must register on a whole-U boundary (carrier-first,
+  // #2158). canPlaceDevice is the rack-level gate; container (sub-U) children
+  // go through canPlaceInContainer, so this only ever guards rail placements.
+  if (!isWholeURailPosition(targetPosition)) {
+    return false;
+  }
+
   // Device must fit within rack height (convert rack height to internal units)
   // A device at position P with height H occupies P to P + H*UNITS_PER_U - 1
   // For a rack of height N, the max valid top is the top of UN = N*UNITS_PER_U + (UNITS_PER_U - 1)
@@ -409,6 +416,22 @@ export function requiresCarrier(deviceType: DeviceType): boolean {
   const isSubU = deviceType.u_height < 1;
   const isNonIntegerHeight = !Number.isInteger(deviceType.u_height);
   return isHalfWidth || isSubU || isNonIntegerHeight;
+}
+
+/**
+ * Whether an internal-unit position sits on a whole-U rail boundary. Rails
+ * register equipment at whole-U boundaries only, so a rail position is always a
+ * multiple of UNITS_PER_U (carrier-first, #2158). This mirrors the schema rule
+ * (LayoutSchema.superRefine) so the store rejects a fractional rail position at
+ * the place/move chokepoint rather than letting it through to an opaque
+ * save-time failure. Container (sub-U) children use 0-indexed positions and are
+ * checked through canPlaceInContainer, never this predicate.
+ *
+ * @param positionInternal - Rail position in internal units (e.g., 6 for U1)
+ * @returns true when the position is a whole-U boundary
+ */
+export function isWholeURailPosition(positionInternal: number): boolean {
+  return positionInternal % UNITS_PER_U === 0;
 }
 
 /**

--- a/src/tests/collision.test.ts
+++ b/src/tests/collision.test.ts
@@ -7,8 +7,9 @@ import {
   findCollisions,
   findValidDropPositions,
   snapToNearestValidPosition,
+  isWholeURailPosition,
 } from "$lib/utils/collision";
-import { UNITS_PER_U } from "$lib/utils/position";
+import { UNITS_PER_U, toInternalUnits } from "$lib/utils/position";
 import type { DeviceType, Rack, DeviceFace, SlotWidth } from "$lib/types";
 
 // Helper to create test devices
@@ -176,6 +177,35 @@ describe("Collision Detection", () => {
       expect(canPlaceDevice(rack, [device1], 1, 42)).toBe(true);
       // 1U at U4 (position 24) - ends at 29, adjacent to 30
       expect(canPlaceDevice(rack, [device1], 1, 24)).toBe(true);
+    });
+
+    it("rejects a rail placement at a fractional internal position", () => {
+      const rack = createTestRack(42);
+      const deviceLibrary: DeviceType[] = [];
+
+      // U1.5 in internal units = 9, not a multiple of UNITS_PER_U
+      const fractional = toInternalUnits(1.5);
+      expect(canPlaceDevice(rack, deviceLibrary, 1, fractional)).toBe(false);
+    });
+
+    it("accepts a rail placement at a whole-U internal position", () => {
+      const rack = createTestRack(42);
+      const deviceLibrary: DeviceType[] = [];
+
+      expect(canPlaceDevice(rack, deviceLibrary, 1, toInternalUnits(2))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("isWholeURailPosition", () => {
+    it("is true for whole-U internal positions", () => {
+      expect(isWholeURailPosition(UNITS_PER_U)).toBe(true);
+      expect(isWholeURailPosition(toInternalUnits(2))).toBe(true);
+    });
+
+    it("is false for fractional-U internal positions", () => {
+      expect(isWholeURailPosition(toInternalUnits(1.5))).toBe(false);
     });
   });
 

--- a/src/tests/layout-device-actions.test.ts
+++ b/src/tests/layout-device-actions.test.ts
@@ -804,7 +804,7 @@ describe("Layout Store", () => {
   });
 
   describe("0.5U device movement", () => {
-    it("allows moving 0.5U device to half-unit positions", () => {
+    it("rejects moving a 0.5U blank to a half-unit rail position", () => {
       const store = getLayoutStore();
       const rack = store.addRack("Test Rack", 42);
 
@@ -818,18 +818,19 @@ describe("Layout Store", () => {
         }),
       );
 
-      // Place at position 1
+      // Place at whole-U position 1 (rails register at whole-U boundaries)
       const placed = store.placeDevice(rack!.id, halfUType.slug, 1, "front");
       expect(placed).toBe(true);
       expect(store.rack.devices[0]!.position).toBe(toInternalUnits(1));
 
-      // Move to position 1.5 - should succeed
+      // Move to fractional position 1.5 - rejected at the chokepoint, the device
+      // stays at its whole-U position (rail positions must be whole-U, #2667).
       const result = store.moveDevice(rack!.id, 0, 1.5);
-      expect(result).toBe(true);
-      expect(store.rack.devices[0]!.position).toBe(toInternalUnits(1.5));
+      expect(result).toBe(false);
+      expect(store.rack.devices[0]!.position).toBe(toInternalUnits(1));
     });
 
-    it("allows moving 0.5U device to integer positions", () => {
+    it("allows moving a 0.5U blank between whole-U rail positions", () => {
       const store = getLayoutStore();
       const rack = store.addRack("Test Rack", 42);
 
@@ -843,11 +844,11 @@ describe("Layout Store", () => {
         }),
       );
 
-      // Place at position 1.5
-      const placed = store.placeDevice(rack!.id, halfUType.slug, 1.5, "front");
+      // Place at whole-U position 1
+      const placed = store.placeDevice(rack!.id, halfUType.slug, 1, "front");
       expect(placed).toBe(true);
 
-      // Move to position 2 - should succeed
+      // Move to whole-U position 2 - should succeed
       const result = store.moveDevice(rack!.id, 0, 2);
       expect(result).toBe(true);
       expect(store.rack.devices[0]!.position).toBe(toInternalUnits(2));
@@ -900,7 +901,7 @@ describe("Layout Store", () => {
       expect(result).toBe(false);
     });
 
-    it("allows adjacent 0.5U devices without collision", () => {
+    it("rejects moving a 0.5U blank onto a half-unit rail position next to a sibling", () => {
       const store = getLayoutStore();
       const rack = store.addRack("Test Rack", 42);
 
@@ -920,10 +921,11 @@ describe("Layout Store", () => {
       // Place second device at U10
       store.placeDevice(rack!.id, halfUType.slug, 10, "front");
 
-      // Move second device to U5.5 - should succeed (adjacent, no overlap)
+      // Move second device to fractional U5.5 - rejected by the whole-U rail
+      // guard (#2667), so the device keeps its whole-U position.
       const result = store.moveDevice(rack!.id, 1, 5.5);
-      expect(result).toBe(true);
-      expect(store.rack.devices[1]!.position).toBe(toInternalUnits(5.5));
+      expect(result).toBe(false);
+      expect(store.rack.devices[1]!.position).toBe(toInternalUnits(10));
     });
   });
 

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import type { Layout } from "$lib/types";
 import { VERSION } from "$lib/version";
-import { createTestDeviceTypeInput } from "./factories";
+import {
+  createTestDeviceTypeInput,
+  createTestDeviceType,
+  createTestContainerType,
+} from "./factories";
 
 describe("Layout Store", () => {
   beforeEach(() => {
@@ -551,6 +555,95 @@ describe("Layout Store", () => {
       store.updateShowLabelsOnImages(true);
       expect(store.layout.settings.show_labels_on_images).toBe(true);
       expect(store.isDirty).toBe(true);
+    });
+  });
+
+  describe("whole-U rail integer guard", () => {
+    it("rejects a rail placement at a non-integer U", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42)!;
+      const deviceType = createTestDeviceType({
+        slug: "server-1u",
+        u_height: 1,
+      });
+      store.addDeviceTypeRaw(deviceType);
+
+      // U1.5 is a fractional rail position - must be refused at place time.
+      expect(store.placeDevice(rack.id, deviceType.slug, 1.5)).toBe(false);
+      expect(store.rack?.devices ?? []).not.toContainEqual(
+        expect.objectContaining({ device_type: deviceType.slug }),
+      );
+    });
+
+    it("accepts a rail placement at a whole U", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42)!;
+      const deviceType = createTestDeviceType({
+        slug: "server-1u",
+        u_height: 1,
+      });
+      store.addDeviceTypeRaw(deviceType);
+
+      expect(store.placeDevice(rack.id, deviceType.slug, 2)).toBe(true);
+      expect(store.rack?.devices ?? []).toContainEqual(
+        expect.objectContaining({ device_type: deviceType.slug }),
+      );
+    });
+
+    it("rejects moving a rail device to a non-integer U", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42)!;
+      const deviceType = createTestDeviceType({
+        slug: "server-1u",
+        u_height: 1,
+      });
+      store.addDeviceTypeRaw(deviceType);
+      store.placeDevice(rack.id, deviceType.slug, 2);
+      const index = store.rack!.devices.findIndex(
+        (d) => d.device_type === deviceType.slug,
+      );
+
+      expect(store.moveDevice(rack.id, index, 3.5)).toBe(false);
+    });
+
+    it("does not reject a sub-U device placed inside a container", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42)!;
+
+      const containerType = createTestContainerType({
+        slug: "blade-chassis",
+        u_height: 4,
+      });
+      const childType = createTestDeviceType({
+        slug: "blade-server",
+        u_height: 1,
+        slot_width: 1,
+      });
+      store.addDeviceTypeRaw(containerType);
+      store.addDeviceTypeRaw(childType);
+
+      expect(store.placeDevice(rack.id, containerType.slug, 5)).toBe(true);
+      const container = store.rack!.devices.find(
+        (d) => d.device_type === containerType.slug,
+      )!;
+
+      // Container children carry 0-indexed (non-whole-U internal) positions and
+      // must not be rejected by the rail integer guard.
+      expect(
+        store.placeInContainer(
+          rack.id,
+          childType.slug,
+          container.id,
+          "slot-left",
+          0,
+        ),
+      ).toBe(true);
+      expect(store.rack?.devices ?? []).toContainEqual(
+        expect.objectContaining({
+          device_type: childType.slug,
+          container_id: container.id,
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Rail positions must be whole-U integers, but that invariant was only enforced at save time by the schema `superRefine`. The live place/move path let a caller pass a non-integer U (for example `1.5`), producing a fractional internal rail position that the store held and could not later save except with an opaque schema error. This adds a small runtime predicate and applies it at the shared rack-level chokepoint, mirroring the existing `requiresCarrier` guard.

## Changes

- Add exported `isWholeURailPosition(positionInternal: number): boolean` (`positionInternal % UNITS_PER_U === 0`) beside `requiresCarrier` in `src/lib/utils/collision.ts`.
- Check it inside `canPlaceDevice`, the single rack-level bounds/collision gate used by place and both within-rack and cross-rack moves. A fractional rail position is rejected through the existing "cannot place" result. Container (sub-U) placements use `canPlaceInContainer` and are unaffected.
- Rewrite 3 stale `0.5U device movement` tests that asserted fractional rail placements (which create unsaveable layouts) to expect whole-U-only behavior.
- Add unit and store tests: fractional rail place/move rejected at the chokepoint, whole-U place/move accepted, sub-U container placement not rejected by the guard.

## Testing

- [x] `npm run test:run` - 2975 passed (186 files)
- [x] `npm run lint` - clean
- [x] `npm run format:check` - clean
- [x] `npm run check` - no new svelte-check errors (2 pre-existing only)
- [x] `npm run build` - success

## Screenshots

N/A - non-UI change.

## Accessibility

N/A - non-UI change.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality (if applicable)

Closes #2667

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUwpJvjFpgTY4WFoccEgJJ)_


___

## **CodeAnt-AI Description**
**Reject fractional rail positions when placing or moving devices**

### What Changed
- Rail-mounted devices now refuse fractional U positions at place and move time, so invalid layouts are blocked before they can be saved
- Whole-U rail positions still work as expected
- 0.5U blank devices can still be placed and moved between whole-U positions, but not onto fractional rail positions
- Added tests to cover rejected fractional rail positions, accepted whole-U placements, and container placements that are unaffected

### Impact
`✅ Fewer unsavable rack layouts`
`✅ Clearer placement errors`
`✅ Safer device moves`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
