### PR TITLE
docs: M018 spine session report

### DIFF
--- a/session-report.md
+++ b/session-report.md
@@ -1,0 +1,56 @@
+# Session Report - M018 Cloudflare Spine (autonomous, no-credentials slice)
+
+Date: 2026-06-29 Scope: land the storage-to-Workers API spine for milestone M018, each issue as its own PR, merged only after both review bots (CodeRabbit + CodeAnt) cleared and required CI was green. No Cloudflare dashboard actions, no `wrangler deploy`, no secrets, no DNS, no GitHub-environment changes.
+
+## Outcome: all four in-scope items landed on `main`
+
+| Issue | What it delivered | PR | Merge commit |
+| --- | --- | --- | --- |
+| #2624 | Storage driver interface + per-request DI seam | #2636 | `6b8344f` |
+| #2625 | R2 driver + runner-agnostic contract harness | #2689 | `db24f00` |
+| #2032 (self-host half only) | Self-host header + build-env parity guard | #2683 | `9599aa5` |
+| #2626 | Workers entry + argon2-free bundle | #2706 | `927589d` |
+
+`main` is at `927589d`. #2624, #2625, #2626 are closed as completed. #2032 was reopened (see Deferred, below).
+
+## #2626 detail (this session's main work)
+
+Adds the Cloudflare Workers entry that runs the shared Hono app with R2 wired via the env binding and `AUTH_MODE=none`, producing a Worker bundle free of `@node-rs/argon2` and `node:fs`. The self-host Bun path stays behaviour-identical.
+
+- `app.ts`: static `./local-auth` (argon2) import broken - now `await import()` only when `authMode === 'local'`; filesystem-driver default is also a dynamic import; `package.json` version read via a named import so esbuild does not inline the dependency list (which holds the literal `@node-rs/argon2`) into the bundle.
+- `worker.ts`: CF entry - `createR2Driver(env.LAYOUTS)` + shared app, with Access JWT validation in front. App built behind a shared in-flight promise (no cold-start race).
+- `security/access-jwt.ts` (+ test): `jose` `Cf-Access-Jwt-Assertion` validator. Reads `CF_ACCESS_JWKS_URL` / `CF_ACCESS_ISSUER` / `CF_ACCESS_AUD` from env; `jwtVerify` pinned to RS256 with issuer + audience checks. Fail-closed semantics: fully-unset config skips (local `wrangler dev` / `AUTH_MODE=none`, returns 200 for smoke); partial config throws -> worker returns a non-cached 503; malformed JWKS URL -> controlled 403; missing token 401, invalid token 403.
+- `logger.ts` + `logger-console.ts`: runtime logger seam (console-JSON on workerd, pino on Bun).
+- `wrangler.jsonc`: dev worker (R2 `LAYOUTS` binding, `nodejs_compat`, `run_worker_first` for `/api/*`, wrangler floor pinned via package.json). Alias stubs for `@node-rs/argon2`, `pino`, `hono/bun`, and the filesystem driver keep the native addon, `node:fs`, and the Bun adapter out of the worker graph. Placeholders only - no real account/secrets.
+
+### Verification (local, no deploy)
+
+- `bun run typecheck`: clean
+- `bun test`: 364 pass / 0 fail (includes 10 access-jwt tests)
+- `vitest run --config vitest.workers.config.ts`: 10 pass (R2 contract under Miniflare)
+- `npm run lint` + `prettier --check`: clean
+- Bundle grep on the built `dist-worker/worker.js` (via `wrangler deploy --dry-run`, no auth): zero `@node-rs/argon2`, zero `node:fs` (only the sourcemap carries the doc-comment text).
+- `wrangler dev --local` smoke (Miniflare R2, CF*ACCESS*\* unset): `/api/version` 200, `/api/health` 200, `/api/layouts` 200, `PUT /api/layouts/{uuid}` round-trips.
+
+### Review notes
+
+Both bots cleared the final head `13c79a2`. CodeAnt's two findings (malformed-URL 500s; cold-start race) were fixed. CodeRabbit's three actionable findings: the fail-open-on-missing-config one was fixed (partial -> fail closed), the stale compat-date was bumped, and the named-JSON-import one was withdrawn by CodeRabbit after it confirmed the named import is required for the bundle gate.
+
+During the rebase onto current `main` (which had advanced to v26.6.5), a pre-existing `main` breakage surfaced: the v26.6.5 release commit (`30c67e9`) left `ACKNOWLEDGEMENTS.md` prettier-unclean (missing blank line after the `### v26.6.5` heading), which was failing the `validate` gate on every PR that merged main. Fixed in this PR.
+
+## Deferred / not done (by design)
+
+- CF `_headers` half of #2032: reopened #2032. The self-host half shipped in #2683; the CF-surface CSP/VITE parity ACs are blocked on #2029 (prod `_headers`) and #2134 (dev `_headers`). #2032 had been auto-closed when the self-host slice landed; reopened so the deferred ACs are not lost.
+- e2e (self-hosted full suite) CI check is advisory (`continue-on-error`); its debt is tracked in #2643 / #2680, handled in another session. It is not merge-blocking.
+- CodeRabbit "docstring coverage 50% < 80%" is an advisory pre-merge warning, not a required check; left as-is.
+
+## Out of scope this session (not started)
+
+#2675, #2134, #2029, #2030, #2031, #2676, #1986, the CF half of #2032, and trackers #2133 / #1985 / #1984 / #1983 / #2382.
+
+## Exact next human step
+
+1. Provision Cloudflare per #2675: create the R2 bucket, the Worker, the Cloudflare Access application, and set the real values that `wrangler.jsonc` and the Access validator read - `account_id`, the R2 `bucket_name` (replace `rackula-layouts-dev-placeholder`), and the secrets `CF_ACCESS_JWKS_URL`, `CF_ACCESS_ISSUER`, `CF_ACCESS_AUD`. (Code-only here; nothing in this slice touched the dashboard, DNS, or secrets.)
+2. Run the #2134 dev cutover: rewrite the deploy-dev workflow to `wrangler deploy` the API worker, re-point `d.racku.la`, and verify the Access-JWT validation via post-deploy smoke (service-token request carrying the assertion).
+
+After #2675 + #2134, the dev arc of the storage-to-Workers migration is live; prod follows its own track.


