### PR TITLE
chore(ci): auto-format PRs to prevent dependency-bump format drift

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -1,0 +1,83 @@
+name: Autoformat PRs
+
+# Runs prettier on every in-repo PR and commits the result back, so a
+# formatting-affecting dependency bump (e.g. a prettier minor bump) cannot
+# leave the repo failing the format:check gate in test.yml. See issue #2730.
+#
+# Setup required (one-time, by a maintainer): a fine-grained PAT with
+# Contents: read and write on this repo, stored under the name AUTOFORMAT_PAT
+# in BOTH secret stores:
+#   - Settings > Secrets and variables > Actions   (for human in-repo PRs)
+#   - Settings > Secrets and variables > Dependabot (for Dependabot PRs, which
+#     cannot read Actions secrets)
+# The PAT is required, not the default GITHUB_TOKEN: pushes made with
+# GITHUB_TOKEN do not re-trigger other workflows, so the validate workflow
+# would never re-run on the fix commit and the PR would stay blocked.
+#
+# Until the secret exists the job is a green no-op (the gate step below skips
+# the rest), so adding this workflow does not turn every PR red.
+
+on:
+  pull_request:
+    branches: [main]
+
+# Needed to push the format fix back to the PR branch.
+permissions:
+  contents: write
+
+concurrency:
+  group: autoformat-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  autoformat:
+    # Skip forks: we cannot push back to a fork branch, and using
+    # pull_request_target to gain a writable token would expose secrets to the
+    # untrusted PR code this job installs and runs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check AUTOFORMAT_PAT is configured
+        id: gate
+        env:
+          PAT: ${{ secrets.AUTOFORMAT_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "AUTOFORMAT_PAT is not set; skipping (see workflow header for setup)."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.gate.outputs.enabled == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.AUTOFORMAT_PAT }}
+
+      - if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      # --ignore-scripts: actions/checkout stores the push token in .git/config,
+      # so skipping dependency lifecycle scripts stops a bumped dependency from
+      # reading it during install. Prettier needs no install scripts.
+      - if: steps.gate.outputs.enabled == 'true'
+        run: npm ci --ignore-scripts
+
+      - if: steps.gate.outputs.enabled == 'true'
+        run: npm run format
+
+      - name: Commit and push if formatting changed
+        if: steps.gate.outputs.enabled == 'true'
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Already prettier-clean; nothing to commit."
+            exit 0
+          fi
+          git config user.name "rackula-format-bot"
+          git config user.email "rackula-format-bot@users.noreply.github.com"
+          git commit -s -am "chore: prettier auto-format"
+          git push

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -4,37 +4,79 @@ name: Autoformat PRs
 # formatting-affecting dependency bump (e.g. a prettier minor bump) cannot
 # leave the repo failing the format:check gate in test.yml. See issue #2730.
 #
+# Security model (two jobs, so the write token never shares a job with
+# PR-controlled code):
+#   - "format" runs the PR-controlled code (npm ci, prettier config + plugins)
+#     with NO PAT present, so that code cannot read or exfiltrate the token. It
+#     emits the formatting changes as a patch artifact.
+#   - "push" holds AUTOFORMAT_PAT but runs no PR-controlled code: it only applies
+#     the patch and commits/pushes.
+#
 # Setup required (one-time, by a maintainer): a fine-grained PAT with
 # Contents: read and write on this repo, stored under the name AUTOFORMAT_PAT
 # in BOTH secret stores:
 #   - Settings > Secrets and variables > Actions   (for human in-repo PRs)
 #   - Settings > Secrets and variables > Dependabot (for Dependabot PRs, which
 #     cannot read Actions secrets)
