### PR TITLE
chore: reformat repo for prettier 3.9.3

### DIFF
--- a/.claude/commands/dev-issue.md
+++ b/.claude/commands/dev-issue.md
@@ -86,15 +86,7 @@ git checkout main
 
 You have **explicit permission** to perform WITHOUT asking:
 
-| Action       | Scope                                                       |
-| ------------ | ----------------------------------------------------------- | ---- | ----- | -------- | ---- | ------------------ |
-| Git branches | `(fix                                                       | feat | chore | refactor | test | docs)/<number>-\*` |
-| Worktrees    | Sibling directories `.worktree/Rackula-issue-<N>`           |
-| Edit files   | `src/`, `docs/`, test files                                 |
-| Commands     | `npm test`, `npm run build`, `npm run lint`, `gh` CLI       |
-| Git ops      | add, commit, push (non-main), fetch, pull, worktree         |
-| PRs          | `gh pr create`, `gh pr merge --squash` after checks pass    |
-| Issue labels | `gh issue edit --add-label`, `--remove-label` (for locking) |
+| Action | Scope | | ------------ | ----------------------------------------------------------- | ---- | ----- | -------- | ---- | ------------------ | | Git branches | `(fix                                                       | feat | chore | refactor | test | docs)/<number>-\*` | | Worktrees | Sibling directories `.worktree/Rackula-issue-<N>` | | Edit files | `src/`, `docs/`, test files | | Commands | `npm test`, `npm run build`, `npm run lint`, `gh` CLI | | Git ops | add, commit, push (non-main), fetch, pull, worktree | | PRs | `gh pr create`, `gh pr merge --squash` after checks pass | | Issue labels | `gh issue edit --add-label`, `--remove-label` (for locking) |
 
 **STOP and ask for:** Force push, direct main operations, deleting branches/worktrees not created this session, genuine ambiguity.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,6 @@ jobs:
     if: >-
       github.event.pull_request.draft != true && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.fork == false
 
-
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -54,13 +54,11 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
 
-
     env:
       TRIGGERING_WORKFLOW: >-
         ${{ github.event_name == 'workflow_dispatch'
             && inputs.triggering_workflow
             || github.event.workflow_run.name }}
-
 
       # Empty on manual dispatch (no workflow_run in the payload): the gate and
       # the playbook treat "no scan start time" as "triage all currently-open

