### PR TITLE
ci: advisory e2e failure notification and nightly main full-suite run (#2856)

### DIFF
--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -138,6 +138,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TITLE: "Full E2E test suite failing"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           # Dedup on the exact title so this tracker stays separate from other
@@ -147,16 +148,16 @@ jobs:
             --json number,title \
             --jq "map(select(.title == \"$TITLE\")) | first | .number // empty")
           if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --body "Full E2E failed again: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} (${{ github.event_name }}, $(date -u +%Y-%m-%dT%H:%M:%SZ))"
+            gh issue comment "$EXISTING" --body "Full E2E failed again: $RUN_URL ($GITHUB_EVENT_NAME, $(date -u +%Y-%m-%dT%H:%M:%SZ))"
           else
             gh issue create \
               --title "$TITLE" \
               --label "automated,ci-failure" \
               --body "The nightly full E2E test suite failed.
 
-          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          **Trigger:** ${{ github.event_name }}
-          **Ref:** ${{ github.ref }}
+          **Run:** $RUN_URL
+          **Trigger:** $GITHUB_EVENT_NAME
+          **Ref:** $GITHUB_REF
 
           Check the Playwright report artifact for details."
           fi

--- a/.github/workflows/test-full.yml
+++ b/.github/workflows/test-full.yml
@@ -2,7 +2,7 @@ name: Full E2E Tests
 
 on:
   schedule:
-    - cron: "0 6 * * 1" # Monday 6am UTC
+    - cron: "0 6 * * *" # Nightly 6am UTC (full-suite guard on main)
   workflow_call:
   workflow_dispatch:
 
@@ -137,15 +137,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          TITLE: "Full E2E test suite failing"
         run: |
