### PR TITLE
fix: coordinate smoothMoveTo camera animation in a single tween

### DIFF
--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -4,6 +4,7 @@
  */
 
 import type panzoom from "panzoom";
+import { cubicOut } from "svelte/easing";
 import type { Rack, RackGroup, DeviceType } from "$lib/types";
 import {
   calculateFitAll,
@@ -65,6 +66,27 @@ let zoomEndTimer: ReturnType<typeof setTimeout> | null = null;
 let viewportSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let suppressViewportSave = false;
 
+// Camera transition state. A single requestAnimationFrame loop interpolates the
+// whole camera (x, y, and scale together) so every frame lands on one value; there
+// is no separate zoom animation for the pan to drift against, and no stale timeout.
+const CAMERA_ANIM_DURATION_MS = 300;
+let cameraRafId: number | null = null;
+let cameraAnim: {
+  fromX: number;
+  fromY: number;
+  fromScale: number;
+  toX: number;
+  toY: number;
+  toScale: number;
+  startTime: number | null;
+} | null = null;
+
+// prefers-reduced-motion query, allocated once and reused so the check costs
+// nothing per call. (svelte/motion's prefersReducedMotion captures matchMedia at
+// import time, which cannot be re-stubbed per test; this local, resettable query
+// keeps the gate testable while still allocating a single MediaQueryList.)
+let reducedMotionQuery: MediaQueryList | null = null;
+
 // Derived values
 const canZoomIn = $derived(currentZoom < ZOOM_MAX);
 const canZoomOut = $derived(currentZoom > ZOOM_MIN);
@@ -84,6 +106,8 @@ export function resetCanvasStore(): void {
   isZooming = false;
   cancelZoomEnd();
   cancelViewportSave();
+  cancelCameraAnimation();
+  reducedMotionQuery = null;
   suppressViewportSave = false;
 }
 
@@ -201,6 +225,7 @@ function restoreViewport(): boolean {
       y: saved.y,
       scale,
     });
+    cancelCameraAnimation();
     panzoomInstance.zoomAbs(0, 0, scale);
     panzoomInstance.moveTo(saved.x, saved.y);
     currentZoom = scale;