-# The PAT is required, not the default GITHUB_TOKEN: pushes made with
-# GITHUB_TOKEN do not re-trigger other workflows, so the validate workflow
-# would never re-run on the fix commit and the PR would stay blocked.
-#
-# Until the secret exists the job is a green no-op (the gate step below skips
-# the rest), so adding this workflow does not turn every PR red.
+# The PAT (not the default GITHUB_TOKEN) is required because GITHUB_TOKEN pushes
+# do not re-trigger the validate workflow, so format:check would never re-run.
+# Until the secret exists the push job is a green no-op.
 
 on:
   pull_request:
     branches: [main]
 
-# Needed to push the format fix back to the PR branch.
+# Least privilege: the default GITHUB_TOKEN stays read-only. The push job writes
+# via AUTOFORMAT_PAT, not GITHUB_TOKEN, so no write scope is needed here.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: autoformat-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  autoformat:
-    # Skip forks: we cannot push back to a fork branch, and using
-    # pull_request_target to gain a writable token would expose secrets to the
-    # untrusted PR code this job installs and runs.
+  format:
+    # Untrusted: runs PR-controlled code, so it gets no token. Skip forks too.
     if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.fmt.outputs.changed }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci --ignore-scripts
+
+      - id: fmt
+        run: |
+          npm run format
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Already prettier-clean; nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git diff > format.patch
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.fmt.outputs.changed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: format-patch
+          path: format.patch
+          retention-days: 1
+
+  push:
+    # Privileged: holds AUTOFORMAT_PAT but runs no PR-controlled code, only
+    # git apply + commit + push of the patch produced by the untrusted job.
+    needs: format
+    if: needs.format.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check AUTOFORMAT_PAT is configured
@@ -56,25 +98,16 @@ jobs:
           token: ${{ secrets.AUTOFORMAT_PAT }}
 
       - if: steps.gate.outputs.enabled == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          node-version: "22"
-          cache: "npm"
+          name: format-patch
 
-      # --ignore-scripts: actions/checkout stores the push token in .git/config,
-      # so skipping dependency lifecycle scripts stops a bumped dependency from
-      # reading it during install. Prettier needs no install scripts.
-      - if: steps.gate.outputs.enabled == 'true'
-        run: npm ci --ignore-scripts
-
-      - if: steps.gate.outputs.enabled == 'true'
-        run: npm run format
-
-      - name: Commit and push if formatting changed
+      - name: Apply, commit, and push
         if: steps.gate.outputs.enabled == 'true'
         run: |
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "Already prettier-clean; nothing to commit."
+          git apply format.patch
+          if git diff --quiet; then
+            echo "Patch applied to no effect; nothing to commit."
             exit 0
           fi
           git config user.name "rackula-format-bot"

--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -7,17 +7,21 @@ name: Autoformat PRs
 # Security model (two jobs, so the write token never shares a job with
 # PR-controlled code):
 #   - "format" runs the PR-controlled code (npm ci, prettier config + plugins)
-#     with NO PAT present, so that code cannot read or exfiltrate the token. It
-#     emits the formatting changes as a patch artifact.
-#   - "push" holds AUTOFORMAT_PAT but runs no PR-controlled code: it only applies
-#     the patch and commits/pushes.
+#     with NO token (persist-credentials: false) and no secrets, so that code
+#     has nothing to steal. It emits the formatting changes as a patch artifact.
+#   - "push" holds AUTOFORMAT_PAT but runs no PR-controlled code: it clones the
+#     branch only to apply the patch and push. It does not use actions/checkout
+#     to lay down PR code in the privileged job.
 #
-# Setup required (one-time, by a maintainer): a fine-grained PAT with
-# Contents: read and write on this repo, stored under the name AUTOFORMAT_PAT
-# in BOTH secret stores:
+# Setup required (one-time, by a maintainer): a fine-grained PAT stored under
+# the name AUTOFORMAT_PAT in BOTH secret stores:
 #   - Settings > Secrets and variables > Actions   (for human in-repo PRs)
 #   - Settings > Secrets and variables > Dependabot (for Dependabot PRs, which
 #     cannot read Actions secrets)
