### PR TITLE
fix: keep command palette list scrollable and footer visible on first open (#2807)

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -612,6 +612,21 @@
     transform: translateY(0);
   }
 
+  /* Command.Root: bits-ui renders this element and the class is forwarded via
+     the `class` prop, so it must be wrapped in :global() like the other
+     forwarded classes. Without a rule it defaults to display:block and grows to
+     content height, breaking the flex-column scroll chain: the palette (capped,
+     overflow:hidden) then clips the tall browse list and pushes the footer out
+     of view. Making it a filling flex column keeps .command-list as the single
+     bounded scroll region and pins .command-footer below it. */
+  :global(.command-root) {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+  }
+
   .command-input-row {
     display: flex;
     align-items: center;
@@ -687,6 +702,8 @@
   }
 
   :global(.command-list) {
+    flex: 1 1 auto;
+    min-height: 0;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
## **User description**
Closes #2807

## Summary

On first open of the command palette (empty query / browse mode), the tall command list overflowed the palette's `max-height`, clipping rows and pushing the navigation footer (`↑↓ navigate`, `↵ run`, `esc close`) off-screen. Typing a query shrank the list so it fit, masking the bug.

Root cause: `.command-root` (bits-ui `Command.Root`, class forwarded via the `class` prop) had no CSS rule, so it defaulted to `display: block` and grew to content height, breaking the flex-column scroll chain from `.command-palette` (flex column, `max-height: 70dvh`, `overflow: hidden`). `.command-list` had `overflow-y: auto` but no `flex`/`min-height: 0`, so it never became the bounded scroll region.

## Change (CSS only, no markup)

- Add `:global(.command-root)` rule: `display: flex; flex-direction: column; flex: 1 1 auto; min-height: 0; overflow: hidden;` (wrapped in `:global()` because the class is forwarded to the bits-ui element, matching the existing forwarded-class pattern in this file).
- Add `flex: 1 1 auto; min-height: 0;` to `:global(.command-list)` (keeps `overflow-y: auto`).

Resulting flex chain: `.command-palette` (capped) > `.command-root` (fills) > `.command-input-row` (natural) + `.command-list` (scrolls) + `.command-footer` (pinned).

## Verification

Verified live in the dev server via the Preview MCP, inspecting computed layout (not just screenshots):

- Centred (desktop, 1280x800): palette capped at 560px; `.command-list` scrolls (`scrollHeight 952 > clientHeight 452`); `.command-footer` fully visible and pinned below the list.
- Bottom-sheet (mobile-tall viewport): same result, footer within the cap, list scrolls, no clipped rows.
- Empty query (browse mode): footer visible, list scrolls.
- Typing `export`: list filters to matching commands and stays scrollable with the footer pinned.
- No console errors.

Local gates: lint pass, `check` (svelte-check) pass (0 errors), `test:run` pass (all palette/command tests green; two unrelated full-suite timeouts were flaky and passed in isolation), `build` pass.

No unit test added: this is pure CSS layout, not testable at the unit level without brittle DOM/style assertions (ESLint blocks those). Covered by the visual verification above.

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Keep the command palette list scrollable and the footer visible on first open**

### What Changed
- The command palette now keeps its full list inside the panel instead of letting the browse view grow past the visible area.
- The list becomes the scrollable area, so the keyboard hints and close controls stay visible at the bottom.
- This also works in the mobile bottom-sheet layout, where the footer now remains inside the palette bounds.

### Impact
`✅ Fewer clipped command results`
`✅ Footer stays visible in browse mode`
`✅ Clearer command palette on mobile`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
