### PR TITLE
fix: smoke E2E "can delete device from rack" deterministically fails on main after #2757 inspector redesign (#2799)

### DIFF
--- a/e2e/helpers/device-actions.ts
+++ b/e2e/helpers/device-actions.ts
@@ -204,8 +204,15 @@ export async function deleteSelectedDevice(page: Page): Promise<void> {
     expect(countAfterDelete).toBeLessThan(countBeforeDelete);
   }).toPass({ timeout: 5000 });
 
-  // Removing the device clears the selection; the Edit tab returns to empty.
-  await expect(page.locator(locators.sidePanel.editEmpty)).toBeVisible();
+  // Removing the device clears the selection, but the rack it was in stays
+  // the active rack, so the inspector falls back to rack mode rather than
+  // the empty state (#2739, #2757). Unlike deselectDevice(), this never
+  // presses Escape, which is the only path that also clears the active rack.
+  // Assert the Edit tab is still showing content (not just that the
+  // empty-state testid is absent), matching the pairing selectDevice() uses
+  // above so this can't pass vacuously off an unmounted tabpanel.
+  await expect(page.locator(locators.sidePanel.editPanel)).toBeVisible();
+  await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
 }
 
 /**


### PR DESCRIPTION
## **User description**
## Summary

- `#2757` (inspector switches between rack mode and device mode) made the side panel fall back to rack mode whenever an active rack exists, rather than the empty-state prompt, once a selection clears.
- Deleting a device only clears the *selection*, not the *active rack* (unlike Escape, which clears both via `handleEscape` in `src/lib/actions/dispatch.ts`), so after a delete the inspector now shows rack mode rather than the empty state.
- The merge-blocking smoke E2E's `deleteSelectedDevice` helper (`e2e/helpers/device-actions.ts`) still asserted the old empty-state post-condition, failing deterministically (100%, not flaky) on clean `main` and red-gating the required `validate` check on every open PR.

## Fix

Updated `deleteSelectedDevice` to assert the Edit tab still shows content (`editPanel` visible, `editEmpty` not visible) instead of asserting the empty state appears, matching the existing dual-assertion pairing `selectDevice()` already uses a few lines above in the same file (so the check can't pass vacuously off an unmounted tabpanel).

Confirmed the rack-mode-after-delete behaviour is the intentional `#2739`/`#2757` design (documented in the `rackModeRack` comment in `SidePanelContent.svelte`), so the fix is in the test helper, not the component.

Also confirmed no other `editEmpty` assertions in the suite share this bug: all the ones expecting the empty state to appear go through `deselectDevice()` (Escape-based), which does clear the active rack via `handleEscape`.

## Test Plan

- [x] `npm run lint` clean
- [x] `npm run test:e2e:smoke` green locally (`can delete device from rack` passes)
- [x] Verified the fix is correct by reverting it locally and confirming the original assertion still fails for the documented reason
- [x] Grepped all `locators.sidePanel.editEmpty` usages in `e2e/` and confirmed every other assertion is consistent with current behaviour

Closes #2799


___

## **CodeAnt-AI Description**
**Keep the device inspector in rack mode after removing a device**

### What Changed
- After removing a device from a rack, the smoke test now expects the inspector to stay on the Edit tab with content visible instead of switching to the empty state.
- The check now matches the app’s current behavior: deleting a device clears the selection, but keeps the rack active.
- The test also confirms the Edit panel is still mounted, so the check cannot pass just because the panel disappeared.

### Impact
`✅ Fewer failing smoke tests`
`✅ Stable PR validation after device removal`
`✅ Clearer inspector behavior checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
