### PR TITLE
fix: bay exposes a single top-edge resize handle (follow-up to #2740)

### DIFF
--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -805,8 +805,12 @@
             onbaydragcancel={handleBayDragCancel}
           />
           {#if isBaySelected}
+            <!-- One bay-level handle (AC6). It lives on the top edge: the bay is
+                 bottom-anchored in the row, so a top grip grows upward to match
+                 the drag with no preview transform. A bottom grip cannot: the
+                 stacked front+rear rows grow the wrapper by twice the height
+                 delta, so no single translateY tracks the pointer. -->
             {@render resizeGrip(bayTarget, "top")}
-            {@render resizeGrip(bayTarget, "bottom")}
             {#if resizeDrag?.target.kind === "bay" && resizeDrag.target.groupId === item.group.id}
               <div
                 class="resize-readout resize-readout-{resizeDrag.grip}"


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #2740 (merged as c78b3367). The bay-level resize affordance shipped with two grips (top and bottom). The bottom grip is broken and AC6 calls for one handle, so this removes it.

## Why

A bay is bottom-anchored in the canvas row, and its stacked front+rear rows grow the wrapper by twice the height delta. There is no single `translateY` that makes a bottom-edge grip track the pointer the way a standalone rack's single frame does, so a bottom-grip resize previewed in the opposite direction to the drag (caught by CodeAnt on #2740).

A top grip on a bottom-anchored bay grows upward to match an upward drag with no preview transform, and dragging it down (or ArrowDown) shrinks from the top. Grow and shrink both stay consistent, and this matches AC6: "A bay exposes one bay-level resize handle that resizes the height of all racks in the bay together."

## Change

One line in `src/lib/components/RackCanvasView.svelte`: drop the bottom bay grip render, keep the single top-edge handle plus an explanatory comment. Standalone rack resize (two grips with the bottom-grip transform) is unchanged.

Related: #2740


___

## **CodeAnt-AI Description**
**Show only one resize handle for bays**

### What Changed
- Bays now show a single resize handle on the top edge instead of two handles.
- The removed bottom handle no longer appears, so bay resizing follows the drag direction consistently.

### Impact
`✅ Clearer bay resizing`
`✅ Fewer confusing resize previews`
`✅ More predictable drag and keyboard resize behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