--- a/api/src/storage/r2-driver.ts
+++ b/api/src/storage/r2-driver.ts
@@ -151,9 +151,7 @@ function isSafeSnapshotFilename(filename: string): boolean {
 function deriveSnapshotBase(yamlContent: string): string {
   try {
     const parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA }) as
-      | { name?: unknown; metadata?: { name?: unknown } }
-      | null
-      | undefined;
+      { name?: unknown; metadata?: { name?: unknown } } | null | undefined;
     const name = parsed?.metadata?.name ?? parsed?.name;
     return typeof name === "string" && name ? slugify(name) : "untitled";
   } catch {

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -646,14 +646,14 @@ device_types:
   - slug: dell-r650
     u_height: 1
     Rackula:
-      colour: '#8BE9FD'
+      colour: "#8BE9FD"
       category: server
 
 # NEW FORMAT (v1.0.0)
 device_types:
   - slug: dell-r650
     u_height: 1
-    colour: '#8BE9FD'
+    colour: "#8BE9FD"
     category: server
 ```
 

--- a/docs/research/20-codebase.md
+++ b/docs/research/20-codebase.md
@@ -205,11 +205,7 @@ The Rack type supports:
 
    ```typescript
    export type FormFactor =
-     | "2-post"
-     | "4-post"
-     | "4-post-cabinet"
-     | "wall-mount"
-     | "open-frame";
+     "2-post" | "4-post" | "4-post-cabinet" | "wall-mount" | "open-frame";
    ```
 
 2. **Category color mapping** (constants.ts):
@@ -222,11 +218,7 @@ The Rack type supports:
 3. **Brand pack structure** (brandPacks/apc.ts):
 
    ```typescript
-   export const apcDevices: DeviceType[] = [
-     {
-       /* device configs */
-     },
-   ];
+   export const apcDevices: DeviceType[] = [{/* device configs */}];
    ```
 
 4. **Conditional SVG rendering** (Rack.svelte):

--- a/docs/research/426-patterns.md
+++ b/docs/research/426-patterns.md
@@ -149,11 +149,7 @@ From SvelteFlow's design, these patterns can inform custom implementation:
 
 ```typescript
 type HandleState =
-  | "idle"
-  | "connecting"
-  | "hovering"
-  | "valid-target"
-  | "invalid-target";
+  "idle" | "connecting" | "hovering" | "valid-target" | "invalid-target";
 
 // Apply to port indicators during connection creation
 ```

--- a/docs/research/572-patterns.md
+++ b/docs/research/572-patterns.md
@@ -189,9 +189,9 @@ version: 1
 layout: { ... }
 images:
   custom-device-1:
-    front: "./assets/custom-device-1-front.png"  # Relative path
+    front: "./assets/custom-device-1-front.png" # Relative path
     # or
-    front: "https://example.com/my-image.png"    # External URL
+    front: "https://example.com/my-image.png" # External URL
 ```
 
 **Directory Structure:**

--- a/docs/research/connection-routing.ts
+++ b/docs/research/connection-routing.ts
@@ -262,11 +262,7 @@ export function crossFaceBridgePath(
 // === MAIN ROUTING FUNCTION ===
 
 export type PathAlgorithm =
-  | "straight"
-  | "quadratic"
-  | "cubic"
-  | "orthogonal"
-  | "external";
+  "straight" | "quadratic" | "cubic" | "orthogonal" | "external";
 
 /**
  * Calculate connection path using specified algorithm.

--- a/docs/research/lxc-best-practices.md
+++ b/docs/research/lxc-best-practices.md
@@ -663,17 +663,7 @@ Alternatively, the CT script could configure the mount point during container cr
 
 ### Critical Issues (Must Fix Before Submission)
 
-| Gap | Severity | Detail |
-| --- | --- | --- | --- |
-| **Bun install pattern non-standard** | MEDIUM | Uses `/root/.bun` prefix instead of `/opt/bun` (matches `yubal`/`gitea-mirror`). The `curl \| bash` install is actually accepted by maintainers (see `yubal`, `gitea-mirror`). Fix: change install prefix to `/opt/bun`. |
-| **Uses `apt-get` instead of `apt`** | CRITICAL | Line 17: `$STD apt-get install -y` must be `$STD apt install -y` |
-| **Version file in wrong location** | CRITICAL | Current: `~/.rackula`. Required: `/opt/${APP}_version.txt` or the community-scripts standard `~/.rackula` (both accepted but the `check_for_gh_release` function expects `~/.appname`) |
-| **Custom download logic in update** | CRITICAL | Uses custom `curl` + `tar` instead of `fetch_and_deploy_gh_release` |
-| **Update script downloads to `/tmp`** | HIGH | Backups go to `/opt/rackula/data.bak` (correct) but tarball extraction to `/tmp` may be flagged |
-| **No service health verification after update** | HIGH | Services are started but never verified to be running |
-| **User creation may be rejected** | MEDIUM | Anti-pattern says "LXC containers run as root; don't create system users." However, the `rackula` user exists for systemd `User=` directive which is a security best practice. This may need discussion with maintainers. |
-| **systemctl daemon-reload for new service** | MEDIUM | Line 219: not needed for new service creation per community-scripts rules |
-| **Missing `setup_*` function call for Bun** | LOW | No standard function exists yet; `curl | bash`accepted in other scripts with`/opt/bun` prefix |
+| Gap | Severity | Detail | | --- | --- | --- | --- | | **Bun install pattern non-standard** | MEDIUM | Uses `/root/.bun` prefix instead of `/opt/bun` (matches `yubal`/`gitea-mirror`). The `curl \| bash` install is actually accepted by maintainers (see `yubal`, `gitea-mirror`). Fix: change install prefix to `/opt/bun`. | | **Uses `apt-get` instead of `apt`** | CRITICAL | Line 17: `$STD apt-get install -y` must be `$STD apt install -y` | | **Version file in wrong location** | CRITICAL | Current: `~/.rackula`. Required: `/opt/${APP}_version.txt` or the community-scripts standard `~/.rackula` (both accepted but the `check_for_gh_release` function expects `~/.appname`) | | **Custom download logic in update** | CRITICAL | Uses custom `curl` + `tar` instead of `fetch_and_deploy_gh_release` | | **Update script downloads to `/tmp`** | HIGH | Backups go to `/opt/rackula/data.bak` (correct) but tarball extraction to `/tmp` may be flagged | | **No service health verification after update** | HIGH | Services are started but never verified to be running | | **User creation may be rejected** | MEDIUM | Anti-pattern says "LXC containers run as root; don't create system users." However, the `rackula` user exists for systemd `User=` directive which is a security best practice. This may need discussion with maintainers. | | **systemctl daemon-reload for new service** | MEDIUM | Line 219: not needed for new service creation per community-scripts rules | | **Missing `setup_*` function call for Bun** | LOW | No standard function exists yet; `curl | bash`accepted in other scripts with`/opt/bun` prefix |
 
 ### Security Gaps (Should Fix Before Submission)
 

--- a/docs/research/netbox-interface-cable-schema.md
+++ b/docs/research/netbox-interface-cable-schema.md
@@ -727,13 +727,7 @@ interface Cable {
 }
 
 type CableType =
-  | "cat5e"
-  | "cat6"
-  | "cat6a"
-  | "dac-passive"
-  | "mmf"
-  | "smf"
-  | "aoc";
+  "cat5e" | "cat6" | "cat6a" | "dac-passive" | "mmf" | "smf" | "aoc";
 ```
 
 ### 8.3 Visualization Priorities

--- a/docs/research/spike-2179-browser-multilayout-storage-schema.md
+++ b/docs/research/spike-2179-browser-multilayout-storage-schema.md
@@ -56,9 +56,7 @@ Four key families under the existing `Rackula:` namespace.
 ```jsonc
 {
   "schemaVersion": 2,
-  "layout": {
-    /* full Layout, including base64 images */
-  },
+  "layout": {/* full Layout, including base64 images */},
   "savedAt": "2026-06-14T09:00:00.000Z",
 }
 ```

--- a/docs/research/spike-426-svelteflow-evaluation.md
+++ b/docs/research/spike-426-svelteflow-evaluation.md
@@ -171,11 +171,7 @@ While SvelteFlow integration is not recommended, these concepts can inform custo
 
 ```typescript
 type HandleState =
