### PR TITLE
chore: mutate drag tooltip x/y in place instead of spreading per frame

### DIFF
--- a/src/lib/stores/dragTooltip.svelte.ts
+++ b/src/lib/stores/dragTooltip.svelte.ts
@@ -90,11 +90,9 @@ export function updateDragTooltipPosition(
   clientY: number,
 ): void {
   if (tooltipState.visible) {
-    tooltipState = {
-      ...tooltipState,
-      x: clientX + TOOLTIP_OFFSET_X,
-      y: clientY + TOOLTIP_OFFSET_Y,
-    };
+    // Mutate in place: $state proxy property-granularity re-runs only x/y readers.
+    tooltipState.x = clientX + TOOLTIP_OFFSET_X;
+    tooltipState.y = clientY + TOOLTIP_OFFSET_Y;
   }
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Finding 3 of 4 from the 2026-07-03 Svelte 5 hot-path audit.

`updateDragTooltipPosition` in `src/lib/stores/dragTooltip.svelte.ts` mutates `tooltipState.x` and `.y` in place instead of reassigning a `{ ...tooltipState, x, y }` spread on every dragover frame (~60Hz). The `$state` deep-proxy property granularity means only the x/y readers re-execute, so per-frame derived executions drop from about 7 to 2 and the per-frame allocation disappears. DOM writes are identical; this is reactive hygiene.

`showDragTooltip` and `hideDragTooltip` remain whole-object reassignments (they run at drag start/end only).

## Acceptance Criteria

- [x] `updateDragTooltipPosition` mutates x and y in place; no object spread per frame
- [x] `showDragTooltip` and `hideDragTooltip` remain whole-object reassignments
- [x] Tooltip follows the pointer during a drag exactly as today (behaviour preserving)

## Verification

- Confirmed via Svelte MCP docs ($state deep state, property-level granularity) that in-place mutation of a `$state` proxy's property fires only that property's readers.
- Sole state consumer `DragTooltip.svelte` reads `x`/`y` through fine-grained property deriveds, which re-run on in-place mutation.
- svelte-autofixer: clean. Local gates green: lint, svelte-check (0 errors), unit tests (3190 passed), build.

## Test Requirements

None. Nothing tests this store, the change is behaviour-preserving, and a store-shape test would be low value under the testing policy. Verified visually during a drag.

Closes #2875

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Reduce drag tooltip work during pointer movement

### What Changed
- The drag tooltip now updates its position without rebuilding the whole tooltip state on every pointer move
- Tooltip movement stays the same for users, but it does less work while dragging
- The tooltip still appears and disappears normally at drag start and end

### Impact
`✅ Smoother drag interactions`
`✅ Lower CPU during dragging`
`✅ Fewer frame drops while moving items`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
