### PR TITLE
test: disabled e2e test triage sweep (#2855)

### DIFF
--- a/e2e/android-chrome.spec.ts
+++ b/e2e/android-chrome.spec.ts
@@ -167,25 +167,41 @@ test.describe("Bottom Sheet", () => {
     await expect(bottomSheet).not.toBeVisible({ timeout: 2000 });
   });
 
-  // Swipe-to-dismiss requires real touch events (hasTouch context)
-  test.skip("bottom sheet swipe does not trigger Android back gesture", async ({
-    page,
-  }) => {
+  test("bottom sheet closes on swipe-down gesture", async ({ page }) => {
     await openDeviceLibraryFromBottomNav(page);
 
     const bottomSheet = page.locator(locators.mobile.bottomSheet);
     await expect(bottomSheet).toBeVisible();
 
-    const box = await bottomSheet.boundingBox();
-    if (box) {
-      const startY = box.y + 50;
-      const centerX = box.x + box.width / 2;
+    // The swipe starts on the sheet header's bare background: Dialog.svelte only
+    // begins a drag there (not on the close button or header actions), and only
+    // for touch/pen pointers. Mouse synthesis is rejected by design, so drive
+    // real touch input through CDP, which produces genuine pointerType="touch"
+    // events with a valid pointerId (mouse.move/down would arrive as "mouse").
+    const dragHandle = page.locator(locators.mobile.dragHandleBar);
+    const box = await dragHandle.boundingBox();
+    expect(box).toBeTruthy();
 
-      await page.mouse.move(centerX, startY);
-      await page.mouse.down();
-      await page.mouse.move(centerX, startY + 200, { steps: 10 });
-      await page.mouse.up();
+    const client = await page.context().newCDPSession(page);
+    const x = box!.x + box!.width / 2;
+    const startY = box!.y + box!.height / 2;
+
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x, y: startY }],
+    });
+    // Drag down well past the 100px close threshold in steps so each pointermove
+    // fires and dragOffset accumulates.
+    for (let step = 1; step <= 10; step++) {
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x, y: startY + step * 25 }],
+      });
     }
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
 
     await expect(bottomSheet).not.toBeVisible({ timeout: 2000 });
   });

--- a/e2e/basic-workflow.spec.ts
+++ b/e2e/basic-workflow.spec.ts
@@ -22,21 +22,6 @@ test.describe("Basic Workflow", () => {
     await expect(page.locator(locators.rackView.dualViewName)).toBeVisible();
   });
 
-  // FIXME(#1438): Restore when replace-rack flow is reintroduced with current UX.
-  test.fixme("can replace current rack with a new one", async ({
-    page: _page,
-  }) => {
-    // The v0.2 "Replace" flow used a toolbar button + replace dialog
-    // This may have changed in the current app version
-  });
-
-  // FIXME(#1438): Restore when replace-rack flow is reintroduced with current UX.
-  test.fixme("rack appears on canvas after replacement", async ({
-    page: _page,
-  }) => {
-    // Same as above - v0.2 replace flow may have changed
-  });
-
   test("can drag device from palette to rack", async ({ page }) => {
     // In v0.4 dual-view mode, two rack containers exist
     await expect(page.locator(locators.rack.container).first()).toBeVisible();
@@ -101,13 +86,5 @@ test.describe("Basic Workflow", () => {
 
     // Device should be removed
     await expect(page.locator(locators.rack.device)).not.toBeVisible();
-  });
-
-  // FIXME(#1438): Restore when rack deletion flow is validated in current UX.
-  test.fixme("can clear rack (v0.2 does not remove the rack)", async ({
-    page: _page,
-  }) => {
-    // This test clicks on the rack-svg to select the rack, then expects a Delete button
-    // The current UI may have different rack selection/deletion mechanics
   });
 });

--- a/e2e/custom-device.spec.ts
+++ b/e2e/custom-device.spec.ts
@@ -41,12 +41,13 @@ test.describe("Custom Device Height (Issue #166)", () => {
     // The placed device announces its height through its accessible name
     // (RackDevice ariaLabel: "<name>, <u_height>U <category> at U<n>"). A 4U
     // device that survived placement announces "4U"; the #166 regression would
-    // announce "1U". Scope to the front face so the full-depth twin on the rear
-    // does not double the match.
+    // announce "1U". getByRole substring-matches a plain string name, so no
+    // dynamic regex is built. Scope to the front face so the full-depth twin on
+    // the rear does not double the match.
     await expect(
       page
         .locator(locators.rackView.front)
-        .getByRole("button", { name: new RegExp(`${deviceName}, 4U`) }),
+        .getByRole("button", { name: `${deviceName}, 4U` }),
     ).toBeVisible();
   });
 });

