### PR TITLE
fix: enforce the inflateBounded size ceiling in decompressed bytes

### DIFF
--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -463,8 +463,14 @@ function inflateBounded(compressed: Uint8Array): string {
     throw new Error(inflator.msg || "Failed to inflate share link");
   }
   // Flush any bytes the streaming decoder buffered from a trailing partial
-  // sequence. Bounded by the same ceiling already enforced above.
-  result += decoder.decode();
+  // sequence (at most one replacement char), applying the same ceiling so the
+  // size guard stays strict rather than allowing the flush to slip past it.
+  const tail = decoder.decode();
+  length += tail.length;
+  if (length > MAX_DECOMPRESSED_BYTES) {
+    throw new Error("Decompressed share link exceeds size limit");
+  }
+  result += tail;
   return result;
 }
 

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -439,22 +439,23 @@ export const MAX_DECOMPRESSED_BYTES = 8 * 1024 * 1024;
  */
 function inflateBounded(compressed: Uint8Array): string {
   const inflator = new pako.Inflate();
-  // pako 3.x always emits Uint8Array chunks. Decode with a single streaming
-  // TextDecoder so a multi-byte UTF-8 sequence split across a chunk boundary is
-  // reassembled correctly (an 8 MB payload spans many 64 KB pako Inflate chunks).
+  // pako 3.x emits Uint8Array chunks. Count decompressed bytes directly (the
+  // chunk's byte length) so the ceiling is enforced in the same unit as
+  // MAX_DECOMPRESSED_BYTES; a character count would under-measure multi-byte
+  // UTF-8. Decode with a single streaming TextDecoder so a multi-byte sequence
+  // split across a chunk boundary is reassembled correctly.
   const decoder = new TextDecoder();
   let result = "";
-  let length = 0;
+  let byteLength = 0;
 
   inflator.onData = (chunk) => {
-    const text = decoder.decode(chunk, { stream: true });
-    length += text.length;
-    if (length > MAX_DECOMPRESSED_BYTES) {
+    byteLength += chunk.length;
+    if (byteLength > MAX_DECOMPRESSED_BYTES) {
       // Throw from the chunk callback to abort pako's inflate loop early, so a
       // high-ratio payload cannot finish inflating its full output.
       throw new Error("Decompressed share link exceeds size limit");
     }
-    result += text;
+    result += decoder.decode(chunk, { stream: true });
   };
 
   inflator.push(compressed, true);
@@ -463,14 +464,8 @@ function inflateBounded(compressed: Uint8Array): string {
     throw new Error(inflator.msg || "Failed to inflate share link");
   }
   // Flush any bytes the streaming decoder buffered from a trailing partial
-  // sequence (at most one replacement char), applying the same ceiling so the
-  // size guard stays strict rather than allowing the flush to slip past it.
-  const tail = decoder.decode();
-  length += tail.length;
-  if (length > MAX_DECOMPRESSED_BYTES) {
-    throw new Error("Decompressed share link exceeds size limit");
-  }
-  result += tail;
+  // sequence. Those bytes were already counted above, so no further check.
+  result += decoder.decode();
   return result;
 }
 

--- a/src/tests/share.test.ts
+++ b/src/tests/share.test.ts
@@ -404,6 +404,36 @@ describe("decodeLayout", () => {
     expect(result.layout).toBeNull();
     expect(result.error).toBeDefined();
   });
+
+  it("rejects a payload whose byte length exceeds the ceiling even when its character count does not", () => {
+    // Byte-accuracy guard: 中 is 3 UTF-8 bytes but one UTF-16 code unit, so ~3M of
+    // them decode to ~9 MB (over MAX_DECOMPRESSED_BYTES) while the string length
+    // (~3M) stays under it. A character-based guard would wrongly accept this; the
+    // byte-based guard rejects it. Compresses tiny, so the input-size guard passes
+    // and the decompressed byte ceiling is the thing under test.
+    const oversizedByBytes = "中".repeat(3_000_000);
+    expect(oversizedByBytes.length).toBeLessThan(MAX_DECOMPRESSED_BYTES);
+    const layout = createTestLayout({
+      name: oversizedByBytes,
+      racks: [
+        createTestRack({
+          devices: [
+            createTestDevice({ device_type: "pako-server", position: 2 }),
+          ],
+        }),
+      ],
+      device_types: [createTestDeviceType({ slug: "pako-server" })],
+    });
+    const encoded = base64UrlEncode(
+      pako.deflate(JSON.stringify(toMinimalLayout(layout))),
+    );
+    expect(encoded.length).toBeLessThanOrEqual(MAX_ENCODED_LENGTH);
+
+    const result = decodeLayout(encoded);
+
+    expect(result.layout).toBeNull();
+    expect(result.error).toBeDefined();
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #2750 (PR #2843), addressing two CodeAnt review findings on `inflateBounded` in `src/lib/utils/share.ts`, the legacy pako share-link decode path guarded by `MAX_DECOMPRESSED_BYTES` (decompression-bomb protection).

## What changed

The size guard now counts decompressed **bytes** (the pako chunk's byte length) instead of decoded string length:

```ts
inflator.onData = (chunk) => {
  byteLength += chunk.length;              // decompressed bytes
  if (byteLength > MAX_DECOMPRESSED_BYTES) throw ...;
  result += decoder.decode(chunk, { stream: true });
};
```

This resolves both findings:

- Char-vs-byte ceiling: the guard previously measured `text.length` (UTF-16 code units) against a byte-defined constant, so a multi-byte UTF-8 payload (worst case ~3 bytes per code unit) could exceed the byte ceiling while its character count stayed under it. Counting bytes makes the bound match the constant's name and docs.
- Flush bypass: because every decompressed byte is now counted during streaming, the trailing `TextDecoder` flush only re-emits already-counted bytes, so it needs no separate guard. The flush-specific check from the first commit is removed.

## Test

Adds a regression test: a ~3M-character run of a 3-byte CJK character (~9 MB decoded, over the 8 MiB ceiling) whose string length stays under it. It is rejected by the byte-based guard and was proven to be wrongly accepted under the old character-based guard.

- [x] `npm run check` (0 errors)
- [x] `share.test.ts` (42 tests) pass
- [x] `npm run lint` + `prettier --check` clean

Related to #2750
