### PR TITLE
feat: ensure-visible camera on resize and bay commits (#2825)

### DIFF
--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -215,6 +215,16 @@
     } else {
       layoutStore.resizeBayedGroupHeight(target.groupId, height);
     }
+    // Direct-manipulation commit (drag release or keyboard step): nudge the
+    // camera by the minimum needed to keep the resized extent on screen.
+    // Growing past an edge pans (or zooms out) just enough; an in-viewport
+    // resize or a shrink stays put. Undo/redo mutate the store directly and
+    // never reach here, so the camera holds still for them.
+    canvasStore.ensureRacksVisible(
+      resizeTargetRackIds(target),
+      layoutStore.racks,
+      layoutStore.rack_groups,
+    );
   }
 
   // Dragging away from the rack body grows it: up for the top grip, down for
@@ -367,6 +377,17 @@
     // Select the resulting bay so its bay-level affordances surface at once.
     layoutStore.setActiveRack(sourceRackId);
     selectionStore.selectGroup(result.groupId, sourceRackId);
+    // Direct-manipulation commit: keep the bay group (including the new member)
+    // on screen with minimal camera movement. Passing the group's rack_ids
+    // resolves to the whole group's extent so the new member ends up visible.
+    const group = layoutStore.getRackGroupById(result.groupId);
+    if (group) {
+      canvasStore.ensureRacksVisible(
+        group.rack_ids,
+        layoutStore.racks,
+        layoutStore.rack_groups,
+      );
+    }
   }
 
   // Resistant right-edge drag on an empty rack: a rubber-band ghost that snaps

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -7,6 +7,8 @@ import type panzoom from "panzoom";
 import type { Rack, RackGroup, DeviceType } from "$lib/types";
 import {
   calculateFitAll,
+  calculateRacksBoundingBox,
+  ensureVisibleTransform,
   racksToPositions,
   racksToPositionsWithIds,
 } from "$lib/utils/canvas";
