### PR TITLE
fix: e2e positional-selector sweep, name the default device (#2851)

### DIFF
--- a/e2e/dual-view.spec.ts
+++ b/e2e/dual-view.spec.ts
@@ -66,22 +66,27 @@ test.describe("Dual-View Rack Display", () => {
     expect(rearDevices).toBeGreaterThan(0);
   });
 
-  test("blocked slot visual appears for full-depth devices", async ({
+  test("blocked slot visual appears for a half-depth device on the opposite face", async ({
     page,
   }) => {
     await expect(page.locator(locators.rackView.dualView)).toBeVisible();
 
-    await dragDeviceToRack(page, { view: "front" });
+    // Only a half-depth device hatches its slots on the opposite face. A
+    // full-depth device (effectiveFace "both", e.g. the "Server" default) is
+    // visible from both sides and is skipped by getBlockedSlots, so this must
+    // drop an explicitly half-depth device to exercise the hatching path.
+    await dragDeviceToRack(page, {
+      view: "front",
+      deviceName: "Patch Panel (24-Port)",
+    });
     await expect(page.locator(locators.rackView.frontDevice)).toBeVisible({
       timeout: 5000,
     });
 
+    // The half-depth device occupies the front only, so its slots render as
+    // blocked hatching on the rear. Assert unconditionally.
     const blockedSlots = page.locator(locators.rackView.rearBlockedSlot);
-    const hasBlockedSlots = (await blockedSlots.count()) > 0;
-
-    if (hasBlockedSlots) {
-      await expect(blockedSlots.first()).toBeVisible();
-    }
+    await expect(blockedSlots.first()).toBeVisible();
   });
 
   test("dual-view rack can be selected", async ({ page }) => {

--- a/e2e/dual-view.spec.ts
+++ b/e2e/dual-view.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "./helpers/base-test";
-import type { Page } from "@playwright/test";
 import {
   gotoWithRack,
   SMALL_RACK_SHARE,
@@ -7,68 +6,6 @@ import {
   clickExport,
   locators,
 } from "./helpers";
-
-/**
- * Helper to drag a device from palette to a specific rack view (front or rear)
- */
-async function dragDeviceToRackView(page: Page, view: "front" | "rear") {
-  await expect(page.locator(locators.device.paletteItem).first()).toBeVisible();
-
-  const viewSelector =
-    view === "front" ? locators.rackView.frontSvg : locators.rackView.rearSvg;
-
-  const deviceHandle = await page
-    .locator(locators.device.paletteItem)
-    .first()
-    .elementHandle();
-  const rackHandle = await page.locator(viewSelector).elementHandle();
-
-  if (!deviceHandle || !rackHandle) {
-    throw new Error(`Could not find device item or ${view} rack view`);
-  }
-
-  await page.evaluate(
-    ([device, rack]) => {
-      const dataTransfer = new DataTransfer();
-
-      device.dispatchEvent(
-        new DragEvent("dragstart", {
-          bubbles: true,
-          cancelable: true,
-          dataTransfer,
-        }),
-      );
-      rack.dispatchEvent(
-        new DragEvent("dragover", {
-          bubbles: true,
-          cancelable: true,
-          dataTransfer,
-        }),
-      );
-      rack.dispatchEvent(
-        new DragEvent("drop", {
-          bubbles: true,
-          cancelable: true,
-          dataTransfer,
-        }),
-      );
-      device.dispatchEvent(
-        new DragEvent("dragend", {
-          bubbles: true,
-          cancelable: true,
-          dataTransfer,
-        }),
-      );
-    },
-    [deviceHandle, rackHandle] as const,
-  );
-
-  // Wait for state update
-  await expect(async () => {
-    const count = await page.locator(locators.rack.device).count();
-    expect(count).toBeGreaterThan(0);
-  }).toPass({ timeout: 5000 });
-}
 
 test.describe("Dual-View Rack Display", () => {
   test.beforeEach(async ({ page }) => {
@@ -102,7 +39,7 @@ test.describe("Dual-View Rack Display", () => {
   }) => {
     await expect(page.locator(locators.rackView.dualView)).toBeVisible();
 
-    await dragDeviceToRackView(page, "front");
+    await dragDeviceToRack(page, { view: "front" });
 
     await expect(page.locator(locators.rackView.frontDevice)).toBeVisible({
       timeout: 5000,
@@ -117,7 +54,7 @@ test.describe("Dual-View Rack Display", () => {
   test("drag-drop to rear view sets device face to rear", async ({ page }) => {
     await expect(page.locator(locators.rackView.dualView)).toBeVisible();
 
-    await dragDeviceToRackView(page, "rear");
+    await dragDeviceToRack(page, { view: "rear" });
 
     await expect(page.locator(locators.rackView.rearDevice)).toBeVisible({
       timeout: 5000,
@@ -134,7 +71,7 @@ test.describe("Dual-View Rack Display", () => {
   }) => {
     await expect(page.locator(locators.rackView.dualView)).toBeVisible();
 
-    await dragDeviceToRackView(page, "front");
+    await dragDeviceToRack(page, { view: "front" });
     await expect(page.locator(locators.rackView.frontDevice)).toBeVisible({
       timeout: 5000,
     });
@@ -164,7 +101,7 @@ test.describe("Dual-View Rack Display", () => {
   test("device selection works in both views", async ({ page }) => {
     await expect(page.locator(locators.rackView.dualView)).toBeVisible();
 
-    await dragDeviceToRackView(page, "front");
+    await dragDeviceToRack(page, { view: "front" });
     await expect(page.locator(locators.rackView.frontDevice)).toBeVisible({
       timeout: 5000,
     });
@@ -181,7 +118,7 @@ test.describe("Dual-View Rack Display", () => {
   test("both views show same devices when face is both", async ({ page }) => {
     await expect(page.locator(locators.rackView.dualView)).toBeVisible();
 
-    await dragDeviceToRackView(page, "front");
+    await dragDeviceToRack(page, { view: "front" });
 
     const frontDevices = await page
       .locator(locators.rackView.frontDevice)

--- a/e2e/helpers/device-actions.ts
+++ b/e2e/helpers/device-actions.ts
@@ -17,9 +17,12 @@ import { locators } from "./locators";
  *
  * @param page - Playwright page
  * @param options.yOffsetPercent - Vertical position in rack (0-100), default 10
- * @param options.deviceName - Visible name of the palette device to drag (preferred)
- * @param options.deviceIndex - Positional fallback when no name is given (default 0 = first)
+ * @param options.deviceName - Visible name of the palette device to drag. Defaults
+ *   to the generic full-width "Server" when no deviceIndex is given (preferred).
+ * @param options.deviceIndex - Positional selection; when given, it overrides the
+ *   name default. Fragile under virtualization (#2094), so prefer deviceName.
  * @param options.rackIndex - Zero-based index of the target rack in multi-rack layouts (default 0)
+ * @param options.view - Rack face to drop onto: "front" (default) or "rear"
  * @returns Number of devices in rack after drag
  */
 export async function dragDeviceToRack(
@@ -29,19 +32,41 @@ export async function dragDeviceToRack(
     deviceName?: string;
     deviceIndex?: number;
     rackIndex?: number;
+    view?: "front" | "rear";
   },
 ): Promise<number> {
   const yPercent = options?.yOffsetPercent ?? 10;
-  const deviceName = options?.deviceName ?? null;
+  // Default to the generic full-width "Server" when the caller names neither a
+  // device nor an index. After #2745 alphabetized the palette the first item is
+  // a half-width carrier-required "Blade Server (Full-Height)" that placeDevice
+  // refuses to place on the rails, so an index-0 default placed nothing (#2851,
+  // #2755). An explicit deviceIndex still selects positionally.
+  const deviceName =
+    options?.deviceName ??
+    (options?.deviceIndex === undefined ? "Server" : null);
   const deviceIndex = options?.deviceIndex ?? 0;
   const rackIndex = options?.rackIndex ?? 0;
+  const view = options?.view ?? "front";
 
   await expect(page.locator(locators.device.paletteItem).first()).toBeVisible();
+
+  // When targeting by name, wait for that item to render before the one-shot
+  // evaluate below. The palette search input debounces 150ms
+  // (DevicePalette.svelte) and the virtualized list unmounts off-window rows
+  // (#2094); without this wait the querySelectorAll snapshot can miss the named
+  // device and throw. Playwright auto-waits here (no fixed timeout). The name
+  // can resolve to several identical generic entries (e.g. the 1U-4U Servers),
+  // so scope to the first match: all share a placeable full-width form.
+  if (deviceName !== null) {
+    await paletteItemByName(page, deviceName)
+      .first()
+      .waitFor({ state: "visible" });
+  }
 
   const deviceCountBefore = await page.locator(locators.rack.device).count();
 
   await page.evaluate(
-    ({ yPercent, deviceName, deviceIndex, rackIndex }) => {
+    ({ yPercent, deviceName, deviceIndex, rackIndex, view }) => {
       const deviceItems = Array.from(
         document.querySelectorAll('[data-testid="device-palette-item"]'),
       );
@@ -57,9 +82,10 @@ export async function dragDeviceToRack(
                 deviceName,
             )
           : deviceItems[deviceIndex];
-      // Use front-view SVGs so rackIndex maps directly to rack number
+      // Use the requested view's SVGs so rackIndex maps directly to rack number.
+      // Dropping on the rear view sets the placed device's face to rear.
       const rackSvgs = document.querySelectorAll(
-        '[data-testid="rack-front"] .rack-svg',
+        `[data-testid="rack-${view}"] .rack-svg`,
       );
       const rack = rackSvgs[rackIndex];
       if (!rack) {
@@ -118,7 +144,7 @@ export async function dragDeviceToRack(
         }),
       );
     },
-    { yPercent, deviceName, deviceIndex, rackIndex },
+    { yPercent, deviceName, deviceIndex, rackIndex, view },
   );
 
   // Wait for device count to increase
@@ -143,8 +169,12 @@ export async function dragDeviceToRack(
  * `page.getByTestId("device-palette-favourites")`, then call `.first()`.
  */
 export function paletteItemByName(page: Page, deviceName: string): Locator {
-  // Exact match on the .device-name span, matching dragDeviceToRack's
-  // comparison. Substring matching would let "Server" match "Server 2U".
+  // Exact match on the item's own .device-name span, matching dragDeviceToRack's
+  // in-page comparison. Substring matching would let "Server" match "Server 2U".
+  // The has-locator is scoped to each candidate item, so it targets the item's
+  // .device-name child directly (paletteItemName is the relative selector). A
+  // full "[data-testid=...] .device-name" selector would instead require a
+  // nested palette item (there is none) and match nothing, dropping every item.
   return page.getByTestId("device-palette-item").filter({
     has: page.locator(locators.device.paletteItemName, {
       hasText: new RegExp(`^${escapeRegExp(deviceName)}$`),

--- a/e2e/helpers/locators.ts
+++ b/e2e/helpers/locators.ts
@@ -56,7 +56,12 @@ export const locators = {
 
   device: {
     paletteItem: '[data-testid="device-palette-item"]',
-    paletteItemName: '[data-testid="device-palette-item"] .device-name',
+    /**
+     * The name span inside a palette item, relative to the item. Use only as a
+     * has-locator scoped to a paletteItem (e.g. paletteItemByName): the class is
+     * shared with rack devices, so it is not safe as a page-level selector.
+     */
+    paletteItemName: ".device-name",
     palette: ".device-palette",
     /** Scrolling device-list region inside the palette. */
     list: ".device-list",

--- a/e2e/ios-safari.spec.ts
+++ b/e2e/ios-safari.spec.ts
@@ -9,7 +9,12 @@
 import { test, expect } from "./helpers/base-test";
 import type { Page } from "@playwright/test";
 import { openDeviceLibraryFromBottomNav } from "./helpers/mobile-navigation";
-import { EMPTY_RACK_SHARE, dragDeviceToRack, locators } from "./helpers";
+import {
+  EMPTY_RACK_SHARE,
+  dragDeviceToRack,
+  paletteItemByName,
+  locators,
+} from "./helpers";
 
 // iOS Device viewport matrix
 const iosDevices = [
@@ -226,12 +231,12 @@ test.describe("Tap-to-place on touch (#2454)", () => {
   }) => {
     const devicesBefore = await page.locator(locators.rack.device).count();
 
-    // Arm placement: tap a palette device. This closes the bottom sheet and
-    // surfaces the "Placing:" banner. Do NOT press Escape — it cancels.
+    // Arm placement: tap a placeable full-width Server. This closes the bottom
+    // sheet and surfaces the "Placing:" banner. Do NOT press Escape, it cancels.
     await openDeviceLibraryFromBottomNav(page);
-    const firstDevice = page.locator(locators.device.paletteItem).first();
-    await expect(firstDevice).toBeVisible();
-    await firstDevice.tap();
+    const serverDevice = paletteItemByName(page, "Server").first();
+    await expect(serverDevice).toBeVisible();
+    await serverDevice.tap();
 
     const placementBanner = page
       .getByRole("status")
@@ -268,9 +273,9 @@ test.describe("Tap-to-place on touch (#2454)", () => {
     const devicesBefore = await page.locator(locators.rack.device).count();
 
     await openDeviceLibraryFromBottomNav(page);
-    const firstDevice = page.locator(locators.device.paletteItem).first();
-    await expect(firstDevice).toBeVisible();
-    await firstDevice.tap();
+    const serverDevice = paletteItemByName(page, "Server").first();
+    await expect(serverDevice).toBeVisible();
+    await serverDevice.tap();
 
     const placementBanner = page
       .getByRole("status")

--- a/e2e/keyboard-placement.spec.ts
+++ b/e2e/keyboard-placement.spec.ts
@@ -11,6 +11,7 @@
  * keyboard path this issue adds.
  */
 import { test, expect } from "./helpers/base-test";
+import type { Page } from "@playwright/test";
 import {
   gotoWithRack,
   SMALL_RACK_SHARE,
@@ -22,6 +23,17 @@ import {
 const announcer = '[data-testid="placement-sr-announcer"]';
 const placementBanner = '[data-testid="rack-canvas"] [role="status"]';
 
+// Focus a placeable full-width Server in the palette, ready to arm keyboard
+// placement with Enter. Every test here starts the same way; "Server" is named
+// because the alphabetized palette's first item is an unplaceable half-width
+// device (#2851).
+async function armServerForKeyboard(page: Page) {
+  const serverDevice = paletteItemByName(page, "Server").first();
+  await expect(serverDevice).toBeVisible();
+  await serverDevice.focus();
+  return serverDevice;
+}
+
 test.describe("Keyboard device placement (#106)", () => {
   test.beforeEach(async ({ page }) => {
     // SMALL_RACK_SHARE is an empty 12U rack; the Devices sidebar tab is the
@@ -32,13 +44,10 @@ test.describe("Keyboard device placement (#106)", () => {
   test("pick up with Enter, move with arrows, place with Enter", async ({
     page,
   }) => {
-    const serverDevice = paletteItemByName(page, "Server").first();
-    await expect(serverDevice).toBeVisible();
-
     const devicesBefore = await page.locator(locators.rack.device).count();
 
     // Enter on a focused palette device picks it up (enters placement mode).
-    await serverDevice.focus();
+    await armServerForKeyboard(page);
     await page.keyboard.press("Enter");
 
     // Placement mode is announced: the "Placing:" banner appears and the
@@ -73,12 +82,9 @@ test.describe("Keyboard device placement (#106)", () => {
   });
 
   test("Space confirms placement", async ({ page }) => {
-    const serverDevice = paletteItemByName(page, "Server").first();
-    await expect(serverDevice).toBeVisible();
-
     const devicesBefore = await page.locator(locators.rack.device).count();
 
-    await serverDevice.focus();
+    await armServerForKeyboard(page);
     await page.keyboard.press("Enter");
     await expect(
       page.locator(placementBanner).filter({ hasText: "Placing:" }),
@@ -94,12 +100,9 @@ test.describe("Keyboard device placement (#106)", () => {
   });
 
   test("Escape cancels placement with no side effects", async ({ page }) => {
-    const serverDevice = paletteItemByName(page, "Server").first();
-    await expect(serverDevice).toBeVisible();
-
     const devicesBefore = await page.locator(locators.rack.device).count();
 
-    await serverDevice.focus();
+    await armServerForKeyboard(page);
     await page.keyboard.press("Enter");
     await expect(
       page.locator(placementBanner).filter({ hasText: "Placing:" }),
@@ -128,10 +131,7 @@ test.describe("Keyboard device placement (#106)", () => {
     // Devices so the palette is on screen.
     await page.getByRole("tab", { name: "Devices" }).click();
 
-    const serverDevice = paletteItemByName(page, "Server").first();
-    await expect(serverDevice).toBeVisible();
-
-    await serverDevice.focus();
+    await armServerForKeyboard(page);
     await page.keyboard.press("Enter");
 
     // The cursor seeds in the active rack (the newly created Second Rack).
@@ -155,12 +155,9 @@ test.describe("Keyboard device placement (#106)", () => {
   test("placement survives undo (placed device can be undone)", async ({
     page,
   }) => {
-    const serverDevice = paletteItemByName(page, "Server").first();
-    await expect(serverDevice).toBeVisible();
-
     const devicesBefore = await page.locator(locators.rack.device).count();
 
-    await serverDevice.focus();
+    await armServerForKeyboard(page);
     await page.keyboard.press("Enter");
     await page.keyboard.press("Enter"); // place at seeded slot
 

--- a/e2e/keyboard-placement.spec.ts
+++ b/e2e/keyboard-placement.spec.ts
@@ -15,6 +15,7 @@ import {
   gotoWithRack,
   SMALL_RACK_SHARE,
   createRackDirect,
+  paletteItemByName,
   locators,
 } from "./helpers";
 
@@ -31,13 +32,13 @@ test.describe("Keyboard device placement (#106)", () => {
   test("pick up with Enter, move with arrows, place with Enter", async ({
     page,
   }) => {
-    const firstDevice = page.locator(locators.device.paletteItem).first();
-    await expect(firstDevice).toBeVisible();
+    const serverDevice = paletteItemByName(page, "Server").first();
+    await expect(serverDevice).toBeVisible();
 
     const devicesBefore = await page.locator(locators.rack.device).count();
 
     // Enter on a focused palette device picks it up (enters placement mode).
-    await firstDevice.focus();
+    await serverDevice.focus();
     await page.keyboard.press("Enter");
 
     // Placement mode is announced: the "Placing:" banner appears and the
@@ -72,12 +73,12 @@ test.describe("Keyboard device placement (#106)", () => {
   });
 
   test("Space confirms placement", async ({ page }) => {
-    const firstDevice = page.locator(locators.device.paletteItem).first();
-    await expect(firstDevice).toBeVisible();
+    const serverDevice = paletteItemByName(page, "Server").first();
+    await expect(serverDevice).toBeVisible();
 
     const devicesBefore = await page.locator(locators.rack.device).count();
 
-    await firstDevice.focus();
+    await serverDevice.focus();
     await page.keyboard.press("Enter");
     await expect(
       page.locator(placementBanner).filter({ hasText: "Placing:" }),
@@ -93,12 +94,12 @@ test.describe("Keyboard device placement (#106)", () => {
   });
 
   test("Escape cancels placement with no side effects", async ({ page }) => {
-    const firstDevice = page.locator(locators.device.paletteItem).first();
-    await expect(firstDevice).toBeVisible();
+    const serverDevice = paletteItemByName(page, "Server").first();
+    await expect(serverDevice).toBeVisible();
 
     const devicesBefore = await page.locator(locators.rack.device).count();
 
-    await firstDevice.focus();
+    await serverDevice.focus();
     await page.keyboard.press("Enter");
     await expect(
       page.locator(placementBanner).filter({ hasText: "Placing:" }),
@@ -127,10 +128,10 @@ test.describe("Keyboard device placement (#106)", () => {
     // Devices so the palette is on screen.
     await page.getByRole("tab", { name: "Devices" }).click();
 
-    const firstDevice = page.locator(locators.device.paletteItem).first();
-    await expect(firstDevice).toBeVisible();
+    const serverDevice = paletteItemByName(page, "Server").first();
+    await expect(serverDevice).toBeVisible();
 
-    await firstDevice.focus();
+    await serverDevice.focus();
     await page.keyboard.press("Enter");
 
     // The cursor seeds in the active rack (the newly created Second Rack).
@@ -154,12 +155,12 @@ test.describe("Keyboard device placement (#106)", () => {
   test("placement survives undo (placed device can be undone)", async ({
     page,
   }) => {
-    const firstDevice = page.locator(locators.device.paletteItem).first();
-    await expect(firstDevice).toBeVisible();
+    const serverDevice = paletteItemByName(page, "Server").first();
+    await expect(serverDevice).toBeVisible();
 
     const devicesBefore = await page.locator(locators.rack.device).count();
 
-    await firstDevice.focus();
+    await serverDevice.focus();
     await page.keyboard.press("Enter");
     await page.keyboard.press("Enter"); // place at seeded slot
 

--- a/e2e/mobile-placement-mouse.spec.ts
+++ b/e2e/mobile-placement-mouse.spec.ts
@@ -22,7 +22,12 @@
  */
 import { test, expect } from "./helpers/base-test";
 import { openDeviceLibraryFromBottomNav } from "./helpers/mobile-navigation";
-import { EMPTY_RACK_SHARE, gotoWithRack, locators } from "./helpers";
+import {
+  EMPTY_RACK_SHARE,
+  gotoWithRack,
+  paletteItemByName,
+  locators,
+} from "./helpers";
 
 // Desktop Chrome (mouse, hasTouch:false) at a narrow viewport -> mobile mode
 // (breakpoint is max-width:1024px). 944x1039 matches the original bug report.
@@ -45,13 +50,13 @@ test.describe("Mobile tap-to-place with a mouse (#1757)", () => {
 
     const devicesBefore = await page.locator(locators.rack.device).count();
 
-    // Open the device library and pick the first device. On mobile this starts
-    // placement mode and auto-closes the bottom sheet (do NOT press Escape — it
-    // would cancel placement).
+    // Open the device library and pick a placeable full-width Server. On mobile
+    // this starts placement mode and auto-closes the bottom sheet (do NOT press
+    // Escape, it would cancel placement).
     await openDeviceLibraryFromBottomNav(page);
-    const firstDevice = page.locator(locators.device.paletteItem).first();
-    await expect(firstDevice).toBeVisible();
-    await firstDevice.click();
+    const serverDevice = paletteItemByName(page, "Server").first();
+    await expect(serverDevice).toBeVisible();
+    await serverDevice.click();
 
     // Placement mode is active: the "Placing:" status banner appears and the
     // bottom sheet has closed. The banner is a single role="status" overlay

--- a/e2e/shelf-category.spec.ts
+++ b/e2e/shelf-category.spec.ts
@@ -33,8 +33,9 @@ test.describe("Shelf Category", () => {
     const searchInput = page.locator('[data-testid="search-devices"]');
     await searchInput.fill("shelf");
 
-    // Drag shelf device to rack using shared helper (first visible item after filter)
-    await dragDeviceToRack(page);
+    // Drag the shelf by name. The palette default first item is a half-width
+    // carrier-required device, so naming the device keeps the helper placeable.
+    await dragDeviceToRack(page, { deviceName: "Shelf" });
 
     // Verify shelf is placed in rack
     await expect(page.locator(locators.rack.device).first()).toBeVisible({
@@ -59,21 +60,30 @@ test.describe("Shelf Category", () => {
     await expect(icon).toBeVisible();
   });
 
-  test("placed shelf device has a fill colour", async ({ page }) => {
+  test("placed device is a shelf and has a fill colour", async ({ page }) => {
     // Filter to shelf
     const searchInput = page.locator('[data-testid="search-devices"]');
     await searchInput.fill("shelf");
 
-    // Add shelf device using shared helper
-    await dragDeviceToRack(page);
+    // Add the shelf by name so a placeable shelf is placed, not whatever the
+    // palette happens to list first.
+    await dragDeviceToRack(page, { deviceName: "Shelf" });
 
-    // Check the device has the shelf colour
     const placedDevice = page.locator(locators.rack.device).first();
     await expect(placedDevice).toBeVisible({ timeout: 5000 });
 
-    // The fill should be the shelf colour #8B4513
+    // Assert the placed device is actually a shelf, not merely that some fill is
+    // set. The rack device's accessible name carries its category in the form
+    // "<name>, <n>U <category> at U<pos>", so a shelf announces "... U shelf ...".
+    await expect(placedDevice).toHaveAttribute(
+      "aria-label",
+      /,\s*\d+U shelf\b/i,
+    );
+
+    // And it renders with a fill colour (asserted without a hardcoded literal,
+    // which the design tokens can change and ESLint blocks).
     const deviceRect = placedDevice.locator("rect").first();
     const fill = await deviceRect.getAttribute("fill");
-    expect(fill?.toLowerCase()).toBeTruthy(); // Shelf color is set
+    expect(fill?.trim()).toBeTruthy();
   });
 });

--- a/e2e/starter-library.spec.ts
+++ b/e2e/starter-library.spec.ts
@@ -287,8 +287,9 @@ test.describe("Starter Library", () => {
     // Ensure rack is visible
     await expect(page.locator(locators.rack.container).first()).toBeVisible();
 
-    // Drag first device to rack using shared helper
-    await dragDeviceToRack(page);
+    // Drag the 24-Port Switch by name so the test matches its title rather than
+    // relying on whatever the palette lists first.
+    await dragDeviceToRack(page, { deviceName: "Switch (24-Port)" });
 
     // Verify device appears in rack
     await expect(page.locator(locators.rack.device).first()).toBeVisible({


### PR DESCRIPTION
## **User description**
## Root cause

The full advisory Playwright e2e suite is red on main: ~116 of 118 failures share one root cause. After #2745 alphabetized the device palette, the first palette item became "Blade Server (Full-Height)", a half-width, carrier-required device that `placeDevice` correctly refuses to place directly on the rails. Every test that selected the palette device positionally (`first()` / `.nth()` / the index-0 default) therefore placed nothing, and count assertions like `expect(count).toBeGreaterThan(0)` failed with "Expected: > 0, Received: 0".

## Changes (test-side only)

- `dragDeviceToRack`: default `deviceName` to the generic full-width "Server" (slug `1u-server`) when neither `deviceName` nor `deviceIndex` is given, restoring the pre-#2745 de facto default. Explicit `deviceIndex` still selects positionally.
- Add a precondition wait: when dragging by name, wait for the named palette item to be visible before the one-shot `evaluate`. This closes the 150ms search-debounce race (`DevicePalette.svelte`) and virtualization unmount races. Uses Playwright auto-waiting, no `waitForTimeout`.
- Add a `view` option to `dragDeviceToRack` so it can drop onto the rear face, then delete `dual-view.spec.ts`'s local duplicate `dragDeviceToRackView` and route its call sites through the shared helper.
- Fix `paletteItemByName` (previously unused, and broken): its `has`-locator used the absolute `[data-testid="device-palette-item"] .device-name` selector, which requires a nested palette item and matched nothing, so the filter dropped every item. Scope it to the item's own `.device-name` child instead.
- Convert positional arming sites to select a known-placeable device by name: `keyboard-placement.spec.ts` (5), `ios-safari.spec.ts` (2), `mobile-placement-mouse.spec.ts` (1). `android-chrome.spec.ts` already armed via the shared helper, so it inherits the "Server" default.
- `shelf-category.spec.ts`: pass `deviceName: "Shelf"` explicitly, and strengthen the fill test to assert the placed device is actually a shelf via its accessible name (`aria-label` carries the category), not a hardcoded colour literal.
- `starter-library.spec.ts`: pass `deviceName: "Switch (24-Port)"` so the test matches its own title.

## Scope note

The remaining `paletteItem.first()` usages in `accessibility.spec.ts`, `axe.spec.ts`, `responsive.spec.ts`, and `starter-library.spec.ts:282` are visibility assertions or arm-for-banner checks that do not depend on the first device being placeable, so they are outside this issue's four enumerated bug paths. They can be swept in a later wave if the epic wants a hard zero-`first()` invariant.

## Verification

Local gates (worktree): `npm run lint` clean, `npm run test:run` 3192/3192 unit tests pass, `npm run build` succeeds, `npm run check` (svelte-check) has one pre-existing error in `src/lib/utils/share.ts` introduced by #2846 and unrelated to this test-only change (this diff adds zero svelte-check errors).

Targeted e2e on the previously-red specs, all green:
- chromium: `keyboard-placement` (5), `shelf-category` (4), `dual-view` (16), `basic-workflow`, `starter-library`, `mobile-placement-mouse`.
- ios-safari: `Tap-to-place` (2), `Device Label Positioning` (2).
- android-chrome: `Device Label Positioning` (3), `tap-to-select`.

## CI note

The `e2e-self-hosted` advisory job will be red on this PR. It is `continue-on-error` and only greens once Wave 0 lands on main, so it must not block. `validate` (lint + unit + smoke + build) is the gate.

Closes #2851
Closes #2755
Wave 0A of epic #2859.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VdfSncy42Fj4Zoz9zh478A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdfSncy42Fj4Zoz9zh478A


___

## **CodeAnt-AI Description**
**Use placeable devices by name in e2e placement tests**

### What Changed
- Placement helpers now default to a placeable full-width "Server" instead of the first palette item, so tests no longer try to place an unusable device.
- Tests that place devices now target specific items by name, including keyboard, mobile, shelf, and starter library flows, so they match the intended device instead of whichever item happens to be first.
- Dual-view placement now uses the shared helper for both front and rear rack faces, and shelf tests now verify the placed item is actually a shelf.

### Impact
`✅ Fewer false e2e failures`
`✅ More reliable device placement tests`
`✅ Clearer coverage for front and rear rack placement`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
