### PR TITLE
fix: apply the forward-compat version gate on the autosave read-door chokepoint

### DIFF
--- a/src/lib/storage/working-copy.test.ts
+++ b/src/lib/storage/working-copy.test.ts
@@ -1,0 +1,65 @@
+// src/lib/storage/working-copy.test.ts
+//
+// The autosave door (loadSessionWithTimestamp) reads an untrusted layout body out
+// of localStorage and routes it through the shared parseLayoutObject chokepoint.
+// Before #2664 that door ran LayoutSchema but NOT the forward-compat version gate,
+// so a future-major body in localStorage would load on the autosave path while the
+// YAML file door refused it. These tests pin the door's behaviour on the RESULT
+// object (never the DOM): a future-major body is refused (returns null), and
+// current / prior-release bodies still load.
+import { describe, it, expect, beforeEach } from "vitest";
+import { loadSessionWithTimestamp } from "./working-copy";
+import { createTestLayout } from "../../tests/factories";
+
+const STORAGE_KEY = "Rackula:autosave";
+
+/** Seed the autosave slot with a SessionData wrapper around the given body. */
+function seedAutosave(body: unknown): void {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      layout: body,
+      savedAt: "2026-06-29T00:00:00.000Z",
+      serverUpdatedAt: null,
+      changesSinceExport: 0,
+      hasEverExported: false,
+      storageMode: "browser",
+    }),
+  );
+}
+
+function bodyWithSchemaVersion(version: string): Record<string, unknown> {
+  const layout = createTestLayout();
+  return {
+    ...layout,
+    metadata: {
+      id: "22222222-2222-4222-8222-222222222222",
+      name: layout.name,
+      schema_version: version,
+    },
+  };
+}
+
+describe("loadSessionWithTimestamp: forward-compat gate on the autosave door (#2664)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("refuses a future-major autosave body, returning null", () => {
+    seedAutosave(bodyWithSchemaVersion("2.0"));
+    expect(loadSessionWithTimestamp()).toBeNull();
+  });
+
+  it("loads a current-major autosave body", () => {
+    seedAutosave(bodyWithSchemaVersion("1.0"));
+    const result = loadSessionWithTimestamp();
+    expect(result).not.toBeNull();
+    expect(result?.savedAt).toBe("2026-06-29T00:00:00.000Z");
+  });
+
+  it("loads an autosave body with no schema_version (legacy predates versioning)", () => {
+    seedAutosave(createTestLayout());
+    const result = loadSessionWithTimestamp();
+    expect(result).not.toBeNull();
+  });
+});

