### PR TITLE
ci: reduce rackula-format-bot churn (#2840)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,12 @@ reviews:
   # Enable auto-review on all PRs
   auto_review:
     enabled: true
+    # Skip auto-review for the autoformat bot. Note: ignore_usernames is
+    # PR-author-scoped, so this may not suppress incremental re-review of the
+    # bot's pushes to a human-authored PR; the reliable mitigation is keeping
+    # branches prettier-clean so the bot never fires. See issue #2840.
+    ignore_usernames:
+      - rackula-format-bot
 
 chat:
   auto_reply: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # A prettier reformat cannot change behaviour, rendering, or a11y, so when the
+  # rackula-format-bot pushes a "chore: prettier auto-format" commit, only the
+  # validate gate (which re-runs format:check, the reason the commit re-triggers
+  # CI) needs to run. Detect that commit here so the behaviour jobs can skip it.
+  # A PAT push makes github.actor the token owner, not the bot, so the commit
+  # author/subject is the reliable signal. See issue #2840.
+  detect:
+    name: detect autoformat commit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      autoformat: ${{ steps.check.outputs.autoformat }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+      - id: check
+        run: |
+          author="$(git log -1 --format='%an')"
+          subject="$(git log -1 --format='%s')"
+          if [ "$author" = "rackula-format-bot" ] || [ "$subject" = "chore: prettier auto-format" ]; then
+            echo "Autoformat commit detected; behaviour jobs will be skipped."
+            echo "autoformat=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "autoformat=false" >> "$GITHUB_OUTPUT"
+          fi
+
   api:
     name: api (typecheck + tests)
+    needs: detect
+    if: needs.detect.outputs.autoformat != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -128,8 +160,8 @@ jobs:
   # untrusted code executes on the homelab runner.
   e2e-self-hosted:
     name: e2e (self-hosted full suite)
-    needs: validate
-    if: github.event_name == 'pull_request'
+    needs: [validate, detect]
+    if: github.event_name == 'pull_request' && needs.detect.outputs.autoformat != 'true'
     # Advisory, not merge-blocking. Per spike #1994 the self-hosted tier is
     # *additive* to the GH-hosted chromium smoke (the validate job), which stays
     # the hard gate. This job runs on a single homelab VM (one runner, one host)
@@ -194,6 +226,8 @@ jobs:
 
   visual:
     name: visual regression
+    needs: detect
+    if: needs.detect.outputs.autoformat != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -237,6 +271,8 @@ jobs:
 
   a11y:
     name: a11y (axe-core)
+    needs: detect
+    if: needs.detect.outputs.autoformat != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           author="$(git log -1 --format='%an')"
           subject="$(git log -1 --format='%s')"
-          if [ "$author" = "rackula-format-bot" ] || [ "$subject" = "chore: prettier auto-format" ]; then
+          if [ "$author" = "rackula-format-bot" ] && [ "$subject" = "chore: prettier auto-format" ]; then
             echo "Autoformat commit detected; behaviour jobs will be skipped."
             echo "autoformat=true" >> "$GITHUB_OUTPUT"
           else
@@ -55,7 +55,9 @@ jobs:
   api:
     name: api (typecheck + tests)
     needs: detect
-    if: needs.detect.outputs.autoformat != 'true'
+    # Fail open: skip only on a confirmed autoformat detection. A failed or
+    # cancelled detect job must not silently skip the behaviour tests.
+    if: ${{ !cancelled() && !(needs.detect.result == 'success' && needs.detect.outputs.autoformat == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -161,7 +163,8 @@ jobs:
   e2e-self-hosted:
     name: e2e (self-hosted full suite)
     needs: [validate, detect]
-    if: github.event_name == 'pull_request' && needs.detect.outputs.autoformat != 'true'
+    # Fail open on detect; still gate on validate succeeding and PR context.
+    if: ${{ !cancelled() && needs.validate.result == 'success' && github.event_name == 'pull_request' && !(needs.detect.result == 'success' && needs.detect.outputs.autoformat == 'true') }}
     # Advisory, not merge-blocking. Per spike #1994 the self-hosted tier is
     # *additive* to the GH-hosted chromium smoke (the validate job), which stays
     # the hard gate. This job runs on a single homelab VM (one runner, one host)
@@ -227,7 +230,9 @@ jobs:
   visual:
     name: visual regression
     needs: detect
-    if: needs.detect.outputs.autoformat != 'true'
+    # Fail open: skip only on a confirmed autoformat detection. A failed or
+    # cancelled detect job must not silently skip the behaviour tests.
+    if: ${{ !cancelled() && !(needs.detect.result == 'success' && needs.detect.outputs.autoformat == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -272,7 +277,9 @@ jobs:
   a11y:
     name: a11y (axe-core)
     needs: detect
-    if: needs.detect.outputs.autoformat != 'true'
+    # Fail open: skip only on a confirmed autoformat detection. A failed or
+    # cancelled detect job must not silently skip the behaviour tests.
+    if: ${{ !cancelled() && !(needs.detect.result == 'success' && needs.detect.outputs.autoformat == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ This project uses automated code formatting and linting:
 
 Pre-commit hooks automatically format staged files with Prettier.
 
+Before pushing, run `npm run format` and verify with `npm run format:check` (the exact `prettier --check .` gate CI runs). First make sure your installed Prettier matches `package-lock.json`: run `npm ci` if you are unsure, or if you work in a git worktree that reuses a stale root `node_modules`. Prettier reformats differently between versions, so a stale local Prettier can pass locally yet leave drift that the `rackula-format-bot` reformats on your PR, which re-runs CI. A branch that passes `npm run format:check` under the locked Prettier version never triggers the bot.
+
 ```bash
 # Run linting
 npm run lint


### PR DESCRIPTION
## **User description**
Closes #2840.

Reduces `rackula-format-bot` CI churn. The bot's re-trigger is by design (it pushes with `AUTOFORMAT_PAT` precisely so `format:check` re-runs green on the formatted head, issue #2730), so this does not touch that mechanism. It stops the bot firing on clean branches and stops paying for behaviour jobs when it does fire.

## Changes

1. **`test.yml`: skip behaviour jobs on an autoformat commit.** New `detect` job reads the head commit author/subject (a PAT push makes `github.actor` the token owner, not the bot, so author/subject is the reliable signal). When the head is a `chore: prettier auto-format` commit by `rackula-format-bot`, `api`, `e2e (self-hosted full suite)`, `visual regression`, and `a11y` are skipped; `validate` (which runs `format:check`) still runs. A prettier reformat cannot change behaviour, rendering, or a11y, so this is safe and it frees the 30-minute self-hosted runner (helps the contention in #2838).

2. **`CONTRIBUTING.md`: format with the locked Prettier before pushing.** Root cause of the churn is a Prettier version mismatch: a stale or worktree-symlinked `node_modules` can run an older Prettier (seen locally: 3.8.4) than the pinned `package-lock.json` version (3.9.4), so a branch passes locally yet the bot (which runs `npm ci`) reformats it. The note tells contributors to match the locked version (`npm ci`) and run `npm run format:check` before pushing. A branch clean under the locked Prettier never triggers the bot.

3. **`.coderabbit.yaml`: ignore the bot (best-effort).** Adds `rackula-format-bot` to `reviews.auto_review.ignore_usernames`, with an inline note that this is PR-author-scoped and may not suppress incremental re-review of the bot's pushes; change 2 is the reliable mitigation.

## Testing

- YAML parses for `test.yml` and `.coderabbit.yaml`.
- The three changed files pass `prettier@3.9.4 --check` (the CI-pinned version).
- The `detect` gate is exercised on this PR itself: this commit is not an autoformat commit, so all jobs run normally.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Reduce extra CI runs from auto-format commits**

### What Changed
- When the auto-format bot pushes a Prettier-only commit, the test workflow now skips behavior checks like API tests, full end-to-end tests, visual regression, and accessibility checks.
- The validation step still runs so formatting is still checked after the bot’s commit.
- Contributing guidance now tells developers to use the locked Prettier version before pushing, so branches that already pass formatting check do not trigger the bot.
- Code review is now set to ignore the auto-format bot where possible.

### Impact
`✅ Fewer unnecessary CI runs after formatting-only changes`
`✅ Shorter wait times for PRs that only reformat code`
`✅ Less runner time spent on changes that do not affect behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
