### PR TITLE
feat: split canvas controls into upper-left history and lower-left view (#2697)

### DIFF
--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -58,6 +58,37 @@ test.describe("Responsive Layout", () => {
       expect(viewBox.y + viewBox.height).toBeGreaterThan(canvasMidY);
     });
 
+    test("history controls clear the placement banner during placement (#2697)", async ({
+      page,
+    }) => {
+      // The placement banner is a full-width top overlay stacked above the
+      // controls. The upper-left History group must drop below it so undo/redo
+      // stays reachable while a device is armed.
+      const firstDevice = page.locator(locators.device.paletteItem).first();
+      await expect(firstDevice).toBeVisible();
+      await firstDevice.focus();
+      await page.keyboard.press("Enter");
+
+      const banner = page
+        .locator('[data-testid="rack-canvas"] [role="status"]')
+        .filter({ hasText: "Placing:" });
+      await expect(banner).toBeVisible();
+
+      const history = page.getByRole("group", { name: "History actions" });
+      await expect(history).toBeVisible();
+
+      const bannerBox = await banner.boundingBox();
+      const historyBox = await history.boundingBox();
+      expect(bannerBox).not.toBeNull();
+      expect(historyBox).not.toBeNull();
+      if (!bannerBox || !historyBox) return;
+
+      // History's top edge sits at or below the banner's bottom edge: no overlap.
+      expect(historyBox.y).toBeGreaterThanOrEqual(
+        bannerBox.y + bannerBox.height,
+      );
+    });
+
     test("sidebar pane is visible", async ({ page }) => {
       const sidebar = page.locator(locators.sidebar.pane);
       await expect(sidebar).toBeVisible();

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -23,6 +23,41 @@ test.describe("Responsive Layout", () => {
       await expect(logoMark).toBeVisible();
     });
 
+    test("canvas controls split into upper-left history and lower-left view (#2697)", async ({
+      page,
+    }) => {
+      // History (undo/redo) anchors to the canvas upper-left; the view/zoom pill
+      // stays at the canvas lower-left. Both are on the canvas, left-aligned, and
+      // do not overlap each other.
+      const history = page.getByRole("group", { name: "History actions" });
+      const view = page.getByRole("group", { name: "View actions" });
+      await expect(history).toBeVisible();
+      await expect(view).toBeVisible();
+
+      const canvas = page.locator(locators.canvas.root);
+      const canvasBox = await canvas.boundingBox();
+      const historyBox = await history.boundingBox();
+      const viewBox = await view.boundingBox();
+      expect(canvasBox).not.toBeNull();
+      expect(historyBox).not.toBeNull();
+      expect(viewBox).not.toBeNull();
+      if (!canvasBox || !historyBox || !viewBox) return;
+
+      // History sits above View (upper-left vs lower-left).
+      expect(historyBox.y + historyBox.height).toBeLessThanOrEqual(viewBox.y);
+
+      // Both hug the left edge of the canvas, roughly aligned to the same column.
+      const canvasMidX = canvasBox.x + canvasBox.width / 2;
+      expect(historyBox.x).toBeLessThan(canvasMidX);
+      expect(viewBox.x).toBeLessThan(canvasMidX);
+      expect(Math.abs(historyBox.x - viewBox.x)).toBeLessThan(24);
+
+      // History is anchored to the top half, View to the bottom half.
+      const canvasMidY = canvasBox.y + canvasBox.height / 2;
+      expect(historyBox.y).toBeLessThan(canvasMidY);
+      expect(viewBox.y + viewBox.height).toBeGreaterThan(canvasMidY);
+    });
+
     test("sidebar pane is visible", async ({ page }) => {
       const sidebar = page.locator(locators.sidebar.pane);
       await expect(sidebar).toBeVisible();

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -1,8 +1,9 @@
 <!--
   CanvasViewControls Component
-  Bottom-left canvas cluster holding the view and history controls in two
-  visually separated groups: History (undo, redo) and View (zoom out, zoom
-  readout, zoom in, fit, display-mode lens).
+  Canvas overlay holding the view and history controls as two visually
+  separated groups anchored to opposite left corners: History (undo, redo) at
+  the canvas upper-left, and View (zoom out, zoom readout, zoom in, fit,
+  display-mode lens) at the canvas lower-left (#2697).
 
   This surfaces existing handlers; it does not own view or history logic. The
   display-mode lens here is the canonical layout-scoped control; the side panel
@@ -63,7 +64,11 @@
 </script>
 
 <div class="canvas-view-controls">
-  <div class="control-group" role="group" aria-label="History actions">
+  <div
+    class="control-group control-group--history"
+    role="group"
+    aria-label="History actions"
+  >
     <Tooltip
       text={layoutStore.undoDescription ?? "Undo"}
       shortcut={undoShortcut}
@@ -191,18 +196,26 @@
 </div>
 
 <style>
+  /* Full-region overlay: the wrapper covers the canvas so each group can anchor
+     to its own corner. It stays click-through (pointer-events: none) between the
+     corners; only the pills capture pointer events (#2697). */
   .canvas-view-controls {
     position: absolute;
-    bottom: max(var(--space-3), env(safe-area-inset-bottom, 0px));
-    left: max(var(--space-3), env(safe-area-inset-left, 0px));
+    inset: 0;
     z-index: calc(var(--z-toolbar) + 1);
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
     pointer-events: none;
   }
 
+  /* A group anchors to the canvas lower-left by default; the --history modifier
+     re-anchors to the upper-left. The base rule owns the left inset and a
+     bottom fallback so a group is always explicitly placed, even if a future
+     one ships without a modifier. Both anchors keep their safe-area insets so
+     the pills never tuck under a notch or home indicator on inset-aware
+     displays. */
   .control-group {
+    position: absolute;
+    left: max(var(--space-3), env(safe-area-inset-left, 0px));
+    bottom: max(var(--space-3), env(safe-area-inset-bottom, 0px));
     pointer-events: auto;
     display: inline-flex;
     align-items: center;
@@ -214,6 +227,13 @@
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     box-shadow: var(--shadow-sm);
+  }
+
+  /* History anchors to the canvas upper-left. Clearing the inherited bottom
+     anchor avoids a group stretched between both edges. */
+  .control-group--history {
+    top: max(var(--space-3), env(safe-area-inset-top, 0px));
+    bottom: auto;
   }
 
   .control-button {

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -213,6 +213,15 @@
     inset: 0;
     z-index: calc(var(--z-toolbar) + 1);
     pointer-events: none;
+
+    /* Outer height of the placement banner (PlacementIndicator): its
+       min-height (--touch-target-min) plus its vertical padding (--space-2 top
+       and bottom) and its 2px bottom border. Kept as a single named value so
+       the below-banner offset has one source of truth; the placement-overlap
+       E2E check (responsive.spec.ts) fails loudly if the banner outgrows it. */
+    --banner-clearance: calc(
+      var(--touch-target-min) + var(--space-2) * 2 + 2px
+    );
   }
 
   /* A group anchors to the canvas lower-left by default; the --history modifier
@@ -246,13 +255,13 @@
   }
 
   /* While a device is armed, the full-width placement banner occupies the top
-     edge above this group. Drop History below the banner (its min-height plus
-     its vertical padding and bottom border) so undo/redo never tucks under it.
-     The transition keeps the shift from snapping when placement toggles. */
+     edge above this group. Drop History below the banner (--banner-clearance)
+     so undo/redo never tucks under it. The transition keeps the shift from
+     snapping when placement toggles. */
   .control-group--below-banner {
     top: calc(
       max(var(--space-3), env(safe-area-inset-top, 0px)) +
-        var(--touch-target-min) + var(--space-2) * 2 + 2px
+        var(--banner-clearance)
     );
     transition: top var(--duration-fast) var(--ease-out);
   }

--- a/src/lib/components/canvas/CanvasViewControls.svelte
+++ b/src/lib/components/canvas/CanvasViewControls.svelte
@@ -14,6 +14,7 @@
   import { getActionTooltip } from "$lib/actions/registry";
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
+  import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import { DISPLAY_MODE_LABELS, type DisplayMode } from "$lib/types";
   import Tooltip from "../Tooltip.svelte";
@@ -38,7 +39,14 @@
 
   const canvasStore = getCanvasStore();
   const layoutStore = getLayoutStore();
+  const placementStore = getPlacementStore();
   const toastStore = getToastStore();
+
+  // The placement banner (PlacementIndicator) is a full-width top overlay shown
+  // while a device is armed, and it stacks above these controls. Drop the
+  // upper-left History group below the banner during placement so undo/redo
+  // stays reachable instead of tucking under it (#2697).
+  const isPlacing = $derived(placementStore.isPlacing);
 
   // Shortcuts come from the registry so they cannot drift from the keyboard
   // handler or help overlay (#117). Zoom in/out have no registry action (they
@@ -66,6 +74,7 @@
 <div class="canvas-view-controls">
   <div
     class="control-group control-group--history"
+    class:control-group--below-banner={isPlacing}
     role="group"
     aria-label="History actions"
   >
@@ -236,6 +245,18 @@
     bottom: auto;
   }
 
+  /* While a device is armed, the full-width placement banner occupies the top
+     edge above this group. Drop History below the banner (its min-height plus
+     its vertical padding and bottom border) so undo/redo never tucks under it.
+     The transition keeps the shift from snapping when placement toggles. */
+  .control-group--below-banner {
+    top: calc(
+      max(var(--space-3), env(safe-area-inset-top, 0px)) +
+        var(--touch-target-min) + var(--space-2) * 2 + 2px
+    );
+    transition: top var(--duration-fast) var(--ease-out);
+  }
+
   .control-button {
     display: inline-flex;
     align-items: center;
@@ -293,7 +314,8 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .control-button {
+    .control-button,
+    .control-group--below-banner {
       transition: none;
     }
   }


### PR DESCRIPTION
## **User description**
## Summary

Splits the single bottom-left canvas control cluster into two corner-anchored groups (#2697):

- History (undo/redo) now anchors to the canvas upper-left.
- The zoom/view pill stays at the canvas lower-left.

## Approach

`.canvas-view-controls` becomes a full-region, click-through overlay (`inset: 0; pointer-events: none`). Each `.control-group` is absolutely positioned inside it and captures pointer events only over the pill itself, so the space between the two corners passes clicks through to the canvas.

- `.control-group` owns the shared left inset and a default lower-left (`bottom`) anchor, so any group is explicitly placed even without a modifier.
- `.control-group--history` overrides to the upper-left (`top`, `bottom: auto`).
- Both anchors keep their `env(safe-area-inset-*)` handling (top/bottom + left).
- DOM order is unchanged (History then View), so tooltips and keyboard focus order are preserved.

## Acceptance criteria

- [x] Undo/redo controls render at the canvas upper-left.
- [x] Zoom/view pill renders at the canvas lower-left corner.
- [x] Both groups stay anchored to the canvas region and do not overlap each other at small viewports.
- [x] Safe-area insets respected.
- [x] Tooltips and keyboard focus order intact (unchanged DOM order).

## Tests

Adds an E2E check in `responsive.spec.ts` asserting, via bounding-box geometry, that the History group sits above the View group, both hug the left edge in the same column, and each anchors to its half of the canvas. Reached with `getByRole("group", { name })`, which doubles as an accessibility check.

## Verification

- `npm run lint`: clean
- `npm run check` (svelte-check): 0 errors
- `npm run test:run`: 3139 passed
- `npm run build`: succeeds
- New E2E corner-placement test: passes

Closes #2697


___

## **CodeAnt-AI Description**
**Split canvas controls into upper-left history and lower-left view**

### What Changed
- Undo and redo now appear in the canvas upper-left corner, while zoom and view controls stay in the lower-left corner
- The space between the two control groups no longer blocks clicks, so interactions pass through to the canvas
- Both control groups keep safe-area spacing, so they stay clear of notches and home indicators
- Added a responsive layout check that confirms the two groups stay in the correct corners without overlapping

### Impact
`✅ Clearer canvas controls`
`✅ Fewer mis-clicks on the canvas`
`✅ Safer display on notch and home-indicator screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
