### PR TITLE
feat: create new rack directly on canvas without the wizard (#2732)

### DIFF
--- a/src/lib/utils/dialog-actions.ts
+++ b/src/lib/utils/dialog-actions.ts
@@ -8,16 +8,34 @@ import { getSelectionStore } from "$lib/stores/selection.svelte";
 import { getToastStore } from "$lib/stores/toast.svelte";
 import { getViewportStore } from "$lib/utils/viewport.svelte";
 import { dialogStore } from "$lib/stores/dialogs.svelte";
+import { handleFitAll } from "$lib/utils/app-actions";
 
-/** Open the New Rack dialog; warns when the rack limit is reached. */
+/** Stage-1 default height for a directly-created rack (#2732). */
+const NEW_RACK_DEFAULT_HEIGHT = 24;
+/** Default name for a directly-created rack; renameable in the inspector. */
+const NEW_RACK_DEFAULT_NAME = "Racky McRackface";
+
+/**
+ * Create a 24U rack directly on the canvas and select it, skipping the wizard
+ * (#2732). The rack uses stage-1 defaults: width 19, ascending U-numbering, and
+ * the schema default form factor. It is appended to the end of the row. Warns
+ * when the rack limit is reached.
+ */
 export function handleNewRack(): void {
   const layoutStore = getLayoutStore();
+  const selectionStore = getSelectionStore();
   const toastStore = getToastStore();
   if (!layoutStore.canAddRack) {
     toastStore.showToast("Maximum number of racks reached", "warning");
     return;
   }
-  dialogStore.open("newRack");
+  const rack = layoutStore.addRack(
+    NEW_RACK_DEFAULT_NAME,
+    NEW_RACK_DEFAULT_HEIGHT,
+  );
+  if (!rack) return;
+  selectionStore.selectRack(rack.id);
+  requestAnimationFrame(() => handleFitAll());
 }
 
 /** Open the confirm-delete dialog for the selected rack or device. */

--- a/src/tests/dialog-actions.test.ts
+++ b/src/tests/dialog-actions.test.ts
@@ -5,10 +5,13 @@
  * The critical invariant: dialogStore.open() closes any open sheet so dialogs
  * always render without a sheet underneath them. This prevents the mobile
  * device-details bottom sheet from occluding the confirm dialog (#2490).
+ *
+ * Also covers handleNewRack(), which creates a 24U rack directly on the canvas
+ * and selects it instead of opening the New Rack wizard (#2732).
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { handleDelete } from "$lib/utils/dialog-actions";
+import { handleDelete, handleNewRack } from "$lib/utils/dialog-actions";
 import { dialogStore } from "$lib/stores/dialogs.svelte";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import {
@@ -84,5 +87,46 @@ describe("handleDelete", () => {
 
     expect(dialogStore.isOpen("confirmDelete")).toBe(false);
     expect(dialogStore.deleteTarget).toBeNull();
+  });
+});
+
+describe("handleNewRack", () => {
+  beforeEach(resetAll);
+
+  it("creates a 24U rack and selects it, without opening the wizard", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+    const before = layoutStore.racks.length;
+
+    handleNewRack();
+
+    expect(layoutStore.racks.length).toBe(before + 1);
+    const created = layoutStore.racks[layoutStore.racks.length - 1]!;
+    expect(created.height).toBe(24);
+    expect(selectionStore.isRackSelected).toBe(true);
+    expect(selectionStore.selectedRackId).toBe(created.id);
+    expect(dialogStore.isOpen("newRack")).toBe(false);
+  });
+
+  it("applies stage-1 defaults (width 19, ascending U-numbering)", () => {
+    const layoutStore = getLayoutStore();
+
+    handleNewRack();
+
+    const created = layoutStore.racks[layoutStore.racks.length - 1]!;
+    expect(created.width).toBe(19);
+    expect(created.desc_units).toBe(false);
+  });
+
+  it("undo removes the rack it created", () => {
+    const layoutStore = getLayoutStore();
+    const before = layoutStore.racks.length;
+
+    handleNewRack();
+    expect(layoutStore.racks.length).toBe(before + 1);
+
+    layoutStore.undo();
+
+    expect(layoutStore.racks.length).toBe(before);
   });
 });

--- a/src/tests/dialog-actions.test.ts
+++ b/src/tests/dialog-actions.test.ts
@@ -96,37 +96,42 @@ describe("handleNewRack", () => {
   it("creates a 24U rack and selects it, without opening the wizard", () => {
     const layoutStore = getLayoutStore();
     const selectionStore = getSelectionStore();
-    const before = layoutStore.racks.length;
+    const beforeIds = new Set(layoutStore.racks.map((rack) => rack.id));
 
     handleNewRack();
 
-    expect(layoutStore.racks.length).toBe(before + 1);
-    const created = layoutStore.racks[layoutStore.racks.length - 1]!;
-    expect(created.height).toBe(24);
+    const created = layoutStore.racks.find((rack) => !beforeIds.has(rack.id));
+    expect(created).toBeDefined();
+    expect(created?.height).toBe(24);
     expect(selectionStore.isRackSelected).toBe(true);
-    expect(selectionStore.selectedRackId).toBe(created.id);
+    expect(selectionStore.selectedRackId).toBe(created?.id);
     expect(dialogStore.isOpen("newRack")).toBe(false);
   });
 
   it("applies stage-1 defaults (width 19, ascending U-numbering)", () => {
     const layoutStore = getLayoutStore();
+    const beforeIds = new Set(layoutStore.racks.map((rack) => rack.id));
 
     handleNewRack();
 
-    const created = layoutStore.racks[layoutStore.racks.length - 1]!;
-    expect(created.width).toBe(19);
-    expect(created.desc_units).toBe(false);
+    const created = layoutStore.racks.find((rack) => !beforeIds.has(rack.id));
+    expect(created).toBeDefined();
+    expect(created?.width).toBe(19);
+    expect(created?.desc_units).toBe(false);
   });
 
   it("undo removes the rack it created", () => {
     const layoutStore = getLayoutStore();
-    const before = layoutStore.racks.length;
+    const beforeIds = new Set(layoutStore.racks.map((rack) => rack.id));
 
     handleNewRack();
-    expect(layoutStore.racks.length).toBe(before + 1);
+    const created = layoutStore.racks.find((rack) => !beforeIds.has(rack.id));
+    expect(created).toBeDefined();
 
     layoutStore.undo();
 
-    expect(layoutStore.racks.length).toBe(before);
+    expect(layoutStore.racks.some((rack) => rack.id === created?.id)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

The new-rack action now creates a 24U rack directly on the canvas instead of opening the New Rack wizard. The rack uses stage-1 defaults: width 19, ascending U-numbering (`desc_units` false), and the schema default form factor. It is appended to the end of the row and becomes the selected rack, so the inspector opens in rack mode.

## Changes

- `handleNewRack()` in `dialog-actions.ts` now calls `layoutStore.addRack()` with a 24U default, selects the new rack, and re-fits the canvas, instead of `dialogStore.open("newRack")`.
- Added behavioural tests in `dialog-actions.test.ts`: the action adds one 24U rack with stage-1 defaults and selects it without opening the wizard, and undo removes it.

## Scope note

`NewRackWizard` is left in place because it is still reached by the New layout, reset-and-create, and mobile racks-sheet flows, so it is not yet orphaned. Follow-up #2747 tracks migrating those entry points and removing the wizard.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:run` (dialog-actions suite green; a few render-heavy tests timed out only under local CPU contention from concurrent agents and pass in isolation)

Closes #2732


___

## **CodeAnt-AI Description**
**Create a new rack directly on the canvas**

### What Changed
- New rack now appears on the canvas immediately instead of opening the New Rack wizard
- The rack is created with stage-1 defaults: 24U height, 19-inch width, ascending U-numbering, and the default form factor
- The new rack is selected right away so its settings open in the inspector
- The canvas is refit after creation, and undo still removes the new rack

### Impact
`✅ Faster rack creation`
`✅ Fewer setup steps`
`✅ Clearer rack editing flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