@@ -126,6 +128,7 @@ export function getCanvasStore() {
     moveTo,
     smoothMoveTo,
     fitAll,
+    ensureRacksVisible,
     focusRack,
     zoomToDevice,
     restoreViewport,
@@ -411,6 +414,66 @@ function fitAll(
   canvasDebug.transform("fitAll applied: %o", panzoomInstance.getTransform());
 
   suppressViewportSave = false;
+}
+
+/**
+ * Ensure the given racks stay fully visible after a direct-manipulation commit
+ * (resize release, keyboard resize step, or bay creation).
+ *
+ * Animates the camera by the minimum pan and zoom needed to bring the changed
+ * extent on screen. When the extent already fits (an in-viewport resize, a
+ * shrink, or an undo/redo that leaves it contained) the camera does not move.
+ * Trigger this from the commit handlers, never from store mutations, so undo
+ * and redo stay still.
+ *
+ * @param rackIds - IDs of the racks whose extent must stay visible (pass a
+ *   bayed group's rack_ids to keep the whole group, including a new member,
+ *   on screen)
+ * @param allRacks - All racks from the layout store
+ * @param rackGroups - All rack groups from the layout store (for bayed racks)
+ * @param rightOffset - Optional offset for a right-side overlay (e.g., drawer)
+ */
+function ensureRacksVisible(
+  rackIds: string[],
+  allRacks: Rack[],
+  rackGroups: RackGroup[] = [],
+  rightOffset: number = 0,
+): void {
+  if (!panzoomInstance || !canvasElement || rackIds.length === 0) return;
+
+  // Union the canvas positions of the target racks into a single extent. Bayed
+  // group members share one position object, so any member resolves to the
+  // whole group's bounding box.
+  const targetIds = new Set(rackIds);
+  const targetPositions = racksToPositionsWithIds(allRacks, rackGroups).filter(
+    (pos) => pos.rackIds.some((id) => targetIds.has(id)),
+  );
+  if (targetPositions.length === 0) return;
+
+  const target = calculateRacksBoundingBox(targetPositions);
+
+  const viewportWidth = canvasElement.clientWidth - rightOffset;
+  const viewportHeight = canvasElement.clientHeight;
+
+  const current = panzoomInstance.getTransform();
+  const next = ensureVisibleTransform(
+    target,
+    { width: viewportWidth, height: viewportHeight },
+    { scale: current.scale, panX: current.x, panY: current.y },
+  );
+
+  // Already fully visible (contained, a shrink, or an undo/redo that leaves the
+  // extent on screen): keep the camera still.
+  if (
+    next.scale === current.scale &&
+    next.panX === current.x &&
+    next.panY === current.y
+  ) {
+    return;
+  }
+
+  canvasDebug.transform("ensureRacksVisible: %o", { target, current, next });
+  smoothMoveTo(next.panX, next.panY, next.scale);
 }
 
 /**

--- a/src/lib/utils/canvas.ts
+++ b/src/lib/utils/canvas.ts
@@ -170,6 +170,125 @@ export function calculateFitAll(
   return { zoom, panX, panY };
 }
 
+/**
+ * Viewport rectangle in screen pixels.
+ */
+export interface Viewport {
+  width: number;
+  height: number;
+}
+
+/**
+ * Panzoom transform: screenPos = canvasPos * scale + pan.
+ */
+export interface Transform {
+  scale: number;
+  panX: number;
+  panY: number;
+}
+
+/**
+ * Clamp a pan offset on one axis so the target extent stays inside the viewport.
+ *
+ * The near edge (canvas `start`) must satisfy start*scale + pan >= 0, and the
+ * far edge (canvas start+size) must satisfy (start+size)*scale + pan <=
+ * viewportSize. When the scaled extent is wider than the viewport the two
+ * bounds cross; align the near edge to the viewport origin so the top/left
+ * stays visible, matching the top-left alignment in calculateFitAll.
+ */
+function clampPanAxis(
+  pan: number,
+  start: number,
+  size: number,
+  scale: number,
+  viewportSize: number,
+): number {
+  const panForNearEdge = -start * scale; // pan >= this keeps the near edge visible
+  const panForFarEdge = viewportSize - (start + size) * scale; // pan <= this
+  const clamped =
+    panForNearEdge > panForFarEdge
+      ? panForNearEdge
+      : Math.min(Math.max(pan, panForNearEdge), panForFarEdge);
+  // Normalise -0 to 0 so callers get stable, comparable pan values.
+  return clamped === 0 ? 0 : clamped;
+}
+
+/**
+ * Compute the minimal transform that keeps `target` (canvas coords) fully
+ * visible in the viewport, given the current transform.
+ *
+ * Returns the current transform unchanged when the target already fits inside
+ * the viewport. Only ever zooms out (never in) and pans by the least amount
+ * needed. A shrinking or already-contained extent is therefore a no-op, so a
+ * caller can invoke this on every direct-manipulation commit without special-
+ * casing grow vs. shrink.
+ *
+ * @param target - Extent to keep visible, in canvas coordinates
+ * @param viewport - Viewport size in screen pixels
+ * @param current - Current panzoom transform
+ * @param minZoom - Lowest zoom the result may use (default FIT_ALL_MIN_ZOOM)
+ * @param maxZoom - Highest zoom the result may use (default FIT_ALL_MAX_ZOOM)
+ */
+export function ensureVisibleTransform(
+  target: Bounds,
+  viewport: Viewport,
+  current: Transform,
+  minZoom: number = FIT_ALL_MIN_ZOOM,
+  maxZoom: number = FIT_ALL_MAX_ZOOM,
+): Transform {
+  // Degenerate target or viewport: nothing to contain, leave the camera still.
+  if (
+    target.width <= 0 ||
+    target.height <= 0 ||
+    viewport.width <= 0 ||
+    viewport.height <= 0
+  ) {
+    return current;
+  }
+
+  const { scale, panX, panY } = current;
+
+  // Project the target to screen space at the current transform.
+  const left = target.x * scale + panX;
+  const top = target.y * scale + panY;
+  const right = (target.x + target.width) * scale + panX;
+  const bottom = (target.y + target.height) * scale + panY;
+
+  const contained =
+    left >= 0 &&
+    top >= 0 &&
+    right <= viewport.width &&
+    bottom <= viewport.height;
+  if (contained) return current;
+
+  // Zoom out just enough to fit the target when it no longer fits at the
+  // current scale; never zoom in (that would move the camera on a contained
+  // or shrinking extent).
+  const fitScale = Math.min(
+    viewport.width / target.width,
+    viewport.height / target.height,
+  );
+  const nextScale =
+    fitScale < scale ? Math.max(minZoom, Math.min(fitScale, maxZoom)) : scale;
+
+  const nextPanX = clampPanAxis(
+    panX,
+    target.x,
+    target.width,
+    nextScale,
+    viewport.width,
+  );
+  const nextPanY = clampPanAxis(
+    panY,
+    target.y,
+    target.height,
+    nextScale,
+    viewport.height,
+  );
+
+  return { scale: nextScale, panX: nextPanX, panY: nextPanY };
+}
+
 // =============================================================================
 // Bayed Rack Dimension Constants
 // =============================================================================

--- a/src/tests/canvas-store.test.ts
+++ b/src/tests/canvas-store.test.ts
@@ -511,6 +511,60 @@ describe("Canvas Store", () => {
     });
   });
 
