### PR TITLE
docs: reconcile milestone convention in GitHub workflow doc

### DIFF
--- a/docs/reference/GITHUB-WORKFLOW.md
+++ b/docs/reference/GITHUB-WORKFLOW.md
@@ -25,7 +25,7 @@ INTERNAL INPUT:
     → `ready` label immediately
 
 EXECUTION:
-  Claude Code queries: label:ready milestone:v0.x.x
+  Claude Code queries: label:ready milestone:"M002 -- LXC Release & Stability"
     → Picks next issue
     → Implements with TDD
     → Closes issue on completion
@@ -79,7 +79,7 @@ EXECUTION:
 Find next work item:
 
 ```
-label:ready milestone:v0.6.0 sort:created-asc
+label:ready milestone:"M002 -- LXC Release & Stability" sort:created-asc
 ```
 
 Find blocked items:
@@ -96,10 +96,10 @@ Triage queue:
 label:triage
 ```
 
-Current sprint:
+Current milestone:
 
 ```
-milestone:v0.6.0 is:open
+milestone:"M002 -- LXC Release & Stability" is:open
 ```
 
 All bugs:
@@ -190,11 +190,12 @@ The issue body IS the prompt. Claude Code should:
 
 ## Milestones
 
-Milestones = version releases. Use strict semver:
+Milestones are thematic, named work tracks of the form `Mxxx -- Name`, tracked on the [project board](https://github.com/orgs/RackulaLives/projects/2). They group related issues by theme, not by release. Examples:
 
-- `v0.6.1` — Patch release
-- `v0.7.0` — Minor release
-- `v1.0.0` — Major release
+- `M002 -- LXC Release & Stability`
+- `M003 -- Data Format & Interop`
+
+Milestones are decoupled from version numbers. A milestone does not map to a single release, and multiple milestones may ship in the same release window. Releases use CalVer (`YY.M.MICRO`, for example `v26.6.0`) per the versioning policy in CLAUDE.md, not semver.
 
 Every implementation-ready issue should have a milestone assigned.
 


### PR DESCRIPTION
## **User description**
## Summary

The Milestones section of `docs/reference/GITHUB-WORKFLOW.md` said milestones were version releases using strict semver (`v0.6.1`, `v0.7.0`), and the query examples used `milestone:v0.6.0`. This contradicted CLAUDE.md, which uses thematic `Mxxx -- Name` milestones tracked on the project board (decoupled from versioning) and CalVer (`YY.M.MICRO`) for releases. This PR fixes the doc to match reality, treating CLAUDE.md as the source of truth.

## Changes

- Rewrote the Milestones section: milestones are thematic `Mxxx -- Name` work tracks on the project board, decoupled from version numbers. Removed the strict-semver claim and noted that releases use CalVer per the CLAUDE.md versioning policy.
- Updated the stale `milestone:v0.x.x` execution example in the Issue Lifecycle block to the `Mxxx` form.
- Updated the "For Claude Code" next-work-item query and the maintainer current-milestone query to use `milestone:"M002 -- LXC Release & Stability"` (renamed the latter header from "Current sprint" to "Current milestone").
- Left labels, lifecycle, triage, and template sections intact.

A grep of `docs/` confirmed the three `milestone:v0.` references were all in this file; the remaining `v0.x.x` strings elsewhere are historical version numbers in research spikes and changelogs, not milestone guidance.

## Testing

How was this tested?

- [ ] Unit tests pass (`npm run test:run`)
- [ ] E2E tests pass (`npm run test:e2e`)
- [ ] Manual testing completed

Docs-only change; no code paths affected.

## Accessibility

Not applicable (docs-only change).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [ ] Tests added for new functionality (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNV61imWpxXS77RYTrrdgv)_


___

## **CodeAnt-AI Description**
**Align milestone guidance with the project board naming scheme**

### What Changed
- Replaced version-based milestone examples with named `Mxxx -- Name` milestones used on the project board
- Updated workflow search examples so they point to the current named milestone instead of `v0.x.x` values
- Clarified that milestones track themed work, not release versions, and that releases use CalVer

### Impact
`✅ Clearer issue routing`
`✅ Fewer outdated milestone searches`
`✅ Less confusion between milestones and releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
