### PR TITLE
fix: fill A-Z device list to panel height (#2698)

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -97,6 +97,7 @@ To add yourself to this list, see [CONTRIBUTING.md](CONTRIBUTING.md).
 Contributors who made merged pull requests in each release. For the full contributors table, see above.
 
 ### v26.6.5
+
 - No external contributors in this release
 
 ### v26.6.4

--- a/e2e/device-palette-az-fill.spec.ts
+++ b/e2e/device-palette-az-fill.spec.ts
@@ -69,6 +69,62 @@ test.describe("Device palette A-Z fill (#2698)", () => {
     expect(renderedRows).toBeLessThan(100);
   });
 
+  test("non-virtualized A-Z search results render without overflow", async ({
+    page,
+  }) => {
+    const palette = page.locator(locators.device.palette);
+    await palette.getByRole("button", { name: "A-Z" }).click();
+
+    // A narrow query drops the flat list below VIRTUALIZE_THRESHOLD, so it
+    // renders as plain DOM (no .virtual-section) - the branch this fill change
+    // explicitly preserves. fill-flat must not engage and clip the short list.
+    await page.getByTestId("search-devices").fill("raspberry");
+
+    const virtualSection = palette.locator(locators.device.virtualSection);
+    await expect.poll(async () => virtualSection.count()).toBe(0);
+
+    const items = palette.locator(locators.device.paletteItem);
+    const count = await items.count();
+    expect(count).toBeGreaterThan(0);
+    // Every matched row is visible (not clipped by a zero-height fill box).
+    for (let i = 0; i < count; i++) {
+      await expect(items.nth(i)).toBeVisible();
+    }
+    // Footer stays in place and the short list does not overflow the panel.
+    await expect(palette.locator(locators.device.paletteFooter)).toBeVisible();
+    const listOverflows = await palette
+      .locator(locators.device.list)
+      .evaluate((el) => el.scrollHeight > el.clientHeight + 1);
+    expect(listOverflows).toBe(false);
+  });
+
+  test("collapsing the A-Z section shrinks it back to its header", async ({
+    page,
+  }) => {
+    const palette = page.locator(locators.device.palette);
+    await palette.getByRole("button", { name: "A-Z" }).click();
+
+    const item = palette.locator(locators.device.accordionItem).first();
+    const openBox = await item.boundingBox();
+    if (!openBox) {
+      throw new Error("expected the open A-Z section to be measurable");
+    }
+    // Open and filling, the section holds most of the panel.
+    expect(openBox.height).toBeGreaterThan(400);
+
+    // Collapse the sole "All Devices" section.
+    await palette.getByRole("button", { name: /All Devices/ }).click();
+
+    // The fill grow is gated on [data-state="open"], so a collapsed section
+    // shrinks back to roughly its header height instead of holding the panel.
+    await expect
+      .poll(async () => {
+        const b = await item.boundingBox();
+        return b ? b.height : Infinity;
+      })
+      .toBeLessThan(120);
+  });
+
   test("Category mode keeps per-section windowing capped (no unbounded fill)", async ({
     page,
   }) => {

--- a/e2e/device-palette-az-fill.spec.ts
+++ b/e2e/device-palette-az-fill.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from "./helpers/base-test";
+import { gotoWithRack, locators } from "./helpers";
+
+/**
+ * #2698: A-Z (flat) mode must fill the device-library panel height instead of
+ * capping the single windowed section at VIRTUAL_VIEWPORT_MAX (480px), which
+ * left a large blank gap above the "Add custom device" footer. Grouped views
+ * (Brand/Category) must keep that per-section cap so no one section stretches
+ * the palette unbounded.
+ *
+ * These are layout assertions, so they run in a real browser (jsdom has no
+ * layout engine). A tall viewport makes the pre-fix dead space unambiguous.
+ */
+test.describe("Device palette A-Z fill (#2698)", () => {
+  test.use({ viewport: { width: 1280, height: 1200 } });
+
+  test.beforeEach(async ({ page, isMobile }) => {
+    test.skip(!!isMobile, "Desktop sidebar layout only");
+    await gotoWithRack(page);
+    await page.getByTestId("sidebar-tab-devices").click();
+    await expect(page.locator(locators.device.palette)).toBeVisible();
+  });
+
+  test("A-Z list fills the panel with no dead space above the footer", async ({
+    page,
+  }) => {
+    const palette = page.locator(locators.device.palette);
+    await palette.getByRole("button", { name: "A-Z" }).click();
+    await expect(palette.getByRole("button", { name: "A-Z" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    const deviceList = palette.locator(locators.device.list);
+    const footer = palette.locator(locators.device.paletteFooter);
+    const virtualSection = palette.locator(locators.device.virtualSection);
+    await expect(virtualSection).toBeVisible();
+
+    const listBox = await deviceList.boundingBox();
+    const footerBox = await footer.boundingBox();
+    const sectionBox = await virtualSection.boundingBox();
+    if (!listBox || !footerBox || !sectionBox) {
+      throw new Error("expected palette layout boxes to be measurable");
+    }
+
+    // The windowed list fills most of the available height. On a 1200px-tall
+    // viewport the old fixed 480px cap filled well under half.
+    expect(sectionBox.height / listBox.height).toBeGreaterThan(0.7);
+
+    // No large blank area between the bottom of the list and the footer.
+    const deadSpace = footerBox.y - (sectionBox.y + sectionBox.height);
+    expect(deadSpace).toBeLessThan(80);
+
+    // The list still virtualizes: it scrolls within itself (content overflows
+    // the filled viewport) and renders only a windowed slice of the 747
+    // devices, not every row. This also guards the flex height chain - if the
+    // section's fill height failed to resolve, nothing would overflow.
+    const virtualList = palette.locator(locators.device.virtualList);
+    const scroll = await virtualList.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+    expect(scroll.scrollHeight).toBeGreaterThan(scroll.clientHeight + 100);
+
+    const renderedRows = await virtualList
+      .locator(locators.device.paletteItem)
+      .count();
+    expect(renderedRows).toBeGreaterThan(0);
+    expect(renderedRows).toBeLessThan(100);
+  });
+
+  test("Category mode keeps per-section windowing capped (no unbounded fill)", async ({
+    page,
+  }) => {
+    const palette = page.locator(locators.device.palette);
+    await palette.getByRole("button", { name: "Category" }).click();
+    await expect(
+      palette.getByRole("button", { name: "Category" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    // The default-expanded Server category has >100 devices, so it windows.
+    // The expanded section is the only visible one (others are collapsed).
+    const visibleSection = palette
+      .locator(locators.device.virtualSection)
+      .filter({ visible: true })
+      .first();
+    await expect(visibleSection).toBeVisible();
+
+    const box = await visibleSection.boundingBox();
+    if (!box) {
+      throw new Error("expected the expanded section box to be measurable");
+    }
+    // A grouped section stays near the VIRTUAL_VIEWPORT_MAX (480px) cap rather
+    // than stretching to fill the tall panel.
+    expect(box.height).toBeLessThanOrEqual(520);
+  });
+});
+
+/**
+ * Regression for the fill chain: a long pinned-favourites strip must not starve
+ * the A-Z library to zero height. Seeds many favourites on a short panel, where
+ * an uncapped pinned strip would otherwise consume the whole list area.
+ */
+test.describe("Device palette A-Z fill with pinned favourites (#2698)", () => {
+  test.use({ viewport: { width: 1280, height: 700 } });
+
+  // Starter-library generics; always present and 19"-compatible, so they all
+  // resolve as pinned devices.
+  const MANY_FAVOURITES = [
+    "1u-server",
+    "2u-server",
+    "3u-server",
+    "4u-server",
+    "1u-router-firewall",
+    "2u-router-firewall",
+    "24-port-switch",
+    "48-port-switch",
+    "1u-storage",
+    "2u-storage",
+    "3u-storage",
+    "4u-storage",
+    "1u-pdu",
+    "2u-pdu",
+    "2u-ups",
+    "4u-ups",
+    "1u-fiber-patch-panel",
+    "24-port-patch-panel",
+    "48-port-patch-panel",
+    "1u-console-drawer",
+  ];
+
+  test.beforeEach(async ({ page, isMobile }) => {
+    test.skip(!!isMobile, "Desktop sidebar layout only");
+    await page.addInitScript((slugs) => {
+      localStorage.setItem("Rackula-device-favourites", JSON.stringify(slugs));
+    }, MANY_FAVOURITES);
+    await gotoWithRack(page);
+    await page.getByTestId("sidebar-tab-devices").click();
+    await expect(page.locator(locators.device.palette)).toBeVisible();
+  });
+
+  test("A-Z library stays usable; the pinned strip cannot starve it to zero", async ({
+    page,
+  }) => {
+    const palette = page.locator(locators.device.palette);
+    await palette.getByRole("button", { name: "A-Z" }).click();
+    await expect(palette.getByRole("button", { name: "A-Z" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // The pinned strip is plain DOM (20 < virtualize threshold), so the only
+    // windowed section is the A-Z library.
+    const librarySection = palette
+      .locator(locators.device.virtualSection)
+      .filter({ visible: true })
+      .first();
+    await expect(librarySection).toBeVisible();
+
+    const box = await librarySection.boundingBox();
+    if (!box) {
+      throw new Error("expected the A-Z library section to be measurable");
+    }
+    // Pre-fix the section collapsed to ~0 here; it must keep a usable height.
+    expect(box.height).toBeGreaterThan(120);
+  });
+});

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -58,6 +58,8 @@ export const locators = {
     virtualSection: ".virtual-section",
     /** VirtualList's internal scroll viewport. */
     virtualList: ".virtual-list",
+    /** A grouping accordion section's item wrapper (carries data-state). */
+    accordionItem: ".accordion-item",
   },
 
   toolbar: {

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -50,6 +50,14 @@ export const locators = {
     paletteItem: '[data-testid="device-palette-item"]',
     paletteItemName: '[data-testid="device-palette-item"] .device-name',
     palette: ".device-palette",
+    /** Scrolling device-list region inside the palette. */
+    list: ".device-list",
+    /** "Add custom device" footer pinned below the list. */
+    paletteFooter: ".palette-footer",
+    /** A windowed (virtualized) accordion section's outer box. */
+    virtualSection: ".virtual-section",
+    /** VirtualList's internal scroll viewport. */
+    virtualList: ".virtual-list",
   },
 
   toolbar: {

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -380,6 +380,15 @@
     searchDevices(allDevicesCombined, searchQuery),
   );
 
+  // Flat A-Z mode renders a single windowed section. Unlike grouped views,
+  // where many sections share the panel under the VIRTUAL_VIEWPORT_MAX cap,
+  // this lone section should grow to fill the panel and scroll within itself.
+  // Gate the fill on the virtualized path: short, search-filtered results stay
+  // on the plain-DOM branch and keep their natural height + the list scroll.
+  const flatFill = $derived(
+    groupingMode === "flat" && filteredAllDevices.length > VIRTUALIZE_THRESHOLD,
+  );
+
   // Pinned devices: resolve favourite slugs against the same width/compat/search
   // filtered pool the rest of the palette uses, preserving favourite order.
   // Collect only the matching devices (favourites are few) rather than indexing
@@ -566,7 +575,7 @@
   </div>
 
   <!-- Device List -->
-  <div class="device-list">
+  <div class="device-list" class:fill-flat={flatFill}>
     {#snippet deviceRow(device: DeviceType)}
       <DevicePaletteItem
         {device}
@@ -583,14 +592,14 @@
 
     <!-- Flat device list: windowed when long, plain DOM when short, so the
          accordion height animation survives for small sections. -->
-    {#snippet deviceList(devices: DeviceType[], label: string)}
+    {#snippet deviceList(devices: DeviceType[], label: string, fill = false)}
       {#if devices.length > VIRTUALIZE_THRESHOLD}
         <div
           class="virtual-section"
-          style:height="{Math.min(
-            devices.length * ROW_HEIGHT,
-            VIRTUAL_VIEWPORT_MAX,
-          )}px"
+          class:fill
+          style:height={fill
+            ? null
+            : `${Math.min(devices.length * ROW_HEIGHT, VIRTUAL_VIEWPORT_MAX)}px`}
         >
           <VirtualList
             items={devices}
@@ -694,8 +703,9 @@
                     {/if}
                   {/each}
                 {:else}
-                  <!-- All other sections show devices in a flat list -->
-                  {@render deviceList(section.devices, section.title)}
+                  <!-- All other sections show devices in a flat list. In flat
+                       A-Z mode the lone section fills the panel (see flatFill). -->
+                  {@render deviceList(section.devices, section.title, flatFill)}
                 {/if}
               </div>
             </Accordion.Content>
@@ -704,11 +714,19 @@
       {/snippet}
 
       {#if accordionMode === "multiple"}
-        <Accordion.Root type="multiple" bind:value={accordionMultipleValue}>
+        <Accordion.Root
+          type="multiple"
+          bind:value={accordionMultipleValue}
+          class="device-accordion"
+        >
           {@render accordionSections()}
         </Accordion.Root>
       {:else}
-        <Accordion.Root type="single" bind:value={accordionSingleValue}>
+        <Accordion.Root
+          type="single"
+          bind:value={accordionSingleValue}
+          class="device-accordion"
+        >
           {@render accordionSections()}
         </Accordion.Root>
       {/if}
@@ -970,6 +988,63 @@
   /* Windowed section: fixed height so VirtualList can scroll within it. */
   .virtual-section {
     overflow: hidden;
+  }
+
+  /* Flat A-Z fill (#2698): the lone windowed section grows to fill the panel
+     and scrolls within itself, instead of being pinned to VIRTUAL_VIEWPORT_MAX.
+     A flex chain runs device-list -> accordion -> item -> open content -> inner
+     -> section so the section resolves a definite fill height, and VirtualList's
+     max-height: 100% then drives the internal scroll. Scoped to .fill-flat so
+     grouped views (Brand/Category) keep the fixed per-section cap. */
+  .device-list.fill-flat {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Pinned favourites sit at the top and the accordion fills the rest. Cap the
+     pinned strip so a long favourites list can never starve the A-Z library to
+     zero height (it scrolls within itself past the cap); the accordion always
+     keeps the majority of the panel. */
+  .device-list.fill-flat > .pinned-section {
+    flex: 0 1 auto;
+    min-height: 0;
+    max-height: 45%;
+    overflow-y: auto;
+  }
+
+  .device-list.fill-flat :global(.device-accordion),
+  .device-list.fill-flat :global(.device-accordion .accordion-item) {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  /* Only the open section fills; gating on [data-state="open"] lets a closed
+     one still collapse via the grid 0fr rule (see transition note below). */
+  .device-list.fill-flat
+    :global(.device-accordion .accordion-content[data-state="open"]) {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .device-list.fill-flat :global(.accordion-content-inner) {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .virtual-section.fill {
+    flex: 1;
+    min-height: 0;
+  }
+
+  /* In fill mode the open section is flex-sized, so the grid-row slide no longer
+     tracks the box (flex refills the freed space and the box snaps at the end).
+     Collapse instantly instead; the sole A-Z section is open by default, so the
+     only transition this drops is the rare manual collapse/expand. */
+  .device-list.fill-flat :global(.accordion-content) {
+    transition: none;
   }
 
   .pinned-section {

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -1012,8 +1012,17 @@
     overflow-y: auto;
   }
 
-  .device-list.fill-flat :global(.device-accordion),
-  .device-list.fill-flat :global(.device-accordion .accordion-item) {
+  .device-list.fill-flat :global(.device-accordion) {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  /* Fill only the open section, so a manually-collapsed A-Z section shrinks back
+     to its header height instead of an open item holding the full panel. */
+  .device-list.fill-flat
+    :global(.device-accordion .accordion-item[data-state="open"]) {
     display: flex;
     flex: 1;
     flex-direction: column;


### PR DESCRIPTION
## **User description**
## What

In the device library panel, the **A-Z (flat)** view rendered all ~747 devices as one windowed section capped at `VIRTUAL_VIEWPORT_MAX` (480px), while the surrounding `.device-list` is `flex: 1` and fills the panel. The capped section could not grow, so everything below ~10 rows rendered as a large blank gap above the "Add custom device" footer. Brand and Category views were unaffected (multiple sections stack).

This lets the lone flat section grow to fill the panel and scroll within itself, while keeping the 480px cap for grouped views where many sections must coexist.

Closes #2698.

## How

- `flatFill` derived gates the fill on the **virtualized flat path** (`groupingMode === "flat" && filteredAllDevices.length > VIRTUALIZE_THRESHOLD`). Short, search-filtered results (<= 30) stay on the unchanged plain-DOM branch and keep their natural height plus the normal list scroll, so there is no clip regression.
- A flex chain scoped to `.device-list.fill-flat` plumbs a definite fill height down `device-list -> .device-accordion -> .accordion-item -> open .accordion-content -> .accordion-content-inner -> .virtual-section.fill`. `VirtualList`'s existing `max-height: 100%` then drives the internal scroll. Brand/Category never get the `.fill-flat` class, so they are byte-identical.

### Hardening from an adversarial review pass

Two empirically-measured defects found and fixed before pushing:

- **Pinned favourites starving the list.** With a long favourites strip, the uncapped `.pinned-section` could push the A-Z library to 0px (the list vanished, plus an outer scrollbar). Fixed by capping the pinned strip (`max-height: 45%` + its own scroll), so the accordion always keeps the majority of the panel and can never be starved to zero.
- **Collapse animation snapping.** In fill mode the open section is flex-sized, so the grid-row slide no longer tracked the box on collapse (it held full height, then snapped). Fixed by dropping the slide transition in fill mode; the sole A-Z section is open by default, so this only affects the rare manual collapse.

## Done-when (from the issue)

- [x] A-Z view fills the available panel height, no blank area above the footer.
- [x] Still virtualizes and stays performant with 747+ devices (renders a windowed slice, scrolls internally).
- [x] Brand and Category views unaffected (long sections stay capped).
- [x] Search-filtered A-Z results fill correctly (broad filter fills; narrow filter falls to the natural plain-DOM list, no overflow).

## Tests

New `e2e/device-palette-az-fill.spec.ts` (green on chromium + webkit, dev and production configs):

- A-Z list fills the panel (height ratio + dead-space + still-virtualizes assertions).
- Category mode keeps per-section windowing capped (regression guard).
- A-Z library stays usable with many pinned favourites (guards the starvation regression; verified red on the pre-fix CSS).

Unit suite, `svelte-check`, ESLint, Prettier, and `svelte-autofixer` all clean. No visual baseline change expected: the only palette snapshot (`sidebar-devices`) is captured in the default Brand mode, which this change leaves identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ovwypYGd2D39QWnU9SafF


___

## **CodeAnt-AI Description**
**Fill the A-Z device list to the panel height and keep grouped views capped**

### What Changed
- The A-Z device library now stretches to fill the sidebar panel instead of stopping at a short fixed height, so the footer no longer sits below a large blank gap.
- Brand and Category views still keep their per-section height limit, so grouped lists do not grow unbounded.
- A long pinned-favourites list can no longer push the A-Z library down to zero height; it now scrolls on its own when needed.
- Collapsing the filled A-Z section no longer snaps awkwardly during the height change.

### Impact
`✅ Fewer blank gaps in the device library`
`✅ Usable A-Z list with many pinned favourites`
`✅ Consistent grouped-device scrolling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
