### PR TITLE
fix: consolidate filename-slug sanitization and dedupe URange

### DIFF
--- a/api/src/schemas/layout.test.ts
+++ b/api/src/schemas/layout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { slugify, buildYamlFilename } from "./layout";
+
+describe("slugify (api)", () => {
+  it("maps a trailing plus to -plus, matching the frontend slugify", () => {
+    expect(slugify("Synology DS920+")).toBe("synology-ds920-plus");
+  });
+
+  it("trims and collapses leading, trailing and repeated separators", () => {
+    expect(slugify("--My  Homelab!!--")).toBe("my-homelab");
+  });
+
+  it("falls back to untitled when the name has no slug characters", () => {
+    expect(slugify("...")).toBe("untitled");
+  });
+});
+
+describe("buildYamlFilename (api)", () => {
+  it("derives the filename from the consolidated slug", () => {
+    expect(buildYamlFilename("Synology DS920+")).toBe(
+      "synology-ds920-plus.rackula.yaml",
+    );
+  });
+});

--- a/api/src/schemas/layout.ts
+++ b/api/src/schemas/layout.ts
@@ -71,13 +71,24 @@ export function buildFolderName(name: string, uuid: string): string {
 /**
  * Slugify a layout name to create a safe filename
  * Handles Unicode names by returning "untitled" if result is empty
+ *
+ * Behaviour mirrors the frontend slugify (src/lib/utils/slug.ts): a "+" becomes
+ * "-plus" before other processing so "DS920+" maps to "ds920-plus", and hyphens
+ * are trimmed and collapsed consistently. The api is a separate Bun package and
+ * cannot import the frontend module, so the rules are kept in sync here.
  */
 export function slugify(name: string): string {
   const slug = name
     .toLowerCase()
     .trim()
+    // Replace plus signs with 'plus' before other processing
+    .replace(/\+/g, "-plus")
+    // Replace non-alphanumeric with hyphens
     .replace(/[^a-z0-9]+/g, "-")
+    // Remove leading/trailing hyphens
     .replace(/^-+|-+$/g, "")
+    // Collapse multiple hyphens
+    .replace(/-+/g, "-")
     .slice(0, 100)
     .replace(/-+$/g, ""); // Remove trailing hyphens after truncation
 

--- a/src/lib/components/RackFrame.svelte
+++ b/src/lib/components/RackFrame.svelte
@@ -8,7 +8,7 @@
   Must be rendered as an early SVG layer (devices render on top).
 -->
 <script lang="ts">
-  import type { URange } from "$lib/utils/blocked-slots";
+  import type { URange } from "$lib/utils/collision";
 
   interface Props {
     /** Total rack width in pixels */

--- a/src/lib/utils/archive.ts
+++ b/src/lib/utils/archive.ts
@@ -788,5 +788,5 @@ export {
   buildYamlFilename,
   extractUuidFromFolderName,
   isUuid,
-  slugifyForFilename,
 } from "./folder-structure";
+export { slugifyForFilename } from "./slug";

--- a/src/lib/utils/blocked-slots.ts
+++ b/src/lib/utils/blocked-slots.ts
@@ -7,15 +7,8 @@
 
 import type { Rack, DeviceType, RackView } from "$lib/types";
 import { toHumanUnits } from "$lib/utils/position";
+import { doRangesOverlap, type URange } from "$lib/utils/collision";
 import { effectiveFace } from "./effective-face";
-
-/**
- * Represents a range of U positions (inclusive)
- */
-export interface URange {
-  bottom: number; // Lower U position
-  top: number; // Upper U position
-}
 
 /**
  * Calculate which U slots should show hatching for the given view.
@@ -75,9 +68,8 @@ export function isPositionBlocked(
   blockedSlots: URange[],
   position: number,
 ): boolean {
-  return blockedSlots.some(
-    (range) => position >= range.bottom && position <= range.top,
-  );
+  const point: URange = { bottom: position, top: position };
+  return blockedSlots.some((range) => doRangesOverlap(point, range));
 }
 
 /**
@@ -93,15 +85,6 @@ export function wouldOverlapBlocked(
   position: number,
   height: number,
 ): boolean {
-  const deviceTop = position + height - 1;
-
-  return blockedSlots.some(
-    (range) =>
-      // Device starts within blocked range
-      (position >= range.bottom && position <= range.top) ||
-      // Device ends within blocked range
-      (deviceTop >= range.bottom && deviceTop <= range.top) ||
-      // Device spans entire blocked range
-      (position < range.bottom && deviceTop > range.top),
-  );
+  const deviceRange: URange = { bottom: position, top: position + height - 1 };
+  return blockedSlots.some((range) => doRangesOverlap(deviceRange, range));
 }

--- a/src/lib/utils/export/utils.ts
+++ b/src/lib/utils/export/utils.ts
@@ -1,4 +1,5 @@
 import type { ExportFormat } from "$lib/types";
+import { slugifyForFilename } from "$lib/utils/slug";
 
 /**
  * Trigger download of a blob
@@ -31,13 +32,8 @@ export function generateExportFilename(
   view: "front" | "rear" | "both" | null,
   format: ExportFormat,
 ): string {
-  // Slugify the layout name: lowercase, hyphens, no special chars
-  const slugified = layoutName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  const baseName = slugified || "Rackula-export";
+  // Slugify the layout name through the shared filename sanitizer.
+  const baseName = slugifyForFilename(layoutName, "Rackula-export");
 
   // Format date as YYYY-MM-DD
   const now = new Date();

--- a/src/lib/utils/folder-structure.ts
+++ b/src/lib/utils/folder-structure.ts
@@ -6,6 +6,8 @@
  * @see docs/plans/2026-01-22-data-directory-refactor-design.md
  */
 
+import { slugifyForFilename } from "$lib/utils/slug";
+
 /**
  * UUID format: 8-4-4-4-12 hex characters with hyphens
  * Accepts any valid UUID (not just v4) since we generate UUIDs but may import from other sources
@@ -83,21 +85,5 @@ function sanitizeFolderNameForZip(name: string): string {
  * // 'my-homelab.rackula.yaml'
  */
 export function buildYamlFilename(name: string): string {
-  const slug = slugifyForFilename(name);
-  return `${slug || "layout"}.rackula.yaml`;
-}
-
-/**
- * Slugify a name for use in filenames
- * Lowercase, hyphens, no special chars
- *
- * @example
- * slugifyForFilename('My Homelab Setup!')
- * // 'my-homelab-setup'
- */
-export function slugifyForFilename(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+  return `${slugifyForFilename(name, "layout")}.rackula.yaml`;
 }

--- a/src/lib/utils/slug.ts
+++ b/src/lib/utils/slug.ts
@@ -36,6 +36,27 @@ export function slugify(input: string): string {
 }
 
 /**
+ * Slugify a name for use in a filename, with a fallback when the result is
+ * empty. This is the single sanitizer shared by every export path (image
+ * export, multi-rack ZIP, YAML folder structure) so the same layout or rack
+ * name always yields the same filename regardless of which path produced it.
+ *
+ * Built on slugify so the "+" rule and trim/collapse behaviour stay consistent
+ * (e.g. "DS920+" becomes "ds920-plus", leading/trailing/repeated separators are
+ * trimmed and collapsed).
+ *
+ * @param name - The human-readable name to sanitize
+ * @param fallback - Value returned when the name slugifies to an empty string
+ *
+ * @example
+ * slugifyForFilename('My Homelab Setup!', 'layout') // 'my-homelab-setup'
+ * slugifyForFilename('!!!', 'rack') // 'rack'
+ */
+export function slugifyForFilename(name: string, fallback: string): string {
+  return slugify(name) || fallback;
+}
+
+/**
  * Generate slug from device information
  *
  * Priority:

--- a/src/lib/utils/zip.ts
+++ b/src/lib/utils/zip.ts
@@ -4,6 +4,7 @@
  */
 
 import { getJSZip } from "./archive";
+import { slugifyForFilename } from "$lib/utils/slug";
 
 export interface ZipFile {
   /** Filename within the ZIP (e.g., 'rack-name-front.png') */
@@ -42,13 +43,8 @@ export function generateRackFilename(
   view: "front" | "rear" | "both",
   format: string,
 ): string {
-  // Slugify the rack name: lowercase, hyphens, no special chars
-  const slugified = rackName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-
-  const baseName = slugified || "rack";
+  // Slugify the rack name through the shared filename sanitizer.
+  const baseName = slugifyForFilename(rackName, "rack");
 
   return `${baseName}-${view}.${format}`;
 }

--- a/src/tests/blocked-slots.test.ts
+++ b/src/tests/blocked-slots.test.ts
@@ -6,7 +6,12 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { getBlockedSlots } from "$lib/utils/blocked-slots";
+import {
+  getBlockedSlots,
+  isPositionBlocked,
+  wouldOverlapBlocked,
+} from "$lib/utils/blocked-slots";
+import type { URange } from "$lib/utils/collision";
 import {
   createTestRack,
   createTestDeviceType,
@@ -193,5 +198,55 @@ describe("getBlockedSlots", () => {
 
       expect(blockedSlots.length).toBe(0);
     });
+  });
+});
+
+// These pin the edge-inclusive overlap semantics after #2670 routed the checks
+// through doRangesOverlap. A device touching a blocked range edge counts as
+// overlapping (the whole-U invariant depends on it); a device strictly adjacent
+// does not.
+describe("isPositionBlocked", () => {
+  const blocked: URange[] = [{ bottom: 5, top: 9 }];
+
+  it("treats the range edges as blocked (inclusive)", () => {
+    expect(isPositionBlocked(blocked, 5)).toBe(true);
+    expect(isPositionBlocked(blocked, 9)).toBe(true);
+  });
+
+  it("treats positions inside the range as blocked", () => {
+    expect(isPositionBlocked(blocked, 7)).toBe(true);
+  });
+
+  it("treats positions outside the range as not blocked", () => {
+    expect(isPositionBlocked(blocked, 4)).toBe(false);
+    expect(isPositionBlocked(blocked, 10)).toBe(false);
+  });
+});
+
+describe("wouldOverlapBlocked", () => {
+  const blocked: URange[] = [{ bottom: 5, top: 9 }];
+
+  it("reports overlap when the device touches the bottom edge", () => {
+    // Device spans U4-U5: its top edge touches the blocked bottom (U5).
+    expect(wouldOverlapBlocked(blocked, 4, 2)).toBe(true);
+  });
+
+  it("reports overlap when the device touches the top edge", () => {
+    // Device spans U9-U10: its bottom edge touches the blocked top (U9).
+    expect(wouldOverlapBlocked(blocked, 9, 2)).toBe(true);
+  });
+
+  it("reports overlap when the device spans the entire range", () => {
+    expect(wouldOverlapBlocked(blocked, 3, 10)).toBe(true);
+  });
+
+  it("reports no overlap when the device is strictly above the range", () => {
+    // Device spans U10-U11: strictly above the blocked range (5-9).
+    expect(wouldOverlapBlocked(blocked, 10, 2)).toBe(false);
+  });
+
+  it("reports no overlap when the device is strictly below the range", () => {
+    // Device spans U3-U4: strictly below the blocked range (5-9).
+    expect(wouldOverlapBlocked(blocked, 3, 2)).toBe(false);
   });
 });

--- a/src/tests/slug.test.ts
+++ b/src/tests/slug.test.ts
@@ -6,10 +6,14 @@
 import { describe, it, expect } from "vitest";
 import {
   slugify,
+  slugifyForFilename,
   generateDeviceSlug,
   isValidSlug,
   ensureUniqueSlug,
 } from "$lib/utils/slug";
+import { generateExportFilename } from "$lib/utils/export/utils";
+import { generateRackFilename } from "$lib/utils/zip";
+import { buildYamlFilename } from "$lib/utils/folder-structure";
 
 describe("Slug Utilities", () => {
   describe("slugify", () => {
@@ -71,6 +75,48 @@ describe("Slug Utilities", () => {
 
     it("handles underscores", () => {
       expect(slugify("some_thing")).toBe("some-thing");
+    });
+  });
+
+  describe("slugifyForFilename", () => {
+    it("applies the +-to-plus rule like slugify", () => {
+      expect(slugifyForFilename("DS920+", "fallback")).toBe("ds920-plus");
+    });
+
+    it("trims and collapses leading/trailing/repeated separators", () => {
+      expect(slugifyForFilename("--My  Homelab!!--", "fallback")).toBe(
+        "my-homelab",
+      );
+    });
+
+    it("returns the fallback when the name slugifies to empty", () => {
+      expect(slugifyForFilename("!!!", "rack")).toBe("rack");
+      expect(slugifyForFilename("", "layout")).toBe("layout");
+    });
+  });
+
+  describe("filename consistency across export paths", () => {
+    // The same name must produce the same slug regardless of which export path
+    // builds the filename (image export, multi-rack ZIP, YAML folder). The bug
+    // (#2670) was that these paths had diverged: "DS920+" became "ds920-" on
+    // some paths and "ds920-plus" via slugify.
+    it("produces one consistent slug for the +-case across paths", () => {
+      const exportName = generateExportFilename("DS920+", "front", "png");
+      const rackName = generateRackFilename("DS920+", "front", "png");
+      const yamlName = buildYamlFilename("DS920+");
+
+      expect(exportName).toContain("ds920-plus-front-");
+      expect(rackName).toBe("ds920-plus-front.png");
+      expect(yamlName).toBe("ds920-plus.rackula.yaml");
+    });
+
+    it("trims leading/trailing/repeated separators identically across paths", () => {
+      const name = "--My  Homelab!!--";
+      const rackName = generateRackFilename(name, "rear", "png");
+      const yamlName = buildYamlFilename(name);
+
+      expect(rackName).toBe("my-homelab-rear.png");
+      expect(yamlName).toBe("my-homelab.rackula.yaml");
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Consolidates the filename-slug sanitization that had diverged across export paths, and removes duplicate `URange`/overlap code in `blocked-slots`.

## Changes

Part A - filename slug consolidation:
- New shared `slugifyForFilename(name, fallback)` in `slug.ts`, built on `slugify`.
- Image export (`generateExportFilename`), multi-rack ZIP (`generateRackFilename`), and YAML folder (`buildYamlFilename`) all route through it. Previously these omitted the `+`->`-plus` rule (so `DS920+` became `ds920-` not `ds920-plus`) and the folder variant stripped only one leading/trailing hyphen.
- The api is a separate Bun package and cannot import the frontend module, so `api/src/schemas/layout.ts`'s `slugify` was made behavior-consistent (added `+`->`-plus`, consistent trim/collapse) with an api-side test.

Part B - URange dedup:
- `blocked-slots.ts` now imports `URange` and `doRangesOverlap` from `collision.ts`; its point and range checks are expressed via `doRangesOverlap`. The duplicate `URange` interface and both inline overlap implementations are deleted. `RackFrame.svelte`'s `URange` import re-pointed to `collision.ts`.
- `doRangesOverlap` edge-inclusivity semantics are unchanged (verified by an exhaustive equivalence check across range/position/height combinations).

## Testing

- [x] `npm run test:run` - 2997 passing
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] `npm run check` (svelte-check) - no new errors
- [x] api `slugify` test (`bun test src/schemas/layout.test.ts`)

## Screenshots

N/A (non-UI)

## Accessibility

N/A (non-UI)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2670

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUwpJvjFpgTY4WFoccEgJJ)_


___

## **CodeAnt-AI Description**
**Make exported filenames consistent and keep blocked-slot overlap behavior intact**

### What Changed
- The same layout or rack name now produces the same filename across image export, ZIP export, and YAML export, including names like `DS920+` becoming `ds920-plus`.
- Filenames now handle empty or symbol-only names with the expected fallback instead of ending up blank or inconsistent.
- Blocked-slot checks now use one shared overlap rule, while keeping edge-touching behavior the same.
- Added tests to cover the shared filename rules and confirm blocked-slot edge cases still behave as expected.

### Impact
`✅ Consistent export filenames`
`✅ Fewer broken or mismatched file names`
`✅ Unchanged blocked-slot hatching behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
