### PR TITLE
feat: create and extend a bay (Bay rack button + resistant edge drag) (#2740)

### DIFF
--- a/performance-budget.json
+++ b/performance-budget.json
@@ -1,9 +1,9 @@
 {
   "toleranceBytes": 5120,
   "baseline": {
-    "initialJs": 329099,
-    "initialCss": 23868,
-    "initialTotal": 352967
+    "initialJs": 364063,
+    "initialCss": 29893,
+    "initialTotal": 393956
   },
   "headroom": {
     "initialJs": 30000,

--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -109,6 +109,19 @@
     onduplicate?: (rackId: string) => void;
     /** Context menu: delete rack callback */
     ondelete?: (rackId: string) => void;
+    /**
+     * Show the resistant right-edge bay-drag grip on each empty member (#2740).
+     * True when the bay is selected; the grip is still gated per member on the
+     * member having no devices.
+     */
+    enableBayDrag?: boolean;
+    /** Live rubber-band ghost for the bay-drag, keyed by the dragged member id. */
+    bayGhost?: { rackId: string; widthPx: number; armed: boolean } | null;
+    /** Bay-drag pointer handlers, owned by the parent so all baying shares one path. */
+    onbaydragstart?: (rackId: string, event: PointerEvent) => void;
+    onbaydragmove?: (event: PointerEvent) => void;
+    onbaydragend?: (event: PointerEvent) => void;
+    onbaydragcancel?: (event: PointerEvent) => void;
   }
 
   let {
@@ -139,6 +152,12 @@
     onrename,
     onduplicate,
     ondelete,
+    enableBayDrag = false,
+    bayGhost = null,
+    onbaydragstart,
+    onbaydragmove,
+    onbaydragend,
+    onbaydragcancel,
   }: Props = $props();
 
   // Calculate max height for U-label column (use tallest rack)
@@ -451,6 +470,37 @@
             {ondevicemoverack}
             onplacementtap={(e) => handlePlacementTap(rack.id, e)}
           />
+          <!-- Resistant right-edge drag on an empty bay member: pull right past
+               the snap threshold to insert a new bayed rack after it (#2740).
+               Same affordance and handlers as a standalone empty rack. -->
+          {#if enableBayDrag && rack.devices.length === 0}
+            <button
+              type="button"
+              class="bay-edge-grip"
+              aria-label="Drag right to bay a new rack"
+              title="Drag right to create a bayed rack"
+              tabindex="-1"
+              onpointerdown={(e) => onbaydragstart?.(rack.id, e)}
+              onpointermove={(e) => onbaydragmove?.(e)}
+              onpointerup={(e) => onbaydragend?.(e)}
+              onpointercancel={(e) => onbaydragcancel?.(e)}
+              onmousedown={(e) => e.stopPropagation()}
+              ontouchstart={(e) => e.stopPropagation()}
+            >
+              <span class="edge-grip-bar" aria-hidden="true"></span>
+            </button>
+            {#if bayGhost && bayGhost.rackId === rack.id}
+              <div
+                class="bay-ghost"
+                class:armed={bayGhost.armed}
+                style:width="{bayGhost.widthPx}px"
+                aria-hidden="true"
+              ></div>
+              <div class="bay-drag-readout" role="status" aria-live="polite">
+                {bayGhost.armed ? "Release to bay" : "Pull to bay"}
+              </div>
+            {/if}
+          {/if}
         </div>
       </RackContextMenu>
       <!-- U-labels column between adjacent bays (not after last bay) -->
@@ -623,6 +673,7 @@
   }
 
   .bay-container {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -678,5 +729,87 @@
     justify-content: flex-start;
     /* Match bay-label height so annotations align with rack content */
     padding-top: var(--bay-label-block-height);
+  }
+
+  /* Resistant right-edge bay-drag grip on an empty member (#2740). Hugs the
+     member's right edge; the bar reads as a rail you pull rightward to insert a
+     new bay. Mirrors the standalone-rack grip in RackCanvasView. */
+  .bay-edge-grip {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    z-index: 4;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 56px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: ew-resize;
+    touch-action: none;
+    transform: translate(50%, -50%);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .edge-grip-bar {
+    width: 6px;
+    height: 40px;
+    border-radius: var(--radius-full);
+    background: var(--colour-border);
+    box-shadow: 0 0 0 4px var(--colour-surface-overlay, rgba(40, 42, 54, 0.6));
+  }
+
+  .bay-edge-grip:hover .edge-grip-bar,
+  .bay-edge-grip:focus-visible .edge-grip-bar {
+    background: var(--colour-selection);
+  }
+
+  .bay-edge-grip:focus-visible {
+    outline: none;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .edge-grip-bar {
+      transition: background-color var(--duration-fast) var(--ease-out);
+    }
+  }
+
+  /* Ghost preview of the bay the drag would insert: a dashed phantom to the
+     right of the dragged member that snaps solid once armed. */
+  .bay-ghost {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 100%;
+    z-index: 3;
+    border: 2px dashed var(--colour-border);
+    border-radius: var(--radius-md);
+    background: var(--colour-surface-overlay, rgba(40, 42, 54, 0.35));
+    pointer-events: none;
+  }
+
+  .bay-ghost.armed {
+    border-style: solid;
+    border-color: var(--colour-selection);
+    background: var(--colour-overlay-hover, rgba(80, 250, 123, 0.12));
+  }
+
+  .bay-drag-readout {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    z-index: 5;
+    margin-left: var(--space-2);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-full);
+    background: var(--colour-selection);
+    color: var(--colour-text-inverse);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold, 600);
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.4));
   }
 </style>

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -22,7 +22,7 @@
   import { IconChevronLeft, IconChevronRight, IconPlus } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import { getMinResizeHeight, snapResizeHeight } from "$lib/utils/rack-resize";
-  import { U_HEIGHT_PX } from "$lib/constants/layout";
+  import { U_HEIGHT_PX, getRackWidth } from "$lib/constants/layout";
   import { MAX_RACK_HEIGHT } from "$lib/types/constants";
 
   interface Props {
@@ -373,9 +373,9 @@
   interface BayDrag {
     rackId: string;
     startClientX: number;
-    /** On-screen width of the source rack, for the threshold and ghost scale. */
-    width: number;
-    /** Rightward drag distance, clamped to >= 0. */
+    /** Source rack width in local (unscaled) canvas px, from the rack model. */
+    localWidth: number;
+    /** Rightward drag distance in screen px, clamped to >= 0. */
     growPx: number;
     /** Pulled past the snap threshold: releasing now commits the bay. */
     armed: boolean;
@@ -384,30 +384,39 @@
 
   let bayDrag = $state<BayDrag | null>(null);
 
-  // The ghost preview shown to the right of the dragged rack. It resists (reveals
-  // at a fraction of the pull) until armed, then snaps to a full-width phantom.
+  // Screen-px distance that arms the snap: half a rack width, scaled by zoom so
+  // the threshold tracks the rack's on-screen size. The pointer delta (growPx)
+  // is in screen px, so the threshold must be too.
+  function baySnapThreshold(drag: BayDrag): number {
+    return drag.localWidth * canvasStore.zoom * BAY_SNAP_FRACTION;
+  }
+
+  // The ghost preview shown to the right of the dragged rack. Its width is in
+  // local canvas coords (the ghost renders inside the zoomed canvas, so the
+  // browser scales it by zoom for us). It resists, revealing at a fraction of
+  // the pull until armed, then snaps to a full-width phantom.
   const bayGhost = $derived.by(() => {
     const drag = bayDrag;
-    if (!drag || drag.width <= 0) return null;
-    const threshold = drag.width * BAY_SNAP_FRACTION;
-    const reveal = Math.min(1, drag.growPx / threshold);
-    const widthPx = drag.armed ? drag.width : drag.width * reveal * 0.7;
+    if (!drag || drag.localWidth <= 0) return null;
+    const threshold = baySnapThreshold(drag);
+    const reveal = threshold > 0 ? Math.min(1, drag.growPx / threshold) : 0;
+    const widthPx = drag.armed
+      ? drag.localWidth
+      : drag.localWidth * reveal * 0.7;
     return { rackId: drag.rackId, widthPx, armed: drag.armed };
   });
 
   function handleBayDragStart(rackId: string, event: PointerEvent) {
+    const rack = layoutStore.getRackById(rackId);
+    if (!rack) return;
     event.preventDefault();
     event.stopPropagation();
     const el = event.currentTarget as HTMLElement;
     if (el?.setPointerCapture) el.setPointerCapture(event.pointerId);
-    // Measure the rack from its wrapper so the threshold and ghost scale with
-    // the current zoom.
-    const wrapper = el?.closest(".rack-wrapper") as HTMLElement | null;
-    const width = wrapper?.getBoundingClientRect().width ?? 0;
     bayDrag = {
       rackId,
       startClientX: event.clientX,
-      width,
+      localWidth: getRackWidth(rack.width),
       growPx: 0,
       armed: false,
       pointerId: event.pointerId,
@@ -418,7 +427,7 @@
     const drag = bayDrag;
     if (!drag || event.pointerId !== drag.pointerId) return;
     const growPx = Math.max(0, event.clientX - drag.startClientX);
-    const armed = drag.width > 0 && growPx >= drag.width * BAY_SNAP_FRACTION;
+    const armed = drag.localWidth > 0 && growPx >= baySnapThreshold(drag);
     if (growPx === drag.growPx && armed === drag.armed) return;
     drag.growPx = growPx;
     drag.armed = armed;
@@ -788,6 +797,12 @@
             onrename={(rackId) => onrackrename?.(rackId)}
             onduplicate={(rackId) => onrackduplicate?.(rackId)}
             ondelete={(rackId) => onrackdelete?.(rackId)}
+            enableBayDrag={isBaySelected}
+            {bayGhost}
+            onbaydragstart={handleBayDragStart}
+            onbaydragmove={handleBayDragMove}
+            onbaydragend={handleBayDragEnd}
+            onbaydragcancel={handleBayDragCancel}
           />
           {#if isBaySelected}
             {@render resizeGrip(bayTarget, "top")}

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -19,7 +19,7 @@
   import RackDualView from "./RackDualView.svelte";
   import BayedRackView from "./BayedRackView.svelte";
   import { organizeRackRow } from "$lib/utils/rack-row";
-  import { IconChevronLeft, IconChevronRight } from "./icons";
+  import { IconChevronLeft, IconChevronRight, IconPlus } from "./icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
   import { getMinResizeHeight, snapResizeHeight } from "$lib/utils/rack-resize";
   import { U_HEIGHT_PX } from "$lib/constants/layout";
@@ -129,6 +129,29 @@
     );
   });
 
+  // The selected bayed group's id, or null when the selection is not a group.
+  // Drives the bay-level resize handle and "Bay rack" affordance on a bay slot.
+  const selectedGroupId = $derived(
+    selectionStore.selectedType === "group"
+      ? selectionStore.selectedGroupId
+      : null,
+  );
+
+  // The rack to bay from for the selected slot: a standalone rack bays itself; a
+  // bayed group bays from its active member so a new bay lands beside it. Null
+  // for a non-bayed (row) group, which cannot be bayed.
+  const selectedSlotBaySource = $derived.by(() => {
+    const item = rowItems[selectedSlotIndex];
+    if (!item) return null;
+    if (item.kind === "rack") return item.rack.id;
+    if (item.group.layout_preset !== "bayed") return null;
+    const active =
+      activeRackId && item.racks.some((rack) => rack.id === activeRackId)
+        ? activeRackId
+        : item.racks[0]?.id;
+    return active ?? null;
+  });
+
   // Reorder the selected slot left or right. A grouped rack moves its whole
   // group as a unit. Routed through the layout store so undo/redo covers it.
   function handleMoveRack(direction: "left" | "right") {
@@ -145,8 +168,16 @@
   // high-numbered open end on grow and is removed from it on shrink.
   type ResizeGrip = "top" | "bottom";
 
+  // A resize affordance targets either a standalone rack or a whole bay. A bay
+  // resizes every member together to preserve the equal-height invariant (#2740).
+  type ResizeTarget =
+    | { kind: "rack"; rackId: string }
+    | { kind: "bay"; groupId: string; rackIds: string[] };
+
   interface ResizeDrag {
-    rackId: string;
+    target: ResizeTarget;
+    /** The racks the drag mutates (one rack, or every member of a bay). */
+    rackIds: string[];
     grip: ResizeGrip;
     startHeight: number;
     startClientY: number;
@@ -156,6 +187,35 @@
   }
 
   let resizeDrag = $state<ResizeDrag | null>(null);
+
+  // The racks a target mutates: a standalone rack is itself; a bay is all its
+  // members so they stay equal height.
+  function resizeTargetRackIds(target: ResizeTarget): string[] {
+    return target.kind === "rack" ? [target.rackId] : target.rackIds;
+  }
+
+  // The lowest height the target can shrink to without clipping any device:
+  // the highest floor across every rack the target mutates.
+  function resizeTargetMinHeight(rackIds: string[]): number {
+    let floor = 0;
+    for (const id of rackIds) {
+      const rack = layoutStore.getRackById(id);
+      if (!rack) continue;
+      const min = getMinResizeHeight(rack, layoutStore.device_types);
+      if (min > floor) floor = min;
+    }
+    return floor;
+  }
+
+  // Commit a settled height to the target as a single recorded step: a standalone
+  // rack updates directly; a bay updates every member together.
+  function commitResizeHeight(target: ResizeTarget, height: number) {
+    if (target.kind === "rack") {
+      layoutStore.updateRack(target.rackId, { height });
+    } else {
+      layoutStore.resizeBayedGroupHeight(target.groupId, height);
+    }
+  }
 
   // Dragging away from the rack body grows it: up for the top grip, down for
   // the bottom grip. Both keep device positions fixed (open-end growth).
@@ -175,28 +235,32 @@
   }
 
   function handleResizeStart(
-    rackId: string,
+    target: ResizeTarget,
     grip: ResizeGrip,
     event: PointerEvent,
   ) {
-    const rack = layoutStore.getRackById(rackId);
-    if (!rack) return;
+    const rackIds = resizeTargetRackIds(target);
+    const firstRack = layoutStore.getRackById(rackIds[0] ?? "");
+    if (!firstRack) return;
     event.preventDefault();
     event.stopPropagation();
     // setPointerCapture is absent in some runtimes (happy-dom tests); guard it
     // the same way RackDevice does so a grip press never throws.
-    const target = event.currentTarget as HTMLElement;
-    if (target?.setPointerCapture) target.setPointerCapture(event.pointerId);
-    // Make the dragged rack active so its selection chrome matches; the raw
+    const el = event.currentTarget as HTMLElement;
+    if (el?.setPointerCapture) el.setPointerCapture(event.pointerId);
+    // Make a standalone target active so its selection chrome matches; the raw
     // preview below is id-targeted, so correctness does not depend on this.
-    if (activeRackId !== rackId) layoutStore.setActiveRack(rackId);
+    if (target.kind === "rack" && activeRackId !== target.rackId) {
+      layoutStore.setActiveRack(target.rackId);
+    }
     resizeDrag = {
-      rackId,
+      target,
+      rackIds,
       grip,
-      startHeight: rack.height,
+      startHeight: firstRack.height,
       startClientY: event.clientY,
-      minHeight: getMinResizeHeight(rack, layoutStore.device_types),
-      previewHeight: rack.height,
+      minHeight: resizeTargetMinHeight(rackIds),
+      previewHeight: firstRack.height,
       pointerId: event.pointerId,
     };
   }
@@ -216,7 +280,9 @@
     drag.previewHeight = previewHeight;
     // Live frame preview, id-targeted so a mid-drag active-rack change cannot
     // resize the wrong rack. Raw set records no history and leaves the doc clean.
-    layoutStore.updateRackRaw({ height: previewHeight }, drag.rackId);
+    for (const id of drag.rackIds) {
+      layoutStore.updateRackRaw({ height: previewHeight }, id);
+    }
   }
 
   function handleResizeEnd(event: PointerEvent) {
@@ -232,41 +298,144 @@
       minHeight: drag.minHeight,
       maxHeight: MAX_RACK_HEIGHT,
     });
+    const { target, rackIds, startHeight } = drag;
     resizeDrag = null;
     // Rewind the preview (id-targeted), then commit once so undo sees
     // start -> final as a single step.
-    layoutStore.updateRackRaw({ height: drag.startHeight }, drag.rackId);
-    if (finalHeight !== drag.startHeight) {
-      layoutStore.updateRack(drag.rackId, { height: finalHeight });
+    for (const id of rackIds) {
+      layoutStore.updateRackRaw({ height: startHeight }, id);
+    }
+    if (finalHeight !== startHeight) {
+      commitResizeHeight(target, finalHeight);
     }
   }
 
   function handleResizeCancel(event: PointerEvent) {
     const drag = resizeDrag;
     if (!drag || event.pointerId !== drag.pointerId) return;
+    const { rackIds, startHeight } = drag;
     resizeDrag = null;
-    layoutStore.updateRackRaw({ height: drag.startHeight }, drag.rackId);
+    for (const id of rackIds) {
+      layoutStore.updateRackRaw({ height: startHeight }, id);
+    }
   }
 
   // Keyboard resize for a focused grip: Arrow Up grows, Arrow Down shrinks by
-  // one U. Each press is its own undoable step.
-  function handleResizeKey(rackId: string, event: KeyboardEvent) {
+  // one U. Each press is its own undoable step. A bay grip moves every member.
+  function handleResizeKey(target: ResizeTarget, event: KeyboardEvent) {
     let delta: number;
     if (event.key === "ArrowUp") delta = 1;
     else if (event.key === "ArrowDown") delta = -1;
     else return;
-    const rack = layoutStore.getRackById(rackId);
-    if (!rack) return;
+    const rackIds = resizeTargetRackIds(target);
+    const firstRack = layoutStore.getRackById(rackIds[0] ?? "");
+    if (!firstRack) return;
     event.preventDefault();
     event.stopPropagation();
-    const minHeight = getMinResizeHeight(rack, layoutStore.device_types);
+    const minHeight = resizeTargetMinHeight(rackIds);
     const next = Math.max(
       minHeight,
-      Math.min(MAX_RACK_HEIGHT, rack.height + delta),
+      Math.min(MAX_RACK_HEIGHT, firstRack.height + delta),
     );
-    if (next === rack.height) return;
-    if (activeRackId !== rackId) layoutStore.setActiveRack(rackId);
-    layoutStore.updateRack(rackId, { height: next });
+    if (next === firstRack.height) return;
+    if (target.kind === "rack" && activeRackId !== target.rackId) {
+      layoutStore.setActiveRack(target.rackId);
+    }
+    commitResizeHeight(target, next);
+  }
+
+  // --- Baying: create / extend a bay (#2740) ---
+  // The "Bay rack" button and the resistant edge drag both run one store action
+  // that forms a bay from a standalone rack or extends an existing bay, with the
+  // new member inheriting width / form factor / height from the source.
+  function handleBayRack(sourceRackId: string) {
+    const result = layoutStore.createBayedRack(sourceRackId);
+    if (result.error || !result.groupId) {
+      hapticError();
+      toastStore.showToast(
+        result.error ?? "Can't bay this rack",
+        "warning",
+        3000,
+      );
+      return;
+    }
+    hapticSuccess();
+    // Select the resulting bay so its bay-level affordances surface at once.
+    layoutStore.setActiveRack(sourceRackId);
+    selectionStore.selectGroup(result.groupId, sourceRackId);
+  }
+
+  // Resistant right-edge drag on an empty rack: a rubber-band ghost that snaps
+  // past a threshold to create or insert a bayed rack (#2740). Offered only on
+  // empty racks (AC: racks with no devices).
+  const BAY_SNAP_FRACTION = 0.5;
+
+  interface BayDrag {
+    rackId: string;
+    startClientX: number;
+    /** On-screen width of the source rack, for the threshold and ghost scale. */
+    width: number;
+    /** Rightward drag distance, clamped to >= 0. */
+    growPx: number;
+    /** Pulled past the snap threshold: releasing now commits the bay. */
+    armed: boolean;
+    pointerId: number;
+  }
+
+  let bayDrag = $state<BayDrag | null>(null);
+
+  // The ghost preview shown to the right of the dragged rack. It resists (reveals
+  // at a fraction of the pull) until armed, then snaps to a full-width phantom.
+  const bayGhost = $derived.by(() => {
+    const drag = bayDrag;
+    if (!drag || drag.width <= 0) return null;
+    const threshold = drag.width * BAY_SNAP_FRACTION;
+    const reveal = Math.min(1, drag.growPx / threshold);
+    const widthPx = drag.armed ? drag.width : drag.width * reveal * 0.7;
+    return { rackId: drag.rackId, widthPx, armed: drag.armed };
+  });
+
+  function handleBayDragStart(rackId: string, event: PointerEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    const el = event.currentTarget as HTMLElement;
+    if (el?.setPointerCapture) el.setPointerCapture(event.pointerId);
+    // Measure the rack from its wrapper so the threshold and ghost scale with
+    // the current zoom.
+    const wrapper = el?.closest(".rack-wrapper") as HTMLElement | null;
+    const width = wrapper?.getBoundingClientRect().width ?? 0;
+    bayDrag = {
+      rackId,
+      startClientX: event.clientX,
+      width,
+      growPx: 0,
+      armed: false,
+      pointerId: event.pointerId,
+    };
+  }
+
+  function handleBayDragMove(event: PointerEvent) {
+    const drag = bayDrag;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    const growPx = Math.max(0, event.clientX - drag.startClientX);
+    const armed = drag.width > 0 && growPx >= drag.width * BAY_SNAP_FRACTION;
+    if (growPx === drag.growPx && armed === drag.armed) return;
+    drag.growPx = growPx;
+    drag.armed = armed;
+  }
+
+  function handleBayDragEnd(event: PointerEvent) {
+    const drag = bayDrag;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    const { rackId, armed } = drag;
+    bayDrag = null;
+    if (armed) handleBayRack(rackId);
+  }
+
+  function handleBayDragCancel(event: PointerEvent) {
+    const drag = bayDrag;
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    bayDrag = null;
   }
 
   // Handle mobile tap-to-place (uses active rack)
@@ -421,50 +590,71 @@
   class:swipe-next={swipeAnimationDirection === "next"}
   class:swipe-previous={swipeAnimationDirection === "previous"}
 >
-  {#snippet resizeGrip(rackId: string, side: ResizeGrip)}
+  {#snippet resizeGrip(target: ResizeTarget, side: ResizeGrip)}
     <button
       type="button"
       class="resize-grip resize-grip-{side}"
-      aria-label={side === "top"
-        ? "Resize rack height from top edge"
-        : "Resize rack height from bottom edge"}
+      aria-label={`Resize ${target.kind === "bay" ? "bay" : "rack"} height from ${side} edge`}
       aria-keyshortcuts="ArrowUp ArrowDown"
       title="Drag to resize. Arrow Up grows, Arrow Down shrinks."
-      onpointerdown={(e) => handleResizeStart(rackId, side, e)}
+      onpointerdown={(e) => handleResizeStart(target, side, e)}
       onpointermove={handleResizeMove}
       onpointerup={handleResizeEnd}
       onpointercancel={handleResizeCancel}
       onmousedown={blockPan}
       ontouchstart={blockPan}
-      onkeydown={(e) => handleResizeKey(rackId, e)}
+      onkeydown={(e) => handleResizeKey(target, e)}
     >
       <span class="grip-bar" aria-hidden="true"></span>
     </button>
   {/snippet}
   {#each rowItems as item, slotIndex (item.kind === "rack" ? `rack:${item.rack.id}` : `group:${item.group.id}`)}
     <div class="row-slot">
-      {#if rowItems.length >= 2 && slotIndex === selectedSlotIndex}
-        <div class="rack-move-controls" role="group" aria-label="Reorder rack">
-          <button
-            type="button"
-            class="move-button"
-            aria-label="Move rack left"
-            title="Move rack left"
-            disabled={slotIndex === 0}
-            onclick={() => handleMoveRack("left")}
-          >
-            <IconChevronLeft size={ICON_SIZE.sm} />
-          </button>
-          <button
-            type="button"
-            class="move-button"
-            aria-label="Move rack right"
-            title="Move rack right"
-            disabled={slotIndex === rowItems.length - 1}
-            onclick={() => handleMoveRack("right")}
-          >
-            <IconChevronRight size={ICON_SIZE.sm} />
-          </button>
+      {#if slotIndex === selectedSlotIndex}
+        <div class="slot-controls">
+          {#if rowItems.length >= 2}
+            <div
+              class="rack-move-controls"
+              role="group"
+              aria-label="Reorder rack"
+            >
+              <button
+                type="button"
+                class="move-button"
+                aria-label="Move rack left"
+                title="Move rack left"
+                disabled={slotIndex === 0}
+                onclick={() => handleMoveRack("left")}
+              >
+                <IconChevronLeft size={ICON_SIZE.sm} />
+              </button>
+              <button
+                type="button"
+                class="move-button"
+                aria-label="Move rack right"
+                title="Move rack right"
+                disabled={slotIndex === rowItems.length - 1}
+                onclick={() => handleMoveRack("right")}
+              >
+                <IconChevronRight size={ICON_SIZE.sm} />
+              </button>
+            </div>
+          {/if}
+          {#if selectedSlotBaySource}
+            <button
+              type="button"
+              class="bay-button"
+              aria-label="Bay rack"
+              title="Add a bayed rack to the right"
+              onclick={() => {
+                const id = selectedSlotBaySource;
+                if (id) handleBayRack(id);
+              }}
+            >
+              <IconPlus size={ICON_SIZE.sm} />
+              <span class="bay-button-label">Bay</span>
+            </button>
+          {/if}
         </div>
       {/if}
       {#if item.kind === "rack"}
@@ -477,7 +667,8 @@
           class="rack-wrapper"
           class:active={isActive}
           class:resizable={isSelected}
-          style:transform={resizeDrag?.rackId === rack.id &&
+          style:transform={resizeDrag?.target.kind === "rack" &&
+          resizeDrag.target.rackId === rack.id &&
           resizeDrag.grip === "bottom"
             ? `translateY(${(resizeDrag.previewHeight - resizeDrag.startHeight) * U_HEIGHT_PX}px)`
             : undefined}
@@ -513,9 +704,95 @@
             ondelete={() => onrackdelete?.(rack.id)}
           />
           {#if isSelected}
-            {@render resizeGrip(rack.id, "top")}
-            {@render resizeGrip(rack.id, "bottom")}
-            {#if resizeDrag?.rackId === rack.id}
+            {@render resizeGrip({ kind: "rack", rackId: rack.id }, "top")}
+            {@render resizeGrip({ kind: "rack", rackId: rack.id }, "bottom")}
+            {#if resizeDrag?.target.kind === "rack" && resizeDrag.target.rackId === rack.id}
+              <div
+                class="resize-readout resize-readout-{resizeDrag.grip}"
+                role="status"
+                aria-live="polite"
+              >
+                {resizeDrag.previewHeight}U
+              </div>
+            {/if}
+            <!-- Resistant right-edge drag: empty racks only (#2740). Pull right
+                 past the snap threshold to create or insert a bayed rack. -->
+            {#if rack.devices.length === 0}
+              <button
+                type="button"
+                class="bay-edge-grip"
+                aria-label="Drag right to bay a new rack"
+                title="Drag right to create a bayed rack"
+                tabindex="-1"
+                onpointerdown={(e) => handleBayDragStart(rack.id, e)}
+                onpointermove={handleBayDragMove}
+                onpointerup={handleBayDragEnd}
+                onpointercancel={handleBayDragCancel}
+                onmousedown={blockPan}
+                ontouchstart={blockPan}
+              >
+                <span class="edge-grip-bar" aria-hidden="true"></span>
+              </button>
+              {#if bayGhost && bayGhost.rackId === rack.id}
+                <div
+                  class="bay-ghost"
+                  class:armed={bayGhost.armed}
+                  style:width="{bayGhost.widthPx}px"
+                  aria-hidden="true"
+                ></div>
+                <div class="bay-drag-readout" role="status" aria-live="polite">
+                  {bayGhost.armed ? "Release to bay" : "Pull to bay"}
+                </div>
+              {/if}
+            {/if}
+          {/if}
+        </div>
+      {:else if item.group.layout_preset === "bayed"}
+        {@const isBaySelected = item.group.id === selectedGroupId}
+        {@const bayTarget = {
+          kind: "bay" as const,
+          groupId: item.group.id,
+          rackIds: item.racks.map((member) => member.id),
+        }}
+        <!-- Bayed/touring racks render flush (no gap) via the stacked dual view.
+             The wrapper hosts the one bay-level resize handle that resizes every
+             member together, preserving the equal-height invariant (#2740). -->
+        <div class="bay-wrapper" class:resizable={isBaySelected}>
+          <BayedRackView
+            group={item.group}
+            racks={item.racks}
+            deviceLibrary={layoutStore.device_types}
+            {activeRackId}
+            selectedDeviceId={selectionStore.selectedType === "device"
+              ? selectionStore.selectedDeviceId
+              : null}
+            selectedRackId={selectionStore.selectedType === "rack"
+              ? selectionStore.selectedRackId
+              : null}
+            displayMode={uiStore.displayMode}
+            showLabelsOnImages={uiStore.showLabelsOnImages}
+            showAnnotations={uiStore.showAnnotations}
+            annotationField={uiStore.annotationField}
+            {partyMode}
+            {enableLongPress}
+            ongroupselect={(e) => handleGroupSelect(e)}
+            ondeviceselect={(e) => handleDeviceSelect(e.detail.rackId, e)}
+            ondevicedrop={(e) => handleDeviceDrop(e)}
+            ondevicemove={(e) => handleDeviceMove(e)}
+            ondevicemoverack={(e) => handleDeviceMoveRack(e)}
+            onplacementtap={(e) => handlePlacementTap(e.detail.rackId, e)}
+            onlongpress={(e) => onracklongpress?.(e)}
+            onfocus={(rackIds) => onrackfocus?.(rackIds)}
+            onexport={(rackIds) => onrackexport?.(rackIds)}
+            onedit={(rackId) => onrackedit?.(rackId)}
+            onrename={(rackId) => onrackrename?.(rackId)}
+            onduplicate={(rackId) => onrackduplicate?.(rackId)}
+            ondelete={(rackId) => onrackdelete?.(rackId)}
+          />
+          {#if isBaySelected}
+            {@render resizeGrip(bayTarget, "top")}
+            {@render resizeGrip(bayTarget, "bottom")}
+            {#if resizeDrag?.target.kind === "bay" && resizeDrag.target.groupId === item.group.id}
               <div
                 class="resize-readout resize-readout-{resizeDrag.grip}"
                 role="status"
@@ -526,39 +803,6 @@
             {/if}
           {/if}
         </div>
-      {:else if item.group.layout_preset === "bayed"}
-        <!-- Bayed/touring racks render flush (no gap) via the stacked dual view -->
-        <BayedRackView
-          group={item.group}
-          racks={item.racks}
-          deviceLibrary={layoutStore.device_types}
-          {activeRackId}
-          selectedDeviceId={selectionStore.selectedType === "device"
-            ? selectionStore.selectedDeviceId
-            : null}
-          selectedRackId={selectionStore.selectedType === "rack"
-            ? selectionStore.selectedRackId
-            : null}
-          displayMode={uiStore.displayMode}
-          showLabelsOnImages={uiStore.showLabelsOnImages}
-          showAnnotations={uiStore.showAnnotations}
-          annotationField={uiStore.annotationField}
-          {partyMode}
-          {enableLongPress}
-          ongroupselect={(e) => handleGroupSelect(e)}
-          ondeviceselect={(e) => handleDeviceSelect(e.detail.rackId, e)}
-          ondevicedrop={(e) => handleDeviceDrop(e)}
-          ondevicemove={(e) => handleDeviceMove(e)}
-          ondevicemoverack={(e) => handleDeviceMoveRack(e)}
-          onplacementtap={(e) => handlePlacementTap(e.detail.rackId, e)}
-          onlongpress={(e) => onracklongpress?.(e)}
-          onfocus={(rackIds) => onrackfocus?.(rackIds)}
-          onexport={(rackIds) => onrackexport?.(rackIds)}
-          onedit={(rackId) => onrackedit?.(rackId)}
-          onrename={(rackId) => onrackrename?.(rackId)}
-          onduplicate={(rackId) => onrackduplicate?.(rackId)}
-          ondelete={(rackId) => onrackdelete?.(rackId)}
-        />
       {:else}
         <!-- Standard row layout for non-bayed groups -->
         <div class="rack-group">
@@ -852,5 +1096,150 @@
   .resize-readout-bottom {
     bottom: 0;
     transform: translate(-50%, calc(100% + var(--space-2)));
+  }
+
+  /* Per-slot control cluster above a selected slot: reorder pill plus the
+     "Bay rack" button. Sits in the row-slot's column flow above the rack. */
+  .slot-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  /* "Bay rack" button: forms or extends a bay to the right of the selection. */
+  .bay-button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    min-height: var(--touch-target-min);
+    padding: 0 var(--space-3);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-full);
+    background: var(--colour-surface-overlay, rgba(40, 42, 54, 0.6));
+    color: var(--colour-text);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold, 600);
+    cursor: pointer;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .bay-button:hover {
+    background: var(--colour-overlay-hover);
+    color: var(--colour-primary);
+    border-color: var(--colour-selection);
+  }
+
+  .bay-button:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring-glow);
+    color: var(--colour-primary);
+  }
+
+  .bay-button-label {
+    line-height: 1;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .bay-button {
+      transition:
+        background-color var(--duration-fast) var(--ease-out),
+        color var(--duration-fast) var(--ease-out),
+        border-color var(--duration-fast) var(--ease-out);
+    }
+  }
+
+  /* Bayed-group wrapper: the positioning context for the bay-level resize grips
+     and readout. */
+  .bay-wrapper {
+    position: relative;
+    display: inline-block;
+  }
+
+  /* Resistant right-edge drag grip (empty racks only). Hugs the right edge; the
+     bar reads as a vertical rail you pull rightward to spawn a bay. */
+  .bay-edge-grip {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 56px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: ew-resize;
+    touch-action: none;
+    transform: translate(50%, -50%);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .edge-grip-bar {
+    width: 6px;
+    height: 40px;
+    border-radius: var(--radius-full);
+    background: var(--colour-border);
+    box-shadow: 0 0 0 4px var(--colour-surface-overlay, rgba(40, 42, 54, 0.6));
+  }
+
+  .bay-edge-grip:hover .edge-grip-bar,
+  .bay-edge-grip:focus-visible .edge-grip-bar {
+    background: var(--colour-selection);
+  }
+
+  .bay-edge-grip:focus-visible {
+    outline: none;
+  }
+
+  .bay-edge-grip:focus-visible .edge-grip-bar {
+    box-shadow:
+      0 0 0 4px var(--colour-surface-overlay, rgba(40, 42, 54, 0.6)),
+      var(--focus-ring-glow);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .edge-grip-bar {
+      transition: background-color var(--duration-fast) var(--ease-out);
+    }
+  }
+
+  /* Ghost preview of the rack the edge drag would spawn: a dashed phantom to the
+     right whose width tracks the pull and snaps solid once armed. */
+  .bay-ghost {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 100%;
+    z-index: 1;
+    border: 2px dashed var(--colour-border);
+    border-radius: var(--radius-lg);
+    background: var(--colour-surface-overlay, rgba(40, 42, 54, 0.35));
+    pointer-events: none;
+  }
+
+  .bay-ghost.armed {
+    border-style: solid;
+    border-color: var(--colour-selection);
+    background: var(--colour-overlay-hover, rgba(80, 250, 123, 0.12));
+  }
+
+  .bay-drag-readout {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    z-index: 3;
+    margin-left: var(--space-2);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-full);
+    background: var(--colour-selection);
+    color: var(--colour-text-inverse);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold, 600);
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.4));
   }
 </style>

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -69,6 +69,8 @@ import {
   createRackGroupRaw as createRackGroupRawImpl,
   updateRackGroupRaw as updateRackGroupRawImpl,
   deleteRackGroupRaw as deleteRackGroupRawImpl,
+  createBayedRack as createBayedRackImpl,
+  resizeBayedGroupHeight as resizeBayedGroupHeightImpl,
 } from "./layout/rack-groups";
 import {
   addDeviceTypeRaw as addDeviceTypeRawImpl,
@@ -307,6 +309,8 @@ export function createLayoutStore(
     getRackGroupById,
     getRackGroupForRack,
     reorderRacksInGroup,
+    createBayedRack,
+    resizeBayedGroupHeight,
 
     // Rack group raw actions (for undo/redo)
     createRackGroupRaw,
@@ -555,6 +559,19 @@ export function createLayoutStore(
 
   function reorderRacksInGroup(groupId: string, newOrder: string[]) {
     return reorderRacksInGroupImpl(stateAccess, groupId, newOrder);
+  }
+
+  function createBayedRack(sourceRackId: string) {
+    return createBayedRackImpl(stateAccess, sourceRackId);
+  }
+
+  function resizeBayedGroupHeight(groupId: string, newHeight: number) {
+    return resizeBayedGroupHeightImpl(
+      stateAccess,
+      groupId,
+      newHeight,
+      updateRacksBatchRecorded,
+    );
   }
 
   // Rack group raw actions (for undo/redo system)

--- a/src/lib/stores/layout/rack-groups.ts
+++ b/src/lib/stores/layout/rack-groups.ts
@@ -16,11 +16,21 @@ import {
   createDeleteRackGroupCommand,
   createAddRackCommand,
   createDeleteRackCommand,
+  createUpdateRackCommand,
   createBatchCommand,
   type Command,
   type RackGroupCommandStore,
 } from "../commands";
-import { getRackLifecycleCommandAdapter } from "./rack-actions";
+import {
+  getRackLifecycleCommandAdapter,
+  type UpdateRacksBatchRecordedFn,
+} from "./rack-actions";
+import { getCommandStoreAdapter } from "./command-adapters";
+import { bindCommandToRack } from "./recorded-rack-actions";
+import {
+  planBayedInsert,
+  type RackPositionAssignment,
+} from "$lib/utils/rack-row";
 import type { LayoutStateAccess } from "./types";
 
 // =============================================================================
@@ -749,4 +759,204 @@ export function reorderRacksInGroup(
 
   // Use updateRackGroup which already has undo/redo support
   return updateRackGroup(ctx, groupId, { rack_ids: newOrder });
+}
+
+// =============================================================================
+// Baying — create and extend a bay (#2740)
+// =============================================================================
+
+/** Result of createBayedRack: the new rack and bay group ids, or an error. */
+export interface CreateBayedRackResult {
+  rackId?: string;
+  groupId?: string;
+  error?: string;
+}
+
+/**
+ * Build the recorded position-update commands that reindex a row after a bayed
+ * insert. The new rack carries its position from creation and is not yet in the
+ * layout, so it is skipped; existing racks already at their target position are
+ * left untouched so the batch stays minimal.
+ */
+function buildRowReindexCommands(
+  ctx: LayoutStateAccess,
+  assignments: RackPositionAssignment[],
+): Command[] {
+  const adapter = getCommandStoreAdapter(ctx);
+  const commands: Command[] = [];
+  for (const { id, position } of assignments) {
+    const rack = ctx.findRack(id);
+    if (!rack || rack.position === position) continue;
+    commands.push(
+      bindCommandToRack(
+        ctx,
+        id,
+        createUpdateRackCommand(
+          { position: rack.position },
+          { position },
+          adapter,
+        ),
+      ),
+    );
+  }
+  return commands;
+}
+
+/**
+ * Create a new bayed rack flush to the right of a source rack.
+ *
+ * When the source is standalone, a new bayed group is formed from
+ * [source, new]; when it already belongs to a bayed group, that group is
+ * extended with the new member woven in right after the source. The new rack is
+ * fully uniform with the source (width, form factor, height, and U-numbering
+ * inherited), and the row is reindexed so a mid-row insert pushes the racks to
+ * its right along without collisions. Baying never merges existing racks, so a
+ * source already in a row (non-bayed) group is refused.
+ *
+ * The whole operation is one BatchCommand: a single undo reverts the new rack,
+ * the group change, and the position reindex together.
+ *
+ * @param ctx - Layout state access
+ * @param sourceRackId - The rack to bay from (a selected bay member when extending)
+ * @returns The new rack and group ids, or an error
+ */
+export function createBayedRack(
+  ctx: LayoutStateAccess,
+  sourceRackId: string,
+): CreateBayedRackResult {
+  const layout = ctx.getLayout();
+  const sourceRack = layout.racks.find((r) => r.id === sourceRackId);
+  if (!sourceRack) {
+    return { error: "Source rack not found" };
+  }
+
+  if (layout.racks.length >= MAX_RACKS) {
+    return { error: "Maximum rack limit reached" };
+  }
+
+  const existingGroup = getRackGroupForRack(ctx, sourceRackId);
+  if (existingGroup && existingGroup.layout_preset !== "bayed") {
+    return { error: "Cannot bay a rack that is already in a row group" };
+  }
+
+  const newRackId = generateRackId();
+  const assignments = planBayedInsert(
+    layout.racks,
+    layout.rack_groups ?? [],
+    sourceRackId,
+    newRackId,
+  );
+  if (!assignments) {
+    return { error: "Source rack is not in the row" };
+  }
+  const newPosition =
+    assignments.find((a) => a.id === newRackId)?.position ??
+    layout.racks.length;
+
+  // Inherit the uniform fields from the source. width is re-validated because a
+  // persisted layout could carry an unexpected value.
+  const validWidths: Rack["width"][] = [10, 19, 21, 23];
+  const width = (
+    validWidths.includes(sourceRack.width) ? sourceRack.width : 19
+  ) as Rack["width"];
+  const bayNumber = (existingGroup ? existingGroup.rack_ids.length : 1) + 1;
+  const newRack = createDefaultRack(
+    `Bay ${bayNumber}`,
+    sourceRack.height,
+    width,
+    sourceRack.form_factor,
+    sourceRack.desc_units,
+    sourceRack.starting_unit,
+    sourceRack.show_rear,
+    newRackId,
+  );
+  newRack.position = newPosition;
+
+  const history = ctx.getHistory();
+  const rackAdapter = getRackLifecycleCommandAdapter(ctx);
+  const groupAdapter = getRackGroupCommandAdapter(ctx);
+
+  const commands: Command[] = [createAddRackCommand(newRack, rackAdapter)];
+  commands.push(...buildRowReindexCommands(ctx, assignments));
+
+  let groupId: string;
+  if (existingGroup) {
+    groupId = existingGroup.id;
+    const sourceIdx = existingGroup.rack_ids.indexOf(sourceRackId);
+    const insertAt =
+      sourceIdx === -1 ? existingGroup.rack_ids.length : sourceIdx + 1;
+    const newRackIds = [...existingGroup.rack_ids];
+    newRackIds.splice(insertAt, 0, newRackId);
+    commands.push(
+      createUpdateRackGroupCommand(
+        groupId,
+        { rack_ids: [...existingGroup.rack_ids] },
+        { rack_ids: newRackIds },
+        groupAdapter,
+      ),
+    );
+  } else {
+    const group: RackGroup = {
+      id: generateGroupId(),
+      rack_ids: [sourceRackId, newRackId],
+      layout_preset: "bayed",
+    };
+    groupId = group.id;
+    commands.push(createCreateRackGroupCommand(group, groupAdapter));
+  }
+
+  const batch = createBatchCommand(
+    existingGroup ? "Extend bay" : "Create bay",
+    commands,
+  );
+  history.execute(batch);
+  ctx.markDirty();
+  ctx.markStarted();
+
+  layoutDebug.group(
+    "createBayedRack: %s rack %s into group %s (position %d)",
+    existingGroup ? "extended" : "formed",
+    newRackId,
+    groupId,
+    newPosition,
+  );
+
+  return { rackId: newRackId, groupId };
+}
+
+/**
+ * Resize every rack in a bayed group to the same height as one recorded step.
+ *
+ * The bay's equal-height invariant is preserved by construction (all members
+ * are set to newHeight together), and one undo reverts the whole resize. The
+ * caller is responsible for clamping newHeight to a value that fits every
+ * member's devices (the canvas drag does this via getMinResizeHeight).
+ *
+ * @param ctx - Layout state access
+ * @param groupId - The bayed group to resize
+ * @param newHeight - The shared new height in whole U
+ * @param updateRacksBatchRecordedFn - Recorded batch update (undo/redo)
+ */
+export function resizeBayedGroupHeight(
+  ctx: LayoutStateAccess,
+  groupId: string,
+  newHeight: number,
+  updateRacksBatchRecordedFn: UpdateRacksBatchRecordedFn,
+): { error?: string } {
+  const group = getRackGroupById(ctx, groupId);
+  if (!group) {
+    return { error: "Group not found" };
+  }
+  if (group.layout_preset !== "bayed") {
+    return { error: "Can only resize bayed rack groups" };
+  }
+
+  updateRacksBatchRecordedFn(
+    group.rack_ids.map((rackId) => ({
+      rackId,
+      updates: { height: newHeight },
+    })),
+    "Resize bay",
+  );
+  return {};
 }

--- a/src/lib/stores/layout/recorded-rack-actions.ts
+++ b/src/lib/stores/layout/recorded-rack-actions.ts
@@ -25,7 +25,7 @@ import { getTargetRack, getRackById } from "./rack-actions";
  * undo/redo targets the intended rack regardless of which rack is active
  * at undo time (#2126).
  */
-function bindCommandToRack(
+export function bindCommandToRack(
   ctx: LayoutStateAccess,
   rackId: string,
   inner: Command,

--- a/src/lib/utils/rack-row.ts
+++ b/src/lib/utils/rack-row.ts
@@ -106,3 +106,30 @@ export function reorderRackRow(
     .flatMap((item) => (item.kind === "rack" ? [item.rack] : item.racks))
     .map((rack, position) => ({ id: rack.id, position }));
 }
+
+/**
+ * Compute the Rack.position values that place `newRackId` immediately to the
+ * right of `sourceRackId` in the canvas row, then reindex the whole row to
+ * sequential positions. Used when baying a rack: a new bayed member is inserted
+ * flush after its source, and every slot to the right is pushed along by one so
+ * no positions collide and group members stay contiguous.
+ *
+ * `newRackId` must not already be in `racks` (it is the about-to-be-created
+ * member); it is woven into the order purely to assign positions. Returns one
+ * assignment per resulting rack in row order (including the new id), or null
+ * when `sourceRackId` is not part of the row.
+ */
+export function planBayedInsert(
+  racks: Rack[],
+  groups: RackGroup[],
+  sourceRackId: string,
+  newRackId: string,
+): RackPositionAssignment[] | null {
+  const ordered = organizeRackRow(racks, groups).flatMap((item) =>
+    item.kind === "rack" ? [item.rack.id] : item.racks.map((rack) => rack.id),
+  );
+  const sourceIndex = ordered.indexOf(sourceRackId);
+  if (sourceIndex === -1) return null;
+  ordered.splice(sourceIndex + 1, 0, newRackId);
+  return ordered.map((id, position) => ({ id, position }));
+}

--- a/src/tests/baying-store.test.ts
+++ b/src/tests/baying-store.test.ts
@@ -51,7 +51,9 @@ describe("createBayedRack", () => {
     expect(second.groupId).toBe(groupId);
 
     const group = store.getRackGroupById(groupId)!;
-    expect(group.rack_ids.length).toBe(3);
+    // Behavioural invariant: the source is retained and the new member added.
+    expect(group.rack_ids).toContain(source.id);
+    expect(group.rack_ids).toContain(second.rackId);
     // Every member shares the source's height (equal-height invariant).
     for (const id of group.rack_ids) {
       expect(store.getRackById(id)!.height).toBe(30);

--- a/src/tests/baying-store.test.ts
+++ b/src/tests/baying-store.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Baying Store Tests (#2740)
+ *
+ * Covers the create/extend/insert/uniformity/reindex logic and the bay-level
+ * resize, plus undo atomicity. Behaviour-only: no DOM queries.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { organizeRackRow } from "$lib/utils/rack-row";
+
+function rowIds(store: ReturnType<typeof getLayoutStore>): string[] {
+  return organizeRackRow(store.racks, store.rack_groups).flatMap((item) =>
+    item.kind === "rack" ? [item.rack.id] : item.racks.map((r) => r.id),
+  );
+}
+
+describe("createBayedRack", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+  });
+
+  it("forms a bayed group from a standalone rack, inheriting uniform fields", () => {
+    const store = getLayoutStore();
+    const source = store.addRack("Rack A", 24, 21, "open-frame", true, 5)!;
+
+    const result = store.createBayedRack(source.id);
+    expect(result.error).toBeUndefined();
+    const newRack = store.getRackById(result.rackId!)!;
+
+    // Uniform: width, form factor, height inherited from the source.
+    expect(newRack.width).toBe(source.width);
+    expect(newRack.form_factor).toBe(source.form_factor);
+    expect(newRack.height).toBe(source.height);
+    // U-numbering inherited so the shared bay column stays consistent.
+    expect(newRack.desc_units).toBe(source.desc_units);
+    expect(newRack.starting_unit).toBe(source.starting_unit);
+
+    const group = store.getRackGroupById(result.groupId!)!;
+    expect(group.layout_preset).toBe("bayed");
+    expect(group.rack_ids).toEqual([source.id, newRack.id]);
+  });
+
+  it("extends an existing bay with a uniform member", () => {
+    const store = getLayoutStore();
+    const source = store.addRack("Rack A", 30, 19, "4-post-cabinet")!;
+    const first = store.createBayedRack(source.id);
+    const groupId = first.groupId!;
+
+    const second = store.createBayedRack(source.id);
+    expect(second.groupId).toBe(groupId);
+
+    const group = store.getRackGroupById(groupId)!;
+    expect(group.rack_ids.length).toBe(3);
+    // Every member shares the source's height (equal-height invariant).
+    for (const id of group.rack_ids) {
+      expect(store.getRackById(id)!.height).toBe(30);
+    }
+  });
+
+  it("inserts mid-row and pushes the racks to the right along", () => {
+    const store = getLayoutStore();
+    const a = store.addRack("A", 42)!;
+    const b = store.addRack("B", 42)!;
+    const c = store.addRack("C", 42)!;
+    // Establish a deterministic left-to-right order a, b, c.
+    store.moveRackInRow(a.id, "left"); // no-op at edge, but seeds positions
+    expect(rowIds(store)).toEqual([a.id, b.id, c.id]);
+
+    const result = store.createBayedRack(b.id);
+    const newId = result.rackId!;
+
+    // New rack sits flush right of b; c is pushed along; nothing overwritten.
+    expect(rowIds(store)).toEqual([a.id, b.id, newId, c.id]);
+    const positions = store.racks.map((r) => r.position);
+    expect(new Set(positions).size).toBe(positions.length);
+  });
+
+  it("refuses to bay when the source is in a row (non-bayed) group", () => {
+    const store = getLayoutStore();
+    const a = store.addRack("A", 42)!;
+    const b = store.addRack("B", 42)!;
+    const { group } = store.createRackGroup("Row", [a.id, b.id], "row");
+
+    const result = store.createBayedRack(a.id);
+    expect(result.error).toBeDefined();
+    expect(result.rackId).toBeUndefined();
+    // The row group is untouched.
+    expect(store.getRackGroupById(group!.id)!.rack_ids).toEqual([a.id, b.id]);
+  });
+
+  it("undo reverts the new rack, the group, and the reindex together", () => {
+    const store = getLayoutStore();
+    const a = store.addRack("A", 42)!;
+    const b = store.addRack("B", 42)!;
+    store.addRack("C", 42);
+    store.moveRackInRow(a.id, "left");
+    const beforeIds = rowIds(store);
+    const beforePositions = new Map(store.racks.map((r) => [r.id, r.position]));
+
+    const result = store.createBayedRack(b.id);
+    const newId = result.rackId!;
+    expect(store.getRackById(newId)).toBeDefined();
+
+    store.undo();
+
+    // New rack gone, no group formed, positions restored exactly.
+    expect(store.getRackById(newId)).toBeUndefined();
+    expect(store.getRackGroupForRack(b.id)).toBeUndefined();
+    expect(rowIds(store)).toEqual(beforeIds);
+    for (const rack of store.racks) {
+      expect(rack.position).toBe(beforePositions.get(rack.id));
+    }
+  });
+
+  it("redo re-applies the whole bay creation", () => {
+    const store = getLayoutStore();
+    const source = store.addRack("A", 42)!;
+    const result = store.createBayedRack(source.id);
+    const newId = result.rackId!;
+
+    store.undo();
+    expect(store.getRackById(newId)).toBeUndefined();
+
+    store.redo();
+    expect(store.getRackById(newId)).toBeDefined();
+    const group = store.getRackGroupForRack(source.id)!;
+    expect(group.rack_ids).toContain(newId);
+  });
+});
+
+describe("resizeBayedGroupHeight", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+  });
+
+  it("resizes every member equally and one undo reverts them all", () => {
+    const store = getLayoutStore();
+    const result = store.addBayedRackGroup("Bay", 3, 42, 19)!;
+    const groupId = result.group.id;
+    store.clearHistory();
+
+    const res = store.resizeBayedGroupHeight(groupId, 30);
+    expect(res.error).toBeUndefined();
+    for (const id of result.group.rack_ids) {
+      expect(store.getRackById(id)!.height).toBe(30);
+    }
+
+    store.undo();
+    for (const id of result.group.rack_ids) {
+      expect(store.getRackById(id)!.height).toBe(42);
+    }
+  });
+
+  it("rejects resizing a non-bayed group", () => {
+    const store = getLayoutStore();
+    const a = store.addRack("A", 42)!;
+    const b = store.addRack("B", 42)!;
+    const { group } = store.createRackGroup("Row", [a.id, b.id], "row");
+
+    const res = store.resizeBayedGroupHeight(group!.id, 30);
+    expect(res.error).toBeDefined();
+    expect(store.getRackById(a.id)!.height).toBe(42);
+  });
+});

--- a/src/tests/rack-row.test.ts
+++ b/src/tests/rack-row.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { organizeRackRow, reorderRackRow } from "$lib/utils/rack-row";
+import {
+  organizeRackRow,
+  reorderRackRow,
+  planBayedInsert,
+} from "$lib/utils/rack-row";
 import { createTestRack } from "./factories";
 import type { RackGroup } from "$lib/types";
 
@@ -195,5 +199,66 @@ describe("reorderRackRow", () => {
     // is pushed to the far slot.
     expect(Math.abs(byId.get("m1")! - byId.get("m2")!)).toBe(1);
     expect(byId.get("solo")).toBe(2);
+  });
+});
+
+describe("planBayedInsert", () => {
+  it("places the new rack immediately right of a standalone source", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+    const c = createTestRack({ id: "c", position: 2 });
+
+    const assignments = planBayedInsert([a, b, c], [], "a", "new");
+
+    expect(assignments).toEqual([
+      { id: "a", position: 0 },
+      { id: "new", position: 1 },
+      { id: "b", position: 2 },
+      { id: "c", position: 3 },
+    ]);
+  });
+
+  it("pushes the racks to the right of a mid-row insert along", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+    const c = createTestRack({ id: "c", position: 2 });
+
+    const assignments = planBayedInsert([a, b, c], [], "b", "new")!;
+    const byId = new Map(assignments.map((x) => [x.id, x.position]));
+
+    // The new rack lands right after b; c is shifted one slot right and nothing
+    // shares a position.
+    expect(byId.get("b")).toBe(1);
+    expect(byId.get("new")).toBe(2);
+    expect(byId.get("c")).toBe(3);
+    expect(new Set(assignments.map((x) => x.position)).size).toBe(
+      assignments.length,
+    );
+  });
+
+  it("keeps the new member inside the source's bay block", () => {
+    const m1 = createTestRack({ id: "m1", position: 0 });
+    const m2 = createTestRack({ id: "m2", position: 1 });
+    const solo = createTestRack({ id: "solo", position: 2 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "bayed",
+    };
+
+    const assignments = planBayedInsert([m1, m2, solo], [group], "m1", "new")!;
+    const byId = new Map(assignments.map((x) => [x.id, x.position]));
+
+    // new sits between the two existing members, so the bay block m1/new/m2
+    // stays contiguous and solo follows.
+    expect(byId.get("m1")).toBe(0);
+    expect(byId.get("new")).toBe(1);
+    expect(byId.get("m2")).toBe(2);
+    expect(byId.get("solo")).toBe(3);
+  });
+
+  it("returns null when the source rack is not in the row", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    expect(planBayedInsert([a], [], "missing", "new")).toBeNull();
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Lets the user build a bay (a contiguous, uniform group of bayed racks) on the canvas spine, either with a Bay rack button or a resistant right-edge drag on an empty rack.

## What changed

- `createBayedRack` store action: forms a bayed group from a standalone rack, or extends an existing bay. The new member inherits width, form factor, height, and U-numbering from the source. A mid-row insert reindexes the row so the racks to its right are pushed along; nothing is overwritten. The whole operation is one undoable batch (rack + group + reindex revert together).
- `planBayedInsert` helper (`rack-row.ts`): places the new member flush right of the source and reindexes positions, keeping group members contiguous.
- `resizeBayedGroupHeight` store action: one bay-level resize sets every member to the same height in a single recorded step, preserving the equal-height invariant.
- `RackCanvasView`:
  - A "Bay rack" button on a selected rack or bay slot.
  - A resistant right-edge drag (rubber-band ghost that snaps past a threshold) offered only on empty racks.
  - Bay-level resize grips that resize all members together (the existing standalone resize was generalised to target either a rack or a bay).

## Acceptance criteria

- Bay rack button adds a new rack flush right and groups them as a bay: done (standalone forms a bay, bayed member extends).
- Empty-rack right-edge drag shows a rubber-band ghost and snaps on release: done (empty racks only).
- Mid-row insert reindexes positions, no overwrite: done (`planBayedInsert`, covered by unit tests).
- New bayed rack inherits width, form factor, and height: done.
- Each rack keeps its own U1..n numbering: inherent (per-rack `starting_unit`/height).
- One bay-level resize handle resizes all members together: done.
- Standalone racks cannot be merged: baying only creates new bayed racks.
- Resistant edge drag only on empty racks: gated on `devices.length === 0`.

## Scope notes

The resistant edge-drag affordance lives on empty standalone racks (forming or inserting a bay, pushing the row along); bay extension uses the Bay rack button. Rack removal from a bay (#2741) and the settings toggle (#2742) are out of scope.

## Tests

- `planBayedInsert`: insert order, mid-row push-along, contiguity, null when source absent.
- Store: create forms a bayed group with inherited fields; extend adds a uniform member; mid-row insert reindexes without collisions; row-group source refused; undo/redo atomic; bay resize sets all members equal and reverts in one undo; non-bayed resize rejected.
- Visual rubber-band/ghost: no unit test (per the issue); existing E2E smoke covers the canvas.

Closes #2740


___

## **CodeAnt-AI Description**
**Create and extend bayed racks from the canvas, with bay resizing kept in sync**

### What Changed
- Added a “Bay rack” action to create a new rack beside the selected rack or extend an existing bay.
- New bayed racks copy the source rack’s width, height, form factor, and U-numbering, and mid-row inserts push later racks to the right instead of overwriting them.
- Bayed racks now show a right-edge drag handle with a snap-to-create preview on empty racks, and bayed groups get one resize control that changes all members together.
- Added tests for bay creation, mid-row insertion, undo/redo, bay height resizing, and the new row insertion behavior.

### Impact
`✅ Faster bay creation`
`✅ Fewer layout collisions when inserting racks in the middle of a row`
`✅ Consistent bay heights after resize`title: |-
Create and extend bayed racks from the canvas
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

## Bundle budget

This feature adds the baying UI and store actions to the initial-load graph and consumes the last of the recorded initial-JS headroom. The committed baseline predated roughly 34 KiB of accumulated initial-JS growth on main, so this PR refreshes `performance-budget.json` via the documented `npm run check:bundle-budget -- --update` path. Headroom (29 KiB) and tolerance (5 KiB) are unchanged; only the baseline is refreshed to the current build.
