### PR TITLE
feat: interaction feedback cluster (selection keydown fix, clipPath ids, motion polish, SR announcements)

### DIFF
--- a/src/lib/actions/selection-actions.ts
+++ b/src/lib/actions/selection-actions.ts
@@ -11,6 +11,7 @@ import { getSelectionStore } from "$lib/stores/selection.svelte";
 import { getCanvasStore } from "$lib/stores/canvas.svelte";
 import { getUIStore } from "$lib/stores/ui.svelte";
 import { getToastStore } from "$lib/stores/toast.svelte";
+import { getPlacementStore } from "$lib/stores/placement.svelte";
 import { hapticSuccess, hapticError } from "$lib/utils/haptics";
 import { getRackSlotControls } from "$lib/utils/rack-row";
 import { findNextValidPosition } from "$lib/utils/device-movement";
@@ -66,12 +67,23 @@ function _moveSelectedDevice(direction: 1 | -1): void {
     direction,
   );
 
+  // Announce through the assertive live region DialogOrchestrator renders
+  // (placement-sr-announcer). A focused element's aria-label change is not
+  // reliably re-announced, and a blocked move must not fail silently.
+  const placementStore = getPlacementStore();
   if (result.success && result.newPosition !== null) {
     const humanPosition = toHumanUnits(result.newPosition);
     layoutStore.moveDevice(
       selectionStore.selectedRackId!,
       deviceIndex,
       humanPosition,
+    );
+    placementStore.announcePosition(`Moved to U${humanPosition}`);
+  } else {
+    placementStore.announcePosition(
+      direction === 1
+        ? "Cannot move up, no free position"
+        : "Cannot move down, no free position",
     );
   }
 }

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -374,7 +374,11 @@
   });
 
   function handleCanvasKeydown(event: KeyboardEvent) {
-    // Handle Enter/Space as click for accessibility
+    // Only act when the canvas surface itself is the target. Keydown bubbles,
+    // so without this guard Enter/Space on a rack, device, or the verb bar
+    // would clear the selection those elements just made (same guard as
+    // handleCanvasClick above).
+    if (event.target !== event.currentTarget) return;
     if (event.key === "Enter" || event.key === " ") {
       selectionStore.clearSelection();
     }

--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -580,6 +580,17 @@
     </div>
   </div>
 
+  <!-- Search outcome for screen readers. The visual list filters live, but
+       AT users need the result announced; polite so it never interrupts
+       typing. Text settles at most once per debounce (150ms). -->
+  <div class="sr-only" role="status" data-testid="palette-search-announcer">
+    {#if isSearchActive}
+      {hasResults
+        ? `${totalDevicesCount} ${totalDevicesCount === 1 ? "device" : "devices"} found`
+        : "No devices match"}
+    {/if}
+  </div>
+
   <!-- Device List -->
   <div class="device-list" class:fill-flat={flatFill}>
     {#snippet deviceRow(device: DeviceType)}

--- a/src/lib/components/PlacementIndicator.svelte
+++ b/src/lib/components/PlacementIndicator.svelte
@@ -29,7 +29,10 @@
     class="placement-indicator"
     role="status"
     aria-live="polite"
-    transition:fly={{ y: prefersReducedMotion.current ? 0 : -12, duration: 150 }}
+    transition:fly={{
+      y: prefersReducedMotion.current ? 0 : -12,
+      duration: 150,
+    }}
   >
     <div class="indicator-content">
       <span class="indicator-text">

--- a/src/lib/components/PlacementIndicator.svelte
+++ b/src/lib/components/PlacementIndicator.svelte
@@ -7,6 +7,8 @@
   import type { DeviceType } from "$lib/types";
   import { hapticCancel } from "$lib/utils/haptics";
   import { IconClose } from "./icons";
+  import { fly } from "svelte/transition";
+  import { prefersReducedMotion } from "svelte/motion";
 
   interface Props {
     isPlacing: boolean;
@@ -23,7 +25,12 @@
 </script>
 
 {#if isPlacing && device}
-  <div class="placement-indicator" role="status" aria-live="polite">
+  <div
+    class="placement-indicator"
+    role="status"
+    aria-live="polite"
+    transition:fly={{ y: prefersReducedMotion.current ? 0 : -12, duration: 150 }}
+  >
     <div class="indicator-content">
       <span class="indicator-text">
         Placing: <strong

--- a/src/lib/components/PlacementIndicator.svelte
+++ b/src/lib/components/PlacementIndicator.svelte
@@ -31,7 +31,7 @@
     aria-live="polite"
     transition:fly={{
       y: prefersReducedMotion.current ? 0 : -12,
-      duration: 150,
+      duration: prefersReducedMotion.current ? 0 : 150,
     }}
   >
     <div class="indicator-content">

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -157,7 +157,6 @@
   // --- Drag state ---
   let justFinishedDrag = $state(false);
   let dragDebounceTimeout: ReturnType<typeof setTimeout> | null = null;
-  let shiftKeyHeld = $state(false);
   let svgElement: SVGSVGElement | null = $state(null);
   let dropPreview = $state<DropPreviewState | null>(null);
   let containerHoverInfo = $state<ContainerHoverInfo | null>(null);
@@ -441,16 +440,7 @@
       onselect?.(new CustomEvent("select", { detail: { rackId: rack.id } }));
     }
   }
-
-  function handleShiftDown(event: KeyboardEvent) {
-    if (event.key === "Shift") shiftKeyHeld = true;
-  }
-  function handleShiftUp(event: KeyboardEvent) {
-    if (event.key === "Shift") shiftKeyHeld = false;
-  }
 </script>
-
-<svelte:window onkeydown={handleShiftDown} onkeyup={handleShiftUp} />
 
 <!-- The rack is a list item that holds interactive devices, so it is a
      non-interactive role="listitem" container, not an interactive role="option"
@@ -510,7 +500,6 @@
       rackName={rack.name}
       {viewLabel}
       nameYOffset={NAME_Y_OFFSET}
-      {shiftKeyHeld}
       {blockedSlots}
       dropPreview={activePreview}
       {isPlacementMode}

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -43,6 +43,8 @@
   import { validStartPositions } from "$lib/utils/placement-keyboard";
   import { SvelteSet, SvelteMap } from "svelte/reactivity";
   import { toHumanUnits } from "$lib/utils/position";
+  import { fade } from "svelte/transition";
+  import { prefersReducedMotion } from "svelte/motion";
   import {
     U_HEIGHT_PX,
     RAIL_WIDTH as RAIL_WIDTH_CONST,
@@ -514,43 +516,57 @@
           ? getContainerContext(placedDevice)
           : undefined}
         {@const children = containerChildren.get(placedDevice.id) ?? []}
-        {#if device}
-          {@const isHoveredContainer =
-            containerHoverInfo?.containerId === placedDevice.id}
-          <RackDevice
-            {device}
-            position={placedDevice.position}
-            rackHeight={rack.height}
-            rackId={rack.id}
-            deviceIndex={originalIndex}
-            selected={selectedDeviceId === placedDevice.id}
-            uHeight={U_HEIGHT}
-            rackWidth={RACK_WIDTH}
-            {displayMode}
-            rackView={effectiveFaceFilter}
-            {showLabelsOnImages}
-            placedDeviceName={placedDevice.name}
-            placedDeviceId={placedDevice.id}
-            frontImageRef={placedDevice.front_image}
-            rearImageRef={placedDevice.rear_image}
-            colourOverride={placedDevice.colour_override}
-            containerContext={containerCtx}
-            {deviceLibrary}
-            containerChildDevices={children}
-            selectedChildId={selectedDeviceId}
-            isDragOverContainer={isHoveredContainer}
-            dragTargetSlotId={isHoveredContainer
-              ? (containerHoverInfo?.targetSlotId ?? null)
-              : null}
-            isDragTargetValid={isHoveredContainer &&
-              (containerHoverInfo?.isValidTarget ?? false)}
-            onselect={ondeviceselect}
-            ondragend={() => setDragFinished()}
-            onduplicate={(e) =>
-              contextActions.handleDuplicate(rack, { ...e.detail, x: 0, y: 0 })}
-            oncontextmenuopen={ctxMenu.handleOpen}
-          />
-        {/if}
+        <!-- Transition wrapper must sit directly in the each item: local
+             transitions only play when their own block is created/destroyed,
+             so inside the if it would never fire on place/delete, and being
+             local it correctly skips initial mount and tab switches. -->
+        <g
+          transition:fade={{
+            duration: prefersReducedMotion.current ? 0 : 150,
+          }}
+        >
+          {#if device}
+            {@const isHoveredContainer =
+              containerHoverInfo?.containerId === placedDevice.id}
+            <RackDevice
+              {device}
+              position={placedDevice.position}
+              rackHeight={rack.height}
+              rackId={rack.id}
+              deviceIndex={originalIndex}
+              selected={selectedDeviceId === placedDevice.id}
+              uHeight={U_HEIGHT}
+              rackWidth={RACK_WIDTH}
+              {displayMode}
+              rackView={effectiveFaceFilter}
+              {showLabelsOnImages}
+              placedDeviceName={placedDevice.name}
+              placedDeviceId={placedDevice.id}
+              frontImageRef={placedDevice.front_image}
+              rearImageRef={placedDevice.rear_image}
+              colourOverride={placedDevice.colour_override}
+              containerContext={containerCtx}
+              {deviceLibrary}
+              containerChildDevices={children}
+              selectedChildId={selectedDeviceId}
+              isDragOverContainer={isHoveredContainer}
+              dragTargetSlotId={isHoveredContainer
+                ? (containerHoverInfo?.targetSlotId ?? null)
+                : null}
+              isDragTargetValid={isHoveredContainer &&
+                (containerHoverInfo?.isValidTarget ?? false)}
+              onselect={ondeviceselect}
+              ondragend={() => setDragFinished()}
+              onduplicate={(e) =>
+                contextActions.handleDuplicate(rack, {
+                  ...e.detail,
+                  x: 0,
+                  y: 0,
+                })}
+              oncontextmenuopen={ctxMenu.handleOpen}
+            />
+          {/if}
+        </g>
       {/each}
     </g>
 

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -936,6 +936,17 @@
     stroke: var(--colour-selection);
     stroke-width: 2;
     pointer-events: none;
+    animation: selection-settle 120ms ease-out;
+  }
+
+  /* One-shot settle when the selection rect mounts. No `to` block: the
+     animation ends on the computed stroke-width (2 desktop, 3 small screens).
+     The global prefers-reduced-motion reset collapses the duration. */
+  @keyframes selection-settle {
+    from {
+      stroke-opacity: 0;
+      stroke-width: 4;
+    }
   }
 
   @media (max-width: 430px) {

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -41,6 +41,8 @@
     DEVICE_LABEL_ICON_SPACE_RIGHT,
   } from "$lib/utils/text-sizing";
   import { toHumanUnits } from "$lib/utils/position";
+  import { Tween, prefersReducedMotion } from "svelte/motion";
+  import { cubicOut } from "svelte/easing";
 
   interface Props {
     device: DeviceType;
@@ -257,6 +259,14 @@
   const yPosition = $derived(
     (rackHeight - positionHuman - device.u_height + 1) * uHeight,
   );
+
+  // Settle committed moves (drop, keyboard nudge, undo). Positions are
+  // whole-U integers that change only on commit, never per-frame during a
+  // drag, so the tween never fights the pointer.
+  const yMotion = Tween.of(() => yPosition, {
+    duration: 120,
+    easing: cubicOut,
+  });
   const deviceHeight = $derived(device.u_height * uHeight);
   // Full interior width (between rails)
   const fullWidth = $derived(rackWidth - RAIL_WIDTH * 2);
@@ -621,7 +631,9 @@
   data-device-face={currentFace}
   data-device-position={position}
   data-testid="rack-device"
-  transform="translate({RAIL_WIDTH + slotXOffset}, {yPosition})"
+  transform="translate({RAIL_WIDTH + slotXOffset}, {prefersReducedMotion.current
+    ? yPosition
+    : yMotion.current})"
   class="rack-device"
   class:selected
   class:dragging={isDragging}

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -326,8 +326,12 @@
     showImage ? deviceWidth + IMAGE_OVERFLOW * 2 : deviceWidth,
   );
 
-  // Unique clipPath ID for this device instance
-  const clipId = $derived(`clip-${device.slug}-${position}`);
+  // Unique clipPath ID for this device instance. $props.id() is per component
+  // instance, so dual-view front/rear renders and same-type-same-U devices in
+  // different racks can never collide (duplicate SVG ids clip with the wrong
+  // geometry).
+  const uid = $props.id();
+  const clipId = `clip-${uid}`;
 
   // Detect if this device is a container (has slots)
   const isContainer = $derived(

--- a/src/lib/components/RackDropZone.svelte
+++ b/src/lib/components/RackDropZone.svelte
@@ -8,6 +8,8 @@
 -->
 <script lang="ts">
   import type { DropFeedback } from "$lib/utils/dragdrop";
+  import { Tween, prefersReducedMotion } from "svelte/motion";
+  import { cubicOut } from "svelte/easing";
 
   interface Props {
     /** Drop preview position (1-indexed U position from bottom) */
@@ -43,12 +45,19 @@
   const previewY = $derived(
     (rackHeight - position - height + 1) * uHeight + rackPadding + railWidth,
   );
+
+  // Glide between whole-U slots. Slot targets are discrete commits, never
+  // per-frame pointer tracking, so the tween cannot fight the pointer.
+  const previewYMotion = Tween.of(() => previewY, {
+    duration: 90,
+    easing: cubicOut,
+  });
 </script>
 
 <!-- Drop preview rectangle (carrier-first: always full-width) -->
 <rect
   x={railWidth + 2}
-  y={previewY}
+  y={prefersReducedMotion.current ? previewY : previewYMotion.current}
   width={interiorWidth - 4}
   height={height * uHeight - 2}
   class="drop-preview"

--- a/src/lib/components/RackFrame.svelte
+++ b/src/lib/components/RackFrame.svelte
@@ -41,8 +41,6 @@
     viewLabel?: string;
     /** Y offset for the rack name */
     nameYOffset: number;
-    /** Whether Shift key is held (shows half-U grid lines) */
-    shiftKeyHeld?: boolean;
     /** Unique rack identifier for SVG pattern IDs */
     rackId: string;
     /** Blocked slot ranges for crosshatch overlay */
@@ -75,7 +73,6 @@
     viewLabel,
     nameYOffset,
     rackId,
-    shiftKeyHeld = false,
     blockedSlots = [],
     dropPreview = null,
     isPlacementMode = false,
@@ -188,19 +185,6 @@
     class="rack-grid-line"
   />
 {/each}
-
-<!-- Half-U grid lines (shown when Shift is held for fine positioning) -->
-{#if shiftKeyHeld}
-  {#each Array(rackHeight).fill(null) as _halfLine, i (i)}
-    <line
-      x1={railWidth}
-      y1={i * uHeight + uHeight / 2 + rackPadding + railWidth}
-      x2={rackWidth - railWidth}
-      y2={i * uHeight + uHeight / 2 + rackPadding + railWidth}
-      class="rack-grid-line-half"
-    />
-  {/each}
-{/if}
 
 <!-- Rail mounting holes (3 per U on each rail) - rendered first so labels appear on top -->
 {#each Array(rackHeight).fill(null) as _hole, i (i)}
@@ -393,13 +377,6 @@
   .rack-grid-line {
     stroke: var(--rack-grid);
     stroke-width: 1;
-  }
-
-  .rack-grid-line-half {
-    stroke: var(--colour-selection);
-    stroke-width: 1;
-    stroke-dasharray: 4 2;
-    opacity: 0.6;
   }
 
   .u-label {

--- a/src/tests/Canvas.selection-keydown.test.ts
+++ b/src/tests/Canvas.selection-keydown.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression test for the 2026-07-03 audit finding: Enter/Space keydown
+ * bubbling up from canvas children (racks, devices, verb bar) must not clear
+ * the selection. Only a keydown on the canvas surface itself clears it,
+ * mirroring the guard handleCanvasClick already has.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
+import Canvas from "$lib/components/Canvas.svelte";
+import { resetCanvasStore } from "$lib/stores/canvas.svelte";
+import { resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getSelectionStore,
+  resetSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { resetUIStore } from "$lib/stores/ui.svelte";
+import { resetPlacementStore } from "$lib/stores/placement.svelte";
+import { resetViewportStore } from "$lib/utils/viewport.svelte";
+
+describe("Canvas keyboard selection clearing", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetUIStore();
+    resetCanvasStore();
+    resetPlacementStore();
+    resetViewportStore();
+
+    vi.stubGlobal("matchMedia", (query: string): MediaQueryList => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => true,
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the selection when Enter bubbles up from a canvas child", async () => {
+    const selectionStore = getSelectionStore();
+    const { getByTestId } = render(Canvas);
+    selectionStore.selectRack("rack-1");
+
+    await fireEvent.keyDown(getByTestId("add-rack-affordance"), {
+      key: "Enter",
+    });
+
+    expect(selectionStore.selectedRackId).toBe("rack-1");
+  });
+
+  it("clears the selection when Enter targets the canvas surface itself", async () => {
+    const selectionStore = getSelectionStore();
+    const { getByTestId } = render(Canvas);
+    selectionStore.selectRack("rack-1");
+
+    await fireEvent.keyDown(getByTestId("rack-canvas"), { key: "Enter" });
+
+    expect(selectionStore.selectedRackId).toBeNull();
+  });
+});

--- a/src/tests/Canvas.selection-keydown.test.ts
+++ b/src/tests/Canvas.selection-keydown.test.ts
@@ -26,16 +26,19 @@ describe("Canvas keyboard selection clearing", () => {
     resetPlacementStore();
     resetViewportStore();
 
-    vi.stubGlobal("matchMedia", (query: string): MediaQueryList => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: () => {},
-      removeListener: () => {},
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      dispatchEvent: () => true,
-    }));
+    vi.stubGlobal(
+      "matchMedia",
+      (query: string): MediaQueryList => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    );
   });
 
   afterEach(() => {

--- a/src/tests/Canvas.selection-keydown.test.ts
+++ b/src/tests/Canvas.selection-keydown.test.ts
@@ -26,19 +26,16 @@ describe("Canvas keyboard selection clearing", () => {
     resetPlacementStore();
     resetViewportStore();
 
-    vi.stubGlobal(
-      "matchMedia",
-      (query: string): MediaQueryList => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => true,
-      }),
-    );
+    vi.stubGlobal("matchMedia", (query: string): MediaQueryList => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => true,
+    }));
   });
 
   afterEach(() => {

--- a/src/tests/palette-search-announcements.test.ts
+++ b/src/tests/palette-search-announcements.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Palette search must announce its outcome to screen readers: a status
+ * region reports the match count after the debounce settles, reports
+ * "No devices match" for a miss, and stays silent while search is empty.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/svelte";
+import TestDevicePalette from "./helpers/TestDevicePalette.svelte";
+import { resetLayoutStore } from "$lib/stores/layout.svelte";
+import { resetUIStore } from "$lib/stores/ui.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+
+describe("palette search result announcements", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetUIStore();
+    resetToastStore();
+  });
+
+  it("stays silent while search is empty", () => {
+    render(TestDevicePalette);
+    expect(screen.getByTestId("palette-search-announcer")).toHaveTextContent(
+      /^$/,
+    );
+  });
+
+  it("announces no matches for a miss", async () => {
+    render(TestDevicePalette);
+    await fireEvent.input(screen.getByTestId("search-devices"), {
+      target: { value: "zzz-no-such-device" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("palette-search-announcer")).toHaveTextContent(
+        "No devices match",
+      );
+    });
+  });
+
+  it("announces a match count for a hit", async () => {
+    render(TestDevicePalette);
+    await fireEvent.input(screen.getByTestId("search-devices"), {
+      target: { value: "shelf" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("palette-search-announcer")).toHaveTextContent(
+        /\d+ devices? found/,
+      );
+    });
+  });
+});

--- a/src/tests/selection-move-announcements.test.ts
+++ b/src/tests/selection-move-announcements.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Arrow-key device moves must be perceivable without vision: a successful
+ * move announces the new U position through the assertive live region
+ * (placementStore.placementAnnouncement, rendered by DialogOrchestrator),
+ * and a blocked move announces the failure instead of no-oping silently.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getSelectionStore,
+  resetSelectionStore,
+} from "$lib/stores/selection.svelte";
+import {
+  getPlacementStore,
+  resetPlacementStore,
+} from "$lib/stores/placement.svelte";
+import { resetHistoryStore } from "$lib/stores/history.svelte";
+import {
+  moveSelectedDeviceUp,
+  moveSelectedDeviceDown,
+} from "$lib/actions/selection-actions";
+import { createTestDeviceTypeInput } from "./factories";
+
+describe("arrow-key device move announcements", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetPlacementStore();
+    resetHistoryStore();
+  });
+
+  function placeAndSelect(positionU: number): void {
+    const layoutStore = getLayoutStore();
+    const rack = layoutStore.addRack("Test Rack", 12);
+    const dt = layoutStore.addDeviceType(createTestDeviceTypeInput());
+    layoutStore.placeDeviceSmart(rack!.id, dt.slug, positionU);
+    // Store mutations replace arrays immutably (rack-actions.ts), so re-read
+    // the rack from the store rather than trusting the creation-time reference.
+    const liveRack = layoutStore.racks.find((r) => r.id === rack!.id)!;
+    getSelectionStore().selectDevice(rack!.id, liveRack.devices[0]!.id);
+  }
+
+  it("announces the new position after a successful move up", () => {
+    placeAndSelect(5);
+    moveSelectedDeviceUp();
+    expect(getPlacementStore().placementAnnouncement).toBe("Moved to U6");
+  });
+
+  it("announces failure when the device is already at the top", () => {
+    placeAndSelect(12);
+    moveSelectedDeviceUp();
+    expect(getPlacementStore().placementAnnouncement).toBe(
+      "Cannot move up, no free position",
+    );
+  });
+
+  it("announces failure when the device is already at the bottom", () => {
+    placeAndSelect(1);
+    moveSelectedDeviceDown();
+    expect(getPlacementStore().placementAnnouncement).toBe(
+      "Cannot move down, no free position",
+    );
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Implements the committed interaction feedback cluster plan (`docs/plans/2026-07-03-interaction-feedback-cluster.md`). Fixes the two interaction correctness bugs from the 2026-07-03 Svelte 5 hot-path audit, deletes the vestigial half-U Shift grid, and adds restrained, reduced-motion-safe feedback to placement, movement, and selection, plus two screen-reader announcement gaps.

All motion uses Svelte 5 primitives only (`transition:fade`/`fly`, `Tween.of`, one scoped CSS keyframe) and every JS-driven motion has an explicit `prefersReducedMotion.current` guard. Stored rail positions stay whole-U integers; only rendered attributes interpolate.

## Tasks implemented

1. fix: only clear selection when the canvas surface itself receives Enter/Space (guard against bubbled Enter/Space from racks, devices, verb bar) + regression test
2. fix: instance-unique clipPath ids via `$props.id()` (duplicate SVG ids clipped images with the wrong geometry in dual view and across racks)
3. refactor: delete the vestigial half-U Shift grid and per-rack window key listeners (Rack.svelte, RackFrame.svelte)
4. feat: placement banner fly transition with reduced-motion fallback (PlacementIndicator.svelte)
5. feat: fade devices in and out on placement, removal, and undo (Rack.svelte; local transition wrapper sits directly in the each item)
6. feat: selection settle keyframe on the device outline (RackDevice.svelte)
7. feat: drop preview glides between U slots via `Tween.of` (RackDropZone.svelte)
8. feat: committed device moves settle instead of teleporting via `Tween.of` (RackDevice.svelte)
9. feat: announce arrow-key device moves via the assertive live region (selection-actions.ts) + test
10. feat: announce palette search results to screen readers (DevicePalette.svelte) + test

## Verification

- `npm run lint`: pass
- `npm run check` (svelte-check): pass, 0 errors / 0 warnings (run explicitly; the validate gate does not run svelte-check)
- `npm run test:run`: the three new test files pass and the full suite is green when run without concurrent-suite resource contention
- `npm run build`: pass
- Prettier clean on all touched files
- svelte-autofixer clean on every changed component (no issues on added code)

## Reduced motion

With `prefers-reduced-motion: reduce`: no fly, no fade time, no glide, instant snaps. Svelte transitions/tweens use the explicit guard; the selection keyframe is covered by the global CSS reset.

Closes #2876

Co-Authored-By: Claude <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
**Improve keyboard feedback, screen-reader updates, and placement motion**

### What Changed
- Enter and Space now clear the canvas selection only when pressed on the canvas surface itself, so key presses from racks, devices, or the verb bar no longer wipe out the current selection.
- Device moves via arrow keys now announce the new rack position, and blocked moves announce why they could not move.
- Device palette searches now announce when results are found or when no devices match, so screen-reader users get the search outcome without relying on the visual list.
- Placement banners, device additions/removals, drop previews, and selected device outlines now animate with reduced-motion-safe transitions instead of snapping.

### Impact
`✅ Fewer accidental selection clears`
`✅ Clearer device move feedback for screen-reader users`
`✅ Easier palette search for non-visual users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
