### PR TITLE
feat: gate bay affordances to empty standalone racks and bay groups (#2823)

### DIFF
--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -46,6 +46,14 @@ export const locators = {
     rearBlockedSlot: '[data-testid="rack-rear"] .blocked-slot',
   },
 
+  bayGroup: {
+    // The group wrapper itself is reached by role/name at the call site
+    // (role="group", accessible name "N bays"). This registry holds only the
+    // structural leaf used to count members.
+    /** Front-row member rack SVGs of a bayed group, one per bay. */
+    frontMemberSvg: ".front-row .rack-svg",
+  },
+
   device: {
     paletteItem: '[data-testid="device-palette-item"]',
     paletteItemName: '[data-testid="device-palette-item"] .device-name',

--- a/e2e/rack-controls.spec.ts
+++ b/e2e/rack-controls.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Rack controls: verb bar reorder + bay gating and bay creation/extension
+ * (#2822 verb bar, #2823 bay affordance gating).
+ *
+ * These drive the deterministic click/keyboard paths only. The right-edge drag
+ * grip is deliberately not exercised here: drag-based E2E is flaky in this repo,
+ * and the verb bar is the stable equivalent of every gesture the grip performs.
+ *
+ * Selectors are role/name based (getByRole with the accessible label) so they
+ * survive row reordering and DOM restructuring. Bay affordances are enabled by
+ * default (enableBayedRacks defaults to on), so no setup toggling is needed.
+ */
+import { test, expect } from "./helpers/base-test";
+import type { Page } from "@playwright/test";
+import {
+  gotoWithRack,
+  createRackDirect,
+  createTestLayout,
+  SMALL_RACK_SHARE,
+  locators,
+} from "./helpers";
+
+/** The floating verb bar for a rack or bay-group selection. */
+function rackActions(page: Page) {
+  return page.getByRole("toolbar", { name: "Rack actions" });
+}
+
+/** A bay group renders as role="group" with an "N bays" accessible name. */
+function bayGroup(page: Page) {
+  return page.getByRole("group", { name: /bays/ });
+}
+
+/** The front-row rack SVG of each bay member (one per bay). */
+function bayMembers(page: Page) {
+  return bayGroup(page).locator(locators.bayGroup.frontMemberSvg);
+}
+
+/**
+ * Select a standalone rack (by name when given, else the first one) via its
+ * canvas click target and wait for its verb bar to appear.
+ */
+async function selectStandaloneRack(page: Page, name?: string): Promise<void> {
+  const rack = name
+    ? page.locator(locators.rackView.dualView).filter({
+        has: page.locator(locators.rackView.dualViewName, { hasText: name }),
+      })
+    : page.locator(locators.rackView.dualView).first();
+  await rack.locator(locators.rackView.frontSvg).click();
+  await expect(rackActions(page)).toBeVisible();
+}
+
+/** Select a bay group via one of its members and wait for its verb bar. */
+async function selectBayGroup(page: Page): Promise<void> {
+  await bayMembers(page).first().click();
+  await expect(rackActions(page)).toBeVisible();
+}
+
+test.describe("Rack reorder via the verb bar (#2822)", () => {
+  test("Move rack right swaps the selected rack past its neighbour", async ({
+    page,
+  }) => {
+    // Two standalone racks in a known left-to-right order: "Small Rack" then the
+    // freshly created "Bravo".
+    await gotoWithRack(page, SMALL_RACK_SHARE);
+    await createRackDirect(page, { name: "Bravo" });
+    await expect(page.locator(locators.rackView.dualViewName)).toHaveText([
+      "Small Rack",
+      "Bravo",
+    ]);
+
+    // Select the left rack and move it right through the verb bar chevron.
+    await selectStandaloneRack(page, "Small Rack");
+    await page.getByRole("button", { name: "Move rack right" }).click();
+
+    // The row order flips: identity, not index internals, proves the reorder.
+    await expect(page.locator(locators.rackView.dualViewName)).toHaveText([
+      "Bravo",
+      "Small Rack",
+    ]);
+  });
+});
+
+test.describe("Bay verb gating by selection state (#2823)", () => {
+  test("empty standalone rack offers the Bay rack verb", async ({ page }) => {
+    await gotoWithRack(page, SMALL_RACK_SHARE);
+    await selectStandaloneRack(page);
+    await expect(page.getByRole("button", { name: "Bay rack" })).toBeVisible();
+  });
+
+  test("populated standalone rack does not offer the Bay rack verb", async ({
+    page,
+  }) => {
+    // A compact rack with one device pre-placed keeps the whole rack on screen
+    // so the verb bar renders; baying must still be withheld.
+    await gotoWithRack(
+      page,
+      createTestLayout({
+        rackName: "Filled Rack",
+        rackHeight: 12,
+        devices: [{ type: "srv", position: 1, face: "front" }],
+        customTypes: [
+          { slug: "srv", height: 1, colour: "#4A90A4", category: "s" },
+        ],
+      }),
+    );
+    await selectStandaloneRack(page);
+
+    // The verb bar is up (other rack verbs are present), but no bay verb.
+    await expect(rackActions(page)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Bay rack" })).toHaveCount(0);
+  });
+
+  test("bay group offers the Bay rack verb", async ({ page }) => {
+    await gotoWithRack(page, SMALL_RACK_SHARE);
+    await selectStandaloneRack(page);
+    await page.getByRole("button", { name: "Bay rack" }).click();
+    await expect(bayGroup(page)).toBeVisible();
+
+    await selectBayGroup(page);
+    await expect(page.getByRole("button", { name: "Bay rack" })).toBeVisible();
+  });
+});
+
+test.describe("Bay creation and extension via the verb bar (#2823)", () => {
+  test("baying an empty standalone rack forms a two-bay group with empty members", async ({
+    page,
+  }) => {
+    await gotoWithRack(page, SMALL_RACK_SHARE);
+    await selectStandaloneRack(page);
+    await page.getByRole("button", { name: "Bay rack" }).click();
+
+    // A bay group with two members now exists; the standalone view is gone and
+    // both members are empty.
+    await expect(bayGroup(page)).toBeVisible();
+    await expect(bayMembers(page)).toHaveCount(2);
+    await expect(page.locator(locators.rackView.dualView)).toHaveCount(0);
+    await expect(page.locator(locators.rack.device)).toHaveCount(0);
+  });
+
+  test("extending a bay group via the verb adds an empty member at group height", async ({
+    page,
+  }) => {
+    // The verb-driven extension path end-to-end: baying a group again grows it
+    // by one empty member and holds the equal-height invariant. That the new
+    // member stays empty and at group height even when existing members are
+    // populated is locked at the store level in baying-store.test.ts (placement
+    // into a bayed member has no stable UI path to drive here).
+    await gotoWithRack(page, SMALL_RACK_SHARE);
+
+    // Bay the empty rack into a two-member group.
+    await selectStandaloneRack(page);
+    await page.getByRole("button", { name: "Bay rack" }).click();
+    await expect(bayMembers(page)).toHaveCount(2);
+
+    // Extend the group through the verb bar.
+    await selectBayGroup(page);
+    await page.getByRole("button", { name: "Bay rack" }).click();
+    await expect(bayMembers(page)).toHaveCount(3);
+
+    // Every member is empty: extension creates a new bay, it never copies gear.
+    await expect(page.locator(locators.rack.device)).toHaveCount(0);
+
+    // Equal-height invariant, observed: every rendered member is the same height.
+    const heights = await bayMembers(page).evaluateAll((svgs) =>
+      svgs.map((svg) => svg.getBoundingClientRect().height),
+    );
+    for (const height of heights) {
+      expect(Math.abs(height - heights[0]!)).toBeLessThanOrEqual(2);
+    }
+  });
+});

--- a/src/lib/components/BayedRackView.svelte
+++ b/src/lib/components/BayedRackView.svelte
@@ -470,10 +470,13 @@
             {ondevicemoverack}
             onplacementtap={(e) => handlePlacementTap(rack.id, e)}
           />
-          <!-- Resistant right-edge drag on an empty bay member: pull right past
-               the snap threshold to insert a new bayed rack after it (#2740).
-               Same affordance and handlers as a standalone empty rack. -->
-          {#if enableBayDrag && rack.devices.length === 0}
+          <!-- Resistant right-edge drag on the group's right edge (#2823): a
+               bay group always extends, whatever its members contain, so the one
+               grip sits on the last member and pulls right past the snap
+               threshold to append a new empty member at group height. Same
+               affordance and handlers as a standalone empty rack. enableBayDrag
+               already encodes selection, the bayed-racks setting, and read-only. -->
+          {#if enableBayDrag && bayIndex === racks.length - 1}
             <button
               type="button"
               class="bay-edge-grip"

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -18,7 +18,7 @@
   import type { DeviceFace } from "$lib/types";
   import RackDualView from "./RackDualView.svelte";
   import BayedRackView from "./BayedRackView.svelte";
-  import { organizeRackRow } from "$lib/utils/rack-row";
+  import { organizeRackRow, baySourceForItem } from "$lib/utils/rack-row";
   import { bayRack } from "$lib/actions/selection-actions";
   import { getMinResizeHeight, snapResizeHeight } from "$lib/utils/rack-resize";
   import { U_HEIGHT_PX, getRackWidth } from "$lib/constants/layout";
@@ -323,9 +323,11 @@
   // existing bay, with the new member inheriting width / form factor / height
   // from the source, then keeps the result on screen (#2822, #2825).
 
-  // Resistant right-edge drag on an empty rack: a rubber-band ghost that snaps
-  // past a threshold to create or insert a bayed rack (#2740). Offered only on
-  // empty racks (AC: racks with no devices).
+  // Resistant right-edge drag: a rubber-band ghost that snaps past a threshold
+  // to create or extend a bay (#2740). Baying is a creation-time affordance, so
+  // the grip is offered only on an empty standalone rack and on a bay group's
+  // right edge (populated standalone racks show none), matching baySourceForItem
+  // and the verb bar bay action (#2823).
   const BAY_SNAP_FRACTION = 0.5;
 
   interface BayDrag {
@@ -635,10 +637,13 @@
                 {resizeDrag.previewHeight}U
               </div>
             {/if}
-            <!-- Resistant right-edge drag: empty racks only (#2740). Pull right
-                 past the snap threshold to create or insert a bayed rack.
-                 Gated on the bayed-racks setting (#2742). -->
-            {#if uiStore.enableBayedRacks && rack.devices.length === 0}
+            <!-- Resistant right-edge drag, gated to match the verb bar bay
+                 action (#2823): baySourceForItem offers it only on an empty
+                 standalone rack (populated standalone racks show no bay
+                 affordance), ANDed with the bayed-racks setting (#2742) and
+                 suppressed in read-only mode. Pull right past the snap threshold
+                 to create a bayed rack. -->
+            {#if !uiStore.readOnly && uiStore.enableBayedRacks && baySourceForItem(item, activeRackId) !== null}
               <button
                 type="button"
                 class="bay-edge-grip"
@@ -709,7 +714,9 @@
             onrename={(rackId) => onrackrename?.(rackId)}
             onduplicate={(rackId) => onrackduplicate?.(rackId)}
             ondelete={(rackId) => onrackdelete?.(rackId)}
-            enableBayDrag={isBaySelected && uiStore.enableBayedRacks}
+            enableBayDrag={isBaySelected &&
+              uiStore.enableBayedRacks &&
+              !uiStore.readOnly}
             {bayGhost}
             onbaydragstart={handleBayDragStart}
             onbaydragmove={handleBayDragMove}

--- a/src/tests/baying-store.test.ts
+++ b/src/tests/baying-store.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { organizeRackRow } from "$lib/utils/rack-row";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
 
 function rowIds(store: ReturnType<typeof getLayoutStore>): string[] {
   return organizeRackRow(store.racks, store.rack_groups).flatMap((item) =>
@@ -58,6 +59,44 @@ describe("createBayedRack", () => {
     for (const id of group.rack_ids) {
       expect(store.getRackById(id)!.height).toBe(30);
     }
+  });
+
+  it("extends a populated bay group with an empty member at group height", () => {
+    // A bay group can be extended regardless of member contents (#2823). The
+    // new member is created empty at group height, so the equal-height invariant
+    // holds even when existing members are populated.
+    const store = getLayoutStore();
+    const created = store.addBayedRackGroup("Bay", 2, 42, 19)!;
+    const groupId = created.group.id;
+    const firstId = created.group.rack_ids[0]!;
+    const lastId = created.group.rack_ids[created.group.rack_ids.length - 1]!;
+
+    const dt = store.addDeviceType({
+      name: "Server 1U",
+      u_height: 1,
+      category: "server",
+      colour: CATEGORY_COLOURS.server,
+    });
+    expect(store.placeDevice(firstId, dt.slug, 5)).toBe(true);
+    expect(store.getRackById(firstId)!.devices.length).toBeGreaterThan(0);
+
+    // Extend from the group's right edge (its last member), as the grip does.
+    const result = store.createBayedRack(lastId);
+    expect(result.error).toBeUndefined();
+
+    // The new member arrives empty: baying is a creation-time decision, not a
+    // copy of the source's contents.
+    const newRack = store.getRackById(result.rackId!)!;
+    expect(newRack.devices).toEqual([]);
+
+    // Every member (populated or not) shares the group height.
+    const group = store.getRackGroupById(groupId)!;
+    for (const id of group.rack_ids) {
+      expect(store.getRackById(id)!.height).toBe(42);
+    }
+    // It joined the same group at its right edge.
+    expect(group.rack_ids).toContain(result.rackId);
+    expect(group.rack_ids[group.rack_ids.length - 1]).toBe(result.rackId);
   });
 
   it("inserts mid-row and pushes the racks to the right along", () => {

--- a/src/tests/rack-row.test.ts
+++ b/src/tests/rack-row.test.ts
@@ -421,3 +421,57 @@ describe("baySourceForItem (#2822)", () => {
     expect(baySourceForItem(undefined, null)).toBeNull();
   });
 });
+
+describe("bay affordance gating by selection state (#2823)", () => {
+  // The grip and the verb bar bay action share baySourceForItem: a non-null
+  // source means the bay affordance is offered for that selection. These cover
+  // the three acceptance-criteria selection states.
+
+  it("offers baying on an empty standalone rack (bays itself)", () => {
+    const a = createTestRack({ id: "a", position: 0 });
+    const [item] = organizeRackRow([a], []);
+    expect(baySourceForItem(item, "a")).toBe("a");
+  });
+
+  it("withholds baying on a populated standalone rack", () => {
+    const a = createTestRack({
+      id: "a",
+      position: 0,
+      devices: [createTestDevice()],
+    });
+    const [item] = organizeRackRow([a], []);
+    expect(baySourceForItem(item, "a")).toBeNull();
+  });
+
+  it("offers baying on a bay group whose members are all empty", () => {
+    const m1 = createTestRack({ id: "m1", position: 0 });
+    const m2 = createTestRack({ id: "m2", position: 1 });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "bayed",
+    };
+    const [item] = organizeRackRow([m1, m2], [group]);
+    expect(baySourceForItem(item, "m1")).toBe("m1");
+  });
+
+  it("offers baying on a bay group with populated members", () => {
+    const m1 = createTestRack({
+      id: "m1",
+      position: 0,
+      devices: [createTestDevice()],
+    });
+    const m2 = createTestRack({
+      id: "m2",
+      position: 1,
+      devices: [createTestDevice()],
+    });
+    const group: RackGroup = {
+      id: "g1",
+      rack_ids: ["m1", "m2"],
+      layout_preset: "bayed",
+    };
+    const [item] = organizeRackRow([m1, m2], [group]);
+    expect(baySourceForItem(item, "m1")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Baying is a creation-time decision, so bay affordances now appear only where they can act. This re-gates the right-edge bay grip to match the verb bar bay action (#2822): an empty standalone rack shows it (bays itself), a bay group shows it on the group's right edge (extends regardless of member contents), and a populated standalone rack shows nothing. This is the intentional 26.6.6 capability change from the resize/bay corrections design.

Design: `docs/superpowers/specs/2026-07-01-resize-bay-corrections-design.md` (Bay affordances, locked decisions).

## Changes

- `RackCanvasView.svelte`: the standalone edge grip is now gated by the shared `baySourceForItem(item, activeRackId)` (empty standalone only), ANDed with `enableBayedRacks` and suppressed in read-only mode, matching the verb bar. Populated standalone racks show no grip.
- `BayedRackView.svelte`: the one bay grip now sits on the group's right edge (the last member) and shows regardless of member contents, instead of one-per-empty-member. It routes through the same `bayRack` path, which preserves the ensure-visible camera move (#2825).
- Group extension: `createBayedRack` already creates the new member empty and at the source (group) height, so the equal-height invariant holds when extending a populated group. No store change was needed; a store test locks it in.

The grip's display gating uses `baySourceForItem` (consistent with the verb). For a group the grip extends from the last member so the grip, ghost preview, and insertion all sit on the group's right edge, exactly as the design specifies. The resistant drag threshold and ghost preview behaviour are unchanged.

## Acceptance criteria

- [x] Empty standalone rack selected: edge grip and bay verb visible
- [x] Populated standalone rack selected: no edge grip, no bay verb
- [x] Bay group selected: edge grip on the group right edge and bay verb visible regardless of member contents
- [x] Extending a group adds an empty member at group height (equal-height invariant holds)
- [x] Resistant drag threshold and ghost preview behaviour unchanged

## Tests

Unit/store (behavioural):
- `baying-store.test.ts`: extending a populated bay group adds an empty member at group height (equal-height invariant).
- `rack-row.test.ts`: bay affordance gating for the three selection states (empty standalone offers baying, populated standalone withholds it, bay group offers it whether members are empty or populated).

E2E (`e2e/rack-controls.spec.ts`, new): stable verb-bar click and keyboard paths only, no drag-grip gesture (drag E2E is flaky in this repo). Passes locally on chromium and webkit.
- Rack reorder via the verb bar chevron (asserts by visible rack identity).
- Bay verb gating by selection state (empty standalone, populated standalone, bay group).
- Bay creation from an empty standalone rack (forms a two-member group with empty members).
- Bay extension via the verb bar (grows the group by one empty member, equal height preserved). Populated-group extension is locked at the store level; placement into a bayed member has no stable UI path to drive in E2E.

Local gates: lint, check (svelte-check, 0 errors), test:run (3179 passed), build all green.

Closes #2823

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show bay actions only where they can be used**

### What Changed
- The bay action and right-edge grip now appear only for an empty standalone rack or a bay group, and stay hidden on a populated standalone rack.
- Bay groups now show a single bay grip on the group’s right edge, so extending the group works from the visible end of the row.
- Read-only mode now hides the bay grip and disables bay dragging.
- Added end-to-end coverage for baying empty racks, blocking baying on populated racks, extending bay groups, and rack reordering.

### Impact
`✅ Fewer confusing bay options`
`✅ Clearer rack editing controls`
`✅ More reliable baying and reorder checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
