### PR TITLE
feat: split + control with starter template menu (#2829)

### DIFF
--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -50,6 +50,7 @@ import {
 import { handleLoad, handleExportAll } from "$lib/storage";
 import { runImportDevices } from "$lib/actions/import-devices-trigger";
 import { runRestoreFromFile } from "$lib/actions/restore-file-trigger";
+import { openStarterById } from "$lib/stores/starter-templates.svelte";
 
 export type ActionDispatch = Record<ActionId, () => void>;
 
@@ -178,6 +179,12 @@ export function createActionDispatch(): ActionDispatch {
         resetAndCreateNewRack();
       }
     },
+    // Starter templates open in a NEW tab (non-destructive), so they route
+    // through the shared starter-open path, not the replace-current new-layout.
+    "new-layout-template-home-lab": () => openStarterById("home-lab"),
+    "new-layout-template-network-closet": () =>
+      openStarterById("network-closet"),
+    "new-layout-template-media-server": () => openStarterById("media-server"),
     "import-devices": runImportDevices,
     "import-netbox": handleImportFromNetBox,
     "new-custom-device": handleAddDevice,

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -32,6 +32,9 @@ export type ActionId =
   | "export-all"
   | "restore-file"
   | "new-layout"
+  | "new-layout-template-home-lab"
+  | "new-layout-template-network-closet"
+  | "new-layout-template-media-server"
   | "load"
   | "import-devices"
   | "import-netbox"
@@ -428,6 +431,32 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     bindings: [],
     appMenuGroup: "layout",
     keywords: ["new", "rack", "create", "blank"],
+  },
+  // Starter-template entries (#2829). One per shipped starter, opening it in a
+  // new tab via the shared starter-open path. No bindings; palette/search only.
+  {
+    id: "new-layout-template-home-lab",
+    label: "New layout from template: Home Lab",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "layout",
+    keywords: ["template", "starter", "home lab", "homelab", "new"],
+  },
+  {
+    id: "new-layout-template-network-closet",
+    label: "New layout from template: Network Closet",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "layout",
+    keywords: ["template", "starter", "network closet", "new"],
+  },
+  {
+    id: "new-layout-template-media-server",
+    label: "New layout from template: Media Server",
+    scope: "global",
+    bindings: [],
+    appMenuGroup: "layout",
+    keywords: ["template", "starter", "media server", "new"],
   },
   {
     id: "load",

--- a/src/lib/components/LayoutTabs.svelte
+++ b/src/lib/components/LayoutTabs.svelte
@@ -35,6 +35,7 @@
   import { partitionTabs, tabHasClose } from "./layout-tabs";
   import { nextDuplicateName } from "./layouts-library";
   import LayoutContextMenu from "./LayoutContextMenu.svelte";
+  import NewLayoutMenu from "./NewLayoutMenu.svelte";
   import "$lib/styles/menu.css";
   import "$lib/styles/tabs.css";
 
@@ -46,6 +47,10 @@
   let { onexport }: Props = $props();
 
   const workspace = getWorkspaceStore();
+
+  // Open state for the split "+"'s starter-template menu (#2829). The "+"'s
+  // right-click sets this true, opening the same menu the chevron does.
+  let newMenuOpen = $state(false);
 
   // One tab occupies roughly this width including its gap. Used only to estimate
   // how many tabs fit; the active tab is always pinned regardless.
@@ -93,6 +98,9 @@
   // something actually overflows. This stops a tab being hidden behind a
   // chevron when dropping the chevron would have let every tab fit.
   const CONTROL_WIDTH_PX = 44;
+  // The split "+"'s chevron (NewLayoutMenu) is a permanent control beside the
+  // "+", so reserve its width from the lane too (#2829).
+  const NEW_LAYOUT_CHEVRON_WIDTH_PX = 28;
   const partition = $derived.by(() => {
     const budget = (reserved: number) =>
       Number.isFinite(laneWidth)
@@ -101,14 +109,14 @@
     const firstPass = partitionTabs(
       tabViews,
       workspace.activeId,
-      budget(CONTROL_WIDTH_PX),
+      budget(CONTROL_WIDTH_PX + NEW_LAYOUT_CHEVRON_WIDTH_PX),
       TAB_WIDTH_PX,
     );
     if (firstPass.hidden.length === 0) return firstPass;
     return partitionTabs(
       tabViews,
       workspace.activeId,
-      budget(CONTROL_WIDTH_PX * 2),
+      budget(CONTROL_WIDTH_PX * 2 + NEW_LAYOUT_CHEVRON_WIDTH_PX),
       TAB_WIDTH_PX,
     );
   });
@@ -373,9 +381,20 @@
     aria-label="New layout"
     data-testid="btn-new-layout-tab"
     onclick={handleNewLayout}
+    oncontextmenu={(e) => {
+      e.preventDefault();
+      newMenuOpen = true;
+    }}
   >
     <IconPlus size={ICON_SIZE.sm} />
   </button>
+
+  <NewLayoutMenu
+    bind:open={newMenuOpen}
+    variant="toolbar"
+    onblank={handleNewLayout}
+    chevronTestId="btn-new-layout-menu-tab"
+  />
 
   {#if hiddenTabs.length > 0}
     <DropdownMenu.Root>

--- a/src/lib/components/LayoutsLibrary.svelte
+++ b/src/lib/components/LayoutsLibrary.svelte
@@ -33,6 +33,7 @@
   } from "./layout-preview-cache";
   import { renderLayoutPreviewSvg } from "./layout-preview-render";
   import LayoutContextMenu from "./LayoutContextMenu.svelte";
+  import NewLayoutMenu from "./NewLayoutMenu.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import Dialog from "./Dialog.svelte";
   import Tooltip from "./Tooltip.svelte";
@@ -48,6 +49,15 @@
 
   const workspaceStore = getWorkspaceStore();
   const toastStore = getToastStore();
+
+  // Open state for the split "+"'s starter-template menu (#2829). The "+"'s
+  // right-click sets this true, opening the same menu the chevron does.
+  let newMenuOpen = $state(false);
+
+  // The "Blank layout" menu row and the primary "+" share one handler.
+  function handleBlankLayout(): void {
+    onnewlayout?.();
+  }
 
   const rows = $derived(
     buildLayoutRows(
@@ -322,20 +332,32 @@
       {rows.length} Layout{rows.length !== 1 ? "s" : ""}
     </span>
     {#if onnewlayout}
-      <Tooltip text="New Layout" position="bottom">
-        {#snippet triggerChild({ props })}
-          <button
-            {...props}
-            type="button"
-            class="new-layout-btn"
-            onclick={onnewlayout}
-            aria-label="New Layout"
-            data-testid="btn-new-layout"
-          >
-            +
-          </button>
-        {/snippet}
-      </Tooltip>
+      <div class="new-layout-controls">
+        <Tooltip text="New Layout" position="bottom">
+          {#snippet triggerChild({ props })}
+            <button
+              {...props}
+              type="button"
+              class="new-layout-btn"
+              onclick={handleBlankLayout}
+              oncontextmenu={(e) => {
+                e.preventDefault();
+                newMenuOpen = true;
+              }}
+              aria-label="New Layout"
+              data-testid="btn-new-layout"
+            >
+              +
+            </button>
+          {/snippet}
+        </Tooltip>
+        <NewLayoutMenu
+          bind:open={newMenuOpen}
+          variant="panel"
+          onblank={handleBlankLayout}
+          chevronTestId="btn-new-layout-menu"
+        />
+      </div>
     {/if}
   </div>
 
@@ -493,6 +515,12 @@
   .layout-count {
     font-size: var(--font-size-sm);
     color: var(--colour-text-muted);
+  }
+
+  .new-layout-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
   }
 
   .new-layout-btn {

--- a/src/lib/components/NewLayoutMenu.svelte
+++ b/src/lib/components/NewLayoutMenu.svelte
@@ -1,0 +1,204 @@
+<!--
+  NewLayoutMenu Component (#2829)
+
+  The dropdown half of the split "+" control, shared by the tab-bar "+"
+  (LayoutTabs) and the Layouts-panel "+" (LayoutsLibrary). It renders a focusable
+  chevron trigger plus the menu content: a "Blank layout" row and, when starters
+  have loaded, a "From template" section listing each starter with a colour dot,
+  name, and rack/device meta.
+
+  Split-control wiring:
+  - The host keeps its own primary "+" button (plain click unchanged, #2829 R1).
+  - This chevron opens the menu on click.
+  - The host binds `open` and sets it true from a right-click (oncontextmenu) on
+    its primary "+", so chevron and right-click open the same menu.
+
+  Starters lazy-load on first open through the shared starter-templates source,
+  so the fetch never runs until a menu is opened and repeat opens reuse the cache.
+  On load failure the source stays empty and only "Blank layout" renders.
+
+  Accessibility: bits-ui DropdownMenu provides roving focus, arrow/Home/End
+  navigation, and Escape-to-close. The chevron is a real focusable button.
+-->
+<script lang="ts">
+  import { DropdownMenu } from "bits-ui";
+  import { IconChevronDown } from "./icons";
+  import { ICON_SIZE } from "$lib/constants/sizing";
+  import {
+    ensureStartersLoaded,
+    getStarterTemplates,
+    openStarter,
+  } from "$lib/stores/starter-templates.svelte";
+  import { starterRackSummary } from "$lib/templates/starter-templates";
+  import "$lib/styles/menu.css";
+
+  interface Props {
+    /**
+     * Create a blank layout. Wired to the host's existing primary "+" handler so
+     * the "Blank layout" row does exactly what a plain "+" click does (#2829 R1).
+     */
+    onblank: () => void;
+    /** Bindable open state, so the host's "+" right-click can open this menu. */
+    open?: boolean;
+    /** Visual variant matching the host's "+": the toolbar tab strip or the panel header. */
+    variant?: "toolbar" | "panel";
+    /** Test id for the chevron trigger. */
+    chevronTestId?: string;
+  }
+
+  let {
+    onblank,
+    open = $bindable(false),
+    variant = "toolbar",
+    chevronTestId,
+  }: Props = $props();
+
+  const starters = $derived(getStarterTemplates());
+
+  // Lazy-load starters the first time any menu opens; the shared source caches
+  // the result across every "+" control and the palette.
+  function handleOpenChange(next: boolean): void {
+    if (next) void ensureStartersLoaded();
+  }
+</script>
+
+<DropdownMenu.Root bind:open onOpenChange={handleOpenChange}>
+  <DropdownMenu.Trigger>
+    {#snippet child({ props })}
+      <button
+        {...props}
+        type="button"
+        class="new-layout-chevron {variant}"
+        aria-label="New layout options"
+        data-testid={chevronTestId}
+      >
+        <IconChevronDown size={ICON_SIZE.sm} />
+      </button>
+    {/snippet}
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Portal>
+    <DropdownMenu.Content
+      class="menu-content menu-inline"
+      sideOffset={4}
+      align="end"
+    >
+      <DropdownMenu.Item
+        class="menu-item"
+        data-testid="new-layout-item-blank"
+        onSelect={onblank}
+      >
+        <span class="menu-label">Blank layout</span>
+      </DropdownMenu.Item>
+
+      {#if starters.length > 0}
+        <DropdownMenu.Group>
+          <DropdownMenu.GroupHeading class="menu-label-header">
+            From template
+          </DropdownMenu.GroupHeading>
+          {#each starters as template (template.id)}
+            <DropdownMenu.Item
+              class="menu-item"
+              data-testid="new-layout-item-{template.id}"
+              onSelect={() => openStarter(template)}
+            >
+              <span
+                class="starter-dot"
+                style:background={template.colour}
+                aria-hidden="true"
+              ></span>
+              <span class="menu-label starter-text">
+                <span class="starter-name">{template.layout.name}</span>
+                <span class="starter-meta">{starterRackSummary(template)}</span>
+              </span>
+            </DropdownMenu.Item>
+          {/each}
+        </DropdownMenu.Group>
+      {/if}
+    </DropdownMenu.Content>
+  </DropdownMenu.Portal>
+</DropdownMenu.Root>
+
+<style>
+  .new-layout-chevron {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--colour-text-muted);
+    cursor: pointer;
+    transition:
+      background var(--duration-fast) var(--ease-out),
+      color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+  }
+
+  .new-layout-chevron:hover,
+  .new-layout-chevron[data-state="open"] {
+    background: var(--colour-surface-hover);
+    color: var(--colour-text);
+  }
+
+  .new-layout-chevron:focus-visible {
+    outline: none;
+    color: var(--colour-text);
+    box-shadow:
+      0 0 0 2px var(--colour-bg),
+      0 0 0 4px var(--colour-focus-ring);
+  }
+
+  /* Toolbar tab strip: raw px to pixel-align with the sibling .layout-tab-add
+     control in LayoutTabs (itself 44px tall); no 44px design token exists. */
+  .new-layout-chevron.toolbar {
+    width: 28px;
+    height: 44px;
+  }
+
+  /* Panel header: matches the small square, bordered "+" button. */
+  .new-layout-chevron.panel {
+    width: var(--space-6);
+    height: var(--space-8);
+    background: var(--colour-surface-secondary);
+    border-color: var(--colour-border);
+  }
+
+  .new-layout-chevron.panel:hover,
+  .new-layout-chevron.panel[data-state="open"] {
+    border-color: var(--colour-border-hover);
+  }
+
+  /* Starter row: colour dot, then a two-line name/meta stack. */
+  .starter-dot {
+    flex: 0 0 auto;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  .starter-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    min-width: 0;
+  }
+
+  .starter-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .starter-meta {
+    font-size: var(--font-size-xs);
+    color: var(--colour-text-muted-inverse);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .new-layout-chevron {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/components/NewLayoutMenu.svelte
+++ b/src/lib/components/NewLayoutMenu.svelte
@@ -68,7 +68,7 @@
       <button
         {...props}
         type="button"
-        class="new-layout-chevron {variant}"
+        class="new-layout-chevron new-layout-chevron--{variant}"
         aria-label="New layout options"
         data-testid={chevronTestId}
       >
@@ -152,21 +152,21 @@
 
   /* Toolbar tab strip: raw px to pixel-align with the sibling .layout-tab-add
      control in LayoutTabs (itself 44px tall); no 44px design token exists. */
-  .new-layout-chevron.toolbar {
+  .new-layout-chevron--toolbar {
     width: 28px;
     height: 44px;
   }
 
   /* Panel header: matches the small square, bordered "+" button. */
-  .new-layout-chevron.panel {
+  .new-layout-chevron--panel {
     width: var(--space-6);
     height: var(--space-8);
     background: var(--colour-surface-secondary);
     border-color: var(--colour-border);
   }
 
-  .new-layout-chevron.panel:hover,
-  .new-layout-chevron.panel[data-state="open"] {
+  .new-layout-chevron--panel:hover,
+  .new-layout-chevron--panel[data-state="open"] {
     border-color: var(--colour-border-hover);
   }
 

--- a/src/lib/stores/starter-templates.svelte.ts
+++ b/src/lib/stores/starter-templates.svelte.ts
@@ -1,0 +1,121 @@
+/**
+ * Starter-template menu source (#2829).
+ *
+ * One shared, lazily-loaded source of the starter templates for every "new
+ * layout" surface: the split "+" menus on the tab bar and Layouts panel, the
+ * command palette, and (later) mobile. Loading is deferred until the first menu
+ * open and cached, so the fetch never runs for users who never open the menu,
+ * and repeat opens reuse the same result.
+ *
+ * Opening a starter always produces an independent layout in a new tab. The
+ * shipped YAML carries a baked-in metadata.id, and the workspace library keys
+ * identity on that id, so the open path regenerates the id per open. Without
+ * that, opening the same starter twice would alias one library entry (#2829, D2).
+ */
+import type { Layout } from "$lib/types";
+import {
+  loadStarterTemplates,
+  type StarterTemplate,
+  type StarterTemplateId,
+} from "$lib/templates/starter-templates";
+import { getWorkspaceStore } from "./workspace.svelte";
+import { getCanvasStore } from "./canvas.svelte";
+import { generateId } from "$lib/utils/device";
+
+// The loaded starters, empty until the first load resolves. Reactive so every
+// menu that reads it re-renders when the lazy load completes.
+let templates = $state<StarterTemplate[]>([]);
+let loaded = $state(false);
+// The in-flight (or resolved) load promise, so concurrent first-opens share one
+// fetch and later opens skip the network entirely.
+let loadPromise: Promise<StarterTemplate[]> | null = null;
+
+/**
+ * Load the starters once and cache the result. Safe to call on every menu open:
+ * the first call fetches, the rest return the same promise. `fetcher` is
+ * injectable for tests and forwarded to the loader; it is ignored once a load is
+ * already in flight or resolved.
+ */
+export function ensureStartersLoaded(
+  fetcher: typeof fetch = fetch,
+): Promise<StarterTemplate[]> {
+  if (loadPromise) return loadPromise;
+  const pending = loadStarterTemplates(fetcher).then(
+    (result) => {
+      templates = result;
+      loaded = true;
+      return result;
+    },
+    () => {
+      // A rejected load must not poison the cache: drop it so a later open
+      // retries instead of reusing the failure, and degrade to an empty set
+      // (the menu then shows Blank only). loadStarterTemplates is best-effort
+      // and does not reject today; this keeps the cache resilient if it ever
+      // does, and resolves rather than rejects so no caller sees an unhandled
+      // rejection.
+      if (loadPromise === pending) loadPromise = null;
+      return [] as StarterTemplate[];
+    },
+  );
+  loadPromise = pending;
+  return pending;
+}
+
+/** The starters loaded so far. Empty until {@link ensureStartersLoaded} resolves. */
+export function getStarterTemplates(): StarterTemplate[] {
+  return templates;
+}
+
+/** Whether a starter load has completed (success or empty). */
+export function areStartersLoaded(): boolean {
+  return loaded;
+}
+
+/**
+ * Open a starter template in a new tab (#2829, D2). Clones the loaded layout so
+ * repeat opens never share state, regenerates metadata.id so the workspace
+ * library treats each open as a distinct layout, and opens it in a fresh tab
+ * (fresh undo history by construction). fitAll runs after the tab is live so the
+ * whole rack is framed on arrival.
+ */
+export function openStarter(template: StarterTemplate): void {
+  const workspace = getWorkspaceStore();
+  // The shared source holds starters in $state, so template.layout may be a
+  // reactive proxy; snapshot to a plain object before structuredClone, which
+  // throws on a Proxy. Snapshot is a no-op on the plain layouts tests pass in.
+  const clone: Layout = structuredClone($state.snapshot(template.layout));
+  clone.metadata = { ...clone.metadata, id: generateId() };
+  workspace.openTab(clone);
+  // Capture the just-opened tab's store now: openTab made it active, but the
+  // active tab could change before the rAF fires, and fitAll must frame the
+  // layout we opened, not whatever happens to be active a frame later.
+  const openedStore = workspace.activeStore;
+  const canvasStore = getCanvasStore();
+  requestAnimationFrame(() => {
+    canvasStore.fitAll(openedStore.racks, openedStore.rack_groups);
+  });
+}
+
+/**
+ * Open the starter with the given id, loading the set first if needed. Used by
+ * the command-palette entries, which dispatch by id and have no live template
+ * reference. A missing id (load failed, or unknown id) is a no-op.
+ */
+export function openStarterById(id: StarterTemplateId): void {
+  void ensureStartersLoaded()
+    .then((result) => {
+      const template = result.find((t) => t.id === id);
+      if (template) openStarter(template);
+    })
+    .catch(() => {
+      // ensureStartersLoaded degrades to [] rather than rejecting; this guard
+      // just ensures a dispatch entry can never surface an unhandled rejection.
+    });
+}
+
+/** Reset the cached starters so a test starts from a cold load. Test-only. */
+export function resetStarterTemplatesForTest(): void {
+  templates = [];
+  loaded = false;
+  loadPromise = null;
+}

--- a/src/lib/stores/starter-templates.svelte.ts
+++ b/src/lib/stores/starter-templates.svelte.ts
@@ -31,28 +31,37 @@ let loaded = $state(false);
 let loadPromise: Promise<StarterTemplate[]> | null = null;
 
 /**
- * Load the starters once and cache the result. Safe to call on every menu open:
- * the first call fetches, the rest return the same promise. `fetcher` is
- * injectable for tests and forwarded to the loader; it is ignored once a load is
- * already in flight or resolved.
+ * Load the starters once and cache a successful, non-empty result. Safe to call
+ * on every menu open: after a successful load later opens serve the cache, and
+ * concurrent opens share one in-flight fetch. A total failure (an empty result,
+ * since loadStarterTemplates is best-effort and resolves to [] rather than
+ * rejecting) is NOT cached, so the next open retries and the "From template"
+ * section can recover without a reload. `fetcher` is injectable for tests.
  */
 export function ensureStartersLoaded(
   fetcher: typeof fetch = fetch,
 ): Promise<StarterTemplate[]> {
+  // Already loaded a non-empty set once: serve it without refetching.
+  if (loaded) return Promise.resolve(templates);
+  // A load is in flight: share it so concurrent opens fetch only once.
   if (loadPromise) return loadPromise;
   const pending = loadStarterTemplates(fetcher).then(
     (result) => {
-      templates = result;
-      loaded = true;
+      if (result.length > 0) {
+        // Cache a successful, non-empty load for the rest of the session.
+        templates = result;
+        loaded = true;
+      } else {
+        // Every template failed to load. Do not cache the failure: clear the
+        // shared promise and leave `loaded` false so the next open retries.
+        if (loadPromise === pending) loadPromise = null;
+      }
       return result;
     },
     () => {
-      // A rejected load must not poison the cache: drop it so a later open
-      // retries instead of reusing the failure, and degrade to an empty set
-      // (the menu then shows Blank only). loadStarterTemplates is best-effort
-      // and does not reject today; this keeps the cache resilient if it ever
-      // does, and resolves rather than rejects so no caller sees an unhandled
-      // rejection.
+      // Defensive: loadStarterTemplates does not reject today, but if it ever
+      // does, drop the shared promise so a later open retries instead of reusing
+      // the failure, and degrade to an empty set so no caller sees a rejection.
       if (loadPromise === pending) loadPromise = null;
       return [] as StarterTemplate[];
     },
@@ -64,11 +73,6 @@ export function ensureStartersLoaded(
 /** The starters loaded so far. Empty until {@link ensureStartersLoaded} resolves. */
 export function getStarterTemplates(): StarterTemplate[] {
   return templates;
-}
-
-/** Whether a starter load has completed (success or empty). */
-export function areStartersLoaded(): boolean {
-  return loaded;
 }
 
 /**

--- a/src/lib/templates/starter-templates.ts
+++ b/src/lib/templates/starter-templates.ts
@@ -1,16 +1,18 @@
 /**
  * Starter templates
  *
- * Loads the example layouts shown in the empty-canvas template chooser (#2095).
- * Each template is a `.rackula.yaml` file in `static/templates`, fetched at
- * runtime and validated against the layout schema. Adding a template is a
- * data-only change: drop a new file in that directory and add its manifest
- * entry below, no component code changes.
+ * Loads the example layouts offered behind the split "+" control (#2829) and,
+ * transiently, the empty-canvas chooser (#2095). Each template is a
+ * `.rackula.yaml` file in `static/templates`, fetched at runtime and validated
+ * against the layout schema. Adding a template is a data-only change: drop a new
+ * file in that directory and add its manifest entry below. A distinct menu-dot
+ * hue also needs a matching STARTER_COLOURS entry; without one the template
+ * falls back to the muted default. No component code changes either way.
  *
  * Loading is best-effort. A template that fails to fetch or parse is skipped,
- * never thrown: the empty state degrades to its baseline (add-rack) rather than
- * breaking the first-run experience (#2095 AC: "remains the WelcomeScreen
- * baseline when templates fail to load").
+ * never thrown: the menu degrades to "Blank layout" only rather than breaking
+ * the new-layout path (#2829: "on load failure the From template section does
+ * not render").
  */
 
 import type { Layout } from "$lib/types";
@@ -23,6 +25,12 @@ export interface StarterTemplate {
   id: string;
   /** The validated, runtime-ready layout to load when chosen. */
   layout: Layout;
+  /**
+   * The brand-palette colour for this starter's menu dot, as a CSS custom
+   * property reference so the value stays tokenised (#2829, R2). Resolved from
+   * the id manifest below, with a muted fallback for an unknown id.
+   */
+  colour: string;
 }
 
 /**
@@ -35,6 +43,41 @@ export const TEMPLATE_FILES = [
   "network-closet",
   "media-server",
 ] as const;
+
+/** A shipped starter's id, i.e. one of {@link TEMPLATE_FILES}. */
+export type StarterTemplateId = (typeof TEMPLATE_FILES)[number];
+
+/**
+ * Menu-dot colour per starter id, referencing the Dracula brand tokens in
+ * tokens.css (#2829, R2). CSS custom property references, never raw hex, so the
+ * dot follows the design tokens. A starter without an entry falls back to the
+ * muted text colour.
+ */
+const STARTER_COLOURS: Record<string, string> = {
+  "home-lab": "var(--dracula-purple)",
+  "network-closet": "var(--dracula-cyan)",
+  "media-server": "var(--dracula-green)",
+};
+
+/** Resolve a starter's menu-dot colour token, defaulting to the muted colour. */
+function resolveStarterColour(id: string): string {
+  return STARTER_COLOURS[id] ?? "var(--colour-text-muted)";
+}
+
+/**
+ * Human-readable rack/device summary for a starter, e.g. "1 rack, 8 devices".
+ * Pure so menus and tests can render the meta line without a component (#2829).
+ */
+export function starterRackSummary(template: StarterTemplate): string {
+  const rackCount = template.layout.racks.length;
+  const deviceCount = template.layout.racks.reduce(
+    (sum, rack) => sum + rack.devices.length,
+    0,
+  );
+  const rackWord = rackCount === 1 ? "rack" : "racks";
+  const deviceWord = deviceCount === 1 ? "device" : "devices";
+  return `${rackCount} ${rackWord}, ${deviceCount} ${deviceWord}`;
+}
 
 /**
  * Build the URL for a template file under the app's base path.
@@ -68,7 +111,7 @@ async function loadTemplate(
     }
     const yamlText = await response.text();
     const layout = await parseLayoutYaml(yamlText);
-    return { id, layout };
+    return { id, layout, colour: resolveStarterColour(id) };
   } catch (error) {
     layoutDebug.state("starter template %s failed to load: %o", id, error);
     return null;
@@ -79,8 +122,8 @@ async function loadTemplate(
  * Load all starter templates that parse successfully, preserving manifest order.
  *
  * `fetcher` is injectable for testing; it defaults to the global `fetch`.
- * Returns an empty array when nothing loads, which the empty state treats as
- * "no templates" and falls back to the baseline affordance.
+ * Returns an empty array when nothing loads, which the menu treats as
+ * "no templates" and shows only the blank-layout row.
  */
 export async function loadStarterTemplates(
   fetcher: typeof fetch = fetch,

--- a/src/lib/templates/starter-templates.ts
+++ b/src/lib/templates/starter-templates.ts
@@ -5,9 +5,9 @@
  * transiently, the empty-canvas chooser (#2095). Each template is a
  * `.rackula.yaml` file in `static/templates`, fetched at runtime and validated
  * against the layout schema. Adding a template is a data-only change: drop a new
- * file in that directory and add its manifest entry below. A distinct menu-dot
- * hue also needs a matching STARTER_COLOURS entry; without one the template
- * falls back to the muted default. No component code changes either way.
+ * file in that directory and add its manifest entry below. Each shipped starter
+ * also needs a matching STARTER_COLOURS entry; the typed colour map makes a
+ * missing entry a compile error. No component code changes either way.
  *
  * Loading is best-effort. A template that fails to fetch or parse is skipped,
  * never thrown: the menu degrades to "Blank layout" only rather than breaking
@@ -53,14 +53,14 @@ export type StarterTemplateId = (typeof TEMPLATE_FILES)[number];
  * dot follows the design tokens. A starter without an entry falls back to the
  * muted text colour.
  */
-const STARTER_COLOURS: Record<string, string> = {
+const STARTER_COLOURS: Record<StarterTemplateId, string> = {
   "home-lab": "var(--dracula-purple)",
   "network-closet": "var(--dracula-cyan)",
   "media-server": "var(--dracula-green)",
 };
 
 /** Resolve a starter's menu-dot colour token, defaulting to the muted colour. */
-function resolveStarterColour(id: string): string {
+function resolveStarterColour(id: StarterTemplateId): string {
   return STARTER_COLOURS[id] ?? "var(--colour-text-muted)";
 }
 
@@ -96,7 +96,7 @@ function templateUrl(id: string): string {
  * single bad template never sinks the rest of the chooser.
  */
 async function loadTemplate(
-  id: string,
+  id: StarterTemplateId,
   fetcher: typeof fetch,
 ): Promise<StarterTemplate | null> {
   try {

--- a/src/tests/starter-templates-store.test.ts
+++ b/src/tests/starter-templates-store.test.ts
@@ -4,7 +4,6 @@ import {
   openStarterById,
   ensureStartersLoaded,
   getStarterTemplates,
-  areStartersLoaded,
   resetStarterTemplatesForTest,
 } from "$lib/stores/starter-templates.svelte";
 import {
@@ -137,29 +136,55 @@ describe("ensureStartersLoaded", () => {
     resetStarterTemplatesForTest();
   });
 
-  it("exposes no starters when every load fails, so only Blank remains", async () => {
-    const failing = vi.fn(async () => {
-      throw new Error("offline");
-    }) as unknown as typeof fetch;
+  function okFetcher(name: string) {
+    const yaml = validStarterYaml(name);
+    return vi.fn(
+      async () =>
+        ({ ok: true, status: 200, text: async () => yaml }) as Response,
+    );
+  }
 
-    const result = await ensureStartersLoaded(failing);
+  it("caches a successful load, so a repeat open does not refetch", async () => {
+    const fetcher = okFetcher("Home Lab");
 
-    expect(result).toEqual([]);
-    expect(getStarterTemplates()).toEqual([]);
-    expect(areStartersLoaded()).toBe(true);
+    const first = await ensureStartersLoaded(
+      fetcher as unknown as typeof fetch,
+    );
+    expect(first.length).toBeGreaterThan(0);
+    // Cardinality-immune: snapshot the real fetch count, then assert a second
+    // open adds none, rather than pinning a literal tied to TEMPLATE_FILES.length.
+    const callsAfterFirst = fetcher.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    await ensureStartersLoaded(fetcher as unknown as typeof fetch);
+
+    expect(fetcher.mock.calls.length).toBe(callsAfterFirst);
   });
 
-  it("loads once and caches, so repeat opens do not refetch", async () => {
+  it("does not cache a failed load, so the next open retries and recovers", async () => {
     const failing = vi.fn(async () => {
       throw new Error("offline");
-    }) as unknown as typeof fetch;
+    });
 
-    await ensureStartersLoaded(failing);
-    await ensureStartersLoaded(failing);
+    const failed = await ensureStartersLoaded(
+      failing as unknown as typeof fetch,
+    );
+    expect(failed).toEqual([]);
+    expect(getStarterTemplates()).toEqual([]);
+    const failingCalls = failing.mock.calls.length;
 
-    // One load fetched each shipped template file exactly once; the second call
-    // reused the cached promise and issued no further fetches.
-    expect(failing).toHaveBeenCalledTimes(3);
+    // The failure was not cached: a later open retries. Give it a working
+    // fetcher and confirm the starters populate.
+    const working = okFetcher("Home Lab");
+    const recovered = await ensureStartersLoaded(
+      working as unknown as typeof fetch,
+    );
+
+    expect(recovered.length).toBeGreaterThan(0);
+    expect(getStarterTemplates().length).toBeGreaterThan(0);
+    // The retry issued fresh fetches rather than reusing the failed attempt.
+    expect(failing.mock.calls.length).toBe(failingCalls);
+    expect(working.mock.calls.length).toBeGreaterThan(0);
   });
 });
 
@@ -175,19 +200,20 @@ describe("openStarterById", () => {
     vi.unstubAllGlobals();
   });
 
-  it("is a no-op for an id that did not load", async () => {
+  it("is a no-op when starters cannot be loaded", async () => {
     const failing = vi.fn(async () => {
       throw new Error("offline");
     }) as unknown as typeof fetch;
-    // Prime the cache with a failed load so the set is empty.
-    await ensureStartersLoaded(failing);
+    // openStarterById loads via the default global fetch; stub it to fail so the
+    // internal load degrades to [] and there is no matching starter to open.
+    vi.stubGlobal("fetch", failing);
 
     const ws = getWorkspaceStore();
     const before = ws.tabs.length;
 
     openStarterById("home-lab");
-    // Let the internal ensureStartersLoaded promise settle.
-    await Promise.resolve();
+    // Flush the internal ensureStartersLoaded().then chain.
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(ws.tabs.length).toBe(before);
   });

--- a/src/tests/starter-templates-store.test.ts
+++ b/src/tests/starter-templates-store.test.ts
@@ -61,6 +61,14 @@ settings:
 `;
 }
 
+/** A vitest mock fetcher that resolves every request with valid starter YAML. */
+function okFetcher(name: string) {
+  const yaml = validStarterYaml(name);
+  return vi.fn(
+    async () => ({ ok: true, status: 200, text: async () => yaml }) as Response,
+  );
+}
+
 describe("openStarter", () => {
   beforeEach(() => {
     resetHistoryStore();
@@ -112,11 +120,7 @@ describe("openStarter", () => {
     // getStarterTemplates() is a reactive proxy. openStarter must snapshot it
     // before structuredClone, which throws on a Proxy. This guards that path,
     // which makeStarter() (a plain object) does not exercise.
-    const yaml = validStarterYaml("Home Lab");
-    const fetcher = vi.fn(
-      async () =>
-        ({ ok: true, status: 200, text: async () => yaml }) as Response,
-    ) as unknown as typeof fetch;
+    const fetcher = okFetcher("Home Lab") as unknown as typeof fetch;
     await ensureStartersLoaded(fetcher);
 
     const ws = getWorkspaceStore();
@@ -135,14 +139,6 @@ describe("ensureStartersLoaded", () => {
   beforeEach(() => {
     resetStarterTemplatesForTest();
   });
-
-  function okFetcher(name: string) {
-    const yaml = validStarterYaml(name);
-    return vi.fn(
-      async () =>
-        ({ ok: true, status: 200, text: async () => yaml }) as Response,
-    );
-  }
 
   it("caches a successful load, so a repeat open does not refetch", async () => {
     const fetcher = okFetcher("Home Lab");
@@ -219,11 +215,7 @@ describe("openStarterById", () => {
   });
 
   it("opens the matching starter after a successful load", async () => {
-    const yaml = validStarterYaml("Home Lab");
-    const fetcher = vi.fn(
-      async () =>
-        ({ ok: true, status: 200, text: async () => yaml }) as Response,
-    ) as unknown as typeof fetch;
+    const fetcher = okFetcher("Home Lab") as unknown as typeof fetch;
     await ensureStartersLoaded(fetcher);
 
     const ws = getWorkspaceStore();
@@ -237,11 +229,7 @@ describe("openStarterById", () => {
   });
 
   it("is a no-op for an unknown id after a successful load", async () => {
-    const yaml = validStarterYaml("Home Lab");
-    const fetcher = vi.fn(
-      async () =>
-        ({ ok: true, status: 200, text: async () => yaml }) as Response,
-    ) as unknown as typeof fetch;
+    const fetcher = okFetcher("Home Lab") as unknown as typeof fetch;
     await ensureStartersLoaded(fetcher);
 
     const ws = getWorkspaceStore();

--- a/src/tests/starter-templates-store.test.ts
+++ b/src/tests/starter-templates-store.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  openStarter,
+  openStarterById,
+  ensureStartersLoaded,
+  getStarterTemplates,
+  areStartersLoaded,
+  resetStarterTemplatesForTest,
+} from "$lib/stores/starter-templates.svelte";
+import {
+  getWorkspaceStore,
+  resetWorkspaceStore,
+} from "$lib/stores/workspace.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { createLayout } from "$lib/utils/serialization";
+import { createTestRack } from "./factories";
+import type {
+  StarterTemplate,
+  StarterTemplateId,
+} from "$lib/templates/starter-templates";
+import type { Layout } from "$lib/types";
+
+/**
+ * Build a starter carrying a fixed baked-in metadata.id, mirroring the shipped
+ * YAML (each starter file bakes an id). The open path must regenerate that id so
+ * the workspace library never aliases repeat opens of the same starter (#2829).
+ */
+function makeStarter(): StarterTemplate {
+  const layout: Layout = createLayout("Home Lab");
+  layout.racks = [createTestRack({ id: "rack-1" })];
+  layout.metadata = { ...layout.metadata, id: "baked-starter-id" };
+  return { id: "home-lab", layout, colour: "var(--dracula-purple)" };
+}
+
+/** A minimal, schema-valid starter YAML, parameterised by name. */
+function validStarterYaml(name: string): string {
+  return `version: "1.0.0"
+name: "${name}"
+racks:
+  - id: "rack-1"
+    name: "${name}"
+    height: 4
+    width: 19
+    desc_units: false
+    show_rear: true
+    form_factor: "4-post-cabinet"
+    starting_unit: 1
+    position: 0
+    devices:
+      - id: "dev-1"
+        device_type: "1u-server"
+        position: 1
+        face: "front"
+device_types:
+  - slug: "1u-server"
+    u_height: 1
+    colour: "#4A7A8A"
+    category: "server"
+settings:
+  display_mode: "label"
+  show_labels_on_images: false
+`;
+}
+
+describe("openStarter", () => {
+  beforeEach(() => {
+    resetHistoryStore();
+    resetWorkspaceStore();
+    resetStarterTemplatesForTest();
+    // fitAll is scheduled via rAF and no-ops without a live panzoom; stub rAF so
+    // the schedule never runs and cannot touch a later test's workspace.
+    vi.stubGlobal("requestAnimationFrame", () => 0);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens the same starter twice as two independent layouts with distinct ids", () => {
+    const ws = getWorkspaceStore();
+    const before = ws.tabs.length;
+    const starter = makeStarter();
+
+    openStarter(starter);
+    openStarter(starter);
+
+    expect(ws.tabs.length).toBe(before + 2);
+    const [first, second] = ws.tabs.slice(before);
+    // Each open regenerated the id: distinct from each other and from the baked
+    // starter id, so neither aliases the other in the workspace library.
+    expect(first!.layoutId).not.toBe(second!.layoutId);
+    expect(first!.layoutId).not.toBe("baked-starter-id");
+    expect(second!.layoutId).not.toBe("baked-starter-id");
+    // Independence, not a fixed count: the two stores hold distinct rack
+    // arrays (separate clones), each carrying the starter's rack content.
+    expect(first!.store.racks).not.toBe(second!.store.racks);
+    expect(first!.store.racks.length).toBeGreaterThan(0);
+    expect(second!.store.racks.length).toBeGreaterThan(0);
+  });
+
+  it("makes the opened starter the active tab", () => {
+    const ws = getWorkspaceStore();
+    const starter = makeStarter();
+
+    openStarter(starter);
+
+    expect(ws.activeId).toBe(ws.tabs[ws.tabs.length - 1]!.id);
+    expect(ws.activeStore.layout.name).toBe("Home Lab");
+  });
+
+  it("opens a starter read back from the reactive source (state proxy)", async () => {
+    // The shared source holds starters in $state, so a template read via
+    // getStarterTemplates() is a reactive proxy. openStarter must snapshot it
+    // before structuredClone, which throws on a Proxy. This guards that path,
+    // which makeStarter() (a plain object) does not exercise.
+    const yaml = validStarterYaml("Home Lab");
+    const fetcher = vi.fn(
+      async () =>
+        ({ ok: true, status: 200, text: async () => yaml }) as Response,
+    ) as unknown as typeof fetch;
+    await ensureStartersLoaded(fetcher);
+
+    const ws = getWorkspaceStore();
+    const before = ws.tabs.length;
+    const loaded = getStarterTemplates();
+    expect(loaded.length).toBeGreaterThan(0);
+
+    openStarter(loaded[0]!);
+
+    expect(ws.tabs.length).toBe(before + 1);
+    expect(ws.activeStore.layout.name).toBe("Home Lab");
+  });
+});
+
+describe("ensureStartersLoaded", () => {
+  beforeEach(() => {
+    resetStarterTemplatesForTest();
+  });
+
+  it("exposes no starters when every load fails, so only Blank remains", async () => {
+    const failing = vi.fn(async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+
+    const result = await ensureStartersLoaded(failing);
+
+    expect(result).toEqual([]);
+    expect(getStarterTemplates()).toEqual([]);
+    expect(areStartersLoaded()).toBe(true);
+  });
+
+  it("loads once and caches, so repeat opens do not refetch", async () => {
+    const failing = vi.fn(async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+
+    await ensureStartersLoaded(failing);
+    await ensureStartersLoaded(failing);
+
+    // One load fetched each shipped template file exactly once; the second call
+    // reused the cached promise and issued no further fetches.
+    expect(failing).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("openStarterById", () => {
+  beforeEach(() => {
+    resetHistoryStore();
+    resetWorkspaceStore();
+    resetStarterTemplatesForTest();
+    vi.stubGlobal("requestAnimationFrame", () => 0);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("is a no-op for an id that did not load", async () => {
+    const failing = vi.fn(async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    // Prime the cache with a failed load so the set is empty.
+    await ensureStartersLoaded(failing);
+
+    const ws = getWorkspaceStore();
+    const before = ws.tabs.length;
+
+    openStarterById("home-lab");
+    // Let the internal ensureStartersLoaded promise settle.
+    await Promise.resolve();
+
+    expect(ws.tabs.length).toBe(before);
+  });
+
+  it("opens the matching starter after a successful load", async () => {
+    const yaml = validStarterYaml("Home Lab");
+    const fetcher = vi.fn(
+      async () =>
+        ({ ok: true, status: 200, text: async () => yaml }) as Response,
+    ) as unknown as typeof fetch;
+    await ensureStartersLoaded(fetcher);
+
+    const ws = getWorkspaceStore();
+    const before = ws.tabs.length;
+
+    openStarterById("home-lab");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ws.tabs.length).toBe(before + 1);
+    expect(ws.activeStore.layout.name).toBe("Home Lab");
+  });
+
+  it("is a no-op for an unknown id after a successful load", async () => {
+    const yaml = validStarterYaml("Home Lab");
+    const fetcher = vi.fn(
+      async () =>
+        ({ ok: true, status: 200, text: async () => yaml }) as Response,
+    ) as unknown as typeof fetch;
+    await ensureStartersLoaded(fetcher);
+
+    const ws = getWorkspaceStore();
+    const before = ws.tabs.length;
+
+    openStarterById("not-a-real-starter" as StarterTemplateId);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(ws.tabs.length).toBe(before);
+  });
+});


### PR DESCRIPTION
## **User description**
Closes #2829

## Summary

Splits both "+" controls (tab bar and Layouts panel) into a primary button plus a chevron/right-click menu. Plain click still creates a blank layout exactly as before; the menu lists "Blank layout" plus the three starters (colour dot, name, and "N rack, N devices" meta). Choosing a starter opens it in a new tab with a regenerated `metadata.id`, fresh undo history, and `fitAll` applied, so opening the same starter twice yields two independent layouts. Starters lazy-load on first menu open through one shared source consumed by both "+" controls and the command palette, which gains one entry per starter. On load failure only "Blank layout" renders.

Implements D2 and D4 of the template-starter-integration design.

## What changed

- New `src/lib/stores/starter-templates.svelte.ts`: the single lazy-loaded starter source (`ensureStartersLoaded`, `getStarterTemplates`) plus the open path (`openStarter`, `openStarterById`). Clone + `metadata.id` regen + `openTab` + rAF `fitAll`, mirroring the existing duplicate pattern; never routes through `openFromLibrary`.
- New `src/lib/components/NewLayoutMenu.svelte`: the chevron + bits-ui `DropdownMenu` content, reused by both "+" sites (toolbar and panel variants). bits-ui provides roving focus, arrow/Home/End, and Escape.
- `LayoutTabs.svelte` / `LayoutsLibrary.svelte`: primary "+" unchanged on click; added `oncontextmenu` to open the shared menu and the chevron beside it.
- `starter-templates.ts` loader: added a tokenised `colour` per starter (Dracula brand tokens), a `StarterTemplateId` type, and a pure `starterRackSummary` helper.
- `registry.ts` / `dispatch.ts`: three `new-layout-template-*` palette actions -> the shared open path.

## Orchestrator reconciliation (spec wins)

- R1: Neither primary "+" click behaviour changed. The tab-bar "+" still calls `workspace.openTab()` (empty) and the panel "+" still adds a rack; only a chevron + right-click affordance was added.
- R2: No per-starter colour existed. Added a small `STARTER_COLOURS` manifest in `starter-templates.ts` mapping the three ids to Dracula brand tokens (`var(--dracula-purple/cyan/green)`); surfaced as `StarterTemplate.colour`. No YAML schema change.
- R3: Starter open = clone loaded layout, `clone.metadata = { ...clone.metadata, id: generateId() }`, `workspace.openTab(clone)` (fresh history), then rAF `fitAll`. Mirrors the existing duplicate pattern. Does not use `handleChooseTemplate` or `openFromLibrary`.
- R4: Purely additive. WelcomeScreen, TemplatePicker, `handleChooseTemplate`, and the Canvas-side `loadStarterTemplates` `$effect` are untouched (they are removed in #2831). This PR adds a new menu-triggered lazy load shared across both controls and the palette.

## Verification

- `npm run lint`: pass
- `npm run check` (svelte-check): 0 errors
- `npm run test:run`: 197 files, 3170 tests pass (incl. new store tests: open twice -> distinct ids + independent tabs; reactive-proxy open path; empty-set on load failure; cache-once; palette-by-id success/unknown/failed paths)
- `npm run build`: pass
- Prettier `--check`: clean
- svelte-autofixer: no issues on all new/changed components
- CodeRabbit local review: major + both minors fixed (cache-poisoning resilience, capture opened tab's store for rAF, literal-length assertion, added palette-by-id coverage, type-couple starter ids). One trivial skipped with reason: the toolbar chevron uses raw px to pixel-align with the sibling `.layout-tab-add` (also 44px raw in LayoutTabs); no 44px design token exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RELMaFsc4spEM439zeH1zZ


___

## **CodeAnt-AI Description**
**Split the New layout controls into a quick blank action and a starter-template menu**

### What Changed
- Clicking the main `+` still creates a blank layout, while the new chevron and right-click menu open a list of starter templates.
- Starter templates now show a colored dot, name, and rack/device summary, and opening one creates a new tab with its own layout state and undo history.
- The same starter can be opened multiple times as separate layouts without sharing state.
- Starter templates load only when the menu is opened; if loading fails, the menu shows only Blank layout.
- The command palette now includes one action for each starter template.

### Impact
`✅ Faster access to blank layouts`
`✅ Fewer accidental overwrites when opening starter layouts`
`✅ Clearer template picking when loading fails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
