### PR TITLE
ci: cut E2E + LXC gate over to pve-prod self-hosted runners (#2721)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
     name: "Gate: LXC smoke test"
     needs: [validate, stage-lxc]
     if: ${{ !inputs.gate_override }}
-    runs-on: [self-hosted, pve-rusty]
+    runs-on: [self-hosted, lxc-gate]
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,10 +182,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      # The ci-runner is not ephemeral: it reuses _work across jobs, and a prior
-      # sparse checkout (e.g. the LXC gate) leaves an index that makes
-      # actions/checkout's clean fail with "not uptodate; will not remove".
-      # Wipe the workspace first so the checkout below starts from a clean slate.
+      # The e2e runner is ephemeral (snapshot-reverts to @clean per job), so the
+      # workspace normally starts pristine. This wipe is a cheap safety net (e.g. a
+      # JIT runner that somehow reused a dirty _work) so actions/checkout's clean
+      # can never fail with "not uptodate; will not remove" — start from a clean slate.
       - name: Clean self-hosted workspace
         run: |
           if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,11 @@ jobs:
     # block PRs. continue-on-error keeps the full-suite result visible as signal
     # while letting the overall Test run conclude green.
     continue-on-error: true
-    runs-on: [self-hosted, ci-runner]
+    runs-on: [self-hosted, e2e]
+    # Parallelise the full suite on the pve-prod ephemeral e2e runner (VMID 360,
+    # more cores); playwright.config.ts reads PW_WORKERS (else Playwright default).
+    env:
+      PW_WORKERS: 8
     timeout-minutes: 30
     environment: ${{ github.event.pull_request.head.repo.full_name == 'RackulaLives/Rackula' && 'e2e-trusted' || 'e2e-approval' }}
     permissions:

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   },
   testDir: ".",
   fullyParallel: true,
+  // Honour PW_WORKERS (set by the self-hosted e2e runner) so the pve-prod host
+  // parallelises the full suite; fall back to Playwright's default otherwise.
+  workers: process.env.PW_WORKERS ? Number(process.env.PW_WORKERS) : undefined,
   forbidOnly: !!process.env.CI,
   retries: 1,
   // CI uses the blob reporter so sharded runs (test-full.yml) can be merged

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
   // Honour PW_WORKERS (set by the self-hosted e2e runner) so the pve-prod host
   // parallelises the full suite; guard against a non-numeric/zero value
   // (Number("x") -> NaN), else fall back to Playwright's default.
-  workers: ((n) => (Number.isFinite(n) && n > 0 ? n : undefined))(Number(process.env.PW_WORKERS)),
+  workers: ((n) => (Number.isFinite(n) && n > 0 ? n : undefined))(
+    Number(process.env.PW_WORKERS),
+  ),
   forbidOnly: !!process.env.CI,
   retries: 1,
   // CI uses the blob reporter so sharded runs (test-full.yml) can be merged

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,8 +9,9 @@ export default defineConfig({
   testDir: ".",
   fullyParallel: true,
   // Honour PW_WORKERS (set by the self-hosted e2e runner) so the pve-prod host
-  // parallelises the full suite; fall back to Playwright's default otherwise.
-  workers: process.env.PW_WORKERS ? Number(process.env.PW_WORKERS) : undefined,
+  // parallelises the full suite; guard against a non-numeric/zero value
+  // (Number("x") -> NaN), else fall back to Playwright's default.
+  workers: ((n) => (Number.isFinite(n) && n > 0 ? n : undefined))(Number(process.env.PW_WORKERS)),
   forbidOnly: !!process.env.CI,
   retries: 1,
   // CI uses the blob reporter so sharded runs (test-full.yml) can be merged


### PR DESCRIPTION
## **User description**
## What

Cut the two self-hosted CI tiers over from the legacy pve-rusty `ci-runner` to the new pve-prod runners (repo side of RackulaLives/Rackula#2721):

- **`test.yml` — `e2e-self-hosted`**: `runs-on: [self-hosted, ci-runner]` → `[self-hosted, e2e]`; adds job-level `env: PW_WORKERS: 8`. Keeps `continue-on-error` and the `e2e-trusted` / `e2e-approval` environments.
- **`release.yml` — `gate-lxc`**: `runs-on: [self-hosted, pve-rusty]` → `[self-hosted, lxc-gate]`.
- **`e2e/playwright.config.ts`**: adds `workers: process.env.PW_WORKERS ? Number(process.env.PW_WORKERS) : undefined` — honours `PW_WORKERS` on the beefier pve-prod e2e host, else falls back to Playwright's default.

## The new runners (homelab-infra side, already built + validated)

- **`e2e` (VMID 360)** — ephemeral, snapshot-revert per job, JIT-registered by a pve-prod controller, **zero stored credentials**. Each job self-provisions (node + deps + Playwright), runs, powers off; the controller reverts the VM to `@clean` and mints a fresh JIT. `PW_WORKERS` lets the suite parallelise on the larger host.
- **`lxc-gate` (VMID 361)** — persistent, carries a **least-privileged** Proxmox API token scoped to the `ci-smoke` pool.

## Validation already done

- **e2e (360):** a real job landed, self-provisioned, ran green, powered off; controller reverted to `@clean` and re-minted — full cycle, no snapshot residue.
- **gate (361):** the real `lxc-smoke-test.sh` ran green — spawned CT 2000 (`rackula-smoke-*`) in `ci-smoke`, SSHed in, installed Rackula from the `v26.6.6` tarball, passed all 9 CT-local health checks, tore the CT down. Token least-privilege confirmed (200 on pool/nextid, **403** on out-of-pool `fme`).

Opening this PR triggers a live `e2e-self-hosted` run on the new `[self-hosted, e2e]` runner (per-PR validation). `gate-lxc` is exercised on the next release (or `workflow_dispatch`).

## Follow-ups (not in this PR)

- Update spike #1994 with the corrected host-sensitivity finding + ephemeral/egress posture.
- Decommission the legacy pve-rusty `ci-runner` (VMID 300) once this is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWSv1AYtRSuBcfEriM9UxQ


___

## **CodeAnt-AI Description**
**Move the full E2E suite and LXC gate to the new self-hosted runners**

### What Changed
- The full E2E job now runs on the new `e2e` self-hosted runner and uses 8 workers there, so the suite can finish faster on the larger host.
- E2E worker count now respects `PW_WORKERS` only when it is a valid positive number; invalid or missing values fall back to the default.
- The LXC smoke-test gate now runs on the new `lxc-gate` self-hosted runner instead of the legacy runner.

### Impact
`✅ Faster E2E test runs`
`✅ Fewer delays on self-hosted CI`
`✅ More reliable runner selection for release gating`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
