### PR TITLE
feat: consolidate rack controls into the verb bar (#2822)

### DIFF
--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -219,10 +219,20 @@ export function createActionDispatch(): ActionDispatch {
     // Rack reorder and bay verbs live on the floating verb bar (#2822); they
     // have no keybinding and are excluded from the palette, so these entries
     // exist only to keep the dispatch map total. Their real gating (row length,
-    // empty-vs-populated, bay group) is resolved inside the shared handlers.
-    "move-rack-left": () => moveSelectedRack("left"),
-    "move-rack-right": () => moveSelectedRack("right"),
-    "bay-rack": baySelectedRack,
+    // empty-vs-populated, bay group) is resolved inside the shared handlers;
+    // read-only is enforced here like the other mutation verbs.
+    "move-rack-left": () => {
+      if (getUIStore().readOnly) return;
+      moveSelectedRack("left");
+    },
+    "move-rack-right": () => {
+      if (getUIStore().readOnly) return;
+      moveSelectedRack("right");
+    },
+    "bay-rack": () => {
+      if (getUIStore().readOnly) return;
+      baySelectedRack();
+    },
     // rack-actions take string[] not string; wrap selectedRackId in array
     "focus-rack": () => {
       const id = getSelectionStore().selectedRackId;

--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -27,6 +27,8 @@ import {
   moveSelectedDeviceToSlot,
   duplicateSelection,
   flipSelectedDeviceFace,
+  moveSelectedRack,
+  baySelectedRack,
 } from "$lib/actions/selection-actions";
 import {
   maybeSave,
@@ -214,6 +216,13 @@ export function createActionDispatch(): ActionDispatch {
       if (getUIStore().readOnly) return;
       flipSelectedDeviceFace();
     },
+    // Rack reorder and bay verbs live on the floating verb bar (#2822); they
+    // have no keybinding and are excluded from the palette, so these entries
+    // exist only to keep the dispatch map total. Their real gating (row length,
+    // empty-vs-populated, bay group) is resolved inside the shared handlers.
+    "move-rack-left": () => moveSelectedRack("left"),
+    "move-rack-right": () => moveSelectedRack("right"),
+    "bay-rack": baySelectedRack,
     // rack-actions take string[] not string; wrap selectedRackId in array
     "focus-rack": () => {
       const id = getSelectionStore().selectedRackId;

--- a/src/lib/actions/palette-commands.ts
+++ b/src/lib/actions/palette-commands.ts
@@ -37,6 +37,12 @@ export interface PaletteCommandGroup {
 const EXCLUDED: ReadonlySet<ActionId> = new Set<ActionId>([
   "command-palette",
   "escape",
+  // Verb-bar-only rack controls (#2822): their availability turns on row
+  // geometry (row length, empty-vs-populated, bay group) that the palette's
+  // context cannot express, so they surface only on the floating verb bar.
+  "move-rack-left",
+  "move-rack-right",
+  "bay-rack",
 ]);
 
 /**

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -53,6 +53,9 @@ export type ActionId =
   | "flip-device-face"
   | "focus-rack"
   | "export-rack"
+  | "move-rack-left"
+  | "move-rack-right"
+  | "bay-rack"
   | "cycle-rack-prev"
   | "cycle-rack-next"
   | "escape"
@@ -334,6 +337,28 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     bindings: [],
     enabledWhen: (ctx) => ctx.isRackSelected,
     keywords: ["download", "svg", "pdf", "png"],
+  },
+  // Rack reorder and bay verbs live only on the floating verb bar (#2822).
+  // Their availability depends on row geometry (row length, empty-vs-populated,
+  // bay group) that ActionEnabledContext does not carry, so the verb bar gates
+  // them from the row model and they are excluded from the command palette.
+  {
+    id: "move-rack-left",
+    label: "Move rack left",
+    scope: "selection",
+    bindings: [],
+  },
+  {
+    id: "move-rack-right",
+    label: "Move rack right",
+    scope: "selection",
+    bindings: [],
+  },
+  {
+    id: "bay-rack",
+    label: "Bay rack",
+    scope: "selection",
+    bindings: [],
   },
 
   // --- File -----------------------------------------------------------------

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -347,18 +347,21 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     label: "Move rack left",
     scope: "selection",
     bindings: [],
+    enabledWhen: (ctx) => !ctx.readOnly,
   },
   {
     id: "move-rack-right",
     label: "Move rack right",
     scope: "selection",
     bindings: [],
+    enabledWhen: (ctx) => !ctx.readOnly,
   },
   {
     id: "bay-rack",
     label: "Bay rack",
     scope: "selection",
     bindings: [],
+    enabledWhen: (ctx) => !ctx.readOnly,
   },
 
   // --- File -----------------------------------------------------------------

--- a/src/lib/actions/selection-actions.ts
+++ b/src/lib/actions/selection-actions.ts
@@ -8,7 +8,11 @@
 
 import { getLayoutStore } from "$lib/stores/layout.svelte";
 import { getSelectionStore } from "$lib/stores/selection.svelte";
+import { getCanvasStore } from "$lib/stores/canvas.svelte";
+import { getUIStore } from "$lib/stores/ui.svelte";
 import { getToastStore } from "$lib/stores/toast.svelte";
+import { hapticSuccess, hapticError } from "$lib/utils/haptics";
+import { getRackSlotControls } from "$lib/utils/rack-row";
 import { findNextValidPosition } from "$lib/utils/device-movement";
 import {
   canPlaceDevice,
@@ -149,6 +153,89 @@ export function moveSelectedDeviceToSlot(): void {
   if (deviceIndex === null) return;
 
   layoutStore.moveDeviceToSlot(selectionStore.selectedRackId, deviceIndex);
+}
+
+/**
+ * Reorder the selected rack (or bayed group) one slot left or right in the
+ * canvas row. A group moves as a unit, since its active member carries the
+ * selection's rack id. No-op unless a rack or group is selected. Routed through
+ * the layout store so undo/redo covers it. Shared by the verb bar (#2822).
+ */
+export function moveSelectedRack(direction: "left" | "right"): void {
+  const selectionStore = getSelectionStore();
+  const layoutStore = getLayoutStore();
+
+  if (!selectionStore.isRackSelected && !selectionStore.isGroupSelected) return;
+  const id = selectionStore.selectedRackId;
+  if (!id) return;
+
+  layoutStore.moveRackInRow(id, direction);
+}
+
+/**
+ * Create a bay from a standalone rack, or extend an existing bay, from the
+ * given source rack. The new member inherits the source's width, form factor,
+ * and height. On success it selects the resulting bay and keeps it on screen
+ * with a minimal ensure-visible camera move (#2825); on failure it surfaces a
+ * toast. Shared by the verb bar (#2822) and the edge-drag grip so both baying
+ * paths behave identically.
+ */
+export function bayRack(sourceRackId: string): void {
+  const layoutStore = getLayoutStore();
+  const selectionStore = getSelectionStore();
+  const canvasStore = getCanvasStore();
+  const toastStore = getToastStore();
+
+  const result = layoutStore.createBayedRack(sourceRackId);
+  if (result.error || !result.groupId) {
+    hapticError();
+    toastStore.showToast(
+      result.error ?? "Can't bay this rack",
+      "warning",
+      3000,
+    );
+    return;
+  }
+  hapticSuccess();
+  // Select the resulting bay so its bay-level affordances surface at once.
+  layoutStore.setActiveRack(sourceRackId);
+  selectionStore.selectGroup(result.groupId, sourceRackId);
+  // Direct-manipulation commit: keep the bay group (including the new member)
+  // on screen with minimal camera movement. Passing the group's rack_ids
+  // resolves to the whole group's extent so the new member ends up visible.
+  const group = layoutStore.getRackGroupById(result.groupId);
+  if (group) {
+    canvasStore.ensureRacksVisible(
+      group.rack_ids,
+      layoutStore.racks,
+      layoutStore.rack_groups,
+    );
+  }
+}
+
+/**
+ * Bay the current selection: resolve the bay source for the selected rack or
+ * group (an empty standalone rack bays itself; a bayed group extends from its
+ * active member) and run bayRack on it. No-op unless the bayed-racks setting is
+ * on, a rack or group is selected, and that slot offers a bay source. Shared by
+ * the verb bar's bay action and the dispatch spine so both gate baying the same
+ * way as the edge grip.
+ */
+export function baySelectedRack(): void {
+  const selectionStore = getSelectionStore();
+  const layoutStore = getLayoutStore();
+  const uiStore = getUIStore();
+
+  if (!uiStore.enableBayedRacks) return;
+  if (!selectionStore.isRackSelected && !selectionStore.isGroupSelected) return;
+
+  const { baySource } = getRackSlotControls(
+    layoutStore.racks,
+    layoutStore.rack_groups,
+    selectionStore.selectedRackId,
+    layoutStore.activeRackId,
+  );
+  if (baySource) bayRack(baySource);
 }
 
 /**

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -19,8 +19,7 @@
   import RackDualView from "./RackDualView.svelte";
   import BayedRackView from "./BayedRackView.svelte";
   import { organizeRackRow } from "$lib/utils/rack-row";
-  import { IconChevronLeft, IconChevronRight, IconPlus } from "./icons";
-  import { ICON_SIZE } from "$lib/constants/sizing";
+  import { bayRack } from "$lib/actions/selection-actions";
   import { getMinResizeHeight, snapResizeHeight } from "$lib/utils/rack-resize";
   import { U_HEIGHT_PX, getRackWidth } from "$lib/constants/layout";
   import { MAX_RACK_HEIGHT } from "$lib/types/constants";
@@ -106,59 +105,13 @@
   // organizeRackRow for the ordering and grouping rules.
   const rowItems = $derived(organizeRackRow(racks, rackGroups));
 
-  // The selected row slot is the rack or group the user has selected; a device
-  // selection does not surface the reorder controls. For a selected group the
-  // selection store holds its active member, so the slot lookup resolves to the
-  // group that owns that member.
-  const selectedSlotRackId = $derived(
-    selectionStore.selectedType === "rack" ||
-      selectionStore.selectedType === "group"
-      ? selectionStore.selectedRackId
-      : null,
-  );
-
-  // Index of the selected slot within the row, or -1 when nothing reorderable
-  // is selected. A grouped rack resolves to its group's single slot.
-  const selectedSlotIndex = $derived.by(() => {
-    const id = selectedSlotRackId;
-    if (!id) return -1;
-    return rowItems.findIndex((item) =>
-      item.kind === "rack"
-        ? item.rack.id === id
-        : item.racks.some((rack) => rack.id === id),
-    );
-  });
-
   // The selected bayed group's id, or null when the selection is not a group.
-  // Drives the bay-level resize handle and "Bay rack" affordance on a bay slot.
+  // Drives the bay-level resize handle on a bay slot.
   const selectedGroupId = $derived(
     selectionStore.selectedType === "group"
       ? selectionStore.selectedGroupId
       : null,
   );
-
-  // The rack to bay from for the selected slot: a standalone rack bays itself; a
-  // bayed group bays from its active member so a new bay lands beside it. Null
-  // for a non-bayed (row) group, which cannot be bayed.
-  const selectedSlotBaySource = $derived.by(() => {
-    const item = rowItems[selectedSlotIndex];
-    if (!item) return null;
-    if (item.kind === "rack") return item.rack.id;
-    if (item.group.layout_preset !== "bayed") return null;
-    const active =
-      activeRackId && item.racks.some((rack) => rack.id === activeRackId)
-        ? activeRackId
-        : item.racks[0]?.id;
-    return active ?? null;
-  });
-
-  // Reorder the selected slot left or right. A grouped rack moves its whole
-  // group as a unit. Routed through the layout store so undo/redo covers it.
-  function handleMoveRack(direction: "left" | "right") {
-    const id = selectedSlotRackId;
-    if (!id) return;
-    layoutStore.moveRackInRow(id, direction);
-  }
 
   // --- Canvas drag-to-resize for standalone racks (#2737) ---
   // Grips on a selected standalone rack drag its height in whole-U steps. The
@@ -365,36 +318,10 @@
   }
 
   // --- Baying: create / extend a bay (#2740) ---
-  // The "Bay rack" button and the resistant edge drag both run one store action
-  // that forms a bay from a standalone rack or extends an existing bay, with the
-  // new member inheriting width / form factor / height from the source.
-  function handleBayRack(sourceRackId: string) {
-    const result = layoutStore.createBayedRack(sourceRackId);
-    if (result.error || !result.groupId) {
-      hapticError();
-      toastStore.showToast(
-        result.error ?? "Can't bay this rack",
-        "warning",
-        3000,
-      );
-      return;
-    }
-    hapticSuccess();
-    // Select the resulting bay so its bay-level affordances surface at once.
-    layoutStore.setActiveRack(sourceRackId);
-    selectionStore.selectGroup(result.groupId, sourceRackId);
-    // Direct-manipulation commit: keep the bay group (including the new member)
-    // on screen with minimal camera movement. Passing the group's rack_ids
-    // resolves to the whole group's extent so the new member ends up visible.
-    const group = layoutStore.getRackGroupById(result.groupId);
-    if (group) {
-      canvasStore.ensureRacksVisible(
-        group.rack_ids,
-        layoutStore.racks,
-        layoutStore.rack_groups,
-      );
-    }
-  }
+  // Both the verb bar's bay action and the resistant edge drag run one shared
+  // store action (bayRack) that forms a bay from a standalone rack or extends an
+  // existing bay, with the new member inheriting width / form factor / height
+  // from the source, then keeps the result on screen (#2822, #2825).
 
   // Resistant right-edge drag on an empty rack: a rubber-band ghost that snaps
   // past a threshold to create or insert a bayed rack (#2740). Offered only on
@@ -469,7 +396,7 @@
     if (!drag || event.pointerId !== drag.pointerId) return;
     const { rackId, armed } = drag;
     bayDrag = null;
-    if (armed) handleBayRack(rackId);
+    if (armed) bayRack(rackId);
   }
 
   function handleBayDragCancel(event: PointerEvent) {
@@ -648,55 +575,8 @@
       <span class="grip-bar" aria-hidden="true"></span>
     </button>
   {/snippet}
-  {#each rowItems as item, slotIndex (item.kind === "rack" ? `rack:${item.rack.id}` : `group:${item.group.id}`)}
+  {#each rowItems as item (item.kind === "rack" ? `rack:${item.rack.id}` : `group:${item.group.id}`)}
     <div class="row-slot">
-      {#if slotIndex === selectedSlotIndex}
-        <div class="slot-controls">
-          {#if rowItems.length >= 2}
-            <div
-              class="rack-move-controls"
-              role="group"
-              aria-label="Reorder rack"
-            >
-              <button
-                type="button"
-                class="move-button"
-                aria-label="Move rack left"
-                title="Move rack left"
-                disabled={slotIndex === 0}
-                onclick={() => handleMoveRack("left")}
-              >
-                <IconChevronLeft size={ICON_SIZE.sm} />
-              </button>
-              <button
-                type="button"
-                class="move-button"
-                aria-label="Move rack right"
-                title="Move rack right"
-                disabled={slotIndex === rowItems.length - 1}
-                onclick={() => handleMoveRack("right")}
-              >
-                <IconChevronRight size={ICON_SIZE.sm} />
-              </button>
-            </div>
-          {/if}
-          {#if uiStore.enableBayedRacks && selectedSlotBaySource}
-            <button
-              type="button"
-              class="bay-button"
-              aria-label="Bay rack"
-              title="Add a bayed rack to the right"
-              onclick={() => {
-                const id = selectedSlotBaySource;
-                if (id) handleBayRack(id);
-              }}
-            >
-              <IconPlus size={ICON_SIZE.sm} />
-              <span class="bay-button-label">Bay</span>
-            </button>
-          {/if}
-        </div>
-      {/if}
       {#if item.kind === "rack"}
         {@const rack = item.rack}
         {@const isActive = rack.id === activeRackId}
@@ -996,67 +876,14 @@
     }
   }
 
-  /* Each row slot stacks its reorder controls above the rack. The wrapper is
-     the flex child the row gap and bottom-alignment act on, so unselected slots
-     are the rack alone and the selected slot grows upward without shifting the
-     shared baseline. */
+  /* One row slot per rack or bayed group. The wrapper is the flex child the
+     row gap and bottom-alignment act on, so slots share the baseline whatever
+     their height. Reorder and bay controls now live on the floating verb bar
+     (#2822), not in this lane. */
   .row-slot {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--space-2);
-  }
-
-  .rack-move-controls {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    padding: var(--space-1);
-    border-radius: var(--radius-full);
-    border: 1px solid var(--colour-border);
-    background: var(--colour-surface-overlay, rgba(40, 42, 54, 0.6));
-  }
-
-  .move-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: var(--touch-target-min);
-    min-height: var(--touch-target-min);
-    width: var(--touch-target-min);
-    height: var(--touch-target-min);
-    padding: 0;
-    border: none;
-    border-radius: var(--radius-full);
-    background: transparent;
-    color: var(--colour-text);
-    cursor: pointer;
-    touch-action: manipulation;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  .move-button:hover:not(:disabled) {
-    background: var(--colour-overlay-hover);
-    color: var(--colour-primary);
-  }
-
-  .move-button:focus-visible {
-    outline: none;
-    box-shadow: var(--focus-ring-glow);
-    color: var(--colour-primary);
-  }
-
-  .move-button:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .move-button {
-      transition:
-        background-color var(--duration-fast) var(--ease-out),
-        color var(--duration-fast) var(--ease-out);
-    }
   }
 
   /* Drag-to-resize grips on a selected standalone rack (#2737). The wrapper is
@@ -1148,57 +975,6 @@
   .resize-readout-bottom {
     bottom: 0;
     transform: translate(-50%, calc(100% + var(--space-2)));
-  }
-
-  /* Per-slot control cluster above a selected slot: reorder pill plus the
-     "Bay rack" button. Sits in the row-slot's column flow above the rack. */
-  .slot-controls {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-  }
-
-  /* "Bay rack" button: forms or extends a bay to the right of the selection. */
-  .bay-button {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    min-height: var(--touch-target-min);
-    padding: 0 var(--space-3);
-    border: 1px solid var(--colour-border);
-    border-radius: var(--radius-full);
-    background: var(--colour-surface-overlay, rgba(40, 42, 54, 0.6));
-    color: var(--colour-text);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-semibold, 600);
-    cursor: pointer;
-    touch-action: manipulation;
-    -webkit-tap-highlight-color: transparent;
-  }
-
-  .bay-button:hover {
-    background: var(--colour-overlay-hover);
-    color: var(--colour-primary);
-    border-color: var(--colour-selection);
-  }
-
-  .bay-button:focus-visible {
-    outline: none;
-    box-shadow: var(--focus-ring-glow);
-    color: var(--colour-primary);
-  }
-
-  .bay-button-label {
-    line-height: 1;
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    .bay-button {
-      transition:
-        background-color var(--duration-fast) var(--ease-out),
-        color var(--duration-fast) var(--ease-out),
-        border-color var(--duration-fast) var(--ease-out);
-    }
   }
 
   /* Bayed-group wrapper: the positioning context for the bay-level resize grips

--- a/src/lib/components/VerbBar.svelte
+++ b/src/lib/components/VerbBar.svelte
@@ -21,10 +21,12 @@
   import {
     IconChevronUp,
     IconChevronDown,
+    IconChevronLeft,
     IconChevronRight,
     IconCopy,
     IconDownloadBold,
     IconFitAllBold,
+    IconPlus,
     IconTransitionRight,
     IconTrash,
   } from "./icons";
@@ -32,6 +34,10 @@
   export interface VerbItem {
     id: ActionId;
     label: string;
+    /** Rendered but not activatable, e.g. a reorder chevron at a row end. */
+    disabled?: boolean;
+    /** Draw a divider before this item, separating position from object verbs. */
+    dividerBefore?: boolean;
   }
 
   interface Props {
@@ -49,6 +55,9 @@
     "move-device-up": IconChevronUp,
     "move-device-down": IconChevronDown,
     "move-device-slot": IconChevronRight,
+    "move-rack-left": IconChevronLeft,
+    "move-rack-right": IconChevronRight,
+    "bay-rack": IconPlus,
     "flip-device-face": IconTransitionRight,
     "duplicate-selection": IconCopy,
     "delete-selection": IconTrash,
@@ -93,6 +102,9 @@
     {#each verbs as verb, index (verb.id)}
       {@const Icon = iconForVerb[verb.id]}
       {@const tooltip = getActionTooltip(verb.id)}
+      {#if verb.dividerBefore}
+        <span class="verb-divider" aria-hidden="true"></span>
+      {/if}
       <Tooltip text={tooltip?.label ?? verb.label} shortcut={tooltip?.shortcut}>
         {#snippet triggerChild({ props })}
           <button
@@ -102,8 +114,11 @@
             class:destructive={isDestructive(verb.id)}
             type="button"
             aria-label={verb.label}
+            aria-disabled={verb.disabled ? "true" : undefined}
             tabindex={index === clampedActiveIndex ? 0 : -1}
-            onclick={() => ondispatch(verb.id)}
+            onclick={() => {
+              if (!verb.disabled) ondispatch(verb.id);
+            }}
           >
             {#if Icon}
               <Icon size={ICON_SIZE.md} />
@@ -195,6 +210,28 @@
   .verb-button.destructive:hover,
   .verb-button.destructive:focus-visible {
     color: var(--colour-button-destructive);
+  }
+
+  /* A disabled reorder chevron stays visible and focusable (aria-disabled, not
+     the native attribute, so the roving toolbar stays reachable at a row end)
+     but reads as inert and does not react to hover. */
+  .verb-button[aria-disabled="true"] {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .verb-button[aria-disabled="true"]:hover {
+    background: transparent;
+    color: var(--colour-text);
+  }
+
+  /* Hairline separating the leading position verbs from the object verbs. */
+  .verb-divider {
+    flex: none;
+    width: 1px;
+    height: var(--space-5);
+    margin-inline: var(--space-1);
+    background: var(--verb-bar-border);
   }
 
   @media (prefers-reduced-motion: no-preference) {

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -110,20 +110,21 @@
 
     if (!isRackOrGroup) return objectVerbs;
 
-    const position: VerbItem[] = slotControls.canReorder && !ctx.readOnly
-      ? [
-          {
-            id: "move-rack-left",
-            label: "Move rack left",
-            disabled: !slotControls.canMoveLeft,
-          },
-          {
-            id: "move-rack-right",
-            label: "Move rack right",
-            disabled: !slotControls.canMoveRight,
-          },
-        ]
-      : [];
+    const position: VerbItem[] =
+      slotControls.canReorder && !ctx.readOnly
+        ? [
+            {
+              id: "move-rack-left",
+              label: "Move rack left",
+              disabled: !slotControls.canMoveLeft,
+            },
+            {
+              id: "move-rack-right",
+              label: "Move rack right",
+              disabled: !slotControls.canMoveRight,
+            },
+          ]
+        : [];
 
     const bayVerbs: VerbItem[] = showBayVerb
       ? [{ id: "bay-rack", label: "Bay rack" }]

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -81,12 +81,19 @@
           selection.selectedRackId,
           layout.activeRackId,
         )
-      : { canReorder: false, canMoveLeft: false, canMoveRight: false, baySource: null },
+      : {
+          canReorder: false,
+          canMoveLeft: false,
+          canMoveRight: false,
+          baySource: null,
+        },
   );
 
   // The bay verb is offered only for empty standalone racks and bay groups
   // (baySource), and only when the bayed-racks setting is on.
-  const showBayVerb = $derived(ui.enableBayedRacks && slotControls.baySource !== null);
+  const showBayVerb = $derived(
+    ui.enableBayedRacks && slotControls.baySource !== null,
+  );
 
   // Compose the bar: leading reorder chevrons (position verbs), then a divider,
   // then the object verbs (bay plus the registry-filtered selection verbs).

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -11,8 +11,9 @@
   canvas transform. VerbBar stays presentation-only.
 -->
 <script lang="ts">
-  import VerbBar from "./VerbBar.svelte";
+  import VerbBar, { type VerbItem } from "./VerbBar.svelte";
   import { getVerbsForSelection } from "$lib/actions/verb-bars";
+  import { getRackSlotControls } from "$lib/utils/rack-row";
   import {
     computeVerbBarPosition,
     VERB_BAR_LOW_ZOOM_THRESHOLD,
@@ -26,6 +27,8 @@
     canMoveSelectedDeviceSlot,
     flipSelectedDeviceFace,
     duplicateSelection,
+    moveSelectedRack,
+    baySelectedRack,
   } from "$lib/actions/selection-actions";
   import { getSelectionStore } from "$lib/stores/selection.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
@@ -63,9 +66,70 @@
     readOnly: ui.readOnly,
   });
 
-  const verbs = $derived(
-    getVerbsForSelection(ctx).map((a) => ({ id: a.id, label: a.label })),
+  // Reorder and bay availability for the selected row slot. A rack or a bayed
+  // group carries the target rack id (a group's active member); a device
+  // selection has no row-slot controls.
+  const isRackOrGroup = $derived(
+    selection.isRackSelected || selection.isGroupSelected,
   );
+
+  const slotControls = $derived(
+    isRackOrGroup
+      ? getRackSlotControls(
+          layout.racks,
+          layout.rack_groups,
+          selection.selectedRackId,
+          layout.activeRackId,
+        )
+      : { canReorder: false, canMoveLeft: false, canMoveRight: false, baySource: null },
+  );
+
+  // The bay verb is offered only for empty standalone racks and bay groups
+  // (baySource), and only when the bayed-racks setting is on.
+  const showBayVerb = $derived(ui.enableBayedRacks && slotControls.baySource !== null);
+
+  // Compose the bar: leading reorder chevrons (position verbs), then a divider,
+  // then the object verbs (bay plus the registry-filtered selection verbs).
+  // Device selections keep the object-verb-only bar. Chevrons show only when the
+  // row has two or more slots and disable at the ends.
+  const verbs = $derived.by<VerbItem[]>(() => {
+    const objectVerbs: VerbItem[] = getVerbsForSelection(ctx).map((a) => ({
+      id: a.id,
+      label: a.label,
+    }));
+
+    if (!isRackOrGroup) return objectVerbs;
+
+    const position: VerbItem[] = slotControls.canReorder
+      ? [
+          {
+            id: "move-rack-left",
+            label: "Move rack left",
+            disabled: !slotControls.canMoveLeft,
+          },
+          {
+            id: "move-rack-right",
+            label: "Move rack right",
+            disabled: !slotControls.canMoveRight,
+          },
+        ]
+      : [];
+
+    const bayVerbs: VerbItem[] = showBayVerb
+      ? [{ id: "bay-rack", label: "Bay rack" }]
+      : [];
+    const trailing: VerbItem[] = [...bayVerbs, ...objectVerbs];
+
+    // The divider sits before the first object verb only when both sides exist.
+    const withDivider =
+      position.length > 0
+        ? trailing.map((verb, i) =>
+            i === 0 ? { ...verb, dividerBefore: true } : verb,
+          )
+        : trailing;
+
+    return [...position, ...withDivider];
+  });
 
   const ariaLabel = $derived(
     selection.isDeviceSelected ? "Device actions" : "Rack actions",
@@ -95,6 +159,15 @@
         break;
       case "duplicate-selection":
         duplicateSelection();
+        break;
+      case "move-rack-left":
+        moveSelectedRack("left");
+        break;
+      case "move-rack-right":
+        moveSelectedRack("right");
+        break;
+      case "bay-rack":
+        baySelectedRack();
         break;
       case "delete-selection":
         ondelete?.();
@@ -129,7 +202,13 @@
       return canvasEl.querySelector(`[data-device-uuid="${uuid}"]`);
     }
 
-    if (selection.isRackSelected && selection.selectedRackId) {
+    // A rack selection, or a bayed-group selection whose active member carries
+    // the rack id, anchors to that rack's container. Group members render with
+    // data-rack-id in BayedRackView, so the same query resolves both.
+    if (
+      (selection.isRackSelected || selection.isGroupSelected) &&
+      selection.selectedRackId
+    ) {
       return canvasEl.querySelector(
         `[data-rack-id="${CSS.escape(selection.selectedRackId)}"]`,
       );

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -90,15 +90,18 @@
   );
 
   // The bay verb is offered only for empty standalone racks and bay groups
-  // (baySource), and only when the bayed-racks setting is on.
+  // (baySource), and only when the bayed-racks setting is on. Baying is a
+  // mutation, so it is withheld in read-only mode like the other mutation verbs.
   const showBayVerb = $derived(
-    ui.enableBayedRacks && slotControls.baySource !== null,
+    !ctx.readOnly && ui.enableBayedRacks && slotControls.baySource !== null,
   );
 
   // Compose the bar: leading reorder chevrons (position verbs), then a divider,
   // then the object verbs (bay plus the registry-filtered selection verbs).
   // Device selections keep the object-verb-only bar. Chevrons show only when the
-  // row has two or more slots and disable at the ends.
+  // row has two or more slots and disable at the ends. Reorder is a mutation, so
+  // it is withheld in read-only mode (matching getVerbsForSelection's filtering
+  // of the object verbs and the move-rack-* enabledWhen predicates).
   const verbs = $derived.by<VerbItem[]>(() => {
     const objectVerbs: VerbItem[] = getVerbsForSelection(ctx).map((a) => ({
       id: a.id,
@@ -107,7 +110,7 @@
 
     if (!isRackOrGroup) return objectVerbs;
 
-    const position: VerbItem[] = slotControls.canReorder
+    const position: VerbItem[] = slotControls.canReorder && !ctx.readOnly
       ? [
           {
             id: "move-rack-left",

--- a/src/lib/utils/rack-row.ts
+++ b/src/lib/utils/rack-row.ts
@@ -63,6 +63,77 @@ export function organizeRackRow(
   return slots.map((slot) => slot.item);
 }
 
+/**
+ * The rack to bay from for a row item, or null when baying is not offered.
+ *
+ * Baying is a creation-time affordance (design 2026-07-01): it appears only on
+ * an empty standalone rack, which bays from itself, and on a bayed group, which
+ * extends from its active member whatever the members contain. A populated
+ * standalone rack and a non-bayed group return null. The active member is the
+ * one matching activeRackId, or the group's first member when activeRackId is
+ * not part of the group. Does not consult the bayed-racks setting; the caller
+ * ANDs that in. Shared by the verb bar and the edge grip (#2823) so both gate
+ * baying identically.
+ */
+export function baySourceForItem(
+  item: RackRowItem | undefined,
+  activeRackId: string | null,
+): string | null {
+  if (!item) return null;
+  if (item.kind === "rack") {
+    return item.rack.devices.length === 0 ? item.rack.id : null;
+  }
+  if (item.group.layout_preset !== "bayed") return null;
+  const active =
+    activeRackId !== null && item.racks.some((rack) => rack.id === activeRackId)
+      ? activeRackId
+      : item.racks[0]?.id;
+  return active ?? null;
+}
+
+/** Reorder and bay controls for the row slot holding a selected rack or group. */
+export interface RackSlotControls {
+  /** The row has two or more slots, so the reorder chevrons should show. */
+  canReorder: boolean;
+  /** The slot can move left (it is not the first slot). */
+  canMoveLeft: boolean;
+  /** The slot can move right (it is not the last slot). */
+  canMoveRight: boolean;
+  /** The rack to bay from, or null when baying is not offered for this slot. */
+  baySource: string | null;
+}
+
+/**
+ * Reorder availability and bay source for the row slot containing
+ * selectedRackId (a standalone rack, or a group's active member). Chevrons show
+ * only when the row has two or more slots and disable at the ends, matching the
+ * retired slot-controls lane. Baying follows baySourceForItem. Returns the empty
+ * state when nothing reorderable is selected.
+ */
+export function getRackSlotControls(
+  racks: Rack[],
+  groups: RackGroup[],
+  selectedRackId: string | null,
+  activeRackId: string | null,
+): RackSlotControls {
+  const items = organizeRackRow(racks, groups);
+  const index =
+    selectedRackId === null
+      ? -1
+      : items.findIndex((item) =>
+          item.kind === "rack"
+            ? item.rack.id === selectedRackId
+            : item.racks.some((rack) => rack.id === selectedRackId),
+        );
+  const canReorder = index !== -1 && items.length >= 2;
+  return {
+    canReorder,
+    canMoveLeft: canReorder && index > 0,
+    canMoveRight: canReorder && index < items.length - 1,
+    baySource: baySourceForItem(items[index], activeRackId),
+  };
+}
+
 /** A new Rack.position for a rack, in its new row order. */
 export type RackPositionAssignment = { id: string; position: number };
 

--- a/src/tests/rack-row.test.ts
+++ b/src/tests/rack-row.test.ts
@@ -4,8 +4,10 @@ import {
   reorderRackRow,
   planBayedInsert,
   planRowAfterRemoval,
+  getRackSlotControls,
+  baySourceForItem,
 } from "$lib/utils/rack-row";
-import { createTestRack } from "./factories";
+import { createTestRack, createTestDevice } from "./factories";
 import type { RackGroup } from "$lib/types";
 
 describe("organizeRackRow", () => {
@@ -321,5 +323,101 @@ describe("planRowAfterRemoval", () => {
   it("returns null when the removed rack is not in the row", () => {
     const a = createTestRack({ id: "a", position: 0 });
     expect(planRowAfterRemoval([a], [], "missing")).toBeNull();
+  });
+});
+
+describe("getRackSlotControls (verb bar reorder + bay gating, #2822)", () => {
+  it("offers no reorder for a single-slot row", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const controls = getRackSlotControls([a], [], "a", "a");
+    expect(controls.canReorder).toBe(false);
+    expect(controls.canMoveLeft).toBe(false);
+    expect(controls.canMoveRight).toBe(false);
+  });
+
+  it("enables reorder for a two-slot row and disables the chevron at each end", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+
+    const first = getRackSlotControls([a, b], [], "a", "a");
+    expect(first.canReorder).toBe(true);
+    expect(first.canMoveLeft).toBe(false);
+    expect(first.canMoveRight).toBe(true);
+
+    const last = getRackSlotControls([a, b], [], "b", "b");
+    expect(last.canReorder).toBe(true);
+    expect(last.canMoveLeft).toBe(true);
+    expect(last.canMoveRight).toBe(false);
+  });
+
+  it("returns the empty state when nothing reorderable is selected", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const b = createTestRack({ id: "b", position: 1 });
+    const controls = getRackSlotControls([a, b], [], null, null);
+    expect(controls.canReorder).toBe(false);
+    expect(controls.baySource).toBeNull();
+  });
+
+  it("offers a bay source on an empty standalone rack", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    expect(getRackSlotControls([a], [], "a", "a").baySource).toBe("a");
+  });
+
+  it("withholds the bay source on a populated standalone rack", () => {
+    const a = createTestRack({
+      id: "a",
+      position: 0,
+      devices: [createTestDevice()],
+    });
+    expect(getRackSlotControls([a], [], "a", "a").baySource).toBeNull();
+  });
+
+  it("offers a bay source on a bayed group regardless of member contents", () => {
+    const m1 = createTestRack({
+      id: "m1",
+      position: 0,
+      devices: [createTestDevice()],
+    });
+    const m2 = createTestRack({ id: "m2", position: 1 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "bayed",
+    };
+    // The active member is the bay source so a new bay lands beside it.
+    expect(getRackSlotControls([m1, m2], [group], "m2", "m2").baySource).toBe(
+      "m2",
+    );
+  });
+
+  it("withholds the bay source on a non-bayed (row) group", () => {
+    const m1 = createTestRack({ id: "m1", position: 0 });
+    const m2 = createTestRack({ id: "m2", position: 1 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "row",
+    };
+    expect(getRackSlotControls([m1, m2], [group], "m1", "m1").baySource).toBe(
+      null,
+    );
+  });
+});
+
+describe("baySourceForItem (#2822)", () => {
+  it("falls back to the group's first member when the active rack is elsewhere", () => {
+    const m1 = createTestRack({ id: "m1", position: 0 });
+    const m2 = createTestRack({ id: "m2", position: 1 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "bayed",
+    };
+    const [item] = organizeRackRow([m1, m2], [group]);
+    expect(baySourceForItem(item, "not-in-group")).toBe("m1");
+  });
+
+  it("returns null for an undefined item", () => {
+    expect(baySourceForItem(undefined, null)).toBeNull();
   });
 });

--- a/src/tests/verb-bar-overlay.test.ts
+++ b/src/tests/verb-bar-overlay.test.ts
@@ -10,6 +10,7 @@ import {
 } from "$lib/stores/selection.svelte";
 import { resetToastStore } from "$lib/stores/toast.svelte";
 import { resetCanvasStore } from "$lib/stores/canvas.svelte";
+import { getUIStore, resetUIStore } from "$lib/stores/ui.svelte";
 import { organizeRackRow } from "$lib/utils/rack-row";
 import { createTestDeviceType } from "./factories";
 import type { DeviceFace } from "$lib/types";
@@ -27,6 +28,7 @@ function resetAll() {
   resetSelectionStore();
   resetToastStore();
   resetCanvasStore();
+  resetUIStore();
 }
 
 function setupRackWithDevice(face: DeviceFace = "front") {
@@ -138,6 +140,36 @@ describe("VerbBarOverlay", () => {
           hidden: true,
         }),
       ).toBeNull();
+    });
+  });
+
+  describe("read-only mode", () => {
+    it("withholds the reorder chevrons and bay verb from a rack selection", () => {
+      const ui = getUIStore();
+      ui.setEnableBayedRacks(true);
+      ui.setReadOnly(true);
+      const layout = getLayoutStore();
+      const a = layout.addRack("A", 42);
+      const b = layout.addRack("B", 42);
+      if (!a || !b) throw new Error("addRack returned null");
+      // Two empty racks with baying on: chevrons and the bay verb would show in
+      // edit mode, so their absence here proves read-only withholds them.
+      getSelectionStore().selectRack(a.id);
+      render(VerbBarOverlay, { props: { canvasEl: null } });
+
+      expect(
+        screen.queryByRole("button", { name: "Move rack left", hidden: true }),
+      ).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: "Move rack right", hidden: true }),
+      ).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: "Bay rack", hidden: true }),
+      ).toBeNull();
+      // The read-only-safe object verbs still render, so the bar is present.
+      expect(
+        screen.getByRole("button", { name: "Focus", hidden: true }),
+      ).toBeTruthy();
     });
   });
 });

--- a/src/tests/verb-bar-overlay.test.ts
+++ b/src/tests/verb-bar-overlay.test.ts
@@ -10,8 +10,17 @@ import {
 } from "$lib/stores/selection.svelte";
 import { resetToastStore } from "$lib/stores/toast.svelte";
 import { resetCanvasStore } from "$lib/stores/canvas.svelte";
+import { organizeRackRow } from "$lib/utils/rack-row";
 import { createTestDeviceType } from "./factories";
 import type { DeviceFace } from "$lib/types";
+
+/** Row order as slot ids (a rack's id, or a group's id) for order assertions. */
+function rowOrder(): string[] {
+  const layout = getLayoutStore();
+  return organizeRackRow(layout.racks, layout.rack_groups).map((item) =>
+    item.kind === "rack" ? item.rack.id : item.group.id,
+  );
+}
 
 function resetAll() {
   resetLayoutStore();
@@ -99,6 +108,36 @@ describe("VerbBarOverlay", () => {
 
       await clickVerb("Delete selected");
       expect(ondelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("rack reorder", () => {
+    it("reorders the row when the move-rack-right verb is clicked", async () => {
+      const layout = getLayoutStore();
+      const a = layout.addRack("A", 42);
+      const b = layout.addRack("B", 42);
+      if (!a || !b) throw new Error("addRack returned null");
+      getSelectionStore().selectRack(a.id);
+      render(VerbBarOverlay, { props: { canvasEl: null } });
+
+      expect(rowOrder()).toEqual([a.id, b.id]);
+      await clickVerb("Move rack right");
+      expect(rowOrder()).toEqual([b.id, a.id]);
+    });
+
+    it("shows no reorder chevrons for a single-rack row", () => {
+      const layout = getLayoutStore();
+      const solo = layout.addRack("Solo", 42);
+      if (!solo) throw new Error("addRack returned null");
+      getSelectionStore().selectRack(solo.id);
+      render(VerbBarOverlay, { props: { canvasEl: null } });
+
+      expect(
+        screen.queryByRole("button", {
+          name: "Move rack right",
+          hidden: true,
+        }),
+      ).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Consolidates the rack controls into the floating verb bar and removes the slot-controls lane, so the verb bar is the only floating control surface for a selection (the overlap-with-verb-bar class of bugs is removed by construction). Implements stage 1 of the resize-and-bay corrections design (`docs/superpowers/specs/2026-07-01-resize-bay-corrections-design.md`), verb-bar portion.

- Move-left and move-right chevrons fold into the verb bar for rack and bay-group selections, as position verbs before the object verbs and behind a divider. They show only when the row has two or more slots and disable at the ends, matching the old move buttons.
- A bay action joins the verb bar, gated to empty standalone racks and bay groups (populated standalone racks show no bay affordance). It routes through the shared `bayRack` path, so the ensure-visible camera move (#2825) still fires.
- The floating "+ Bay" button and the whole `.slot-controls` lane are removed, along with the now-dead `.slot-controls`, `.rack-move-controls`, `.move-button`, `.bay-button` styles and the `handleMoveRack` / `handleBayRack` / `selectedSlot*` code in `RackCanvasView`.

## Acceptance criteria

- [x] Move-left/right chevrons appear in the verb bar for rack and bay(-group) selections, separated from object verbs by a divider, only when the row has 2+ items
- [x] A bay action appears in the verb bar per the gating rules (empty standalone racks + bay groups)
- [x] The floating "+ Bay" button and the slot-controls container are removed
- [x] Chevron disabled states match the old move-button behaviour at row ends (first item: move-left disabled; last item: move-right disabled)
- [x] Verb bar tab order includes the new verbs (roving toolbar; disabled chevrons use `aria-disabled` so the toolbar stays reachable at a row end)

## Scope split

This PR is the verb bar only. The right-edge drag grip re-gating and the affordance/store tests are #2823 (serial, next). The bay gating lives in one shared, pure place (`baySourceForItem` / `getRackSlotControls` in `src/lib/utils/rack-row.ts`) so #2823 can mirror it on the grip. The current edge-grip gating in `RackCanvasView`/`BayedRackView` is left untouched.

## Notes / decision needed

On mobile the verb bar overlay is not rendered (`{#if !viewportStore.isMobile}` in `Canvas.svelte`) and the mobile bottom-sheet verbs are device-only, so removing the lane drops rack reorder + bay on phones. This is faithful to the locked design ("the whole slot-controls lane is removed"), but the design's "touch path" language suggests the verb bar should also serve touch. Rendering the verb bar on mobile is out of this issue's scope; flagging for a product/scope decision.

## Tests

- Pure gating tests in `src/tests/rack-row.test.ts` for `getRackSlotControls` / `baySourceForItem`: reorder availability and end-disabling for 1 vs 2 slots; bay source present on empty standalone racks and bay groups (any member contents), absent on populated standalone racks and non-bayed groups; active-member fallback.
- Overlay wiring tests in `src/tests/verb-bar-overlay.test.ts`: clicking "Move rack right" reorders the row; no reorder chevrons for a single-rack row.
- No DOM-structure/`renders-without-throwing` tests (project policy).

Local gates: `npm run lint`, `npm run check`, `npm run test:run` (3173 passed), `npm run build` all green. `svelte-autofixer` reports no issues on the changed components.

Closes #2822

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Move rack controls into the floating verb bar and remove the per-slot control lane**

### What Changed
- Rack reorder buttons now appear in the floating verb bar for selected racks and bay groups, with left/right controls disabled at the row ends.
- The bay action now also appears in the verb bar when baying is allowed, and it keeps the resulting bay in view after creation.
- The separate control lane above the selected rack, including the floating “Bay” button, has been removed.

### Impact
`✅ One place for rack actions`
`✅ Fewer missed reorder clicks at row ends`
`✅ Faster bay creation from selected racks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
