### PR TITLE
fix(ci): make prod smoke-test resilient to a stale self-hosted workspace

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -98,22 +98,28 @@ jobs:
       # The deploy job runs a sparse checkout on this same self-hosted runner and
       # leaves the shared workspace in sparse mode. actions/checkout does not clear
       # an existing sparse cone when the sparse-checkout input is omitted, so the
-      # full tree (package-lock.json, e2e specs) would be missing here, breaking
-      # setup-node's npm cache and the npm ci that follows. Disable any leftover
-      # sparse-checkout before the full checkout below.
-      - name: Clear leftover sparse-checkout from the deploy job
-        run: git -C "$GITHUB_WORKSPACE" sparse-checkout disable 2>/dev/null || true
+      # full tree (package-lock.json, e2e specs) would be missing here. Wipe the
+      # workspace before checkout so the full tree is restored cleanly (mirrors
+      # deploy-dev's root fix for #2327).
+      - name: Clean stale workspace from the deploy job
+        run: |
+          if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then
+            find "$GITHUB_WORKSPACE" -mindepth 1 -delete
+          fi
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag }}
           persist-credentials: false
 
+      # No cache: "npm" here. The npm cache lookup runs before checkout settles
+      # and hard-errors ("Dependencies lock file is not found", #2327) if a stale
+      # workspace ever slips through. The clean-workspace step above is the root
+      # fix; dropping the cache removes the fragile lockfile-hash dependency.
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
-          cache: "npm"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## **User description**
## What

Make the prod-deploy **smoke-test** job (`deploy-prod.yml` -> `smoke-test`) resilient to a stale self-hosted workspace, so it stops failing at `Setup Node.js` on every release.

Closes #2728.

## Why

`vps-rackula` is a self-hosted runner with a persistent `_work` dir. The `deploy` job leaves it in a non-cone sparse-checkout state. The smoke-test job's `git sparse-checkout disable` mitigation does not reliably restore the full tree, so `package-lock.json` is absent when `actions/setup-node` does its `cache: "npm"` lockfile lookup, which hard-errors:

```
Error: Dependencies lock file is not found in /home/linuxuser/actions-runner/_work/Rackula/Rackula.
```

This reds the whole release run even though the deploy itself succeeds, and the browser smoke test (`npm ci` + Playwright + `test:e2e:smoke`) is skipped, so post-deploy verification is silently lost. It bit v26.6.4 (#2648) and v26.6.5.

For v26.6.5 the deploy was fine (the job's earlier `Verify deployment responds` and `Verify live frontend version` steps passed; `count.racku.la/version.json` == `26.6.5`); only the browser smoke step was lost.

## How

Mirror the proven fix already in `deploy-dev.yml` (which solved the same `#2327` failure), which the prod smoke-test never received:

1. Replace `git sparse-checkout disable` with a full workspace wipe (`find "$GITHUB_WORKSPACE" -mindepth 1 -delete`) before checkout. This is the root fix.
2. Drop `cache: "npm"` from `setup-node`, removing the fragile lockfile-hash lookup. `npm ci` still installs deps.

## Verification

- `prettier --check .github/workflows/deploy-prod.yml` passes.
- Pattern is identical to `deploy-dev.yml` (clean-workspace + no `cache: "npm"`), which has been green on dev deploys.
- Real validation happens on the next prod release run (self-hosted-runner behaviour cannot be reproduced locally); the change is confined to the smoke-test job's checkout/setup and does not touch the deploy itself.

## Related

- #2648 (recurring release-failure alert), #2327 (original lock-file fix in deploy-dev), #2720 (surface skipped smoke tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Prevent the prod smoke test from failing on stale runner workspaces**

### What Changed
- The prod release smoke test now clears out any leftover files from the previous deploy run before checking out the code again, so the full project files are restored.
- The Node setup step no longer tries to use npm cache data that can fail when the lockfile is missing in a stale workspace.
- This keeps the post-deploy browser smoke test running instead of stopping at dependency setup.

### Impact
`✅ Fewer failed prod releases`
`✅ Reliable post-deploy smoke tests`
`✅ Clearer deployment verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
