### PR TITLE
feat: mobile New from template row (#2830)

### DIFF
--- a/src/lib/components/mobile/MobileLayoutsSheet.svelte
+++ b/src/lib/components/mobile/MobileLayoutsSheet.svelte
@@ -6,22 +6,39 @@
   New layout action. It reads the shared workspace store directly and routes
   switching through the same verbs the desktop LayoutsLibrary uses
   (openFromLibrary / switchTo), so mobile does not fork the layout-switching
-  logic. Creating a new layout opens a fresh tab and lets the parent raise the
-  New Rack wizard via onnewlayout.
+  logic. Creating a new layout opens a fresh tab, then lets the parent add a
+  rack directly via onnewlayout.
+
+  A "New from template" disclosure sits under "New layout" (#2830, D5). It reuses
+  the desktop split-"+" starter source (ensureStartersLoaded / getStarterTemplates
+  / openStarter), so mobile has no separate template data path. Starters lazy-load
+  when the sheet opens; the row appears only once a non-empty set has loaded, so a
+  load failure leaves it absent. Choosing a starter opens it in a new tab through
+  the same id-regeneration path as desktop, then dismisses the sheet.
 
   Indicators are never colour-only (WCAG 1.4.1): each row pairs a state dot with
   a text label (Active / Open / Closed), and the active row carries
   aria-selected.
 -->
 <script lang="ts">
+  import { untrack } from "svelte";
   import { getWorkspaceStore } from "$lib/stores/workspace.svelte";
   import { createLayout } from "$lib/utils/serialization";
   import { buildLayoutRows, type LayoutRow } from "../layouts-library";
-  import { IconPlusBold } from "$lib/components/icons";
+  import { IconPlusBold, IconChevronDown } from "$lib/components/icons";
   import { ICON_SIZE } from "$lib/constants/sizing";
+  import {
+    ensureStartersLoaded,
+    getStarterTemplates,
+    openStarter,
+  } from "$lib/stores/starter-templates.svelte";
+  import {
+    starterRackSummary,
+    type StarterTemplate,
+  } from "$lib/templates/starter-templates";
 
   interface Props {
-    /** Raise the New Rack wizard after a fresh layout is opened. */
+    /** After a fresh layout is opened, ask the parent to add a rack directly. */
     onnewlayout?: () => void;
     /** Dismiss the sheet (after a switch or a create). */
     onclose?: () => void;
@@ -38,6 +55,20 @@
       workspaceStore.library,
     ),
   );
+
+  // The starters loaded so far, from the shared source. Empty until the lazy
+  // load resolves and empty again after a failed load, so the "New from
+  // template" affordance renders only when there is something to offer.
+  const starters = $derived(getStarterTemplates());
+  let showTemplates = $state(false);
+
+  // Kick the shared lazy load when the sheet mounts (i.e. opens), best-effort.
+  // untrack so the effect never re-runs off the state ensureStartersLoaded
+  // mutates; otherwise a failed load (which clears its in-flight promise) would
+  // retrigger the effect and retry-loop. A fresh mount on the next open retries.
+  $effect(() => {
+    untrack(() => void ensureStartersLoaded());
+  });
 
   /** Stable per-row key: the tab id for an open row, the layout id for a closed one. */
   function rowKey(row: LayoutRow): string {
@@ -57,11 +88,18 @@
   }
 
   // Open a fresh empty layout in its own tab, make it active, then let the
-  // parent raise the New Rack wizard and dismiss the sheet. Mirrors the desktop
-  // New layout flow (App.handleNewLayout) so the two stay aligned.
+  // parent add a rack directly and dismiss the sheet. Mirrors the desktop New
+  // layout flow (App.handleNewLayout) so the two stay aligned.
   function handleNewLayout() {
     workspaceStore.openTab(createLayout());
     onnewlayout?.();
+    onclose?.();
+  }
+
+  // Open the chosen starter in a new tab through the shared open path (clone,
+  // regenerated metadata.id, fitAll), then dismiss the sheet like New layout.
+  function chooseStarter(template: StarterTemplate) {
+    openStarter(template);
     onclose?.();
   }
 </script>
@@ -76,6 +114,54 @@
     <IconPlusBold size={ICON_SIZE.sm} />
     New layout
   </button>
+
+  {#if starters.length > 0}
+    <div class="template-section">
+      <button
+        type="button"
+        class="new-from-template"
+        onclick={() => (showTemplates = !showTemplates)}
+        aria-expanded={showTemplates}
+        aria-controls="mobile-template-list"
+        data-testid="mobile-new-from-template"
+      >
+        <span>New from template</span>
+        <span class="chevron" class:open={showTemplates} aria-hidden="true">
+          <IconChevronDown size={ICON_SIZE.sm} />
+        </span>
+      </button>
+
+      <!-- Kept in the DOM and toggled with `hidden` (not {#if}) so the trigger's
+           aria-controls always resolves; `hidden` still drops it from the a11y
+           tree and tab order while collapsed. -->
+      <div
+        id="mobile-template-list"
+        class="template-list"
+        role="group"
+        aria-label="Starter templates"
+        hidden={!showTemplates}
+      >
+        {#each starters as template (template.id)}
+          <button
+            type="button"
+            class="template-row"
+            onclick={() => chooseStarter(template)}
+            data-testid="mobile-template-{template.id}"
+          >
+            <span
+              class="starter-dot"
+              style:background={template.colour}
+              aria-hidden="true"
+            ></span>
+            <span class="starter-text">
+              <span class="starter-name">{template.layout.name}</span>
+              <span class="starter-meta">{starterRackSummary(template)}</span>
+            </span>
+          </button>
+        {/each}
+      </div>
+    </div>
+  {/if}
 
   <div class="layout-list" role="listbox" aria-label="Layouts">
     {#each rows as row (rowKey(row))}
@@ -163,13 +249,77 @@
     outline-offset: 2px;
   }
 
+  /* New from template: a disclosure that reveals the starter list inline. Shares
+     the New layout button's look but justifies label and chevron apart. */
+  .template-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .new-from-template {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    width: 100%;
+    min-height: var(--touch-target-min);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--colour-border);
+    border-radius: var(--radius-md);
+    background: var(--colour-surface);
+    color: var(--colour-text);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+    transition:
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .new-from-template:hover {
+    background: var(--colour-surface-hover);
+    border-color: var(--colour-text-muted);
+  }
+
+  .new-from-template:active {
+    background: var(--colour-surface-hover);
+    scale: 0.98;
+  }
+
+  .new-from-template:focus-visible {
+    outline: 2px solid var(--colour-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .chevron {
+    display: inline-flex;
+    color: var(--colour-text-muted);
+    transition: rotate var(--duration-fast) var(--ease-out);
+  }
+
+  .chevron.open {
+    rotate: 180deg;
+  }
+
+  .template-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
   .layout-list {
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
   }
 
-  .layout-row {
+  /* Layout rows and starter rows share a base: a full-width, touch-sized row
+     with a leading marker and a name/meta stack. */
+  .layout-row,
+  .template-row {
     display: flex;
     align-items: center;
     gap: var(--space-2);
@@ -189,11 +339,13 @@
     -webkit-tap-highlight-color: transparent;
   }
 
-  .layout-row:hover {
+  .layout-row:hover,
+  .template-row:hover {
     background: var(--colour-surface-hover);
   }
 
-  .layout-row:active {
+  .layout-row:active,
+  .template-row:active {
     scale: 0.99;
   }
 
@@ -202,7 +354,8 @@
     border-color: var(--colour-selection);
   }
 
-  .layout-row:focus-visible {
+  .layout-row:focus-visible,
+  .template-row:focus-visible {
     outline: 2px solid var(--colour-selection);
     outline-offset: -2px;
   }
@@ -258,5 +411,43 @@
 
   .layout-row.active .row-state {
     color: var(--colour-success);
+  }
+
+  /* Starter row: a brand colour dot (the starter's palette token) then a
+     name/meta stack, mirroring the desktop From template menu section. The dot
+     is decorative; the name is the accessible label. */
+  .starter-dot {
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  .starter-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    min-width: 0;
+  }
+
+  .starter-name {
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-medium);
+    color: var(--colour-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .starter-meta {
+    font-size: var(--font-size-xs);
+    color: var(--colour-text-muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chevron {
+      transition: none;
+    }
   }
 </style>

--- a/src/tests/MobileLayoutsSheet.test.ts
+++ b/src/tests/MobileLayoutsSheet.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import MobileLayoutsSheet from "$lib/components/mobile/MobileLayoutsSheet.svelte";
 import {
@@ -7,6 +7,11 @@ import {
 } from "$lib/stores/workspace.svelte";
 import { resetHistoryStore } from "$lib/stores/history.svelte";
 import { resetToastStore } from "$lib/stores/toast.svelte";
+import {
+  ensureStartersLoaded,
+  getStarterTemplates,
+  resetStarterTemplatesForTest,
+} from "$lib/stores/starter-templates.svelte";
 import { createLayout } from "$lib/utils/serialization";
 
 function renderSheet(
@@ -21,6 +26,63 @@ function renderSheet(
   return props;
 }
 
+/** A minimal, schema-valid starter YAML (1 rack, 1 device), parameterised by name. */
+/** A valid UUID baked into the test starter, mirroring the shipped YAML headers. */
+const BAKED_METADATA_ID = "a1b2c3d4-0001-4001-8001-000000000001";
+
+function validStarterYaml(name: string): string {
+  return `metadata:
+  id: "${BAKED_METADATA_ID}"
+  name: "${name}"
+  schema_version: "1.0"
+version: "1.0.0"
+name: "${name}"
+racks:
+  - id: "rack-1"
+    name: "${name}"
+    height: 4
+    width: 19
+    desc_units: false
+    show_rear: true
+    form_factor: "4-post-cabinet"
+    starting_unit: 1
+    position: 0
+    devices:
+      - id: "dev-1"
+        device_type: "1u-server"
+        position: 1
+        face: "front"
+device_types:
+  - slug: "1u-server"
+    u_height: 1
+    colour: "#4A7A8A"
+    category: "server"
+settings:
+  display_mode: "label"
+  show_labels_on_images: false
+`;
+}
+
+/**
+ * A mock fetcher that resolves each starter request with valid YAML named after
+ * the file id in the URL, so the three starters load with distinct names (e.g.
+ * "Home Lab", "Network Closet"). Distinct names keep the row queries unambiguous.
+ */
+function okFetcher() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const id = String(input).split("/").pop()!.replace(".rackula.yaml", "");
+    const name = id
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+    return {
+      ok: true,
+      status: 200,
+      text: async () => validStarterYaml(name),
+    } as Response;
+  });
+}
+
 describe("MobileLayoutsSheet", () => {
   beforeEach(() => {
     // The first tab shares the app-session history singleton; reset it so each
@@ -28,6 +90,25 @@ describe("MobileLayoutsSheet", () => {
     resetHistoryStore();
     resetWorkspaceStore();
     resetToastStore();
+    // Start each test from a cold starter cache so the mount-time lazy load and
+    // the "New from template" affordance are deterministic per test.
+    resetStarterTemplatesForTest();
+    // openStarter schedules fitAll via rAF, which no-ops without a live panzoom;
+    // stub rAF so it never runs and cannot touch a later test's workspace.
+    vi.stubGlobal("requestAnimationFrame", () => 0);
+    // The sheet lazy-loads starters on mount via the default fetch. Stub it so
+    // tests never hit the network; starter tests pass an explicit fetcher, so
+    // this default only serves the tests that expect no starters (degrades to []).
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("no network in tests");
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("switches the active layout when a different layout row is tapped", async () => {
@@ -94,6 +175,54 @@ describe("MobileLayoutsSheet", () => {
     const props = renderSheet();
 
     await fireEvent.click(screen.getByRole("option", { name: /Homelab/ }));
+
+    expect(props.onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a chosen starter as a fresh populated tab and closes the sheet", async () => {
+    // Pre-load starters through the shared source so the mount-time load serves
+    // the cache and the "New from template" affordance renders.
+    await ensureStartersLoaded(okFetcher() as unknown as typeof fetch);
+    const template = getStarterTemplates()[0]!;
+    const templateName = template.layout.name;
+    // Known baked id from the YAML header; the open path must regenerate it.
+    const bakedId = template.layout.metadata!.id;
+
+    const ws = getWorkspaceStore();
+    const startingTabIds = ws.tabs.map((t) => t.id);
+
+    renderSheet();
+
+    // Reveal the starter list, then choose the first starter.
+    await fireEvent.click(
+      screen.getByRole("button", { name: /New from template/ }),
+    );
+    await fireEvent.click(
+      screen.getByRole("button", { name: new RegExp(templateName) }),
+    );
+
+    const newTab = ws.tabs.find((t) => !startingTabIds.includes(t.id));
+    expect(newTab).toBeDefined();
+    // The starter opened as the active tab, populated with the starter's racks.
+    expect(ws.activeId).toBe(newTab!.id);
+    expect(newTab!.store.racks.length).toBeGreaterThan(0);
+    // The open regenerated the id: the new tab is not keyed on the starter's
+    // baked-in layout id, so repeat opens never alias one library entry.
+    expect(newTab!.layoutId).not.toBe(bakedId);
+  });
+
+  it("dismisses the sheet when a starter is chosen", async () => {
+    await ensureStartersLoaded(okFetcher() as unknown as typeof fetch);
+    const templateName = getStarterTemplates()[0]!.layout.name;
+
+    const props = renderSheet();
+
+    await fireEvent.click(
+      screen.getByRole("button", { name: /New from template/ }),
+    );
+    await fireEvent.click(
+      screen.getByRole("button", { name: new RegExp(templateName) }),
+    );
 
     expect(props.onclose).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## **User description**
Adds a "New from template" affordance to the mobile Layouts sheet, under "New layout", listing the three starters (colour dot, name, rack/device meta) and opening the chosen one as a new tab. Reuses the #2829 shared starter source and open path (`ensureStartersLoaded` / `getStarterTemplates` / `openStarter`) - no separate mobile data path. "New layout" behaviour is unchanged.

Closes #2830

## Reconciliation notes (spec D5)
- Lazy vs "row hidden on failure": the sheet triggers `ensureStartersLoaded()` on open and renders the template affordance only when `getStarterTemplates()` is non-empty (reactive), so a load failure leaves the row absent while keeping loading lazy (no eager boot load).
- Mobile presentation: tapping reveals the three starters inline within the sheet (no nested dropdown, no long-press), matching the desktop section; choosing one calls `openStarter` and closes the sheet.
- Comment cleanup: this PR owns the stale New-Rack-wizard comment removal in MobileLayoutsSheet.svelte (spec listed it under #2831 too; #2831 does not touch this file).

## Verification
lint clean; svelte-check 0 errors; test:run 3184 passed; build ok; prettier clean.

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Add a "New from template" option to the mobile Layouts sheet**

### What Changed
- Added a new "New from template" disclosure under "New layout" on mobile, showing the available starter layouts inline in the sheet.
- Choosing a starter opens it as a new populated tab, then closes the sheet.
- Starter templates now appear on mobile only when they have loaded successfully; if loading fails, the option stays hidden.
- Added coverage for opening a starter, creating a fresh tab, and closing the sheet after selection.

### Impact
`✅ Faster setup from starter layouts`
`✅ Fewer steps to create a new layout on mobile`
`✅ No empty template option when starters fail to load`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
