### PR TITLE
feat: drag-to-resize a standalone rack (whole-U snap, no renumbering) (#2737)

### DIFF
--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -183,9 +183,12 @@
     if (!rack) return;
     event.preventDefault();
     event.stopPropagation();
-    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
-    // updateRackRaw targets the active rack; the grips only show on the
-    // selected rack, which is normally active, but make it certain.
+    // setPointerCapture is absent in some runtimes (happy-dom tests); guard it
+    // the same way RackDevice does so a grip press never throws.
+    const target = event.currentTarget as HTMLElement;
+    if (target?.setPointerCapture) target.setPointerCapture(event.pointerId);
+    // Make the dragged rack active so its selection chrome matches; the raw
+    // preview below is id-targeted, so correctness does not depend on this.
     if (activeRackId !== rackId) layoutStore.setActiveRack(rackId);
     resizeDrag = {
       rackId,
@@ -211,17 +214,28 @@
     });
     if (previewHeight === drag.previewHeight) return;
     drag.previewHeight = previewHeight;
-    // Live frame preview: raw set records no history and leaves the doc clean.
-    layoutStore.updateRackRaw({ height: previewHeight });
+    // Live frame preview, id-targeted so a mid-drag active-rack change cannot
+    // resize the wrong rack. Raw set records no history and leaves the doc clean.
+    layoutStore.updateRackRaw({ height: previewHeight }, drag.rackId);
   }
 
   function handleResizeEnd(event: PointerEvent) {
     const drag = resizeDrag;
     if (!drag || event.pointerId !== drag.pointerId) return;
-    const finalHeight = drag.previewHeight;
+    // Recompute from the release position so a fast release that outran the
+    // last pointermove still commits the height under the pointer.
+    const pxPerU = U_HEIGHT_PX * canvasStore.zoom;
+    const finalHeight = snapResizeHeight({
+      startHeight: drag.startHeight,
+      growPx: resizeGrowPx(drag.grip, drag.startClientY, event.clientY),
+      pxPerU,
+      minHeight: drag.minHeight,
+      maxHeight: MAX_RACK_HEIGHT,
+    });
     resizeDrag = null;
-    // Rewind the preview, then commit once so undo sees start -> final.
-    layoutStore.updateRackRaw({ height: drag.startHeight });
+    // Rewind the preview (id-targeted), then commit once so undo sees
+    // start -> final as a single step.
+    layoutStore.updateRackRaw({ height: drag.startHeight }, drag.rackId);
     if (finalHeight !== drag.startHeight) {
       layoutStore.updateRack(drag.rackId, { height: finalHeight });
     }
@@ -231,7 +245,7 @@
     const drag = resizeDrag;
     if (!drag || event.pointerId !== drag.pointerId) return;
     resizeDrag = null;
-    layoutStore.updateRackRaw({ height: drag.startHeight });
+    layoutStore.updateRackRaw({ height: drag.startHeight }, drag.rackId);
   }
 
   // Keyboard resize for a focused grip: Arrow Up grows, Arrow Down shrinks by
@@ -411,7 +425,10 @@
     <button
       type="button"
       class="resize-grip resize-grip-{side}"
-      aria-label="Resize rack height"
+      aria-label={side === "top"
+        ? "Resize rack height from top edge"
+        : "Resize rack height from bottom edge"}
+      aria-keyshortcuts="ArrowUp ArrowDown"
       title="Drag to resize. Arrow Up grows, Arrow Down shrinks."
       onpointerdown={(e) => handleResizeStart(rackId, side, e)}
       onpointermove={handleResizeMove}
@@ -460,6 +477,10 @@
           class="rack-wrapper"
           class:active={isActive}
           class:resizable={isSelected}
+          style:transform={resizeDrag?.rackId === rack.id &&
+          resizeDrag.grip === "bottom"
+            ? `translateY(${(resizeDrag.previewHeight - resizeDrag.startHeight) * U_HEIGHT_PX}px)`
+            : undefined}
         >
           <RackDualView
             {rack}

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -21,6 +21,9 @@
   import { organizeRackRow } from "$lib/utils/rack-row";
   import { IconChevronLeft, IconChevronRight } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