+  describe("ensureRacksVisible", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function setup(viewportWidth: number, viewportHeight: number) {
+      const store = getCanvasStore();
+      const mockPanzoom = createMockPanzoom(1);
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn(() => ({ matches: false })),
+      );
+      const mockCanvas = document.createElement("div");
+      Object.defineProperty(mockCanvas, "clientWidth", {
+        value: viewportWidth,
+      });
+      Object.defineProperty(mockCanvas, "clientHeight", {
+        value: viewportHeight,
+      });
+      store.setCanvasElement(mockCanvas);
+      store.setPanzoomInstance(
+        mockPanzoom as ReturnType<typeof import("panzoom").default>,
+      );
+      return { store, mockPanzoom };
+    }
+
+    it("does nothing without a panzoom instance", () => {
+      const store = getCanvasStore();
+      const rack = createTestRack({ id: "rack-1" });
+      expect(() => store.ensureRacksVisible(["rack-1"], [rack])).not.toThrow();
+    });
+
+    it("keeps the camera still when the rack is already fully visible", () => {
+      // A viewport far larger than the rack contains it at scale 1, pan 0.
+      const { store, mockPanzoom } = setup(5000, 5000);
+      const rack = createTestRack({ id: "rack-1", height: 42 });
+
+      store.ensureRacksVisible(["rack-1"], [rack]);
+
+      expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
+      expect(mockPanzoom.moveTo).not.toHaveBeenCalled();
+    });
+
+    it("moves the camera when the rack extends past the viewport", () => {
+      // A tiny viewport cannot contain the rack, so the camera must animate.
+      const { store, mockPanzoom } = setup(200, 200);
+      const rack = createTestRack({ id: "rack-1", height: 42 });
+
+      store.ensureRacksVisible(["rack-1"], [rack]);
+
+      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
+    });
+  });
+
   describe("zoomToDevice", () => {
     afterEach(() => {
       vi.unstubAllGlobals();

--- a/src/tests/canvas-utils.test.ts
+++ b/src/tests/canvas-utils.test.ts
@@ -10,6 +10,7 @@ import {
   calculateRacksBoundingBox,
   racksToPositions,
   calculateFitAll,
+  ensureVisibleTransform,
 } from "$lib/utils/canvas";
 import { createTestRack } from "./factories";
 import {
@@ -198,6 +199,72 @@ describe("Canvas Utils", () => {
       // Content should fit within viewport (with some margin for rounding)
       expect(scaledWidth).toBeLessThanOrEqual(viewportWidth + 1);
       expect(scaledHeight).toBeLessThanOrEqual(viewportHeight + 1);
+    });
+  });
+
+  describe("ensureVisibleTransform", () => {
+    const viewport = { width: 800, height: 600 };
+    const identity = { scale: 1, panX: 0, panY: 0 };
+
+    it("returns the current transform when the target is fully contained", () => {
+      const target = { x: 100, y: 100, width: 200, height: 200 };
+      const result = ensureVisibleTransform(target, viewport, identity);
+      expect(result).toEqual(identity);
+    });
+
+    it("returns the current transform for a shrinking, contained extent", () => {
+      // A smaller extent inside the viewport must never move the camera.
+      const target = { x: 300, y: 250, width: 80, height: 80 };
+      const result = ensureVisibleTransform(target, viewport, identity);
+      expect(result).toEqual(identity);
+    });
+
+    it("respects a non-identity current transform when already contained", () => {
+      // At pan -100 the target's left edge sits exactly at the viewport origin.
+      const target = { x: 100, y: 100, width: 200, height: 200 };
+      const current = { scale: 1, panX: -100, panY: 0 };
+      const result = ensureVisibleTransform(target, viewport, current);
+      expect(result).toEqual(current);
+    });
+
+    it("pans left by the minimum needed when the target overflows the right edge", () => {
+      const target = { x: 700, y: 100, width: 200, height: 200 };
+      const result = ensureVisibleTransform(target, viewport, identity);
+      // Right edge is 900 at pan 0; pan -100 lands it exactly on the edge.
+      expect(result).toEqual({ scale: 1, panX: -100, panY: 0 });
+    });
+
+    it("pans up by the minimum needed when the target overflows the bottom edge", () => {
+      const target = { x: 100, y: 500, width: 200, height: 200 };
+      const result = ensureVisibleTransform(target, viewport, identity);
+      // Bottom edge is 700 at pan 0; pan -100 lands it exactly on the edge.
+      expect(result).toEqual({ scale: 1, panX: 0, panY: -100 });
+    });
+
+    it("pans right and down to reveal a target off the top-left", () => {
+      const target = { x: -100, y: -50, width: 200, height: 200 };
+      const result = ensureVisibleTransform(target, viewport, identity);
+      expect(result).toEqual({ scale: 1, panX: 100, panY: 50 });
+    });
+
+    it("zooms out just enough to fit a target taller than the viewport", () => {
+      const target = { x: 0, y: 0, width: 200, height: 1200 };
+      const result = ensureVisibleTransform(target, viewport, identity);
+      // fit scale = min(800/200, 600/1200) = 0.5; height fills the viewport.
+      expect(result).toEqual({ scale: 0.5, panX: 0, panY: 0 });
+    });
+
+    it("clamps to min zoom and aligns top-left when the target cannot fully fit", () => {
+      const target = { x: 0, y: 0, width: 5000, height: 5000 };
+      const result = ensureVisibleTransform(target, viewport, identity);
+      // fit scale 0.12 < min zoom 0.25, so clamp to 0.25 and align near edges.
+      expect(result).toEqual({ scale: 0.25, panX: 0, panY: 0 });
+    });
+
+    it("leaves the camera still for a degenerate target", () => {
+      const target = { x: 0, y: 0, width: 0, height: 0 };
+      const result = ensureVisibleTransform(target, viewport, identity);
+      expect(result).toEqual(identity);
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

After a resize commits (drag release or keyboard step) or a bay is created, the canvas now animates by the minimum pan and zoom needed to keep the changed extent fully visible. Shrinking never moves the camera, and undo/redo never move the camera.

- Added a pure helper `ensureVisibleTransform(target, viewport, current)` in `src/lib/utils/canvas.ts`. It reuses the existing `screenPos = canvasPos * scale + pan` model: returns the current transform unchanged when the target rect is already contained, otherwise the minimal pan (and, only when the extent no longer fits, a zoom-out) to contain it. It never zooms in, so a contained or shrinking extent is always a no-op.
- Added `ensureRacksVisible(rackIds, allRacks, rackGroups, rightOffset)` to the canvas store (`src/lib/stores/canvas.svelte.ts`). It unions the target racks' canvas positions into one extent, calls the pure helper, and animates via the existing `smoothMoveTo` only when the transform actually changes.
- Wired it into `src/lib/components/RackCanvasView.svelte` at the two direct-manipulation commit sites: `commitResizeHeight` (used by both drag release and keyboard steps) and `handleBayRack` (bay creation). It is deliberately NOT triggered from store mutations, so undo and redo stay still.

## Design source

Implements the "Camera" decisions from the epic #2820 spec: ensure-visible on resize commit, animated and minimal, only when the new extent breaks the viewport; shrinking never moves the camera; no mid-drag edge auto-pan (deferred, not built); undo/redo never move the camera; bay creation commit also gets ensure-visible so the new member ends on screen.

## Acceptance criteria

- [x] Growing a rack past the viewport edge: on commit the camera animates just enough to show the full rack
- [x] Resize that stays within the viewport: camera does not move (containment returns identity)
- [x] Shrink: camera does not move (a smaller extent is still contained)
- [x] Keyboard 1U steps follow the same rule (route through `commitResizeHeight`; movement typically nil)
- [x] Bay creation: the new member ends on screen (group extent includes the new member)
- [x] Undo and redo of these operations: no camera movement (only commit handlers call ensure-visible)
- [x] No auto-pan mid-drag at the viewport edge (not built)

## Tests

- `src/tests/canvas-utils.test.ts`: 9 unit tests for the ensure-visible coordinate math (identity when contained; identity for shrink/contained; respects a non-identity current transform; minimal pan for right/bottom/top-left overflow; zoom-out to fit a too-tall target; clamp to min zoom with top-left align; degenerate target).
- `src/tests/canvas-store.test.ts`: 3 tests for `ensureRacksVisible` (no-op without panzoom; no move when contained; animates when the rack overflows a small viewport).

Local gates: lint clean, `npm run check` 0 errors, `npm run test:run` 3154 passed, `npm run build` success.

## Coordination note

The bay-creation ensure-visible hook lives at the end of `handleBayRack` and calls `canvasStore.ensureRacksVisible(group.rack_ids, ...)`. The camera math is a pure, tested helper in `canvas.ts`, so #2823's restructure of the bay path can keep calling the store method after the commit. This PR touches only `commitResizeHeight` and `handleBayRack` in `RackCanvasView.svelte`, not `handleResizeMove`/`handleResizeEnd` (the regions #2821 edits).

Closes #2825

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep resized racks and new bays fully on screen after commit**

### What Changed
- After a rack resize is committed, the camera now pans, or zooms out if needed, just enough to keep the full rack visible.
- Shrinking a rack or making a change that already fits in the viewport no longer moves the camera.
- Creating or extending a bay now keeps the whole bay group visible, including the new member.
- Undo and redo keep the camera still.

### Impact
`✅ Fewer racks cut off after resize`
`✅ Clearer bay creation on screen`
`✅ Camera stays still for contained shrinks and undo/redo`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