-  | "idle"
-  | "connecting"
-  | "hovering"
-  | "valid-target"
-  | "invalid-target";
+  "idle" | "connecting" | "hovering" | "valid-target" | "invalid-target";
 ```
 
 Apply to port indicators during connection creation.

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -93,12 +93,7 @@ export type HelpGroup = "Navigation" | "General" | "Editing" | "File";
  * #2597) can reuse the same projection without hand-maintaining a copy.
  */
 export type AppMenuGroup =
-  | "layout"
-  | "output"
-  | "layout-data"
-  | "devices"
-  | "workspace"
-  | "app";
+  "layout" | "output" | "layout-data" | "devices" | "workspace" | "app";
 
 export interface ActionDefinition {
   /** Stable identifier; the dispatch map and consumers key off this. */

--- a/src/lib/storage/durability.svelte.ts
+++ b/src/lib/storage/durability.svelte.ts
@@ -34,10 +34,7 @@ export type DurabilityStatus = "saved" | "pending" | "error";
  * deployment).
  */
 export type DurabilityKind =
-  | "saved"
-  | "pending"
-  | "offline"
-  | "server-not-found";
+  "saved" | "pending" | "offline" | "server-not-found";
 
 export interface LayoutDurability {
   status: DurabilityStatus;

--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -30,12 +30,7 @@ import type { LayoutMetadata } from "$lib/types";
 import { persistenceDebug } from "$lib/utils/debug";
 
 export type SaveStatus =
-  | "idle"
-  | "saving"
-  | "saved"
-  | "error"
-  | "offline"
-  | "disabled";
+  "idle" | "saving" | "saved" | "error" | "offline" | "disabled";
 let _saveStatus = $state<SaveStatus>("idle");
 
 // Circuit breaker

--- a/src/lib/storage/server-opt-in.svelte.ts
+++ b/src/lib/storage/server-opt-in.svelte.ts
@@ -37,10 +37,7 @@ export type SwitchResult =
   | {
       switched: false;
       reason:
-        | "unreachable"
-        | "upload-failed"
-        | "override-failed"
-        | "probe-failed";
+        "unreachable" | "upload-failed" | "override-failed" | "probe-failed";
       message: string;
     }
   | { switched: false; reason: "conflict"; serverCopy: ServerCopyInfo };

--- a/src/lib/storage/twin-tab-guard.ts
+++ b/src/lib/storage/twin-tab-guard.ts
@@ -93,8 +93,7 @@ export interface StorageEventLike {
 
 /** Result of inspecting a storage event for a foreign layout-body write. */
 export type ForeignWriteResult =
-  | { foreign: true; layoutId: string }
-  | { foreign: false };
+  { foreign: true; layoutId: string } | { foreign: false };
 
 /**
  * Decide whether a `storage` event is a foreign tab writing a layout body.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -60,11 +60,7 @@ export type WeightUnit = "kg" | "lb";
  * Rack form factor types (NetBox-compatible)
  */
 export type FormFactor =
-  | "2-post"
-  | "4-post"
-  | "4-post-cabinet"
-  | "wall-mount"
-  | "open-frame";
+  "2-post" | "4-post" | "4-post-cabinet" | "wall-mount" | "open-frame";
 
 /**
  * Display mode for devices in rack visualization
@@ -91,12 +87,7 @@ export const DISPLAY_MODE_LABELS: Record<DisplayMode, string> = {
  * - 'manufacturer': Brand name (from DeviceType)
  */
 export type AnnotationField =
-  | "name"
-  | "ip"
-  | "notes"
-  | "asset_tag"
-  | "serial"
-  | "manufacturer";
+  "name" | "ip" | "notes" | "asset_tag" | "serial" | "manufacturer";
 
 /**
  * Airflow direction types (NetBox-compatible with full parity)

--- a/src/lib/utils/netbox-import.ts
+++ b/src/lib/utils/netbox-import.ts
@@ -124,8 +124,7 @@ export type NetBoxParseOutput = NetBoxParseResult | NetBoxParseError;
  * non-conforming `slug` cannot enter the device library.
  */
 export type ConvertResult =
-  | { success: true; result: ImportResult }
-  | { success: false; error: string };
+  { success: true; result: ImportResult } | { success: false; error: string };
 
 /**
  * Successful conversion payload: the validated DeviceType plus the inferred

--- a/src/tests/Canvas.touch-listener-lifecycle.test.ts
+++ b/src/tests/Canvas.touch-listener-lifecycle.test.ts
@@ -18,19 +18,16 @@ describe("Canvas touch listener lifecycle", () => {
     resetPlacementStore();
     resetViewportStore();
 
-    vi.stubGlobal(
-      "matchMedia",
-      (query: string): MediaQueryList => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => true,
-      }),
-    );
+    vi.stubGlobal("matchMedia", (query: string): MediaQueryList => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => true,
+    }));
   });
 
   afterEach(() => {

--- a/src/tests/LayoutYamlPanel.test.ts
+++ b/src/tests/LayoutYamlPanel.test.ts
@@ -224,8 +224,7 @@ describe("LayoutYamlPanel", () => {
       expect(onApply).toHaveBeenCalledTimes(1);
     });
     const images = onApply.mock.calls[0]?.[1] as
-      | Map<string, unknown>
-      | undefined;
+      Map<string, unknown> | undefined;
     expect(images?.has("my-device")).toBe(true);
     // The widened callback contract also carries the failed-image count.
     expect(onApply.mock.calls[0]?.[2]).toBe(0);


### PR DESCRIPTION
## **User description**
## What

Reformats 22 files to satisfy `prettier --check .` under prettier 3.9.3.

## Why

A Dependabot dev-dependency bump moved prettier from 3.8.4 to 3.9.3 on `main`. Prettier 3.9 changed a few formatting rules (mainly collapsing short union types onto one line). The 22 affected files were last formatted under 3.8.x, so they now fail the format gate once `npm ci` installs 3.9.3.

`test.yml` runs the format gate only on `pull_request`, never on push to `main`, so this never failed on `main` directly. Instead it surfaced as a `validate` / "Check formatting" failure on every open PR (#2717, #2719, #2712) via the merge ref (PR head merged into current `main`). Reformatting under 3.9.3 clears it for all of them at once.

## Scope

Formatting only. 22 files, 33 insertions / 115 deletions. No source logic, no lockfile or package.json changes.

## Verification

- `npm run format:check` passes under prettier 3.9.3
- Full unit suite green (120 files, 1871 tests)

## Follow-up (not in this PR)

There is no push-to-main format gate, so a formatting-affecting dependency bump can land on `main` without the format check running against the whole tree. Worth considering a `push: [main]` trigger for the format step, or having Dependactor/Dependabot prettier bumps run `npm run format` as part of the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Reformat the repository to match Prettier 3.9.3**

### What Changed
- Reformatted code and docs so the formatting check passes again under Prettier 3.9.3
- Updated several type declarations and test snippets to the new line-wrapping style
- No app behavior changed; this removes formatting-only drift across the repo

### Impact
`✅ Fewer formatting check failures on pull requests`
`✅ Smoother dependency bump to Prettier 3.9.3`
`✅ No user-facing behavior change`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