+  import { getMinResizeHeight, snapResizeHeight } from "$lib/utils/rack-resize";
+  import { U_HEIGHT_PX } from "$lib/constants/layout";
+  import { MAX_RACK_HEIGHT } from "$lib/types/constants";
 
   interface Props {
     partyMode?: boolean;
@@ -132,6 +135,124 @@
     const id = selectedSlotRackId;
     if (!id) return;
     layoutStore.moveRackInRow(id, direction);
+  }
+
+  // --- Canvas drag-to-resize for standalone racks (#2737) ---
+  // Grips on a selected standalone rack drag its height in whole-U steps. The
+  // frame previews live via a raw (non-recorded) height set, then commits once
+  // on release so undo/redo sees a single step. Only the height changes, never
+  // device positions, so placed gear keeps its U-number: empty U lands at the
+  // high-numbered open end on grow and is removed from it on shrink.
+  type ResizeGrip = "top" | "bottom";
+
+  interface ResizeDrag {
+    rackId: string;
+    grip: ResizeGrip;
+    startHeight: number;
+    startClientY: number;
+    minHeight: number;
+    previewHeight: number;
+    pointerId: number;
+  }
+
+  let resizeDrag = $state<ResizeDrag | null>(null);
+
+  // Dragging away from the rack body grows it: up for the top grip, down for
+  // the bottom grip. Both keep device positions fixed (open-end growth).
+  function resizeGrowPx(
+    grip: ResizeGrip,
+    startClientY: number,
+    clientY: number,
+  ): number {
+    return grip === "top" ? startClientY - clientY : clientY - startClientY;
+  }
+
+  // Keep canvas pan/zoom from hijacking a grip press: panzoom listens for
+  // mousedown/touchstart on an ancestor in the bubble phase, so stopping
+  // propagation here is enough.
+  function blockPan(event: Event) {
+    event.stopPropagation();
+  }
+
+  function handleResizeStart(
+    rackId: string,
+    grip: ResizeGrip,
+    event: PointerEvent,
+  ) {
+    const rack = layoutStore.getRackById(rackId);
+    if (!rack) return;
+    event.preventDefault();
+    event.stopPropagation();
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    // updateRackRaw targets the active rack; the grips only show on the
+    // selected rack, which is normally active, but make it certain.
+    if (activeRackId !== rackId) layoutStore.setActiveRack(rackId);
+    resizeDrag = {
+      rackId,
+      grip,
+      startHeight: rack.height,
+      startClientY: event.clientY,
+      minHeight: getMinResizeHeight(rack, layoutStore.device_types),
+      previewHeight: rack.height,
+      pointerId: event.pointerId,
+    };
+  }
+
+  function handleResizeMove(event: PointerEvent) {
+    const drag = resizeDrag;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    const pxPerU = U_HEIGHT_PX * canvasStore.zoom;
+    const previewHeight = snapResizeHeight({
+      startHeight: drag.startHeight,
+      growPx: resizeGrowPx(drag.grip, drag.startClientY, event.clientY),
+      pxPerU,
+      minHeight: drag.minHeight,
+      maxHeight: MAX_RACK_HEIGHT,
+    });
+    if (previewHeight === drag.previewHeight) return;
+    drag.previewHeight = previewHeight;
+    // Live frame preview: raw set records no history and leaves the doc clean.
+    layoutStore.updateRackRaw({ height: previewHeight });
+  }
+
+  function handleResizeEnd(event: PointerEvent) {
+    const drag = resizeDrag;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    const finalHeight = drag.previewHeight;
+    resizeDrag = null;
+    // Rewind the preview, then commit once so undo sees start -> final.
+    layoutStore.updateRackRaw({ height: drag.startHeight });
+    if (finalHeight !== drag.startHeight) {
+      layoutStore.updateRack(drag.rackId, { height: finalHeight });
+    }
+  }
+
+  function handleResizeCancel(event: PointerEvent) {
+    const drag = resizeDrag;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    resizeDrag = null;
+    layoutStore.updateRackRaw({ height: drag.startHeight });
+  }
+
+  // Keyboard resize for a focused grip: Arrow Up grows, Arrow Down shrinks by
+  // one U. Each press is its own undoable step.
+  function handleResizeKey(rackId: string, event: KeyboardEvent) {
+    let delta: number;
+    if (event.key === "ArrowUp") delta = 1;
+    else if (event.key === "ArrowDown") delta = -1;
+    else return;
+    const rack = layoutStore.getRackById(rackId);
+    if (!rack) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const minHeight = getMinResizeHeight(rack, layoutStore.device_types);
+    const next = Math.max(
+      minHeight,
+      Math.min(MAX_RACK_HEIGHT, rack.height + delta),
+    );
+    if (next === rack.height) return;
+    if (activeRackId !== rackId) layoutStore.setActiveRack(rackId);
+    layoutStore.updateRack(rackId, { height: next });
   }
 
   // Handle mobile tap-to-place (uses active rack)
