### PR TITLE
fix: command palette device bridge visible on no-match query (#2853)

### DIFF
--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -511,14 +511,22 @@
                       {/if}
                     </Command.Item>
                   {/each}
-                  <!-- No-command-match bridge to the device catalogue (#2779,
-                       rule 11). Shown only when the query matches zero command
-                       rows (so top-level search stays commands-only and it never
-                       hijacks Enter past a greyed row). forceMount keeps it
-                       mounted despite its value not matching the query, so on a
-                       true no-match it is the sole armed item; selecting it
-                       enters device search pre-filled with the typed query. -->
-                  {#if canAddDevice && noCommandMatch}
+                </Command.GroupItems>
+              </Command.Group>
+              <!-- No-command-match bridge to the device catalogue (#2779,
+                   rule 11). Shown only when the query matches zero command rows
+                   (so top-level search stays commands-only and it never hijacks
+                   Enter past a greyed row). It lives in its OWN forceMounted
+                   group, NOT the command group above: bits-ui culls a group
+                   whose items all score zero by setting hidden on the group
+                   element, which hides a forceMounted item nested inside it too
+                   (#2853). forceMount on the group keeps it rendered and
+                   forceMount on the item keeps the item mounted, so on a true
+                   no-match the bridge is the sole armed item; selecting it enters
+                   device search pre-filled with the typed query. -->
+              {#if canAddDevice && noCommandMatch}
+                <Command.Group forceMount class="command-group">
+                  <Command.GroupItems>
                     <Command.Item
                       forceMount
                       value="add device"
@@ -535,9 +543,9 @@
                         >
                       </span>
                     </Command.Item>
-                  {/if}
-                </Command.GroupItems>
-              </Command.Group>
+                  </Command.GroupItems>
+                </Command.Group>
+              {/if}
             {/if}
           </Command.Viewport>
         </Command.List>


### PR DESCRIPTION
## **User description**
## Problem

In the command palette, typing a query that matches **no** command is supposed to surface a device bridge row (`command-palette-create-device`, e.g. `Add a device called "zzzqqq"`) so Enter/click opens device search pre-filled. After PR #2803 (which fixed #2779) the bridge was never visible on a true no-match, regressing that behaviour.

## Root cause

The bridge item was `forceMount`ed but lived **inside** the filtered `Command.Group` that holds the command rows. bits-ui culls a group whose items all score zero by setting `hidden` on the group element (`CommandGroupContainerState.shouldRender` -> `props.hidden`). On a true no-match every command row in that group scores zero, so the group went `hidden` (`display:none`), which hides everything nested inside it, including the `forceMount`ed bridge. Item-level `forceMount` keeps the item in the DOM (`itemState.shouldRender` was true) but cannot override the **group-level** no-match culling, so the element resolved in the DOM but was visually hidden. That is exactly the failure signature: element present, but not visible.

## Fix

Move the bridge into its **own** `Command.Group` marked `forceMount`. A force-mounted group short-circuits `shouldRender` to `true`, so it is never given the `hidden` attribute regardless of filtering, and the force-mounted item inside it renders and stays the sole armed row on a no-match. Selecting it (click or Enter) still opens device search pre-filled with the typed query. The searchCommands group is left untouched, so it still culls normally.

This uses bits-ui's documented `forceMount`-on-group mechanism rather than a CSS/attribute bandaid.

## Behaviour preserved

- Bridge appears only on a real no-match with a non-empty/non-whitespace query (empty query = browse, never a bridge) - the `canAddDevice && noCommandMatch` gate is unchanged.
- A partial/greyed match still offers no bridge and keeps Enter inert.
- Selecting the bridge opens device search pre-filled with the query.

Re-enables `e2e/command-palette.spec.ts:416` ("a query that matches no command offers the device bridge, pre-filled").

## Verification

- `npm run lint`: clean.
- `npm run check` (svelte-check): zero new errors (only the pre-existing unrelated `src/lib/utils/share.ts:452` error remains).
- `npm run build`: green.
- `npm run test:e2e -- --project=chromium --project=webkit e2e/command-palette.spec.ts`: 44/44 pass, including :416 on both chromium and webkit.

Note: the `e2e-self-hosted` advisory job stays red (continue-on-error) until this wave lands; `validate` is the gate.

Wave 1 of epic #2859.

Closes #2853

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdfSncy42Fj4Zoz9zh478A


___

## **CodeAnt-AI Description**
Make the device bridge appear again when no command matches

### What Changed
- The “Add a device called …” option now shows up again when a query matches no commands, so Enter or click can open device search with the typed text.
- The bridge is kept separate from the normal command results, which prevents it from being hidden when the command list has no matches.
- Existing command results still behave the same, including normal filtering and disabled items.

### Impact
`✅ No-match queries can open device search`
`✅ Fewer missing options in command palette`
`✅ Clearer path from search to adding a device`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