+# Required PAT permissions (repository, this repo only):
+#   - Contents: read and write   (commit and push)
+#   - Workflows: read and write  (GitHub rejects pushes that touch
+#     .github/workflows/* without this; prettier formats workflow YAML too)
 # The PAT (not the default GITHUB_TOKEN) is required because GITHUB_TOKEN pushes
 # do not re-trigger the validate workflow, so format:check would never re-run.
 # Until the secret exists the push job is a green no-op.
@@ -46,6 +50,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -61,7 +66,7 @@ jobs:
             echo "Already prettier-clean; nothing to do."
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            git diff > format.patch
+            git diff > "$GITHUB_WORKSPACE/format.patch"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -73,8 +78,8 @@ jobs:
           retention-days: 1
 
   push:
-    # Privileged: holds AUTOFORMAT_PAT but runs no PR-controlled code, only
-    # git apply + commit + push of the patch produced by the untrusted job.
+    # Privileged: holds AUTOFORMAT_PAT but runs no PR-controlled code. It clones
+    # the branch only to apply the patch from the untrusted job, then pushes.
     needs: format
     if: needs.format.outputs.changed == 'true'
     runs-on: ubuntu-latest
@@ -92,20 +97,21 @@ jobs:
           fi
 
       - if: steps.gate.outputs.enabled == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.AUTOFORMAT_PAT }}
-
-      - if: steps.gate.outputs.enabled == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: format-patch
 
-      - name: Apply, commit, and push
+      - name: Apply patch and push
         if: steps.gate.outputs.enabled == 'true'
+        env:
+          PAT: ${{ secrets.AUTOFORMAT_PAT }}
+          HEAD_REF: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
         run: |
-          git apply format.patch
+          git clone --depth=1 --branch "$HEAD_REF" \
+            "https://x-access-token:${PAT}@github.com/${REPO}.git" work
+          cd work
+          git apply "$GITHUB_WORKSPACE/format.patch"
           if git diff --quiet; then
             echo "Patch applied to no effect; nothing to commit."
             exit 0


### PR DESCRIPTION
Closes #2730.

## What

Adds `.github/workflows/autoformat.yml`: on every in-repo PR it formats the tree with prettier and commits the result back, so a formatting-affecting dependency bump (like the prettier 3.8.4 to 3.9.3 bump behind #2726) self-heals instead of leaving the repo red on the format gate. test.yml runs that gate only on pull_request, never on push to main.

## Required maintainer setup (the workflow is inert without it)

Create a fine-grained PAT (this repo only) and add it under the name `AUTOFORMAT_PAT` in BOTH secret stores:

- Settings > Secrets and variables > Actions (human in-repo PRs)
- Settings > Secrets and variables > Dependabot (Dependabot PRs cannot read Actions secrets)

PAT permissions:

- Contents: read and write (commit and push)
- Workflows: read and write (GitHub rejects pushes touching `.github/workflows/*` without this, and prettier formats workflow YAML)

A PAT is required rather than the default `GITHUB_TOKEN`, because a `GITHUB_TOKEN` push does not re-trigger the validate workflow, so the format gate would never re-run on the fix commit. Until the secret exists the push job is a green no-op.

## Security design (two jobs)

The write token never shares a job with PR-controlled code:

- format (untrusted): checks out the PR head with `persist-credentials: false`, runs `npm ci --ignore-scripts` + `npm run format`, and uploads the diff as a patch artifact. No token, no secrets, so the PR-controlled prettier config/plugins have nothing to steal.
- push (privileged): holds `AUTOFORMAT_PAT` but runs no PR-controlled code. It does not `actions/checkout` the PR head; it clones the branch in a run step solely to apply the patch and push.

Other notes: forks are skipped (`head.repo.full_name == github.repository`); top-level `permissions: contents: read`; the auto-commit is `git commit -s` for DCO; a guard means already-clean PRs get no commit and the workflow does not loop on its own push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)