### PR TITLE
chore: tokenize dracula-pink editor highlights via semantic aliases (#2743)

### DIFF
--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -633,10 +633,10 @@
 
   /* Long press visual feedback */
   .bayed-rack-view.long-press-active {
-    outline: 3px solid var(--dracula-pink, #ff79c6);
+    outline: 3px solid var(--colour-selection);
     outline-offset: 2px;
     box-shadow: inset 0 0 0 calc(var(--long-press-progress, 0) * 4px)
-      rgba(255, 121, 198, 0.15);
+      color-mix(in srgb, var(--colour-selection) 15%, transparent);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/RackFrame.svelte
+++ b/src/lib/components/RackFrame.svelte
@@ -440,17 +440,17 @@
 
   /* Valid placement slots - subtle pulse highlight */
   .u-slot.placement-valid {
-    fill: rgba(255, 121, 198, 0.15);
+    fill: color-mix(in srgb, var(--colour-placement-valid) 15%, transparent);
     animation: placement-pulse 2s ease-in-out infinite;
   }
 
   @keyframes placement-pulse {
     0%,
     100% {
-      fill: rgba(255, 121, 198, 0.1);
+      fill: color-mix(in srgb, var(--colour-placement-valid) 10%, transparent);
     }
     50% {
-      fill: rgba(255, 121, 198, 0.25);
+      fill: color-mix(in srgb, var(--colour-placement-valid) 25%, transparent);
     }
   }
 
@@ -473,7 +473,7 @@
   @media (prefers-reduced-motion: reduce) {
     .u-slot.placement-valid {
       animation: none;
-      fill: rgba(255, 121, 198, 0.2);
+      fill: color-mix(in srgb, var(--colour-placement-valid) 20%, transparent);
     }
   }
 </style>

--- a/src/lib/styles/tokens.css
+++ b/src/lib/styles/tokens.css
@@ -323,6 +323,11 @@
   --colour-blocked-bg: rgba(239, 68, 68, 0.12); /* Subtle red wash background */
   --colour-blocked-icon: rgba(239, 68, 68, 0.7); /* Directional arrow icon */
 
+  /* Valid placement-slot highlight (counterpart to the blocked-slot tokens).
+     Base hue only; callers derive alpha with color-mix so the pink lives in
+     one place and the pulse animation can vary opacity. */
+  --colour-placement-valid: var(--dracula-pink);
+
   /* Toolbar */
   --toolbar-height: 48px;
   --toolbar-bg: var(--dracula-bg-darker);


### PR DESCRIPTION
## **User description**
## Summary

Applies the Dracula design tokens consistently across the new-rack-editor surfaces by replacing the last raw `rgba(255, 121, 198, ...)` (dracula-pink) values with semantic aliases from `tokens.css`.

Closes #2743.

## Changes

- **`tokens.css`**: add `--colour-placement-valid` (base hue `var(--dracula-pink)`), a sibling to the existing `--colour-blocked-*` tokens. Comment documents that callers derive alpha via `color-mix` so the pulse animation can vary opacity from one source of truth.
- **`RackFrame.svelte`**: the `.u-slot.placement-valid` pulse (base, keyframes, and reduced-motion fallback) now uses `color-mix(in srgb, var(--colour-placement-valid) N%, transparent)` instead of four hardcoded pink rgba values.
- **`BayedRackView.svelte`**: the `.long-press-active` affordance points at `var(--colour-selection)` (which resolves to `--dracula-pink`) instead of the raw `var(--dracula-pink, #ff79c6)` fallback and a hardcoded rgba box-shadow.

## Verification

- Pure token application: `--colour-selection` and `--colour-placement-valid` both resolve to `--dracula-pink` (`#ff79c6`), and `color-mix(in srgb, C P%, transparent)` is exactly `C` at alpha `P%`. Every value renders identically, so there is **no colour change** and no visual-snapshot churn. `color-mix` is already established house style (8 files).
- Contrast is unchanged (identical colours); no light-theme assumptions introduced.
- Gates: lint clean, `npm run check` 0 errors, build succeeds. Visual-only change, so no unit tests per the testing policy.

## Out of scope

The rest of the new editor surfaces (`RackCanvasView`, `CanvasViewControls`, `SidePanelContent`, resize grips, ghost/rubber-band visuals) already use `var(--colour-*)`. `Rack.svelte`'s pre-existing selection glow is core-renderer code, not a new-editor surface, so it is left unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Use shared tokens for pink editor highlights without changing their appearance**

### What Changed
- The valid placement pulse in the rack view now uses a shared color token instead of hardcoded pink values.
- The long-press highlight in bayed rack views now uses the same shared selection color for its outline and inset glow.
- Reduced-motion behavior for the valid placement highlight still shows a static pink state.

### Impact
`✅ Consistent editor highlight colors`
`✅ No visible color change for existing users`
`✅ Easier theme-wide color updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
