### PR TITLE
docs(ci): fix stale ci-runner/pve-rusty comments after pve-prod cutover

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,11 +282,12 @@ jobs:
           echo "Persist round-trip gate passed"
           docker compose --profile persist down -v
 
-  # GATE: deploy the staged LXC tarball onto a throwaway unprivileged CT on the
-  # non-prod Proxmox (pve-rusty self-hosted runner) and smoke-test it. No creds.
-  # Skipped only under the emergency override.
+  # GATE: deploy the staged LXC tarball onto a throwaway unprivileged CT in the
+  # ci-smoke pool on pve-prod (lxc-gate self-hosted runner) and smoke-test it, via
+  # a least-privileged Proxmox token scoped to that pool. Skipped only under the
+  # emergency override.
   #
-  # The self-hosted ci-runner (label pve-rusty) runs scripts/lxc-smoke-test.sh in its
+  # The self-hosted lxc-gate runner (label lxc-gate) runs scripts/lxc-smoke-test.sh in its
   # api driver (#1982): CT lifecycle via the Proxmox API + ssh-into-CT, no pct on the runner.
   gate-lxc:
     name: "Gate: LXC smoke test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           retention-days: 7
 
   # Tier 2/3 of the two-tier E2E model (spike #1994). The full browser suite
-  # runs on the self-hosted ci-runner only after the baseline smoke passes.
+  # runs on the self-hosted e2e runner only after the baseline smoke passes.
   # Org PRs use the e2e-trusted environment (auto-runs); fork PRs use
   # e2e-approval, which requires ggfevans to review and approve before any
   # untrusted code executes on the homelab runner.
@@ -214,7 +214,7 @@ jobs:
 
       - name: Install Playwright browsers
         # --with-deps installs OS libraries via apt and needs root; fall back to a
-        # plain browser install when the self-hosted ci-runner already has them.
+        # plain browser install — the self-hosted e2e runner already has the OS libs baked in.
         run: npx playwright install --with-deps || npx playwright install
 
       - name: Run full E2E tests


### PR DESCRIPTION
## **User description**
Follow-up to the #2721 cutover: the functional runs-on changes merged, but three comments still referenced the retired pve-rusty ci-runner. Comment-only, no behaviour change.

- release.yml gate-lxc: pve-rusty self-hosted runner -> lxc-gate / ci-smoke / least-priv token
- test.yml: e2e-self-hosted two-tier note + Playwright-install note now reference the ephemeral e2e runner

Generated with Claude Code


___

## **CodeAnt-AI Description**
**Update CI workflow comments to match the current runner setup**

### What Changed
- Replaced outdated references to the retired `ci-runner`/`pve-rusty` setup in CI workflow comments
- Clarified that the full E2E suite runs on the `e2e` runner
- Clarified that the LXC smoke test runs on the `lxc-gate` runner in the `ci-smoke` pool on `pve-prod` with a least-privileged Proxmox token

### Impact
`✅ Clearer CI runbook comments`
`✅ Fewer stale runner references`
`✅ Easier CI maintenance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
