### PR TITLE
refactor: rename published JSON Schema to evergreen rackula-layout.schema.json

### DIFF
--- a/docs/guides/yaml-schema-validation.md
+++ b/docs/guides/yaml-schema-validation.md
@@ -22,7 +22,7 @@ https://count.racku.la/schemas/rackula-layout.schema.json
 
 The URL is unversioned on purpose: the schema evolves additively in place, so the newest published schema keeps validating files written by older builds. Rackula itself never fetches this URL. It decides whether it can load a file offline from the `metadata.schema_version` field; editor validation is a convenience layered on top.
 
-Availability: production (`count.racku.la`) publishes the schema on a tagged release, and the dev environment (`https://d.racku.la/schemas/rackula-layout.schema.json`) is behind access control. Until a release ships the artifact, an editor cannot download it and the `# yaml-language-server` hint is simply ignored: this does not block editing, and Rackula still loads and validates the file itself offline from `metadata.schema_version`.
+The schema is published on a tagged release. If the artifact is not yet fetchable, an editor simply ignores the `# yaml-language-server` hint: this does not block editing, and Rackula still loads and validates the file itself offline from `metadata.schema_version`.
 
 For the publishing details, see the Published Schema section of [SCHEMA.md](../reference/SCHEMA.md#published-schema).
 

--- a/docs/guides/yaml-schema-validation.md
+++ b/docs/guides/yaml-schema-validation.md
@@ -12,29 +12,26 @@ The schema is generated from Rackula's authoritative Zod schema and describes th
 
 It is a structural contract, not a full validator. The schema covers roughly 80 percent of what Rackula checks on load. The remaining rules (cross-field constraints, referential integrity, the load-time transform) live in the Zod schema and run only when Rackula opens the file. See [Limitations](#limitations) for the full list.
 
-## Schema URLs
+## Schema URL
 
-There are two URLs, and they serve different purposes.
+The schema is published at one evergreen URL. It is both the identifier written inside the schema (`$id`) and the location editors download to validate:
 
-| URL | Purpose |
-| --- | --- |
-| `https://schemas.racku.la/layout/v1.json` | Canonical `$id`. The stable identifier written inside the schema. |
-| `https://count.racku.la/schemas/layout-v1.json` | Interim served URL. The fetchable location editors download to validate. |
+```text
+https://count.racku.la/schemas/rackula-layout.schema.json
+```
 
-The canonical `$id` is an identifier, not a fetch target. Rackula itself decides whether it can load a file offline from the `metadata.schema_version` field and never resolves the `$id` over the network, so the canonical identifier is wired before the `schemas.racku.la` domain exists.
+The URL is unversioned on purpose: the schema evolves additively in place, so the newest published schema keeps validating files written by older builds. Rackula itself never fetches this URL. It decides whether it can load a file offline from the `metadata.schema_version` field; editor validation is a convenience layered on top.
 
-Your editor is different: it must actually download the schema to validate against it. Use the interim served URL for any tooling that fetches a schema, including the `# yaml-language-server: $schema=...` hint below. When `schemas.racku.la` DNS is live it will serve the artifact at the canonical `$id` path and the fetch URL will converge on the `$id`.
+Availability: production (`count.racku.la`) publishes the schema on a tagged release, and the dev environment (`https://d.racku.la/schemas/rackula-layout.schema.json`) is behind access control. Until a release ships the artifact, an editor cannot download it and the `# yaml-language-server` hint is simply ignored: this does not block editing, and Rackula still loads and validates the file itself offline from `metadata.schema_version`.
 
-Availability: the served URL goes live with the next Rackula release. Production (`count.racku.la`) publishes the schema only on a tagged release, and the dev environment (`https://d.racku.la/schemas/layout-v1.json`) is behind access control, so neither is fetchable by an external editor until then. Until the artifact is published, an editor cannot download the schema and the `# yaml-language-server` hint is simply ignored: this does not block editing, and Rackula still loads and validates the file itself offline from `metadata.schema_version`.
-
-For the full identifier-versus-fetch rationale, see the Published Schema section of [SCHEMA.md](../reference/SCHEMA.md#published-schema).
+For the publishing details, see the Published Schema section of [SCHEMA.md](../reference/SCHEMA.md#published-schema).
 
 ## Sample layout with inline schema hint
 
 Add a `# yaml-language-server: $schema=...` comment as the first line of your layout file. yaml-language-server reads this comment and validates the rest of the document against the schema it points to. This sample is a minimal but valid Rackula layout:
 
 ```yaml
-# yaml-language-server: $schema=https://count.racku.la/schemas/layout-v1.json
+# yaml-language-server: $schema=https://count.racku.la/schemas/rackula-layout.schema.json
 metadata:
   id: 1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed
   name: Homelab Rack
@@ -101,7 +98,7 @@ Validation in VS Code is provided by the Red Hat YAML extension ([redhat.vscode-
 Add the schema hint as the first line of the file, exactly as in the sample above:
 
 ```yaml
-# yaml-language-server: $schema=https://count.racku.la/schemas/layout-v1.json
+# yaml-language-server: $schema=https://count.racku.la/schemas/rackula-layout.schema.json
 ```
 
 The comment travels with the file, so anyone who opens it gets validation without changing their own settings. This is the recommended approach for files you share.
@@ -113,7 +110,7 @@ Map a file glob to the schema in your workspace `.vscode/settings.json`. This va
 ```json
 {
   "yaml.schemas": {
-    "https://count.racku.la/schemas/layout-v1.json": [
+    "https://count.racku.la/schemas/rackula-layout.schema.json": [
       "*.rackula.yaml",
       "*.rackula.yml"
     ]

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -70,30 +70,22 @@ The reject-newer-MAJOR check lives at the shared validation ingress (`parseLayou
 
 ## Published Schema
 
-A language-agnostic JSON Schema is generated from the Zod source and committed at `static/schemas/layout-v1.json`. It is the structural contract for the saved-layout format. Run `npm run generate-schema` to regenerate it after changing the Zod schema; a CI drift check fails if the committed artifact and the generated output diverge.
+A language-agnostic JSON Schema is generated from the Zod source and committed at `static/schemas/rackula-layout.schema.json`. It is the structural contract for the saved-layout format. Run `npm run generate-schema` to regenerate it after changing the Zod schema; a CI drift check fails if the committed artifact and the generated output diverge.
 
-### Canonical `$id`
+### Published URL and `$id`
 
-The artifact carries the canonical identifier `https://schemas.racku.la/layout/v{MAJOR}.json`, which for the current MAJOR is:
+The published name is evergreen: there is one schema file, updated in place as the format evolves. The artifact's `$id` is the prod URL it is served from. `static/` is served at the deployment root, so a release publishes the artifact at:
 
-```text
-https://schemas.racku.la/layout/v1.json
-```
-
-The `$id` is an identifier, not a fetch target. Readers decide loadability offline from `metadata.schema_version` (see the reader rule above) and never resolve the `$id` over the network, so the canonical `$id` is wired before the `schemas.racku.la` domain exists.
-
-### Served location (interim fetch URL)
-
-`static/` is served at the deployment root, so the artifact is published at these paths once a release deploys it:
-
-| Environment | URL                                             |
-| ----------- | ----------------------------------------------- |
-| Prod        | `https://count.racku.la/schemas/layout-v1.json` |
-| Dev         | `https://d.racku.la/schemas/layout-v1.json`     |
+| Environment | URL                                                         |
+| ----------- | ----------------------------------------------------------- |
+| Prod        | `https://count.racku.la/schemas/rackula-layout.schema.json` |
+| Dev         | `https://d.racku.la/schemas/rackula-layout.schema.json`     |
 
 Availability: production (`count.racku.la`) publishes the schema only on a tagged release, and the dev path is behind access control, so the artifact is not externally fetchable until the next release ships it. The committed file in `static/schemas/` is the source of truth, and the reader rule above works offline regardless of whether the schema is served.
 
-Until the `schemas.racku.la` DNS is live, use the prod served URL above as the fetch URL for tooling that resolves a schema (for example a `# yaml-language-server: $schema=...` editor hint). The served path (`/schemas/layout-v1.json`) differs from the canonical `$id` path (`/layout/v1.json`) on purpose: the `$id` follows the long-term canonical shape while the served path matches the committed artifact's location. When `schemas.racku.la` is configured, it will serve the artifact at the canonical `$id` path and the fetch URL converges on the `$id`.
+### Why the published name is unversioned
+
+Schema evolution is additive by policy (MINOR changes above), and the generated schema is permissive about unknown fields, so the newest published schema keeps validating files written by older builds. Compatibility never hangs on this URL: readers gate offline on `metadata.schema_version` and never fetch the schema. If a breaking MAJOR change ever ships, freeze the final MAJOR-1 artifact from git history under a versioned name (for example `rackula-layout-v1.schema.json`) and publish it alongside. Until then, a version segment in the published name is unused complexity.
 
 ### Editor validation
 

--- a/docs/reference/SCHEMA.md
+++ b/docs/reference/SCHEMA.md
@@ -74,14 +74,13 @@ A language-agnostic JSON Schema is generated from the Zod source and committed a
 
 ### Published URL and `$id`
 
-The published name is evergreen: there is one schema file, updated in place as the format evolves. The artifact's `$id` is the prod URL it is served from. `static/` is served at the deployment root, so a release publishes the artifact at:
+The published name is evergreen: there is one schema file, updated in place as the format evolves. `static/` is served at the deployment root, so a tagged release publishes the artifact at the production URL, which is also the artifact's `$id`:
 
-| Environment | URL                                                         |
-| ----------- | ----------------------------------------------------------- |
-| Prod        | `https://count.racku.la/schemas/rackula-layout.schema.json` |
-| Dev         | `https://d.racku.la/schemas/rackula-layout.schema.json`     |
+```text
+https://count.racku.la/schemas/rackula-layout.schema.json
+```
 
-Availability: production (`count.racku.la`) publishes the schema only on a tagged release, and the dev path is behind access control, so the artifact is not externally fetchable until the next release ships it. The committed file in `static/schemas/` is the source of truth, and the reader rule above works offline regardless of whether the schema is served.
+The committed file in `static/schemas/` is the source of truth, and the reader rule above works offline from `metadata.schema_version` regardless of whether the schema is served.
 
 ### Why the published name is unversioned
 

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -1,7 +1,7 @@
 /**
  * Generate the layout JSON Schema from the Zod source (issue #2226).
  *
- * Emits static/schemas/layout-v1.json from LayoutSchema using Zod 4's native
+ * Emits static/schemas/rackula-layout.schema.json from LayoutSchema using Zod 4's native
  * z.toJSONSchema(). The JSON Schema is the published, language-agnostic contract
  * for the saved-layout format; the Zod schema in src/lib/schemas/index.ts stays
  * the single source of truth and this script is its deterministic projection.
@@ -29,7 +29,12 @@ import type { LayoutSchema as LayoutSchemaType } from "$lib/schemas/index.ts";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SCRIPT_DIR, "..");
-const OUTPUT_FILE = join(ROOT, "static", "schemas", "layout-v1.json");
+const OUTPUT_FILE = join(
+  ROOT,
+  "static",
+  "schemas",
+  "rackula-layout.schema.json",
+);
 
 /** JSON Schema dialect this artifact targets; pinned so the published contract
  * does not silently follow Zod's default. */
@@ -37,14 +42,14 @@ export const JSON_SCHEMA_DIALECT =
   "https://json-schema.org/draft/2020-12/schema";
 
 /**
- * Canonical schema identifier per docs/reference/SCHEMA.md
- * (schemas.racku.la/layout/v{MAJOR}.json). This is an identifier, not a fetch
- * target: readers gate loadability offline on metadata.schema_version, so the
- * canonical $id is set before schemas.racku.la DNS exists. The artifact is
- * served in the interim at the count.racku.la/d.racku.la /schemas/ path (see
- * the Published Schema section of SCHEMA.md).
+ * Published schema identifier per docs/reference/SCHEMA.md. The name is
+ * evergreen (no version segment): the schema evolves additively in place and
+ * readers gate loadability offline on metadata.schema_version, never on this
+ * URL. The $id doubles as the served prod URL, since static/ is served at the
+ * deployment root (see the Published Schema section of SCHEMA.md).
  */
-export const SCHEMA_ID = "https://schemas.racku.la/layout/v1.json";
+export const SCHEMA_ID =
+  "https://count.racku.la/schemas/rackula-layout.schema.json";
 
 export const SCHEMA_DESCRIPTION =
   "Beta. Generated from the Rackula Zod layout schema. Covers the structural " +

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -41,26 +41,13 @@ function warnDuplicateDeviceIds(layout: Layout): void {
 const STANDARD_RACK_WIDTH = 19;
 
 /**
- * Interim served base for the published layout JSON Schema. Editors that honour
- * the `# yaml-language-server: $schema=...` hint fetch this URL, so it must be a
- * real served, fetchable location, not the canonical `$id`
- * (`https://schemas.racku.la/layout/v{MAJOR}.json`) whose DNS does not exist
- * yet. The served path is the prod URL from the Published Schema section of
- * docs/reference/SCHEMA.md. The `v{MAJOR}` segment is appended from the layout's
- * `schema_version` MAJOR.
+ * Editor `$schema` hint for exported YAML. Points at the published evergreen
+ * schema (the prod URL from the Published Schema section of
+ * docs/reference/SCHEMA.md). The schema evolves additively in place;
+ * loadability is gated offline by `metadata.schema_version`, not by this URL.
  */
-const SCHEMA_FETCH_BASE = "https://count.racku.la/schemas/layout-v";
-
-/**
- * Build the editor `$schema` hint comment, deriving the schema MAJOR from a
- * `schema_version` string (e.g. "1.0" -> v1). Absent or unparseable versions
- * default to MAJOR 1, matching the read-side default in SCHEMA.md.
- */
-function buildSchemaHintComment(schemaVersion: string | undefined): string {
-  const major = parseInt(schemaVersion ?? "1.0", 10);
-  const majorSegment = Number.isNaN(major) || major < 1 ? 1 : major;
-  return `# yaml-language-server: $schema=${SCHEMA_FETCH_BASE}${majorSegment}.json`;
-}
+const SCHEMA_HINT_COMMENT =
+  "# yaml-language-server: $schema=https://count.racku.la/schemas/rackula-layout.schema.json";
 
 /**
  * Lazily load js-yaml library
@@ -133,7 +120,7 @@ export async function serializeLayoutToYaml(
   // Prepend the editor schema hint so YAML language servers validate the export
   // out of the box (#2230). A leading `#` comment is ignored on read.
   const body = await serializeToYaml(layoutForSerialization);
-  return `${buildSchemaHintComment(layout.metadata?.schema_version)}\n${body}`;
+  return `${SCHEMA_HINT_COMMENT}\n${body}`;
 }
 
 /**
@@ -166,9 +153,9 @@ export async function serializeLayoutToYamlWithMetadata(
   const layoutForSerialization = orderLayoutFields(layout, { metadata });
 
   // Prepend the editor schema hint so the folder-ZIP `.rackula.yaml` validates
-  // out of the box too (#2230). MAJOR comes from the metadata written here.
+  // out of the box too (#2230).
   const body = await serializeToYaml(layoutForSerialization);
-  return `${buildSchemaHintComment(metadata.schema_version)}\n${body}`;
+  return `${SCHEMA_HINT_COMMENT}\n${body}`;
 }
 
 /**

--- a/src/tests/layout-json-schema.test.ts
+++ b/src/tests/layout-json-schema.test.ts
@@ -23,7 +23,7 @@ const ARTIFACT_PATH = join(
   process.cwd(),
   "static",
   "schemas",
-  "layout-v1.json",
+  "rackula-layout.schema.json",
 );
 
 describe("layout JSON Schema artifact", () => {

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -203,7 +203,7 @@ describe("YAML editor schema hint (#2230)", () => {
   // comment line.
   const HINT_PREFIX = "# yaml-language-server: $schema=";
 
-  it("prepends a yaml-language-server $schema comment as the first line for a v1 layout", async () => {
+  it("prepends a yaml-language-server $schema comment as the first line", async () => {
     const layout = createTestLayout({
       metadata: {
         id: "11111111-1111-4111-8111-111111111111",
@@ -214,34 +214,9 @@ describe("YAML editor schema hint (#2230)", () => {
 
     const yaml = await serializeLayoutToYaml(layout);
     const firstLine = yaml.split("\n")[0];
-    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/layout-v1.json`;
+    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/rackula-layout.schema.json`;
 
     expect(firstLine.startsWith(HINT_PREFIX)).toBe(true);
-    expect(firstLine === expected).toBe(true);
-  });
-
-  it("derives the schema URL MAJOR from the layout's schema_version", async () => {
-    const layout = createTestLayout({
-      metadata: {
-        id: "22222222-2222-4222-8222-222222222222",
-        name: "Future Layout",
-        schema_version: "2.3",
-      },
-    });
-
-    const yaml = await serializeLayoutToYaml(layout);
-    const firstLine = yaml.split("\n")[0];
-    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/layout-v2.json`;
-
-    expect(firstLine === expected).toBe(true);
-  });
-
-  it("defaults to MAJOR 1 when schema_version is absent", async () => {
-    // createTestLayout has no metadata block, so there is no schema_version.
-    const yaml = await serializeLayoutToYaml(createTestLayout());
-    const firstLine = yaml.split("\n")[0];
-    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/layout-v1.json`;
-
     expect(firstLine === expected).toBe(true);
   });
 
@@ -256,14 +231,14 @@ describe("YAML editor schema hint (#2230)", () => {
 
   it("prepends the hint on the folder-ZIP metadata export path too", async () => {
     // The .rackula.yaml inside a folder ZIP is an editor-openable export, so it
-    // carries the same hint, derived from the metadata's schema_version.
+    // carries the same hint.
     const yaml = await serializeLayoutToYamlWithMetadata(createTestLayout(), {
       id: "33333333-3333-4333-8333-333333333333",
       name: "Archive Lab",
       schema_version: "1.0",
     });
     const firstLine = yaml.split("\n")[0];
-    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/layout-v1.json`;
+    const expected = `${HINT_PREFIX}https://count.racku.la/schemas/rackula-layout.schema.json`;
 
     expect(firstLine === expected).toBe(true);
 

--- a/static/schemas/rackula-layout.schema.json
+++ b/static/schemas/rackula-layout.schema.json
@@ -1,6 +1,6 @@
 {
   "$description": "Beta. Generated from the Rackula Zod layout schema. Covers the structural shape of a saved layout but not cross-field rules expressed in Zod (.refine/.superRefine: referential integrity, carrier-first rail placement, slot fit) or the load-time .transform (legacy position migration, rack id generation, unknown-field preservation). Expect roughly 80 percent validation coverage; the Zod schema in src/lib/schemas/index.ts is authoritative.",
-  "$id": "https://schemas.racku.la/layout/v1.json",
+  "$id": "https://count.racku.la/schemas/rackula-layout.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": {},
   "properties": {


### PR DESCRIPTION
## **User description**
## Summary

Renames the published JSON Schema from `layout-v1.json` to the evergreen `rackula-layout.schema.json` and removes schema-MAJOR versioning from the published name and URL.

Closes #2861

## Why

The `v1` segment was the #1113 policy identifier (`schemas.racku.la/layout/v{MAJOR}.json`) flattened into a static filename. It insured against a breaking schema MAJOR bump, but:

- The format evolves additively by policy (backward compatibility is a hard requirement; otherwise a migration plus an upgrade-corpus fixture).
- The generated schema is permissive about unknown fields, so the newest schema keeps validating files written by older builds.
- Loadability is gated offline by `metadata.schema_version` (#2205); readers never fetch this URL. The published schema is an editor convenience only.
- Nobody consumes the current URL, so no alias or redirect is kept.

If a breaking MAJOR change ever ships, freeze the final MAJOR-1 artifact from git history under a versioned name at that point. Until then, the version segment is unused complexity.

## Changes

- `scripts/generate-schema.ts` emits `static/schemas/rackula-layout.schema.json`; the `$id` becomes the served prod URL (`https://count.racku.la/schemas/rackula-layout.schema.json`), retiring the `schemas.racku.la` DNS dependency.
- `static/schemas/layout-v1.json` deleted; artifact regenerated under the new name (content identical apart from `$id`).
- `src/lib/utils/yaml.ts`: the export hint is now a constant `SCHEMA_HINT_COMMENT`; `buildSchemaHintComment` and its MAJOR parsing are deleted.
- Tests: drift test points at the new artifact; round-trip hint tests assert the new URL; the two MAJOR-derivation tests are deleted with the behaviour.
- `docs/reference/SCHEMA.md`: Published Schema section rewritten (evergreen URL and `$id`, freeze-on-breaking-change contingency); canonical-`$id`-versus-interim-URL split removed.
- `docs/guides/yaml-schema-validation.md`: single evergreen URL, simplified availability note, sample and VS Code snippets updated.

Untouched by design: upgrade-corpus fixtures, `docs/research/`, `docs/plans/` (historical records), `metadata.schema_version` semantics and the version-rejection gate.

## Verification

- `npx vitest run src/tests/layout-json-schema.test.ts src/tests/yaml-roundtrip.test.ts`: 16 passed.
- `npm run check`: 0 errors, 0 warnings.
- ESLint and Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cuHbbisgzzY599Zu3oRcs


___

## **CodeAnt-AI Description**
**Use one evergreen URL for the published layout schema**

### What Changed
- The published layout schema now uses a single unversioned file name and URL.
- YAML exports now point editors to that same evergreen schema URL instead of changing it by schema version.
- The schema docs and validation guide now show the new URL and explain that older layouts still validate against the newest published schema.
- The old versioned schema artifact and related version-based hint behavior were removed.

### Impact
`✅ Simpler editor setup`
`✅ Fewer broken schema links`
`✅ Clearer layout validation docs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
