### PR TITLE
fix: migrate legacy U-positions for devices with empty-string container_id

### DIFF
--- a/src/lib/schemas/migrations.ts
+++ b/src/lib/schemas/migrations.ts
@@ -96,12 +96,12 @@ export function needsPositionMigration(
 
   // Check 2: Heuristic fallback
   // If any rack-level device has position < UNITS_PER_U, it's old format
-  // (U1 in new format = UNITS_PER_U, so valid positions are >= UNITS_PER_U)
+  // (U1 in new format = UNITS_PER_U, so valid positions are >= UNITS_PER_U).
+  // A falsy container_id (undefined or "") is rack-level here, matching how
+  // PlacedDeviceSchema, the carrier-first refine, and clampOverRackPositions
+  // distinguish rail devices from container children.
   const hasOldFormatPosition = devices.some(
-    (d) =>
-      d.container_id === undefined &&
-      d.position >= 1 &&
-      d.position < UNITS_PER_U,
+    (d) => !d.container_id && d.position >= 1 && d.position < UNITS_PER_U,
   );
   if (hasOldFormatPosition) {
     return true;
@@ -128,8 +128,10 @@ export function migrateDevicePositions<
   T extends { position: number; container_id?: string },
 >(devices: T[]): T[] {
   return devices.map((device) => {
-    // Container children keep their 0-indexed positions
-    if (device.container_id !== undefined) {
+    // Container children keep their 0-indexed positions. A falsy container_id
+    // (undefined or "") is rack-level here, matching PlacedDeviceSchema, the
+    // carrier-first refine, and clampOverRackPositions.
+    if (device.container_id) {
       return device;
     }
     // Rack-level devices: snap to the nearest whole U (min U1), in internal units.

--- a/src/tests/migrations.test.ts
+++ b/src/tests/migrations.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Position-migration helper tests (#2699).
+ *
+ * The rest of the schema treats a falsy container_id (undefined or "") as
+ * rack-level: PlacedDeviceSchema uses `!data.container_id`, the carrier-first
+ * refine uses `if (!device.container_id)`, and clampOverRackPositions uses
+ * `if (device.container_id)`. These helpers must agree, so a prior-release
+ * device serialised with container_id "" is migrated like any other rail
+ * device instead of being mistaken for a container child.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  needsPositionMigration,
+  migrateDevicePositions,
+} from "$lib/schemas/migrations";
+import { UNITS_PER_U } from "$lib/types/constants";
+
+describe("migrateDevicePositions container_id semantics", () => {
+  it("migrates a rack-level device whose container_id is an empty string", () => {
+    // Legacy U position 5 must scale to internal units, not pass through.
+    const [device] = migrateDevicePositions([
+      { position: 5, container_id: "" },
+    ]);
+    expect(device.position).toBe(5 * UNITS_PER_U);
+  });
+
+  it("migrates a rack-level device whose container_id is undefined", () => {
+    const [device] = migrateDevicePositions([{ position: 5 }]);
+    expect(device.position).toBe(5 * UNITS_PER_U);
+  });
+
+  it("leaves a real container child unmigrated", () => {
+    // A genuine container child keeps its 0-indexed container-relative position.
+    const [device] = migrateDevicePositions([
+      { position: 2, container_id: "container-1" },
+    ]);
+    expect(device.position).toBe(2);
+  });
+});
+
+describe("needsPositionMigration container_id semantics", () => {
+  it("detects old format via the heuristic when an empty-string container_id rail device sits below U1", () => {
+    // Version >= 0.7.0 so check 1 does not short-circuit; the empty-string
+    // device with a sub-UNITS_PER_U position must trip the heuristic.
+    expect(
+      needsPositionMigration("0.7.0", [{ position: 1, container_id: "" }]),
+    ).toBe(true);
+  });
+
+  it("does not flag a real container child sitting at a low 0-indexed position", () => {
+    // A genuine container child legitimately has a small position and must not
+    // be misread as an old-format rail device.
+    expect(
+      needsPositionMigration("0.7.0", [
+        { position: 1, container_id: "container-1" },
+      ]),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Closes #2699 (epic #2696, M003).

`needsPositionMigration` and `migrateDevicePositions` in `src/lib/schemas/migrations.ts` used strict `container_id === undefined` / `!== undefined` checks. A prior-release rack-level device serialised with `container_id: ""` (empty string) was therefore misclassified as a container child:

- `needsPositionMigration`'s heuristic skipped it, so old-format detection could miss.
- `migrateDevicePositions` skipped it, so its legacy U-value was never scaled to internal units. The device then loaded and rendered at the wrong rack position.

The rest of the schema already treats a falsy `container_id` (`undefined` or `""`) as rack-level: `PlacedDeviceSchema` uses `!data.container_id`, the carrier-first refine uses `if (!device.container_id)`, and `clampOverRackPositions` uses `if (device.container_id)`. This change makes the two migration helpers agree with that convention.

## Changes

- `needsPositionMigration`: heuristic now uses `!d.container_id` (falsy) instead of `d.container_id === undefined`.
- `migrateDevicePositions`: contained-child guard now uses `if (device.container_id)` (truthy) instead of `!== undefined`.

`undefined` and real container ids are unaffected (regression-guarded by tests).

## Tests

Added `src/tests/migrations.test.ts` (fast unit tests on the pure helpers):

- empty-string `container_id` rack-level device gets its legacy U-position scaled to internal units (the fix).
- regression guards: `undefined` still migrated; a real container child stays unmigrated; the heuristic does not flag a real container child at a low 0-indexed position.

Minimal literals (not `createTestDevice`) are used deliberately: the factory pre-converts positions to internal units, which is the input these helpers are meant to migrate from.

## Local gates

- `npm run lint`: clean
- `npm run test:run` (migration + schema + upgrade-corpus suites): 269 passed, 0 failed; new tests red-before / green-after
- `npm run build`: ok

## Out of scope (sibling note)

`src/lib/storage/migrate-layout.ts:69` (browser localStorage migration path) carries the same `container_id === undefined` pattern. Left untouched here to respect issue #2699's file scope; flagged for the epic #2696 orchestrator to route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Treat empty container IDs as rack-level devices during position migration**

### What Changed
- Devices saved with an empty `container_id` now get migrated like rack-level devices, so their old U-based positions are converted to the correct internal position on load.
- Migration checks now match the rest of the app’s behavior: only real container children are left unchanged, while empty or missing container IDs are handled as rack devices.
- Added tests covering empty-string, missing, and real container IDs, plus the old-format detection path.

### Impact
`✅ Correct rack positions after loading older devices`
`✅ Fewer mispositioned devices from legacy saves`
`✅ Safer migration checks for container and rack layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
