### PR TITLE
feat: R2 storage driver + runner-agnostic contract harness (#2625)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,13 @@ jobs:
         with:
           bun-version: "1"
 
+      # The workers-pool storage contract runs under Vitest on Node (workerd via
+      # Miniflare), not Bun, so Node is needed alongside Bun for this job.
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+
       - name: Install API dependencies
         working-directory: api
         run: bun install --frozen-lockfile
@@ -45,9 +52,15 @@ jobs:
         working-directory: api
         run: bun run typecheck
 
-      - name: Run API tests
+      - name: Run API tests (filesystem driver)
         working-directory: api
         run: bun test
+
+      # Slice 2 (#2625): the same storage contract against the R2 driver inside
+      # workerd via Miniflare, plus the R2-specific prune/quota/asset specs.
+      - name: Run R2 storage contract (workers pool)
+        working-directory: api
+        run: npx vitest run --config vitest.workers.config.ts
 
   validate:
     name: validate

--- a/api/bun.lock
+++ b/api/bun.lock
@@ -13,10 +13,12 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "0.16.20",
         "@types/bun": "^1.3.14",
         "@types/js-yaml": "^4.0.9",
         "pino-pretty": "^13.1.3",
         "typescript": "^6.0.3",
+        "vitest": "4.1.9",
       },
     },
   },
