### PR TITLE
fix: standardize undo/redo device commands on resolve-by-id

### DIFF
--- a/src/lib/stores/commands/device.ts
+++ b/src/lib/stores/commands/device.ts
@@ -8,6 +8,55 @@ import { getImageStore } from "../images.svelte";
 import { placementKey } from "$lib/utils/placement-key";
 
 /**
+ * Find the current array index of the device whose id matches `id`, scanning the
+ * active rack via getDeviceAtIndex. Returns undefined when no device has that id.
+ *
+ * This is the shared building block for resolve-by-id command targeting (#2665).
+ * It mirrors createCrossRackMoveCommand.resolveIndicesDescending, generalized so
+ * every device command can find its target at runtime instead of trusting a
+ * creation-time index that another command may have invalidated.
+ */
+function resolveIndexById(
+  store: Pick<DeviceCommandStore, "getDeviceAtIndex">,
+  id: string,
+): number | undefined {
+  let i = 0;
+  while (true) {
+    const d = store.getDeviceAtIndex(i);
+    if (!d) break;
+    if (d.id === id) return i;
+    i++;
+  }
+  return undefined;
+}
+
+/**
+ * Build a target resolver for a command that was created against `initialIndex`.
+ *
+ * The first execute/undo runs while `initialIndex` is still valid: it reads the
+ * device's stable id there and caches it. Every later run (redo after an
+ * intervening insert/remove, repeated undo/redo) resolves the live index by that
+ * id, so the command can never act on whichever device has since shifted into the
+ * old slot. Returns undefined only when the device is genuinely absent, letting
+ * callers no-op instead of mutating an unrelated device (#2665).
+ */
+function createTargetResolver(
+  store: Pick<DeviceCommandStore, "getDeviceAtIndex">,
+  initialIndex: number,
+): () => number | undefined {
+  let trackedId: string | undefined;
+  return function resolveTargetIndex(): number | undefined {
+    if (trackedId !== undefined) {
+      return resolveIndexById(store, trackedId);
+    }
+    const device = store.getDeviceAtIndex(initialIndex);
+    if (!device) return undefined;
+    trackedId = device.id;
+    return initialIndex;
+  };
+}
+
+/**
  * Interface for layout store operations needed by device commands
  */
 export interface DeviceCommandStore {
@@ -49,19 +98,30 @@ export function createPlaceDeviceCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
-  let placedIndex: number = -1;
+  // Track the placed device by id (#2665). placeDeviceRaw appends and may remap
+  // the id on a collision (#1363), so read the live device back to learn its
+  // actual id. undo resolves the current index by that id rather than trusting
+  // the placement-time index, which an intervening command may have shifted.
+  let placedId: string | undefined;
 
   return {
     type: "PLACE_DEVICE",
     description: `Place ${deviceName}`,
     timestamp: Date.now(),
     execute() {
-      placedIndex = store.placeDeviceRaw(device);
+      const placedIndex = store.placeDeviceRaw(device);
+      if (placedIndex < 0) {
+        placedId = undefined;
+        return;
+      }
+      const placed = store.getDeviceAtIndex(placedIndex);
+      placedId = placed?.id ?? device.id;
     },
     undo() {
-      if (placedIndex >= 0) {
-        store.removeDeviceAtIndexRaw(placedIndex);
-      }
+      if (placedId === undefined) return;
+      const targetIndex = resolveIndexById(store, placedId);
+      if (targetIndex === undefined) return;
+      store.removeDeviceAtIndexRaw(targetIndex);
     },
   };
 }
@@ -76,15 +136,23 @@ export function createMoveDeviceCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
+  // Resolve the target by id at runtime (#2665) so redo/undo move the device the
+  // command was created for, even after another command shifted array positions.
+  const resolveTargetIndex = createTargetResolver(store, index);
+
   return {
     type: "MOVE_DEVICE",
     description: `Move ${deviceName}`,
     timestamp: Date.now(),
     execute() {
-      store.moveDeviceRaw(index, newPosition);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.moveDeviceRaw(targetIndex, newPosition);
     },
     undo() {
-      store.moveDeviceRaw(index, oldPosition);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.moveDeviceRaw(targetIndex, oldPosition);
     },
   };
 }
