### PR TITLE
ci: widen the validate merge gate with svelte-check and high-value smoke specs (#2857)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,11 @@ jobs:
       - name: Run unit tests
         run: npm run test:run
 
+      # Typecheck the Svelte + TS sources. Closes the #2794 blindspot where a
+      # svelte-check/tsc error could merge green because no gate ran it.
+      - name: Run svelte-check
+        run: npm run check
+
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/e2e/playwright.smoke.config.ts
+++ b/e2e/playwright.smoke.config.ts
@@ -23,9 +23,12 @@ const cfAccessHeaders =
  *
  * Two modes:
  * - Local mode (no SMOKE_TEST_URL): builds locally, serves on port 4173, and runs
- *   the local-build smoke set (smoke.spec.ts, basic-workflow.spec.ts). These
- *   exercise full UI flows, including state-mutating drag-and-drop, which is safe
- *   against a throwaway local server.
+ *   the local-build smoke set (smoke.spec.ts, basic-workflow.spec.ts,
+ *   keyboard-placement.spec.ts, undo-redo.spec.ts, persistence.spec.ts). These
+ *   exercise full UI flows, including state-mutating drag-and-drop, keyboard
+ *   placement, undo/redo, and save/load persistence, which is safe against a
+ *   throwaway local server. This set is the merge gate (validate job in
+ *   test.yml), so it stays fast and high-signal.
  * - Deploy mode (SMOKE_TEST_URL set): tests against a live URL and runs ONLY the
  *   post-deploy smoke set (deploy-smoke.spec.ts). These are read-only and fast:
  *   they verify the deployed bundle boots, renders, and serves a well-formed
@@ -42,7 +45,13 @@ export default defineConfig({
   testDir: ".",
   testMatch: smokeTestUrl
     ? ["deploy-smoke.spec.ts"]
-    : ["smoke.spec.ts", "basic-workflow.spec.ts"],
+    : [
+        "smoke.spec.ts",
+        "basic-workflow.spec.ts",
+        "keyboard-placement.spec.ts",
+        "undo-redo.spec.ts",
+        "persistence.spec.ts",
+      ],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: 1,

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -448,7 +448,7 @@ function inflateBounded(compressed: Uint8Array): string {
   let result = "";
   let byteLength = 0;
 
-  inflator.onData = (chunk) => {
+  inflator.onData = (chunk: Uint8Array) => {
     byteLength += chunk.length;
     if (byteLength > MAX_DECOMPRESSED_BYTES) {
       // Throw from the chunk callback to abort pako's inflate loop early, so a


### PR DESCRIPTION
## **User description**
## Summary

Widens the `validate` merge gate so more real behaviour and the typecheck
actually block merges. Before this, only `smoke.spec.ts` and
`basic-workflow.spec.ts` functionally gated merges (everything else is advisory
or weekly), and the `validate` job never ran svelte-check, the known #2794
blindspot where a TypeScript/svelte-check error merges green.

Wave 3 of epic #2859.

## Changes

### Prerequisite: fix the pre-existing svelte-check error (share.ts:452)

`npm run check` reported exactly one error before this PR, introduced by #2846:

```
src/lib/utils/share.ts:452:25 Property 'length' does not exist on type 'Data'.
  Property 'length' does not exist on type 'ArrayBuffer'.
```

pako's `Inflate.onData` is typed `onData(chunk: Data): void` where
`Data = Uint8Array | ArrayBuffer`, and `ArrayBuffer` has no `.length`. At
runtime, pako with default options only ever emits `Uint8Array` chunks, so the
fix narrows the callback parameter:

```diff
-  inflator.onData = (chunk) => {
+  inflator.onData = (chunk: Uint8Array) => {
     byteLength += chunk.length;
```

`onData` is declared with method syntax in `@types/pako`, so its parameter is
compared bivariantly, and assigning a `Uint8Array` param is accepted under
strict mode. The annotation is compile-time only, so the byte-accurate
size-guard behaviour is bit-for-bit identical. After the fix, `npm run check`
reports zero errors.

### Add svelte-check to the validate job (closes #2794)

`.github/workflows/test.yml` `validate` job now runs `npm run check` after the
unit tests. Once this merges, every future PR's `validate` run typechecks the
Svelte + TS sources, so a type error can no longer merge green.

### Promote high-value specs into the validate smoke set

`e2e/playwright.smoke.config.ts` local smoke set now also runs
`keyboard-placement.spec.ts`, `undo-redo.spec.ts`, and `persistence.spec.ts`
alongside the existing `smoke.spec.ts` and `basic-workflow.spec.ts`. This
covers keyboard placement, undo/redo, and save/load persistence at the gate.

## Verification

- `npm run check`: 0 errors (was 1).
- `npm run lint`: clean. `npm run test:run`: 3190 passed. `npm run build`: green.
- `npm run test:e2e:smoke` (CI mode, fresh build): 31 tests, 28 passed, 3 skipped
  (the pre-existing v0.2 basic-workflow skips), measured wall-clock ~9.7s
  locally including the build. The three promoted specs pass individually 19/19.
  Well under the ~5-minute budget.

Closes #2857


___

## **CodeAnt-AI Description**
Expand the merge gate to cover more smoke tests and block type errors

### What Changed
- The merge-gate smoke run now includes keyboard placement, undo/redo, and save/load persistence checks in addition to the existing core flows
- The main CI validation job now runs type checking, so Svelte/TypeScript errors fail the merge gate instead of passing unnoticed
- Fixed the share-link decompression check so the type checker passes again without changing the size-limit behavior

### Impact
`✅ Fewer broken UI changes reaching merge`
`✅ Catch type errors before they ship`
`✅ More reliable share-link validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