@@ -44,11 +46,139 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.3.1", "", {}, "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g=="],
 
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.16.20", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "wrangler": "4.105.0", "zod": "3.25.76" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-buw0YgsAMT7s60wcmyxbtciEJjMJzKcWzayDMPhWaqMqfQzW+0WPLV67Lobn4C80nkNQhYocEJPnrEhLWnOf+A=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260625.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260625.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260625.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260625.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260625.1", "", { "os": "win32", "cpu": "x64" }, "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260629.1", "", {}, "sha512-5vq2ErIFVRSQ8Dcw5YOeEoBdZBudqBjHFKTWD3SBGiJR5hD1+/86aRUV/DTpEK9sXXCGOTGgpWBGlPSlW7djVg=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
@@ -88,7 +218,51 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
+    "@oxc-project/types": ["@oxc-project/types@0.137.0", "", {}, "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.3", "", { "os": "android", "cpu": "arm64" }, "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.3", "", { "os": "linux", "cpu": "arm" }, "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.3", "", { "os": "none", "cpu": "arm64" }, "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.3", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -96,11 +270,33 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/node": ["@types/node@25.1.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
@@ -108,19 +304,45 @@
 
     "better-call": ["better-call@1.3.7", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w=="],
 
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.2.3", "", {}, "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="],
+
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.2.0", "", {}, "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "fast-copy": ["fast-copy@4.0.3", "", {}, "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw=="],
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
@@ -132,15 +354,57 @@
 
     "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
 
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
     "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "miniflare": ["miniflare@4.20260625.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260625.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+
     "nanostores": ["nanostores@1.3.0", "", {}, "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA=="],
+
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
 
@@ -150,6 +414,8 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
+    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
@@ -158,32 +424,88 @@
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
+    "rolldown": ["rolldown@1.1.3", "", { "dependencies": { "@oxc-project/types": "=0.137.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.3", "@rolldown/binding-darwin-arm64": "1.1.3", "@rolldown/binding-darwin-x64": "1.1.3", "@rolldown/binding-freebsd-x64": "1.1.3", "@rolldown/binding-linux-arm-gnueabihf": "1.1.3", "@rolldown/binding-linux-arm64-gnu": "1.1.3", "@rolldown/binding-linux-arm64-musl": "1.1.3", "@rolldown/binding-linux-ppc64-gnu": "1.1.3", "@rolldown/binding-linux-s390x-gnu": "1.1.3", "@rolldown/binding-linux-x64-gnu": "1.1.3", "@rolldown/binding-linux-x64-musl": "1.1.3", "@rolldown/binding-openharmony-arm64": "1.1.3", "@rolldown/binding-wasm32-wasi": "1.1.3", "@rolldown/binding-win32-arm64-msvc": "1.1.3", "@rolldown/binding-win32-x64-msvc": "1.1.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g=="],
+
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
     "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
     "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "vite": ["vite@8.1.0", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "~1.1.2", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "workerd": ["workerd@1.20260625.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260625.1", "@cloudflare/workerd-darwin-arm64": "1.20260625.1", "@cloudflare/workerd-linux-64": "1.20260625.1", "@cloudflare/workerd-linux-arm64": "1.20260625.1", "@cloudflare/workerd-windows-64": "1.20260625.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA=="],
+
+    "wrangler": ["wrangler@4.105.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260625.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260625.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260625.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "cf-wrangler": "bin/cf-wrangler.js", "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "@cloudflare/vitest-pool-workers/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -10,6 +10,7 @@
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
     "test": "bun test",
+    "test:workers": "vitest run --config vitest.workers.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "overrides": {
@@ -26,9 +27,11 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "0.16.20",
     "@types/bun": "^1.3.14",
     "@types/js-yaml": "^4.0.9",
     "pino-pretty": "^13.1.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "4.1.9"
   }
 }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -895,9 +895,7 @@ export async function createApp(
   // Storage quota — enforce layout and asset count limits on write operations.
   // Applied after body limits (so request body is already validated) and before
   // route handlers. Skips check when both quotas are unlimited (max=0).
-  const dataDir = env.DATA_DIR ?? "./data";
   const storageQuotaMiddleware = createStorageQuotaMiddleware({
-    dataDir,
     maxLayouts: securityConfig.maxLayouts,
     maxAssetsPerLayout: securityConfig.maxAssetsPerLayout,
   });

--- a/api/src/cloudflare-test-env.d.ts
+++ b/api/src/cloudflare-test-env.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Ambient typing for the `cloudflare:test` virtual module provided by
+ * vitest-pool-workers (#2625). Declared here (not in the spec) so the spec is a
+ * plain module and the binding is typed against the minimal R2 surface the
+ * driver uses; the real Miniflare binding is a structural superset.
+ */
+declare module "cloudflare:test" {
+  import type { R2BucketLike } from "./storage/r2-driver";
+  export const env: { LAYOUTS: R2BucketLike };
+}

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -11,22 +11,24 @@
  * PUT    /api/assets/:layoutId/:deviceSlug/:face - Upload asset image
  * DELETE /api/assets/:layoutId/:deviceSlug/:face - Delete asset image
  * (nginx strips /api prefix before forwarding to API)
+ *
+ * Storage goes through the per-request driver (#2625): filesystem on self-host,
+ * R2 on Workers. The magic-byte sniff is the shared chokepoint inside
+ * driver.saveAsset (asset-validation.ts), so a spoofed Content-Type cannot pick
+ * the stored format on either backend.
  */
 import { Hono } from "hono";
 import { LayoutIdSchema } from "../schemas/layout";
+import type { StorageVariables } from "../storage/driver";
 import {
-  getAsset,
-  saveAsset,
-  deleteAsset,
-  listLayoutAssets,
   isValidImageType,
   isValidDeviceSlug,
   AssetRejectedError,
   MAX_SIZE,
-} from "../storage/assets";
+} from "../storage/asset-validation";
 import { logger } from "../logger";
 
-const assets = new Hono();
+const assets = new Hono<{ Variables: StorageVariables }>();
 
 // Validate face parameter
 function isValidFace(face: string): face is "front" | "rear" {
@@ -35,10 +37,9 @@ function isValidFace(face: string): face is "front" | "rear" {
 
 // List the on-disk asset faces for a layout. Drives the save-time set-diff
 // reconcile (#2530): the client diffs this against the layout's current custom
-// faces and deletes the difference. A valid UUID whose layout folder does not
-// exist yet (e.g. a reconcile run before the first YAML PUT lands) is "no
-// assets on disk", not an error, so it returns an empty list rather than a 404.
-// Inherits the per-asset GET read posture (no auth beyond app-level middleware).
+// faces and deletes the difference. A valid UUID whose layout does not exist
+// yet (e.g. a reconcile run before the first YAML PUT lands) is "no assets",
+// not an error, so it returns an empty list rather than a 404.
 assets.get("/:layoutId", async (c) => {
   const { layoutId } = c.req.param();
 
@@ -48,11 +49,11 @@ assets.get("/:layoutId", async (c) => {
   }
 
   try {
-    const list = await listLayoutAssets(layoutId);
+    const list = await c.get("storage").listLayoutAssets(layoutId);
     return c.json({ assets: list }, 200);
   } catch (error) {
-    // listLayoutAssets throws "Layout not found" when the layout folder is
-    // absent. For the reconcile that means an empty on-disk set, not a failure.
+    // listLayoutAssets throws "Layout not found" when the layout is absent. For
+    // the reconcile that means an empty on-disk set, not a failure.
     if (
       error instanceof Error &&
       error.message.startsWith("Layout not found")
@@ -91,7 +92,7 @@ assets.get("/:layoutId/:deviceSlug/:face", async (c) => {
   }
 
   try {
-    const asset = await getAsset(layoutId, deviceSlug, face);
+    const asset = await c.get("storage").getAsset(layoutId, deviceSlug, face);
     if (!asset) {
       return c.json({ error: "Asset not found" }, 404);
     }
@@ -154,14 +155,14 @@ assets.put("/:layoutId/:deviceSlug/:face", async (c) => {
       return c.json({ error: "File too large. Maximum size is 5MB" }, 413);
     }
 
-    await saveAsset(layoutId, deviceSlug, face, data, contentType);
+    await c
+      .get("storage")
+      .saveAsset(layoutId, deviceSlug, face, data, contentType);
 
     return c.json({ message: "Asset uploaded" }, 200);
   } catch (error) {
     // Client errors (oversized body, rejected bytes) are expected bad uploads,
     // not server faults, so they return a 4xx without logging at error level.
-    // Logging them would make routine bad uploads look like server failures in
-    // logs and alerts.
     if (error instanceof Error && error.message.includes("too large")) {
       return c.json({ error: error.message }, 413);
     }
@@ -199,7 +200,9 @@ assets.delete("/:layoutId/:deviceSlug/:face", async (c) => {
   }
 
   try {
-    const deleted = await deleteAsset(layoutId, deviceSlug, face);
+    const deleted = await c
+      .get("storage")
+      .deleteAsset(layoutId, deviceSlug, face);
     if (!deleted) {
       return c.json({ error: "Asset not found" }, 404);
     }

--- a/api/src/routes/assets.ts
+++ b/api/src/routes/assets.ts
@@ -176,6 +176,18 @@ assets.put("/:layoutId/:deviceSlug/:face", async (c) => {
       return c.json({ error: error.message }, 400);
     }
 
+    // A route-valid-but-non-UUID layout id is a bad request, and a write to a
+    // missing layout is a 404, not a server fault. The driver throws these with
+    // fixed category prefixes that interpolate only validated values.
+    if (error instanceof Error) {
+      if (error.message.startsWith("Invalid layout UUID")) {
+        return c.json({ error: "Invalid layout ID format" }, 400);
+      }
+      if (error.message.startsWith("Layout not found")) {
+        return c.json({ error: "Layout not found" }, 404);
+      }
+    }
+
     // Anything reaching here is an unexpected server fault: log it.
     logger.error({ err: error }, `Failed to save asset`);
     return c.json({ error: "Failed to save asset" }, 500);

--- a/api/src/routes/layouts.test.ts
+++ b/api/src/routes/layouts.test.ts
@@ -243,6 +243,36 @@ describe("createApp storage driver injection (#2624)", () => {
         calls.push("getPreCarrierBackup");
         return null;
       },
+      async layoutExists() {
+        calls.push("layoutExists");
+        return false;
+      },
+      async countLayouts() {
+        calls.push("countLayouts");
+        return 0;
+      },
+      async countAssets() {
+        calls.push("countAssets");
+        return 0;
+      },
+      async getAsset() {
+        calls.push("getAsset");
+        return null;
+      },
+      async saveAsset() {
+        calls.push("saveAsset");
+      },
+      async deleteAsset() {
+        calls.push("deleteAsset");
+        return false;
+      },
+      async deleteLayoutAssets() {
+        calls.push("deleteLayoutAssets");
+      },
+      async listLayoutAssets() {
+        calls.push("listLayoutAssets");
+        return [];
+      },
     };
 
     const stubApp = await createApp(

--- a/api/src/routes/layouts.test.ts
+++ b/api/src/routes/layouts.test.ts
@@ -266,9 +266,6 @@ describe("createApp storage driver injection (#2624)", () => {
         calls.push("deleteAsset");
         return false;
       },
-      async deleteLayoutAssets() {
-        calls.push("deleteLayoutAssets");
-      },
       async listLayoutAssets() {
         calls.push("listLayoutAssets");
         return [];

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -31,7 +31,6 @@ import * as yaml from "js-yaml";
 import { UuidSchema, LayoutFileSchema } from "../schemas/layout";
 import type { StorageVariables } from "../storage/driver";
 import { SNAPSHOT_NAME_PATTERN } from "../storage/snapshot-name";
-import { deleteLayoutAssets } from "../storage/assets";
 import { logger } from "../logger";
 
 /** Header carrying the layout's updatedAt for echo-based conflict detection. */
@@ -212,11 +211,10 @@ layouts.delete("/:uuid", async (c) => {
       return c.json({ error: "Layout not found" }, 404);
     }
 
-    // Assets are now stored inside the layout folder
-    // They get deleted when the folder is removed, but we call this
-    // for any cleanup of orphaned assets or backwards compatibility
+    // Assets live alongside the layout; deleteLayout removes them with the
+    // folder/prefix, but call this for any cleanup of orphaned assets.
     try {
-      await deleteLayoutAssets(uuidResult.data);
+      await c.get("storage").deleteLayoutAssets(uuidResult.data);
     } catch (assetError) {
       logger.warn(
         { err: assetError },

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -211,17 +211,9 @@ layouts.delete("/:uuid", async (c) => {
       return c.json({ error: "Layout not found" }, 404);
     }
 
-    // Assets live alongside the layout; deleteLayout removes them with the
-    // folder/prefix, but call this for any cleanup of orphaned assets.
-    try {
-      await c.get("storage").deleteLayoutAssets(uuidResult.data);
-    } catch (assetError) {
-      logger.warn(
-        { err: assetError },
-        `Failed to delete assets for layout ${uuidResult.data}`,
-      );
-    }
-
+    // deleteLayout removes the whole layout subtree, including its assets, so no
+    // separate asset cleanup is needed (a second delete would race a concurrent
+    // recreate of the same UUID).
     return c.json({ message: "Layout deleted" }, 200);
   } catch (error) {
     logger.error({ err: error }, `Failed to delete layout ${uuidResult.data}`);

--- a/api/src/security/storage-quota-middleware.test.ts
+++ b/api/src/security/storage-quota-middleware.test.ts
@@ -86,26 +86,35 @@ describe("createStorageQuotaMiddleware", () => {
   describe("layout quota", () => {
     it("allows layout creation when under the limit", async () => {
       const app = createTestApp({ maxLayouts: 5, maxAssetsPerLayout: 50 });
-      const res = await app.request("/layouts/new-uuid-here", {
-        method: "PUT",
-      });
+      const res = await app.request(
+        "/layouts/99999999-9999-4999-8999-999999999999",
+        {
+          method: "PUT",
+        },
+      );
       expect(res.status).toBe(201);
     });
 
     it("allows layout creation via /api/ prefix", async () => {
       const app = createTestApp({ maxLayouts: 5, maxAssetsPerLayout: 50 });
-      const res = await app.request("/api/layouts/new-uuid-here", {
-        method: "PUT",
-      });
+      const res = await app.request(
+        "/api/layouts/99999999-9999-4999-8999-999999999999",
+        {
+          method: "PUT",
+        },
+      );
       expect(res.status).toBe(201);
     });
 
     it("rejects layout creation when at the limit", async () => {
       // Already have 1 layout (created in beforeEach), set limit to 1
       const app = createTestApp({ maxLayouts: 1, maxAssetsPerLayout: 50 });
-      const res = await app.request("/layouts/new-uuid-here", {
-        method: "PUT",
-      });
+      const res = await app.request(
+        "/layouts/99999999-9999-4999-8999-999999999999",
+        {
+          method: "PUT",
+        },
+      );
       expect(res.status).toBe(429);
 
       const body = await res.json();
@@ -127,9 +136,12 @@ describe("createStorageQuotaMiddleware", () => {
 
     it("allows all requests when both quotas are unlimited (max=0)", async () => {
       const app = createTestApp({ maxLayouts: 0, maxAssetsPerLayout: 0 });
-      const res = await app.request("/layouts/new-uuid-here", {
-        method: "PUT",
-      });
+      const res = await app.request(
+        "/layouts/99999999-9999-4999-8999-999999999999",
+        {
+          method: "PUT",
+        },
+      );
       expect(res.status).toBe(201);
     });
 
@@ -143,9 +155,12 @@ describe("createStorageQuotaMiddleware", () => {
 
     it("does not include Retry-After header for hard quota errors", async () => {
       const app = createTestApp({ maxLayouts: 1, maxAssetsPerLayout: 50 });
-      const res = await app.request("/layouts/new-uuid-here", {
-        method: "PUT",
-      });
+      const res = await app.request(
+        "/layouts/99999999-9999-4999-8999-999999999999",
+        {
+          method: "PUT",
+        },
+      );
       // Retry-After is for rate limits, not hard storage quotas
       expect(res.headers.get("Retry-After")).toBeNull();
     });

--- a/api/src/security/storage-quota-middleware.test.ts
+++ b/api/src/security/storage-quota-middleware.test.ts
@@ -4,6 +4,8 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createStorageQuotaMiddleware } from "./storage-quota-middleware";
+import { createFilesystemDriver } from "../storage/filesystem-driver";
+import type { StorageVariables } from "../storage/driver";
 
 const originalDataDir = process.env.DATA_DIR;
 
@@ -42,11 +44,17 @@ function createTestApp(config: {
   maxLayouts: number;
   maxAssetsPerLayout: number;
 }) {
-  const app = new Hono();
+  // The filesystem driver reads DATA_DIR (set to testDir in beforeEach), so the
+  // quota middleware counts the test directory through the injected driver.
+  const driver = createFilesystemDriver();
+  const app = new Hono<{ Variables: StorageVariables }>();
+  app.use("*", async (c, next) => {
+    c.set("storage", driver);
+    await next();
+  });
   app.use(
     "*",
     createStorageQuotaMiddleware({
-      dataDir: testDir,
       maxLayouts: config.maxLayouts,
       maxAssetsPerLayout: config.maxAssetsPerLayout,
     }),

--- a/api/src/security/storage-quota-middleware.ts
+++ b/api/src/security/storage-quota-middleware.ts
@@ -65,12 +65,13 @@ export function createStorageQuotaMiddleware(
 
     // Layout quota: PUT /layouts/:uuid or PUT /api/layouts/:uuid
     const layoutMatch = pathname.match(/^\/(?:api\/)?layouts\/([^/]+)$/);
-    if (layoutMatch && maxLayouts > 0) {
-      const uuid = layoutMatch[1];
-
+    const layoutId = layoutMatch?.[1];
+    // Only enforce quota for syntactically valid UUIDs; a malformed id is the
+    // route's 400, not a 429 (which would also leak quota saturation).
+    if (layoutId && isUuid(layoutId) && maxLayouts > 0) {
       // Only enforce quota on create, not update
-      if (uuid && isUuid(uuid) && (await storage.layoutExists(uuid))) {
-        logger.debug(`quota: layout update for ${uuid}, skipping check`);
+      if (await storage.layoutExists(layoutId)) {
+        logger.debug(`quota: layout update for ${layoutId}, skipping check`);
         await next();
         return;
       }
@@ -99,33 +100,43 @@ export function createStorageQuotaMiddleware(
       /^\/(?:api\/)?assets\/([^/]+)\/([^/]+)\/([^/]+)$/,
     );
     if (assetMatch && maxAssetsPerLayout > 0) {
-      const layoutId = assetMatch[1];
+      const assetLayoutId = assetMatch[1];
+      const deviceSlug = assetMatch[2];
+      const face = assetMatch[3];
 
       if (
-        layoutId &&
-        isUuid(layoutId) &&
-        (await storage.layoutExists(layoutId))
+        assetLayoutId &&
+        isUuid(assetLayoutId) &&
+        (await storage.layoutExists(assetLayoutId))
       ) {
-        const current = await storage.countAssets(layoutId);
+        const current = await storage.countAssets(assetLayoutId);
         if (current >= maxAssetsPerLayout) {
-          logger.warn(
-            `quota: asset quota exceeded for layout ${layoutId}: ${current}/${maxAssetsPerLayout}`,
-          );
-          return c.json(
-            {
-              error: "Storage quota exceeded",
-              message: `Asset limit reached for this layout (${current}/${maxAssetsPerLayout}). Remove existing assets to add new ones.`,
-              current,
-              max: maxAssetsPerLayout,
-            },
-            507,
-          );
+          // Overwriting an existing asset does not increase the count, so only
+          // reject a genuinely new asset at the cap.
+          const isReplacement =
+            (face === "front" || face === "rear") &&
+            deviceSlug !== undefined &&
+            (await storage.getAsset(assetLayoutId, deviceSlug, face)) !== null;
+          if (!isReplacement) {
+            logger.warn(
+              `quota: asset quota exceeded for layout ${assetLayoutId}: ${current}/${maxAssetsPerLayout}`,
+            );
+            return c.json(
+              {
+                error: "Storage quota exceeded",
+                message: `Asset limit reached for this layout (${current}/${maxAssetsPerLayout}). Remove existing assets to add new ones.`,
+                current,
+                max: maxAssetsPerLayout,
+              },
+              507,
+            );
+          }
         }
       } else {
         // Layout doesn't exist — the route handler will return 404 (or create
         // semantics do not apply to assets).
         logger.debug(
-          `quota: layout ${layoutId} not found, skipping asset check`,
+          `quota: layout ${assetLayoutId} not found, skipping asset check`,
         );
       }
     }

--- a/api/src/security/storage-quota-middleware.ts
+++ b/api/src/security/storage-quota-middleware.ts
@@ -16,6 +16,7 @@
 
 import type { MiddlewareHandler } from "hono";
 import { isUuid } from "../schemas/layout";
+import { isValidDeviceSlug } from "../storage/asset-validation";
 import type { StorageVariables } from "../storage/driver";
 import { logger } from "../logger";
 
@@ -104,9 +105,14 @@ export function createStorageQuotaMiddleware(
       const deviceSlug = assetMatch[2];
       const face = assetMatch[3];
 
+      // Only enforce the asset quota for a well-formed target; a malformed
+      // deviceSlug/face is the route's 400, not a 507.
       if (
         assetLayoutId &&
         isUuid(assetLayoutId) &&
+        deviceSlug &&
+        isValidDeviceSlug(deviceSlug) &&
+        (face === "front" || face === "rear") &&
         (await storage.layoutExists(assetLayoutId))
       ) {
         const current = await storage.countAssets(assetLayoutId);
@@ -114,8 +120,6 @@ export function createStorageQuotaMiddleware(
           // Overwriting an existing asset does not increase the count, so only
           // reject a genuinely new asset at the cap.
           const isReplacement =
-            (face === "front" || face === "rear") &&
-            deviceSlug !== undefined &&
             (await storage.getAsset(assetLayoutId, deviceSlug, face)) !== null;
           if (!isReplacement) {
             logger.warn(

--- a/api/src/security/storage-quota-middleware.ts
+++ b/api/src/security/storage-quota-middleware.ts
@@ -1,31 +1,28 @@
 /**
- * Hono middleware for enforcing storage quotas on layout and asset write operations.
+ * Hono middleware for enforcing storage quotas on layout and asset writes.
  *
- * Checks layout count and per-layout asset count before allowing write operations.
- * Layout quota is only enforced on create (UUID not found), not on update.
- * Asset quota is enforced on every PUT to /assets/:layoutId/:deviceSlug/:face.
+ * Counts come from the per-request storage driver (#2625), not the filesystem,
+ * so the middleware works behind any backend (filesystem or R2) and never pulls
+ * a storage module (and node:fs) into the Workers bundle. Layout quota is only
+ * enforced on create (layout does not yet exist), not on update. Asset quota is
+ * enforced on every PUT to /assets/:layoutId/:deviceSlug/:face.
  *
  * When a quota is exceeded, returns:
  * - 429 (Too Many Requests) for layout count quota
  * - 507 (Insufficient Storage) for per-layout asset count quota
  *
- * Both responses include a JSON body with error details.
- *
  * @module storage-quota-middleware
  */
 
 import type { MiddlewareHandler } from "hono";
-import { checkLayoutQuota, checkAssetQuota } from "../storage/quota";
-import { findFolderByUuid } from "../storage/filesystem";
 import { isUuid } from "../schemas/layout";
+import type { StorageVariables } from "../storage/driver";
 import { logger } from "../logger";
 
 /**
  * Configuration for the storage quota middleware.
  */
 export interface StorageQuotaMiddlewareConfig {
-  /** Path to the data directory containing layouts. */
-  dataDir: string;
   /** Maximum number of layouts. 0 = unlimited. */
   maxLayouts: number;
   /** Maximum number of assets per layout. 0 = unlimited. */
@@ -39,14 +36,13 @@ export interface StorageQuotaMiddlewareConfig {
  * - PUT /layouts/:uuid — checks layout count quota (create only, not update)
  * - PUT /assets/:layoutId/:deviceSlug/:face — checks per-layout asset count quota
  *
- * All other routes and methods are passed through without quota checks.
- * When both maxLayouts and maxAssetsPerLayout are 0 (unlimited), the middleware
- * is a no-op pass-through.
+ * All other routes and methods pass through. When both maxLayouts and
+ * maxAssetsPerLayout are 0 (unlimited), the middleware is a no-op pass-through.
  */
 export function createStorageQuotaMiddleware(
   config: StorageQuotaMiddlewareConfig,
-): MiddlewareHandler {
-  const { dataDir, maxLayouts, maxAssetsPerLayout } = config;
+): MiddlewareHandler<{ Variables: StorageVariables }> {
+  const { maxLayouts, maxAssetsPerLayout } = config;
 
   // When both quotas are unlimited, skip all checks
   const unlimited = maxLayouts === 0 && maxAssetsPerLayout === 0;
@@ -58,83 +54,79 @@ export function createStorageQuotaMiddleware(
     }
 
     const method = c.req.method.toUpperCase();
-    const { pathname } = new URL(c.req.url);
-
     // Only enforce quotas on PUT (create/update) requests
     if (method !== "PUT") {
       await next();
       return;
     }
 
+    const { pathname } = new URL(c.req.url);
+    const storage = c.get("storage");
+
     // Layout quota: PUT /layouts/:uuid or PUT /api/layouts/:uuid
     const layoutMatch = pathname.match(/^\/(?:api\/)?layouts\/([^/]+)$/);
-    if (layoutMatch) {
+    if (layoutMatch && maxLayouts > 0) {
       const uuid = layoutMatch[1];
 
       // Only enforce quota on create, not update
-      if (uuid && isUuid(uuid)) {
-        const existingFolder = await findFolderByUuid(uuid, dataDir);
-        if (existingFolder) {
-          logger.debug(`quota: layout update for ${uuid}, skipping check`);
-          await next();
-          return;
-        }
+      if (uuid && isUuid(uuid) && (await storage.layoutExists(uuid))) {
+        logger.debug(`quota: layout update for ${uuid}, skipping check`);
+        await next();
+        return;
       }
 
-      // Create — enforce layout quota
-      // NOTE: Quota check and write are not atomic. Concurrent PUT requests can
-      // both pass the check before either writes, temporarily exceeding the limit.
-      // This is an accepted trade-off for self-hosted homelab use (low concurrency).
-      // Adding file locks would introduce complexity not justified by the threat model.
-      const quota = await checkLayoutQuota(dataDir, maxLayouts);
-      if (!quota.allowed) {
-        logger.warn(
-          `quota: layout quota exceeded ${quota.current}/${quota.max}`,
-        );
+      // Create — enforce layout quota.
+      // NOTE: count and write are not atomic. Concurrent PUTs can both pass the
+      // check before either writes, temporarily exceeding the limit. Accepted
+      // trade-off for self-hosted/low-concurrency use.
+      const current = await storage.countLayouts();
+      if (current >= maxLayouts) {
+        logger.warn(`quota: layout quota exceeded ${current}/${maxLayouts}`);
         return c.json(
           {
             error: "Storage quota exceeded",
-            message: `Layout limit reached (${quota.current}/${quota.max}). Delete existing layouts to create new ones.`,
-            current: quota.current,
-            max: quota.max,
+            message: `Layout limit reached (${current}/${maxLayouts}). Delete existing layouts to create new ones.`,
+            current,
+            max: maxLayouts,
           },
           429,
         );
       }
     }
 
-    // Asset quota: PUT /assets/:layoutId/:deviceSlug/:face or PUT /api/assets/:layoutId/:deviceSlug/:face
+    // Asset quota: PUT /assets/:layoutId/:deviceSlug/:face or /api/assets/...
     const assetMatch = pathname.match(
       /^\/(?:api\/)?assets\/([^/]+)\/([^/]+)\/([^/]+)$/,
     );
-    if (assetMatch) {
+    if (assetMatch && maxAssetsPerLayout > 0) {
       const layoutId = assetMatch[1];
 
-      // Find the layout folder to count its assets
-      if (layoutId && isUuid(layoutId)) {
-        const layoutFolder = await findFolderByUuid(layoutId, dataDir);
-        if (layoutFolder) {
-          const quota = await checkAssetQuota(layoutFolder, maxAssetsPerLayout);
-          if (!quota.allowed) {
-            logger.warn(
-              `quota: asset quota exceeded for layout ${layoutId}: ${quota.current}/${quota.max}`,
-            );
-            return c.json(
-              {
-                error: "Storage quota exceeded",
-                message: `Asset limit reached for this layout (${quota.current}/${quota.max}). Remove existing assets to add new ones.`,
-                current: quota.current,
-                max: quota.max,
-              },
-              507,
-            );
-          }
-        } else {
-          // Layout doesn't exist — the route handler will return 404
-          logger.debug(
-            `quota: layout ${layoutId} not found, skipping asset check`,
+      if (
+        layoutId &&
+        isUuid(layoutId) &&
+        (await storage.layoutExists(layoutId))
+      ) {
+        const current = await storage.countAssets(layoutId);
+        if (current >= maxAssetsPerLayout) {
+          logger.warn(
+            `quota: asset quota exceeded for layout ${layoutId}: ${current}/${maxAssetsPerLayout}`,
+          );
+          return c.json(
+            {
+              error: "Storage quota exceeded",
+              message: `Asset limit reached for this layout (${current}/${maxAssetsPerLayout}). Remove existing assets to add new ones.`,
+              current,
+              max: maxAssetsPerLayout,
+            },
+            507,
           );
         }
+      } else {
+        // Layout doesn't exist — the route handler will return 404 (or create
+        // semantics do not apply to assets).
+        logger.debug(
+          `quota: layout ${layoutId} not found, skipping asset check`,
+        );
       }
     }
 

--- a/api/src/storage/asset-validation.ts
+++ b/api/src/storage/asset-validation.ts
@@ -9,19 +9,32 @@
 import { z } from "zod";
 import { isUuid } from "../schemas/layout";
 
-// Allowed image types
+/** Image MIME types accepted for stored device assets. */
 const ALLOWED_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
+/** File extensions the storage layer may use for validated device assets. */
 export const ALLOWED_EXTS = new Set(["png", "jpg", "webp"]);
+/** Maximum accepted asset size in bytes. */
 export const MAX_SIZE = 5 * 1024 * 1024; // 5MB
 
+/** Supported device image face identifiers. */
 export type AssetFace = "front" | "rear";
 
+/** Metadata returned when listing a layout's stored assets. */
 export interface AssetInfo {
   layoutId: string;
   deviceSlug: string;
   face: AssetFace;
   ext: string;
   size: number;
+}
+
+/**
+ * Reduce a Content-Type header to its bare media-type token: drop any
+ * parameters (e.g. `; charset=binary`) and lowercase. Lets a parameterized or
+ * differently-cased header still match the allowlist and the sniffed type.
+ */
+function normalizeMediaType(contentType: string): string {
+  return (contentType.split(";")[0] ?? "").trim().toLowerCase();
 }
 
 /**
@@ -114,7 +127,7 @@ export const DeviceSlugSchema = z
  * Validate image content type
  */
 export function isValidImageType(contentType: string): boolean {
-  return ALLOWED_TYPES.has(contentType);
+  return ALLOWED_TYPES.has(normalizeMediaType(contentType));
 }
 
 /**
@@ -190,7 +203,10 @@ export function validateAssetBytes(
   data: ArrayBuffer,
   contentType: string,
 ): { ext: string } {
-  if (!isValidImageType(contentType)) {
+  // Compare against the bare media type so a parameterized/cased header (e.g.
+  // "image/png; charset=binary") is handled the same as "image/png".
+  const mediaType = normalizeMediaType(contentType);
+  if (!ALLOWED_TYPES.has(mediaType)) {
     throw new Error(`Invalid content type: ${contentType}`);
   }
 
@@ -212,9 +228,9 @@ export function validateAssetBytes(
       "Rejected asset: bytes do not match an allowed image format (png/jpeg/webp)",
     );
   }
-  if (sniffedType !== contentType) {
+  if (sniffedType !== mediaType) {
     throw new AssetRejectedError(
-      `Rejected asset: declared content type ${contentType} disagrees with sniffed type ${sniffedType}`,
+      `Rejected asset: declared content type ${mediaType} disagrees with sniffed type ${sniffedType}`,
     );
   }
 

--- a/api/src/storage/asset-validation.ts
+++ b/api/src/storage/asset-validation.ts
@@ -1,0 +1,221 @@
+/**
+ * Runtime-agnostic asset validation (#2625).
+ *
+ * The magic-byte sniff and the allowed-format rules are pure (no node:fs), so
+ * both the filesystem driver and the R2 driver share one chokepoint for what is
+ * allowed to be stored, and the layout routes can import the validators without
+ * dragging the filesystem module (and node:fs) into the Workers bundle.
+ */
+import { z } from "zod";
+import { isUuid } from "../schemas/layout";
+import { logger } from "../logger";
+
+// Allowed image types
+const ALLOWED_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
+export const ALLOWED_EXTS = new Set(["png", "jpg", "webp"]);
+export const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+
+export type AssetFace = "front" | "rear";
+
+export interface AssetInfo {
+  layoutId: string;
+  deviceSlug: string;
+  face: AssetFace;
+  ext: string;
+  size: number;
+}
+
+/**
+ * Detect an image MIME type purely from leading magic bytes.
+ *
+ * Recognises PNG, JPEG, and WebP. Returns null for anything unrecognised
+ * (including GIF, SVG, and text/HTML starting with "<"), so the asset write
+ * path can reject untrusted or disallowed content without trusting the
+ * declared Content-Type. SVG is excluded by construction (it has no raster
+ * magic bytes), which keeps stored-XSS payloads off the app origin.
+ *
+ * ALLOWLIST PARITY: this is an independent copy of the client detector
+ * `detectImageMime` in `src/lib/utils/image-encoding.ts` (the Bun API cannot
+ * import the Svelte bundle). The two must accept the same formats; if you
+ * change one, change the other. The client pre-check is advisory; this server
+ * copy is the authority for what lands in storage.
+ */
+export function detectImageMime(bytes: Uint8Array): string | null {
+  // PNG: full 8-byte signature 89 50 4E 47 0D 0A 1A 0A
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+
+  // JPEG: FF D8 FF
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+
+  // WebP: "RIFF" at 0-3 and "WEBP" at 8-11
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+
+  return null;
+}
+
+/**
+ * Thrown when an asset write is rejected because the bytes fail the magic-byte
+ * sniff (non-raster, SVG/GIF/polyglot) or sniff to a type that disagrees with
+ * the declared Content-Type. This is a client error (the upload is bad), so the
+ * route maps it to a 400. A typed error keeps that mapping robust against
+ * message rewording (a plain Error would fall through to a 500).
+ */
+export class AssetRejectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AssetRejectedError";
+  }
+}
+
+// Schema for device slug validation
+// Prevents path traversal attacks
+// Note: Device slugs allow underscores (unlike LayoutIdSchema) to support
+// device type slugs like "dell_r640" that come from external sources
+export const DeviceSlugSchema = z
+  .string()
+  .min(1)
+  .max(200)
+  .regex(
+    /^[a-z0-9][a-z0-9_-]*[a-z0-9]$|^[a-z0-9]$/,
+    "Device slug must be lowercase alphanumeric with hyphens/underscores, not starting/ending with special chars",
+  );
+
+/**
+ * Validate image content type
+ */
+export function isValidImageType(contentType: string): boolean {
+  return ALLOWED_TYPES.has(contentType);
+}
+
+/**
+ * Get extension from content type
+ * Throws for unsupported content types
+ */
+export function getExtFromContentType(contentType: string): string {
+  switch (contentType) {
+    case "image/png":
+      return "png";
+    case "image/jpeg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    default:
+      throw new Error(`Unsupported content type: ${contentType}`);
+  }
+}
+
+/**
+ * Get content type from extension
+ */
+export function getContentTypeFromExt(ext: string): string {
+  switch (ext.toLowerCase()) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    default:
+      logger.warn(`Unknown extension for content type lookup: ${ext}`);
+      return "application/octet-stream";
+  }
+}
+
+/**
+ * Validate layout UUID format
+ * Returns null if invalid
+ */
+export function validateLayoutUuid(layoutId: string): string | null {
+  return isUuid(layoutId) ? layoutId : null;
+}
+
+/**
+ * Validate and sanitize device slug
+ * Returns null if invalid
+ */
+export function validateDeviceSlug(deviceSlug: string): string | null {
+  const parsed = DeviceSlugSchema.safeParse(deviceSlug);
+  return parsed.success ? parsed.data : null;
+}
+
+/**
+ * Check if device slug is valid (exported for use in routes)
+ */
+export function isValidDeviceSlug(slug: string): boolean {
+  return DeviceSlugSchema.safeParse(slug).success;
+}
+
+/**
+ * The shared write chokepoint: validate the declared type, enforce the size
+ * cap, and sniff the magic bytes. The on-disk/object extension is derived from
+ * the SNIFFED type, never the declared header, so a spoofed Content-Type cannot
+ * pick the filename. Throws a plain Error for a disallowed type or oversized
+ * body, and {@link AssetRejectedError} when the bytes do not vouch for the
+ * declared type. Returns the storage extension on success.
+ */
+export function validateAssetBytes(
+  data: ArrayBuffer,
+  contentType: string,
+): { ext: string } {
+  if (!isValidImageType(contentType)) {
+    throw new Error(`Invalid content type: ${contentType}`);
+  }
+
+  if (data.byteLength > MAX_SIZE) {
+    throw new Error(
+      `Image too large: ${data.byteLength} bytes (max ${MAX_SIZE})`,
+    );
+  }
+
+  // Magic-byte sniff is the authority for what reaches storage. The declared
+  // Content-Type is advisory: a non-image body sent as image/png, an SVG, a
+  // GIF, or an HTML/JS polyglot would otherwise be stored and served from the
+  // app origin (stored XSS / MIME confusion). Reject when the bytes do not
+  // sniff to a raster format, or sniff to a format that disagrees with the
+  // declared type.
+  const sniffedType = detectImageMime(new Uint8Array(data));
+  if (!sniffedType) {
+    throw new AssetRejectedError(
+      "Rejected asset: bytes do not match an allowed image format (png/jpeg/webp)",
+    );
+  }
+  if (sniffedType !== contentType) {
+    throw new AssetRejectedError(
+      `Rejected asset: declared content type ${contentType} disagrees with sniffed type ${sniffedType}`,
+    );
+  }
+
+  return { ext: getExtFromContentType(sniffedType) };
+}

--- a/api/src/storage/asset-validation.ts
+++ b/api/src/storage/asset-validation.ts
@@ -8,7 +8,6 @@
  */
 import { z } from "zod";
 import { isUuid } from "../schemas/layout";
-import { logger } from "../logger";
 
 // Allowed image types
 const ALLOWED_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
@@ -148,7 +147,9 @@ export function getContentTypeFromExt(ext: string): string {
     case "webp":
       return "image/webp";
     default:
-      logger.warn(`Unknown extension for content type lookup: ${ext}`);
+      // Defensive fallback for an unknown extension. Callers only pass entries
+      // from ALLOWED_EXTS, so this is unreachable in practice; kept dependency
+      // free (no logger) so this module stays pure for the Workers bundle.
       return "application/octet-stream";
   }
 }

--- a/api/src/storage/assets.ts
+++ b/api/src/storage/assets.ts
@@ -15,7 +15,6 @@ import {
   unlink,
   mkdir,
   readdir,
-  rm,
   stat,
   rename,
 } from "node:fs/promises";
@@ -181,29 +180,6 @@ export async function deleteAsset(
   }
 
   return deleted;
-}
-
-/**
- * Delete all assets for a layout
- * Removes the assets/ subfolder inside the layout folder
- */
-export async function deleteLayoutAssets(layoutId: string): Promise<void> {
-  const validLayoutId = validateLayoutUuid(layoutId);
-  if (!validLayoutId) {
-    throw new Error(`Invalid layout UUID: ${layoutId}`);
-  }
-
-  const assetsDir = await getLayoutAssetsDir(validLayoutId);
-  if (!assetsDir) {
-    // Layout doesn't exist, nothing to delete
-    return;
-  }
-
-  try {
-    await rm(assetsDir, { recursive: true });
-  } catch {
-    // Ignore if doesn't exist
-  }
 }
 
 /**

--- a/api/src/storage/assets.ts
+++ b/api/src/storage/assets.ts
@@ -1,7 +1,13 @@
 /**
- * Asset storage layer for device images
- * Handles upload/download of images to layout-local assets folder:
+ * Filesystem asset storage for device images.
+ *
+ * Handles read/write of images to the layout-local assets folder:
  * /data/{Layout Name}-{UUID}/assets/{deviceSlug}/{face}.{ext}
+ *
+ * The runtime-agnostic validation (magic-byte sniff, allowed formats, device
+ * slug rules) lives in ./asset-validation so the R2 driver and the routes share
+ * the same chokepoint without importing node:fs. This module is the filesystem
+ * implementation, used by the filesystem storage driver.
  */
 import {
   readFile,
@@ -15,175 +21,30 @@ import {
 } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { join, dirname } from "node:path";
-import { z } from "zod";
 import { getLayoutAssetsDir } from "./filesystem";
-import { isUuid } from "../schemas/layout";
-import { logger } from "../logger";
+import {
+  ALLOWED_EXTS,
+  validateAssetBytes,
+  validateDeviceSlug,
+  validateLayoutUuid,
+  getContentTypeFromExt,
+  type AssetFace,
+  type AssetInfo,
+} from "./asset-validation";
 
-// Allowed image types
-const ALLOWED_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
-const ALLOWED_EXTS = new Set(["png", "jpg", "webp"]);
-export const MAX_SIZE = 5 * 1024 * 1024; // 5MB
-
-/**
- * Detect an image MIME type purely from leading magic bytes.
- *
- * Recognises PNG, JPEG, and WebP. Returns null for anything unrecognised
- * (including GIF, SVG, and text/HTML starting with "<"), so the asset write
- * path can reject untrusted or disallowed content without trusting the
- * declared Content-Type. SVG is excluded by construction (it has no raster
- * magic bytes), which keeps stored-XSS payloads off the app origin.
- *
- * ALLOWLIST PARITY: this is an independent copy of the client detector
- * `detectImageMime` in `src/lib/utils/image-encoding.ts` (the Bun API cannot
- * import the Svelte bundle). The two must accept the same formats; if you
- * change one, change the other. The client pre-check is advisory; this server
- * copy is the authority for what lands on disk.
- */
-function detectImageMime(bytes: Uint8Array): string | null {
-  // PNG: full 8-byte signature 89 50 4E 47 0D 0A 1A 0A
-  if (
-    bytes.length >= 8 &&
-    bytes[0] === 0x89 &&
-    bytes[1] === 0x50 &&
-    bytes[2] === 0x4e &&
-    bytes[3] === 0x47 &&
-    bytes[4] === 0x0d &&
-    bytes[5] === 0x0a &&
-    bytes[6] === 0x1a &&
-    bytes[7] === 0x0a
-  ) {
-    return "image/png";
-  }
-
-  // JPEG: FF D8 FF
-  if (
-    bytes.length >= 3 &&
-    bytes[0] === 0xff &&
-    bytes[1] === 0xd8 &&
-    bytes[2] === 0xff
-  ) {
-    return "image/jpeg";
-  }
-
-  // WebP: "RIFF" at 0-3 and "WEBP" at 8-11
-  if (
-    bytes.length >= 12 &&
-    bytes[0] === 0x52 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x46 &&
-    bytes[8] === 0x57 &&
-    bytes[9] === 0x45 &&
-    bytes[10] === 0x42 &&
-    bytes[11] === 0x50
-  ) {
-    return "image/webp";
-  }
-
-  return null;
-}
-
-/**
- * Thrown by saveAsset when a write is rejected because the bytes fail the
- * magic-byte sniff (non-raster, SVG/GIF/polyglot) or sniff to a type that
- * disagrees with the declared Content-Type. This is a client error (the upload
- * is bad), so the route maps it to a 400. A typed error keeps that mapping
- * robust against message rewording (a plain Error would fall through to a 500).
- */
-export class AssetRejectedError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AssetRejectedError";
-  }
-}
-
-// Schema for device slug validation
-// Prevents path traversal attacks
-// Note: Device slugs allow underscores (unlike LayoutIdSchema) to support
-// device type slugs like "dell_r640" that come from external sources
-export const DeviceSlugSchema = z
-  .string()
-  .min(1)
-  .max(200)
-  .regex(
-    /^[a-z0-9][a-z0-9_-]*[a-z0-9]$|^[a-z0-9]$/,
-    "Device slug must be lowercase alphanumeric with hyphens/underscores, not starting/ending with special chars",
-  );
-
-export interface AssetInfo {
-  layoutId: string;
-  deviceSlug: string;
-  face: "front" | "rear";
-  ext: string;
-  size: number;
-}
-
-/**
- * Validate image content type
- */
-export function isValidImageType(contentType: string): boolean {
-  return ALLOWED_TYPES.has(contentType);
-}
-
-/**
- * Get extension from content type
- * Throws for unsupported content types
- */
-export function getExtFromContentType(contentType: string): string {
-  switch (contentType) {
-    case "image/png":
-      return "png";
-    case "image/jpeg":
-      return "jpg";
-    case "image/webp":
-      return "webp";
-    default:
-      throw new Error(`Unsupported content type: ${contentType}`);
-  }
-}
-
-/**
- * Get content type from extension
- */
-export function getContentTypeFromExt(ext: string): string {
-  switch (ext.toLowerCase()) {
-    case "png":
-      return "image/png";
-    case "jpg":
-    case "jpeg":
-      return "image/jpeg";
-    case "webp":
-      return "image/webp";
-    default:
-      logger.warn(`Unknown extension for content type lookup: ${ext}`);
-      return "application/octet-stream";
-  }
-}
-
-/**
- * Validate layout UUID format
- * Returns null if invalid
- */
-function validateLayoutUuid(layoutId: string): string | null {
-  return isUuid(layoutId) ? layoutId : null;
-}
-
-/**
- * Validate and sanitize device slug
- * Returns null if invalid
- */
-function validateDeviceSlug(deviceSlug: string): string | null {
-  const parsed = DeviceSlugSchema.safeParse(deviceSlug);
-  return parsed.success ? parsed.data : null;
-}
-
-/**
- * Check if device slug is valid (exported for use in routes)
- */
-export function isValidDeviceSlug(slug: string): boolean {
-  return DeviceSlugSchema.safeParse(slug).success;
-}
+// Re-export the validation surface so existing importers (routes, tests) keep
+// resolving these from ./assets.
+export {
+  MAX_SIZE,
+  AssetRejectedError,
+  DeviceSlugSchema,
+  isValidImageType,
+  isValidDeviceSlug,
+  getExtFromContentType,
+  getContentTypeFromExt,
+  type AssetFace,
+  type AssetInfo,
+} from "./asset-validation";
 
 /**
  * Build asset path with validation
@@ -193,7 +54,7 @@ export function isValidDeviceSlug(slug: string): boolean {
 async function buildAssetPath(
   layoutId: string,
   deviceSlug: string,
-  face: "front" | "rear",
+  face: AssetFace,
   ext: string,
 ): Promise<string> {
   const validLayoutId = validateLayoutUuid(layoutId);
@@ -225,42 +86,13 @@ async function buildAssetPath(
 export async function saveAsset(
   layoutId: string,
   deviceSlug: string,
-  face: "front" | "rear",
+  face: AssetFace,
   data: ArrayBuffer,
   contentType: string,
 ): Promise<void> {
-  if (!isValidImageType(contentType)) {
-    throw new Error(`Invalid content type: ${contentType}`);
-  }
-
-  if (data.byteLength > MAX_SIZE) {
-    throw new Error(
-      `Image too large: ${data.byteLength} bytes (max ${MAX_SIZE})`,
-    );
-  }
-
-  // Magic-byte sniff is the authority for what reaches disk. The declared
-  // Content-Type is advisory: a non-image body sent as image/png, an SVG, a
-  // GIF, or an HTML/JS polyglot would otherwise be stored and served from the
-  // app origin (stored XSS / MIME confusion). Reject when the bytes do not
-  // sniff to a raster format, or sniff to a format that disagrees with the
-  // declared type. Every disk write (PUT and the migration rewrite) flows
-  // through here, so both share this one chokepoint.
-  const sniffedType = detectImageMime(new Uint8Array(data));
-  if (!sniffedType) {
-    throw new AssetRejectedError(
-      "Rejected asset: bytes do not match an allowed image format (png/jpeg/webp)",
-    );
-  }
-  if (sniffedType !== contentType) {
-    throw new AssetRejectedError(
-      `Rejected asset: declared content type ${contentType} disagrees with sniffed type ${sniffedType}`,
-    );
-  }
-
-  // Derive the on-disk extension from the SNIFFED type, never the declared
-  // header, so a spoofed Content-Type cannot pick the filename.
-  const ext = getExtFromContentType(sniffedType);
+  // Shared chokepoint: type allowlist, size cap, and magic-byte sniff. The
+  // extension is derived from the sniffed bytes, never the declared header.
+  const { ext } = validateAssetBytes(data, contentType);
   const assetPath = await buildAssetPath(layoutId, deviceSlug, face, ext);
 
   // Ensure directory exists (creates assets/ and device folder only when needed)
@@ -309,8 +141,8 @@ export async function saveAsset(
 export async function getAsset(
   layoutId: string,
   deviceSlug: string,
-  face: "front" | "rear",
-): Promise<{ data: Buffer; contentType: string } | null> {
+  face: AssetFace,
+): Promise<{ data: Uint8Array; contentType: string } | null> {
   // Try each extension
   for (const ext of ALLOWED_EXTS) {
     try {
@@ -334,7 +166,7 @@ export async function getAsset(
 export async function deleteAsset(
   layoutId: string,
   deviceSlug: string,
-  face: "front" | "rear",
+  face: AssetFace,
 ): Promise<boolean> {
   let deleted = false;
 
@@ -412,7 +244,7 @@ export async function listLayoutAssets(layoutId: string): Promise<AssetInfo[]> {
               assets.push({
                 layoutId: validLayoutId,
                 deviceSlug,
-                face: match[1] as "front" | "rear",
+                face: match[1] as AssetFace,
                 ext: match[2],
                 size: fileStat.size,
               });

--- a/api/src/storage/driver.ts
+++ b/api/src/storage/driver.ts
@@ -85,8 +85,6 @@ export interface StorageDriver {
     deviceSlug: string,
     face: AssetFace,
   ): Promise<boolean>;
-  /** Delete every asset for a layout. */
-  deleteLayoutAssets(layoutUuid: string): Promise<void>;
   /** List a layout's stored assets. */
   listLayoutAssets(layoutUuid: string): Promise<AssetInfo[]>;
 }

--- a/api/src/storage/driver.ts
+++ b/api/src/storage/driver.ts
@@ -1,16 +1,17 @@
 /**
- * Storage driver interface (#2624, slice 1 of #2133).
+ * Storage driver interface (#2624 seam, #2625 R2 + quota/asset surface).
  *
  * The seam that lets the API serve layouts from different backends: the
- * filesystem (self-host / Bun) today, Cloudflare R2 (#2625) next. Routes resolve
- * the driver per-request from the Hono context instead of importing the
- * filesystem free functions directly, so the backend is selected once at the
- * edge (createApp / the future Workers entry) rather than baked into every
- * handler. The R2 driver implements this same interface and is proven against
- * the shared storage contract (#2091).
+ * filesystem (self-host / Bun) today, Cloudflare R2 (#2625) on Workers. Routes
+ * and middleware resolve the driver per-request from the Hono context instead
+ * of importing the filesystem free functions directly, so the backend is
+ * selected once at the edge (createApp / the Workers entry) rather than baked
+ * into every handler. The R2 driver implements this same interface and is
+ * proven against the shared storage contract (#2091).
  */
 import type { LayoutListItem } from "../schemas/layout";
 import type { SnapshotListItem } from "./filesystem";
+import type { AssetFace, AssetInfo } from "./asset-validation";
 
 export interface StorageDriver {
   /** List all stored layouts. */
@@ -20,14 +21,11 @@ export interface StorageDriver {
     uuid: string,
   ): Promise<{ content: string; updatedAt: string } | null>;
   /**
-   * Create or update a layout. `echoedUpdatedAt` is the updatedAt the client
-   * last received; a mismatch with the stored copy snapshots the diverged copy
-   * before overwriting it. Returns the stored copy's new updatedAt.
-   *
-   * Argument order is (yamlContent, existingId, ...), matching the filesystem
-   * free function. The #2091 contract harness (StorageContractDriver) takes
-   * (id, yamlContent, ...), so its adapter swaps the two; keep that swap when
-   * wiring a new driver into the contract. Slice 2 (#2625) aligns the orders.
+   * Create or update a layout. `existingId` is the UUID from the URL (the
+   * authoritative identity); when absent a new UUID is minted. `echoedUpdatedAt`
+   * is the updatedAt the client last received; a mismatch with the stored copy
+   * snapshots the diverged copy before overwriting it. Returns the stored copy's
+   * new (strictly monotonic) updatedAt.
    */
   saveLayout(
     yamlContent: string,
@@ -37,6 +35,8 @@ export interface StorageDriver {
   ): Promise<{ id: string; isNew: boolean; updatedAt: string }>;
   /** Delete a layout by UUID. Returns false if it did not exist. */
   deleteLayout(uuid: string): Promise<boolean>;
+  /** Whether a layout with this UUID exists. */
+  layoutExists(uuid: string): Promise<boolean>;
   /** List a layout's pre-overwrite snapshots, or null if the layout is missing. */
   listSnapshots(uuid: string): Promise<SnapshotListItem[] | null>;
   /** Read a single snapshot's YAML content, or null if not found. */
@@ -51,6 +51,44 @@ export interface StorageDriver {
   ): Promise<{ filename: string } | null>;
   /** Read the durable pre-carrier-migration backup, or null if absent. */
   getPreCarrierBackup(uuid: string): Promise<string | null>;
+
+  // Quota counts (#2625). The quota middleware consumes these instead of
+  // scanning the filesystem, so it never imports a storage backend directly.
+  /** Number of stored layouts (for the layout-count quota). */
+  countLayouts(): Promise<number>;
+  /** Number of image assets stored for a layout (for the per-layout quota). */
+  countAssets(uuid: string): Promise<number>;
+
+  // Asset storage (#2625). The magic-byte sniff is the shared write chokepoint
+  // (asset-validation.ts); each driver only stores already-validated bytes.
+  /** Read a device-image asset, or null if absent. */
+  getAsset(
+    layoutUuid: string,
+    deviceSlug: string,
+    face: AssetFace,
+  ): Promise<{ data: Uint8Array; contentType: string } | null>;
+  /**
+   * Validate (magic-byte sniff, size cap, type allowlist) and store a
+   * device-image asset. Throws on a bad upload; the extension is derived from
+   * the sniffed bytes, never the declared content type.
+   */
+  saveAsset(
+    layoutUuid: string,
+    deviceSlug: string,
+    face: AssetFace,
+    data: ArrayBuffer,
+    contentType: string,
+  ): Promise<void>;
+  /** Delete a device-image asset. Returns false if nothing was deleted. */
+  deleteAsset(
+    layoutUuid: string,
+    deviceSlug: string,
+    face: AssetFace,
+  ): Promise<boolean>;
+  /** Delete every asset for a layout. */
+  deleteLayoutAssets(layoutUuid: string): Promise<void>;
+  /** List a layout's stored assets. */
+  listLayoutAssets(layoutUuid: string): Promise<AssetInfo[]>;
 }
 
 /** Hono context Variables carrying the per-request storage driver. */

--- a/api/src/storage/filesystem-contract.test.ts
+++ b/api/src/storage/filesystem-contract.test.ts
@@ -1,67 +1,23 @@
 /**
  * Runs the shared storage contract (#2091) against the filesystem driver.
  *
- * Each driver instance binds to a fresh temp DATA_DIR. The same harness will
- * later run against the R2 driver (#2133) to prove both uphold the atomic
- * snapshot-on-mismatch invariant.
+ * Each driver instance binds to a fresh temp DATA_DIR. The R2 driver runs the
+ * same harness (src/storage/r2-contract.workers.ts) under vitest-pool-workers
+ * to prove both uphold the atomic snapshot-on-mismatch invariant.
  */
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { describe, it, expect } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  runStorageContract,
-  type StorageContractDriver,
-} from "./storage-contract";
+import { runStorageContract, type MakeDriver } from "./storage-contract";
 
-async function makeFilesystemDriver(): Promise<{
-  driver: StorageContractDriver;
-  cleanup: () => Promise<void>;
-}> {
+const makeFilesystemDriver: MakeDriver = async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "rackula-fs-contract-"));
   const previousDataDir = process.env.DATA_DIR;
   process.env.DATA_DIR = dataDir;
 
   const { createFilesystemDriver } = await import("./filesystem-driver");
-  const fsDriver = createFilesystemDriver();
-
-  async function snapshotContents(id: string): Promise<string[]> {
-    const entries = await readdir(dataDir, { withFileTypes: true });
-    const folder = entries.find(
-      (entry) =>
-        entry.isDirectory() &&
-        entry.name.toLowerCase().endsWith(id.toLowerCase()),
-    );
-    if (!folder) {
-      return [];
-    }
-    const snapshotsDir = join(dataDir, folder.name, "snapshots");
-    let files: string[];
-    try {
-      files = await readdir(snapshotsDir);
-    } catch {
-      return [];
-    }
-    return Promise.all(
-      files.map((file) => readFile(join(snapshotsDir, file), "utf-8")),
-    );
-  }
-
-  const driver: StorageContractDriver = {
-    async saveLayout(id, yamlContent, echoedUpdatedAt) {
-      const result = await fsDriver.saveLayout(
-        yamlContent,
-        id,
-        echoedUpdatedAt,
-      );
-      return { updatedAt: result.updatedAt };
-    },
-    getLayout(id) {
-      return fsDriver.getLayout(id);
-    },
-    getSnapshotContents(id) {
-      return snapshotContents(id);
-    },
-  };
+  const driver = createFilesystemDriver();
 
   return {
     driver,
@@ -74,6 +30,6 @@ async function makeFilesystemDriver(): Promise<{
       await rm(dataDir, { recursive: true, force: true });
     },
   };
-}
+};
 
-runStorageContract(makeFilesystemDriver);
+runStorageContract(makeFilesystemDriver, { describe, it, expect });

--- a/api/src/storage/filesystem-contract.test.ts
+++ b/api/src/storage/filesystem-contract.test.ts
@@ -16,20 +16,25 @@ const makeFilesystemDriver: MakeDriver = async () => {
   const previousDataDir = process.env.DATA_DIR;
   process.env.DATA_DIR = dataDir;
 
-  const { createFilesystemDriver } = await import("./filesystem-driver");
-  const driver = createFilesystemDriver();
-
-  return {
-    driver,
-    async cleanup() {
-      if (previousDataDir === undefined) {
-        delete process.env.DATA_DIR;
-      } else {
-        process.env.DATA_DIR = previousDataDir;
-      }
-      await rm(dataDir, { recursive: true, force: true });
-    },
+  const restore = async () => {
+    if (previousDataDir === undefined) {
+      delete process.env.DATA_DIR;
+    } else {
+      process.env.DATA_DIR = previousDataDir;
+    }
+    await rm(dataDir, { recursive: true, force: true });
   };
+
+  // Restore DATA_DIR and remove the tempdir even if driver setup throws, so a
+  // setup failure does not leak env state or the directory into later tests.
+  try {
+    const { createFilesystemDriver } = await import("./filesystem-driver");
+    const driver = createFilesystemDriver();
+    return { driver, cleanup: restore };
+  } catch (error) {
+    await restore();
+    throw error;
+  }
 };
 
 runStorageContract(makeFilesystemDriver, { describe, it, expect });

--- a/api/src/storage/filesystem-driver.ts
+++ b/api/src/storage/filesystem-driver.ts
@@ -1,11 +1,11 @@
 /**
- * Filesystem-backed StorageDriver (#2624).
+ * Filesystem-backed StorageDriver (#2624 seam, #2625 quota/asset surface).
  *
- * A thin adapter over the api/src/storage/filesystem.ts free functions;
- * behaviour is unchanged (per-layout write locks, atomic snapshot-on-mismatch,
- * monotonic updatedAt all live in filesystem.ts). This is the default driver
- * for the self-host / Bun runtime; the Workers runtime binds an R2 driver
- * (#2625) behind the same interface.
+ * A thin adapter over the filesystem free functions; behaviour is unchanged
+ * (per-layout write locks, atomic snapshot-on-mismatch, monotonic updatedAt,
+ * magic-byte-sniffed assets all live in filesystem.ts / assets.ts). This is the
+ * default driver for the self-host / Bun runtime; the Workers runtime binds an
+ * R2 driver behind the same interface.
  */
 import type { StorageDriver } from "./driver";
 import {
@@ -13,11 +13,21 @@ import {
   getLayout,
   saveLayout,
   deleteLayout,
+  layoutExists,
   listSnapshots,
   getSnapshot,
   saveSnapshot,
   getPreCarrierBackup,
+  countLayouts,
+  countAssets,
 } from "./filesystem";
+import {
+  getAsset,
+  saveAsset,
+  deleteAsset,
+  deleteLayoutAssets,
+  listLayoutAssets,
+} from "./assets";
 
 /** Construct the filesystem storage driver. */
 export function createFilesystemDriver(): StorageDriver {
@@ -26,9 +36,17 @@ export function createFilesystemDriver(): StorageDriver {
     getLayout,
     saveLayout,
     deleteLayout,
+    layoutExists,
     listSnapshots,
     getSnapshot,
     saveSnapshot,
     getPreCarrierBackup,
+    countLayouts,
+    countAssets,
+    getAsset,
+    saveAsset,
+    deleteAsset,
+    deleteLayoutAssets,
+    listLayoutAssets,
   };
 }

--- a/api/src/storage/filesystem-driver.ts
+++ b/api/src/storage/filesystem-driver.ts
@@ -21,13 +21,7 @@ import {
   countLayouts,
   countAssets,
 } from "./filesystem";
-import {
-  getAsset,
-  saveAsset,
-  deleteAsset,
-  deleteLayoutAssets,
-  listLayoutAssets,
-} from "./assets";
+import { getAsset, saveAsset, deleteAsset, listLayoutAssets } from "./assets";
 
 /** Construct the filesystem storage driver. */
 export function createFilesystemDriver(): StorageDriver {
@@ -46,7 +40,6 @@ export function createFilesystemDriver(): StorageDriver {
     getAsset,
     saveAsset,
     deleteAsset,
-    deleteLayoutAssets,
     listLayoutAssets,
   };
 }

--- a/api/src/storage/filesystem.ts
+++ b/api/src/storage/filesystem.ts
@@ -15,6 +15,7 @@ import {
 import { join } from "node:path";
 import * as yaml from "js-yaml";
 import { SNAPSHOT_NAME_PATTERN } from "./snapshot-name";
+import { countLayoutsInDir, countAssetsInDir } from "./quota";
 import {
   LayoutFileSchema,
   isUuid,
@@ -989,6 +990,26 @@ export async function getLayoutAssetsDir(uuid: string): Promise<string | null> {
     return null;
   }
   return join(folder, "assets");
+}
+
+/**
+ * Count stored layouts for the layout-count quota (#2625).
+ * Delegates to the shared counter so the count rule lives in one place.
+ */
+export async function countLayouts(): Promise<number> {
+  return countLayoutsInDir(getDataDir());
+}
+
+/**
+ * Count image assets stored for a layout for the per-layout asset quota (#2625).
+ * A missing layout counts as zero.
+ */
+export async function countAssets(uuid: string): Promise<number> {
+  const folder = await findFolderByUuid(uuid);
+  if (!folder) {
+    return 0;
+  }
+  return countAssetsInDir(folder);
 }
 
 // Re-export slugify from schemas for backwards compatibility

--- a/api/src/storage/quota.ts
+++ b/api/src/storage/quota.ts
@@ -100,8 +100,17 @@ export async function countAssetsInDir(layoutDir: string): Promise<number> {
             count += 1;
           }
         }
-      } catch {
-        // Directory might have been deleted between readdir and read -- skip
+      } catch (err) {
+        // A directory deleted between the listing and this read is fine; any
+        // other error (permissions, I/O) must surface so quota enforcement is
+        // never silently weakened by an incomplete scan.
+        if (
+          err instanceof Error &&
+          (err as NodeJS.ErrnoException).code === "ENOENT"
+        ) {
+          continue;
+        }
+        throw err;
       }
     }
   }

--- a/api/src/storage/quota.ts
+++ b/api/src/storage/quota.ts
@@ -1,8 +1,10 @@
 /**
- * Storage quota enforcement for layouts and assets.
+ * Filesystem layout/asset counting for storage quotas.
  *
- * Checks filesystem-based quota limits before write operations.
- * Uses directory counts (fast, no disk-size scanning required).
+ * The pure counters ({@link countLayoutsInDir}, {@link countAssetsInDir}) are
+ * the single source of the count rule, used by the filesystem storage driver
+ * (which the quota middleware consumes via the driver seam, #2625). The
+ * `check*Quota` helpers pair a count with a limit.
  *
  * @module quota
  */
@@ -25,104 +27,64 @@ export interface QuotaCheckResult {
 }
 
 /**
- * Check whether creating a new layout would exceed the layout count quota.
+ * Count stored layouts in a data directory.
  *
- * Counts both UUID-suffixed directories (new format) and legacy .yaml/.yml
- * flat files (old format) in the data directory. If `maxLayouts` is 0,
- * returns immediately with `allowed: true` (unlimited mode).
- *
- * @param dataDir - Path to the data directory containing layouts.
- * @param maxLayouts - Maximum number of layouts allowed. 0 = unlimited.
- * @returns Quota check result with current count and max limit.
+ * Counts UUID-suffixed directories (new format) and legacy .yaml/.yml flat
+ * files (old format). A missing directory counts as zero; permission/I-O errors
+ * propagate so a failure never silently disables quota enforcement.
  */
-export async function checkLayoutQuota(
-  dataDir: string,
-  maxLayouts: number,
-): Promise<QuotaCheckResult> {
-  if (maxLayouts === 0) {
-    logger.debug("quota: layout quota unlimited, skipping check");
-    return { allowed: true, current: 0, max: 0 };
-  }
-
+export async function countLayoutsInDir(dataDir: string): Promise<number> {
   let entries;
   try {
     entries = await readdir(dataDir, { withFileTypes: true });
   } catch (err) {
-    // Only allow writes if the directory genuinely doesn't exist yet.
-    // Permission errors, I/O failures, or corruption must not silently
-    // disable quota enforcement.
     if (
       err instanceof Error &&
       (err as NodeJS.ErrnoException).code === "ENOENT"
     ) {
-      return { allowed: true, current: 0, max: maxLayouts };
+      return 0;
     }
     throw err;
   }
 
-  let layoutCount = 0;
+  let count = 0;
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      const uuid = extractUuidFromFolderName(entry.name);
-      if (uuid) {
-        layoutCount += 1;
+      if (extractUuidFromFolderName(entry.name)) {
+        count += 1;
       }
     } else if (
       entry.isFile() &&
       (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml"))
     ) {
-      layoutCount += 1;
+      count += 1;
     }
   }
-
-  const allowed = layoutCount < maxLayouts;
-  logger.debug(
-    `quota: layout check ${layoutCount}/${maxLayouts} ${allowed ? "allowed" : "exceeded"}`,
-  );
-
-  return { allowed, current: layoutCount, max: maxLayouts };
+  return count;
 }
 
 /**
- * Check whether adding an asset to a layout would exceed the per-layout asset quota.
- *
- * Counts image files (png, jpg, jpeg, webp) located directly within each device
- * subdirectory of the layout's assets directory (one level deep).
- * If the assets directory does not exist, current count is 0. If `maxAssetsPerLayout`
- * is 0, returns immediately with `allowed: true` (unlimited mode).
- *
- * @param layoutDir - Path to the layout's folder (containing the assets/ subdirectory).
- * @param maxAssetsPerLayout - Maximum number of assets per layout. 0 = unlimited.
- * @returns Quota check result with current count and max limit.
+ * Count image assets for a layout: png/jpg/jpeg/webp files located one level
+ * deep within each device subdirectory of the layout's assets directory. A
+ * missing assets directory counts as zero; other I/O errors propagate.
  */
-export async function checkAssetQuota(
-  layoutDir: string,
-  maxAssetsPerLayout: number,
-): Promise<QuotaCheckResult> {
-  if (maxAssetsPerLayout === 0) {
-    logger.debug("quota: asset quota unlimited, skipping check");
-    return { allowed: true, current: 0, max: 0 };
-  }
-
+export async function countAssetsInDir(layoutDir: string): Promise<number> {
   const assetsDir = join(layoutDir, "assets");
 
   let deviceDirs;
   try {
     deviceDirs = await readdir(assetsDir, { withFileTypes: true });
   } catch (err) {
-    // Only allow writes if the directory genuinely doesn't exist yet.
-    // Permission errors, I/O failures, etc. must not silently disable quotas.
     if (
       err instanceof Error &&
       (err as NodeJS.ErrnoException).code === "ENOENT"
     ) {
-      logger.debug(`quota: no assets directory, 0/${maxAssetsPerLayout}`);
-      return { allowed: true, current: 0, max: maxAssetsPerLayout };
+      return 0;
     }
     throw err;
   }
 
-  let assetCount = 0;
+  let count = 0;
   for (const deviceDir of deviceDirs) {
     if (deviceDir.isDirectory()) {
       try {
@@ -135,7 +97,7 @@ export async function checkAssetQuota(
             ext === "jpeg" ||
             ext === "webp"
           ) {
-            assetCount += 1;
+            count += 1;
           }
         }
       } catch {
@@ -143,11 +105,48 @@ export async function checkAssetQuota(
       }
     }
   }
+  return count;
+}
 
-  const allowed = assetCount < maxAssetsPerLayout;
+/**
+ * Check whether creating a new layout would exceed the layout count quota.
+ * If `maxLayouts` is 0, returns immediately with `allowed: true` (unlimited).
+ */
+export async function checkLayoutQuota(
+  dataDir: string,
+  maxLayouts: number,
+): Promise<QuotaCheckResult> {
+  if (maxLayouts === 0) {
+    logger.debug("quota: layout quota unlimited, skipping check");
+    return { allowed: true, current: 0, max: 0 };
+  }
+
+  const current = await countLayoutsInDir(dataDir);
+  const allowed = current < maxLayouts;
   logger.debug(
-    `quota: asset check for ${layoutDir} ${assetCount}/${maxAssetsPerLayout} ${allowed ? "allowed" : "exceeded"}`,
+    `quota: layout check ${current}/${maxLayouts} ${allowed ? "allowed" : "exceeded"}`,
   );
+  return { allowed, current, max: maxLayouts };
+}
 
-  return { allowed, current: assetCount, max: maxAssetsPerLayout };
+/**
+ * Check whether adding an asset to a layout would exceed the per-layout asset
+ * quota. If `maxAssetsPerLayout` is 0, returns immediately with `allowed: true`
+ * (unlimited).
+ */
+export async function checkAssetQuota(
+  layoutDir: string,
+  maxAssetsPerLayout: number,
+): Promise<QuotaCheckResult> {
+  if (maxAssetsPerLayout === 0) {
+    logger.debug("quota: asset quota unlimited, skipping check");
+    return { allowed: true, current: 0, max: 0 };
+  }
+
+  const current = await countAssetsInDir(layoutDir);
+  const allowed = current < maxAssetsPerLayout;
+  logger.debug(
+    `quota: asset check for ${layoutDir} ${current}/${maxAssetsPerLayout} ${allowed ? "allowed" : "exceeded"}`,
+  );
+  return { allowed, current, max: maxAssetsPerLayout };
 }

--- a/api/src/storage/r2-contract.workers.ts
+++ b/api/src/storage/r2-contract.workers.ts
@@ -1,0 +1,131 @@
+/**
+ * Runs the shared storage contract (#2091) against the R2 driver inside workerd
+ * via vitest-pool-workers / Miniflare, plus R2-specific behaviours (snapshot
+ * prune-to-5, prefix-count quota, asset round-trip). Named `*.workers.ts` so
+ * `bun test` never picks it up; run via `npm run test:workers` (#2625).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { runStorageContract, type MakeDriver } from "./storage-contract";
+import { createR2Driver, type R2BucketLike } from "./r2-driver";
+
+// The Miniflare R2 binding (`cloudflare:test` env) is declared in
+// src/cloudflare-test-env.d.ts; annotate against the minimal R2 surface the
+// driver uses (the real binding is a structural superset).
+const bucket: R2BucketLike = env.LAYOUTS;
+
+async function clearBucket(): Promise<void> {
+  let cursor: string | undefined;
+  do {
+    const page = await bucket.list({ cursor });
+    if (page.objects.length > 0) {
+      await bucket.delete(page.objects.map((object) => object.key));
+    }
+    cursor = page.truncated ? page.cursor : undefined;
+  } while (cursor);
+}
+
+const makeR2Driver: MakeDriver = async () => {
+  await clearBucket();
+  return {
+    driver: createR2Driver(bucket),
+    cleanup: clearBucket,
+  };
+};
+
+runStorageContract(makeR2Driver, { describe, it, expect });
+
+function layoutYaml(name: string): string {
+  return `version: "1.0.0"\nname: ${name}\nracks: []`;
+}
+
+/** A 12-byte PNG body: full 8-byte signature plus a short tail. */
+function pngBytes(): ArrayBuffer {
+  return Uint8Array.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+  ]).buffer;
+}
+
+describe("R2 driver specifics", () => {
+  beforeEach(async () => {
+    await clearBucket();
+  });
+
+  const ID = "550e8400-e29b-41d4-a716-446655440000";
+
+  it("prunes snapshots to the 5 most recent", async () => {
+    const driver = createR2Driver(bucket);
+    await driver.saveLayout(layoutYaml("Prune"), ID);
+    // Seven uploaded losing copies; only the 5 newest must survive.
+    for (let i = 0; i < 7; i += 1) {
+      const saved = await driver.saveSnapshot(ID, layoutYaml(`snap-${i}`));
+      expect(saved).not.toBeNull();
+    }
+    const snapshots = await driver.listSnapshots(ID);
+    expect(snapshots?.length).toBe(5);
+  });
+
+  it("counts layouts via prefix listing", async () => {
+    const driver = createR2Driver(bucket);
+    expect(await driver.countLayouts()).toBe(0);
+    await driver.saveLayout(
+      layoutYaml("A"),
+      "11111111-1111-4111-8111-111111111111",
+    );
+    await driver.saveLayout(
+      layoutYaml("B"),
+      "22222222-2222-4222-8222-222222222222",
+    );
+    await driver.saveLayout(
+      layoutYaml("C"),
+      "33333333-3333-4333-8333-333333333333",
+    );
+    expect(await driver.countLayouts()).toBe(3);
+  });
+
+  it("round-trips, lists, counts, and deletes an asset", async () => {
+    const driver = createR2Driver(bucket);
+    await driver.saveLayout(layoutYaml("WithAsset"), ID);
+
+    await driver.saveAsset(ID, "dell-r640", "front", pngBytes(), "image/png");
+
+    const asset = await driver.getAsset(ID, "dell-r640", "front");
+    expect(asset?.contentType).toBe("image/png");
+    expect(await driver.countAssets(ID)).toBe(1);
+
+    const listed = await driver.listLayoutAssets(ID);
+    expect(listed).toContainEqual(
+      expect.objectContaining({
+        deviceSlug: "dell-r640",
+        face: "front",
+        ext: "png",
+      }),
+    );
+
+    expect(await driver.deleteAsset(ID, "dell-r640", "front")).toBe(true);
+    expect(await driver.getAsset(ID, "dell-r640", "front")).toBeNull();
+    expect(await driver.countAssets(ID)).toBe(0);
+  });
+
+  it("rejects a non-image asset body via the shared magic-byte sniff", async () => {
+    const driver = createR2Driver(bucket);
+    await driver.saveLayout(layoutYaml("Sniff"), ID);
+    const svg = new TextEncoder().encode('<svg onload="alert(1)">')
+      .buffer as ArrayBuffer;
+    await expect(
+      driver.saveAsset(ID, "dell-r640", "front", svg, "image/png"),
+    ).rejects.toThrow();
+    expect(await driver.countAssets(ID)).toBe(0);
+  });
+
+  it("returns the durable pre-carrier backup only after a migrating save", async () => {
+    const driver = createR2Driver(bucket);
+    const seeded = await driver.saveLayout(layoutYaml("v1"), ID);
+    expect(await driver.getPreCarrierBackup(ID)).toBeNull();
+
+    await driver.saveLayout(layoutYaml("v2"), ID, seeded.updatedAt, {
+      preCarrierMigration: true,
+    });
+    expect(await driver.getPreCarrierBackup(ID)).toBe(layoutYaml("v1"));
+  });
+});

--- a/api/src/storage/r2-contract.workers.ts
+++ b/api/src/storage/r2-contract.workers.ts
@@ -56,13 +56,25 @@ describe("R2 driver specifics", () => {
   it("prunes snapshots to the 5 most recent", async () => {
     const driver = createR2Driver(bucket);
     await driver.saveLayout(layoutYaml("Prune"), ID);
-    // Seven uploaded losing copies; only the 5 newest must survive.
+    // Seven uploaded losing copies, oldest (snap-0) first.
     for (let i = 0; i < 7; i += 1) {
       const saved = await driver.saveSnapshot(ID, layoutYaml(`snap-${i}`));
       expect(saved).not.toBeNull();
     }
     const snapshots = await driver.listSnapshots(ID);
     expect(snapshots?.length).toBe(5);
+
+    const survivingContents = await Promise.all(
+      (snapshots ?? []).map((snapshot) =>
+        driver.getSnapshot(ID, snapshot.filename),
+      ),
+    );
+    // The two oldest are pruned; the five most recent remain.
+    expect(survivingContents).not.toContain(layoutYaml("snap-0"));
+    expect(survivingContents).not.toContain(layoutYaml("snap-1"));
+    for (let i = 2; i < 7; i += 1) {
+      expect(survivingContents).toContain(layoutYaml(`snap-${i}`));
+    }
   });
 
   it("counts layouts via prefix listing", async () => {

--- a/api/src/storage/r2-driver.ts
+++ b/api/src/storage/r2-driver.ts
@@ -1,0 +1,588 @@
+/**
+ * Cloudflare R2 StorageDriver (#2625, slice 2 of #2133).
+ *
+ * Implements the same {@link StorageDriver} seam as the filesystem driver, but
+ * backed by an R2 bucket binding, for the Workers runtime. Proven against the
+ * shared storage contract (src/storage/r2-contract.workers.ts) under
+ * vitest-pool-workers / Miniflare.
+ *
+ * Key layout (uuid lowercased so case-insensitive ids map to one object):
+ *   layouts/{uuid}/layout.yaml                       the layout YAML
+ *   layouts/{uuid}/snapshots/{base}~YYYYMMDD-HHMMSS[-N].yaml   pre-overwrite snapshots
+ *   layouts/{uuid}/pre-carrier-backup.yaml           durable one-time backup
+ *   layouts/{uuid}/assets/{deviceSlug}/{face}.{ext}  device images
+ *
+ * Concurrency model (per #2132 spike): R2 is strongly read-after-write
+ * consistent and supports conditional PUT. saveLayout reads the current object,
+ * snapshots it on echo divergence, then PUTs conditionally on the read etag; a
+ * lost race returns null from put(), so the loser re-reads, snapshots the now
+ * current copy, and retries. updatedAt is a strictly monotonic token in
+ * customMetadata (R2 has no client-settable mtime).
+ */
+import * as yaml from "js-yaml";
+import type { StorageDriver } from "./driver";
+import {
+  isUuid,
+  slugify,
+  LayoutFileSchema,
+  type LayoutListItem,
+} from "../schemas/layout";
+import { SNAPSHOT_NAME_PATTERN } from "./snapshot-name";
+import {
+  ALLOWED_EXTS,
+  validateAssetBytes,
+  validateDeviceSlug,
+  getContentTypeFromExt,
+  type AssetFace,
+  type AssetInfo,
+} from "./asset-validation";
+
+const MAX_SNAPSHOTS_PER_LAYOUT = 5;
+const SAVE_MAX_ATTEMPTS = 6;
+const PRE_CARRIER_BACKUP_KEY = "pre-carrier-backup.yaml";
+
+/** The minimal R2 binding surface this driver uses (a subset of R2Bucket). */
+export interface R2ObjectMeta {
+  readonly key: string;
+  readonly etag: string;
+  readonly uploaded: Date;
+  readonly size: number;
+  readonly customMetadata?: Record<string, string>;
+}
+export interface R2ObjectBodyLike extends R2ObjectMeta {
+  text(): Promise<string>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+export interface R2ListResult {
+  objects: R2ObjectMeta[];
+  truncated: boolean;
+  cursor?: string;
+  delimitedPrefixes: string[];
+}
+export interface R2PutOnlyIf {
+  etagMatches?: string;
+  etagDoesNotMatch?: string;
+}
+export interface R2PutOptionsLike {
+  onlyIf?: R2PutOnlyIf | Headers;
+  customMetadata?: Record<string, string>;
+  httpMetadata?: { contentType?: string };
+}
+export interface R2ListOptionsLike {
+  prefix?: string;
+  delimiter?: string;
+  cursor?: string;
+  limit?: number;
+}
+export interface R2BucketLike {
+  head(key: string): Promise<R2ObjectMeta | null>;
+  get(key: string): Promise<R2ObjectBodyLike | null>;
+  put(
+    key: string,
+    value: string | ArrayBuffer | ArrayBufferView,
+    options?: R2PutOptionsLike,
+  ): Promise<R2ObjectMeta | null>;
+  delete(keys: string | string[]): Promise<void>;
+  list(options?: R2ListOptionsLike): Promise<R2ListResult>;
+}
+
+const LAYOUTS_PREFIX = "layouts/";
+
+function layoutDir(uuid: string): string {
+  return `${LAYOUTS_PREFIX}${uuid.toLowerCase()}/`;
+}
+function layoutKey(uuid: string): string {
+  return `${layoutDir(uuid)}layout.yaml`;
+}
+function snapshotsPrefix(uuid: string): string {
+  return `${layoutDir(uuid)}snapshots/`;
+}
+function assetsPrefix(uuid: string): string {
+  return `${layoutDir(uuid)}assets/`;
+}
+function assetKey(
+  uuid: string,
+  deviceSlug: string,
+  face: AssetFace,
+  ext: string,
+): string {
+  return `${assetsPrefix(uuid)}${deviceSlug}/${face}.${ext}`;
+}
+
+/** Create-if-absent condition (If-None-Match: *). */
+function ifAbsent(): Headers {
+  return new Headers({ "If-None-Match": "*" });
+}
+
+/** Format a snapshot timestamp as YYYYMMDD-HHMMSS (UTC), matching the FS driver. */
+function formatSnapshotTimestamp(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+    `-${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`
+  );
+}
+
+/**
+ * Mint a strictly-monotonic updatedAt token: at least the current time, and
+ * always strictly greater than the previous token. R2 has no client-settable
+ * mtime, so this token (stored in customMetadata) is the echo identity.
+ */
+function nextUpdatedAt(previous?: string): string {
+  const now = Date.now();
+  const previousMs = previous ? Date.parse(previous) : Number.NaN;
+  const ms = Number.isNaN(previousMs) ? now : Math.max(now, previousMs + 1);
+  return new Date(ms).toISOString();
+}
+
+/** A snapshot filename is a bare {base}~YYYYMMDD-HHMMSS[-N].yaml with no path. */
+function isSafeSnapshotFilename(filename: string): boolean {
+  if (filename.includes("/") || filename.includes("\\")) {
+    return false;
+  }
+  // eslint-disable-next-line no-control-regex -- reject control chars (C0 + DEL)
+  if (/[\u0000-\u001f\u007f]/.test(filename)) {
+    return false;
+  }
+  return SNAPSHOT_NAME_PATTERN.test(filename);
+}
+
+/** Derive a snapshot base name from a layout body, mirroring the FS slug. */
+function deriveSnapshotBase(yamlContent: string): string {
+  try {
+    const parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA }) as
+      | { name?: unknown; metadata?: { name?: unknown } }
+      | null
+      | undefined;
+    const name = parsed?.metadata?.name ?? parsed?.name;
+    return typeof name === "string" && name ? slugify(name) : "untitled";
+  } catch {
+    return "untitled";
+  }
+}
+
+function countDevices(racks: Array<{ devices?: unknown[] }>): number {
+  return racks.reduce((sum, rack) => sum + (rack.devices?.length ?? 0), 0);
+}
+
+/** Build a LayoutListItem from a stored layout body, mirroring the FS reader. */
+function buildListItem(
+  uuid: string,
+  content: string,
+  updatedAt: string,
+): LayoutListItem {
+  try {
+    const parsed = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as unknown;
+    const metadata = LayoutFileSchema.safeParse(parsed);
+    if (metadata.success) {
+      const racks = metadata.data.racks ?? [];
+      return {
+        id: uuid,
+        name: metadata.data.name,
+        version: metadata.data.version,
+        updatedAt,
+        rackCount: racks.length,
+        deviceCount: countDevices(racks),
+        valid: true,
+      };
+    }
+  } catch {
+    // fall through to the invalid shape below
+  }
+  return {
+    id: uuid,
+    name: uuid,
+    version: "unknown",
+    updatedAt,
+    rackCount: 0,
+    deviceCount: 0,
+    valid: false,
+  };
+}
+
+export function createR2Driver(bucket: R2BucketLike): StorageDriver {
+  /** Collect every object under a prefix, following pagination. */
+  async function listAll(prefix: string): Promise<R2ObjectMeta[]> {
+    const out: R2ObjectMeta[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await bucket.list({ prefix, cursor });
+      out.push(...page.objects);
+      cursor = page.truncated ? page.cursor : undefined;
+    } while (cursor);
+    return out;
+  }
+
+  /** Collect the layout sub-prefixes (one per layout), following pagination. */
+  async function listLayoutPrefixes(): Promise<string[]> {
+    const out: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await bucket.list({
+        prefix: LAYOUTS_PREFIX,
+        delimiter: "/",
+        cursor,
+      });
+      out.push(...page.delimitedPrefixes);
+      cursor = page.truncated ? page.cursor : undefined;
+    } while (cursor);
+    return out;
+  }
+
+  /** Delete oldest snapshots so at most MAX_SNAPSHOTS_PER_LAYOUT remain. */
+  async function pruneSnapshots(uuid: string): Promise<void> {
+    const objects = await listAll(snapshotsPrefix(uuid));
+    objects.sort(
+      (a, b) =>
+        b.uploaded.getTime() - a.uploaded.getTime() ||
+        b.key.localeCompare(a.key),
+    );
+    const stale = objects
+      .slice(MAX_SNAPSHOTS_PER_LAYOUT)
+      .map((object) => object.key);
+    if (stale.length > 0) {
+      await bucket.delete(stale);
+    }
+  }
+
+  /** Write a snapshot with an exclusive (If-None-Match: *) create, then prune. */
+  async function writeSnapshot(uuid: string, content: string): Promise<string> {
+    const base = deriveSnapshotBase(content);
+    const timestamp = formatSnapshotTimestamp(new Date());
+    const prefix = snapshotsPrefix(uuid);
+    let filename = `${base}~${timestamp}.yaml`;
+    for (let suffix = 1; ; suffix += 1) {
+      const put = await bucket.put(prefix + filename, content, {
+        onlyIf: ifAbsent(),
+      });
+      if (put !== null) {
+        break;
+      }
+      if (suffix > 1000) {
+        throw new Error("writeSnapshot: too many snapshot-name collisions");
+      }
+      filename = `${base}~${timestamp}-${suffix}.yaml`;
+    }
+    await pruneSnapshots(uuid);
+    return filename;
+  }
+
+  async function getLayout(uuid: string) {
+    if (!isUuid(uuid)) {
+      return null;
+    }
+    const object = await bucket.get(layoutKey(uuid));
+    if (!object) {
+      return null;
+    }
+    return {
+      content: await object.text(),
+      updatedAt:
+        object.customMetadata?.updatedAt ?? object.uploaded.toISOString(),
+    };
+  }
+
+  async function layoutExists(uuid: string): Promise<boolean> {
+    if (!isUuid(uuid)) {
+      return false;
+    }
+    return (await bucket.head(layoutKey(uuid))) !== null;
+  }
+
+  async function saveLayout(
+    yamlContent: string,
+    existingId?: string,
+    echoedUpdatedAt?: string,
+    options?: { preCarrierMigration?: boolean },
+  ): Promise<{ id: string; isNew: boolean; updatedAt: string }> {
+    // Parse + validate, matching the filesystem driver's error contract so the
+    // route maps failures to 400 the same way on both backends.
+    let parsed: unknown;
+    try {
+      parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      throw new Error(`Invalid YAML: ${message}`, { cause: e });
+    }
+    const layout = LayoutFileSchema.safeParse(parsed);
+    if (!layout.success) {
+      const issues = layout.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ");
+      throw new Error(`Invalid layout metadata: ${issues}`);
+    }
+
+    const existingUuid =
+      existingId && isUuid(existingId) ? existingId : undefined;
+    const metadataId = layout.data.metadata?.id;
+    const validMetadataId =
+      metadataId && isUuid(metadataId) ? metadataId : null;
+    const uuid = existingUuid ?? validMetadataId ?? crypto.randomUUID();
+    const key = layoutKey(uuid);
+
+    for (let attempt = 0; attempt < SAVE_MAX_ATTEMPTS; attempt += 1) {
+      const current = await bucket.get(key);
+      const isNew = current === null;
+      const storedUpdatedAt = current?.customMetadata?.updatedAt;
+      const updatedAt = nextUpdatedAt(storedUpdatedAt);
+
+      if (current) {
+        const diverged =
+          echoedUpdatedAt !== undefined && storedUpdatedAt !== echoedUpdatedAt;
+        // Read the prior bytes once if either the rolling snapshot (echo
+        // divergence) or the durable pre-carrier backup needs them.
+        const existingContent =
+          diverged || options?.preCarrierMigration
+            ? await current.text()
+            : undefined;
+        if (diverged && existingContent !== undefined) {
+          await writeSnapshot(uuid, existingContent);
+        }
+        // Durable one-time pre-carrier backup: exclusive create, so a later
+        // migrating save never clobbers the original (idempotent no-op).
+        if (options?.preCarrierMigration && existingContent !== undefined) {
+          await bucket.put(
+            layoutDir(uuid) + PRE_CARRIER_BACKUP_KEY,
+            existingContent,
+            {
+              onlyIf: ifAbsent(),
+            },
+          );
+        }
+      }
+
+      const onlyIf: R2PutOnlyIf | Headers = current
+        ? { etagMatches: current.etag }
+        : ifAbsent();
+      const put = await bucket.put(key, yamlContent, {
+        onlyIf,
+        customMetadata: { updatedAt },
+        httpMetadata: { contentType: "text/yaml" },
+      });
+      if (put !== null) {
+        return { id: uuid, isNew, updatedAt };
+      }
+      // Lost the conditional write: another writer changed the object between
+      // our read and our PUT. Re-read, snapshot the now-current copy (the next
+      // pass sees the divergence), and retry.
+    }
+    throw new Error(
+      "saveLayout: too many conflicting concurrent writes for this layout",
+    );
+  }
+
+  async function deleteLayout(uuid: string): Promise<boolean> {
+    if (!isUuid(uuid)) {
+      return false;
+    }
+    const existed = (await bucket.head(layoutKey(uuid))) !== null;
+    const objects = await listAll(layoutDir(uuid));
+    if (objects.length > 0) {
+      await bucket.delete(objects.map((object) => object.key));
+    }
+    return existed;
+  }
+
+  async function listSnapshots(uuid: string) {
+    if (!(await layoutExists(uuid))) {
+      return null;
+    }
+    const prefix = snapshotsPrefix(uuid);
+    const objects = await listAll(prefix);
+    return objects
+      .map((object) => ({
+        filename: object.key.slice(prefix.length),
+        timestamp: object.uploaded.toISOString(),
+        size: object.size,
+      }))
+      .sort(
+        (a, b) =>
+          b.timestamp.localeCompare(a.timestamp) ||
+          b.filename.localeCompare(a.filename),
+      );
+  }
+
+  async function getSnapshot(
+    uuid: string,
+    filename: string,
+  ): Promise<string | null> {
+    if (!isUuid(uuid) || !isSafeSnapshotFilename(filename)) {
+      return null;
+    }
+    const object = await bucket.get(snapshotsPrefix(uuid) + filename);
+    return object ? object.text() : null;
+  }
+
+  async function saveSnapshot(uuid: string, yamlContent: string) {
+    if (!(await layoutExists(uuid))) {
+      return null;
+    }
+    const filename = await writeSnapshot(uuid, yamlContent);
+    return { filename };
+  }
+
+  async function getPreCarrierBackup(uuid: string): Promise<string | null> {
+    if (!isUuid(uuid)) {
+      return null;
+    }
+    const object = await bucket.get(layoutDir(uuid) + PRE_CARRIER_BACKUP_KEY);
+    return object ? object.text() : null;
+  }
+
+  async function listLayouts(): Promise<LayoutListItem[]> {
+    const prefixes = await listLayoutPrefixes();
+    const items: LayoutListItem[] = [];
+    for (const prefix of prefixes) {
+      const uuid = prefix.slice(LAYOUTS_PREFIX.length).replace(/\/$/, "");
+      const object = await bucket.get(`${prefix}layout.yaml`);
+      if (!object) {
+        continue;
+      }
+      const content = await object.text();
+      const updatedAt =
+        object.customMetadata?.updatedAt ?? object.uploaded.toISOString();
+      items.push(buildListItem(uuid, content, updatedAt));
+    }
+    return items.sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+    );
+  }
+
+  async function countLayouts(): Promise<number> {
+    return (await listLayoutPrefixes()).length;
+  }
+
+  async function countAssets(uuid: string): Promise<number> {
+    if (!isUuid(uuid)) {
+      return 0;
+    }
+    return (await listAll(assetsPrefix(uuid))).length;
+  }
+
+  async function getAsset(uuid: string, deviceSlug: string, face: AssetFace) {
+    if (!isUuid(uuid) || !validateDeviceSlug(deviceSlug)) {
+      return null;
+    }
+    for (const ext of ALLOWED_EXTS) {
+      const object = await bucket.get(assetKey(uuid, deviceSlug, face, ext));
+      if (object) {
+        return {
+          data: new Uint8Array(await object.arrayBuffer()),
+          contentType: getContentTypeFromExt(ext),
+        };
+      }
+    }
+    return null;
+  }
+
+  async function saveAsset(
+    uuid: string,
+    deviceSlug: string,
+    face: AssetFace,
+    data: ArrayBuffer,
+    contentType: string,
+  ): Promise<void> {
+    // Shared chokepoint (type allowlist, size cap, magic-byte sniff); the
+    // extension comes from the sniffed bytes.
+    const { ext } = validateAssetBytes(data, contentType);
+    if (!isUuid(uuid)) {
+      throw new Error(`Invalid layout UUID: ${uuid}`);
+    }
+    if (!validateDeviceSlug(deviceSlug)) {
+      throw new Error(`Invalid device slug: ${deviceSlug}`);
+    }
+    if (!(await layoutExists(uuid))) {
+      throw new Error(`Layout not found: ${uuid}`);
+    }
+
+    await bucket.put(assetKey(uuid, deviceSlug, face, ext), data, {
+      httpMetadata: { contentType: getContentTypeFromExt(ext) },
+    });
+
+    // Remove any prior copy stored under a different extension for this face.
+    for (const oldExt of ALLOWED_EXTS) {
+      if (oldExt !== ext) {
+        await bucket.delete(assetKey(uuid, deviceSlug, face, oldExt));
+      }
+    }
+  }
+
+  async function deleteAsset(
+    uuid: string,
+    deviceSlug: string,
+    face: AssetFace,
+  ): Promise<boolean> {
+    if (!isUuid(uuid) || !validateDeviceSlug(deviceSlug)) {
+      return false;
+    }
+    let deleted = false;
+    for (const ext of ALLOWED_EXTS) {
+      const key = assetKey(uuid, deviceSlug, face, ext);
+      if (await bucket.head(key)) {
+        await bucket.delete(key);
+        deleted = true;
+      }
+    }
+    return deleted;
+  }
+
+  async function deleteLayoutAssets(uuid: string): Promise<void> {
+    if (!isUuid(uuid)) {
+      throw new Error(`Invalid layout UUID: ${uuid}`);
+    }
+    const objects = await listAll(assetsPrefix(uuid));
+    if (objects.length > 0) {
+      await bucket.delete(objects.map((object) => object.key));
+    }
+  }
+
+  async function listLayoutAssets(uuid: string): Promise<AssetInfo[]> {
+    if (!isUuid(uuid)) {
+      throw new Error(`Invalid layout UUID: ${uuid}`);
+    }
+    const prefix = assetsPrefix(uuid);
+    const objects = await listAll(prefix);
+    const assets: AssetInfo[] = [];
+    for (const object of objects) {
+      const rest = object.key.slice(prefix.length); // {deviceSlug}/{face}.{ext}
+      const slash = rest.indexOf("/");
+      if (slash < 0) {
+        continue;
+      }
+      const deviceSlug = rest.slice(0, slash);
+      const file = rest.slice(slash + 1);
+      const match = file.match(/^(front|rear)\.(png|jpg|webp)$/);
+      if (!match || !match[1] || !match[2] || !validateDeviceSlug(deviceSlug)) {
+        continue;
+      }
+      assets.push({
+        layoutId: uuid,
+        deviceSlug,
+        face: match[1] as AssetFace,
+        ext: match[2],
+        size: object.size,
+      });
+    }
+    return assets;
+  }
+
+  return {
+    listLayouts,
+    getLayout,
+    saveLayout,
+    deleteLayout,
+    layoutExists,
+    listSnapshots,
+    getSnapshot,
+    saveSnapshot,
+    getPreCarrierBackup,
+    countLayouts,
+    countAssets,
+    getAsset,
+    saveAsset,
+    deleteAsset,
+    deleteLayoutAssets,
+    listLayoutAssets,
+  };
+}

--- a/api/src/storage/r2-driver.ts
+++ b/api/src/storage/r2-driver.ts
@@ -312,18 +312,28 @@ export function createR2Driver(bucket: R2BucketLike): StorageDriver {
       throw new Error(`Invalid layout metadata: ${issues}`);
     }
 
-    const existingUuid =
-      existingId && isUuid(existingId) ? existingId : undefined;
+    // existingId is the authoritative URL identity. If it is present but not a
+    // valid UUID, reject rather than silently minting a new layout under a
+    // different id (the route validates the UUID, so this is defense in depth).
+    if (existingId !== undefined && !isUuid(existingId)) {
+      throw new Error(`Invalid layout UUID: ${existingId}`);
+    }
     const metadataId = layout.data.metadata?.id;
     const validMetadataId =
       metadataId && isUuid(metadataId) ? metadataId : null;
-    const uuid = existingUuid ?? validMetadataId ?? crypto.randomUUID();
+    const uuid = existingId ?? validMetadataId ?? crypto.randomUUID();
     const key = layoutKey(uuid);
 
     for (let attempt = 0; attempt < SAVE_MAX_ATTEMPTS; attempt += 1) {
       const current = await bucket.get(key);
       const isNew = current === null;
-      const storedUpdatedAt = current?.customMetadata?.updatedAt;
+      // Use the same token getLayout returns (customMetadata, falling back to
+      // the R2 upload time) so the echo the client received matches what the
+      // divergence check compares against, even for objects written without
+      // customMetadata.updatedAt.
+      const storedUpdatedAt = current
+        ? (current.customMetadata?.updatedAt ?? current.uploaded.toISOString())
+        : undefined;
       const updatedAt = nextUpdatedAt(storedUpdatedAt);
 
       if (current) {
@@ -450,7 +460,13 @@ export function createR2Driver(bucket: R2BucketLike): StorageDriver {
   }
 
   async function countLayouts(): Promise<number> {
-    return (await listLayoutPrefixes()).length;
+    // Count actual layout.yaml objects (not raw prefixes) so the quota count
+    // matches listLayouts: an orphan prefix left behind (e.g. assets/snapshots
+    // without a layout file) must not count as a layout.
+    const objects = await listAll(LAYOUTS_PREFIX);
+    return objects.filter((object) =>
+      /^layouts\/[^/]+\/layout\.yaml$/.test(object.key),
+    ).length;
   }
 
   async function countAssets(uuid: string): Promise<number> {
@@ -527,16 +543,6 @@ export function createR2Driver(bucket: R2BucketLike): StorageDriver {
     return deleted;
   }
 
-  async function deleteLayoutAssets(uuid: string): Promise<void> {
-    if (!isUuid(uuid)) {
-      throw new Error(`Invalid layout UUID: ${uuid}`);
-    }
-    const objects = await listAll(assetsPrefix(uuid));
-    if (objects.length > 0) {
-      await bucket.delete(objects.map((object) => object.key));
-    }
-  }
-
   async function listLayoutAssets(uuid: string): Promise<AssetInfo[]> {
     if (!isUuid(uuid)) {
       throw new Error(`Invalid layout UUID: ${uuid}`);
@@ -582,7 +588,6 @@ export function createR2Driver(bucket: R2BucketLike): StorageDriver {
     getAsset,
     saveAsset,
     deleteAsset,
-    deleteLayoutAssets,
     listLayoutAssets,
   };
 }

--- a/api/src/storage/r2-driver.ts
+++ b/api/src/storage/r2-driver.ts
@@ -464,9 +464,10 @@ export function createR2Driver(bucket: R2BucketLike): StorageDriver {
     // matches listLayouts: an orphan prefix left behind (e.g. assets/snapshots
     // without a layout file) must not count as a layout.
     const objects = await listAll(LAYOUTS_PREFIX);
-    return objects.filter((object) =>
-      /^layouts\/[^/]+\/layout\.yaml$/.test(object.key),
-    ).length;
+    return objects.filter((object) => {
+      const match = object.key.match(/^layouts\/([^/]+)\/layout\.yaml$/);
+      return match?.[1] !== undefined && isUuid(match[1]);
+    }).length;
   }
 
   async function countAssets(uuid: string): Promise<number> {

--- a/api/src/storage/storage-contract.ts
+++ b/api/src/storage/storage-contract.ts
@@ -109,12 +109,16 @@ export function runStorageContract(
       const { driver, cleanup } = await makeDriver();
       try {
         const v1 = layoutYaml("v1");
+        const v2 = layoutYaml("v2");
         const first = await driver.saveLayout(v1, TEST_ID);
 
-        await driver.saveLayout(layoutYaml("v2"), TEST_ID, first.updatedAt);
+        await driver.saveLayout(v2, TEST_ID, first.updatedAt);
 
         const snapshots = await snapshotContents(driver, TEST_ID);
         expect(snapshots).toEqual([]);
+        // The matched-echo save must still commit the new copy.
+        const stored = await driver.getLayout(TEST_ID);
+        expect(stored?.content).toBe(v2);
       } finally {
         await cleanup();
       }
@@ -207,6 +211,9 @@ export function runStorageContract(
         const stored = await driver.getLayout(TEST_ID);
         const finalContent = stored?.content ?? "";
         const snapshots = await snapshotContents(driver, TEST_ID);
+
+        // One of the racing writes must win and persist as the stored copy.
+        expect([v2, v3]).toContain(finalContent);
 
         expect(snapshots.length).toBeGreaterThan(0);
 

--- a/api/src/storage/storage-contract.ts
+++ b/api/src/storage/storage-contract.ts
@@ -7,37 +7,47 @@
  * write to the same layout must never cause a diverged copy to be lost
  * without a snapshot.
  *
- * The surface is deliberately minimal: just the operations this invariant
- * exercises. The filesystem driver runs it today; the future R2 driver
- * (#2133) will run the same harness against its own makeDriver factory.
+ * Runner-agnostic (#2625): the test functions (`describe`/`it`/`expect`) are
+ * injected via {@link ContractHarness} so the same spec runs under `bun test`
+ * (filesystem driver) and `vitest-pool-workers` (R2 driver). This module never
+ * imports `bun:test` or `cloudflare:test`; each runner's entry passes its own
+ * globals in.
  */
-import { describe, it, expect } from "bun:test";
+import type { StorageDriver } from "./driver";
 
 /**
- * Minimal driver surface the contract exercises. A `makeDriver` factory binds
- * a driver to a fresh, isolated backing store so each test starts clean.
+ * The subset of {@link StorageDriver} the contract exercises. A `makeDriver`
+ * factory binds a driver to a fresh, isolated backing store so each test starts
+ * clean. Snapshot bodies are read back through `listSnapshots` + `getSnapshot`,
+ * so the contract needs no backend-specific snapshot accessor.
  */
-export interface StorageContractDriver {
-  /**
-   * Save a layout. `echoedUpdatedAt` is the updatedAt the client last
-   * received; a mismatch with the stored copy must trigger a pre-overwrite
-   * snapshot. Returns the stored copy's updatedAt for the client to echo next.
-   */
-  saveLayout(
-    id: string,
-    yamlContent: string,
-    echoedUpdatedAt?: string,
-  ): Promise<{ updatedAt: string }>;
-  /** Read the stored layout, or null if it does not exist. */
-  getLayout(id: string): Promise<{ content: string; updatedAt: string } | null>;
-  /** Return the raw YAML content of every snapshot held for the layout. */
-  getSnapshotContents(id: string): Promise<string[]>;
-}
+export type StorageContractDriver = Pick<
+  StorageDriver,
+  "saveLayout" | "getLayout" | "listSnapshots" | "getSnapshot"
+>;
 
 export type MakeDriver = () => Promise<{
   driver: StorageContractDriver;
   cleanup: () => Promise<void>;
 }>;
+
+/** The matcher surface the contract relies on. */
+export interface ContractMatchers {
+  toBe(expected: unknown): void;
+  toEqual(expected: unknown): void;
+  toContain(expected: unknown): void;
+  toBeGreaterThan(expected: number): void;
+}
+
+/**
+ * Minimal test-runner surface, injected so the spec is framework-agnostic.
+ * Both `bun:test` and Vitest satisfy this shape.
+ */
+export interface ContractHarness {
+  describe: (name: string, fn: () => void) => void;
+  it: (name: string, fn: () => void | Promise<void>) => void;
+  expect: (actual: unknown) => ContractMatchers;
+}
 
 const TEST_ID = "550e8400-e29b-41d4-a716-446655440000";
 const STALE_UPDATED_AT = "1999-01-01T00:00:00.000Z";
@@ -47,21 +57,45 @@ function layoutYaml(marker: string): string {
 }
 
 /**
- * Run the storage contract against a driver produced by `makeDriver`.
- * Asserts the atomic snapshot-on-mismatch invariant.
+ * Read every snapshot body held for a layout, via the driver's own
+ * `listSnapshots` + `getSnapshot`. Works on any backend (filesystem folders or
+ * R2 prefixes) without the contract knowing the storage layout.
  */
-export function runStorageContract(makeDriver: MakeDriver): void {
+async function snapshotContents(
+  driver: StorageContractDriver,
+  id: string,
+): Promise<string[]> {
+  const snapshots = await driver.listSnapshots(id);
+  if (!snapshots) {
+    return [];
+  }
+  const contents = await Promise.all(
+    snapshots.map((snapshot) => driver.getSnapshot(id, snapshot.filename)),
+  );
+  return contents.filter((content): content is string => content !== null);
+}
+
+/**
+ * Run the storage contract against a driver produced by `makeDriver`, using the
+ * injected test `harness`. Asserts the atomic snapshot-on-mismatch invariant.
+ */
+export function runStorageContract(
+  makeDriver: MakeDriver,
+  harness: ContractHarness,
+): void {
+  const { describe, it, expect } = harness;
+
   describe("storage contract: atomic snapshot on mismatch", () => {
     it("snapshots the existing copy when the echoed updatedAt mismatches", async () => {
       const { driver, cleanup } = await makeDriver();
       try {
         const v1 = layoutYaml("v1");
         const v2 = layoutYaml("v2");
-        await driver.saveLayout(TEST_ID, v1);
+        await driver.saveLayout(v1, TEST_ID);
 
-        await driver.saveLayout(TEST_ID, v2, STALE_UPDATED_AT);
+        await driver.saveLayout(v2, TEST_ID, STALE_UPDATED_AT);
 
-        const snapshots = await driver.getSnapshotContents(TEST_ID);
+        const snapshots = await snapshotContents(driver, TEST_ID);
         expect(snapshots).toContain(v1);
 
         const stored = await driver.getLayout(TEST_ID);
@@ -75,11 +109,11 @@ export function runStorageContract(makeDriver: MakeDriver): void {
       const { driver, cleanup } = await makeDriver();
       try {
         const v1 = layoutYaml("v1");
-        const first = await driver.saveLayout(TEST_ID, v1);
+        const first = await driver.saveLayout(v1, TEST_ID);
 
-        await driver.saveLayout(TEST_ID, layoutYaml("v2"), first.updatedAt);
+        await driver.saveLayout(layoutYaml("v2"), TEST_ID, first.updatedAt);
 
-        const snapshots = await driver.getSnapshotContents(TEST_ID);
+        const snapshots = await snapshotContents(driver, TEST_ID);
         expect(snapshots).toEqual([]);
       } finally {
         await cleanup();
@@ -92,19 +126,19 @@ export function runStorageContract(makeDriver: MakeDriver): void {
         const v1 = layoutYaml("v1");
         const v2 = layoutYaml("v2");
         const v3 = layoutYaml("v3");
-        const seeded = await driver.saveLayout(TEST_ID, v1);
+        const seeded = await driver.saveLayout(v1, TEST_ID);
 
         // A clean overwrite to v2 (echoing the real updatedAt) racing a
         // stale-echo overwrite to v3. Whichever copy is overwritten must
         // survive as a snapshot: no silent data loss.
         await Promise.all([
-          driver.saveLayout(TEST_ID, v2, seeded.updatedAt),
-          driver.saveLayout(TEST_ID, v3, STALE_UPDATED_AT),
+          driver.saveLayout(v2, TEST_ID, seeded.updatedAt),
+          driver.saveLayout(v3, TEST_ID, STALE_UPDATED_AT),
         ]);
 
         const stored = await driver.getLayout(TEST_ID);
         const finalContent = stored?.content ?? "";
-        const snapshots = await driver.getSnapshotContents(TEST_ID);
+        const snapshots = await snapshotContents(driver, TEST_ID);
 
         // A diverged copy was actually snapshotted. Without this guard the
         // case is vacuous: when no snapshot is produced (the bug) the loop
@@ -127,19 +161,18 @@ export function runStorageContract(makeDriver: MakeDriver): void {
     it("issues a strictly newer updatedAt on every overwrite", async () => {
       const { driver, cleanup } = await makeDriver();
       try {
-        // updatedAt is the token clients echo to detect divergence. mtime
-        // resolution is coarse, so back-to-back writes can land on the same
-        // tick; if two stored copies share a token the echoed-updatedAt check
-        // reads them as identical and a diverged copy is overwritten without a
-        // snapshot. Each overwrite must therefore report a strictly newer
-        // token than the copy it replaced, even with no real-time gap between
-        // saves.
+        // updatedAt is the token clients echo to detect divergence. Storage
+        // clocks are coarse, so back-to-back writes can land on the same tick;
+        // if two stored copies share a token the echoed-updatedAt check reads
+        // them as identical and a diverged copy is overwritten without a
+        // snapshot. Each overwrite must therefore report a strictly newer token
+        // than the copy it replaced, even with no real-time gap between saves.
         let echoed: string | undefined;
         let previous: string | undefined;
         for (let i = 0; i < 12; i += 1) {
           const { updatedAt } = await driver.saveLayout(
-            TEST_ID,
             layoutYaml(`v${i}`),
+            TEST_ID,
             echoed,
           );
           if (previous !== undefined) {
@@ -160,20 +193,20 @@ export function runStorageContract(makeDriver: MakeDriver): void {
         const v2 = layoutYaml("v2");
         const v3 = layoutYaml("v3");
         const upperId = TEST_ID.toUpperCase();
-        const seeded = await driver.saveLayout(TEST_ID, v1);
+        const seeded = await driver.saveLayout(v1, TEST_ID);
 
         // Same logical layout, different UUID casing. UUIDs are matched
-        // case-insensitively, so both saves must serialize on one lock.
+        // case-insensitively, so both saves must serialize on one identity.
         // If they did not, the diverged copy could be overwritten without a
         // snapshot, reopening the TOCTOU this contract guards.
         await Promise.all([
-          driver.saveLayout(TEST_ID, v2, seeded.updatedAt),
-          driver.saveLayout(upperId, v3, STALE_UPDATED_AT),
+          driver.saveLayout(v2, TEST_ID, seeded.updatedAt),
+          driver.saveLayout(v3, upperId, STALE_UPDATED_AT),
         ]);
 
         const stored = await driver.getLayout(TEST_ID);
         const finalContent = stored?.content ?? "";
-        const snapshots = await driver.getSnapshotContents(TEST_ID);
+        const snapshots = await snapshotContents(driver, TEST_ID);
 
         expect(snapshots.length).toBeGreaterThan(0);
 

--- a/api/vitest.workers.config.ts
+++ b/api/vitest.workers.config.ts
@@ -1,0 +1,25 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest config for the Workers-pool storage tests (#2625).
+ *
+ * Runs the shared storage contract against the R2 driver inside workerd via
+ * Miniflare, with an in-memory R2 bucket bound as `LAYOUTS`. These specs are
+ * named `*.workers.ts` (not `*.test.ts`) so `bun test` never picks them up; the
+ * Bun runner owns the filesystem driver, this config owns the R2 driver.
+ */
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      miniflare: {
+        compatibilityDate: "2024-09-23",
+        compatibilityFlags: ["nodejs_compat"],
+        r2Buckets: ["LAYOUTS"],
+      },
+    }),
+  ],
+  test: {
+    include: ["src/**/*.workers.ts"],
+  },
+});


### PR DESCRIPTION
## **User description**
## Summary

Slice 2 of #2133. Adds the Cloudflare R2 implementation of the `StorageDriver` seam (slice 1, #2624), makes the shared storage contract framework-agnostic so it runs under both `bun test` (filesystem) and `vitest-pool-workers` (R2 under Miniflare), and absorbs the slice-1 deferrals so the layout, asset, and quota paths all sit behind the driver. That last part is the prerequisite for the node:fs-free Workers bundle in slice 3 (#2626): with assets and quota counting behind the driver, the routes and middleware no longer statically import the filesystem module.

## Changes

- Runner-agnostic harness: `storage-contract.ts` no longer imports `bun:test`; the test functions (`describe`/`it`/`expect`) are injected via a `ContractHarness`, and snapshot bodies are read back through `listSnapshots` + `getSnapshot` so the spec is backend-agnostic. The contract's `saveLayout(yaml, id, ...)` order now matches the driver, removing the slice-1 arg-order adapter.
- Workers test project: adds `@cloudflare/vitest-pool-workers` + `vitest` (pinned 4.1.9 / 0.16.20) and `vitest.workers.config.ts`; `src/storage/r2-contract.workers.ts` runs the same `runStorageContract` against an R2 driver bound to a Miniflare R2 bucket, plus R2-specific specs (prune-to-5, prefix-count quota, asset round-trip, sniff rejection, pre-carrier backup).
- R2 driver (`src/storage/r2-driver.ts`): layout keyed by lowercased UUID (`layouts/{uuid}/layout.yaml`), `updatedAt` a strictly-monotonic token in `customMetadata`. `saveLayout` reads current, snapshots on echo divergence, then conditional PUT on the read etag; a lost race (put returns `null`) re-reads, snapshots the now-current copy, and retries. Snapshots under `layouts/{uuid}/snapshots/`, pruned to 5 by uploaded time; snapshot-name collisions and the one-time pre-carrier backup use If-None-Match exclusive creates. Quota via prefix count.
- Slice-1 deferrals absorbed: the storage-quota middleware counts via the injected driver (`countLayouts` / `countAssets` / `layoutExists`) instead of scanning `DATA_DIR`; asset storage moves behind the driver, with the runtime-agnostic magic-byte sniff and format rules extracted to `asset-validation.ts` (the shared write chokepoint). The filesystem driver keeps the existing on-disk behaviour.
- CI: the `api` job adds Node alongside Bun and runs the R2 contract under the workers pool after the filesystem suite.

## Testing

How was this tested?

- [x] `cd api && bun run typecheck` clean
- [x] `cd api && bun test` (filesystem driver): 350 pass / 0 fail
- [x] `cd api && npx vitest run --config vitest.workers.config.ts` (R2 driver under Miniflare): 10 pass (5 shared contract + 5 R2-specific)
- [x] `npm run lint` and `prettier --check` clean on the changed files
- [ ] E2E tests pass (`npm run test:e2e`) - not applicable (API-only change)

The shared contract proves both drivers uphold the atomic snapshot-on-mismatch invariant, strictly-monotonic `updatedAt`, and no-lost-diverged-copy under concurrent writes (including UUID-casing). The self-host Bun path is behaviour-identical.

## Accessibility

Not applicable: API-only change, no UI.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality (R2 contract + R2-specific specs)

Closes #2625. Part of #2133.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148VTaTnT1JcYQp9YojPY6u)_


___

## **CodeAnt-AI Description**
**Run storage, quotas, and asset uploads through the request-specific backend**

### What Changed
- Layouts and assets now use the active storage backend per request, so the same API behavior works on self-hosted filesystem storage and Cloudflare R2
- Storage limits now count layouts and assets through the backend instead of scanning the local data directory, which keeps quota checks working in Workers
- Asset uploads use the same format checks on both backends, rejecting spoofed content types and non-image bodies before they are stored
- The app now supports the R2 storage path in Workers, including layout saves, snapshots, asset storage, and deletes

### Impact
`✅ Workers can store layouts and assets`
`✅ Quota checks work without filesystem access`
`✅ Fewer bad asset uploads accepted`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
