### PR TITLE
test: multi-rack e2e gap-fill (duplicate, delete, cross-bay, export) (#2858)

### DIFF
--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -11,6 +11,8 @@ export {
   MEDIUM_RACK_SHARE,
   STANDARD_RACK_SHARE,
   RACK_WITH_DEVICE_SHARE,
+  MULTI_RACK_SHARE,
+  BAYED_RACK_SHARE,
   createTestLayout,
   gotoWithRack,
   gotoMobileWithRack,

--- a/e2e/helpers/test-layouts.ts
+++ b/e2e/helpers/test-layouts.ts
@@ -5,7 +5,10 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import * as pako from "pako";
-import type { MinimalLayout } from "../../src/lib/schemas/share";
+import type {
+  MinimalLayout,
+  MinimalLayoutV2,
+} from "../../src/lib/schemas/share";
 import { locators } from "./locators";
 
 export const { version: APP_VERSION } = JSON.parse(
@@ -79,9 +82,13 @@ function toBinaryString(bytes: Uint8Array): string {
 }
 
 /**
- * Encode a minimal layout object to URL-safe base64
+ * Encode a minimal layout object to URL-safe base64.
+ *
+ * Accepts either a v1 (single-rack `r`) or v2 (multi-rack `rs`) minimal layout.
+ * decodeLayout() detects the version by field presence, so the same pako +
+ * base64url pipeline round-trips both.
  */
-function encodeMinimal(obj: MinimalLayout): string {
+function encodeMinimal(obj: MinimalLayout | MinimalLayoutV2): string {
   const json = JSON.stringify(obj);
   const compressed = pako.deflate(json);
   const base64 = btoa(toBinaryString(compressed));
@@ -102,6 +109,72 @@ export const STANDARD_RACK_SHARE = encodeMinimal(EMPTY_24U_RACK);
 
 /** Rack with one 1U server device pre-placed */
 export const RACK_WITH_DEVICE_SHARE = encodeMinimal(RACK_WITH_DEVICE);
+
+// V2 multi-rack fixtures (share format v2: `rs` for racks, `rg` for groups).
+// Both use the same pako + base64url pipeline as the v1 fixtures above;
+// decodeLayout() detects v2 by the presence of `rs`.
+
+/**
+ * Two standalone 12U racks with distinct names, each carrying one named 1U
+ * server. Useful for multi-rack behaviour (duplicate, delete-one-keep-other,
+ * export composites) where a share-link setup is faster than building two racks
+ * through the UI.
+ */
+const MULTI_RACK_MINIMAL: MinimalLayoutV2 = {
+  v: APP_VERSION,
+  n: "Multi Rack Layout",
+  rs: [
+    {
+      i: "0",
+      n: "Rack Uno",
+      h: 12,
+      w: 19,
+      d: [{ t: "srv", p: 1, f: "front", n: "Widget Uno" }],
+    },
+    {
+      i: "1",
+      n: "Rack Dos",
+      h: 12,
+      w: 19,
+      d: [{ t: "srv", p: 1, f: "front", n: "Widget Dos" }],
+    },
+  ],
+  dt: [{ s: "srv", h: 1, c: "#4A90A4", x: "s" }],
+};
+
+/**
+ * A two-bay bayed group (both 12U), each bay holding a distinctly named 1U
+ * server. Bay 1 (short id "0") holds "Alpha", bay 2 ("1") holds "Beta", so a
+ * test can assert each device renders in its intended bay.
+ */
+const BAYED_RACK_MINIMAL: MinimalLayoutV2 = {
+  v: APP_VERSION,
+  n: "Bayed Rack Layout",
+  rs: [
+    {
+      i: "0",
+      n: "Bay Alpha",
+      h: 12,
+      w: 19,
+      d: [{ t: "srv", p: 1, f: "front", n: "Alpha" }],
+    },
+    {
+      i: "1",
+      n: "Bay Beta",
+      h: 12,
+      w: 19,
+      d: [{ t: "srv", p: 1, f: "front", n: "Beta" }],
+    },
+  ],
+  rg: [{ rs: ["0", "1"], n: "Twin Bay", p: "bayed" }],
+  dt: [{ s: "srv", h: 1, c: "#4A90A4", x: "s" }],
+};
+
+/** Two standalone racks (12U each), each with one named 1U server. */
+export const MULTI_RACK_SHARE = encodeMinimal(MULTI_RACK_MINIMAL);
+
+/** A two-bay bayed group with one named device per bay. */
+export const BAYED_RACK_SHARE = encodeMinimal(BAYED_RACK_MINIMAL);
 
 /**
  * Build a test layout with readable options and return an encoded share link string.

--- a/e2e/multi-rack-gapfill.spec.ts
+++ b/e2e/multi-rack-gapfill.spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Multi-rack gap-fill (#2858, replaces #1230).
+ *
+ * Covers the multi-rack behaviours the existing suites do not:
+ *  - duplicate a rack: its devices are copied and the copies are independent
+ *  - delete a rack: the confirm flow runs, the canvas updates, and a remaining
+ *    rack stays intact
+ *  - cross-bay placement: a bayed group's devices land in their intended bays
+ *  - export composite: an SVG export of a multi-rack layout carries every rack
+ *
+ * multi-rack.spec.ts already covers create/coexist/limit and rack-controls.spec.ts
+ * covers the bay verbs and bay-group formation/extension, so this file does not
+ * repeat them.
+ *
+ * Racks and devices are targeted by accessible name / visible text, never by
+ * positional palette index, and there are no fixed timeouts (Playwright's
+ * web-first assertions auto-wait).
+ */
+import { test, expect } from "./helpers/base-test";
+import type { Locator, Page } from "@playwright/test";
+import {
+  gotoWithRack,
+  createTestLayout,
+  deleteSelectedDevice,
+  clickExport,
+  MULTI_RACK_SHARE,
+  BAYED_RACK_SHARE,
+  locators,
+} from "./helpers";
+
+/** The floating verb bar shown for a rack (or device) selection. */
+function rackActions(page: Page): Locator {
+  return page.getByRole("toolbar", { name: "Rack actions" });
+}
+
+/** The dual-view wrapper for a standalone rack addressed by its exact name. */
+function dualViewByName(page: Page, name: string): Locator {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return page.locator(locators.rackView.dualView).filter({
+    has: page.locator(locators.rackView.dualViewName, {
+      hasText: new RegExp(`^${escaped}$`),
+    }),
+  });
+}
+
+/** Front-view devices inside a named standalone rack. */
+function frontDevicesIn(page: Page, rackName: string): Locator {
+  return dualViewByName(page, rackName).locator(locators.rackView.frontDevice);
+}
+
+/**
+ * Select a standalone rack by clicking its front face and wait for its verb bar.
+ * The click lands on the empty middle of the rack (devices here sit at the top),
+ * so it selects the rack rather than a device.
+ */
+async function selectRack(page: Page, name: string): Promise<void> {
+  await dualViewByName(page, name).locator(locators.rackView.frontSvg).click();
+  await expect(rackActions(page)).toBeVisible();
+}
+
+test.describe("Duplicate rack (#2858)", () => {
+  test("duplicating a rack copies its devices into an independent copy", async ({
+    page,
+  }) => {
+    await gotoWithRack(
+      page,
+      createTestLayout({
+        name: "Dup Layout",
+        rackName: "Original",
+        rackHeight: 12,
+        devices: [
+          { type: "srv", position: 1, face: "front", name: "Widget One" },
+        ],
+        customTypes: [
+          { slug: "srv", height: 1, colour: "#4A90A4", category: "s" },
+        ],
+      }),
+    );
+
+    // Duplicate the populated rack through its verb bar.
+    await selectRack(page, "Original");
+    await page.getByRole("button", { name: "Duplicate selection" }).click();
+
+    // A "(Copy)" sibling appears and both racks carry the copied device.
+    await expect(dualViewByName(page, "Original (Copy)")).toBeVisible();
+    await expect(frontDevicesIn(page, "Original")).toHaveCount(1);
+    await expect(frontDevicesIn(page, "Original (Copy)")).toHaveCount(1);
+
+    // Independence: removing the copy's device must not touch the original.
+    await frontDevicesIn(page, "Original (Copy)").first().click();
+    await deleteSelectedDevice(page);
+
+    await expect(frontDevicesIn(page, "Original (Copy)")).toHaveCount(0);
+    await expect(frontDevicesIn(page, "Original")).toHaveCount(1);
+  });
+});
+
+test.describe("Delete rack (#2858)", () => {
+  test("confirming the delete dialog removes one rack and keeps the other", async ({
+    page,
+  }) => {
+    await gotoWithRack(page, MULTI_RACK_SHARE);
+
+    const fronts = page.locator(locators.rackView.front);
+    await expect(fronts).toHaveCount(2);
+
+    // Delete "Rack Dos" via the verb bar, which opens the confirm dialog.
+    await selectRack(page, "Rack Dos");
+    await page.getByRole("button", { name: "Delete selected" }).click();
+
+    const confirm = page.getByRole("dialog", { name: "Delete Rack" });
+    await expect(confirm).toBeVisible();
+    await expect(confirm).toContainText("Rack Dos");
+    await confirm.getByTestId("btn-confirm-action").click();
+
+    // The canvas drops to a single rack; the untouched rack keeps its device.
+    await expect(fronts).toHaveCount(1);
+    await expect(dualViewByName(page, "Rack Uno")).toBeVisible();
+    await expect(dualViewByName(page, "Rack Dos")).toHaveCount(0);
+    await expect(frontDevicesIn(page, "Rack Uno")).toHaveCount(1);
+  });
+});
+
+test.describe("Cross-bay device placement (#2858)", () => {
+  test("each bay of a bayed group renders its own device", async ({ page }) => {
+    await gotoWithRack(page, BAYED_RACK_SHARE);
+
+    const bayGroup = page.getByRole("group", { name: /bays/ });
+    await expect(bayGroup).toBeVisible();
+
+    const members = bayGroup.locator(locators.bayGroup.frontMemberSvg);
+    await expect(members).toHaveCount(2);
+
+    // Bay 1 holds "Alpha" only; bay 2 holds "Beta" only. Each device landed in
+    // its intended bay, and neither bled into the other.
+    await expect(members.nth(0)).toContainText("Alpha");
+    await expect(members.nth(0)).not.toContainText("Beta");
+    await expect(members.nth(1)).toContainText("Beta");
+    await expect(members.nth(1)).not.toContainText("Alpha");
+  });
+});
+
+test.describe("Export multiple racks (#2858)", () => {
+  test("an SVG export of two racks contains both racks", async ({ page }) => {
+    await gotoWithRack(page, MULTI_RACK_SHARE);
+    await expect(page.locator(locators.rackView.front)).toHaveCount(2);
+
+    await clickExport(page);
+    const dialog = page.getByRole("dialog", { name: "Export" });
+    // Both racks are selected by default; export the composite as SVG.
+    await dialog.getByLabel("Format").selectOption("svg");
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByTestId("btn-export-confirm").click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.svg$/);
+
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+      stream?.on("data", (chunk: Buffer) => chunks.push(chunk));
+      stream?.on("end", () => resolve());
+      stream?.on("error", reject);
+    });
+    const svg = Buffer.concat(chunks).toString("utf-8");
+
+    expect(svg).toContain("Rack Uno");
+    expect(svg).toContain("Rack Dos");
+  });
+});


### PR DESCRIPTION
## **User description**
## What

Fills the multi-rack e2e coverage gaps left by the existing specs. Replaces #1230. Wave 4 of epic #2859.

Existing coverage already handles create/coexist/limit (`multi-rack.spec.ts`) and bay verbs / bay-group formation+extension (`rack-controls.spec.ts`), so this PR does not duplicate them. New tests live in `e2e/multi-rack-gapfill.spec.ts`.

## Gap areas covered

- Duplicate rack: duplicating a populated rack copies its devices, and the copies are independent (removing the copy's device leaves the original's device intact).
- Delete rack: the verb-bar Delete opens the confirm dialog; confirming drops the rack from the canvas while a remaining rack (and its device) stays intact.
- Cross-bay device placement: a two-bay bayed group renders each bay's own device (Bay 1 shows "Alpha" only, Bay 2 shows "Beta" only).
- Export with multiple racks: an SVG export of a two-rack layout contains both rack names.

## Fixtures

Added two v2 (multi-rack share format) fixtures to `e2e/helpers/test-layouts.ts` and exported them from the helpers barrel:

- `MULTI_RACK_SHARE`: two standalone 12U racks ("Rack Uno", "Rack Dos"), each with one named 1U server.
- `BAYED_RACK_SHARE`: a two-bay bayed group, one distinctly named device per bay.

`encodeMinimal` now accepts either a v1 or v2 minimal layout; `decodeLayout` detects the version by field presence.

## Verification

- `npm run test:e2e --project=chromium` for `multi-rack.spec.ts`, `rack-controls.spec.ts`, `multi-rack-gapfill.spec.ts`: 15/15 green.
- New spec on webkit: 4/4 green.
- `npm run lint` clean (complies with the e2e ESLint rules: no querySelector, no toHaveClass, no toHaveLength-literal, no hardcoded colours).
- `npm run build` green.
- `npm run check` adds zero new errors (only the pre-existing `share.ts:452` remains).

Tests use shared helpers, named-device targeting only (no positional palette selection), and web-first assertions (no fixed timeouts).

Note: the e2e-self-hosted advisory job stays red until the earlier waves of epic #2859 land; `validate` is the gate.

Closes #2858


___

## **CodeAnt-AI Description**
**Add multi-rack end-to-end coverage for duplicate, delete, cross-bay, and export flows**

### What Changed
- Added end-to-end tests for duplicating a rack, deleting one rack while keeping another, placing devices in the correct bay, and exporting a layout with multiple racks
- Added reusable multi-rack and bayed-layout fixtures so these scenarios can start from ready-made setups
- Updated shared test layout encoding to support both single-rack and multi-rack share links

### Impact
`✅ Safer multi-rack workflows`
`✅ Fewer missed delete and duplicate regressions`
`✅ Clearer export coverage for layouts with multiple racks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
