### PR TITLE
test: retire the side-panel-edit-empty contract in e2e helpers and specs (#2852)

### DIFF
--- a/e2e/device-name.spec.ts
+++ b/e2e/device-name.spec.ts
@@ -22,8 +22,12 @@ test.describe("Device Custom Names", () => {
     // Click on the device to select it
     await page.locator(locators.rack.device).first().click();
 
-    // Selecting the device surfaces its Edit-tab properties (empty state gone)
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // Selecting the device opens its Edit panel; the display-name control is the
+    // device-specific affordance that confirms it (the retired empty-state testid
+    // never renders with a rack present, #2739/#2757).
+    await expect(
+      page.getByRole("button", { name: "Edit display name" }),
+    ).toBeVisible();
 
     // Click the display name button to start editing
     await startEditingDisplayName(page);
@@ -50,8 +54,10 @@ test.describe("Device Custom Names", () => {
     await expect(page.locator(locators.rack.device).first()).toBeVisible();
     await page.locator(locators.rack.device).first().click();
 
-    // Wait for edit panel to open
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // The device's Edit panel is open once its display-name control renders.
+    await expect(
+      page.getByRole("button", { name: "Edit display name" }),
+    ).toBeVisible();
 
     // Edit the name
     await startEditingDisplayName(page);
@@ -103,8 +109,10 @@ test.describe("Device Custom Names", () => {
     await expect(page.locator(locators.rack.device).first()).toBeVisible();
     await page.locator(locators.rack.device).first().click();
 
-    // Wait for edit panel to open
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // The device's Edit panel is open once its display-name control renders.
+    await expect(
+      page.getByRole("button", { name: "Edit display name" }),
+    ).toBeVisible();
 
     // Get the original device type name
     const originalName = await page
@@ -126,7 +134,11 @@ test.describe("Device Custom Names", () => {
 
     // Deselect device to ensure keyboard shortcuts target the app, not the edit panel
     await page.keyboard.press("Escape");
-    await expect(page.locator(locators.sidePanel.editEmpty)).toBeVisible();
+    // Escape clears the selection; with a rack present the Edit tab falls back
+    // to rack mode rather than the empty state (#2739, #2757), so assert the
+    // panel still shows content instead of the retired empty-state prompt.
+    await expect(page.locator(locators.sidePanel.editPanel)).toBeVisible();
+    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
 
     // Undo (Ctrl+Z)
     await page.keyboard.press(`${PLATFORM_MODIFIER}+z`);
@@ -153,8 +165,10 @@ test.describe("Device Custom Names", () => {
     await expect(page.locator(locators.rack.device).first()).toBeVisible();
     await page.locator(locators.rack.device).first().click();
 
-    // Wait for edit panel to open
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // The device's Edit panel is open once its display-name control renders.
+    await expect(
+      page.getByRole("button", { name: "Edit display name" }),
+    ).toBeVisible();
 
     // Get the original device type name
     const originalName = await page

--- a/e2e/helpers/device-actions.ts
+++ b/e2e/helpers/device-actions.ts
@@ -215,8 +215,14 @@ export async function selectDevice(
  */
 export async function deselectDevice(page: Page): Promise<void> {
   await page.keyboard.press("Escape");
-  // With nothing selected the Edit tab falls back to its empty-state prompt.
-  await expect(page.locator(locators.sidePanel.editEmpty)).toBeVisible();
+  // Escape clears the selection, but with a rack present the Edit tab falls
+  // back to rack mode (SidePanelContent derives rackModeRack =
+  // selectionRack ?? activeRack, and activeRack falls back to racks[0]), so the
+  // empty state never renders (#2739, #2757). Assert the Edit tab is still
+  // showing content, mirroring deleteSelectedDevice(), so this can't pass
+  // vacuously off an unmounted tabpanel.
+  await expect(page.locator(locators.sidePanel.editPanel)).toBeVisible();
+  await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
 }
 
 /**

--- a/e2e/keyboard.spec.ts
+++ b/e2e/keyboard.spec.ts
@@ -54,14 +54,20 @@ test.describe("Keyboard Shortcuts", () => {
     // Select the rack (click on first rack-svg in dual-view)
     await page.locator(locators.rack.svg).first().click();
 
-    // Selecting the rack surfaces its Edit-tab properties (empty state gone)
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // The rack is a role="listitem"; selection is announced through its
+    // accessible name (a trailing ", selected"), not aria-selected (see
+    // dual-view.spec.ts "dual-view rack can be selected").
+    const rack = page.locator(locators.rackView.dualView).first();
+    await expect(rack).toHaveAttribute("aria-label", /, selected$/);
 
     // Press Escape
     await page.keyboard.press("Escape");
 
-    // Clearing the selection returns the Edit tab to its empty state
-    await expect(page.locator(locators.sidePanel.editEmpty)).toBeVisible();
+    // Escape clears the selection, so the rack's accessible name no longer
+    // carries the ", selected" suffix. The Edit tab itself falls back to rack
+    // mode with a rack present (#2739, #2757), so its empty state never renders;
+    // the selection state is the real deselection observable.
+    await expect(rack).not.toHaveAttribute("aria-label", /, selected$/);
   });
 
   test("? key opens help dialog", async ({ page }) => {

--- a/e2e/rack-select-editpanel.spec.ts
+++ b/e2e/rack-select-editpanel.spec.ts
@@ -27,13 +27,17 @@ test.describe("Rack selection populates the Edit panel (#2407)", () => {
     // Select the FIRST rack: it becomes the active + selected rack and the
     // Edit panel populates for it.
     await firstRack.locator(locators.rackView.frontSvg).click();
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // Selection is announced through the rack's accessible name (a trailing
+    // ", selected"), not aria-selected: it is a role="listitem" (see
+    // dual-view.spec.ts). The retired empty-state testid never renders with a
+    // rack present (#2739/#2757).
+    await expect(firstRack).toHaveAttribute("aria-label", /, selected$/);
 
     // Now select the SECOND rack via its click target while the first rack is
     // active. The panel must update to the second rack, not fall back to its
     // empty state (#2407).
     await secondRack.locator(locators.rackView.frontSvg).click();
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    await expect(secondRack).toHaveAttribute("aria-label", /, selected$/);
     await expect(page.getByLabel("Name", { exact: true })).toHaveValue(
       "Second Rack",
     );
@@ -50,14 +54,18 @@ test.describe("Rack selection populates the Edit panel (#2407)", () => {
 
     // Make the first rack the active + selected one.
     await firstRack.locator(locators.rackView.frontSvg).click();
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // Selection is announced through the rack's accessible name (a trailing
+    // ", selected"), not aria-selected: it is a role="listitem" (see
+    // dual-view.spec.ts). The retired empty-state testid never renders with a
+    // rack present (#2739/#2757).
+    await expect(firstRack).toHaveAttribute("aria-label", /, selected$/);
 
     // Click the SECOND rack's name (outer chrome, not the rack body). This is
     // the "area around the rack / the title" click target from #2407: it must
     // select the rack and populate the Edit panel, not merely focus the
     // container (whose focus outline looks identical to the selection box).
     await secondRack.locator(locators.rackView.dualViewName).click();
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    await expect(secondRack).toHaveAttribute("aria-label", /, selected$/);
     await expect(page.getByLabel("Name", { exact: true })).toHaveValue(
       "Second Rack",
     );

--- a/e2e/view-reset.spec.ts
+++ b/e2e/view-reset.spec.ts
@@ -63,7 +63,14 @@ test.describe("View Reset on Rack Changes", () => {
   }) => {
     // Select the rack to open EditPanel BEFORE panning away
     await page.locator(locators.rack.svg).first().click();
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // Selecting the rack opens its Edit panel; the Height control is the
+    // rack-specific affordance that confirms it (the retired empty-state testid
+    // never renders with a rack present, #2739/#2757).
+    await expect(
+      page.getByTestId("side-panel-panel-edit").getByLabel("Height", {
+        exact: true,
+      }),
+    ).toBeVisible();
 
     // Pan the view to an offset position
     await page.evaluate(() => {
@@ -102,7 +109,14 @@ test.describe("View Reset on Rack Changes", () => {
   }) => {
     // Select the rack BEFORE panning away
     await page.locator(locators.rack.svg).first().click();
-    await expect(page.locator(locators.sidePanel.editEmpty)).not.toBeVisible();
+    // Selecting the rack opens its Edit panel; the Height control is the
+    // rack-specific affordance that confirms it (the retired empty-state testid
+    // never renders with a rack present, #2739/#2757).
+    await expect(
+      page.getByTestId("side-panel-panel-edit").getByLabel("Height", {
+        exact: true,
+      }),
+    ).toBeVisible();
 
     // Pan away after selection
     await page.evaluate(() => {


### PR DESCRIPTION
## **User description**
## Summary

Wave 0B of the E2E suite recovery epic (#2859). Test-side only.

Since the inspector rework (#2739/#2757), when a layout has any rack the Edit tab falls back to rack mode after deselection (`rackModeRack = selectionRack ?? activeRack`, and `activeRack` falls back to `racks[0]` even after Escape). The empty-state testid `side-panel-edit-empty` therefore only renders in a zero-rack layout, so every helper and spec that asserted it becomes visible now fails once drags succeed (Wave 0A, #2851).

## Changes

- `deselectDevice()` (e2e/helpers/device-actions.ts): after Escape, assert the rack-mode fallback (editPanel visible, editEmpty not visible), mirroring `deleteSelectedDevice()`. This single helper change fixes every caller, including the `device-metadata` suite the issue text omitted.
- `keyboard.spec.ts` "Escape clears selection": assert a real deselection observable (the rack's accessible name no longer ends in `, selected`) instead of the retired empty-state prompt.
- Swept the vacuous `editEmpty` `not.toBeVisible()` guards in `device-name`, `rack-select-editpanel`, and `view-reset` so they assert a positive signal (Edit-display-name button, rack selection state, or the Height control), reusing locators sibling tests already trust.
- Updated the skipped `device-name` undo/redo test body so #2855 can re-enable it without inheriting the stale assertion (kept `.skip`).

## Verification

- Targeted specs pass on chromium and webkit: undo-redo (move/edit-IP/rename-rack), the full device-metadata suite, keyboard (Escape clears selection with the non-vacuous aria-label observable), rack-select-editpanel, view-reset.
- `npm run lint` clean. `npm run build` green. `npm run check` shows only the pre-existing unrelated `share.ts:452` error (#2846); zero new svelte-check errors.

This clears the 18 side-panel-edit-empty residual failures from the post-#2851 full-suite run, leaving only the command-palette bridge (#2853).

Note: the `e2e (self-hosted full suite)` advisory job is continue-on-error and stays red until Wave 0 lands on main; `validate` is the merge gate.

Closes #2852

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Retire the empty-state check from edit-panel tests**

### What Changed
- Replaced checks for the removed empty Edit tab state with visible rack/device-specific signals, such as the Edit display name button and Height control.
- Updated Escape and rack-selection tests to assert real selection changes, including the rack’s “selected” state and the Edit panel still showing content when a rack is present.
- Changed the shared device deselection helper to confirm the Edit panel stays populated after Escape instead of waiting for an empty state that no longer appears.

### Impact
`✅ Fewer false test failures after selecting or deselecting items`
`✅ Stable edit-panel tests with racks present`
`✅ Clearer checks for keyboard selection behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
