### PR TITLE
test: reconcile Full E2E specs with direct new-rack creation (#2732)

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -15,7 +15,7 @@ import type { Page } from "@playwright/test";
 import {
   gotoWithRack,
   gotoMobileWithRack,
-  clickNewRack,
+  clickNewLayout,
   locators,
 } from "./helpers";
 
@@ -152,7 +152,7 @@ test.describe("Accessibility", () => {
         "WebKit skips buttons in Tab order by default (macOS keyboard setting)",
       );
 
-      await clickNewRack(page);
+      await clickNewLayout(page);
 
       const dialog = page.getByRole("dialog");
       await expect(dialog).toBeVisible();
@@ -190,11 +190,13 @@ test.describe("Accessibility", () => {
         "WebKit does not focus buttons on activation by default (macOS keyboard setting)",
       );
 
-      // Switch to the Racks tab and open the wizard from the New Rack button
-      // via keyboard, so the trigger genuinely holds focus before the dialog
-      // opens, the way a keyboard user would experience it.
-      await page.getByTestId("sidebar-tab-racks").click();
-      const trigger = page.getByTestId("btn-new-rack");
+      // Switch to the Layouts tab and open the wizard from the New layout
+      // button via keyboard, so the trigger genuinely holds focus before the
+      // dialog opens, the way a keyboard user would experience it. #2732 rewired
+      // the New Rack button to create directly, so the wizard now opens via New
+      // layout (#2747).
+      await page.getByTestId("sidebar-tab-layouts").click();
+      const trigger = page.getByTestId("btn-new-layout");
       await trigger.focus();
       await expect(trigger).toBeFocused();
       await page.keyboard.press("Enter");

--- a/e2e/device-metadata.spec.ts
+++ b/e2e/device-metadata.spec.ts
@@ -5,8 +5,7 @@ import {
   dragDeviceToRack,
   selectDevice,
   deselectDevice,
-  clickNewRack,
-  completeWizardWithClicks,
+  createRackDirect,
   PLATFORM_MODIFIER,
   locators,
   startEditingDisplayName,
@@ -329,16 +328,15 @@ test.describe("Device Metadata Persistence", () => {
       await setDeviceName(page, TEST_METADATA.name);
       await deselectDevice(page);
 
-      // Create a second rack (multi-rack mode — wizard opens directly)
-      await clickNewRack(page);
-      await completeWizardWithClicks(page, { name: "Second Rack", height: 24 });
+      // Create a second rack directly (#2732: New Rack adds a rack immediately)
+      await createRackDirect(page);
 
       // Wait for the second rack container to mount before continuing —
       // otherwise dragDeviceToRack({ rackIndex: 1 }) can race against the mount
       const rackFronts = page.locator(locators.rackView.front);
       await expect(rackFronts).toHaveCount(2);
 
-      // Switch back to Devices tab (clickNewRack switches to Racks tab)
+      // Switch back to Devices tab (createRackDirect leaves the sidebar on Racks)
       await page.getByTestId("sidebar-tab-devices").click();
 
       // Add a device to the second rack (rackIndex 1)

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -30,11 +30,13 @@ export {
 export {
   completeWizardWithKeyboard,
   completeWizardWithClicks,
+  createRackDirect,
 } from "./rack-setup";
 
 // Toolbar actions
 export {
   clickNewRack,
+  clickNewLayout,
   clickSave,
   clickLoad,
   clickExport,

--- a/e2e/helpers/rack-setup.ts
+++ b/e2e/helpers/rack-setup.ts
@@ -4,6 +4,7 @@
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import { locators } from "./locators";
+import { clickNewRack } from "./toolbar-actions";
 
 interface WizardOptions {
   name?: string;
@@ -186,4 +187,34 @@ export async function completeWizardWithClicks(
     .locator(locators.rack.container)
     .first()
     .waitFor({ state: "visible" });
+}
+
+/**
+ * Create a rack directly via the sidebar New Rack button (#2732) and wait for
+ * the new rack to appear. #2732 makes New Rack add a 24U rack immediately
+ * instead of opening the wizard, so this replaces clickNewRack + completeWizard*
+ * in setup-only specs. When `name` is given, the freshly-created rack (selected
+ * on create) is renamed through the Edit panel so callers can address it by name.
+ * @param page - Playwright page
+ * @param options - Optional rack name to apply after creation
+ */
+export async function createRackDirect(
+  page: Page,
+  options?: { name?: string },
+): Promise<void> {
+  const fronts = page.locator(locators.rackView.front);
+  const before = await fronts.count();
+  await clickNewRack(page);
+  await expect(fronts).toHaveCount(before + 1);
+
+  if (options?.name) {
+    // The new rack is auto-selected, so the Edit panel shows its name field.
+    const nameInput = page.locator("#rack-name");
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill(options.name);
+    await nameInput.press("Enter");
+    await expect(
+      page.locator(locators.rackView.dualViewName, { hasText: options.name }),
+    ).toBeVisible();
+  }
 }

--- a/e2e/helpers/rack-setup.ts
+++ b/e2e/helpers/rack-setup.ts
@@ -213,8 +213,13 @@ export async function createRackDirect(
     await expect(nameInput).toBeVisible();
     await nameInput.fill(options.name);
     await nameInput.press("Enter");
+    // Anchor the match so a name that is a substring of another rack's name
+    // cannot satisfy this before the rename actually lands.
+    const escaped = options.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     await expect(
-      page.locator(locators.rackView.dualViewName, { hasText: options.name }),
+      page.locator(locators.rackView.dualViewName, {
+        hasText: new RegExp(`^${escaped}$`),
+      }),
     ).toBeVisible();
   }
 }

--- a/e2e/helpers/toolbar-actions.ts
+++ b/e2e/helpers/toolbar-actions.ts
@@ -34,6 +34,21 @@ export async function clickNewRack(page: Page): Promise<void> {
 }
 
 /**
+ * Open the New Rack wizard via the "New layout" entry point in the sidebar
+ * Layouts tab. #2732 rewired the sidebar New Rack button to create a 24U rack
+ * directly, so the wizard now lives behind New layout (and reset-and-create /
+ * the mobile racks-sheet). Switches to the Layouts tab and clicks the + button,
+ * which opens a fresh layout and raises the wizard for its first rack.
+ */
+export async function clickNewLayout(page: Page): Promise<void> {
+  const layoutsTab = page.getByTestId("sidebar-tab-layouts");
+  await layoutsTab.click();
+  const newLayoutBtn = page.getByTestId("btn-new-layout");
+  await newLayoutBtn.waitFor({ state: "visible" });
+  await newLayoutBtn.click();
+}
+
+/**
  * Save via the app menu. In browser mode this is "Export backup", which
  * downloads the layout as a YAML archive.
  */

--- a/e2e/keyboard-placement.spec.ts
+++ b/e2e/keyboard-placement.spec.ts
@@ -14,8 +14,7 @@ import { test, expect } from "./helpers/base-test";
 import {
   gotoWithRack,
   SMALL_RACK_SHARE,
-  clickNewRack,
-  completeWizardWithClicks,
+  createRackDirect,
   locators,
 } from "./helpers";
 
@@ -121,12 +120,11 @@ test.describe("Keyboard device placement (#106)", () => {
 
   test("Tab switches the target rack during placement", async ({ page }) => {
     // Add a second rack so there is somewhere to Tab to.
-    await clickNewRack(page);
-    await completeWizardWithClicks(page, { name: "Second Rack", height: 12 });
+    await createRackDirect(page, { name: "Second Rack" });
     await expect(page.locator(locators.rackView.dualViewName)).toHaveCount(2);
 
-    // The wizard left the sidebar on the Racks tab; switch back to Devices so
-    // the palette is on screen.
+    // Creating the rack left the sidebar on the Racks tab; switch back to
+    // Devices so the palette is on screen.
     await page.getByRole("tab", { name: "Devices" }).click();
 
     const firstDevice = page.locator(locators.device.paletteItem).first();

--- a/e2e/keyboard.spec.ts
+++ b/e2e/keyboard.spec.ts
@@ -3,7 +3,7 @@ import {
   gotoWithRack,
   SMALL_RACK_SHARE,
   dragDeviceToRack,
-  clickNewRack,
+  clickNewLayout,
   PLATFORM_MODIFIER,
   locators,
 } from "./helpers";
@@ -92,8 +92,8 @@ test.describe("Keyboard Shortcuts", () => {
   });
 
   test("Escape closes dialogs", async ({ page }) => {
-    // Open new rack wizard dialog
-    await clickNewRack(page);
+    // Open the New Rack wizard. #2732 moved it behind New layout (#2747).
+    await clickNewLayout(page);
     await expect(page.locator(locators.dialog.root)).toBeVisible();
 
     // Press Escape

--- a/e2e/multi-rack.spec.ts
+++ b/e2e/multi-rack.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from "./helpers/base-test";
 import {
   gotoWithRack,
   clickNewRack,
-  completeWizardWithClicks,
+  clickNewLayout,
+  createRackDirect,
   locators,
 } from "./helpers";
 
@@ -18,33 +19,31 @@ test.describe("Multi-Rack Mode", () => {
     await expect(page.locator(locators.rackView.dualViewName)).toBeVisible();
   });
 
-  test("clicking New Rack opens wizard directly (no replace dialog)", async ({
+  test("clicking New Rack creates a rack directly (no wizard, no replace dialog)", async ({
     page,
   }) => {
+    const fronts = page.locator(locators.rackView.front);
+    await expect(fronts).toHaveCount(1);
+
     await clickNewRack(page);
 
-    // Wizard should open directly — no ConfirmReplaceDialog
-    await expect(page.getByRole("dialog", { name: "New Rack" })).toBeVisible();
-    await expect(page.getByLabel("Rack Name", { exact: true })).toBeVisible();
+    // #2732: a 24U rack is added immediately. No wizard or replace dialog opens.
+    await expect(fronts).toHaveCount(2);
+    await expect(page.locator(locators.dialog.root)).not.toBeVisible();
   });
 
   test("can create a second rack", async ({ page }) => {
-    // Create a second rack via the wizard
-    await clickNewRack(page);
-    await completeWizardWithClicks(page, { name: "Second Rack", height: 24 });
+    // #2732: New Rack adds a rack directly.
+    await createRackDirect(page);
 
-    // Should now have 2 racks (4 containers in dual-view: 2 per rack)
+    // Should now have 2 racks (dual-view renders one name header per rack).
     await expect(page.locator(locators.rackView.dualViewName)).toHaveCount(2);
   });
 
   test("both racks coexist after creation", async ({ page }) => {
-    // Create first named rack
-    await clickNewRack(page);
-    await completeWizardWithClicks(page, { name: "Rack Alpha" });
-
-    // Create second named rack
-    await clickNewRack(page);
-    await completeWizardWithClicks(page, { name: "Rack Beta" });
+    // Create two more racks directly, naming each via the inspector (#2732).
+    await createRackDirect(page, { name: "Rack Alpha" });
+    await createRackDirect(page, { name: "Rack Beta" });
 
     // Both rack names should be visible
     await expect(
@@ -56,28 +55,25 @@ test.describe("Multi-Rack Mode", () => {
   });
 
   test("max rack limit shows toast warning", async ({ page }) => {
-    // Creating 9 racks sequentially through the wizard can take a while on CI
+    // Creating 9 racks sequentially can take a while on CI.
     test.setTimeout(60000);
 
-    // Create 9 more racks (already have 1 from share link) to hit the limit of 10
+    const fronts = page.locator(locators.rackView.front);
+    // Create 9 more racks (already have 1 from the share link) to hit the limit of 10.
     for (let i = 2; i <= 10; i++) {
-      await clickNewRack(page);
-      await completeWizardWithClicks(page, { name: `Rack ${i}` });
+      await createRackDirect(page);
     }
+    await expect(fronts).toHaveCount(10);
 
-    // Attempt to create 11th rack — should show toast warning
+    // The 11th exceeds the limit: no rack is added and a warning toast appears.
     await clickNewRack(page);
-
-    // Wizard should NOT open — wait for hidden to ensure the warning path was taken
-    // rather than racing against wizard mount
-    await expect(page.getByLabel("Rack Name", { exact: true })).toBeHidden();
-
-    // Toast warning should appear
     await expect(page.locator(locators.toast.warning)).toBeVisible();
+    await expect(fronts).toHaveCount(10);
   });
 
-  test("Escape closes wizard dialog", async ({ page }) => {
-    await clickNewRack(page);
+  test("Escape closes the New Rack wizard dialog", async ({ page }) => {
+    // The wizard now opens via New layout (#2732 / #2747), not the New Rack button.
+    await clickNewLayout(page);
     await expect(page.locator(locators.dialog.root)).toBeVisible();
 
     await page.keyboard.press("Escape");

--- a/e2e/rack-configuration.spec.ts
+++ b/e2e/rack-configuration.spec.ts
@@ -1,14 +1,16 @@
 import { test, expect } from "./helpers/base-test";
 import type { Page } from "@playwright/test";
-import { gotoWithRack, clickNewRack, locators } from "./helpers";
+import { gotoWithRack, clickNewLayout, locators } from "./helpers";
 
 /**
  * Helper to open the New Rack wizard and advance past step 1 (name/type).
- * In multi-rack mode, clicking New Rack opens the wizard directly.
- * Fills name in step 1, clicks Next to reach step 2 (width + height).
+ * #2732 rewired the New Rack button to create a rack directly, so the wizard is
+ * reached via New layout, which opens a fresh layout and raises the wizard for
+ * its first rack. Fills name in step 1, clicks Next to reach step 2 (width +
+ * height).
  */
 async function openWizardStep2(page: Page, name: string) {
-  await clickNewRack(page);
+  await clickNewLayout(page);
   await expect(page.getByRole("dialog", { name: "New Rack" })).toBeVisible();
   await page.getByLabel("Rack Name", { exact: true }).fill(name);
   // Advance from step 1 (Name/Type) to step 2 (Width/Height)

--- a/e2e/rack-select-editpanel.spec.ts
+++ b/e2e/rack-select-editpanel.spec.ts
@@ -1,10 +1,5 @@
 import { test, expect } from "./helpers/base-test";
-import {
-  gotoWithRack,
-  clickNewRack,
-  completeWizardWithClicks,
-  locators,
-} from "./helpers";
+import { gotoWithRack, createRackDirect, locators } from "./helpers";
 
 /**
  * Regression: clicking a rack's canvas click target must populate the Edit
@@ -23,8 +18,7 @@ test.describe("Rack selection populates the Edit panel (#2407)", () => {
     page,
   }) => {
     // Two standalone racks.
-    await clickNewRack(page);
-    await completeWizardWithClicks(page, { name: "Second Rack", height: 24 });
+    await createRackDirect(page, { name: "Second Rack" });
     await expect(page.locator(locators.rackView.dualViewName)).toHaveCount(2);
 
     const firstRack = page.locator(locators.rackView.dualView).first();
@@ -48,8 +42,7 @@ test.describe("Rack selection populates the Edit panel (#2407)", () => {
   test("clicking the rack name / outer chrome (not the body) populates the Edit panel", async ({
     page,
   }) => {
-    await clickNewRack(page);
-    await completeWizardWithClicks(page, { name: "Second Rack", height: 24 });
+    await createRackDirect(page, { name: "Second Rack" });
     await expect(page.locator(locators.rackView.dualViewName)).toHaveCount(2);
 
     const firstRack = page.locator(locators.rackView.dualView).first();

--- a/e2e/undo-redo.spec.ts
+++ b/e2e/undo-redo.spec.ts
@@ -6,8 +6,7 @@ import {
   selectDevice,
   deselectDevice,
   deleteSelectedDevice,
-  clickNewRack,
-  completeWizardWithClicks,
+  createRackDirect,
   PLATFORM_MODIFIER,
   locators,
 } from "./helpers";
@@ -119,8 +118,7 @@ test.describe("Undo/Redo", () => {
     // Start state has a single rack.
     await expect(page.locator(locators.rackView.front)).toHaveCount(1);
 
-    await clickNewRack(page);
-    await completeWizardWithClicks(page, { name: "Second Rack", height: 24 });
+    await createRackDirect(page);
     await expect(page.locator(locators.rackView.front)).toHaveCount(2);
 
     await undo(page);

--- a/e2e/view-reset.spec.ts
+++ b/e2e/view-reset.spec.ts
@@ -3,7 +3,7 @@ import type { Page } from "@playwright/test";
 import {
   gotoWithRack,
   SMALL_RACK_SHARE,
-  clickNewRack,
+  createRackDirect,
   locators,
 } from "./helpers";
 
@@ -43,13 +43,8 @@ test.describe("View Reset on Rack Changes", () => {
     const transformBefore = await getPanzoomTransform(page);
     expect(transformBefore).toBeTruthy();
 
-    // Create a new rack via wizard (multi-rack mode — no replace dialog)
-    await clickNewRack(page);
-    await page.getByLabel("Rack Name", { exact: true }).fill("Test Rack");
-    await page.click('[data-testid="btn-wizard-next"]');
-    await page.click('[data-testid="btn-height-24"]');
-    await page.click('[data-testid="btn-wizard-next"]');
-    await expect(page.locator(locators.rack.container).first()).toBeVisible();
+    // Create a new rack directly (#2732: New Rack adds a rack and resets the view)
+    await createRackDirect(page);
 
     // Wait for the view to reset (transform should change from panned position)
     await expect


### PR DESCRIPTION
## **User description**
## Summary

#2732 rewired the sidebar New Rack button (`btn-new-rack` / `handleNewRack`) to create a 24U rack directly instead of opening `NewRackWizard`. The Full E2E suite (`test-full.yml`, weekly) had 9 specs that clicked New Rack and then drove or asserted the wizard. This reconciles them with the new flow before the next scheduled run.

## Helpers

- `createRackDirect` (e2e/helpers/rack-setup.ts): clicks New Rack, waits for the new rack to appear, and optionally renames it through the inspector.
- `clickNewLayout` (e2e/helpers/toolbar-actions.ts): opens the still-valid wizard entry point (sidebar Layouts tab, New layout button).
- `completeWizard*` are kept: the wizard still exists via New layout, reset-and-create, and the mobile racks-sheet.

## Setup-only specs (converted to direct create)

- `undo-redo.spec.ts`, `view-reset.spec.ts`: `createRackDirect`.
- `rack-select-editpanel.spec.ts`, `keyboard-placement.spec.ts`: `createRackDirect` with a name (renamed via the inspector so the existing name assertions hold).
- `device-metadata.spec.ts`: second-rack creation via `createRackDirect`.

## Wizard-feature specs (re-pointed to New layout, coverage preserved)

- `rack-configuration.spec.ts`: width / height / name driven through the wizard opened via New layout.
- `accessibility.spec.ts`: dialog tab-trap and focus-restoration re-pointed to the New layout button.
- `keyboard.spec.ts`: Escape-closes-dialog re-pointed.
- `multi-rack.spec.ts`: Escape test re-pointed to New layout; the direct-create, multi-create, coexistence, and rack-limit tests now exercise `createRackDirect`.

No `test.fixme` was needed: New layout is a reachable, valid wizard entry point for every wizard-feature spec.

## Verification

Run locally under chromium against current main: `multi-rack`, `rack-configuration`, `rack-select-editpanel`, `accessibility`, `view-reset` all green, plus the changed `undo-redo` and `keyboard` cases. `device-metadata` and `keyboard-placement` rack-creation setups share the same `createRackDirect` path; their full runs are blocked only by a pre-existing drag-and-drop flake that also fails on clean main (e2e debt #2643). `npm run lint` and prettier are clean.

Closes #2753


___

## **CodeAnt-AI Description**
**Keep E2E tests aligned with the new direct rack creation flow**

### What Changed
- Tests that used the sidebar New Rack button now expect it to add a rack immediately instead of opening the wizard
- Setup-only flows create racks directly and can still rename the new rack when a test needs a specific name
- Wizard coverage now opens through the New layout button, keeping dialog, keyboard, and accessibility checks in place
- Multi-rack checks now verify the new direct-create behavior, including the rack limit warning and Escape closing the wizard from its new entry point

### Impact
`✅ Fewer broken full E2E runs`
`✅ Accurate coverage for direct rack creation`
`✅ Preserved wizard keyboard and accessibility checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
