### PR TITLE
feat: remove a rack from a bay and close the row (#2741)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -268,7 +268,11 @@
       if (group?.layout_preset === "bayed") {
         const { error } = layoutStore.removeRackFromBay(rackId);
         if (error) {
-          layoutDebug.group("removeRackFromBay failed for %s: %s", rackId, error);
+          layoutDebug.group(
+            "removeRackFromBay failed for %s: %s",
+            rackId,
+            error,
+          );
         } else {
           selectionStore.clearSelection();
         }

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -56,7 +56,7 @@
   import { parseDeviceLibraryImport } from "$lib/utils/import";
   import { registerImportDevicesTrigger } from "$lib/actions/import-devices-trigger";
   import { hapticTap } from "$lib/utils/haptics";
-  import { appDebug, dialogDebug } from "$lib/utils/debug";
+  import { appDebug, dialogDebug, layoutDebug } from "$lib/utils/debug";
   import type { ImageData } from "$lib/types/images";
   import type { DisplayMode, Layout, RackWidth } from "$lib/types";
   import type { ImportResult } from "$lib/utils/netbox-import";
@@ -266,11 +266,16 @@
       // standalone rack deletes plainly (#2741).
       const group = layoutStore.getRackGroupForRack(rackId);
       if (group?.layout_preset === "bayed") {
-        layoutStore.removeRackFromBay(rackId);
+        const { error } = layoutStore.removeRackFromBay(rackId);
+        if (error) {
+          layoutDebug.group("removeRackFromBay failed for %s: %s", rackId, error);
+        } else {
+          selectionStore.clearSelection();
+        }
       } else {
         layoutStore.deleteRack(rackId);
+        selectionStore.clearSelection();
       }
-      selectionStore.clearSelection();
     } else if (deleteTarget?.type === "device") {
       const rackId = selectionStore.selectedRackId;
       const rack = rackId ? layoutStore.getRackById(rackId) : null;

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -261,7 +261,15 @@
 
   function handleConfirmDelete() {
     if (deleteTarget?.type === "rack" && selectionStore.selectedRackId) {
-      layoutStore.deleteRack(selectionStore.selectedRackId);
+      const rackId = selectionStore.selectedRackId;
+      // A bay member removal closes the row and dissolves a 1-member bay; a
+      // standalone rack deletes plainly (#2741).
+      const group = layoutStore.getRackGroupForRack(rackId);
+      if (group?.layout_preset === "bayed") {
+        layoutStore.removeRackFromBay(rackId);
+      } else {
+        layoutStore.deleteRack(rackId);
+      }
       selectionStore.clearSelection();
     } else if (deleteTarget?.type === "device") {
       const rackId = selectionStore.selectedRackId;

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -71,6 +71,7 @@ import {
   deleteRackGroupRaw as deleteRackGroupRawImpl,
   createBayedRack as createBayedRackImpl,
   resizeBayedGroupHeight as resizeBayedGroupHeightImpl,
+  removeRackFromBay as removeRackFromBayImpl,
 } from "./layout/rack-groups";
 import {
   addDeviceTypeRaw as addDeviceTypeRawImpl,
@@ -310,6 +311,7 @@ export function createLayoutStore(
     getRackGroupForRack,
     reorderRacksInGroup,
     createBayedRack,
+    removeRackFromBay,
     resizeBayedGroupHeight,
 
     // Rack group raw actions (for undo/redo)
@@ -563,6 +565,10 @@ export function createLayoutStore(
 
   function createBayedRack(sourceRackId: string) {
     return createBayedRackImpl(stateAccess, sourceRackId);
+  }
+
+  function removeRackFromBay(rackId: string) {
+    return removeRackFromBayImpl(stateAccess, rackId);
   }
 
   function resizeBayedGroupHeight(groupId: string, newHeight: number) {

--- a/src/lib/stores/layout/rack-groups.ts
+++ b/src/lib/stores/layout/rack-groups.ts
@@ -29,6 +29,7 @@ import { getCommandStoreAdapter } from "./command-adapters";
 import { bindCommandToRack } from "./recorded-rack-actions";
 import {
   planBayedInsert,
+  planRowAfterRemoval,
   type RackPositionAssignment,
 } from "$lib/utils/rack-row";
 import type { LayoutStateAccess } from "./types";
@@ -958,5 +959,89 @@ export function resizeBayedGroupHeight(
     })),
     "Resize bay",
   );
+  return {};
+}
+
+/**
+ * Remove a rack from its bayed group and close the row.
+ *
+ * The rack is deleted and its id dropped from the group. When that leaves the
+ * group with fewer than two members, the group is dissolved so the lone
+ * remaining rack becomes standalone: a one-member bay is never left behind. The
+ * remaining racks reindex so the row closes the gap. The whole operation is one
+ * BatchCommand, so a single undo restores the rack, its group membership, and
+ * the row positions together.
+ *
+ * Confirmation when the rack holds gear is the caller's concern; this action
+ * deletes unconditionally.
+ *
+ * @param ctx - Layout state access
+ * @param rackId - The bay member to remove
+ * @returns Error when the rack is missing or not in a bayed group
+ */
+export function removeRackFromBay(
+  ctx: LayoutStateAccess,
+  rackId: string,
+): { error?: string } {
+  const layout = ctx.getLayout();
+  const rack = layout.racks.find((r) => r.id === rackId);
+  if (!rack) {
+    return { error: "Rack not found" };
+  }
+
+  const group = getRackGroupForRack(ctx, rackId);
+  if (!group || group.layout_preset !== "bayed") {
+    return { error: "Rack is not in a bayed group" };
+  }
+
+  const remainingIds = group.rack_ids.filter((id) => id !== rackId);
+
+  const history = ctx.getHistory();
+  const rackAdapter = getRackLifecycleCommandAdapter(ctx);
+  const groupAdapter = getRackGroupCommandAdapter(ctx);
+
+  const commands: Command[] = [];
+
+  // 1. Update or dissolve the group first. Dissolve when fewer than two members
+  //    remain so the lone survivor becomes standalone instead of a 1-member bay.
+  if (remainingIds.length >= 2) {
+    commands.push(
+      createUpdateRackGroupCommand(
+        group.id,
+        { rack_ids: [...group.rack_ids] },
+        { rack_ids: remainingIds },
+        groupAdapter,
+      ),
+    );
+  } else {
+    commands.push(createDeleteRackGroupCommand(group, groupAdapter));
+  }
+
+  // 2. Reindex the remaining racks so the row closes the gap.
+  const assignments = planRowAfterRemoval(
+    layout.racks,
+    layout.rack_groups ?? [],
+    rackId,
+  );
+  if (assignments) {
+    commands.push(...buildRowReindexCommands(ctx, assignments));
+  }
+
+  // 3. Delete the rack itself. Group membership is already handled above, so no
+  //    affected groups are passed: undo restores the rack alone and the group
+  //    command restores its membership.
+  commands.push(createDeleteRackCommand(rack, [], rackAdapter));
+
+  const batch = createBatchCommand("Remove rack from bay", commands);
+  history.execute(batch);
+  ctx.markDirty();
+
+  layoutDebug.group(
+    "removeRackFromBay: removed rack %s from group %s (%d members remain)",
+    rackId,
+    group.id,
+    remainingIds.length,
+  );
+
   return {};
 }

--- a/src/lib/utils/rack-actions.ts
+++ b/src/lib/utils/rack-actions.ts
@@ -11,6 +11,7 @@ import { getToastStore } from "$lib/stores/toast.svelte";
 import { dialogStore } from "$lib/stores/dialogs.svelte";
 import { DRAWER_WIDTH } from "$lib/constants/layout";
 import { handleFitAll, prepareExportQrCode } from "./app-actions";
+import { layoutDebug } from "$lib/utils/debug";
 
 /** Duplicate a rack, then fit all on success or toast the error. */
 export function handleRackContextDuplicate(rackId: string): void {
@@ -39,8 +40,12 @@ export function handleRackContextDelete(rackId: string): void {
 
   const group = layoutStore.getRackGroupForRack(rackId);
   if (group?.layout_preset === "bayed" && rack.devices.length === 0) {
-    layoutStore.removeRackFromBay(rackId);
-    selectionStore.clearSelection();
+    const { error } = layoutStore.removeRackFromBay(rackId);
+    if (error) {
+      layoutDebug.group("removeRackFromBay failed for %s: %s", rackId, error);
+    } else {
+      selectionStore.clearSelection();
+    }
     return;
   }
 

--- a/src/lib/utils/rack-actions.ts
+++ b/src/lib/utils/rack-actions.ts
@@ -25,17 +25,29 @@ export function handleRackContextDuplicate(rackId: string): void {
   }
 }
 
-/** Select a rack and open the confirm-delete dialog targeting it. */
+/**
+ * Remove a rack via the context menu. A bay member is removed from its bay and
+ * the row closes the gap; the confirm dialog only gates a member that holds
+ * gear, so an empty member is removed immediately (#2741). A standalone rack
+ * always opens the confirm dialog.
+ */
 export function handleRackContextDelete(rackId: string): void {
   const layoutStore = getLayoutStore();
   const selectionStore = getSelectionStore();
   const rack = layoutStore.getRackById(rackId);
-  if (rack) {
-    layoutStore.setActiveRack(rackId);
-    selectionStore.selectRack(rackId);
-    dialogStore.deleteTarget = { type: "rack", name: rack.name };
-    dialogStore.open("confirmDelete");
+  if (!rack) return;
+
+  const group = layoutStore.getRackGroupForRack(rackId);
+  if (group?.layout_preset === "bayed" && rack.devices.length === 0) {
+    layoutStore.removeRackFromBay(rackId);
+    selectionStore.clearSelection();
+    return;
   }
+
+  layoutStore.setActiveRack(rackId);
+  selectionStore.selectRack(rackId);
+  dialogStore.deleteTarget = { type: "rack", name: rack.name };
+  dialogStore.open("confirmDelete");
 }
 
 /** Open the export dialog for the given racks; warns if none are selected. */

--- a/src/lib/utils/rack-row.ts
+++ b/src/lib/utils/rack-row.ts
@@ -133,3 +133,34 @@ export function planBayedInsert(
   ordered.splice(sourceIndex + 1, 0, newRackId);
   return ordered.map((id, position) => ({ id, position }));
 }
+
+/**
+ * Compute the Rack.position values that close the canvas row after
+ * `removedRackId` is taken out of it. The removed rack is dropped from the row
+ * and from any group, and the remaining racks are reindexed to sequential
+ * positions so no empty slot is left where the rack was. A group that loses its
+ * only resolvable member contributes nothing, so its lone survivor (if any)
+ * simply reindexes as a standalone slot.
+ *
+ * Returns one assignment per remaining rack in row order, or null when
+ * `removedRackId` is not in `racks`.
+ */
+export function planRowAfterRemoval(
+  racks: Rack[],
+  groups: RackGroup[],
+  removedRackId: string,
+): RackPositionAssignment[] | null {
+  if (!racks.some((rack) => rack.id === removedRackId)) return null;
+
+  const remainingRacks = racks.filter((rack) => rack.id !== removedRackId);
+  const remainingGroups = groups.map((group) => ({
+    ...group,
+    rack_ids: group.rack_ids.filter((id) => id !== removedRackId),
+  }));
+
+  return organizeRackRow(remainingRacks, remainingGroups)
+    .flatMap((item) =>
+      item.kind === "rack" ? [item.rack.id] : item.racks.map((r) => r.id),
+    )
+    .map((id, position) => ({ id, position }));
+}

--- a/src/tests/rack-row.test.ts
+++ b/src/tests/rack-row.test.ts
@@ -3,6 +3,7 @@ import {
   organizeRackRow,
   reorderRackRow,
   planBayedInsert,
+  planRowAfterRemoval,
 } from "$lib/utils/rack-row";
 import { createTestRack } from "./factories";
 import type { RackGroup } from "$lib/types";
@@ -260,5 +261,65 @@ describe("planBayedInsert", () => {
   it("returns null when the source rack is not in the row", () => {
     const a = createTestRack({ id: "a", position: 0 });
     expect(planBayedInsert([a], [], "missing", "new")).toBeNull();
+  });
+});
+
+describe("planRowAfterRemoval", () => {
+  it("drops the removed rack and reindexes the remaining row contiguously", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+    const c = createTestRack({ id: "c", position: 2 });
+
+    const assignments = planRowAfterRemoval([a, b, c], [], "b");
+
+    expect(assignments).toEqual([
+      { id: "a", position: 0 },
+      { id: "c", position: 1 },
+    ]);
+  });
+
+  it("reindexes a bay member removal so the survivors stay contiguous", () => {
+    const m1 = createTestRack({ id: "m1", position: 0 });
+    const m2 = createTestRack({ id: "m2", position: 1 });
+    const m3 = createTestRack({ id: "m3", position: 2 });
+    const solo = createTestRack({ id: "solo", position: 3 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2", "m3"],
+      layout_preset: "bayed",
+    };
+
+    const assignments = planRowAfterRemoval([m1, m2, m3, solo], [group], "m1")!;
+
+    expect(assignments).toEqual([
+      { id: "m2", position: 0 },
+      { id: "m3", position: 1 },
+      { id: "solo", position: 2 },
+    ]);
+  });
+
+  it("treats a group's lone survivor as a standalone slot", () => {
+    const m1 = createTestRack({ id: "m1", position: 0 });
+    const m2 = createTestRack({ id: "m2", position: 1 });
+    const solo = createTestRack({ id: "solo", position: 2 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "bayed",
+    };
+
+    // Removing m1 leaves the group with a single member; the survivor m2
+    // reindexes ahead of solo exactly as if it were standalone.
+    const assignments = planRowAfterRemoval([m1, m2, solo], [group], "m1")!;
+
+    expect(assignments).toEqual([
+      { id: "m2", position: 0 },
+      { id: "solo", position: 1 },
+    ]);
+  });
+
+  it("returns null when the removed rack is not in the row", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    expect(planRowAfterRemoval([a], [], "missing")).toBeNull();
   });
 });

--- a/src/tests/remove-rack-from-bay-store.test.ts
+++ b/src/tests/remove-rack-from-bay-store.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Remove-rack-from-bay Tests (#2741)
+ *
+ * Covers removing a rack from a bayed group: the rack is deleted, dropped from
+ * the group, the row closes the gap (positions reindex), a bay that drops to a
+ * single member dissolves to a standalone rack, and the whole step undoes as
+ * one. Also covers the confirm-gating seam in handleRackContextDelete, where an
+ * empty member removes immediately and a member holding gear confirms first.
+ * Behaviour-only: no DOM queries.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { resetSelectionStore } from "$lib/stores/selection.svelte";
+import { dialogStore } from "$lib/stores/dialogs.svelte";
+import { handleRackContextDelete } from "$lib/utils/rack-actions";
+import { organizeRackRow } from "$lib/utils/rack-row";
+import { createTestDeviceType } from "./factories";
+
+function rowIds(store: ReturnType<typeof getLayoutStore>): string[] {
+  return organizeRackRow(store.racks, store.rack_groups).flatMap((item) =>
+    item.kind === "rack" ? [item.rack.id] : item.racks.map((r) => r.id),
+  );
+}
+
+function sortedPositions(store: ReturnType<typeof getLayoutStore>): number[] {
+  return store.racks.map((r) => r.position).sort((a, b) => a - b);
+}
+
+describe("removeRackFromBay", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+  });
+
+  it("deletes the member, drops it from the group, and closes the row", () => {
+    const store = getLayoutStore();
+    const { group } = store.addBayedRackGroup("Bay", 3, 42, 19)!;
+    const [b1, b2, b3] = group.rack_ids;
+    store.clearHistory();
+
+    const res = store.removeRackFromBay(b2!);
+    expect(res.error).toBeUndefined();
+
+    expect(store.getRackById(b2!)).toBeUndefined();
+    expect(store.getRackGroupById(group.id)!.rack_ids).toEqual([b1, b3]);
+    expect(rowIds(store)).toEqual([b1, b3]);
+    expect(sortedPositions(store)).toEqual([0, 1]);
+  });
+
+  it("dissolves the bay to a standalone rack when one member remains", () => {
+    const store = getLayoutStore();
+    const { group } = store.addBayedRackGroup("Bay", 2, 42, 19)!;
+    const [b1, b2] = group.rack_ids;
+    store.clearHistory();
+
+    store.removeRackFromBay(b2!);
+
+    expect(store.getRackById(b2!)).toBeUndefined();
+    // The group is dissolved entirely: never a one-member bay.
+    expect(store.getRackGroupById(group.id)).toBeUndefined();
+    expect(store.getRackGroupForRack(b1!)).toBeUndefined();
+    // The lone survivor stays as a standalone rack in the row.
+    expect(store.getRackById(b1!)).toBeDefined();
+    expect(rowIds(store)).toEqual([b1]);
+  });
+
+  it("reindexes so there is no gap when a mid-row member is removed", () => {
+    const store = getLayoutStore();
+    const { group } = store.addBayedRackGroup("Bay", 3, 42, 19)!;
+    const [b1, b2, b3] = group.rack_ids;
+    const d = store.addRack("D", 42)!;
+    store.clearHistory();
+
+    store.removeRackFromBay(b1!);
+
+    // Survivors reindex to a contiguous 0..n-1 with no empty slot.
+    expect(sortedPositions(store)).toEqual([0, 1, 2]);
+    expect(new Set(store.racks.map((r) => r.position)).size).toBe(
+      store.racks.length,
+    );
+    expect(rowIds(store)).toEqual([b2, b3, d.id]);
+  });
+
+  it("removes a member that holds gear (the store deletes unconditionally)", () => {
+    const store = getLayoutStore();
+    const { group } = store.addBayedRackGroup("Bay", 3, 42, 19)!;
+    const [, b2] = group.rack_ids;
+    const dt = createTestDeviceType({ slug: "srv", u_height: 1 });
+    store.addDeviceTypeRaw(dt);
+    store.placeDevice(b2!, dt.slug, 5);
+    expect(store.getRackById(b2!)!.devices.length).toBeGreaterThan(0);
+    store.clearHistory();
+
+    const res = store.removeRackFromBay(b2!);
+    expect(res.error).toBeUndefined();
+    expect(store.getRackById(b2!)).toBeUndefined();
+  });
+
+  it("errors and leaves the rack untouched when it is standalone", () => {
+    const store = getLayoutStore();
+    const a = store.addRack("A", 42)!;
+
+    const res = store.removeRackFromBay(a.id);
+
+    expect(res.error).toBeDefined();
+    expect(store.getRackById(a.id)).toBeDefined();
+  });
+
+  it("errors when the rack is in a row (non-bayed) group", () => {
+    const store = getLayoutStore();
+    const a = store.addRack("A", 42)!;
+    const b = store.addRack("B", 42)!;
+    const { group } = store.createRackGroup("Row", [a.id, b.id], "row");
+
+    const res = store.removeRackFromBay(a.id);
+
+    expect(res.error).toBeDefined();
+    expect(store.getRackById(a.id)).toBeDefined();
+    expect(store.getRackGroupById(group!.id)!.rack_ids).toEqual([a.id, b.id]);
+  });
+
+  it("undo restores the rack, its group membership, and the row positions", () => {
+    const store = getLayoutStore();
+    const { group } = store.addBayedRackGroup("Bay", 3, 42, 19)!;
+    const [b1, b2, b3] = group.rack_ids;
+    store.addRack("D", 42);
+    store.clearHistory();
+
+    const beforeIds = rowIds(store);
+    const beforePositions = new Map(store.racks.map((r) => [r.id, r.position]));
+
+    store.removeRackFromBay(b2!);
+    expect(store.getRackById(b2!)).toBeUndefined();
+
+    store.undo();
+
+    expect(store.getRackById(b2!)).toBeDefined();
+    expect(store.getRackGroupById(group.id)!.rack_ids).toEqual([b1, b2, b3]);
+    expect(rowIds(store)).toEqual(beforeIds);
+    for (const rack of store.racks) {
+      expect(rack.position).toBe(beforePositions.get(rack.id));
+    }
+  });
+
+  it("undo restores a dissolved bay with both members", () => {
+    const store = getLayoutStore();
+    const { group } = store.addBayedRackGroup("Bay", 2, 42, 19)!;
+    const [b1, b2] = group.rack_ids;
+    store.clearHistory();
+
+    store.removeRackFromBay(b2!);
+    expect(store.getRackGroupById(group.id)).toBeUndefined();
+
+    store.undo();
+
+    const restored = store.getRackGroupById(group.id);
+    expect(restored).toBeDefined();
+    expect(restored!.rack_ids).toEqual([b1, b2]);
+    expect(restored!.layout_preset).toBe("bayed");
+    expect(store.getRackById(b2!)).toBeDefined();
+  });
+});
+
+describe("handleRackContextDelete bay-member gating", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    dialogStore.close();
+    dialogStore.closeSheet();
+  });
+
+  it("removes an empty bay member immediately without a confirm dialog", () => {
+    const store = getLayoutStore();
+    const { group } = store.addBayedRackGroup("Bay", 3, 42, 19)!;
+    const [, b2] = group.rack_ids;
+
+    handleRackContextDelete(b2!);
+
+    expect(dialogStore.isOpen("confirmDelete")).toBe(false);
+    expect(store.getRackById(b2!)).toBeUndefined();
+  });
+
+  it("confirms before removing a bay member that holds gear", () => {
+    const store = getLayoutStore();
+    const { group } = store.addBayedRackGroup("Bay", 3, 42, 19)!;
+    const [, b2] = group.rack_ids;
+    const dt = createTestDeviceType({ slug: "srv", u_height: 1 });
+    store.addDeviceTypeRaw(dt);
+    store.placeDevice(b2!, dt.slug, 5);
+
+    handleRackContextDelete(b2!);
+
+    // The dialog gates the deletion: the rack is still present until confirmed.
+    expect(dialogStore.isOpen("confirmDelete")).toBe(true);
+    expect(store.getRackById(b2!)).toBeDefined();
+  });
+
+  it("always confirms before deleting a standalone rack", () => {
+    const store = getLayoutStore();
+    const a = store.addRack("A", 42)!;
+
+    handleRackContextDelete(a.id);
+
+    expect(dialogStore.isOpen("confirmDelete")).toBe(true);
+    expect(store.getRackById(a.id)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Lets the user remove a rack from a bay. The row closes the gap, a one-member bay dissolves to a standalone rack, and a member that holds gear confirms before deletion.

Part of epic #2744 (M014 Canvas UX Overhaul, stage-1 new-rack editor).

## What changed

- New `removeRackFromBay` store action: deletes the member, drops its id from the bayed group, dissolves the group to a standalone rack when fewer than two members remain, and reindexes the row so no empty slot is left. The whole thing is one recorded BatchCommand, so a single undo restores the rack, its group membership, and the row positions together.
- New `planRowAfterRemoval` row helper that computes the reindexed positions for the survivors.
- The bayed-member context-menu delete now routes through it: an empty member is removed immediately, a member holding gear confirms first via the existing confirm dialog. Standalone rack deletion is unchanged.

## Acceptance criteria

- Removing a rack from a bay deletes the rack and removes its id from the bay group: yes
- The row closes the gap, remaining racks reindex with no empty slot: yes
- A bay dropping to a single rack dissolves so that rack becomes standalone: yes
- A rack holding one or more devices requires confirmation before deletion: yes
- Removing an empty rack from a bay requires no confirmation: yes

## Tests

- Unit: removal deletes the rack, updates `rack_ids`, reindexes positions, dissolves a 1-member group, and undoes as one step.
- Unit: the confirm gate opens for a member holding gear and is skipped for an empty member; standalone deletion still confirms.
- Pure-function coverage for `planRowAfterRemoval` (contiguity, lone-survivor reindex, not-in-row null).

Local gates green: lint, svelte-check (0 errors), build, full unit suite (3136 tests).

Closes #2741

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove a rack from a bay and close the row**

### What Changed
- Removing a rack from a bay now deletes that rack, removes it from the bay, and closes the gap so the remaining racks shift into place.
- If a bay is reduced to one rack, the bay is removed and the last rack becomes standalone instead of leaving a one-rack bay behind.
- Empty bay members delete immediately from the context menu; racks with gear still ask for confirmation first. Standalone rack deletion still uses confirmation.
- Undo restores the removed rack, its bay membership, and the original rack positions in one step.

### Impact
`✅ No empty gaps after rack removal`
`✅ Fewer clicks for deleting empty bay members`
`✅ Clearer delete confirmation for racks with gear`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
