### PR TITLE
fix: honest placement for half-width oversize devices; height-matched carriers (#2854)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -527,6 +527,7 @@
         setCursor: (rackId, position) =>
           placementStore.setCursor(rackId, position),
         announce: (text) => placementStore.announcePosition(text),
+        abandonPlacement: () => placementStore.abandonPlacement(),
       },
       device,
     );

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -42,6 +42,7 @@
     setCursor: (rackId, position) => placementStore.setCursor(rackId, position),
     announce: (text) => placementStore.announcePosition(text),
     cancelPlacement: () => placementStore.cancelPlacement(),
+    abandonPlacement: () => placementStore.abandonPlacement(),
     placeDevice: (rackId, slug, position, face) =>
       layoutStore.placeDeviceSmart(rackId, slug, position, face),
     completePlacement: (summary) => placementStore.completePlacement(summary),

--- a/src/lib/data/starterLibrary.ts
+++ b/src/lib/data/starterLibrary.ts
@@ -338,6 +338,32 @@ const STARTER_DEVICES: StarterDeviceSpec[] = [
     ],
   },
   {
+    // Height-matched carrier for whole-U half-width gear taller than 1U (#2854).
+    // Same two-column shape as carrier-1u-2col but 2U tall, so a generic 2U
+    // half-width device can rail-mount inside it. Stable synthesis target.
+    slug: "carrier-2u-2col",
+    model: "Carrier (2U, 2 Column)",
+    u_height: 2,
+    category: "shelf",
+    subdevice_role: "parent",
+    slots: [
+      {
+        id: "col-1",
+        name: "Column 1",
+        position: { row: 0, col: 0 },
+        width_fraction: 0.5,
+        height_units: 2,
+      },
+      {
+        id: "col-2",
+        name: "Column 2",
+        position: { row: 0, col: 1 },
+        width_fraction: 0.5,
+        height_units: 2,
+      },
+    ],
+  },
+  {
     slug: "carrier-1u-2x2",
     model: "Carrier (1U, 2x2)",
     u_height: 1,

--- a/src/lib/storage/adapt-legacy-layout.ts
+++ b/src/lib/storage/adapt-legacy-layout.ts
@@ -48,6 +48,8 @@ function legacySlot(d: PlacedDevice): "left" | "right" | "full" | undefined {
 /** Stable synthesized-carrier slugs (defined in C1's starter library). */
 export const CARRIER_2COL_SLUG = "carrier-1u-2col";
 export const CARRIER_2X2_SLUG = "carrier-1u-2x2";
+/** Height-matched 2U carrier for whole-U half-width gear taller than 1U (#2854). */
+export const CARRIER_2U_2COL_SLUG = "carrier-2u-2col";
 
 /** Slot ids on carrier-1u-2col (full-height half-width columns). */
 const COL_SLOTS = ["col-1", "col-2"] as const;
@@ -58,6 +60,7 @@ const GRID_SLOTS = ["r0-c0", "r0-c1", "r1-c0", "r1-c1"] as const;
 const KNOWN_CARRIER_SLUGS = new Set<string>([
   CARRIER_2COL_SLUG,
   CARRIER_2X2_SLUG,
+  CARRIER_2U_2COL_SLUG,
 ]);
 
 /** A rack-level device has none of the child-placement markers set. */

--- a/src/lib/utils/collision.ts
+++ b/src/lib/utils/collision.ts
@@ -398,6 +398,7 @@ export function canPlaceInSlot(childType: DeviceType, slot: Slot): boolean {
  */
 export const CARRIER_2COL_SLUG = "carrier-1u-2col";
 export const CARRIER_2X2_SLUG = "carrier-1u-2x2";
+export const CARRIER_2U_2COL_SLUG = "carrier-2u-2col";
 
 /**
  * Whether a device must mount inside a carrier rather than directly on the
@@ -437,14 +438,22 @@ export function isWholeURailPosition(positionInternal: number): boolean {
 /**
  * Pick the carrier slug that a half-width device must mount inside, based on
  * its height. Both synthesised carriers have half-width cells, so only
- * half-width gear can be carrier-mounted: a half-height device needs the 2x2
- * grid; a full-height device needs the 1-row 2-column carrier.
+ * half-width gear can be carrier-mounted: a sub-U device needs the 2x2 grid; a
+ * whole-U device needs a height-matched column carrier (1U or 2U).
  *
- * Full-width devices (sub-U or whole-U) return null: there is no full-width
- * carrier to synthesise, so they are not routed through the carrier path.
+ * Returns null (no rail carrier) when:
+ * - the device is full-width (there is no full-width carrier to synthesise);
+ * - the device is a chassis child (subdevice_role "child") - it mounts only
+ *   inside an existing parent bay, never on the rails;
+ * - the whole-U height has no matching carrier defined (e.g. a 3U half-width) -
+ *   returning a too-small carrier is exactly the bug this replaced (#2854).
+ *
+ * A null result for a device that `requiresCarrier` is true for is the honest
+ * "cannot rail-mount, needs a chassis" signal the placement layers share (see
+ * `requiresChassisBay`).
  *
  * @param deviceType - The device being placed
- * @returns The carrier slug to synthesise, or null when no carrier applies
+ * @returns The carrier slug to synthesise, or null when no rail carrier applies
  */
 export function synthesizeCarrierForDevice(
   deviceType: DeviceType,
@@ -454,11 +463,45 @@ export function synthesizeCarrierForDevice(
     return null;
   }
 
-  // Sub-U (half-height) devices need the 2x2 grid; a full-height half-width
-  // device uses the 2-column carrier.
-  return Number.isInteger(deviceType.u_height)
-    ? CARRIER_2COL_SLUG
-    : CARRIER_2X2_SLUG;
+  // Chassis children never get a rail carrier: they mount only inside an
+  // existing parent bay.
+  if (deviceType.subdevice_role === "child") {
+    return null;
+  }
+
+  // Sub-U / non-integer heights use the 2x2 grid carrier.
+  if (!Number.isInteger(deviceType.u_height)) {
+    return CARRIER_2X2_SLUG;
+  }
+
+  // Whole-U half-width gear uses a height-matched column carrier. Heights with
+  // no matching carrier return null rather than a too-small carrier.
+  if (deviceType.u_height === 1) return CARRIER_2COL_SLUG;
+  if (deviceType.u_height === 2) return CARRIER_2U_2COL_SLUG;
+  return null;
+}
+
+/**
+ * Whether a device can never register on the rails, even inside a synthesised
+ * carrier, so it can be placed ONLY inside an existing chassis/carrier bay. It
+ * requires a carrier (half-width / sub-U / non-integer) but no carrier can be
+ * synthesised for it - a chassis child, or a half-width device whose integer
+ * height has no matching carrier.
+ *
+ * This is the single predicate the preview (resolveDropTarget), the keyboard
+ * (validStartPositions / primeKeyboardPlacement), and the store (placeDeviceSmart
+ * via placeDeviceRecorded's requiresCarrier guard) share so bare-rails validity
+ * agrees across all three: an invalid preview, no announced rail slot, and a
+ * refused placement, all with the honest "requires a chassis" message.
+ *
+ * @param deviceType - The device being placed
+ * @returns true when the device cannot rail-mount and needs an existing bay
+ */
+export function requiresChassisBay(deviceType: DeviceType): boolean {
+  return (
+    requiresCarrier(deviceType) &&
+    synthesizeCarrierForDevice(deviceType) === null
+  );
 }
 
 /**

--- a/src/lib/utils/collision.ts
+++ b/src/lib/utils/collision.ts
@@ -469,9 +469,14 @@ export function synthesizeCarrierForDevice(
     return null;
   }
 
-  // Sub-U / non-integer heights use the 2x2 grid carrier.
-  if (!Number.isInteger(deviceType.u_height)) {
+  // Sub-1U gear uses the 2x2 grid carrier (its cells are half-U tall). A
+  // non-integer height at or above 1U has no matching carrier, so it falls
+  // through to null rather than a too-small carrier.
+  if (deviceType.u_height < 1) {
     return CARRIER_2X2_SLUG;
+  }
+  if (!Number.isInteger(deviceType.u_height)) {
+    return null;
   }
 
   // Whole-U half-width gear uses a height-matched column carrier. Heights with

--- a/src/lib/utils/placement-keyboard-controller.ts
+++ b/src/lib/utils/placement-keyboard-controller.ts
@@ -18,12 +18,14 @@
  */
 
 import type { Rack, DeviceType, DeviceFace } from "$lib/types";
+import { requiresChassisBay } from "./collision";
 import {
   validStartPositions,
   initialCursorPosition,
   nextCursorPosition,
   pickUpAnnouncement,
   pickUpNoSpaceAnnouncement,
+  pickUpNeedsChassisAnnouncement,
   positionAnnouncement,
   noSpaceAnnouncement,
   singleRackAnnouncement,
@@ -48,6 +50,8 @@ export interface PlacementKeyboardDeps {
   setCursor: (rackId: string, position: number | null) => void;
   announce: (text: string) => void;
   cancelPlacement: () => void;
+  /** Silently exit placement mode (no "cancelled" announcement). */
+  abandonPlacement: () => void;
   /** Place the armed device. Returns true on success. */
   placeDevice: (
     rackId: string,
@@ -91,6 +95,7 @@ export type PlacementPrimeDeps = Pick<
   | "setActiveRack"
   | "setCursor"
   | "announce"
+  | "abandonPlacement"
 >;
 
 function resolveActiveRack(deps: PlacementPrimeDeps): Rack | null {
@@ -122,6 +127,16 @@ export function primeKeyboardPlacement(
   deps: PlacementPrimeDeps,
   device: DeviceType,
 ): void {
+  // A device that can only mount inside a chassis bay (a chassis child, or a
+  // half-width device with no rail carrier) has no rail target in any rack.
+  // State the honest requirement and exit placement mode rather than arming a
+  // futile cursor the user could only Escape out of (#2854).
+  if (requiresChassisBay(device)) {
+    deps.abandonPlacement();
+    deps.announce(pickUpNeedsChassisAnnouncement(device));
+    return;
+  }
+
   const rack = resolveActiveRack(deps);
   if (!rack) {
     // Armed with no rack to place into: say so rather than fall silent.
@@ -261,6 +276,10 @@ export function createPlacementKeyboardController(deps: PlacementKeyboardDeps) {
     if (deps.getCursorPosition() == null) {
       if (!navOrPlaceKeys.includes(event.key)) return false;
       primeCursor(device);
+      // Priming may have exited placement mode (e.g. a chassis child has no rail
+      // target): consume the key and stop rather than fall through to place(),
+      // which would re-announce a misleading "No space" (#2854).
+      if (!deps.isPlacing()) return true;
       if (event.key === "ArrowUp" || event.key === "ArrowDown") return true;
     }
 

--- a/src/lib/utils/placement-keyboard.ts
+++ b/src/lib/utils/placement-keyboard.ts
@@ -15,6 +15,7 @@
 
 import type { Rack, DeviceType, DeviceFace } from "$lib/types";
 import { getDropFeedback } from "./dragdrop";
+import { requiresChassisBay } from "./collision";
 
 /**
  * Whole-U start positions (1-indexed, human units, ascending) where `device`
@@ -28,6 +29,11 @@ export function validStartPositions(
   device: DeviceType,
   face: DeviceFace = "front",
 ): number[] {
+  // A device that can only live in a chassis bay (a chassis child, or a
+  // half-width device with no rail carrier) has no valid rail start position:
+  // announcing one would be dishonest and Enter would fail (#2854).
+  if (requiresChassisBay(device)) return [];
+
   const positions: number[] = [];
   const deviceHeight = device.u_height;
   const lastStart = rack.height - deviceHeight + 1;
@@ -120,6 +126,17 @@ export function pickUpNoSpaceAnnouncement(
 ): string {
   const name = device.model ?? device.slug;
   return `Placing ${name}. No space in ${rackName}. Tab to switch racks, Escape to cancel.`;
+}
+
+/**
+ * Announced when a device that can only mount inside a chassis bay (a chassis
+ * child, or a half-width device with no rail carrier) is armed: it has no rail
+ * target in any rack, so the honest requirement is stated and placement mode
+ * exits rather than leaving a stuck, futile cursor (#2854).
+ */
+export function pickUpNeedsChassisAnnouncement(device: DeviceType): string {
+  const name = device.model ?? device.slug;
+  return `${name} must be placed in a chassis bay. Drop it onto a chassis.`;
 }
 
 /**

--- a/src/lib/utils/rack-drop-coordinator.ts
+++ b/src/lib/utils/rack-drop-coordinator.ts
@@ -24,6 +24,19 @@ import { findDeviceType } from "$lib/utils/device-lookup";
 import { getDeviceDisplayName } from "$lib/utils/device";
 import { screenToSVG } from "$lib/utils/coordinates";
 
+/**
+ * The rail height of a synthesised carrier, defaulting to 1U if the slug is
+ * somehow absent from the library (defensive: the synthesised carriers are
+ * always present). Shared by resolveDropTarget and resolveDropAction so both
+ * validate the same rail footprint.
+ */
+function getCarrierHeight(
+  carrierSlug: string,
+  deviceLibrary: DeviceType[],
+): number {
+  return findDeviceType(carrierSlug, deviceLibrary)?.u_height ?? 1;
+}
+
 /** Pixel-based measurements of a rack, used by the drop calculation pipeline. */
 export interface RackDimensions {
   rackHeight: number;
@@ -221,8 +234,7 @@ export function resolveDropTarget(
     feedback = "valid";
   } else if (carrierSlug) {
     // Synthesise a rail carrier at this U: validate its full rail footprint.
-    const carrierHeight =
-      findDeviceType(carrierSlug, deviceLibrary)?.u_height ?? 1;
+    const carrierHeight = getCarrierHeight(carrierSlug, deviceLibrary);
     feedback = getDropFeedback(
       rack,
       deviceLibrary,
@@ -317,8 +329,7 @@ export function resolveDropAction(
   // carrier at the target U via the store. Validate the carrier's full rail
   // footprint (height-matched: a 2U carrier needs 2U of clear rail).
   if (carrierSlug) {
-    const carrierHeight =
-      findDeviceType(carrierSlug, deviceLibrary)?.u_height ?? 1;
+    const carrierHeight = getCarrierHeight(carrierSlug, deviceLibrary);
     const carrierFeedback = getDropFeedback(
       rack,
       deviceLibrary,

--- a/src/lib/utils/rack-drop-coordinator.ts
+++ b/src/lib/utils/rack-drop-coordinator.ts
@@ -18,7 +18,9 @@ import {
 import {
   findCollisions,
   synthesizeCarrierForDevice,
+  requiresChassisBay,
 } from "$lib/utils/collision";
+import { findDeviceType } from "$lib/utils/device-lookup";
 import { getDeviceDisplayName } from "$lib/utils/device";
 import { screenToSVG } from "$lib/utils/coordinates";
 
@@ -105,6 +107,12 @@ export type DropAction =
       targetU: number;
       deviceHeight: number;
       excludeIndex?: number;
+      /**
+       * Explicit user-facing message that overrides the collision-derived one.
+       * Set for the honest "requires a chassis" case (a chassis child dropped on
+       * bare rails), which has no colliding device to name.
+       */
+      message?: string;
     };
 
 /**
@@ -181,36 +189,61 @@ export function resolveDropTarget(
     faceFilter,
   );
 
-  // Carrier-first: a sub-U / half-width device never lands on a bare rail. Its
-  // preview is valid when an existing carrier under the cursor has a free,
-  // fitting cell (resolvable drop target, not mere compatibility), or else when
-  // a synthesised 1U carrier would fit at this U.
-  const needsCarrier = synthesizeCarrierForDevice(device) !== null;
-  const resolvableContainerTarget = needsCarrier
-    ? detectContainerDropTarget(
-        rack,
-        deviceLibrary,
-        device,
-        mouseY,
-        xOffsetInRack,
-        dims.rackWidth,
-        dims.rackHeight,
-        dims.uHeight,
-        faceFilter,
-      )
-    : null;
-  const feedback = needsCarrier
-    ? resolvableContainerTarget
-      ? "valid"
-      : getDropFeedback(rack, deviceLibrary, 1, targetU, excludeIndex, "both")
-    : getDropFeedback(
-        rack,
-        deviceLibrary,
-        device.u_height,
-        targetU,
-        excludeIndex,
-        faceFilter,
-      );
+  // Carrier-first: a sub-U / half-width device (including a chassis child) never
+  // lands on a bare rail. Its preview is valid when an existing container under
+  // the cursor has a free, fitting cell (a resolvable bay), or else - for a
+  // device that can synthesise its own rail carrier - when that carrier's full
+  // footprint would fit at this U. A device that requires a carrier but has none
+  // synthesisable (a chassis child) is INVALID on bare rails: it can only go
+  // into an existing bay. This mirrors placeDeviceSmart so preview and placement
+  // agree.
+  const carrierSlug = synthesizeCarrierForDevice(device);
+  const needsBay = requiresChassisBay(device);
+  // Both a carrier-synthesising device and a bay-only device can drop into an
+  // existing container cell under the cursor.
+  const resolvableContainerTarget =
+    carrierSlug !== null || needsBay
+      ? detectContainerDropTarget(
+          rack,
+          deviceLibrary,
+          device,
+          mouseY,
+          xOffsetInRack,
+          dims.rackWidth,
+          dims.rackHeight,
+          dims.uHeight,
+          faceFilter,
+        )
+      : null;
+
+  let feedback: DropFeedback;
+  if (resolvableContainerTarget) {
+    feedback = "valid";
+  } else if (carrierSlug) {
+    // Synthesise a rail carrier at this U: validate its full rail footprint.
+    const carrierHeight =
+      findDeviceType(carrierSlug, deviceLibrary)?.u_height ?? 1;
+    feedback = getDropFeedback(
+      rack,
+      deviceLibrary,
+      carrierHeight,
+      targetU,
+      excludeIndex,
+      "both",
+    );
+  } else if (needsBay) {
+    // Requires a chassis bay but none is under the cursor: honestly invalid.
+    feedback = "invalid";
+  } else {
+    feedback = getDropFeedback(
+      rack,
+      deviceLibrary,
+      device.u_height,
+      targetU,
+      excludeIndex,
+      faceFilter,
+    );
+  }
 
   return {
     targetU,
@@ -281,12 +314,15 @@ export function resolveDropAction(
   const excludeIndex = deriveExcludeIndex(dragData, rack.id);
 
   // No container under the cursor: a carriable device synthesises (or fills) a
-  // carrier at the target U via the store. Validate the 1U carrier rail slot.
+  // carrier at the target U via the store. Validate the carrier's full rail
+  // footprint (height-matched: a 2U carrier needs 2U of clear rail).
   if (carrierSlug) {
+    const carrierHeight =
+      findDeviceType(carrierSlug, deviceLibrary)?.u_height ?? 1;
     const carrierFeedback = getDropFeedback(
       rack,
       deviceLibrary,
-      1,
+      carrierHeight,
       targetU,
       excludeIndex,
       "both",
@@ -296,7 +332,7 @@ export function resolveDropAction(
         kind: "invalid",
         feedback: carrierFeedback,
         targetU,
-        deviceHeight: 1,
+        deviceHeight: carrierHeight,
         excludeIndex,
       };
     }
@@ -307,6 +343,22 @@ export function resolveDropAction(
       targetU,
       face: faceFilter ?? "front",
       dragData,
+    };
+  }
+
+  // A device that requires a carrier but has none synthesisable (a chassis
+  // child) can only go into an existing chassis bay - handled above when the
+  // cursor is over one. On bare rails it is honestly invalid: say it needs a
+  // chassis rather than fall through to a rail placement the store would refuse
+  // with a misleading "No space".
+  if (requiresChassisBay(dragData.device)) {
+    return {
+      kind: "invalid",
+      feedback: "invalid",
+      targetU,
+      deviceHeight: dragData.device.u_height,
+      excludeIndex,
+      message: chassisRequirementMessage(dragData.device),
     };
   }
 
@@ -369,6 +421,16 @@ export function resolveDropAction(
     slug: dragData.device.slug,
     targetU,
   };
+}
+
+/**
+ * Honest message for a device that can only mount inside a chassis bay (a
+ * chassis child, or a half-width device with no rail carrier). Shown instead of
+ * a misleading "No space" when such a device is dropped on bare rails.
+ */
+export function chassisRequirementMessage(device: DeviceType): string {
+  const name = device.model ?? device.slug;
+  return `${name} must be placed in a chassis bay`;
 }
 
 /**

--- a/src/lib/utils/rack-drop-handlers.ts
+++ b/src/lib/utils/rack-drop-handlers.ts
@@ -176,15 +176,19 @@ export function dispatchDropAction(
     case "invalid": {
       hapticError();
       if (collisionContext) {
-        const message = buildCollisionMessage(
-          action.feedback,
-          collisionContext.rack,
-          collisionContext.deviceLibrary,
-          action.deviceHeight,
-          action.targetU,
-          action.excludeIndex,
-          collisionContext.faceFilter,
-        );
+        // An explicit message (e.g. the honest "requires a chassis" case) wins
+        // over the collision-derived one, which has no device to name here.
+        const message =
+          action.message ??
+          buildCollisionMessage(
+            action.feedback,
+            collisionContext.rack,
+            collisionContext.deviceLibrary,
+            action.deviceHeight,
+            action.targetU,
+            action.excludeIndex,
+            collisionContext.faceFilter,
+          );
         if (message) {
           collisionContext.toastStore.showToast(message, "warning", 3000);
         }

--- a/src/tests/chassis-child-placement.test.ts
+++ b/src/tests/chassis-child-placement.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Honest placement for half-width oversize devices (#2854).
+ *
+ * Two decisions, one regression suite:
+ *
+ * 1. CHASSIS CHILDREN (subdevice_role === "child", e.g. blade servers) mount
+ *    ONLY into an existing chassis bay. They can never rail-mount, not even
+ *    inside a synthesised carrier. The three placement layers must agree that a
+ *    bare-rails drop is INVALID and say so honestly ("requires a chassis"), not
+ *    "No space":
+ *      - synthesizeCarrierForDevice returns null (no rail carrier)
+ *      - requiresChassisBay is true
+ *      - resolveDropTarget preview feedback is "invalid" on bare rails
+ *      - validStartPositions announces no rail slots (keyboard honesty)
+ *      - placeDeviceSmart refuses the placement
+ *      - resolveDropAction returns invalid with an honest chassis message
+ *    Placing a blade INTO a chassis bay stays valid and unchanged.
+ *
+ * 2. GENERIC HALF-WIDTH gear taller than 1U (no child role, e.g. the DeskPi
+ *    2U 4-Pi RackMate) IS placeable on the rails via a height-matched carrier.
+ *    synthesizeCarrierForDevice selects carrier-2u-2col (2U) so placeDeviceSmart
+ *    can actually place it, and the preview reports it valid.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Control the resolved SVG coordinate without a real DOM geometry. The feedback
+// decision under test is downstream of the coordinate math (which is unchanged).
+vi.mock("$lib/utils/coordinates", async (importActual) => {
+  const actual = await importActual<typeof import("$lib/utils/coordinates")>();
+  return { ...actual, screenToSVG: vi.fn(() => ({ x: 100, y: 200 })) };
+});
+
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import { findStarterDevice } from "$lib/data/starterLibrary";
+import { findBrandDevice } from "$lib/data/brandPacks";
+import { findDeviceType } from "$lib/utils/device-lookup";
+import {
+  synthesizeCarrierForDevice,
+  requiresChassisBay,
+  requiresCarrier,
+} from "$lib/utils/collision";
+import { validStartPositions } from "$lib/utils/placement-keyboard";
+import {
+  resolveDropTarget,
+  resolveDropAction,
+  type RackDimensions,
+  type DropCoordinateInput,
+} from "$lib/utils/rack-drop-coordinator";
+import { createTestRack } from "./factories";
+import type { DeviceType } from "$lib/types";
+
+beforeEach(() => {
+  resetLayoutStore();
+  resetHistoryStore();
+});
+
+/** The real chassis children: half-width, subdevice_role "child", oversize. */
+const bladeHalf = findStarterDevice("blade-server-half")!; // 2U child
+const bladeFull = findStarterDevice("blade-server-full")!; // 4U child
+/** A real generic 2U half-width device (no child role): DeskPi 2U 4-Pi tray. */
+const genericTwoU = findBrandDevice("deskpi-rackmate-2u-4-pi")!; // 2U half-width
+
+// =============================================================================
+// synthesizeCarrierForDevice — height-driven selection, null for children
+// =============================================================================
+
+describe("synthesizeCarrierForDevice (height-matched, child-aware)", () => {
+  it("returns null for a chassis child regardless of height (2U blade)", () => {
+    expect(synthesizeCarrierForDevice(bladeHalf)).toBeNull();
+  });
+
+  it("returns null for a chassis child regardless of height (4U blade)", () => {
+    expect(synthesizeCarrierForDevice(bladeFull)).toBeNull();
+  });
+
+  it("returns the 2U carrier for a generic 2U half-width device", () => {
+    expect(synthesizeCarrierForDevice(genericTwoU)).toBe("carrier-2u-2col");
+  });
+
+  it("still returns the 1U carrier for a generic 1U half-width device", () => {
+    const oneU: DeviceType = {
+      slug: "one-u-half",
+      model: "One U Half",
+      u_height: 1,
+      slot_width: 1,
+      category: "network",
+      colour: "#4A90D9",
+    };
+    expect(synthesizeCarrierForDevice(oneU)).toBe("carrier-1u-2col");
+  });
+
+  it("still returns the 2x2 carrier for a sub-U half-width device", () => {
+    const halfU: DeviceType = {
+      slug: "half-u",
+      model: "Half U",
+      u_height: 0.5,
+      slot_width: 1,
+      category: "network",
+      colour: "#4A90D9",
+    };
+    expect(synthesizeCarrierForDevice(halfU)).toBe("carrier-1u-2x2");
+  });
+
+  it("returns null (not a too-small carrier) for an integer height with no carrier", () => {
+    const threeU: DeviceType = {
+      slug: "three-u-half",
+      model: "Three U Half",
+      u_height: 3,
+      slot_width: 1,
+      category: "network",
+      colour: "#4A90D9",
+    };
+    expect(synthesizeCarrierForDevice(threeU)).toBeNull();
+  });
+
+  it("returns null for a full-width whole-U device", () => {
+    const fullWidth: DeviceType = {
+      slug: "server-1u",
+      model: "Server",
+      u_height: 1,
+      slot_width: 2,
+      category: "server",
+      colour: "#4A90D9",
+    };
+    expect(synthesizeCarrierForDevice(fullWidth)).toBeNull();
+  });
+});
+
+// =============================================================================
+// requiresChassisBay — the shared predicate for the three layers
+// =============================================================================
+
+describe("requiresChassisBay", () => {
+  it("is true for a chassis child (requires a carrier but none synthesisable)", () => {
+    expect(requiresChassisBay(bladeHalf)).toBe(true);
+    expect(requiresChassisBay(bladeFull)).toBe(true);
+    // The child still requires a carrier; it just cannot get a rail one.
+    expect(requiresCarrier(bladeHalf)).toBe(true);
+  });
+
+  it("is false for a generic half-width device that has a rail carrier", () => {
+    expect(requiresChassisBay(genericTwoU)).toBe(false);
+  });
+
+  it("is false for a full-width whole-U rail device", () => {
+    const fullWidth: DeviceType = {
+      slug: "server-1u",
+      model: "Server",
+      u_height: 1,
+      slot_width: 2,
+      category: "server",
+      colour: "#4A90D9",
+    };
+    expect(requiresChassisBay(fullWidth)).toBe(false);
+  });
+});
+
+// =============================================================================
+// validStartPositions — keyboard honesty (layer 2)
+// =============================================================================
+
+describe("validStartPositions (keyboard honesty)", () => {
+  it("announces NO rail slots for a chassis child on an empty rack", () => {
+    const rack = createTestRack({ height: 12, devices: [] });
+    expect(validStartPositions(rack, [], bladeHalf, "front")).toEqual([]);
+  });
+
+  it("announces rail slots for a generic 2U half-width device", () => {
+    const rack = createTestRack({ height: 12, devices: [] });
+    // A 2U carrier fits at U1..U11 on an empty 12U rack.
+    expect(
+      validStartPositions(rack, [], genericTwoU, "front").length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// placeDeviceSmart — actual placement (layer 3)
+// =============================================================================
+
+describe("placeDeviceSmart (store) honesty", () => {
+  type Store = NonNullable<ReturnType<typeof getLayoutStore>>;
+
+  function setupRack(height = 12): { store: Store; rackId: string } {
+    const store = getLayoutStore()!;
+    const rack = store.addRack("Test Rack", height);
+    return { store, rackId: rack!.id };
+  }
+
+  it("refuses a chassis child on the bare rails (no carrier synthesised)", () => {
+    const { store, rackId } = setupRack();
+    store.addDeviceTypeRaw(bladeHalf);
+
+    expect(store.placeDeviceSmart(rackId, bladeHalf.slug, 5)).toBe(false);
+    // Nothing lands on the rails: no child, and no phantom carrier.
+    expect(store.rack!.devices.length).toBe(0);
+  });
+
+  it("places a generic 2U half-width device via a synthesised 2U carrier", () => {
+    const { store, rackId } = setupRack();
+    store.addDeviceTypeRaw(genericTwoU);
+
+    expect(store.placeDeviceSmart(rackId, genericTwoU.slug, 5)).toBe(true);
+
+    const carrier = store.rack!.devices.find((d) =>
+      d.device_type.startsWith("carrier"),
+    );
+    expect(carrier?.device_type).toBe("carrier-2u-2col");
+    expect(carrier?.auto_created).toBe(true);
+
+    const child = store.rack!.devices.find(
+      (d) => d.container_id === carrier?.id,
+    );
+    expect(child?.device_type).toBe(genericTwoU.slug);
+  });
+
+  it("places a 2U half-width blank via the 2U carrier (blank is carried, not bay-only)", () => {
+    // A half-width blank is exempt from requiresCarrier but is still half-width,
+    // so it mounts inside a synthesised carrier. The height-matched 2U carrier
+    // lets a 2U half blank place where the old 1U carrier could not (#2854).
+    const { store, rackId } = setupRack();
+    const blank2u = findStarterDevice("2u-half-blank")!;
+    store.addDeviceTypeRaw(blank2u);
+
+    expect(requiresChassisBay(blank2u)).toBe(false);
+    expect(store.placeDeviceSmart(rackId, blank2u.slug, 5)).toBe(true);
+
+    const carrier = store.rack!.devices.find((d) =>
+      d.device_type.startsWith("carrier"),
+    );
+    expect(carrier?.device_type).toBe("carrier-2u-2col");
+  });
+});
+
+// =============================================================================
+// Chassis-bay placement is unchanged (blades still mount into a chassis)
+// =============================================================================
+
+describe("chassis-bay placement (unchanged)", () => {
+  it("places a blade child into a real chassis bay", () => {
+    const store = getLayoutStore()!;
+    const chassis = findStarterDevice("blade-chassis-4u")!;
+    store.addDeviceTypeRaw(chassis);
+    store.addDeviceTypeRaw(bladeHalf);
+
+    const rack = store.addRack("Test Rack", 42)!;
+    store.placeDevice(rack.id, chassis.slug, 5);
+    const placedChassis = store.rack!.devices.find(
+      (d) => d.device_type === chassis.slug,
+    )!;
+
+    const ok = store.placeInContainer(
+      rack.id,
+      bladeHalf.slug,
+      placedChassis.id,
+      "bay-1",
+      0,
+    );
+    expect(ok).toBe(true);
+
+    const child = store.rack!.devices.find(
+      (d) => d.container_id === placedChassis.id,
+    );
+    expect(child?.device_type).toBe(bladeHalf.slug);
+    expect(child?.slot_id).toBe("bay-1");
+  });
+});
+
+// =============================================================================
+// resolveDropTarget / resolveDropAction — preview + drop agreement (layer 1)
+// =============================================================================
+
+describe("resolveDropTarget / resolveDropAction (bare-rails agreement)", () => {
+  const dims: RackDimensions = {
+    rackHeight: 12, // rack height in U (matches Rack.svelte's rack.height)
+    rackWidth: 220,
+    interiorWidth: 220 - 17 * 2,
+    uHeight: 22,
+    rackPadding: 0,
+    railWidth: 17,
+  };
+  const coords: DropCoordinateInput = {
+    svgElement: {} as SVGSVGElement,
+    clientX: 100,
+    clientY: 200,
+  };
+
+  function emptyRack() {
+    return createTestRack({ height: 12, devices: [] });
+  }
+
+  it("previews a chassis child as INVALID on bare rails", () => {
+    const result = resolveDropTarget(
+      coords,
+      dims,
+      emptyRack(),
+      [],
+      bladeHalf,
+      "front",
+    );
+    expect(result.feedback).toBe("invalid");
+  });
+
+  it("previews a generic 2U half-width device as VALID on bare rails", () => {
+    const result = resolveDropTarget(
+      coords,
+      dims,
+      emptyRack(),
+      [],
+      genericTwoU,
+      "front",
+    );
+    // Carrier-2u-2col is resolvable at this U on an empty rack.
+    expect(findDeviceType("carrier-2u-2col")).toBeDefined();
+    expect(result.feedback).toBe("valid");
+  });
+
+  it("resolves a chassis-child bare-rails drop to invalid with an honest chassis message", () => {
+    const action = resolveDropAction(
+      coords,
+      dims,
+      emptyRack(),
+      [],
+      { type: "palette", device: bladeHalf },
+      "front",
+    );
+    expect(action.kind).toBe("invalid");
+    if (action.kind === "invalid") {
+      expect(action.message).toBeDefined();
+      expect(action.message).toMatch(/chassis/i);
+      expect(action.message).not.toMatch(/no space/i);
+    }
+  });
+
+  it("resolves a generic 2U half-width bare-rails drop to a carrier-drop", () => {
+    const action = resolveDropAction(
+      coords,
+      dims,
+      emptyRack(),
+      [],
+      { type: "palette", device: genericTwoU },
+      "front",
+    );
+    expect(action.kind).toBe("carrier-drop");
+    if (action.kind === "carrier-drop") {
+      expect(action.slug).toBe(genericTwoU.slug);
+    }
+  });
+});

--- a/src/tests/chassis-child-placement.test.ts
+++ b/src/tests/chassis-child-placement.test.ts
@@ -60,6 +60,15 @@ const bladeHalf = findStarterDevice("blade-server-half")!; // 2U child
 const bladeFull = findStarterDevice("blade-server-full")!; // 4U child
 /** A real generic 2U half-width device (no child role): DeskPi 2U 4-Pi tray. */
 const genericTwoU = findBrandDevice("deskpi-rackmate-2u-4-pi")!; // 2U half-width
+/** A full-width whole-U rail device: no carrier applies, never a chassis bay. */
+const fullWidthRail: DeviceType = {
+  slug: "server-1u",
+  model: "Server",
+  u_height: 1,
+  slot_width: 2,
+  category: "server",
+  colour: "#4A90D9",
+};
 
 // =============================================================================
 // synthesizeCarrierForDevice — height-driven selection, null for children
@@ -114,16 +123,20 @@ describe("synthesizeCarrierForDevice (height-matched, child-aware)", () => {
     expect(synthesizeCarrierForDevice(threeU)).toBeNull();
   });
 
-  it("returns null for a full-width whole-U device", () => {
-    const fullWidth: DeviceType = {
-      slug: "server-1u",
-      model: "Server",
-      u_height: 1,
-      slot_width: 2,
-      category: "server",
+  it("returns null (not a too-small carrier) for a non-integer height at or above 1U", () => {
+    const oneAndHalf: DeviceType = {
+      slug: "one-half-u",
+      model: "One and a Half U",
+      u_height: 1.5,
+      slot_width: 1,
+      category: "network",
       colour: "#4A90D9",
     };
-    expect(synthesizeCarrierForDevice(fullWidth)).toBeNull();
+    expect(synthesizeCarrierForDevice(oneAndHalf)).toBeNull();
+  });
+
+  it("returns null for a full-width whole-U device", () => {
+    expect(synthesizeCarrierForDevice(fullWidthRail)).toBeNull();
   });
 });
 
@@ -144,15 +157,7 @@ describe("requiresChassisBay", () => {
   });
 
   it("is false for a full-width whole-U rail device", () => {
-    const fullWidth: DeviceType = {
-      slug: "server-1u",
-      model: "Server",
-      u_height: 1,
-      slot_width: 2,
-      category: "server",
-      colour: "#4A90D9",
-    };
-    expect(requiresChassisBay(fullWidth)).toBe(false);
+    expect(requiresChassisBay(fullWidthRail)).toBe(false);
   });
 });
 
@@ -194,7 +199,13 @@ describe("placeDeviceSmart (store) honesty", () => {
 
     expect(store.placeDeviceSmart(rackId, bladeHalf.slug, 5)).toBe(false);
     // Nothing lands on the rails: no child, and no phantom carrier.
-    expect(store.rack!.devices.length).toBe(0);
+    expect(
+      store.rack!.devices.some(
+        (d) =>
+          d.device_type === bladeHalf.slug ||
+          d.device_type.startsWith("carrier-"),
+      ),
+    ).toBe(false);
   });
 
   it("places a generic 2U half-width device via a synthesised 2U carrier", () => {


### PR DESCRIPTION
## **User description**
## Summary

Wave 1 of the E2E recovery epic (#2859). Implements the decision recorded in #2854 (comment 4874873247).

Half-width devices taller than 1U had a dead placement flow with a green preview: `synthesizeCarrierForDevice` mapped every half-width device to the 1U `carrier-1u-2col`, so `canPlaceInSlot` always failed for `u_height > 1` while `resolveDropTarget` and keyboard placement still reported the drop valid, then `placeDeviceSmart` refused with "No space".

## The decision (hybrid by `subdevice_role`)

- Chassis children (`subdevice_role: "child"`: `blade-server-half` 2U, `blade-server-full` 4U) mount only into an existing chassis bay. They can never rail-mount: `synthesizeCarrierForDevice` returns null, `requiresChassisBay` is true, and `resolveDropTarget` / `validStartPositions` / `placeDeviceSmart` all agree the bare-rails drop is invalid with an honest "requires a chassis" message (not "No space"). Chassis-bay placement is unchanged.
- Generic half-width gear taller than 1U (no child role, e.g. the DeskPi 2U 4-Pi RackMate) is placeable via a height-matched carrier: added `carrier-2u-2col` and made `synthesizeCarrierForDevice` select the carrier by device height instead of hardcoding `carrier-1u-2col` (so a future taller generic device does not resurrect the bug: an integer height with no matching carrier returns null, not a too-small carrier).

Additive schema change only (new `carrier-2u-2col` device); no migration or upgrade-corpus fixture needed.

## Tests

`src/tests/chassis-child-placement.test.ts` covers both halves of the decision and the three-layer agreement (preview validity, keyboard announcements, and actual placement). Full unit suite: 3210 passed (new tests plus zero regressions). Lint clean, build green.

Closes #2854

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Make half-width oversize devices place honestly, and add a 2U carrier for them**

### What Changed
- Chassis-child devices now refuse bare-rails placement and show a clear “must be placed in a chassis bay” message instead of a misleading “No space” error.
- Keyboard placement no longer offers rail slots for chassis children, and exits placement mode immediately when one is selected.
- Generic half-width devices taller than 1U can now rail-mount through a matching 2U carrier, so 2U half-width devices place successfully again.
- Dropping on bare rails and keyboard preview now agree with the final placement result.
- Added regression tests covering chassis children, 2U half-width devices, and the shared placement behavior.

### Impact
`✅ Clearer placement errors`
`✅ Fewer failed drag-and-drop attempts`
`✅ Successful placement for 2U half-width devices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