@@ -93,7 +161,6 @@ export function createMoveDeviceCommand(
  * Create a command to remove a device
  */
 export function createRemoveDeviceCommand(
-  index: number,
   device: PlacedDevice,
   store: DeviceCommandStore,
   deviceName: string = "device",
@@ -103,30 +170,13 @@ export function createRemoveDeviceCommand(
   // structuredClone handles nested objects like ports and custom_fields
   const deviceCopy = structuredClone(device);
 
-  // Track the target device by ID, not by a fixed creation-time index (#2656).
-  // undo() re-appends the device to the end (mutators.ts placeDeviceRaw), which
-  // shifts array positions, so a captured index goes stale and redo would delete
-  // the wrong device. Resolve the current index by ID at execute time, mirroring
-  // createCrossRackMoveCommand's resolveIndicesDescending. currentImageId doubles
+  // Track the target device by ID, not by a fixed creation-time index (#2656,
+  // generalized in #2665). undo() re-appends the device to the end (mutators.ts
+  // placeDeviceRaw), which shifts array positions, so a captured index goes stale
+  // and redo would delete the wrong device. Resolve the current index by ID at
+  // execute time via the shared resolveIndexById helper. currentImageId doubles
   // as the live device ID, kept in sync across undo when placeDeviceRaw remaps it.
   let currentImageId = device.id;
-
-  /**
-   * Find the current array index of the device tracked by currentImageId.
-   * Returns undefined when the ID is not present so execute() can no-op:
-   * falling back to the stale creation-time index could delete whichever
-   * device now occupies that position (#2656).
-   */
-  function resolveCurrentIndex(): number | undefined {
-    let i = 0;
-    while (true) {
-      const d = store.getDeviceAtIndex(i);
-      if (!d) break;
-      if (d.id === currentImageId) return i;
-      i++;
-    }
-    return undefined;
-  }
 
   // Snapshot placement images before removal for undo restoration
   const imageStore = getImageStore();
@@ -144,7 +194,7 @@ export function createRemoveDeviceCommand(
     execute() {
       // Resolve the target by ID at runtime so redo deletes the right device (#2656).
       // If the device is no longer present, no-op rather than touching a stale index.
-      const targetIndex = resolveCurrentIndex();
+      const targetIndex = resolveIndexById(store, currentImageId);
       if (targetIndex === undefined) return;
       // Clean up placement images using current ID (may differ from original after undo remap)
       getImageStore().removeAllDeviceImages(
@@ -181,15 +231,23 @@ export function createUpdateDeviceFaceCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
+  // Resolve the target by id at runtime (#2665) so the right device is updated
+  // even after another command shifted array positions.
+  const resolveTargetIndex = createTargetResolver(store, index);
+
   return {
     type: "UPDATE_DEVICE_FACE",
     description: `Flip ${deviceName}`,
     timestamp: Date.now(),
     execute() {
-      store.updateDeviceFaceRaw(index, newFace);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceFaceRaw(targetIndex, newFace);
     },
     undo() {
-      store.updateDeviceFaceRaw(index, oldFace);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceFaceRaw(targetIndex, oldFace);
     },
   };
 }
@@ -205,15 +263,21 @@ export function createUpdateDeviceNameCommand(
   deviceTypeName: string = "device",
 ): Command {
   const displayName = newName || deviceTypeName;
+  // Resolve the target by id at runtime (#2665).
+  const resolveTargetIndex = createTargetResolver(store, index);
   return {
     type: "UPDATE_DEVICE_NAME",
     description: `Rename ${displayName}`,
     timestamp: Date.now(),
     execute() {
-      store.updateDeviceNameRaw(index, newName);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceNameRaw(targetIndex, newName);
     },
     undo() {
-      store.updateDeviceNameRaw(index, oldName);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceNameRaw(targetIndex, oldName);
     },
   };
 }
@@ -229,15 +293,21 @@ export function createUpdateDevicePlacementImageCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
+  // Resolve the target by id at runtime (#2665).
+  const resolveTargetIndex = createTargetResolver(store, index);
   return {
     type: "UPDATE_DEVICE_PLACEMENT_IMAGE",
     description: `Update ${deviceName} ${face} image`,
     timestamp: Date.now(),
     execute() {
-      store.updateDevicePlacementImageRaw(index, face, newFilename);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDevicePlacementImageRaw(targetIndex, face, newFilename);
     },
     undo() {
-      store.updateDevicePlacementImageRaw(index, face, oldFilename);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDevicePlacementImageRaw(targetIndex, face, oldFilename);
     },
   };
 }
@@ -252,15 +322,21 @@ export function createUpdateDeviceColourCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
+  // Resolve the target by id at runtime (#2665).
+  const resolveTargetIndex = createTargetResolver(store, index);
   return {
     type: "UPDATE_DEVICE_COLOUR",
     description: `Update ${deviceName} colour`,
     timestamp: Date.now(),
     execute() {
-      store.updateDeviceColourRaw(index, newColour);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceColourRaw(targetIndex, newColour);
     },
     undo() {
-      store.updateDeviceColourRaw(index, oldColour);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceColourRaw(targetIndex, oldColour);
     },
   };
 }
@@ -276,15 +352,25 @@ export function createDetachContainerCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
+  // Resolve the target by id at runtime (#2665).
+  const resolveTargetIndex = createTargetResolver(store, index);
   return {
     type: "DETACH_CONTAINER",
     description: `Detach ${deviceName} from container`,
     timestamp: Date.now(),
     execute() {
-      store.updateDeviceContainerLinkageRaw(index, undefined, undefined);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceContainerLinkageRaw(targetIndex, undefined, undefined);
     },
     undo() {
-      store.updateDeviceContainerLinkageRaw(index, oldContainerId, oldSlotId);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceContainerLinkageRaw(
+        targetIndex,
+        oldContainerId,
+        oldSlotId,
+      );
     },
   };
 }
@@ -302,15 +388,29 @@ export function createMoveToSlotCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
+  // Resolve the target by id at runtime (#2665).
+  const resolveTargetIndex = createTargetResolver(store, index);
   return {
     type: "MOVE_TO_SLOT",
     description: `Move ${deviceName} to another cell`,
     timestamp: Date.now(),
     execute() {
-      store.updateDeviceContainerLinkageRaw(index, containerId, newSlotId);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceContainerLinkageRaw(
+        targetIndex,
+        containerId,
+        newSlotId,
+      );
     },
     undo() {
-      store.updateDeviceContainerLinkageRaw(index, containerId, oldSlotId);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceContainerLinkageRaw(
+        targetIndex,
+        containerId,
+        oldSlotId,
+      );
     },
   };
 }
@@ -325,15 +425,21 @@ export function createUpdateDeviceNotesCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
+  // Resolve the target by id at runtime (#2665).
+  const resolveTargetIndex = createTargetResolver(store, index);
   return {
     type: "UPDATE_DEVICE_NOTES",
     description: `Update ${deviceName} notes`,
     timestamp: Date.now(),
     execute() {
-      store.updateDeviceNotesRaw(index, newNotes);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceNotesRaw(targetIndex, newNotes);
     },
     undo() {
-      store.updateDeviceNotesRaw(index, oldNotes);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceNotesRaw(targetIndex, oldNotes);
     },
   };
 }