--- a/src/lib/utils/parse-layout-object.test.ts
+++ b/src/lib/utils/parse-layout-object.test.ts
@@ -1,0 +1,68 @@
+// src/lib/utils/parse-layout-object.test.ts
+//
+// parseLayoutObject is the shared read-door chokepoint for paths that hold a
+// runtime layout object rather than a YAML string: the localStorage autosave
+// (working-copy.ts) and the multi-layout browser workspace (browser-workspace.ts).
+// These tests pin its two load-bearing guards as RESULT-object behaviour (never
+// the DOM):
+//   1. the forward-compat version gate refuses a future-major body (#2664), so a
+//      future-major document in localStorage is rejected on the autosave door,
+//      not just the YAML file door;
+//   2. schema validation still rejects a malformed body (a null device);
+// while prior-release / current bodies continue to load unchanged.
+import { describe, it, expect } from "vitest";
+import { parseLayoutObject } from "./yaml";
+import { createTestLayout } from "../../tests/factories";
+
+/** A schema-valid runtime body with a current-major schema_version header. */
+function currentVersionBody(): Record<string, unknown> {
+  const layout = createTestLayout();
+  return {
+    ...layout,
+    metadata: {
+      id: "11111111-1111-4111-8111-111111111111",
+      name: layout.name,
+      schema_version: "1.0",
+    },
+  };
+}
+
+describe("parseLayoutObject: forward-compat version gate (#2664)", () => {
+  it("refuses a future-major body and returns null (does not throw)", () => {
+    const body = currentVersionBody();
+    (body.metadata as Record<string, unknown>).schema_version = "2.0";
+
+    // The autosave/workspace door must surface a future major as null, the same
+    // refusal the YAML file door produces, without an uncaught throw.
+    let result: ReturnType<typeof parseLayoutObject>;
+    expect(() => {
+      result = parseLayoutObject(body);
+    }).not.toThrow();
+    expect(result!).toBeNull();
+  });
+
+  it("loads a current-major body unchanged (gate is a no-op for the current format)", () => {
+    const result = parseLayoutObject(currentVersionBody());
+    expect(result).not.toBeNull();
+    expect(result?.metadata?.schema_version).toBe("1.0");
+  });
+
+  it("loads a body with an absent schema_version (legacy predates versioning)", () => {
+    const layout = createTestLayout();
+    const result = parseLayoutObject(layout);
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe(layout.name);
+  });
+});
+
+describe("parseLayoutObject: schema validation still rejects malformed bodies", () => {
+  it("rejects a body whose rack carries a null device, returning null", () => {
+    const layout = createTestLayout();
+    const body = {
+      ...layout,
+      racks: [{ ...layout.racks[0], devices: [null] }],
+    };
+    const result = parseLayoutObject(body);
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -475,17 +475,33 @@ function toRuntimeLayout(parsed: LayoutZod): Layout {
  *
  * This is the shared ingress chokepoint for read paths that hold a runtime
  * layout object rather than a serialized YAML string (e.g. the localStorage
- * working copy). It applies the same schema validation, migration, and
- * forward-compat gate as the file/server load path, so no read door bypasses the
- * schema.
+ * working copy and the multi-layout browser workspace). It applies the same
+ * schema validation and forward-compat gate as the file/server load path, so no
+ * read door bypasses the schema. Any new read door must route through this
+ * function (or `validateParsedLayout` for the YAML-string path) rather than
+ * calling `LayoutSchema` directly.
+ *
+ * Forward-compat gate (#2205, #2664): a document whose data-format MAJOR
+ * (`metadata.schema_version`) is newer than this app is refused here, so a
+ * future-major body in localStorage is rejected on EVERY read path, not just the
+ * YAML file door. Unlike `validateParsedLayout`, which throws, this function
+ * keeps its null-on-failure contract: the gate's throw is caught and surfaced as
+ * `null` so no caller (autosave, browser workspace) ever sees an uncaught throw.
  *
  * The runtime layout carries an id-only `metadata` ({ id }) for identity, which
  * is intentionally looser than the strict YAML file-header `LayoutMetadataSchema`
- * (id + name + schema_version). The id is preserved across validation and the
- * metadata is not re-validated here: the schema-versioning gate keys off the
- * top-level `version`, not the runtime metadata block.
+ * (id + name + schema_version). The id is preserved across validation.
  */
 export function parseLayoutObject(parsed: unknown): Layout | null {
+  // Forward-compat gate (#2664): refuse a future-major document before any parse,
+  // matching validateParsedLayout. assertSchemaVersionSupported throws; this door
+  // returns null on failure, so a future major surfaces as null, not a throw.
+  try {
+    assertSchemaVersionSupported(readSchemaVersion(parsed));
+  } catch {
+    return null;
+  }
+
   let metadata: Layout["metadata"];
   let body = parsed;
 


### PR DESCRIPTION
## **User description**
## Summary

Unifies the layout read doors on one validated chokepoint. `parseLayoutObject` (the shared ingress for read paths that hold a runtime layout object: the localStorage autosave and the multi-layout browser workspace) ran `LayoutSchema` but not the forward-compat version gate. A future-major body in localStorage therefore loaded on the autosave path while the YAML file door refused it. This applies `assertSchemaVersionSupported` at that chokepoint so a future-major document is refused on every read path.

## Changes

- Apply `assertSchemaVersionSupported` at the top of `parseLayoutObject`, before any parse, matching the YAML file door (`validateParsedLayout`).
- Preserve `parseLayoutObject`'s null-on-failure contract: the gate's throw is caught and returned as `null`, so no caller (autosave, browser workspace) ever sees an uncaught throw.
- Document `parseLayoutObject` as the single validated entry that new read doors must route through (or `validateParsedLayout` for the YAML-string path).
- The browser-workspace door already gated explicitly (#2657); that is now a harmless double-check and is left in place. It still routes through the chokepoint.
- Add unit tests for the chokepoint and the autosave caller.

## Testing

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run check` (no new errors; one unrelated pre-existing error in `device.ts` is fixed on main by #2665)
- [x] `npm run build`
- [x] `npm run test:run` (189 files, 3028 tests pass)
- [x] New: future-major body refused on the autosave/chokepoint door (returns null, no throw); null device rejected; current-major and absent-version bodies still load; full upgrade corpus (incl. v0.6 single-rack) passes

## Screenshots

N/A (non-UI)

## Accessibility

N/A (non-UI)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2664

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUwpJvjFpgTY4WFoccEgJJ)_


___

## **CodeAnt-AI Description**
**Refuse future-major layouts on every read path**

### What Changed
- Layouts with a newer schema version are now rejected when loading autosave data, matching the file-based load path
- The shared runtime-layout loader still returns `null` instead of throwing, so autosave and browser workspace reads fail safely
- Current-version layouts and older layouts without a schema version still load normally
- Added tests for the autosave path and the shared loader to cover valid layouts, legacy layouts, and malformed data

### Impact
`✅ Fewer autosave restore failures`
`✅ Consistent layout loading across save and file imports`
`✅ Clearer rejection of unsupported layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
