### PR TITLE
chore: drop palette-duplicated shortcuts from help overlay, add docs link (#2808)

### DIFF
--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -90,7 +90,12 @@ export type HelpGroup = "Navigation" | "General" | "Editing" | "File";
  * - "app": application-level entries (about/shortcuts, settings)
  */
 export type AppMenuGroup =
-  "layout" | "output" | "layout-data" | "devices" | "workspace" | "app";
+  | "layout"
+  | "output"
+  | "layout-data"
+  | "devices"
+  | "workspace"
+  | "app";
 
 export interface ActionDefinition {
   /** Stable identifier; the dispatch map and consumers key off this. */
@@ -125,12 +130,6 @@ export interface ActionDefinition {
    * this field only handles the static server-vs-browser item split (#2073).
    */
   storageMode?: StorageMode;
-  /**
-   * Display label for the help overlay key cell, used only when the command has
-   * no keyboard binding (e.g. mouse gestures documented in help). When omitted,
-   * the key is formatted from the primary binding.
-   */
-  helpKeyLabel?: string;
   /** Fuzzy-search synonyms for the future command palette (#2020). */
   keywords?: string[];
 }
@@ -287,7 +286,6 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     bindings: [{ key: "ArrowUp" }],
     enabledWhen: (ctx) => !ctx.readOnly && ctx.isDeviceSelected,
     helpGroup: "Editing",
-    helpKeyLabel: "↑ / ↓",
     keywords: ["nudge", "up"],
   },
   {
@@ -524,27 +522,15 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
   },
 ];
 
-/** The order help groups appear in the overlay. */
-const HELP_GROUP_ORDER: HelpGroup[] = [
-  "Navigation",
-  "General",
-  "Editing",
-  "File",
-];
-
 /**
  * Display-only help rows that document mouse gestures rather than keyboard
  * shortcuts. They live in the help overlay but are not dispatchable commands,
  * so they are not registry actions.
  */
-const HELP_GESTURE_ROWS: { group: HelpGroup; key: string; action: string }[] = [
-  {
-    group: "Navigation",
-    key: "Scroll Wheel",
-    action: "Zoom in/out (at cursor)",
-  },
-  { group: "Navigation", key: "Shift + Scroll", action: "Pan horizontally" },
-  { group: "Navigation", key: "Click + Drag", action: "Pan canvas" },
+const HELP_GESTURE_ROWS: { key: string; action: string }[] = [
+  { key: "Scroll Wheel", action: "Zoom in/out (at cursor)" },
+  { key: "Shift + Scroll", action: "Pan horizontally" },
+  { key: "Click + Drag", action: "Pan canvas" },
 ];
 
 /** Look up an action definition by its id. */
@@ -614,7 +600,7 @@ export interface HelpRow {
 
 /** A named group of help rows. */
 export interface HelpGroupSection {
-  name: HelpGroup;
+  name: string;
   rows: HelpRow[];
 }
 
@@ -631,56 +617,28 @@ function formatBinding(binding: KeyBinding): string {
   return formatShortcut(...parts);
 }
 
-/**
- * Format the help-overlay key cell for an action. Prefers an explicit
- * helpKeyLabel; otherwise renders the primary (first) binding with
- * platform-correct modifier labels.
- */
-function formatHelpKey(action: ActionDefinition): string {
-  if (action.helpKeyLabel) return action.helpKeyLabel;
-  const binding = action.bindings[0];
-  if (!binding) return "";
-  return formatBinding(binding);
-}
-
 /** Render a raw binding key into a display glyph. */
 function formatBindingKey(key: string): string {
   if (key.length === 1) return key.toUpperCase();
   return key;
 }
 
+/** Heading for the mouse-gesture section in the help overlay. */
+const HELP_GESTURE_SECTION_NAME = "Canvas";
+
 /**
- * Build the help overlay's grouped shortcut list from the registry. Only
- * actions that opt into a help group are shown, plus the documented mouse
- * gestures. Groups appear in HELP_GROUP_ORDER; rows follow registry order.
+ * Build the help overlay's mouse-gesture list. Keyboard shortcuts are no longer
+ * listed here: the command palette shows each command's shortcut inline, so the
+ * overlay only documents the mouse gestures the palette has no equivalent for.
  */
 export function getHelpGroups(): HelpGroupSection[] {
-  const sections: HelpGroupSection[] = [];
+  const rows: HelpRow[] = HELP_GESTURE_ROWS.map(({ key, action }) => ({
+    key,
+    action,
+  }));
 
-  for (const groupName of HELP_GROUP_ORDER) {
-    const rows: HelpRow[] = [];
-
-    // Documented mouse gestures first (Navigation only, in practice).
-    for (const gesture of HELP_GESTURE_ROWS) {
-      if (gesture.group === groupName) {
-        rows.push({ key: gesture.key, action: gesture.action });
-      }
-    }
-
-    // Registry actions flagged for this help group.
-    for (const action of ACTION_REGISTRY) {
-      if (action.helpGroup !== groupName) continue;
-      const key = formatHelpKey(action);
-      if (!key) continue;
-      rows.push({ key, action: action.label });
-    }
-
-    if (rows.length > 0) {
-      sections.push({ name: groupName, rows });
-    }
-  }
-
-  return sections;
+  if (rows.length === 0) return [];
+  return [{ name: HELP_GESTURE_SECTION_NAME, rows }];
 }
 
 /**

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -90,12 +90,7 @@ export type HelpGroup = "Navigation" | "General" | "Editing" | "File";
  * - "app": application-level entries (about/shortcuts, settings)
  */
 export type AppMenuGroup =
-  | "layout"
-  | "output"
-  | "layout-data"
-  | "devices"
-  | "workspace"
-  | "app";
+  "layout" | "output" | "layout-data" | "devices" | "workspace" | "app";
 
 export interface ActionDefinition {
   /** Stable identifier; the dispatch map and consumers key off this. */

--- a/src/lib/components/HelpPanel.svelte
+++ b/src/lib/components/HelpPanel.svelte
@@ -7,7 +7,14 @@
   import Dialog from "./Dialog.svelte";
   import { VERSION } from "$lib/version";
   import LogoLockup from "./LogoLockup.svelte";
-  import { IconGitHub, IconBug, IconChat, IconCheck, IconCopy } from "./icons";
+  import {
+    IconGitHub,
+    IconBug,
+    IconChat,
+    IconCheck,
+    IconCopy,
+    IconQuestionBold,
+  } from "./icons";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getHelpGroups } from "$lib/actions/registry";
@@ -129,11 +136,13 @@
     }
   }
 
-  // Keyboard shortcuts, generated from the actions registry so this overlay and
-  // the keyboard handler can never drift apart.
+  // Mouse-gesture rows for the canvas. Keyboard shortcuts are not listed here:
+  // the command palette shows each command's shortcut inline, so the overlay
+  // only documents the gestures the palette has no equivalent for.
   const shortcutGroups = getHelpGroups();
 
   const GITHUB_URL = "https://github.com/RackulaLives/Rackula";
+  const DOCS_URL = "https://docs.racku.la";
 
   // Pre-filled issue URLs
   const bugReportUrl = $derived.by(() => {
@@ -156,7 +165,7 @@
       </div>
     </header>
 
-    <!-- Keyboard Shortcuts (grouped), generated from the actions registry -->
+    <!-- Canvas mouse gestures. Keyboard shortcuts live in the command palette. -->
     {#each shortcutGroups as group (group.name)}
       <section class="shortcut-group">
         <h4>{group.name}</h4>
@@ -199,6 +208,15 @@
       >
         <IconChat />
         Share Ideas
+      </a>
+      <a
+        href={DOCS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="quick-link"
+      >
+        <IconQuestionBold />
+        Documentation
       </a>
     </div>
 

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -176,59 +176,30 @@ describe("actions registry", () => {
   });
 
   describe("getHelpGroups (help overlay generation)", () => {
-    it("groups actions by their help group, preserving group order", () => {
-      const groups = getHelpGroups();
-      const names = groups.map((g) => g.name);
-      // Groups must appear in a stable, declared order.
-      expect(names).toEqual([...new Set(names)]);
-      expect(groups.length).toBeGreaterThan(0);
-    });
-
-    it("only includes registry actions flagged for the help overlay", () => {
-      const groups = getHelpGroups();
+    it("lists only mouse-gesture rows, no registry keyboard shortcuts", () => {
+      // The command palette now shows each command's shortcut inline, so the
+      // overlay documents only the mouse gestures the palette cannot show.
       const shownLabels = new Set(
-        groups.flatMap((g) => g.rows.map((r) => r.action)),
-      );
-      // Every help-flagged registry action with a renderable key appears.
-      const helpActions = ACTION_REGISTRY.filter(
-        (a) => a.helpGroup && (a.bindings.length > 0 || a.helpKeyLabel),
-      );
-      for (const action of helpActions) {
-        expect(shownLabels.has(action.label)).toBe(true);
-      }
-      // Actions without a help group must NOT appear (e.g. toggle-sidebar).
-      const hiddenAction = ACTION_REGISTRY.find((a) => !a.helpGroup);
-      expect(hiddenAction).toBeDefined();
-      expect(shownLabels.has(hiddenAction!.label)).toBe(false);
-    });
-
-    it("formats the displayed key from the action's primary binding", () => {
-      const groups = getHelpGroups();
-      const saveRow = groups
-        .flatMap((g) => g.rows)
-        .find((r) => r.action.toLowerCase().includes("save layout"));
-      expect(saveRow).toBeDefined();
-      // The mod key formats to Ctrl or Cmd; we just assert it includes "S".
-      expect(saveRow?.key).toContain("S");
-    });
-
-    it("supports display-only help rows that have no real keybinding", () => {
-      // e.g. "Scroll Wheel" -> "Zoom" is documented in help but is not a
-      // keydown shortcut, so it carries a helpKeyLabel instead of bindings.
-      const groups = getHelpGroups();
-      const allRows = groups.flatMap((g) => g.rows);
-      const scrollRow = allRows.find((r) =>
-        r.action.toLowerCase().includes("zoom"),
-      );
-      expect(scrollRow).toBeDefined();
-      expect(scrollRow?.key).toBeTruthy();
-    });
-
-    it("includes the command palette in the help overlay", () => {
-      const labels = new Set(
         getHelpGroups().flatMap((g) => g.rows.map((r) => r.action)),
       );
-      expect(labels.has("Command palette")).toBe(true);
+      // No help-flagged registry action leaks a keyboard-shortcut row.
+      const helpActions = ACTION_REGISTRY.filter((a) => a.helpGroup);
+      expect(helpActions.length).toBeGreaterThan(0);
+      for (const action of helpActions) {
+        expect(shownLabels.has(action.label)).toBe(false);
+      }
+    });
+
+    it("keeps the canvas mouse gestures under one section", () => {
+      const groups = getHelpGroups();
+      // The keyboard sections are gone; only the gesture section survives.
+      const names = groups.map((g) => g.name);
+      expect(names).toEqual(["Canvas"]);
+      const zoomRow = groups
+        .flatMap((g) => g.rows)
+        .find((r) => r.action.toLowerCase().includes("zoom"));
+      expect(zoomRow).toBeDefined();
+      expect(zoomRow?.key).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## **User description**
Closes #2808

## Summary

The command palette now shows each command's keyboard shortcut inline, so the About/Help overlay's keyboard-shortcut groups (Navigation / General / Editing / File) were duplicated. This removes those rows and points users to fuller docs instead.

- `src/lib/actions/registry.ts`: `getHelpGroups()` no longer emits registry-action keyboard rows. It returns only the mouse-gesture rows, under a single "Canvas" heading. Dropped the now-dead `HELP_GROUP_ORDER`, `formatHelpKey`, the unused `helpKeyLabel` field, and the unused `group` tag on gesture rows. Broadened `HelpGroupSection.name` from `HelpGroup` to `string` so the section can be labelled "Canvas".
- `src/lib/components/HelpPanel.svelte`: added a "Documentation" quick link to https://docs.racku.la (opens in a new tab, `rel="noopener noreferrer"`, reusing `IconQuestionBold`). Updated the section intro copy since the overlay no longer lists keyboard shortcuts.
- `src/tests/actions-registry.test.ts`: replaced the old help-group tests with ones asserting the behavioural change: `getHelpGroups()` returns no registry keyboard-shortcut rows, only the mouse-gesture section.

## Preserved

- `helpGroup` field on actions and `HELP_GROUP_TO_PALETTE` are untouched: the palette still uses `helpGroup` to bucket commands (`src/lib/actions/palette-commands.ts`).
- About / build-info section unchanged.

## Gates

lint pass, check pass, test:run pass (194 files / 3136 tests), build pass.

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Simplify the About/Help overlay and add a direct docs link

### What Changed
- Removed the keyboard shortcut rows from the About/Help overlay so it no longer repeats shortcuts already shown in the command palette
- Kept the canvas mouse gestures in the overlay under a single "Canvas" section
- Added a Documentation link that opens the project docs in a new tab

### Impact
`✅ Less duplicate help text`
`✅ Clearer About/Help overlay`
`✅ Faster access to project docs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
