### PR TITLE
fix: enforce archive size/ratio limits before decompression and use debug logger

### DIFF
--- a/src/lib/utils/archive-extract.ts
+++ b/src/lib/utils/archive-extract.ts
@@ -15,6 +15,7 @@ import type { ImageData, ImageStoreMap } from "$lib/types/images";
 import { parseLayoutYaml, parseLayoutYamlWithImages } from "./yaml";
 import { extractUuidFromFolderName } from "./folder-structure";
 import { placementKey } from "./placement-key";
+import { archiveDebug } from "./debug";
 
 /**
  * Lazily load JSZip library
@@ -24,6 +25,78 @@ type JSZipConstructor = typeof import("jszip");
 type JSZipInstance = ReturnType<JSZipConstructor>;
 
 let jsZipConstructor: JSZipConstructor | null = null;
+
+/** A single ZIP entry, as exposed on `zip.files[name]`. */
+type JSZipFileEntry = JSZipInstance["files"][string];
+
+/**
+ * JSZip's per-entry streaming surface. The bundled JSZip types only expose
+ * `async()` (which buffers the whole entry into memory) and `nodeStream()`
+ * (Node only), but `internalStream()` is a documented, browser-safe method that
+ * emits the inflated output in chunks. We type just the slice we use so the size
+ * guard can count an entry's inflated bytes incrementally and stop early.
+ */
+interface ZipEntryStream {
+  on(event: "data", handler: (chunk: Uint8Array) => void): ZipEntryStream;
+  on(event: "end", handler: () => void): ZipEntryStream;
+  on(event: "error", handler: (error: Error) => void): ZipEntryStream;
+  pause(): ZipEntryStream;
+  resume(): ZipEntryStream;
+}
+
+interface StreamableZipEntry {
+  internalStream(type: "uint8array"): ZipEntryStream;
+}
+
+/**
+ * Measure a ZIP entry's uncompressed size by streaming its inflated output and
+ * counting bytes, aborting as soon as the running total would exceed
+ * `byteBudget`. Chunks are counted then discarded, so peak memory stays at a
+ * single inflate chunk no matter how large the entry decompresses to. This is
+ * what stops a ZIP bomb from being fully inflated into memory before the size
+ * guard can reject it: trusting the ZIP header's declared uncompressed size is
+ * not safe (it is attacker-controlled and may under-report), so we measure the
+ * real inflated output instead. Resolves with the entry's uncompressed byte
+ * length when it fits within the budget.
+ */
+function measureUncompressedSize(
+  entry: JSZipFileEntry,
+  byteBudget: number,
+): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const stream = (entry as unknown as StreamableZipEntry).internalStream(
+      "uint8array",
+    );
+    let size = 0;
+    let settled = false;
+    const finish = (action: () => void): void => {
+      if (settled) return;
+      settled = true;
+      // Stop the inflate pump so no further chunks are produced.
+      stream.pause();
+      action();
+    };
+    stream
+      .on("data", (chunk) => {
+        if (settled) return;
+        size += chunk.length;
+        if (size > byteBudget) {
+          finish(() =>
+            reject(
+              new Error(
+                `Archive uncompressed size is too large (exceeds ${Math.round(
+                  LIMITS.MAX_TOTAL_UNCOMPRESSED_BYTES / 1024 / 1024,
+                )}MB).`,
+              ),
+            ),
+          );
+        }
+      })
+      .on("error", (error) => finish(() => reject(error)))
+      .on("end", () => finish(() => resolve(size)))
+      .resume();
+  });
+}
 
 export async function getJSZip(): Promise<JSZipConstructor> {
   if (!jsZipConstructor) {
@@ -207,22 +280,24 @@ export async function extractFolderArchive(
     );
   }
 
-  // Guardrail: Total uncompressed size and compression ratio
-  // Uses public API (async decompression) instead of private JSZip internals.
-  // This decompresses each entry once here; extraction functions later decompress
-  // only the YAML/image files they need. The overlap is small and the trade-off
-  // (slightly more work vs lower peak memory from not caching all entries) is acceptable.
+  // Guardrail: Total uncompressed size and compression ratio.
+  // Stream each entry's inflated output and count bytes, aborting the moment the
+  // running total would exceed MAX_TOTAL_UNCOMPRESSED_BYTES. Counting bytes
+  // incrementally (instead of buffering each entry via file.async) keeps peak
+  // memory at a single inflate chunk, so a ZIP bomb is rejected mid-inflation
+  // rather than after being fully decompressed into memory. Extraction later
+  // re-inflates only the YAML/image files it needs; that overlap is small and
+  // bounded by the per-file caps below.
   let totalUncompressedSize = 0;
   for (const name of entries) {
     const file = zip.files[name];
     if (!file || file.dir) continue;
-    const bytes = await file.async("uint8array");
-    totalUncompressedSize += bytes.byteLength;
-    if (totalUncompressedSize > LIMITS.MAX_TOTAL_UNCOMPRESSED_BYTES) {
-      throw new Error(
-        `Archive uncompressed size is too large (${Math.round(totalUncompressedSize / 1024 / 1024)}MB).`,
-      );
-    }
+    // Pass the remaining global budget as this entry's cap so the stream aborts
+    // as soon as the cumulative total would exceed the limit.
+    totalUncompressedSize += await measureUncompressedSize(
+      file,
+      LIMITS.MAX_TOTAL_UNCOMPRESSED_BYTES - totalUncompressedSize,
+    );
   }
 
   const ratio = totalUncompressedSize / blob.size;
@@ -481,7 +556,7 @@ async function extractImageFromZip(
 
     // Graceful degradation: skip images that fail to convert
     if (!dataUrl) {
-      console.warn(`Failed to load image: ${imagePath}`);
+      archiveDebug.extract("Failed to load image: %s", imagePath);
       return { error: true };
     }
 
@@ -494,7 +569,7 @@ async function extractImageFromZip(
     return { imageKey, face, imageData };
   } catch (error) {
     // Catch any unexpected errors during blob extraction
-    console.warn(`Failed to extract image: ${imagePath}`, error);
+    archiveDebug.extract("Failed to extract image: %s", imagePath, error);
     return { error: true };
   }
 }

--- a/src/lib/utils/debug.ts
+++ b/src/lib/utils/debug.ts
@@ -54,7 +54,9 @@ export const dialogDebug = {
   import: Debug("rackula:dialog:import"),
 };
 
+/** Debug loggers for archive import and extraction flows. */
 export const archiveDebug = {
+  /** Recoverable diagnostics for archive extraction and image loading. */
   extract: Debug("rackula:archive:extract"),
 };
 

--- a/src/lib/utils/debug.ts
+++ b/src/lib/utils/debug.ts
@@ -54,6 +54,10 @@ export const dialogDebug = {
   import: Debug("rackula:dialog:import"),
 };
 
+export const archiveDebug = {
+  extract: Debug("rackula:archive:extract"),
+};
+
 export const persistenceDebug = {
   api: Debug("rackula:persistence:api"),
   health: Debug("rackula:persistence:health"),

--- a/src/tests/archive-guardrails.test.ts
+++ b/src/tests/archive-guardrails.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import JSZip from "jszip";
 import { extractFolderArchive } from "$lib/utils/archive";
 
@@ -52,6 +52,76 @@ describe("Archive Guardrails", () => {
     await expect(extractFolderArchive(blob)).rejects.toThrow(
       /suspicious compression ratio/,
     );
+  });
+
+  it("rejects an oversized entry by streaming it, without buffering the whole entry (#2703)", async () => {
+    // A real, tiny archive: one small YAML entry inside a UUID folder.
+    const zip = new JSZip();
+    const folderName = "Layout-550e8400-e29b-41d4-a716-446655440000";
+    zip.folder(folderName)?.file("layout.rackula.yaml", "name: Test\n");
+    const blob = await zip.generateAsync({ type: "blob" });
+
+    // Make the size preflight observe an entry whose inflated output blows past
+    // MAX_TOTAL_UNCOMPRESSED_BYTES (250MB) WITHOUT allocating that memory in the
+    // test. The stub reports oversized chunks by length only, and pauses when
+    // asked. It also still exposes accumulate() (the legacy file.async() path)
+    // so the test can distinguish the streamed guard, which pauses mid-inflation,
+    // from full buffering, which would drain the entry before checking the cap.
+    const probe = new JSZip();
+    probe.file("probe", "x");
+    const entryPrototype = Object.getPrototypeOf(probe.file("probe")!) as {
+      internalStream: (type: string) => unknown;
+    };
+
+    let pauseCalls = 0;
+    let accumulateCalled = false;
+    const CHUNK_BYTES = 50 * 1024 * 1024; // 50MB reported per chunk
+    const CHUNK_COUNT = 8; // 400MB if fully drained; guard must stop near 250MB
+
+    const spy = vi
+      .spyOn(entryPrototype, "internalStream")
+      .mockImplementation(() => {
+        const handlers: Record<string, ((arg?: unknown) => void)[]> = {};
+        let paused = false;
+        const stream = {
+          on(event: string, handler: (arg?: unknown) => void) {
+            (handlers[event] ??= []).push(handler);
+            return stream;
+          },
+          pause() {
+            paused = true;
+            pauseCalls += 1;
+            return stream;
+          },
+          resume() {
+            paused = false;
+            for (let i = 0; i < CHUNK_COUNT && !paused; i++) {
+              handlers["data"]?.forEach((fn) => fn({ length: CHUNK_BYTES }));
+            }
+            if (!paused) handlers["end"]?.forEach((fn) => fn());
+            return stream;
+          },
+          // Legacy buffering path (file.async): resolve a lightweight stand-in
+          // whose byteLength reports the full size without allocating it.
+          accumulate() {
+            accumulateCalled = true;
+            return Promise.resolve({ byteLength: CHUNK_BYTES * CHUNK_COUNT });
+          },
+        };
+        return stream;
+      });
+
+    try {
+      await expect(extractFolderArchive(blob)).rejects.toThrow(
+        /uncompressed size/i,
+      );
+      // The guard streamed the entry and paused it mid-inflation once the cap
+      // was crossed, rather than draining it through the buffering async() path.
+      expect(pauseCalls).toBeGreaterThan(0);
+      expect(accumulateCalled).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("rejects archives with oversized YAML (MAX_YAML_BYTES = 5MB)", async () => {


### PR DESCRIPTION
## **User description**
## Summary

Fixes two archive-extraction bugs in `src/lib/utils/archive-extract.ts` (sub-issues of epic #2696).

Closes #2703
Closes #2704

### #2703 (security): ZIP-bomb guard ran after full decompression

The folder-archive preflight called `file.async("uint8array")` on every entry, which **fully inflates each entry into memory before** `MAX_TOTAL_UNCOMPRESSED_BYTES` / `MAX_COMPRESSION_RATIO` were checked. A small ZIP that inflates to gigabytes was therefore decompressed in full before the guard could reject it, defeating the limit and allowing memory exhaustion.

The fix replaces the buffering loop with a new `measureUncompressedSize()` helper that streams each entry through JSZip's `internalStream("uint8array")`, counts inflated bytes incrementally, and pauses/aborts the moment the cumulative total would exceed the limit:

- JSZip feeds the compressed stream in 16KB blocks and pako emits inflate output in 16KB chunks, so **peak memory stays at a single chunk** regardless of how large the entry decompresses to.
- Crossing the cap calls `pause()`, which propagates up the worker chain and **halts further inflation**, so an over-limit archive is rejected mid-inflation rather than after exhausting memory.
- We measure **real inflated output** instead of trusting the ZIP header's declared uncompressed size, which is attacker-controlled and may under-report.

Existing guardrail behaviour (entry count, ZIP size, YAML size, compression ratio, empty archive) is preserved.

### #2704 (minor): use the debug logger instead of console.warn

Replaced the two `console.warn` calls for recoverable image-load failures with the project debug logger under a new `rackula:archive:extract` namespace (added to `src/lib/utils/debug.ts`).

## Tests

- Added a TDD test to `src/tests/archive-guardrails.test.ts` proving an entry that inflates past the cap is rejected by streaming (the guard pauses mid-inflation) rather than buffered through `async()`. The stub reports oversized chunks by length only, so the test exercises the over-limit path without allocating that memory.
- No test added for #2704 (logging-convention swap) per the project testing policy; verified via grep/lint that no `console.*` remains in the file.

## Local gates

- `npm run lint` - clean
- `npm run test:run` (archive + yaml suites, 92 tests) - pass
- `npm run build` - succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MPqtE4sr4VdcKmag1itT7


___

## **CodeAnt-AI Description**
**Reject oversized archives before fully decompressing them**

### What Changed
- Archive size checks now stop inflation as soon as the allowed total would be exceeded, instead of loading each entry into memory first.
- ZIP files that inflate past the limit are rejected during extraction, which prevents large compressed entries from being fully unpacked before the guard runs.
- Recoverable image extraction failures now go through the app’s debug logger instead of printing warnings directly.
- Added a test that verifies an oversized entry is stopped mid-inflation and not processed through the old full-buffer path.

### Impact
`✅ Fewer memory spikes from archive imports`
`✅ Earlier rejection of ZIP bombs`
`✅ Cleaner image-load failure logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