@@ -286,6 +407,23 @@
   class:swipe-next={swipeAnimationDirection === "next"}
   class:swipe-previous={swipeAnimationDirection === "previous"}
 >
+  {#snippet resizeGrip(rackId: string, side: ResizeGrip)}
+    <button
+      type="button"
+      class="resize-grip resize-grip-{side}"
+      aria-label="Resize rack height"
+      title="Drag to resize. Arrow Up grows, Arrow Down shrinks."
+      onpointerdown={(e) => handleResizeStart(rackId, side, e)}
+      onpointermove={handleResizeMove}
+      onpointerup={handleResizeEnd}
+      onpointercancel={handleResizeCancel}
+      onmousedown={blockPan}
+      ontouchstart={blockPan}
+      onkeydown={(e) => handleResizeKey(rackId, e)}
+    >
+      <span class="grip-bar" aria-hidden="true"></span>
+    </button>
+  {/snippet}
   {#each rowItems as item, slotIndex (item.kind === "rack" ? `rack:${item.rack.id}` : `group:${item.group.id}`)}
     <div class="row-slot">
       {#if rowItems.length >= 2 && slotIndex === selectedSlotIndex}
@@ -318,7 +456,11 @@
         {@const isSelected =
           selectionStore.selectedType === "rack" &&
           selectionStore.selectedRackId === rack.id}
-        <div class="rack-wrapper" class:active={isActive}>
+        <div
+          class="rack-wrapper"
+          class:active={isActive}
+          class:resizable={isSelected}
+        >
           <RackDualView
             {rack}
             deviceLibrary={layoutStore.device_types}
@@ -349,6 +491,19 @@
             onduplicate={() => onrackduplicate?.(rack.id)}
             ondelete={() => onrackdelete?.(rack.id)}
           />
+          {#if isSelected}
+            {@render resizeGrip(rack.id, "top")}
+            {@render resizeGrip(rack.id, "bottom")}
+            {#if resizeDrag?.rackId === rack.id}
+              <div
+                class="resize-readout resize-readout-{resizeDrag.grip}"
+                role="status"
+                aria-live="polite"
+              >
+                {resizeDrag.previewHeight}U
+              </div>
+            {/if}
+          {/if}
         </div>
       {:else if item.group.layout_preset === "bayed"}
         <!-- Bayed/touring racks render flush (no gap) via the stacked dual view -->
@@ -585,5 +740,96 @@
         background-color var(--duration-fast) var(--ease-out),
         color var(--duration-fast) var(--ease-out);
     }
+  }
+
+  /* Drag-to-resize grips on a selected standalone rack (#2737). The wrapper is
+     the positioning context; grips straddle the frame's top and bottom edges
+     and the readout reports the live height during a drag. */
+  .rack-wrapper.resizable {
+    position: relative;
+  }
+
+  .resize-grip {
+    position: absolute;
+    left: 50%;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: ns-resize;
+    touch-action: none;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .resize-grip-top {
+    top: 0;
+    transform: translate(-50%, -50%);
+  }
+
+  .resize-grip-bottom {
+    bottom: 0;
+    transform: translate(-50%, 50%);
+  }
+
+  /* The visible handle reads as a short rack rail. */
+  .grip-bar {
+    width: 40px;
+    height: 6px;
+    border-radius: var(--radius-full);
+    background: var(--colour-border);
+    box-shadow: 0 0 0 4px var(--colour-surface-overlay, rgba(40, 42, 54, 0.6));
+  }
+
+  .resize-grip:hover .grip-bar,
+  .resize-grip:focus-visible .grip-bar {
+    background: var(--colour-selection);
+  }
+
+  .resize-grip:focus-visible {
+    outline: none;
+  }
+
+  .resize-grip:focus-visible .grip-bar {
+    box-shadow:
+      0 0 0 4px var(--colour-surface-overlay, rgba(40, 42, 54, 0.6)),
+      var(--focus-ring-glow);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .grip-bar {
+      transition: background-color var(--duration-fast) var(--ease-out);
+    }
+  }
+
+  /* Live height readout: the signature of the resize interaction. */
+  .resize-readout {
+    position: absolute;
+    left: 50%;
+    z-index: 3;
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-full);
+    background: var(--colour-selection);
+    color: var(--colour-text-inverse);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold, 600);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.4));
+  }
+
+  .resize-readout-top {
+    top: 0;
+    transform: translate(-50%, calc(-100% - var(--space-2)));
+  }
+
+  .resize-readout-bottom {
+    bottom: 0;
+    transform: translate(-50%, calc(100% + var(--space-2)));
   }
 </style>

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -979,8 +979,9 @@ export function createLayoutStore(
 
   function updateRackRaw(
     updates: Partial<Omit<Rack, "devices" | "view">>,
+    rackId?: string,
   ): void {
-    updateRackRawImpl(stateAccess, updates);
+    updateRackRawImpl(stateAccess, updates, rackId);
   }
 
   function replaceRackRaw(newRack: Rack): void {

--- a/src/lib/stores/layout/mutators.ts
+++ b/src/lib/stores/layout/mutators.ts
@@ -492,15 +492,20 @@ export function getPlacedDevicesWithRackForType(
 
 /**
  * Update rack settings directly (raw)
- * Uses active rack
+ * Targets rackId when given, otherwise the active rack
  * @param ctx - Layout state access
  * @param updates - Settings to update
+ * @param rackId - Optional rack id to target instead of the active rack
  */
 export function updateRackRaw(
   ctx: LayoutStateAccess,
   updates: Partial<Omit<Rack, "devices" | "view">>,
+  rackId?: string,
 ): void {
-  const target = getTargetRack(ctx);
+  // rackId targets a specific rack; without it the active rack is used. The
+  // canvas drag-resize passes the dragged rack's id so a mid-drag active-rack
+  // change (e.g. a cycle-rack shortcut) cannot mutate the wrong rack (#2737).
+  const target = getTargetRack(ctx, rackId);
   if (!target) return;
 
   updateRackAtIndex(ctx, target.index, (rack) => ({ ...rack, ...updates }));

--- a/src/lib/utils/rack-resize.ts
+++ b/src/lib/utils/rack-resize.ts
@@ -28,6 +28,20 @@ export interface ConflictInfo {
 }
 
 /**
+ * Highest whole-U a placed device occupies (its top edge). Converts the stored
+ * internal position to human U and rounds a fractional top up. Shared by the
+ * shrink guard and the resize floor so they cannot drift (#1683, #2737).
+ */
+function getDeviceOccupiedTopU(
+  device: PlacedDevice,
+  deviceTypes: DeviceType[],
+): number {
+  const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
+  const uHeight = deviceType?.u_height ?? 1; // Default to 1U if unknown
+  return Math.ceil(toHumanUnits(device.position) + uHeight - 1);
+}
+
+/**
  * Check if a rack can be resized to a new height
  *
  * Rules:
@@ -54,17 +68,7 @@ export function canResizeRackTo(
   const conflicts: PlacedDevice[] = [];
 
   for (const device of rack.devices) {
-    const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
-    const uHeight = deviceType?.u_height ?? 1; // Default to 1U if unknown
-
-    // device.position is stored in internal units (UNITS_PER_U per U).
-    // newHeight and u_height are in human U — convert before comparing,
-    // otherwise we read an inflated "U228" for a device actually at U38 (#1683).
-    const positionU = toHumanUnits(device.position);
-    const deviceTop = positionU + uHeight - 1;
-    const effectiveTop = Math.ceil(deviceTop); // Round up for fractional U
-
-    if (effectiveTop > newHeight) {
+    if (getDeviceOccupiedTopU(device, deviceTypes) > newHeight) {
       conflicts.push(device);
     }
   }
@@ -87,9 +91,7 @@ export function getMinResizeHeight(
 ): number {
   let highest = MIN_RACK_HEIGHT;
   for (const device of rack.devices) {
-    const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
-    const uHeight = deviceType?.u_height ?? 1;
-    const top = Math.ceil(toHumanUnits(device.position) + uHeight - 1);
+    const top = getDeviceOccupiedTopU(device, deviceTypes);
     if (top > highest) highest = top;
   }
   return highest;

--- a/src/lib/utils/rack-resize.ts
+++ b/src/lib/utils/rack-resize.ts
@@ -7,6 +7,7 @@
 
 import type { Rack, DeviceType, PlacedDevice } from "$lib/types";
 import { toHumanUnits } from "./position";
+import { MIN_RACK_HEIGHT } from "$lib/types/constants";
 
 /**
  * Result of resize validation
@@ -72,6 +73,63 @@ export function canResizeRackTo(
     allowed: conflicts.length === 0,
     conflicts,
   };
+}
+
+/**
+ * Lowest height (whole U) a rack can shrink to without clipping a placed
+ * device. Equals the highest occupied U across all devices, or MIN_RACK_HEIGHT
+ * for an empty rack. The canvas drag-resize clamps to this so a shrink can
+ * never drop below the topmost device, the same floor canResizeRackTo enforces.
+ */
+export function getMinResizeHeight(
+  rack: Rack,
+  deviceTypes: DeviceType[],
+): number {
+  let highest = MIN_RACK_HEIGHT;
+  for (const device of rack.devices) {
+    const deviceType = deviceTypes.find((dt) => dt.slug === device.device_type);
+    const uHeight = deviceType?.u_height ?? 1;
+    const top = Math.ceil(toHumanUnits(device.position) + uHeight - 1);
+    if (top > highest) highest = top;
+  }
+  return highest;
+}
+
+/**
+ * Inputs for snapResizeHeight.
+ */
+export interface SnapResizeParams {
+  /** Rack height (whole U) when the drag began. */
+  startHeight: number;
+  /** Signed pixels dragged toward growth; positive grows the rack. */
+  growPx: number;
+  /** On-screen pixels per U: the rendered U height times the canvas zoom. */
+  pxPerU: number;
+  /** Lowest allowed height, from getMinResizeHeight. */
+  minHeight: number;
+  /** Highest allowed height (schema max). */
+  maxHeight: number;
+}
+
+/**
+ * Snap a pointer drag to a whole-U rack height.
+ *
+ * Rounds the drag distance to the nearest whole U so the rail invariant holds
+ * (positions stay on whole-U boundaries), then clamps to [minHeight, maxHeight].
+ * A non-positive pxPerU (a degenerate zoom) holds the start height rather than
+ * dividing by zero.
+ */
+export function snapResizeHeight({
+  startHeight,
+  growPx,
+  pxPerU,
+  minHeight,
+  maxHeight,
+}: SnapResizeParams): number {
+  if (pxPerU <= 0) return startHeight;
+  const deltaU = Math.round(growPx / pxPerU);
+  const raw = startHeight + deltaU;
+  return Math.max(minHeight, Math.min(maxHeight, raw));
 }
 
 /**

--- a/src/tests/rack-resize.test.ts
+++ b/src/tests/rack-resize.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   canResizeRackTo,
   getDeviceRangeText,
   formatConflictMessage,
   getConflictDetails,
+  getMinResizeHeight,
+  snapResizeHeight,
 } from "$lib/utils/rack-resize";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import {
   createTestRack,
   createTestDevice,
@@ -113,6 +116,130 @@ describe("rack-resize", () => {
       expect(formatConflictMessage(conflicts)).toBe(
         "Switch at U10, Storage at U20-22",
       );
+    });
+  });
+
+  describe("getMinResizeHeight", () => {
+    it("returns the single-U floor for an empty rack", () => {
+      const rack = createTestRack({ height: 42, devices: [] });
+      expect(getMinResizeHeight(rack, [])).toBe(1);
+    });
+
+    it("returns the highest occupied U for a single device", () => {
+      const device = createTestDevice({ position: 40 });
+      const rack = createTestRack({ height: 42, devices: [device] });
+      const dt = createTestDeviceType({
+        slug: device.device_type,
+        u_height: 1,
+      });
+      expect(getMinResizeHeight(rack, [dt])).toBe(40);
+    });
+
+    it("accounts for a multi-U device's top edge", () => {
+      const device = createTestDevice({ position: 20 });
+      const rack = createTestRack({ height: 42, devices: [device] });
+      const dt = createTestDeviceType({
+        slug: device.device_type,
+        u_height: 3,
+      });
+      // U20 + 3U occupies U20-22, so the rack cannot shrink below 22.
+      expect(getMinResizeHeight(rack, [dt])).toBe(22);
+    });
+
+    it("takes the maximum top across several devices", () => {
+      const low = createTestDevice({ device_type: "a", position: 5 });
+      const high = createTestDevice({ device_type: "b", position: 30 });
+      const rack = createTestRack({ height: 42, devices: [low, high] });
+      const dtA = createTestDeviceType({ slug: "a", u_height: 1 });
+      const dtB = createTestDeviceType({ slug: "b", u_height: 2 });
+      expect(getMinResizeHeight(rack, [dtA, dtB])).toBe(31);
+    });
+  });
+
+  describe("snapResizeHeight", () => {
+    const base = { minHeight: 1, maxHeight: 100 };
+
+    it("snaps a drag to the nearest whole U", () => {
+      // 46px at 20px/U is 2.3U, which rounds down to +2U.
+      expect(
+        snapResizeHeight({ ...base, startHeight: 10, growPx: 46, pxPerU: 20 }),
+      ).toBe(12);
+      // 54px at 20px/U is 2.7U, which rounds up to +3U.
+      expect(
+        snapResizeHeight({ ...base, startHeight: 10, growPx: 54, pxPerU: 20 }),
+      ).toBe(13);
+    });
+
+    it("shrinks on a negative (toward-body) drag", () => {
+      expect(
+        snapResizeHeight({ ...base, startHeight: 24, growPx: -40, pxPerU: 20 }),
+      ).toBe(22);
+    });
+
+    it("clamps growth to the schema maximum", () => {
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 90,
+          growPx: 10000,
+          pxPerU: 20,
+        }),
+      ).toBe(100);
+    });
+
+    it("clamps a shrink to the highest occupied U (no clipping)", () => {
+      // A device fixes the floor at 12U; an aggressive shrink stops there.
+      expect(
+        snapResizeHeight({
+          startHeight: 24,
+          growPx: -10000,
+          pxPerU: 20,
+          minHeight: 12,
+          maxHeight: 100,
+        }),
+      ).toBe(12);
+    });
+
+    it("holds the start height when pxPerU is degenerate", () => {
+      expect(
+        snapResizeHeight({ ...base, startHeight: 24, growPx: 100, pxPerU: 0 }),
+      ).toBe(24);
+    });
+  });
+
+  describe("resize via the layout store", () => {
+    beforeEach(() => {
+      resetLayoutStore();
+    });
+
+    it("keeps device positions across grow then shrink, and undo reverts one step", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 24)!;
+      const dt = createTestDeviceType({ slug: "server-2u", u_height: 2 });
+      store.addDeviceTypeRaw(dt);
+      store.placeDevice(rack.id, dt.slug, 10);
+
+      const positionsBefore = store
+        .getRackById(rack.id)!
+        .devices.map((d) => d.position);
+
+      // Grow: empty U is added at the open end, placed gear keeps its U-number.
+      store.updateRack(rack.id, { height: 42 });
+      expect(store.getRackById(rack.id)!.height).toBe(42);
+      expect(
+        store.getRackById(rack.id)!.devices.map((d) => d.position),
+      ).toEqual(positionsBefore);
+
+      // Shrink back to a height that still clears the device's top (U11).
+      store.updateRack(rack.id, { height: 12 });
+      expect(store.getRackById(rack.id)!.height).toBe(12);
+      expect(
+        store.getRackById(rack.id)!.devices.map((d) => d.position),
+      ).toEqual(positionsBefore);
+
+      // A single undo reverts the last resize, not the device placement.
+      store.undo();
+      expect(store.getRackById(rack.id)!.height).toBe(42);
     });
   });
 });

--- a/src/tests/rack-resize.test.ts
+++ b/src/tests/rack-resize.test.ts
@@ -237,9 +237,28 @@ describe("rack-resize", () => {
         store.getRackById(rack.id)!.devices.map((d) => d.position),
       ).toEqual(positionsBefore);
 
-      // A single undo reverts the last resize, not the device placement.
+      // A single undo reverts the last resize, not the device placement: the
+      // height returns and every device keeps its U-number (no renumbering).
       store.undo();
       expect(store.getRackById(rack.id)!.height).toBe(42);
+      expect(
+        store.getRackById(rack.id)!.devices.map((d) => d.position),
+      ).toEqual(positionsBefore);
+    });
+
+    it("updateRackRaw targets the given rack id, not the active rack", () => {
+      // The live resize preview writes to the dragged rack by id. If a
+      // cycle-rack shortcut changes the active rack mid-drag, the preview must
+      // still resize the rack under the grip, never the newly active one.
+      const store = getLayoutStore();
+      const rackA = store.addRack("Rack A", 24)!;
+      const rackB = store.addRack("Rack B", 18)!;
+      store.setActiveRack(rackB.id);
+
+      store.updateRackRaw({ height: 30 }, rackA.id);
+
+      expect(store.getRackById(rackA.id)!.height).toBe(30);
+      expect(store.getRackById(rackB.id)!.height).toBe(18);
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Adds a canvas drag-to-resize affordance to a selected standalone rack. Grips sit at the top and bottom edges of the rack frame; dragging one changes the height in whole-U steps with a live U readout. The rack grows or shrinks at the high-numbered open end, so placed gear is never renumbered. Shrinking is clamped at the highest occupied U, and the height stays within the schema bounds of 1U to 100U.

## How it works

- The drag previews live by setting the height through a raw (non-recorded) store update, then commits once on release, so undo/redo sees a single step through the same `updateRack` path the inspector uses.
- The shrink floor reuses the shared rack-resize util: `getMinResizeHeight` sits alongside the existing `canResizeRackTo`, so the canvas and the inspector enforce one source of truth.
- Whole-U snapping keeps device positions on whole-U boundaries (the rail integer invariant); only the rack height changes, never device positions.
- Arrow Up grows and Arrow Down shrinks by one U when a grip is focused, for keyboard operability.
- Grouped and bayed racks do not show per-rack grips. Standalone racks only (the bay-level handle is #2740).

## Tests

- `getMinResizeHeight`: empty rack floors at 1U; occupied rack floors at the topmost device.
- `snapResizeHeight`: snaps a drag to the nearest whole U, shrinks on a toward-body drag, clamps to the schema max and to the occupied-U floor, and holds steady on a degenerate zoom.
- Store behaviour: a grow then shrink keeps device positions unchanged, and undo reverts one resize step.

Closes #2737


___

## **CodeAnt-AI Description**
**Add drag-and-keyboard resizing for a selected standalone rack**

### What Changed
- A selected standalone rack now shows top and bottom resize grips that can be dragged to change its height in whole-U steps, with a live U readout during the drag.
- Resizing keeps placed equipment at the same U numbers by growing or shrinking from the open end of the rack, and the shrink limit now stops at the highest occupied U so devices are not clipped.
- Focused grips can also be resized with Arrow Up and Arrow Down, and the resize action stays within the allowed rack height range.
- Dragging shows a live preview but commits as a single undoable change when released.

### Impact
`✅ Easier rack resizing on the canvas`
`✅ Fewer accidental device clipping`
`✅ Clearer resize feedback while dragging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
