### PR TITLE
fix: legacy 2u carrier adapter

### DIFF
--- a/src/lib/storage/adapt-legacy-layout.ts
+++ b/src/lib/storage/adapt-legacy-layout.ts
@@ -199,19 +199,22 @@ function buildCarrier(
 }
 
 /** Carrier shape a sub-U / half-width device needs. */
-type CarrierShape = "2col" | "2x2";
+type CarrierShape = "2col" | "2u-2col" | "2x2";
 
-/** Pick the carrier shape for a device: half-height gear needs the 2x2 grid. */
+/** Pick the carrier shape for a device: sub-U gear needs the 2x2 grid. */
 function carrierShapeFor(deviceType: DeviceType | undefined): CarrierShape {
-  return isSubUHeight(deviceType) ? "2x2" : "2col";
+  if (isSubUHeight(deviceType)) return "2x2";
+  return deviceType?.u_height === 2 ? "2u-2col" : "2col";
 }
 
 const SHAPE_SLUG: Record<CarrierShape, string> = {
   "2col": CARRIER_2COL_SLUG,
+  "2u-2col": CARRIER_2U_2COL_SLUG,
   "2x2": CARRIER_2X2_SLUG,
 };
 const SHAPE_SLOTS: Record<CarrierShape, readonly string[]> = {
   "2col": COL_SLOTS,
+  "2u-2col": COL_SLOTS,
   "2x2": GRID_SLOTS,
 };
 

--- a/src/lib/storage/adapt-legacy-layout.ts
+++ b/src/lib/storage/adapt-legacy-layout.ts
@@ -201,7 +201,7 @@ function buildCarrier(
 /** Carrier shape a sub-U / half-width device needs. */
 type CarrierShape = "2col" | "2u-2col" | "2x2";
 
-/** Pick the carrier shape for a device: sub-U gear needs the 2x2 grid. */
+/** Pick the carrier shape for a device: sub-U gear needs the 2x2 grid, 2U gear needs 2u-2col, others use 2col. */
 function carrierShapeFor(deviceType: DeviceType | undefined): CarrierShape {
   if (isSubUHeight(deviceType)) return "2x2";
   return deviceType?.u_height === 2 ? "2u-2col" : "2col";

--- a/src/tests/adapt-legacy-layout.test.ts
+++ b/src/tests/adapt-legacy-layout.test.ts
@@ -5,6 +5,7 @@ import {
   CARRIER_2X2_SLUG,
 } from "$lib/storage";
 import { LayoutSchema } from "$lib/schemas";
+import { CARRIER_2U_2COL_SLUG } from "$lib/storage/adapt-legacy-layout";
 import { toInternalUnits } from "$lib/utils/position";
 import { UNITS_PER_U } from "$lib/types/constants";
 import { encodeLayout, decodeLayout } from "$lib/utils/share";
@@ -257,6 +258,42 @@ describe("adaptLegacyLayout", () => {
       const carriers = rackLevel(adapted).filter((d) => d.auto_created);
       // eslint-disable-next-line no-restricted-syntax -- a front and a rear carrier, not a pair
       expect(carriers).toHaveLength(2);
+    });
+
+    it("wraps a legacy 2U half-width device into a height-matched carrier", () => {
+      const twoUHalf = createTestDeviceType({
+        slug: "two-u-half",
+        u_height: 2,
+        slot_width: 1,
+      });
+      const layout = createTestLayout({
+        device_types: [twoUHalf],
+        racks: [
+          createTestRack({
+            devices: [
+              createTestDevice({
+                id: "two-u-dev",
+                device_type: "two-u-half",
+                position: 10,
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const adapted = adaptLegacyLayout(layout);
+      const carrier = rackLevel(adapted).find((d) => d.auto_created);
+      expect(carrier?.device_type).toBe(CARRIER_2U_2COL_SLUG);
+      expect(carrier?.position).toBe(toInternalUnits(10));
+
+      const child = children(adapted).find((d) => d.id === "two-u-dev");
+      expect(child?.container_id).toBe(carrier?.id);
+      expect(child?.slot_id).toBe("col-1");
+      expect(
+        adapted.device_types.some(
+          (t) => t.slug === CARRIER_2U_2COL_SLUG && (t.slots?.length ?? 0) > 0,
+        ),
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to CodeAnt feedback on merged PR #2873.

- Maps legacy 2U half-width rack-level devices to `carrier-2u-2col` during adapter wrapping.
- Keeps existing 1U half-width and sub-U adapter behavior unchanged.
- Adds a regression test that verifies the 2U carrier placement and hydrated carrier type.

Closes #2886

## Verification

- `vitest run src/tests/adapt-legacy-layout.test.ts`
- `eslint src/lib/storage/adapt-legacy-layout.ts src/tests/adapt-legacy-layout.test.ts`
- `eslint .`

Co-Authored-By: Codex <codex@openai.com>


___

## **CodeAnt-AI Description**
**Legacy 2U half-width devices now use the correct carrier shape**

### What Changed
- Legacy 2U half-width devices are now wrapped in a height-matched 2-column carrier instead of the generic half-width carrier.
- Half-height devices still use the 2x2 carrier, and other half-width devices keep their existing carrier behavior.
- Added coverage to verify the carrier type, placement, child slot, and that the carrier type is added to the available device types.

### Impact
`✅ Correct carrier placement for 2U devices`
`✅ Fewer layout mismatches after migration`
`✅ More reliable legacy layout conversion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