### PR DESCRIPTION
## **User description**
## Summary

Handoff report for the autonomous, no-credentials M018 (Cloudflare spine) slice. Adds a single file, `session-report.md`, summarizing what shipped, what is deferred, and the exact next human step. The substantive code already merged via the per-issue PRs below; this is the review artifact. Merge or close at your discretion.

## Changes

- Add `session-report.md` documenting:
  - Merged: #2624 (PR #2636, `6b8344f`), #2625 (PR #2689, `db24f00`), #2032 self-host half (PR #2683, `9599aa5`), #2626 (PR #2706, `927589d`)
  - Deferred: CF `_headers` half of #2032 (reopened; blocked on #2029/#2134); advisory e2e debt (#2643/#2680)
  - Next human step: provision Cloudflare per #2675, then the #2134 dev cutover

## Testing

How was this tested?

- [ ] Unit tests pass (`npm run test:run`) - n/a, docs-only (no app inputs changed)
- [ ] E2E tests pass (`npm run test:e2e`) - n/a, docs-only
- [x] Manual testing completed - content reviewed; links/issue references checked

## Accessibility

Not applicable (docs-only, no UI changes).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [ ] Tests added for new functionality (if applicable) - n/a, docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0148VTaTnT1JcYQp9YojPY6u)_


___

## **CodeAnt-AI Description**
**Document the M018 Cloudflare Spine handoff and next steps**

### What Changed
- Adds a session report covering the M018 Cloudflare Spine work, what shipped, what was deferred, and the exact next human step
- Summarizes the four completed issues and notes that the self-host part of #2032 shipped while the Cloudflare-facing part remains open
- Records the Worker-ready outcome: the shared app now runs with R2 wiring, Access JWT checks, and a bundle that avoids Node-only and argon2 code
- Lists the verification results and the remaining Cloudflare setup and dev cutover tasks

### Impact
`✅ Clearer M018 handoff`
`✅ Easier follow-up on deferred Cloudflare work`
`✅ Faster start for the next deployment step`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
