### PR TITLE
feat: restyle resize handles as edge-midpoint squares (#2824)

### DIFF
--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -141,6 +141,25 @@
 
   let resizeDrag = $state<ResizeDrag | null>(null);
 
+  // Resize-handle geometry, all screen-space so the affordance reads the same at
+  // any zoom (#2824). The visible square is a fixed 11px; the invisible hit area
+  // is 44px but shrinks on short racks at low zoom so the top and bottom zones
+  // never overlap, with a small gap between them.
+  const GRIP_SQUARE_PX = 11;
+  const GRIP_HIT_MAX_PX = 44;
+  const GRIP_HIT_GAP_PX = 4;
+
+  // Screen-space height of one grip's hit area. Floored at the visible square so
+  // it never collapses to zero: resize stays reachable at any zoom, even when
+  // half the rack's on-screen height (minus the gap) drops below the square.
+  function resizeHitHeightPx(heightU: number): number {
+    const rackScreenHeight = heightU * U_HEIGHT_PX * canvasStore.zoom;
+    return Math.max(
+      GRIP_SQUARE_PX,
+      Math.min(GRIP_HIT_MAX_PX, rackScreenHeight / 2 - GRIP_HIT_GAP_PX),
+    );
+  }
+
   // The racks a target mutates: a standalone rack is itself; a bay is all its
   // members so they stay equal height.
   function resizeTargetRackIds(target: ResizeTarget): string[] {
@@ -559,10 +578,13 @@
   class:swipe-next={swipeAnimationDirection === "next"}
   class:swipe-previous={swipeAnimationDirection === "previous"}
 >
-  {#snippet resizeGrip(target: ResizeTarget, side: ResizeGrip)}
+  {#snippet resizeGrip(target: ResizeTarget, side: ResizeGrip, heightU: number)}
+    {@const scale = 1 / canvasStore.zoom}
     <button
       type="button"
       class="resize-grip resize-grip-{side}"
+      style:--grip-scale={scale}
+      style:height="{resizeHitHeightPx(heightU) * scale}px"
       aria-label={`Resize ${target.kind === "bay" ? "bay" : "rack"} height from ${side} edge`}
       aria-keyshortcuts="ArrowUp ArrowDown"
       title="Drag to resize. Arrow Up grows, Arrow Down shrinks."
@@ -574,7 +596,7 @@
       ontouchstart={blockPan}
       onkeydown={(e) => handleResizeKey(target, e)}
     >
-      <span class="grip-bar" aria-hidden="true"></span>
+      <span class="grip-square" aria-hidden="true"></span>
     </button>
   {/snippet}
   {#each rowItems as item (item.kind === "rack" ? `rack:${item.rack.id}` : `group:${item.group.id}`)}
@@ -626,8 +648,16 @@
             ondelete={() => onrackdelete?.(rack.id)}
           />
           {#if isSelected}
-            {@render resizeGrip({ kind: "rack", rackId: rack.id }, "top")}
-            {@render resizeGrip({ kind: "rack", rackId: rack.id }, "bottom")}
+            {@render resizeGrip(
+              { kind: "rack", rackId: rack.id },
+              "top",
+              rack.height,
+            )}
+            {@render resizeGrip(
+              { kind: "rack", rackId: rack.id },
+              "bottom",
+              rack.height,
+            )}
             {#if resizeDrag?.target.kind === "rack" && resizeDrag.target.rackId === rack.id}
               <div
                 class="resize-readout resize-readout-{resizeDrag.grip}"
@@ -730,7 +760,7 @@
                  stacked front+rear rows grow the wrapper by twice the height
                  delta, so no single translateY tracks the pointer.
                  Gated on the bayed-racks setting (#2742). -->
-            {@render resizeGrip(bayTarget, "top")}
+            {@render resizeGrip(bayTarget, "top", item.racks[0]?.height ?? 0)}
             {#if resizeDrag?.target.kind === "bay" && resizeDrag.target.groupId === item.group.id}
               <div
                 class="resize-readout resize-readout-{resizeDrag.grip}"
@@ -907,8 +937,9 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 56px;
-    height: 22px;
+    /* Screen-space hit width; height is set inline per rack so the top and
+       bottom zones shrink on short racks at low zoom and never overlap (#2824). */
+    width: calc(44px * var(--grip-scale, 1));
     padding: 0;
     border: none;
     background: transparent;
@@ -927,17 +958,19 @@
     transform: translate(-50%, 50%);
   }
 
-  /* The visible handle reads as a short rack rail. */
-  .grip-bar {
-    width: 40px;
-    height: 6px;
-    border-radius: var(--radius-full);
-    background: var(--colour-border);
-    box-shadow: 0 0 0 4px var(--colour-surface-overlay, rgba(40, 42, 54, 0.6));
+  /* Edge-midpoint square centred on the selection outline: the vector-tool
+     convention for axis-only resize. Sized in screen space via --grip-scale so
+     it holds ~11px at any zoom (#2824). */
+  .grip-square {
+    width: calc(11px * var(--grip-scale, 1));
+    height: calc(11px * var(--grip-scale, 1));
+    border: calc(1.5px * var(--grip-scale, 1)) solid var(--colour-selection);
+    border-radius: calc(2px * var(--grip-scale, 1));
+    background: var(--colour-surface);
   }
 
-  .resize-grip:hover .grip-bar,
-  .resize-grip:focus-visible .grip-bar {
+  .resize-grip:hover .grip-square,
+  .resize-grip:focus-visible .grip-square {
     background: var(--colour-selection);
   }
 
@@ -945,14 +978,12 @@
     outline: none;
   }
 
-  .resize-grip:focus-visible .grip-bar {
-    box-shadow:
-      0 0 0 4px var(--colour-surface-overlay, rgba(40, 42, 54, 0.6)),
-      var(--focus-ring-glow);
+  .resize-grip:focus-visible .grip-square {
+    box-shadow: var(--focus-ring-glow);
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    .grip-bar {
+    .grip-square {
       transition: background-color var(--duration-fast) var(--ease-out);
     }
   }

--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -584,6 +584,8 @@
       type="button"
       class="resize-grip resize-grip-{side}"
       style:--grip-scale={scale}
+      style:--grip-hit-max-px="{GRIP_HIT_MAX_PX}px"
+      style:--grip-square-px="{GRIP_SQUARE_PX}px"
       style:height="{resizeHitHeightPx(heightU) * scale}px"
       aria-label={`Resize ${target.kind === "bay" ? "bay" : "rack"} height from ${side} edge`}
       aria-keyshortcuts="ArrowUp ArrowDown"
@@ -939,7 +941,7 @@
     justify-content: center;
     /* Screen-space hit width; height is set inline per rack so the top and
        bottom zones shrink on short racks at low zoom and never overlap (#2824). */
-    width: calc(44px * var(--grip-scale, 1));
+    width: calc(var(--grip-hit-max-px, 44px) * var(--grip-scale, 1));
     padding: 0;
     border: none;
     background: transparent;
@@ -962,8 +964,8 @@
      convention for axis-only resize. Sized in screen space via --grip-scale so
      it holds ~11px at any zoom (#2824). */
   .grip-square {
-    width: calc(11px * var(--grip-scale, 1));
-    height: calc(11px * var(--grip-scale, 1));
+    width: calc(var(--grip-square-px, 11px) * var(--grip-scale, 1));
+    height: calc(var(--grip-square-px, 11px) * var(--grip-scale, 1));
     border: calc(1.5px * var(--grip-scale, 1)) solid var(--colour-selection);
     border-radius: calc(2px * var(--grip-scale, 1));
     background: var(--colour-surface);


### PR DESCRIPTION
## **User description**
## Summary

Restyles the rack resize handles as edge-midpoint squares, the vector-tool convention for axis-only resize, replacing the 56px straddling pill and its shadow ring.

- Visible square holds ~11px screen-space at any zoom, centred on the selection outline at the top and bottom edge midpoints. It counter-scales through a single `--grip-scale` custom property (`1 / canvasStore.zoom`).
- Invisible hit area is 44px screen-space, computed per rack from the on-screen (post-zoom) height so the top and bottom zones shrink and never overlap on short racks at low zoom. Floored at the visible square so it never collapses: `hitArea = max(11px, min(44px, (rackScreenHeight / 2) - 4px))`. The 11px floor keeps resize reachable at any zoom.
- ns-resize cursor retained; focus-visible ring on the square uses the existing `--focus-ring-glow` token.
- Bay groups keep the single top-edge handle (#2767); it renders through the same snippet, so it is restyled to match automatically.
- Live U readout, keyboard resize (one undoable step per press), hysteresis (#2821) and ensure-visible (#2825) drag behaviour are untouched.

## Acceptance criteria

- [x] Visible square roughly 11px screen-space, centred on the outline at top and bottom edge midpoints
- [x] Invisible 44px hit area, shrinking so the two zones never overlap on short racks at low zoom, floored so it never collapses: `max(11px, min(44px, (rackScreenHeight / 2) - gap))`
- [x] ns-resize cursor and a focus-visible ring on the square
- [x] Bay groups keep the single top-edge handle, restyled to match
- [x] Live U readout behaviour unchanged

## Tests

No new tests (visual-only restyle, per policy). Existing resize coverage (hysteresis, keyboard resize) still passes: lint, check, test:run (3190 tests), and build all green locally.

## Visual regression

The visual regression CI check is EXPECTED to fail on this PR: the committed baselines still show the old 56px pill, and this change intentionally alters the resize-handle appearance. Baselines were deliberately NOT regenerated here; the orchestrator will review the visual diff and regenerate baselines separately.

Closes #2824

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Restyle rack resize handles as small edge squares**

### What Changed
- Replace the old pill-shaped resize handle with a small square centered on the top and bottom edges of selected racks
- Keep the resize target easy to grab at any zoom by using a fixed-size visible square and a larger invisible hit area that shrinks on short racks so the top and bottom zones do not overlap
- Make the bay resize handle match the same square style on the top edge
- Keep the resize cursor, keyboard resize, and live height readout behavior unchanged

### Impact
`✅ Clearer rack resize handles`
`✅ Easier resizing on short racks`
`✅ Consistent bay and rack handle styling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