--- a/e2e/custom-device.spec.ts
+++ b/e2e/custom-device.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect } from "./helpers/base-test";
-import { gotoWithRack, locators } from "./helpers";
+import { gotoWithRack, dragDeviceToRack, locators } from "./helpers";
 
 /**
  * E2E Tests for Custom Device Creation and Placement (Issue #166)
- * Tests that custom multi-U devices preserve their height after placement
+ * Verifies a custom multi-U device keeps its height after placement, the
+ * regression where custom devices reverted to 1U once dropped in the rack.
  */
 
 test.describe("Custom Device Height (Issue #166)", () => {
@@ -11,57 +12,41 @@ test.describe("Custom Device Height (Issue #166)", () => {
     await gotoWithRack(page);
   });
 
-  // Two blockers prevent these tests from running:
-  // 1. Svelte bind:value on <input type="number"> doesn't react to Playwright fill(),
-  //    type(), or nativeInputValueSetter — the custom device is created with default 1U height
-  // 2. Custom devices are inserted into a brand-sorted palette, not appended at the end,
-  //    so deviceIndex: count-1 drags the wrong device
-  // Needs: a dedicated dragDeviceByName() helper + Svelte number input workaround
-  test.skip("custom 4U device renders with correct height after placement", async ({
+  test("custom 4U device keeps its height after placement", async ({
     page,
   }) => {
-    const addDeviceButton = page.getByTestId("btn-create-custom-device");
-    await addDeviceButton.click();
+    const deviceName = "Custom Quad Server";
 
-    const addDeviceDialog = page.getByRole("dialog", { name: "Add Device" });
-    await addDeviceDialog
-      .getByLabel("Name", { exact: true })
-      .fill("RACKOWL 4U Server");
-    const heightInput = addDeviceDialog.getByLabel("Height (U)");
-    await heightInput.click();
-    await heightInput.fill("4");
-    await addDeviceDialog.getByLabel("Category").selectOption("server");
+    // Open the "Add custom device" dialog from the palette footer.
+    await page.getByTestId("btn-create-custom-device").click();
+
+    const dialog = page.getByRole("dialog", { name: "Add Device" });
+    await dialog.getByLabel("Name", { exact: true }).fill(deviceName);
+
+    // Set the height to 4U. Svelte's bind:value on a number input updates from
+    // the input event, which fill() dispatches, so the state tracks the value.
+    await dialog.getByLabel("Height (U)").fill("4");
+    await dialog.getByLabel("Category").selectOption("server");
 
     await page.getByTestId("btn-add-device").click();
 
-    const customDevice = page
-      .getByTestId("device-palette-item")
-      .filter({ hasText: "RACKOWL 4U Server" });
-    await expect(customDevice).toBeVisible();
+    // Filter the palette to the new device so the virtualized list renders it
+    // (off-window rows unmount, #2094); then drag it into the rack by name.
+    await page
+      .getByRole("searchbox", { name: "Search devices" })
+      .fill(deviceName);
 
-    const deviceCount = await page.locator(locators.device.paletteItem).count();
-    await expect(deviceCount).toBeGreaterThan(0);
+    await dragDeviceToRack(page, { deviceName });
 
-    // TODO: drag custom device by name, verify 4U height (>60px)
-  });
-
-  test.skip("custom 2U device blocks correct number of rack positions", async ({
-    page,
-  }) => {
-    const addDeviceButton = page.getByTestId("btn-create-custom-device");
-    await addDeviceButton.click();
-
-    const addDeviceDialog = page.getByRole("dialog", { name: "Add Device" });
-    await addDeviceDialog
-      .getByLabel("Name", { exact: true })
-      .fill("Test 2U Storage");
-    const heightInput = addDeviceDialog.getByLabel("Height (U)");
-    await heightInput.click();
-    await heightInput.fill("2");
-    await addDeviceDialog.getByLabel("Category").selectOption("storage");
-
-    await page.getByTestId("btn-add-device").click();
-
-    // TODO: drag custom device by name, verify 2U height (>30px)
+    // The placed device announces its height through its accessible name
+    // (RackDevice ariaLabel: "<name>, <u_height>U <category> at U<n>"). A 4U
+    // device that survived placement announces "4U"; the #166 regression would
+    // announce "1U". Scope to the front face so the full-depth twin on the rear
+    // does not double the match.
+    await expect(
+      page
+        .locator(locators.rackView.front)
+        .getByRole("button", { name: new RegExp(`${deviceName}, 4U`) }),
+    ).toBeVisible();
   });
 });

--- a/e2e/device-name.spec.ts
+++ b/e2e/device-name.spec.ts
@@ -102,10 +102,9 @@ test.describe("Device Custom Names", () => {
     );
   });
 
-  // Known issue: undo doesn't reliably restore original device name — see #1405
-  test.skip("undo/redo works for display name changes", async ({ page }) => {
+  test("undo/redo works for display name changes", async ({ page }) => {
     // Place a device
-    await dragDeviceToRack(page);
+    await dragDeviceToRack(page, { deviceName: "Server" });
     await expect(page.locator(locators.rack.device).first()).toBeVisible();
     await page.locator(locators.rack.device).first().click();
 


### PR DESCRIPTION
Wave 2 of epic #2859. Clears the unconditionally disabled tests in four e2e specs. All three tracking issues on the disabled tests (#1438, #1405, #166) are closed, so this debt was invisible in the tracker.

## Dispositions

| File | Disabled test | Disposition |
| --- | --- | --- |
| basic-workflow.spec.ts | `can replace current rack with a new one` (fixme, empty body) | Deleted: #1438 closed not-planned, v0.2 replace-rack flow removed |
| basic-workflow.spec.ts | `rack appears on canvas after replacement` (fixme, empty body) | Deleted: same dead replace-rack flow |
| basic-workflow.spec.ts | `can clear rack` (fixme, empty body) | Deleted: superseded by live coverage in keyboard.spec.ts (`Delete key removes rack after confirmation`) |
| custom-device.spec.ts | `custom 2U device blocks correct number of rack positions` (skip, assertion-free stub) | Deleted: duplicated the 4U test's intent, no assertions |
| custom-device.spec.ts | `custom 4U device renders with correct height after placement` (skip) | Rewritten into a real 4U placement test |
| device-name.spec.ts | `undo/redo works for display name changes` (skip, cited closed #1405) | Re-enabled: stable over 5 repeats, no product bug |
| android-chrome.spec.ts | `bottom sheet swipe does not trigger Android back gesture` (skip) | Rewritten with CDP `Input.dispatchTouchEvent` (real touch events) |

## Notes

- Custom-device fill() blocker: does NOT reproduce. The old comment claimed Svelte `bind:value` on a number input ignored Playwright `fill()`; the rewritten test creates a 4U device with `fill("4")` and the placed device announces 4U through its accessible name. No `pressSequentially` needed.
- Custom-device height assertion is user-observable: RackDevice's aria-label encodes `u_height` (`"<name>, <u_height>U <category> at U<n>"`), so a device that reverted to 1U (the #166 regression) would announce "1U" and fail. Scoped to the front face to avoid the full-depth rear twin.
- device-name re-enable: STABLE. The undo/redo test passed 5/5 on chromium (`--repeat-each=5`, all 20 runs green). The #1405 rename-undo misbehaviour no longer reproduces, so no new product issue was filed and the skip is gone.
- android-chrome swipe: chose the CDP rewrite over deletion because the android-chrome/android-tablet projects both carry a hasTouch context (Pixel 7 / Galaxy Tab S4 descriptors), swipe-to-dismiss is a real mobile affordance, and mouse synthesis is rejected by Dialog.svelte by design (it starts a drag only for `pointerType` touch/pen on the bare header background). Verified passing on both projects.
- No new tracking issues filed.
- Task 5 (multi-context.ts `collectStorageEvents` early-exit) was optional and skipped: this PR does not otherwise touch that file.

## Verification (local)

- `npm run lint`: clean
- `npm run build`: green
- `npm run check`: only the pre-existing `src/lib/utils/share.ts:452` error remains (zero new)
- e2e (chromium): `custom-device.spec.ts` pass, `basic-workflow.spec.ts` 5/5 pass, `device-name.spec.ts` 20/20 pass (`--repeat-each=5`)
- e2e (android-chrome + android-tablet): swipe-to-dismiss pass; full `Bottom Sheet` describe 8/8 pass

The e2e-self-hosted advisory job stays red until the wave lands; `validate` is the gate.

Closes #2855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdfSncy42Fj4Zoz9zh478A