### PR TITLE
feat: reorder the selected rack with move-left / move-right (#2734)

### DIFF
--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -19,6 +19,8 @@
   import RackDualView from "./RackDualView.svelte";
   import BayedRackView from "./BayedRackView.svelte";
   import { organizeRackRow } from "$lib/utils/rack-row";
+  import { IconChevronLeft, IconChevronRight } from "./icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
 
   interface Props {
     partyMode?: boolean;
@@ -100,6 +102,37 @@
   // groups stay contiguous and render flush; standalone racks are spaced. See
   // organizeRackRow for the ordering and grouping rules.
   const rowItems = $derived(organizeRackRow(racks, rackGroups));
+
+  // The selected row slot is the rack or group the user has selected; a device
+  // selection does not surface the reorder controls. For a selected group the
+  // selection store holds its active member, so the slot lookup resolves to the
+  // group that owns that member.
+  const selectedSlotRackId = $derived(
+    selectionStore.selectedType === "rack" ||
+      selectionStore.selectedType === "group"
+      ? selectionStore.selectedRackId
+      : null,
+  );
+
+  // Index of the selected slot within the row, or -1 when nothing reorderable
+  // is selected. A grouped rack resolves to its group's single slot.
+  const selectedSlotIndex = $derived.by(() => {
+    const id = selectedSlotRackId;
+    if (!id) return -1;
+    return rowItems.findIndex((item) =>
+      item.kind === "rack"
+        ? item.rack.id === id
+        : item.racks.some((rack) => rack.id === id),
+    );
+  });
+
+  // Reorder the selected slot left or right. A grouped rack moves its whole
+  // group as a unit. Routed through the layout store so undo/redo covers it.
+  function handleMoveRack(direction: "left" | "right") {
+    const id = selectedSlotRackId;
+    if (!id) return;
+    layoutStore.moveRackInRow(id, direction);
+  }
 
   // Handle mobile tap-to-place (uses active rack)
   function handlePlacementTap(
@@ -253,124 +286,150 @@
   class:swipe-next={swipeAnimationDirection === "next"}
   class:swipe-previous={swipeAnimationDirection === "previous"}
 >
-  {#each rowItems as item (item.kind === "rack" ? `rack:${item.rack.id}` : `group:${item.group.id}`)}
-    {#if item.kind === "rack"}
-      {@const rack = item.rack}
-      {@const isActive = rack.id === activeRackId}
-      {@const isSelected =
-        selectionStore.selectedType === "rack" &&
-        selectionStore.selectedRackId === rack.id}
-      <div class="rack-wrapper" class:active={isActive}>
-        <RackDualView
-          {rack}
+  {#each rowItems as item, slotIndex (item.kind === "rack" ? `rack:${item.rack.id}` : `group:${item.group.id}`)}
+    <div class="row-slot">
+      {#if rowItems.length >= 2 && slotIndex === selectedSlotIndex}
+        <div class="rack-move-controls" role="group" aria-label="Reorder rack">
+          <button
+            type="button"
+            class="move-button"
+            aria-label="Move rack left"
+            title="Move rack left"
+            disabled={slotIndex === 0}
+            onclick={() => handleMoveRack("left")}
+          >
+            <IconChevronLeft size={ICON_SIZE.sm} />
+          </button>
+          <button
+            type="button"
+            class="move-button"
+            aria-label="Move rack right"
+            title="Move rack right"
+            disabled={slotIndex === rowItems.length - 1}
+            onclick={() => handleMoveRack("right")}
+          >
+            <IconChevronRight size={ICON_SIZE.sm} />
+          </button>
+        </div>
+      {/if}
+      {#if item.kind === "rack"}
+        {@const rack = item.rack}
+        {@const isActive = rack.id === activeRackId}
+        {@const isSelected =
+          selectionStore.selectedType === "rack" &&
+          selectionStore.selectedRackId === rack.id}
+        <div class="rack-wrapper" class:active={isActive}>
+          <RackDualView
+            {rack}
+            deviceLibrary={layoutStore.device_types}
+            selected={isSelected}
+            {isActive}
+            selectedDeviceId={selectionStore.selectedType === "device" &&
+            selectionStore.selectedRackId === rack.id
+              ? selectionStore.selectedDeviceId
+              : null}
+            displayMode={uiStore.displayMode}
+            showLabelsOnImages={uiStore.showLabelsOnImages}
+            showAnnotations={uiStore.showAnnotations}
+            annotationField={uiStore.annotationField}
+            showBanana={uiStore.showBanana}
+            {partyMode}
+            {enableLongPress}
+            onselect={(e) => handleRackSelect(e)}
+            ondeviceselect={(e) => handleDeviceSelect(rack.id, e)}
+            ondevicedrop={(e) => handleDeviceDrop(e)}
+            ondevicemove={(e) => handleDeviceMove(e)}
+            ondevicemoverack={(e) => handleDeviceMoveRack(e)}
+            onplacementtap={(e) => handlePlacementTap(rack.id, e)}
+            onlongpress={(e) => onracklongpress?.(e)}
+            onfocus={() => onrackfocus?.([rack.id])}
+            onexport={() => onrackexport?.([rack.id])}
+            onedit={() => onrackedit?.(rack.id)}
+            onrename={() => onrackrename?.(rack.id)}
+            onduplicate={() => onrackduplicate?.(rack.id)}
+            ondelete={() => onrackdelete?.(rack.id)}
+          />
+        </div>
+      {:else if item.group.layout_preset === "bayed"}
+        <!-- Bayed/touring racks render flush (no gap) via the stacked dual view -->
+        <BayedRackView
+          group={item.group}
+          racks={item.racks}
           deviceLibrary={layoutStore.device_types}
-          selected={isSelected}
-          {isActive}
-          selectedDeviceId={selectionStore.selectedType === "device" &&
-          selectionStore.selectedRackId === rack.id
+          {activeRackId}
+          selectedDeviceId={selectionStore.selectedType === "device"
             ? selectionStore.selectedDeviceId
+            : null}
+          selectedRackId={selectionStore.selectedType === "rack"
+            ? selectionStore.selectedRackId
             : null}
           displayMode={uiStore.displayMode}
           showLabelsOnImages={uiStore.showLabelsOnImages}
           showAnnotations={uiStore.showAnnotations}
           annotationField={uiStore.annotationField}
-          showBanana={uiStore.showBanana}
           {partyMode}
           {enableLongPress}
-          onselect={(e) => handleRackSelect(e)}
-          ondeviceselect={(e) => handleDeviceSelect(rack.id, e)}
+          ongroupselect={(e) => handleGroupSelect(e)}
+          ondeviceselect={(e) => handleDeviceSelect(e.detail.rackId, e)}
           ondevicedrop={(e) => handleDeviceDrop(e)}
           ondevicemove={(e) => handleDeviceMove(e)}
           ondevicemoverack={(e) => handleDeviceMoveRack(e)}
-          onplacementtap={(e) => handlePlacementTap(rack.id, e)}
+          onplacementtap={(e) => handlePlacementTap(e.detail.rackId, e)}
           onlongpress={(e) => onracklongpress?.(e)}
-          onfocus={() => onrackfocus?.([rack.id])}
-          onexport={() => onrackexport?.([rack.id])}
-          onedit={() => onrackedit?.(rack.id)}
-          onrename={() => onrackrename?.(rack.id)}
-          onduplicate={() => onrackduplicate?.(rack.id)}
-          ondelete={() => onrackdelete?.(rack.id)}
+          onfocus={(rackIds) => onrackfocus?.(rackIds)}
+          onexport={(rackIds) => onrackexport?.(rackIds)}
+          onedit={(rackId) => onrackedit?.(rackId)}
+          onrename={(rackId) => onrackrename?.(rackId)}
+          onduplicate={(rackId) => onrackduplicate?.(rackId)}
+          ondelete={(rackId) => onrackdelete?.(rackId)}
         />
-      </div>
-    {:else if item.group.layout_preset === "bayed"}
-      <!-- Bayed/touring racks render flush (no gap) via the stacked dual view -->
-      <BayedRackView
-        group={item.group}
-        racks={item.racks}
-        deviceLibrary={layoutStore.device_types}
-        {activeRackId}
-        selectedDeviceId={selectionStore.selectedType === "device"
-          ? selectionStore.selectedDeviceId
-          : null}
-        selectedRackId={selectionStore.selectedType === "rack"
-          ? selectionStore.selectedRackId
-          : null}
-        displayMode={uiStore.displayMode}
-        showLabelsOnImages={uiStore.showLabelsOnImages}
-        showAnnotations={uiStore.showAnnotations}
-        annotationField={uiStore.annotationField}
-        {partyMode}
-        {enableLongPress}
-        ongroupselect={(e) => handleGroupSelect(e)}
-        ondeviceselect={(e) => handleDeviceSelect(e.detail.rackId, e)}
-        ondevicedrop={(e) => handleDeviceDrop(e)}
-        ondevicemove={(e) => handleDeviceMove(e)}
-        ondevicemoverack={(e) => handleDeviceMoveRack(e)}
-        onplacementtap={(e) => handlePlacementTap(e.detail.rackId, e)}
-        onlongpress={(e) => onracklongpress?.(e)}
-        onfocus={(rackIds) => onrackfocus?.(rackIds)}
-        onexport={(rackIds) => onrackexport?.(rackIds)}
-        onedit={(rackId) => onrackedit?.(rackId)}
-        onrename={(rackId) => onrackrename?.(rackId)}
-        onduplicate={(rackId) => onrackduplicate?.(rackId)}
-        ondelete={(rackId) => onrackdelete?.(rackId)}
-      />
-    {:else}
-      <!-- Standard row layout for non-bayed groups -->
-      <div class="rack-group">
-        <div class="group-label">{item.group.name ?? "Group"}</div>
-        <div class="group-racks">
-          {#each item.racks as rack (rack.id)}
-            {@const isActive = rack.id === activeRackId}
-            {@const isSelected =
-              selectionStore.selectedType === "rack" &&
-              selectionStore.selectedRackId === rack.id}
-            <div class="rack-wrapper" class:active={isActive}>
-              <RackDualView
-                {rack}
-                deviceLibrary={layoutStore.device_types}
-                selected={isSelected}
-                {isActive}
-                selectedDeviceId={selectionStore.selectedType === "device" &&
-                selectionStore.selectedRackId === rack.id
-                  ? selectionStore.selectedDeviceId
-                  : null}
-                displayMode={uiStore.displayMode}
-                showLabelsOnImages={uiStore.showLabelsOnImages}
-                showAnnotations={uiStore.showAnnotations}
-                annotationField={uiStore.annotationField}
-                showBanana={uiStore.showBanana}
-                {partyMode}
-                {enableLongPress}
-                onselect={(e) => handleRackSelect(e)}
-                ondeviceselect={(e) => handleDeviceSelect(rack.id, e)}
-                ondevicedrop={(e) => handleDeviceDrop(e)}
-                ondevicemove={(e) => handleDeviceMove(e)}
-                ondevicemoverack={(e) => handleDeviceMoveRack(e)}
-                onplacementtap={(e) => handlePlacementTap(rack.id, e)}
-                onlongpress={(e) => onracklongpress?.(e)}
-                onfocus={() => onrackfocus?.([rack.id])}
-                onexport={() => onrackexport?.([rack.id])}
-                onedit={() => onrackedit?.(rack.id)}
-                onrename={() => onrackrename?.(rack.id)}
-                onduplicate={() => onrackduplicate?.(rack.id)}
-                ondelete={() => onrackdelete?.(rack.id)}
-              />
-            </div>
-          {/each}
+      {:else}
+        <!-- Standard row layout for non-bayed groups -->
+        <div class="rack-group">
+          <div class="group-label">{item.group.name ?? "Group"}</div>
+          <div class="group-racks">
+            {#each item.racks as rack (rack.id)}
+              {@const isActive = rack.id === activeRackId}
+              {@const isSelected =
+                selectionStore.selectedType === "rack" &&
+                selectionStore.selectedRackId === rack.id}
+              <div class="rack-wrapper" class:active={isActive}>
+                <RackDualView
+                  {rack}
+                  deviceLibrary={layoutStore.device_types}
+                  selected={isSelected}
+                  {isActive}
+                  selectedDeviceId={selectionStore.selectedType === "device" &&
+                  selectionStore.selectedRackId === rack.id
+                    ? selectionStore.selectedDeviceId
+                    : null}
+                  displayMode={uiStore.displayMode}
+                  showLabelsOnImages={uiStore.showLabelsOnImages}
+                  showAnnotations={uiStore.showAnnotations}
+                  annotationField={uiStore.annotationField}
+                  showBanana={uiStore.showBanana}
+                  {partyMode}
+                  {enableLongPress}
+                  onselect={(e) => handleRackSelect(e)}
+                  ondeviceselect={(e) => handleDeviceSelect(rack.id, e)}
+                  ondevicedrop={(e) => handleDeviceDrop(e)}
+                  ondevicemove={(e) => handleDeviceMove(e)}
+                  ondevicemoverack={(e) => handleDeviceMoveRack(e)}
+                  onplacementtap={(e) => handlePlacementTap(rack.id, e)}
+                  onlongpress={(e) => onracklongpress?.(e)}
+                  onfocus={() => onrackfocus?.([rack.id])}
+                  onexport={() => onrackexport?.([rack.id])}
+                  onedit={() => onrackedit?.(rack.id)}
+                  onrename={() => onrackrename?.(rack.id)}
+                  onduplicate={() => onrackduplicate?.(rack.id)}
+                  ondelete={() => onrackdelete?.(rack.id)}
+                />
+              </div>
+            {/each}
+          </div>
         </div>
-      </div>
-    {/if}
+      {/if}
+    </div>
   {/each}
 </div>
 
@@ -462,6 +521,69 @@
     .racks-wrapper.swipe-next,
     .racks-wrapper.swipe-previous {
       animation: none;
+    }
+  }
+
+  /* Each row slot stacks its reorder controls above the rack. The wrapper is
+     the flex child the row gap and bottom-alignment act on, so unselected slots
+     are the rack alone and the selected slot grows upward without shifting the
+     shared baseline. */
+  .row-slot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .rack-move-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    border-radius: var(--radius-full);
+    border: 1px solid var(--colour-border);
+    background: var(--colour-surface-overlay, rgba(40, 42, 54, 0.6));
+  }
+
+  .move-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--touch-target-min);
+    min-height: var(--touch-target-min);
+    width: var(--touch-target-min);
+    height: var(--touch-target-min);
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-full);
+    background: transparent;
+    color: var(--colour-text);
+    cursor: pointer;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .move-button:hover:not(:disabled) {
+    background: var(--colour-overlay-hover);
+    color: var(--colour-primary);
+  }
+
+  .move-button:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring-glow);
+    color: var(--colour-primary);
+  }
+
+  .move-button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .move-button {
+      transition:
+        background-color var(--duration-fast) var(--ease-out),
+        color var(--duration-fast) var(--ease-out);
     }
   }
 </style>

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -48,6 +48,7 @@ import {
   updateRack as updateRackImpl,
   deleteRack as deleteRackImpl,
   reorderRacks as reorderRacksImpl,
+  moveRackInRow as moveRackInRowImpl,
   duplicateRack as duplicateRackImpl,
   getRackById as getRackByIdImpl,
   setActiveRack as setActiveRackImpl,
@@ -289,6 +290,7 @@ export function createLayoutStore(
     updateRackView,
     deleteRack,
     reorderRacks,
+    moveRackInRow,
     duplicateRack,
     getRackById,
     setActiveRack,
@@ -488,6 +490,15 @@ export function createLayoutStore(
 
   function reorderRacks(fromIndex: number, toIndex: number): void {
     reorderRacksImpl(stateAccess, fromIndex, toIndex);
+  }
+
+  function moveRackInRow(rackId: string, direction: "left" | "right"): boolean {
+    return moveRackInRowImpl(
+      stateAccess,
+      rackId,
+      direction,
+      updateRacksBatchRecorded,
+    );
   }
 
   function duplicateRack(id: string) {

--- a/src/lib/stores/layout/rack-actions.ts
+++ b/src/lib/stores/layout/rack-actions.ts
@@ -22,6 +22,7 @@ import {
 import type { LayoutStateAccess } from "./types";
 import { getRackGroupCommandAdapter, getRackGroupForRack } from "./rack-groups";
 import { setLayoutNamesRaw } from "./mutators";
+import { reorderRackRow } from "$lib/utils/rack-row";
 
 /** Recorded single-rack update action injected by the facade. */
 export type UpdateRackRecordedFn = (
@@ -492,6 +493,42 @@ export function reorderRacks(
     racks: newRacks.map((r, index) => ({ ...r, position: index })),
   });
   ctx.markDirty();
+}
+
+/**
+ * Move the row slot containing `rackId` one place left or right within the
+ * canvas row, reindexing Rack.position so the new order persists. A grouped
+ * rack moves its whole group as a unit; groups are never split. Recorded as a
+ * single undoable step. No-op at the row edges or with a single slot.
+ * @param ctx - Layout state access
+ * @param rackId - The selected rack (a grouped rack moves its whole group)
+ * @param direction - "left" swaps with the previous slot, "right" with the next
+ * @param updateRacksBatchRecordedFn - Recorded batch position update (undo/redo)
+ * @returns true when the row order changed
+ */
+export function moveRackInRow(
+  ctx: LayoutStateAccess,
+  rackId: string,
+  direction: "left" | "right",
+  updateRacksBatchRecordedFn: UpdateRacksBatchRecordedFn,
+): boolean {
+  const layout = ctx.getLayout();
+  const assignments = reorderRackRow(
+    layout.racks,
+    layout.rack_groups ?? [],
+    rackId,
+    direction,
+  );
+  if (!assignments) return false;
+
+  updateRacksBatchRecordedFn(
+    assignments.map(({ id, position }) => ({
+      rackId: id,
+      updates: { position },
+    })),
+    "Reorder rack",
+  );
+  return true;
 }
 
 /**

--- a/src/lib/utils/rack-row.ts
+++ b/src/lib/utils/rack-row.ts
@@ -62,3 +62,47 @@ export function organizeRackRow(
   slots.sort((a, b) => a.sortKey - b.sortKey || a.seq - b.seq);
   return slots.map((slot) => slot.item);
 }
+
+/** A new Rack.position for a rack, in its new row order. */
+export type RackPositionAssignment = { id: string; position: number };
+
+/**
+ * Compute the Rack.position values that move the row slot containing
+ * `selectedRackId` one place left or right, swapping it with its neighbour.
+ *
+ * A group occupies a single row slot, so a grouped rack moves its whole group
+ * as a unit and is never pulled out of its group. The whole row is reindexed to
+ * sequential positions in its new order, so positions stay whole and unique and
+ * group members stay contiguous. Returns one assignment per rack in the new row
+ * order, or null when the move is a no-op: the rack is not in the row, the slot
+ * is already at the target edge, or there are fewer than two slots to reorder.
+ */
+export function reorderRackRow(
+  racks: Rack[],
+  groups: RackGroup[],
+  selectedRackId: string,
+  direction: "left" | "right",
+): RackPositionAssignment[] | null {
+  const items = organizeRackRow(racks, groups);
+  if (items.length < 2) return null;
+
+  const fromIndex = items.findIndex((item) =>
+    item.kind === "rack"
+      ? item.rack.id === selectedRackId
+      : item.racks.some((rack) => rack.id === selectedRackId),
+  );
+  if (fromIndex === -1) return null;
+
+  const toIndex = direction === "left" ? fromIndex - 1 : fromIndex + 1;
+  if (toIndex < 0 || toIndex >= items.length) return null;
+
+  const reordered = [...items];
+  const [moved] = reordered.splice(fromIndex, 1);
+  reordered.splice(toIndex, 0, moved!);
+
+  // Flatten back to one ordered rack list (a group contributes its members in
+  // order) and reindex sequentially so the new order persists in Rack.position.
+  return reordered
+    .flatMap((item) => (item.kind === "rack" ? [item.rack] : item.racks))
+    .map((rack, position) => ({ id: rack.id, position }));
+}

--- a/src/tests/layout-rack-actions.test.ts
+++ b/src/tests/layout-rack-actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { createTestLayoutStore } from "./factories";
+import { organizeRackRow } from "$lib/utils/rack-row";
 
 describe("Layout Store", () => {
   beforeEach(() => {
@@ -393,6 +394,86 @@ describe("Layout Store", () => {
       store.reorderRacks(0, 0);
       // isDirty should not change since no actual reorder happened
       expect(store.isDirty).toBe(false);
+    });
+  });
+
+  describe("moveRackInRow", () => {
+    const rowOrder = (store: ReturnType<typeof getLayoutStore>) =>
+      organizeRackRow(store.racks, store.rack_groups).map((item) =>
+        item.kind === "rack" ? item.rack.id : item.group.id,
+      );
+
+    it("swaps the selected rack with its right neighbour", () => {
+      const store = getLayoutStore();
+      const a = store.addRack("A", 42)!;
+      const b = store.addRack("B", 42)!;
+      const c = store.addRack("C", 42)!;
+
+      const moved = store.moveRackInRow(a.id, "right");
+
+      expect(moved).toBe(true);
+      expect(rowOrder(store)).toEqual([b.id, a.id, c.id]);
+    });
+
+    it("persists position so the order survives a re-sort by position", () => {
+      const store = getLayoutStore();
+      const a = store.addRack("A", 42)!;
+      const b = store.addRack("B", 42)!;
+      store.addRack("C", 42);
+
+      store.moveRackInRow(a.id, "right");
+
+      const posA = store.racks.find((r) => r.id === a.id)!.position;
+      const posB = store.racks.find((r) => r.id === b.id)!.position;
+      // B now sorts before A by persisted position.
+      expect(posB).toBeLessThan(posA);
+    });
+
+    it("is a no-op at the row edges", () => {
+      const store = getLayoutStore();
+      const a = store.addRack("A", 42)!;
+      store.addRack("B", 42);
+      store.markClean();
+
+      expect(store.moveRackInRow(a.id, "left")).toBe(false);
+      expect(store.isDirty).toBe(false);
+    });
+
+    it("undo reverts a reorder", () => {
+      const store = getLayoutStore();
+      const a = store.addRack("A", 42)!;
+      store.addRack("B", 42);
+      store.addRack("C", 42);
+      const before = rowOrder(store);
+
+      store.moveRackInRow(a.id, "right");
+      expect(rowOrder(store)).not.toEqual(before);
+      store.undo();
+
+      expect(rowOrder(store)).toEqual(before);
+    });
+
+    it("moves a bayed group as a unit without splitting it", () => {
+      const store = getLayoutStore();
+      const solo = store.addRack("Solo", 42)!;
+      const bay = store.addBayedRackGroup("Bay", 2, 12)!;
+
+      // All racks start at position 0, so the group (built first) leads the
+      // row; moving it right places it after the standalone rack.
+      const moved = store.moveRackInRow(bay.racks[0].id, "right");
+      expect(moved).toBe(true);
+
+      const row = organizeRackRow(store.racks, store.rack_groups);
+      expect(row[0]).toMatchObject({ kind: "rack", rack: { id: solo.id } });
+      expect(row[1]?.kind).toBe("group");
+      if (row[1]?.kind === "group") {
+        expect(row[1].racks.map((r) => r.id)).toEqual(
+          bay.racks.map((r) => r.id),
+        );
+      }
+      // The group still owns both bays.
+      const group = store.rack_groups.find((g) => g.id === bay.group.id)!;
+      expect(group.rack_ids).toEqual(bay.racks.map((r) => r.id));
     });
   });
 

--- a/src/tests/rack-row.test.ts
+++ b/src/tests/rack-row.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { organizeRackRow } from "$lib/utils/rack-row";
+import { organizeRackRow, reorderRackRow } from "$lib/utils/rack-row";
 import { createTestRack } from "./factories";
 import type { RackGroup } from "$lib/types";
 
@@ -104,5 +104,96 @@ describe("organizeRackRow", () => {
     const g2Item = groups.find((item) => item.group.id === "g2");
     expect(g1Item?.racks.map((rack) => rack.id)).toEqual(["shared"]);
     expect(g2Item?.racks.map((rack) => rack.id)).toEqual(["other"]);
+  });
+});
+
+describe("reorderRackRow", () => {
+  it("swaps a standalone rack right past its neighbour", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+    const c = createTestRack({ id: "c", position: 2 });
+
+    const assignments = reorderRackRow([a, b, c], [], "a", "right");
+
+    expect(assignments).toEqual([
+      { id: "b", position: 0 },
+      { id: "a", position: 1 },
+      { id: "c", position: 2 },
+    ]);
+  });
+
+  it("swaps a standalone rack left past its neighbour", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+
+    const assignments = reorderRackRow([a, b], [], "b", "left");
+
+    expect(assignments).toEqual([
+      { id: "b", position: 0 },
+      { id: "a", position: 1 },
+    ]);
+  });
+
+  it("is a no-op moving the leftmost slot left", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+    expect(reorderRackRow([a, b], [], "a", "left")).toBeNull();
+  });
+
+  it("is a no-op moving the rightmost slot right", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+    expect(reorderRackRow([a, b], [], "b", "right")).toBeNull();
+  });
+
+  it("is a no-op with a single slot", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    expect(reorderRackRow([a], [], "a", "right")).toBeNull();
+    expect(reorderRackRow([a], [], "a", "left")).toBeNull();
+  });
+
+  it("returns null when the rack is not in the row", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+    expect(reorderRackRow([a, b], [], "missing", "right")).toBeNull();
+  });
+
+  it("moves a whole bay group as one unit when a member is selected", () => {
+    const solo = createTestRack({ id: "solo", position: 0 });
+    const m1 = createTestRack({ id: "m1", position: 1 });
+    const m2 = createTestRack({ id: "m2", position: 2 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "bayed",
+    };
+
+    // Row order is [solo, group]; selecting a member and moving left puts the
+    // whole group first, with its members still contiguous and in order.
+    const assignments = reorderRackRow([solo, m1, m2], [group], "m2", "left");
+
+    expect(assignments).toEqual([
+      { id: "m1", position: 0 },
+      { id: "m2", position: 1 },
+      { id: "solo", position: 2 },
+    ]);
+  });
+
+  it("keeps a bay group's members contiguous after a reorder", () => {
+    const solo = createTestRack({ id: "solo", position: 0 });
+    const m1 = createTestRack({ id: "m1", position: 1 });
+    const m2 = createTestRack({ id: "m2", position: 2 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "bayed",
+    };
+
+    const assignments = reorderRackRow([solo, m1, m2], [group], "m1", "left")!;
+    const byId = new Map(assignments.map((a) => [a.id, a.position]));
+    // Members stay adjacent (positions differ by one) and the standalone rack
+    // is pushed to the far slot.
+    expect(Math.abs(byId.get("m1")! - byId.get("m2")!)).toBe(1);
+    expect(byId.get("solo")).toBe(2);
   });
 });


### PR DESCRIPTION
## **User description**
Closes #2734.

Adds move-left and move-right controls on the selected rack or bay group in the canvas row.

## What changed

- `RackCanvasView.svelte`: each row slot can show a small move-left / move-right control bar above the rack when that slot is selected. Controls appear only when two or more row slots exist, and each button is disabled at its row end (left at the leftmost slot, right at the rightmost).
- Layout store `moveRackInRow(rackId, direction)`: swaps the selected slot with its neighbour and reindexes `Rack.position` so the new order persists across save and reload. Recorded as a single undoable step via the existing batched recorded-update path, so undo and redo cover it.
- `rack-row.ts` `reorderRackRow(...)`: pure helper that computes the new `position` values. A group occupies one row slot, so a grouped rack moves its whole bay group as a unit and is never pulled out of its bay; the whole row is reindexed sequentially so members stay contiguous.

## Behaviour notes

- Selection drives the controls: a selected device does not surface them. A selected group resolves to its slot via the active member.
- Edge moves and single-slot rows are no-ops (the helper returns null; the store returns false and records nothing).

## Tests

- `reorderRackRow`: left/right swaps, edge and single-slot no-ops, rack-not-found, and group-moves-as-a-unit with contiguity preserved.
- `moveRackInRow` (store): right-neighbour swap, position persistence, edge no-op (no dirty), undo reverts a reorder, and a bayed group moves as a unit without splitting.

Local gates: lint, svelte-check, build, and the full unit suite (3098 tests) all pass.


___

## **CodeAnt-AI Description**
**Move the selected rack or bay group left and right in the canvas row**

### What Changed
- Added left and right controls above the selected rack or bay group so users can reorder the row directly from the canvas.
- The controls only appear when a row has at least two slots, and each one is disabled at the row edge to prevent invalid moves.
- Reordering now keeps bayed racks together as one unit, preserves their order, and saves the new row position so it remains after reload.
- Row moves are now undoable in one step.

### Impact
`✅ Faster rack reordering`
`✅ Fewer accidental edge moves`
`✅ Bayed groups stay together during reorder`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