@@ -258,6 +283,7 @@ function setPanzoomInstance(instance: PanzoomInstance): void {
 function disposePanzoom(): void {
   cancelViewportSave();
   cancelZoomEnd();
+  cancelCameraAnimation();
   isZooming = false;
   if (panzoomInstance) {
     panzoomInstance.dispose();
@@ -271,6 +297,7 @@ function disposePanzoom(): void {
 function zoomIn(): void {
   if (!panzoomInstance || currentZoom >= ZOOM_MAX) return;
 
+  cancelCameraAnimation();
   const newZoom = snapZoom(currentZoom, "in");
   const transform = panzoomInstance.getTransform();
 
@@ -284,6 +311,7 @@ function zoomIn(): void {
 function zoomOut(): void {
   if (!panzoomInstance || currentZoom <= ZOOM_MIN) return;
 
+  cancelCameraAnimation();
   const newZoom = snapZoom(currentZoom, "out");
   const transform = panzoomInstance.getTransform();
 
@@ -297,6 +325,7 @@ function zoomOut(): void {
 function setZoom(scale: number): void {
   if (!panzoomInstance) return;
 
+  cancelCameraAnimation();
   const clampedScale = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, scale));
   const transform = panzoomInstance.getTransform();
 
@@ -309,6 +338,7 @@ function setZoom(scale: number): void {
 function resetZoom(): void {
   if (!panzoomInstance) return;
 
+  cancelCameraAnimation();
   suppressViewportSave = true;
   clearSavedViewport();
   panzoomInstance.zoomAbs(0, 0, 1);
@@ -331,36 +361,97 @@ function getTransform(): { x: number; y: number; scale: number } {
  */
 function moveTo(x: number, y: number): void {
   if (!panzoomInstance) return;
+  cancelCameraAnimation();
   panzoomInstance.moveTo(x, y);
 }
 
 /**
- * Smooth animated move to position with zoom
+ * Whether the user prefers reduced motion. The MediaQueryList is created once and
+ * reused, so this costs nothing per call.
+ */
+function prefersReducedMotion(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  reducedMotionQuery ??= window.matchMedia("(prefers-reduced-motion: reduce)");
+  return reducedMotionQuery.matches;
+}
+
+/** Stop the camera animation loop and drop its target. */
+function cancelCameraAnimation(): void {
+  if (cameraRafId !== null) {
+    cancelAnimationFrame(cameraRafId);
+    cameraRafId = null;
+  }
+  cameraAnim = null;
+}
+
+/**
+ * One frame of the camera transition. Reads the interpolated (x, y, scale) and
+ * applies zoomAbs at the origin (which scales the pan about (0,0)) then moveTo,
+ * which overwrites the pan with the exact interpolated value. Every frame therefore
+ * settles on one camera value with no drift.
+ */
+function stepCameraAnimation(now: number): void {
+  cameraRafId = null;
+  if (!panzoomInstance || !cameraAnim) return;
+
+  cameraAnim.startTime ??= now;
+  const elapsed = now - cameraAnim.startTime;
+  const raw = Math.min(1, elapsed / CAMERA_ANIM_DURATION_MS);
+  const eased = cubicOut(raw);
+
+  const scale =
+    cameraAnim.fromScale + (cameraAnim.toScale - cameraAnim.fromScale) * eased;
+  const x = cameraAnim.fromX + (cameraAnim.toX - cameraAnim.fromX) * eased;
+  const y = cameraAnim.fromY + (cameraAnim.toY - cameraAnim.fromY) * eased;
+
+  panzoomInstance.zoomAbs(0, 0, scale);
+  panzoomInstance.moveTo(x, y);
+
+  if (raw < 1) {
+    cameraRafId = requestAnimationFrame(stepCameraAnimation);
+  } else {
+    cameraAnim = null;
+  }
+}
+
+/**
+ * Smooth animated move to position with zoom.
+ *
+ * Interpolates x, y, and scale together in a single requestAnimationFrame loop.
+ * Calling it again mid-animation retargets from the current camera (read live from
+ * panzoom), so the previous target is discarded and never applied afterwards.
  */
 function smoothMoveTo(x: number, y: number, scale: number): void {
   if (!panzoomInstance) return;
 
-  // Check for reduced motion preference
-  const prefersReducedMotion = window.matchMedia(
-    "(prefers-reduced-motion: reduce)",
-  ).matches;
-
-  // First apply zoom, then apply pan offset
-  // Note: zoomAbs takes screen coords for zoom center, not pan offset
-  // So we zoom at origin (0,0) then apply the pan
-  if (prefersReducedMotion) {
+  // Reduced motion: land the camera instantly, cancelling any in-flight transition.
+  if (prefersReducedMotion()) {
+    cancelCameraAnimation();
     panzoomInstance.zoomAbs(0, 0, scale);
     panzoomInstance.moveTo(x, y);
-  } else {
-    // For smooth animation, we need to zoom then pan
-    // Use smooth zoom at origin
-    panzoomInstance.smoothZoomAbs(0, 0, scale);
-    // Wait a tick for zoom to start, then move
-    setTimeout(() => {
-      if (panzoomInstance) {
-        panzoomInstance.moveTo(x, y);
-      }
-    }, 0);
+    return;
+  }
+
+  // Retarget from where the camera actually is now. Overwriting cameraAnim drops the
+  // previous target (fixing the interruption race) and re-anchors the clock so the
+  // ease blends smoothly from the current position.
+  const current = panzoomInstance.getTransform();
+  cameraAnim = {
+    fromX: current.x,
+    fromY: current.y,
+    fromScale: current.scale,
+    toX: x,
+    toY: y,
+    toScale: scale,
+    startTime: null,
+  };
+  if (cameraRafId === null) {
+    cameraRafId = requestAnimationFrame(stepCameraAnimation);
   }
 }
 
@@ -386,6 +477,7 @@ function fitAll(
 
   suppressViewportSave = true;
   cancelViewportSave();
+  cancelCameraAnimation();
 
   // Get viewport dimensions, accounting for any right-side overlay
   const viewportWidth = canvasElement.clientWidth - rightOffset;

--- a/src/tests/canvas-store.test.ts
+++ b/src/tests/canvas-store.test.ts
@@ -19,6 +19,17 @@ import {
 } from "$lib/constants/layout";
 import { toInternalUnits } from "$lib/utils/position";
 
+/**
+ * Stub window.matchMedia so the reduced-motion gate resolves to `matches`.
+ * Cleared per test via vi.unstubAllGlobals() in each describe's afterEach.
+ */
+function stubReducedMotion(matches: boolean): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({ matches })),
+  );
+}
+
 describe("Canvas Store", () => {
   beforeEach(() => {
     resetCanvasStore();
@@ -363,10 +374,7 @@ describe("Canvas Store", () => {
     it("interpolates x, y, and scale together and settles on the target", () => {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(1);
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn(() => ({ matches: false })),
-      );
+      stubReducedMotion(false);
       store.setPanzoomInstance(
         mockPanzoom as ReturnType<typeof import("panzoom").default>,
       );
@@ -399,10 +407,7 @@ describe("Canvas Store", () => {
     it("retargets from the current camera and never applies the first target", () => {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(1);
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn(() => ({ matches: false })),
-      );
+      stubReducedMotion(false);
       store.setPanzoomInstance(
         mockPanzoom as ReturnType<typeof import("panzoom").default>,
       );
@@ -439,10 +444,7 @@ describe("Canvas Store", () => {
     it("lands instantly with no animation when reduced motion is preferred", () => {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(1);
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn(() => ({ matches: true })),
-      );
+      stubReducedMotion(true);
       store.setPanzoomInstance(
         mockPanzoom as ReturnType<typeof import("panzoom").default>,
       );
@@ -462,10 +464,7 @@ describe("Canvas Store", () => {
     it("an instant camera op cancels an in-flight animation", () => {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(1);
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn(() => ({ matches: false })),
-      );
+      stubReducedMotion(false);
       store.setPanzoomInstance(
         mockPanzoom as ReturnType<typeof import("panzoom").default>,
       );
@@ -552,11 +551,7 @@ describe("Canvas Store", () => {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(1);
 
-      // Mock matchMedia for reduced motion check
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn(() => ({ matches: false })),
-      );
+      stubReducedMotion(false);
 
       // Mock canvas element for viewport dimensions
       const mockCanvas = document.createElement("div");
@@ -601,10 +596,7 @@ describe("Canvas Store", () => {
     function setup(viewportWidth: number, viewportHeight: number) {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(1);
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn(() => ({ matches: false })),
-      );
+      stubReducedMotion(false);
       const mockCanvas = document.createElement("div");
       Object.defineProperty(mockCanvas, "clientWidth", {
         value: viewportWidth,
@@ -671,10 +663,7 @@ describe("Canvas Store", () => {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(initialScale);
 
-      vi.stubGlobal(
-        "matchMedia",
-        vi.fn(() => ({ matches: prefersReducedMotion })),
-      );
+      stubReducedMotion(prefersReducedMotion);
 
       const mockCanvas = document.createElement("div");
       Object.defineProperty(mockCanvas, "clientWidth", {

--- a/src/tests/canvas-store.test.ts
+++ b/src/tests/canvas-store.test.ts
@@ -355,48 +355,129 @@ describe("Canvas Store", () => {
   });
 
   describe("smoothMoveTo", () => {
-    it("zooms at origin then moves when reduced motion not preferred", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it("interpolates x, y, and scale together and settles on the target", () => {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(1);
-
-      // Mock matchMedia to return false for reduced motion
       vi.stubGlobal(
         "matchMedia",
         vi.fn(() => ({ matches: false })),
       );
-
       store.setPanzoomInstance(
         mockPanzoom as ReturnType<typeof import("panzoom").default>,
       );
+
+      vi.useFakeTimers();
       store.smoothMoveTo(100, 200, 1.5);
+      // Drive the animation loop to completion.
+      vi.advanceTimersByTime(400);
 
-      // Should zoom at origin (0, 0) to avoid coordinate confusion
-      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalledWith(0, 0, 1.5);
-      // Note: moveTo is called async via setTimeout, so we can't test it here easily
-
-      vi.unstubAllGlobals();
+      // The old hand-sequenced zoom is gone: no smoothZoomAbs, no setTimeout hop.
+      expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
+      // Every animated frame lands one interpolated camera: zoomAbs at origin then moveTo.
+      expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(
+        0,
+        0,
+        expect.any(Number),
+      );
+      // The final frame settles exactly on the requested camera (x, y, and scale).
+      const lastMove = mockPanzoom.moveTo.mock.calls.at(-1) as [number, number];
+      expect(lastMove[0]).toBeCloseTo(100, 5);
+      expect(lastMove[1]).toBeCloseTo(200, 5);
+      const lastZoom = mockPanzoom.zoomAbs.mock.calls.at(-1) as [
+        number,
+        number,
+        number,
+      ];
+      expect(lastZoom[2]).toBeCloseTo(1.5, 5);
     });
 
-    it("zooms at origin then moves when reduced motion preferred", () => {
+    it("retargets from the current camera and never applies the first target", () => {
       const store = getCanvasStore();
       const mockPanzoom = createMockPanzoom(1);
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn(() => ({ matches: false })),
+      );
+      store.setPanzoomInstance(
+        mockPanzoom as ReturnType<typeof import("panzoom").default>,
+      );
 
-      // Mock matchMedia to return true for reduced motion
+      vi.useFakeTimers();
+      store.smoothMoveTo(100, 200, 1.5);
+      // Let the camera travel a visible fraction of the first ease, then interrupt.
+      vi.advanceTimersByTime(150);
+      const moved = store.getTransform();
+      expect(moved.x).toBeGreaterThan(0);
+      expect(moved.x).toBeLessThan(100); // partway, not yet at the first target
+
+      const callsBeforeRetarget = mockPanzoom.moveTo.mock.calls.length;
+      store.smoothMoveTo(500, 600, 2);
+
+      // The retargeted tween's first frame must blend from where the camera actually
+      // is (the moved position), not restart from the origin.
+      vi.advanceTimersByTime(16);
+      const firstRetargetMove = mockPanzoom.moveTo.mock.calls[
+        callsBeforeRetarget
+      ] as [number, number];
+      expect(firstRetargetMove[0]).toBeCloseTo(moved.x, 5);
+      expect(firstRetargetMove[1]).toBeCloseTo(moved.y, 5);
+
+      vi.advanceTimersByTime(400);
+      // The camera settles on the second target...
+      const lastMove = mockPanzoom.moveTo.mock.calls.at(-1) as [number, number];
+      expect(lastMove[0]).toBeCloseTo(500, 5);
+      expect(lastMove[1]).toBeCloseTo(600, 5);
+      // ...and the interrupted first target is never applied (no stale-timeout snap).
+      expect(mockPanzoom.moveTo.mock.calls).not.toContainEqual([100, 200]);
+    });
+
+    it("lands instantly with no animation when reduced motion is preferred", () => {
+      const store = getCanvasStore();
+      const mockPanzoom = createMockPanzoom(1);
       vi.stubGlobal(
         "matchMedia",
         vi.fn(() => ({ matches: true })),
       );
-
       store.setPanzoomInstance(
         mockPanzoom as ReturnType<typeof import("panzoom").default>,
       );
+
+      const rafSpy = vi.spyOn(globalThis, "requestAnimationFrame");
       store.smoothMoveTo(100, 200, 1.5);
 
-      // Should zoom at origin (0, 0) then apply pan offset
+      // Instant zoomAbs + moveTo, no animation frame scheduled.
       expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(0, 0, 1.5);
       expect(mockPanzoom.moveTo).toHaveBeenCalledWith(100, 200);
+      expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
+      expect(rafSpy).not.toHaveBeenCalled();
 
-      vi.unstubAllGlobals();
+      rafSpy.mockRestore();
+    });
+
+    it("an instant camera op cancels an in-flight animation", () => {
+      const store = getCanvasStore();
+      const mockPanzoom = createMockPanzoom(1);
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn(() => ({ matches: false })),
+      );
+      store.setPanzoomInstance(
+        mockPanzoom as ReturnType<typeof import("panzoom").default>,
+      );
+
+      vi.useFakeTimers();
+      store.smoothMoveTo(100, 200, 1.5);
+      vi.advanceTimersByTime(150); // animation is mid-flight
+      store.resetZoom(); // instant op: lands the camera at origin, 100%
+
+      // The cancelled animation must not resume and drag the camera to its target.
+      vi.advanceTimersByTime(400);
+      expect(mockPanzoom.getTransform()).toEqual({ x: 0, y: 0, scale: 1 });
     });
   });
 
@@ -513,6 +594,7 @@ describe("Canvas Store", () => {
 
   describe("ensureRacksVisible", () => {
     afterEach(() => {
+      vi.useRealTimers();
       vi.unstubAllGlobals();
     });
 
@@ -550,7 +632,8 @@ describe("Canvas Store", () => {
 
       store.ensureRacksVisible(["rack-1"], [rack]);
 
-      expect(mockPanzoom.smoothZoomAbs).not.toHaveBeenCalled();
+      // Camera still: the animated path never runs, so nothing is applied.
+      expect(mockPanzoom.zoomAbs).not.toHaveBeenCalled();
       expect(mockPanzoom.moveTo).not.toHaveBeenCalled();
     });
 
@@ -559,9 +642,17 @@ describe("Canvas Store", () => {
       const { store, mockPanzoom } = setup(200, 200);
       const rack = createTestRack({ id: "rack-1", height: 42 });
 
+      vi.useFakeTimers();
       store.ensureRacksVisible(["rack-1"], [rack]);
+      vi.advanceTimersByTime(400);
 
-      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
+      // The animated camera lands via per-frame zoomAbs(0, 0, scale) + moveTo.
+      expect(mockPanzoom.zoomAbs).toHaveBeenCalledWith(
+        0,
+        0,
+        expect.any(Number),
+      );
+      expect(mockPanzoom.moveTo).toHaveBeenCalled();
     });
   });
 
@@ -666,11 +757,12 @@ describe("Canvas Store", () => {
         u_height: 1,
       });
 
+      vi.useFakeTimers();
       store.zoomToDevice(rack, 0, [deviceType]);
+      vi.advanceTimersByTime(400);
 
-      // smoothZoomAbs is called by smoothMoveTo (reduced motion = false)
-      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
-      const [, , scale] = mockPanzoom.smoothZoomAbs.mock.calls[0] as [
+      // The camera animates to the (clamped) target via per-frame zoomAbs.
+      const [, , scale] = mockPanzoom.zoomAbs.mock.calls.at(-1) as [
         number,
         number,
         number,
@@ -698,10 +790,11 @@ describe("Canvas Store", () => {
         u_height: 42,
       });
 
+      vi.useFakeTimers();
       store.zoomToDevice(rack, 0, [deviceType]);
+      vi.advanceTimersByTime(400);
 
-      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
-      const [, , scale] = mockPanzoom.smoothZoomAbs.mock.calls[0] as [
+      const [, , scale] = mockPanzoom.zoomAbs.mock.calls.at(-1) as [
         number,
         number,
         number,
@@ -742,9 +835,11 @@ describe("Canvas Store", () => {
 
       vi.useFakeTimers();
       store.zoomToDevice(rack, 0, [deviceType]);
+      // Drive the animation loop to completion so the camera lands on target.
+      vi.advanceTimersByTime(400);
 
-      expect(mockPanzoom.smoothZoomAbs).toHaveBeenCalled();
-      const [, , zoom] = mockPanzoom.smoothZoomAbs.mock.calls[0] as [
+      // The camera settles on the (clamped) target zoom, read from the final frame.
+      const [, , zoom] = mockPanzoom.zoomAbs.mock.calls.at(-1) as [
         number,
         number,
         number,
@@ -766,12 +861,11 @@ describe("Canvas Store", () => {
       const expectedPanY =
         viewportHeight / 2 - (deviceAbsY + deviceHeight / 2) * zoom;
 
-      // smoothMoveTo delivers the moveTo call via setTimeout(..., 0).
-      // Flush all pending timers so moveTo fires synchronously here.
-      vi.runAllTimers();
-
-      expect(mockPanzoom.moveTo).toHaveBeenCalledOnce();
-      const [panX, panY] = mockPanzoom.moveTo.mock.calls[0] as [number, number];
+      // The final animation frame lands the device center at the viewport center.
+      const [panX, panY] = mockPanzoom.moveTo.mock.calls.at(-1) as [
+        number,
+        number,
+      ];
       expect(panX).toBeCloseTo(expectedPanX, 5);
       expect(panY).toBeCloseTo(expectedPanY, 5);
     });


### PR DESCRIPTION
## **User description**
Closes #2874

## Summary

`smoothMoveTo` used to hand-sequence the camera: an animated `panzoom.smoothZoomAbs(0, 0, scale)` followed by an instant `moveTo(x, y)` inside `setTimeout(0)`. The zoom kept scaling the pan about the origin every frame after the single `moveTo` landed, so the pan drifted; and a second call mid-animation left the first call's stale timeout alive to snap the pan back to the old target.

This replaces the sequencing with one `requestAnimationFrame` easing loop that interpolates `x`, `y`, and `scale` together. Each frame applies `zoomAbs(0, 0, scale)` (which scales the pan about the origin) then `moveTo(x, y)` (which overwrites the pan with the exact interpolated value), so every frame settles on one camera value with no drift and no stale timeout.

## Approach: rAF + easing (not Tween-in-effect-root)

The issue proposed a `Tween` driven by an `$effect` inside `$effect.root()`, and explicitly sanctioned a plain rAF + easing loop as the lighter alternative "if the acceptance criteria hold". I chose rAF + easing because it is lighter (no effect root, no effect, no Tween), more testable (deterministic under Vitest fake timers), and more correct for retargeting: it reads the live `panzoom.getTransform()` on each call, so a retarget blends from where the camera actually is, even after a gesture. A Tween's internal `.current` would diverge from the real transform after gesture input.

## Acceptance criteria

- x, y, and scale interpolate together, no drift: single loop lands each frame on `zoomAbs(0,0,scale)` + `moveTo(x,y)`.
- Retarget mid-animation blends from the current camera, previous target never applied: `smoothMoveTo` overwrites the animation from the live transform; no timeout survives.
- prefers-reduced-motion lands instantly with no animation scheduled.
- No `matchMedia` allocation per call: a single `MediaQueryList` is created once and reused. (svelte/motion's `prefersReducedMotion` captures `matchMedia` at import time, which cannot be re-stubbed per unit test, so a local resettable query keeps the gate testable while still allocating one `MediaQueryList`.)
- Teardown: the rAF loop is cancelled in `disposePanzoom` and `resetCanvasStore` (the rAF equivalent of disposing the proposed effect root, so nothing leaks across canvas mounts).

## Also fixed (self-review)

Because the loop is now self-owned and deterministic (full 300ms), an instant camera write landing mid-animation would have been clobbered by the next scheduled frame. Every instant camera writer (`fitAll`, `resetZoom`, `restoreViewport`, `moveTo`, `zoomIn`, `zoomOut`, `setZoom`) now cancels an in-flight transition first, so instant ops win. `cancelCameraAnimation()` is a no-op when idle, so existing behaviour is unchanged.

## Tests

Rewrote the `smoothMoveTo` assertions (per the issue) plus the indirect `smoothZoomAbs` assertions in `ensureRacksVisible` and `zoomToDevice` that were coupled to the old sequencing. New behavioural cases: interpolate-and-settle, retarget-from-moved-camera (advances 150ms then asserts the retargeted tween's first frame blends from the moved position, and the first target is never applied), reduced-motion instant with no rAF scheduled, and an instant op cancelling an in-flight animation.

Local gates: `npm run lint`, `npm run check` (svelte-check, 0 errors), `npm run test:run` (3192 pass), `npm run build` all green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113asHxbBkZLkGd7WsaqYVy


___

## **CodeAnt-AI Description**
Fix camera movement so zoom and pan stay in sync during animated moves

### What Changed
- Animated camera moves now update zoom, position, and final target together, so the view no longer drifts or snaps back to an older destination
- Starting a new camera move now replaces any in-flight move, so interrupted animations follow the current camera instead of the previous target
- Reduced-motion users now get an instant camera jump with no animation queued
- Any direct camera action like reset, zoom, fit, or restore now cancels a running animation so it cannot overwrite the latest view
- Tests now cover the animated path, interrupted moves, reduced-motion behavior, and shared motion stubs

### Impact
`✅ No camera drift during animated moves`
`✅ Fewer wrong-position snaps after quick repeated clicks`
`✅ Instant movement for reduced-motion users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