@@ -348,15 +454,21 @@ export function createUpdateDeviceIpCommand(
   store: DeviceCommandStore,
   deviceName: string = "device",
 ): Command {
+  // Resolve the target by id at runtime (#2665).
+  const resolveTargetIndex = createTargetResolver(store, index);
   return {
     type: "UPDATE_DEVICE_IP",
     description: `Update ${deviceName} IP`,
     timestamp: Date.now(),
     execute() {
-      store.updateDeviceIpRaw(index, newIp);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceIpRaw(targetIndex, newIp);
     },
     undo() {
-      store.updateDeviceIpRaw(index, oldIp);
+      const targetIndex = resolveTargetIndex();
+      if (targetIndex === undefined) return;
+      store.updateDeviceIpRaw(targetIndex, oldIp);
     },
   };
 }
@@ -442,16 +554,8 @@ export function createCrossRackMoveCommand(
   function resolveIndicesDescending(ids: string[]): number[] {
     const indices: number[] = [];
     for (const id of ids) {
-      let i = 0;
-      while (true) {
-        const d = store.getDeviceAtIndex(i);
-        if (!d) break;
-        if (d.id === id) {
-          indices.push(i);
-          break;
-        }
-        i++;
-      }
+      const idx = resolveIndexById(store, id);
+      if (idx !== undefined) indices.push(idx);
     }
     return indices.sort((a, b) => b - a);
   }

--- a/src/lib/stores/commands/device.ts
+++ b/src/lib/stores/commands/device.ts
@@ -33,26 +33,21 @@ function resolveIndexById(
 /**
  * Build a target resolver for a command that was created against `initialIndex`.
  *
- * The first execute/undo runs while `initialIndex` is still valid: it reads the
- * device's stable id there and caches it. Every later run (redo after an
- * intervening insert/remove, repeated undo/redo) resolves the live index by that
- * id, so the command can never act on whichever device has since shifted into the
- * old slot. Returns undefined only when the device is genuinely absent, letting
- * callers no-op instead of mutating an unrelated device (#2665).
+ * The device's stable id is captured at command creation time, while
+ * `initialIndex` is still valid: before any sibling command in a batch can shift
+ * the rack. Every run then resolves the live index by that id, so the command can
+ * never act on whichever device has since shifted into the old slot. Returns
+ * undefined only when the device is genuinely absent, letting callers no-op
+ * instead of mutating an unrelated device (#2665).
  */
 function createTargetResolver(
   store: Pick<DeviceCommandStore, "getDeviceAtIndex">,
   initialIndex: number,
 ): () => number | undefined {
-  let trackedId: string | undefined;
+  const trackedId = store.getDeviceAtIndex(initialIndex)?.id;
   return function resolveTargetIndex(): number | undefined {
-    if (trackedId !== undefined) {
-      return resolveIndexById(store, trackedId);
-    }
-    const device = store.getDeviceAtIndex(initialIndex);
-    if (!device) return undefined;
-    trackedId = device.id;
-    return initialIndex;
+    if (trackedId === undefined) return undefined;
+    return resolveIndexById(store, trackedId);
   };
 }
 
@@ -537,10 +532,6 @@ export function createCrossRackMoveCommand(
   // All device IDs to remove from source rack (resolved by ID at runtime)
   const sourceDeviceIds = [parentCopy.id, ...childrenCopies.map((c) => c.id)];
 
-  // Captured during execute() for undo — target-rack indices of placed devices
-  let parentPlacedIndex = -1;
-  const childPlacedIndices: number[] = [];
-
   // Track current source IDs and image keys — updated across execute/undo when
   // placeDeviceRaw remaps an ID (#1478). Mutable so redo (execute) finds remapped devices.
   const currentSourceDeviceIds = [...sourceDeviceIds];
@@ -576,7 +567,7 @@ export function createCrossRackMoveCommand(
 
       // 2. Place parent in target rack
       store.setActiveRackId(targetRackId);
-      parentPlacedIndex = store.placeDeviceRaw(placedParent);
+      const parentPlacedIndex = store.placeDeviceRaw(placedParent);
 
       // Read back actual parent — placeDeviceRaw may remap the ID (#1363 dedup guard)
       const actualParent = store.getDeviceAtIndex(parentPlacedIndex);
@@ -589,14 +580,12 @@ export function createCrossRackMoveCommand(
       }
 
       // 3. Place children in target rack with remapped container_id
-      childPlacedIndices.length = 0;
       placedChildren.forEach((child, i) => {
         const childToPlace: PlacedDevice =
           child.container_id && child.container_id !== actualParentId
             ? { ...child, container_id: actualParentId }
             : child;
         const idx = store.placeDeviceRaw(childToPlace);
-        childPlacedIndices.push(idx);
 
         // Re-key child placement image if child ID was remapped (#1478)
         const actualChild = store.getDeviceAtIndex(idx);
@@ -614,11 +603,13 @@ export function createCrossRackMoveCommand(
     undo() {
       const savedActiveRack = store.getActiveRackId();
 
-      // 1. Remove devices from target rack (descending index order)
+      // 1. Remove devices from target rack, resolved by id so a change to the
+      // target rack between execute and undo cannot remove the wrong devices (#2665).
       store.setActiveRackId(targetRackId);
-      const allTargetIndices = [parentPlacedIndex, ...childPlacedIndices].sort(
-        (a, b) => b - a,
-      );
+      const allTargetIndices = resolveIndicesDescending([
+        currentParentImageId,
+        ...currentChildImageIds,
+      ]);
       for (const idx of allTargetIndices) {
         store.removeDeviceAtIndexRaw(idx);
       }

--- a/src/lib/stores/layout/recorded-device-actions.ts
+++ b/src/lib/stores/layout/recorded-device-actions.ts
@@ -419,7 +419,6 @@ export function removeDeviceRecorded(
   const adapter = getCommandStoreAdapter(ctx);
 
   const command = createRemoveDeviceCommand(
-    deviceIndex,
     device,
     adapter,
     deviceName,

--- a/src/tests/commands-device.test.ts
+++ b/src/tests/commands-device.test.ts
@@ -29,6 +29,11 @@ function createMockStore(): DeviceCommandStore & {
     moveDeviceRaw: vi.fn().mockReturnValue(true),
     updateDeviceFaceRaw: vi.fn(),
     updateDeviceNameRaw: vi.fn(),
+    updateDevicePlacementImageRaw: vi.fn(),
+    updateDeviceColourRaw: vi.fn(),
+    updateDeviceContainerLinkageRaw: vi.fn(),
+    updateDeviceNotesRaw: vi.fn(),
+    updateDeviceIpRaw: vi.fn(),
     // Resolve-by-id (#2665): commands read the device at their creation index to
     // learn its stable id, then re-resolve that id on later runs. The mock backs
     // a small fixed roster (ids "mock-0".."mock-9") so an id captured at index N
@@ -264,6 +269,11 @@ describe("Device Commands", () => {
         moveDeviceRaw: vi.fn().mockReturnValue(true),
         updateDeviceFaceRaw: vi.fn(),
         updateDeviceNameRaw: vi.fn(),
+        updateDevicePlacementImageRaw: vi.fn(),
+        updateDeviceColourRaw: vi.fn(),
+        updateDeviceContainerLinkageRaw: vi.fn(),
+        updateDeviceNotesRaw: vi.fn(),
+        updateDeviceIpRaw: vi.fn(),
         getDeviceAtIndex: vi.fn((index: number) => placed[index]),
         addDeviceTypeRaw: vi.fn(),
         removeDeviceTypeRaw: vi.fn(),

--- a/src/tests/commands-device.test.ts
+++ b/src/tests/commands-device.test.ts
@@ -13,6 +13,7 @@ import {
 import { createBatchCommand } from "$lib/stores/commands/types";
 import { createTestDevice, createTestDeviceType } from "./factories";
 import { toInternalUnits } from "$lib/utils/position";
+import type { PlacedDevice, DeviceFace } from "$lib/types";
 
 function createMockStore(): DeviceCommandStore & {
   placeDeviceRaw: ReturnType<typeof vi.fn>;
@@ -28,7 +29,15 @@ function createMockStore(): DeviceCommandStore & {
     moveDeviceRaw: vi.fn().mockReturnValue(true),
     updateDeviceFaceRaw: vi.fn(),
     updateDeviceNameRaw: vi.fn(),
-    getDeviceAtIndex: vi.fn(),
+    // Resolve-by-id (#2665): commands read the device at their creation index to
+    // learn its stable id, then re-resolve that id on later runs. The mock backs
+    // a small fixed roster (ids "mock-0".."mock-9") so an id captured at index N
+    // always resolves back to index N, leaving the existing index assertions valid.
+    getDeviceAtIndex: vi.fn((index: number) =>
+      index >= 0 && index < 10
+        ? createTestDevice({ id: `mock-${index}` })
+        : undefined,
+    ),
   };
 }
 
@@ -135,7 +144,7 @@ describe("Device Commands", () => {
       const store = createMockStore();
       const device = createTestDevice();
 
-      const command = createRemoveDeviceCommand(0, device, store, "Switch");
+      const command = createRemoveDeviceCommand(device, store, "Switch");
 
       expect(command.type).toBe("REMOVE_DEVICE");
       expect(command.description).toBe("Remove Switch");
@@ -146,7 +155,7 @@ describe("Device Commands", () => {
       const store = createMockStore();
       const device = createTestDevice();
 
-      const command = createRemoveDeviceCommand(0, device, store);
+      const command = createRemoveDeviceCommand(device, store);
 
       expect(command.description).toBe("Remove device");
     });
@@ -163,7 +172,7 @@ describe("Device Commands", () => {
             : undefined,
       );
 
-      const command = createRemoveDeviceCommand(3, device, store);
+      const command = createRemoveDeviceCommand(device, store);
       command.execute();
 
       expect(store.removeDeviceAtIndexRaw).toHaveBeenCalledTimes(1);
@@ -178,8 +187,8 @@ describe("Device Commands", () => {
         i === 0 ? createTestDevice({ id: "someone-else" }) : undefined,
       );
 
-      // Captured index 0 now points at an unrelated device — must NOT be removed.
-      const command = createRemoveDeviceCommand(0, device, store);
+      // The target id is not present — must NOT remove an unrelated device.
+      const command = createRemoveDeviceCommand(device, store);
       command.execute();
 
       expect(store.removeDeviceAtIndexRaw).not.toHaveBeenCalled();
@@ -192,7 +201,7 @@ describe("Device Commands", () => {
         device_type: "my-device",
       });
 
-      const command = createRemoveDeviceCommand(0, device, store);
+      const command = createRemoveDeviceCommand(device, store);
       command.execute();
       command.undo();
 
@@ -210,7 +219,7 @@ describe("Device Commands", () => {
       const store = createMockStore();
       const device = createTestDevice({ position: 15 });
 
-      const command = createRemoveDeviceCommand(0, device, store);
+      const command = createRemoveDeviceCommand(device, store);
 
       // Mutate original
       device.position = 99;
@@ -239,13 +248,23 @@ describe("Device Commands", () => {
         updateDeviceTypeRaw: ReturnType<typeof vi.fn>;
         getPlacedDevicesForType: ReturnType<typeof vi.fn>;
       } {
+      // Array-backed place/remove so resolve-by-id (#2665) can find the placed
+      // device on undo: getDeviceAtIndex reads the same roster placeDeviceRaw
+      // appends to. The spies still record their calls for assertions.
+      const placed: PlacedDevice[] = [];
       return {
-        placeDeviceRaw: vi.fn().mockReturnValue(0),
-        removeDeviceAtIndexRaw: vi.fn(),
+        placeDeviceRaw: vi.fn((device: PlacedDevice) => {
+          placed.push(device);
+          return placed.length - 1;
+        }),
+        removeDeviceAtIndexRaw: vi.fn((index: number) => {
+          if (index < 0 || index >= placed.length) return undefined;
+          return placed.splice(index, 1)[0];
+        }),
         moveDeviceRaw: vi.fn().mockReturnValue(true),
         updateDeviceFaceRaw: vi.fn(),
         updateDeviceNameRaw: vi.fn(),
-        getDeviceAtIndex: vi.fn(),
+        getDeviceAtIndex: vi.fn((index: number) => placed[index]),
         addDeviceTypeRaw: vi.fn(),
         removeDeviceTypeRaw: vi.fn(),
         updateDeviceTypeRaw: vi.fn(),
@@ -364,7 +383,7 @@ describe("Device Commands", () => {
       const store = createArrayBackedStore([deviceA, deviceB]);
 
       // Remove A (index 0). undo re-appends A, shifting B to index 0.
-      const command = createRemoveDeviceCommand(0, deviceA, store, "Device A");
+      const command = createRemoveDeviceCommand(deviceA, store, "Device A");
 
       command.execute(); // [B]
       expect(store.devices).not.toContainEqual(
@@ -402,7 +421,7 @@ describe("Device Commands", () => {
       });
       const store = createArrayBackedStore([deviceA, deviceB]);
 
-      const command = createRemoveDeviceCommand(0, deviceA, store, "Device A");
+      const command = createRemoveDeviceCommand(deviceA, store, "Device A");
 
       // redo re-runs execute (history.redo)
       const runRedo = () => command.execute();
@@ -434,6 +453,140 @@ describe("Device Commands", () => {
       expect(store.devices).toContainEqual(
         expect.objectContaining({ id: "device-b" }),
       );
+    });
+  });
+
+  describe("interleaved device commands resolve their target by id (#2665)", () => {
+    // Fully-functional array-backed store: place appends, remove filters
+    // positionally, move/face mutate the matched index. Mirrors mutators.ts so an
+    // operation recorded against device A keeps hitting A even after a command on a
+    // LOWER-index device B shifts array positions.
+    function createMutatingStore(
+      initial: PlacedDevice[],
+    ): DeviceCommandStore & {
+      devices: PlacedDevice[];
+    } {
+      const devices = [...initial];
+      return {
+        devices,
+        placeDeviceRaw(device: PlacedDevice): number {
+          devices.push(device);
+          return devices.length - 1;
+        },
+        removeDeviceAtIndexRaw(index: number): PlacedDevice | undefined {
+          if (index < 0 || index >= devices.length) return undefined;
+          return devices.splice(index, 1)[0];
+        },
+        moveDeviceRaw(index: number, newPosition: number): boolean {
+          if (index < 0 || index >= devices.length) return false;
+          devices[index] = { ...devices[index]!, position: newPosition };
+          return true;
+        },
+        updateDeviceFaceRaw(index: number, face: DeviceFace): void {
+          if (index < 0 || index >= devices.length) return;
+          devices[index] = { ...devices[index]!, face };
+        },
+        updateDeviceNameRaw: vi.fn(),
+        updateDevicePlacementImageRaw: vi.fn(),
+        updateDeviceColourRaw: vi.fn(),
+        updateDeviceContainerLinkageRaw: vi.fn(),
+        updateDeviceNotesRaw: vi.fn(),
+        updateDeviceIpRaw: vi.fn(),
+        getDeviceAtIndex(index: number): PlacedDevice | undefined {
+          return devices[index];
+        },
+      };
+    }
+
+    function findById(
+      devices: PlacedDevice[],
+      id: string,
+    ): PlacedDevice | undefined {
+      return devices.find((d) => d.id === id);
+    }
+
+    it("MOVE on device A still moves A after a lower-index B is removed then restored", () => {
+      // createTestDevice takes human U and stores internal units.
+      const deviceA = createTestDevice({ id: "device-a", position: 5 });
+      const deviceB = createTestDevice({ id: "device-b", position: 1 });
+      // B at index 0, A at index 1.
+      const store = createMutatingStore([deviceB, deviceA]);
+
+      // Record a MOVE on A (index 1) and a REMOVE on the lower-index B (index 0).
+      const moveA = createMoveDeviceCommand(
+        1,
+        toInternalUnits(5),
+        toInternalUnits(8),
+        store,
+        "Device A",
+      );
+      const removeB = createRemoveDeviceCommand(deviceB, store, "Device B");
+
+      // Apply the move, then remove B. Removing B shifts A from index 1 to 0.
+      moveA.execute();
+      expect(findById(store.devices, "device-a")?.position).toBe(
+        toInternalUnits(8),
+      );
+      removeB.execute();
+      expect(findById(store.devices, "device-b")).toBeUndefined();
+
+      // Undo the move. It must restore A (now at index 0), not whatever sits at
+      // the original index 1. A captured index would target the wrong slot.
+      moveA.undo();
+      expect(findById(store.devices, "device-a")?.position).toBe(
+        toInternalUnits(5),
+      );
+
+      // Restore B (re-appended to the end), then redo the move on A.
+      removeB.undo();
+      expect(findById(store.devices, "device-b")).toBeDefined();
+      moveA.execute();
+      expect(findById(store.devices, "device-a")?.position).toBe(
+        toInternalUnits(8),
+      );
+      // B is untouched by A's command.
+      expect(findById(store.devices, "device-b")?.position).toBe(
+        toInternalUnits(1),
+      );
+    });
+
+    it("UPDATE_FACE on device A targets A across undo-twice / redo-twice while B shifts", () => {
+      const deviceA = createTestDevice({ id: "device-a", face: "front" });
+      const deviceB = createTestDevice({ id: "device-b", face: "front" });
+      // B at index 0, A at index 1.
+      const store = createMutatingStore([deviceB, deviceA]);
+
+      const flipA = createUpdateDeviceFaceCommand(
+        1,
+        "front",
+        "rear",
+        store,
+        "Device A",
+      );
+      const removeB = createRemoveDeviceCommand(deviceB, store, "Device B");
+
+      // Flip A, then remove B (lower index) so A shifts to index 0.
+      flipA.execute();
+      removeB.execute();
+      expect(findById(store.devices, "device-a")?.face).toBe("rear");
+
+      // Cycle 1: undo + redo of the flip must keep hitting A, not B.
+      flipA.undo();
+      expect(findById(store.devices, "device-a")?.face).toBe("front");
+      flipA.execute();
+      expect(findById(store.devices, "device-a")?.face).toBe("rear");
+
+      // Restore B, re-appended at the end. A's command still resolves to A.
+      removeB.undo();
+      expect(findById(store.devices, "device-b")?.face).toBe("front");
+
+      // Cycle 2: undo-twice-equivalent re-check then redo, both by id.
+      flipA.undo();
+      expect(findById(store.devices, "device-a")?.face).toBe("front");
+      flipA.execute();
+      expect(findById(store.devices, "device-a")?.face).toBe("rear");
+      // B was never flipped by A's command.
+      expect(findById(store.devices, "device-b")?.face).toBe("front");
     });
   });
 

--- a/src/tests/image-undo.test.ts
+++ b/src/tests/image-undo.test.ts
@@ -127,7 +127,6 @@ describe("Image Undo — Device Removal", () => {
 
     // Create the remove command (should snapshot images)
     const cmd = createRemoveDeviceCommand(
-      0,
       device,
       store,
       "Test Device",
@@ -168,7 +167,6 @@ describe("Image Undo — Device Removal", () => {
     );
 
     const cmd = createRemoveDeviceCommand(
-      0,
       device,
       store,
       "Test Device",
@@ -199,7 +197,6 @@ describe("Image Undo — Device Removal", () => {
     const store = createMockDeviceStore(devices);
 
     const cmd = createRemoveDeviceCommand(
-      0,
       device,
       store,
       "Test Device",


### PR DESCRIPTION
## **User description**
## Summary

Generalizes the undo/redo resolve-by-id pattern across all device commands. Device commands previously captured a raw array index at creation and reused it on execute/redo/undo; any insert or remove shifts array positions, so a captured index goes stale and undo/redo mutates the wrong device. #2656 fixed `REMOVE_DEVICE` and #2678 fixed cross-rack move; this fixes the whole class.

## Changes

- Added shared `resolveIndexById` and `createTargetResolver` helpers in `commands/device.ts`, mirroring `createCrossRackMoveCommand.resolveIndicesDescending`.
- Converted PLACE, MOVE, UPDATE_FACE, UPDATE_NAME, UPDATE_PLACEMENT_IMAGE, UPDATE_COLOUR, DETACH_CONTAINER, MOVE_TO_SLOT, UPDATE_NOTES, and UPDATE_IP to resolve their target by device id at execute and undo time.
- `createRemoveDeviceCommand` and `createCrossRackMoveCommand` now share `resolveIndexById` (no behavior regression).
- Removed the now-dead `index` parameter from `createRemoveDeviceCommand` and updated all call sites, clearing the latent svelte-check error at `commands/device.ts:96`.
- Added interleaved multi-device undo/redo tests asserting that an op on device A keeps targeting A after a lower-index device B is removed and restored, across undo-twice/redo-twice cycles, checking store state by id.

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run check` (svelte-check) - 0 errors, 0 warnings (also clears the prior `device.ts:96` error)
- [x] `npm run build`
- [x] `npm run test:run` - 186 files, 2978 tests passed

## Screenshots

N/A (non-UI change)

## Accessibility

N/A (non-UI change)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2665

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUwpJvjFpgTY4WFoccEgJJ)_


___

## **CodeAnt-AI Description**
Stop undo and redo from affecting the wrong device after the list changes

### What Changed
- Device commands now re-find their target by device ID when they run, so undo and redo keep working on the same device even if another device was inserted or removed first
- Removal now skips cleanly when the device is no longer present, instead of touching whatever moved into its old position
- Removing a device no longer needs a saved list index, and related tests were updated to match
- Added tests that cover interleaved undo/redo cases where one device shifts the position of another

### Impact
`✅ Fewer wrong-device undo actions`
`✅ Safer device edits after list changes`
`✅ More reliable undo and redo for device changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