-          EXISTING=$(gh issue list --label ci-failure --state open --limit 1 --json number --jq '.[0].number // empty')
+          set -euo pipefail
+          # Dedup on the exact title so this tracker stays separate from other
+          # ci-failure issues (e.g. the self-hosted advisory tracker in test.yml,
+          # which shares the ci-failure label but uses a different title).
+          EXISTING=$(gh issue list --state open --label ci-failure --limit 100 \
+            --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | first | .number // empty")
           if [ -n "$EXISTING" ]; then
             gh issue comment "$EXISTING" --body "Full E2E failed again: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} (${{ github.event_name }}, $(date -u +%Y-%m-%dT%H:%M:%SZ))"
           else
             gh issue create \
-              --title "Full E2E test suite failing" \
+              --title "$TITLE" \
               --label "automated,ci-failure" \
-              --body "The weekly full E2E test suite failed.
+              --body "The nightly full E2E test suite failed.
 
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           **Trigger:** ${{ github.event_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,6 +263,9 @@ jobs:
     needs: e2e-self-hosted
     if: ${{ !cancelled() && needs.e2e-self-hosted.outputs.e2e_result == 'failure' }}
     runs-on: ubuntu-latest
+    # issues: write is scoped to this GitHub-hosted notification job only, so the
+    # token that can open or comment on issues never runs on the self-hosted
+    # runner; the e2e job itself needs no issue permissions.
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,6 +172,12 @@ jobs:
     # block PRs. continue-on-error keeps the full-suite result visible as signal
     # while letting the overall Test run conclude green.
     continue-on-error: true
+    # Surface the tolerated result to the notify job below. continue-on-error
+    # masks the job result (needs.<job>.result reads 'success' even on failure),
+    # so an always-run capture step records the real outcome into this output and
+    # the notify job keys off it (#2856).
+    outputs:
+      e2e_result: ${{ steps.capture-e2e-outcome.outputs.result }}
     runs-on: [self-hosted, e2e]
     # Parallelise the full suite on the pve-prod ephemeral e2e runner (VMID 360,
     # more cores); playwright.config.ts reads PW_WORKERS (else Playwright default).
@@ -218,7 +224,19 @@ jobs:
         run: npx playwright install --with-deps || npx playwright install
 
       - name: Run full E2E tests
+        id: run-e2e
         run: npm run test:e2e
+
+      # Persist the test result into a job output for the notify job. This step
+      # always runs and always succeeds, so the output is set even when the test
+      # step above fails (which, under continue-on-error, does not fail the run).
+      # Any non-success outcome (a test failure, or an infra failure in an earlier
+      # step that skipped the test) is recorded as a failure to page on; workflow
+      # cancellation is filtered out by the notify job's !cancelled() guard.
+      - name: Capture E2E outcome
+        id: capture-e2e-outcome
+        if: always()
+        run: echo "result=${{ steps.run-e2e.outcome == 'success' && 'success' || 'failure' }}" >> "$GITHUB_OUTPUT"
 
       # The full config (e2e/playwright.config.ts) uses the blob reporter in CI,
       # which writes to blob-report/. View it with `npx playwright merge-reports
@@ -230,6 +248,50 @@ jobs:
           name: blob-report-self-hosted
           path: blob-report/
           retention-days: 7
+
+  # Advisory red must page a human, not wait to be noticed (#2856). Because the
+  # e2e-self-hosted job stays continue-on-error (single-runner SPOF, see above),
+  # its failure is otherwise silent. Mirror the notify-on-failure pattern from
+  # test-full.yml: file one labelled tracking issue, or comment on the existing
+  # one, so repeated failures land on a single issue instead of spamming new
+  # ones. Runs on GitHub-hosted infra with the built-in token + gh, so it uses
+  # reliable infra and keeps the issues-write token off the homelab runner. It
+  # pages when the job ran and did not pass; a runner that never dispatches the
+  # job (fully offline) runs no steps, so it cannot page here.
+  notify-e2e-self-hosted:
+    name: notify on self-hosted e2e failure
+    needs: e2e-self-hosted
+    if: ${{ !cancelled() && needs.e2e-self-hosted.outputs.e2e_result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Notify on failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TITLE: "Self-hosted E2E suite failing (advisory)"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Dedup on the exact title so repeated failures update one issue. The
+          # shared ci-failure label groups CI trackers; the distinct title keeps
+          # this advisory tracker separate from test-full.yml's weekly/nightly one.
+          EXISTING=$(gh issue list --state open --label ci-failure --limit 100 \
+            --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | first | .number // empty")
+          BODY="Advisory self-hosted full E2E suite failed: $RUN_URL ($GITHUB_EVENT_NAME, ref $GITHUB_REF, $(date -u +%Y-%m-%dT%H:%M:%SZ))"
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create \
+              --title "$TITLE" \
+              --label "automated,ci-failure" \
+              --body "$BODY
+
+          This is the additive self-hosted E2E tier (spike #1994): advisory, so it does not block PRs. A notification here means the self-hosted run did not pass: a real test failure, a flake, or an error while the job ran (for example a dependency or browser install failure). A runner that never picks up the job runs no steps and cannot page here, so if runs stop appearing, check that the e2e runner is online. See the blob-report-self-hosted artifact on the run for details."
+          fi
 
   visual:
     name: visual regression

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   webServer: {
     command: "npm run build && npm run preview",
     port: 4173,
+    timeout: 120_000,
     cwd: "..",
   },
   testDir: ".",
@@ -36,11 +37,15 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
       // visual-regression.spec.ts and axe.spec.ts have their own configs
       // (playwright.visual.config.ts, playwright.a11y.config.ts).
+      // deploy-smoke.spec.ts is a live-URL boot check (playwright.smoke.config.ts
+      // in deploy mode); against the local preview it is redundant with the
+      // flows this suite already runs, so it is excluded here.
       testIgnore: [
         "**/ios-safari.spec.ts",
         "**/android-chrome.spec.ts",
         "**/visual-regression.spec.ts",
         "**/axe.spec.ts",
+        "**/deploy-smoke.spec.ts",
       ],
     },
     {
@@ -51,6 +56,7 @@ export default defineConfig({
         "**/android-chrome.spec.ts",
         "**/visual-regression.spec.ts",
         "**/axe.spec.ts",
+        "**/deploy-smoke.spec.ts",
       ],
     },
     // iOS Safari tests


### PR DESCRIPTION
## **User description**
## Summary

Wave 3 of the E2E suite recovery epic (#2859). Implements the "advisory red must page a human" plus nightly-main-guard decision.

The `e2e-self-hosted` job stays `continue-on-error` (single-runner SPOF stays non-blocking), so its failures were silent. This makes them visible.

## Changes

- `.github/workflows/test.yml` (`e2e-self-hosted` job): capture the real test outcome into a job output via an always-run step, because `continue-on-error` masks `needs.<job>.result` (it reads `success` even on failure). A new `notify-e2e-self-hosted` job pages on a real failure by filing, or commenting on, a single labelled tracking issue (deduped on title, so repeated failures land on one issue rather than spamming). It runs on GitHub-hosted infra with the built-in token, keeping the `issues:write` token off the homelab runner.
- `.github/workflows/test-full.yml`: promote the full self-hosted suite to a nightly run on `main` with the same failure notification.
- `e2e/playwright.config.ts`: exclude `deploy-smoke.spec.ts` from the full config desktop projects (it is a live-URL boot check, redundant against local preview), and add a `webServer` timeout for parity with the smoke config.

## Verification

YAML parses and `@action-validator/cli` exits 0 for both workflows; `playwright.config.ts` formatted with prettier 3.9.4.

Note: the `e2e-self-hosted` advisory job stays red until the earlier waves fully land; `validate` is the merge gate.

Closes #2856

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Add advisory alerts for self-hosted E2E failures and run the full suite nightly**

### What Changed
- Self-hosted E2E failures now create or update a single tracking issue instead of staying silent, so failing advisory runs are visible.
- The full E2E suite now runs every night on `main`, and failures are reported on the same kind of tracking issue.
- The full local preview suite now waits longer for the app to start, reducing false failures when the build or preview is slow.
- The local full suite no longer repeats the live-site smoke check, keeping that check in the deploy-focused config instead.

### Impact
`✅ Fewer silent E2E failures`
`✅ Faster awareness of self-hosted test breakage`
`✅ Fewer false failures from slow preview startup`
`✅ Clearer nightly full-suite alerts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
