### PR TITLE
fix: add directional hysteresis to snapResizeHeight (#2821)

### DIFF
--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -277,6 +277,9 @@
       pxPerU,
       minHeight: drag.minHeight,
       maxHeight: MAX_RACK_HEIGHT,
+      // Measure hysteresis from the step already on screen so jitter at a U
+      // boundary does not flip the preview back and forth (#2821).
+      currentHeight: drag.previewHeight,
     });
     if (previewHeight === drag.previewHeight) return;
     drag.previewHeight = previewHeight;
@@ -299,6 +302,9 @@
       pxPerU,
       minHeight: drag.minHeight,
       maxHeight: MAX_RACK_HEIGHT,
+      // Apply the same hysteresis as the live preview so the release cannot
+      // land one U off the height shown under the pointer (#2821).
+      currentHeight: drag.previewHeight,
     });
     const { target, rackIds, startHeight } = drag;
     resizeDrag = null;

--- a/src/lib/utils/rack-resize.ts
+++ b/src/lib/utils/rack-resize.ts
@@ -98,6 +98,14 @@ export function getMinResizeHeight(
 }
 
 /**
+ * Travel, in U, the pointer must move past the current committed step before
+ * the next whole-U step commits (#2821). Larger than half a U so pixel jitter
+ * at the half-U line cannot flip the preview back and forth: each step sits in
+ * a +/-0.6U dead band, so the flicker zone disappears.
+ */
+const STEP_HYSTERESIS_U = 0.6;
+
+/**
  * Inputs for snapResizeHeight.
  */
 export interface SnapResizeParams {
@@ -111,15 +119,23 @@ export interface SnapResizeParams {
   minHeight: number;
   /** Highest allowed height (schema max). */
   maxHeight: number;
+  /**
+   * The height currently previewed for this drag (the committed step). The
+   * hysteresis threshold is measured from here, so a step only reverses after
+   * decisive travel back. Defaults to startHeight for the first move of a drag.
+   */
+  currentHeight?: number;
 }
 
 /**
- * Snap a pointer drag to a whole-U rack height.
+ * Snap a pointer drag to a whole-U rack height with directional hysteresis.
  *
- * Rounds the drag distance to the nearest whole U so the rail invariant holds
- * (positions stay on whole-U boundaries), then clamps to [minHeight, maxHeight].
- * A non-positive pxPerU (a degenerate zoom) holds the start height rather than
- * dividing by zero.
+ * The drag distance is measured in U from the start (growPx / pxPerU), but the
+ * height only steps once that travel passes the current committed step by
+ * STEP_HYSTERESIS_U in the direction of movement. Committed heights stay whole
+ * U so the rail invariant holds (positions never go fractional), and the result
+ * is clamped to [minHeight, maxHeight]. A non-positive pxPerU (a degenerate
+ * zoom) holds the start height rather than dividing by a nonsense scale.
  */
 export function snapResizeHeight({
   startHeight,
@@ -127,11 +143,27 @@ export function snapResizeHeight({
   pxPerU,
   minHeight,
   maxHeight,
+  currentHeight = startHeight,
 }: SnapResizeParams): number {
   if (pxPerU <= 0) return startHeight;
-  const deltaU = Math.round(growPx / pxPerU);
-  const raw = startHeight + deltaU;
-  return Math.max(minHeight, Math.min(maxHeight, raw));
+  const travelU = growPx / pxPerU;
+  // Start from the committed step, clamped so the loops also stop at the bounds
+  // and a degenerate travel value can never spin past the allowed range.
+  let height = Math.max(minHeight, Math.min(maxHeight, currentHeight));
+  // Grow only after ~0.6U of travel past the current step; mirror for shrink.
+  while (
+    height < maxHeight &&
+    travelU - (height - startHeight) >= STEP_HYSTERESIS_U
+  ) {
+    height++;
+  }
+  while (
+    height > minHeight &&
+    height - startHeight - travelU >= STEP_HYSTERESIS_U
+  ) {
+    height--;
+  }
+  return height;
 }
 
 /**

--- a/src/tests/rack-resize.test.ts
+++ b/src/tests/rack-resize.test.ts
@@ -336,6 +336,23 @@ describe("rack-resize", () => {
       ).toBe(8);
     });
 
+    it("skips multiple steps in one call when a fast release outruns the preview", () => {
+      // A quick release can jump several U past the last previewed step before
+      // any pointermove fired. The grow loop must step through every whole U,
+      // not just one: 3.7U of travel from a non-boundary step lands on 14
+      // (10->11->12->13->14, then 3.7 - 4 = -0.3 < 0.6 stops), well clear of
+      // the min/max clamp.
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 10,
+          growPx: 370,
+          pxPerU: 100,
+          currentHeight: 10,
+        }),
+      ).toBe(14);
+    });
+
     it("clamps to maxHeight even from a committed step near the top", () => {
       expect(
         snapResizeHeight({

--- a/src/tests/rack-resize.test.ts
+++ b/src/tests/rack-resize.test.ts
@@ -217,6 +217,149 @@ describe("rack-resize", () => {
       expect(
         snapResizeHeight({ ...base, startHeight: 24, growPx: 100, pxPerU: 0 }),
       ).toBe(24);
+      // A negative pxPerU is equally degenerate: hold the start height rather
+      // than dividing by a nonsense scale, and ignore any committed step.
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 24,
+          growPx: 500,
+          pxPerU: -5,
+          currentHeight: 30,
+        }),
+      ).toBe(24);
+    });
+
+    // --- Directional hysteresis (#2821) ---
+    // A step commits only after roughly 0.6U of travel past the current
+    // committed step in the direction of movement. This kills the half-U
+    // flicker where nearest-U rounding flipped the preview back and forth.
+
+    it("holds the current step until 0.6U of travel past it, then commits", () => {
+      // Fresh drag (current step === start): 0.59U of travel is not enough.
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 10,
+          growPx: 59,
+          pxPerU: 100,
+          currentHeight: 10,
+        }),
+      ).toBe(10);
+      // Exactly 0.6U of travel commits the next whole-U step.
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 10,
+          growPx: 60,
+          pxPerU: 100,
+          currentHeight: 10,
+        }),
+      ).toBe(11);
+    });
+
+    it("does not oscillate when the pointer jitters at the old half-U line", () => {
+      // Nearest-U rounding flipped 10 <-> 11 as travel crossed 0.5U. With
+      // hysteresis the settled step (10) holds across that whole jitter band.
+      for (const growPx of [40, 49, 50, 51, 59]) {
+        expect(
+          snapResizeHeight({
+            ...base,
+            startHeight: 10,
+            growPx,
+            pxPerU: 100,
+            currentHeight: 10,
+          }),
+        ).toBe(10);
+      }
+    });
+
+    it("keeps a committed step steady while the pointer sits on its boundary", () => {
+      // One step is already committed (11). Jitter around that U boundary
+      // (frac ~ 1.0) neither advances to 12 nor retreats to 10.
+      for (const growPx of [90, 100, 110, 150]) {
+        expect(
+          snapResizeHeight({
+            ...base,
+            startHeight: 10,
+            growPx,
+            pxPerU: 100,
+            currentHeight: 11,
+          }),
+        ).toBe(11);
+      }
+    });
+
+    it("requires decisive travel back before reversing a committed step", () => {
+      // Committed at 11; retreating only 0.5U back still holds (needs 0.6U).
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 10,
+          growPx: 50,
+          pxPerU: 100,
+          currentHeight: 11,
+        }),
+      ).toBe(11);
+      // 0.6U back from the step boundary commits the reversal down to 10.
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 10,
+          growPx: 40,
+          pxPerU: 100,
+          currentHeight: 11,
+        }),
+      ).toBe(10);
+    });
+
+    it("mirrors the threshold for shrink drags", () => {
+      // Current step 9 (one below start 10). Travelling 0.59U past that step
+      // holds; 0.6U past it commits the next shrink to 8.
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 10,
+          growPx: -159,
+          pxPerU: 100,
+          currentHeight: 9,
+        }),
+      ).toBe(9);
+      expect(
+        snapResizeHeight({
+          ...base,
+          startHeight: 10,
+          growPx: -160,
+          pxPerU: 100,
+          currentHeight: 9,
+        }),
+      ).toBe(8);
+    });
+
+    it("clamps to maxHeight even from a committed step near the top", () => {
+      expect(
+        snapResizeHeight({
+          startHeight: 98,
+          growPx: 10000,
+          pxPerU: 100,
+          minHeight: 1,
+          maxHeight: 100,
+          currentHeight: 99,
+        }),
+      ).toBe(100);
+    });
+
+    it("clamps to minHeight even from a committed step near the floor", () => {
+      expect(
+        snapResizeHeight({
+          startHeight: 24,
+          growPx: -10000,
+          pxPerU: 100,
+          minHeight: 12,
+          maxHeight: 100,
+          currentHeight: 20,
+        }),
+      ).toBe(12);
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary

`snapResizeHeight` rounded drag travel to the nearest whole U (`Math.round(growPx / pxPerU)`). At the half-U line, pixel jitter flipped the preview height back and forth, and each flip re-rendered the rack frame, so the drag felt twitchy.

This adds directional hysteresis. The threshold is measured from the current committed step (`currentHeight`): a step commits only after roughly 0.6U of travel past it in the direction of movement. That gives each step a +/-0.6U dead band, so the half-U flicker zone disappears. Whole-U stepping stays (rail invariant); continuous preview with snap-on-release was decided against in the epic #2820 spec and is not built here.

Both call sites in `RackCanvasView.svelte` pass the previewed height:

- `handleResizeMove` measures hysteresis from the step already on screen, so jitter at a U boundary does not flip the preview.
- `handleResizeEnd` applies the same rule from the same `previewHeight`, so a release cannot land one U off the height shown under the pointer.

## Acceptance criteria

- [x] A resize step commits only after roughly 0.6U of travel past the current height in the direction of movement
- [x] Holding the pointer at a step boundary produces no height oscillation
- [x] Whole-U snapping and [minHeight, maxHeight] clamping are unchanged
- [x] Keyboard resize (ArrowUp/ArrowDown) is unaffected (it never called `snapResizeHeight`)

## Invariant

Rail positions stay whole-U integers. The hysteresis is preview-step logic only: the committed height is seeded from `currentHeight` and only ever incremented/decremented by one, so it stays whole U. No fractional rail positions or committed heights are introduced.

## Tests

Added boundary unit tests for `snapResizeHeight` in `src/tests/rack-resize.test.ts` (TDD, written red then green):

- 0.59U travel holds; exactly 0.6U commits the next step
- No oscillation across the old half-U jitter band (40..59px at 100px/U all hold)
- A committed step stays steady while the pointer sits on its boundary
- Reversing direction requires 0.6U of decisive travel back
- Shrink threshold mirrors grow
- min/max clamp interaction from a committed step near the top and floor
- Degenerate pxPerU (0 and negative) holds the start height

The loops are bounded by the height range (not travel distance), the two loops are mutually exclusive, and output is integer-only under the integer input contract.

Gates run locally in the worktree: `npm run lint`, `npm run check`, `npm run test:run` (3149 tests pass), `npm run build`.

Closes #2821

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Make rack resizing stop flickering at U boundaries

### What Changed
- Drag resize now waits for a clear move past the current step before changing height, which prevents the preview from bouncing back and forth near half-U positions
- Releasing the drag now uses the same rule as the live preview, so the final height matches what the pointer was showing
- Resize still snaps to whole U values and still respects the minimum and maximum rack heights
- Added tests for boundary cases, including boundary jitter, reversing direction, shrink drags, and clamping at the limits

### Impact
`✅ Fewer resize flickers`
`✅ More stable drag previews`
`✅ Final resize height matches the preview`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
