### PR TITLE
chore: Rack.svelte hot-path memo + dropPreview equality guard (#2877, #2878)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -42,7 +42,6 @@
   import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { validStartPositions } from "$lib/utils/placement-keyboard";
   import { SvelteSet, SvelteMap } from "svelte/reactivity";
-  import { toHumanUnits } from "$lib/utils/position";
   import { fade } from "svelte/transition";
   import { prefersReducedMotion } from "svelte/motion";
   import {
@@ -182,25 +181,13 @@
     };
   });
 
+  // Slug index rebuilt only when deviceLibrary changes; collapses O(D x L)
+  // proxy-trapped finds to O(D) map hits. Same pattern as AnnotationColumn.
+  const bySlug = $derived(new Map(deviceLibrary.map((dt) => [dt.slug, dt])));
+
   // --- Utility lookups ---
   function getDeviceBySlug(slug: string): DeviceType | undefined {
-    return deviceLibrary.find((d) => d.slug === slug);
-  }
-
-  function getContainerContext(childDevice: PlacedDevice) {
-    if (!childDevice.container_id) return undefined;
-    const container = rack.devices.find(
-      (d) => d.id === childDevice.container_id,
-    );
-    if (!container) return undefined;
-    const containerType = getDeviceBySlug(container.device_type);
-    if (!containerType) return undefined;
-    const slot = containerType.slots?.find((s) => s.id === childDevice.slot_id);
-    return {
-      containerName: containerType.model ?? containerType.slug,
-      containerPosition: toHumanUnits(container.position),
-      slotName: slot?.name ?? childDevice.slot_id ?? "Unknown",
-    };
+    return bySlug.get(slug);
   }
 
   // --- Layout constants & derived dimensions ---
@@ -268,7 +255,7 @@
         if (placedDevice.container_id) return false;
         const ef = effectiveFace(
           placedDevice,
-          deviceLibrary.find((d) => d.slug === placedDevice.device_type),
+          bySlug.get(placedDevice.device_type),
         );
         return ef === "both" || ef === effectiveFaceFilter;
       }),
@@ -281,10 +268,7 @@
     >();
     rack.devices.forEach((pd, idx) => {
       if (!pd.container_id) return;
-      const ef = effectiveFace(
-        pd,
-        deviceLibrary.find((d) => d.slug === pd.device_type),
-      );
+      const ef = effectiveFace(pd, bySlug.get(pd.device_type));
       if (ef !== "both" && ef !== effectiveFaceFilter) return;
       const children = map.get(pd.container_id) ?? [];
       children.push({ placedDevice: pd, originalIndex: idx });
@@ -530,9 +514,6 @@
     <g transform="translate(0, {RACK_PADDING + RAIL_WIDTH})">
       {#each visibleDevices as { placedDevice, originalIndex } (placedDevice.id)}
         {@const device = getDeviceBySlug(placedDevice.device_type)}
-        {@const containerCtx = placedDevice.container_id
-          ? getContainerContext(placedDevice)
-          : undefined}
         {@const children = containerChildren.get(placedDevice.id) ?? []}
         <!-- Transition wrapper must sit directly in the each item: local
              transitions only play when their own block is created/destroyed,
@@ -563,7 +544,6 @@
               frontImageRef={placedDevice.front_image}
               rearImageRef={placedDevice.rear_image}
               colourOverride={placedDevice.colour_override}
-              containerContext={containerCtx}
               {deviceLibrary}
               containerChildDevices={children}
               selectedChildId={selectedDeviceId}

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -355,6 +355,28 @@
   // The active preview: a live pointer drag wins; otherwise the keyboard cursor.
   const activePreview = $derived(dropPreview ?? keyboardCursorPreview);
 
+  // resolveDropTarget mints a fresh { position, height, feedback } object on
+  // every pointermove/dragover; assigning it unconditionally wakes the derived
+  // graph (activePreview + every isDropTarget) on each pixel even when the
+  // resolved slot has not changed. Skip the write when all three fields match
+  // the current preview; null (clear) always passes through.
+  function setDropPreviewIfChanged(p: DropPreviewState | null): void {
+    if (p === null) {
+      dropPreview = null;
+      return;
+    }
+    const cur = dropPreview;
+    if (
+      cur !== null &&
+      cur.position === p.position &&
+      cur.height === p.height &&
+      cur.feedback === p.feedback
+    ) {
+      return;
+    }
+    dropPreview = p;
+  }
+
   // --- Handler context for extracted interaction handlers ---
   const handlerCtx = $derived<RackHandlerContext>({
     getRack: () => rack,
@@ -363,9 +385,7 @@
     getFaceFilter: () => effectiveFaceFilter,
     getSelectedDeviceId: () => selectedDeviceId,
     getEventCallbacks: () => eventCallbacks,
-    setDropPreview: (p) => {
-      dropPreview = p;
-    },
+    setDropPreview: setDropPreviewIfChanged,
     setContainerHoverInfo: (i) => {
       containerHoverInfo = i;
     },
@@ -393,9 +413,7 @@
       getFaceFilter: () => effectiveFaceFilter,
       getSelectedDeviceId: () => selectedDeviceId,
       getEventCallbacks: () => eventCallbacks,
-      setDropPreview: (p) => {
-        dropPreview = p;
-      },
+      setDropPreview: setDropPreviewIfChanged,
       setContainerHoverInfo: (i) => {
         containerHoverInfo = i;
       },

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -64,12 +64,6 @@
     rearImageRef?: string;
     /** Custom colour override for this placement (overrides device type colour) */
     colourOverride?: string;
-    /** Container context for child devices (for accessibility announcements) */
-    containerContext?: {
-      containerName: string;
-      containerPosition: number;
-      slotName: string;
-    };
     /** Device library for looking up child device types */
     deviceLibrary?: DeviceType[];
     /** Child devices placed inside this container (if container) */
@@ -129,7 +123,6 @@
     frontImageRef,
     rearImageRef,
     colourOverride,
-    containerContext,
     deviceLibrary = [],
     containerChildDevices = [],
     selectedChildId = null,
@@ -362,11 +355,6 @@
 
     const rearState =
       isRearTreatment && !showImage && !showImagePlaceholder ? ", rear" : "";
-
-    if (containerContext) {
-      // Child device: announce hierarchy per Epic #159
-      return `${base} in ${containerContext.slotName} of ${containerContext.containerName} at U${containerContext.containerPosition}${imageState}${rearState}${selected ? ", selected" : ""}`;
-    }
 
     // Rack-level device: standard announcement
     return `${base} at U${positionHuman}${imageState}${rearState}${selected ? ", selected" : ""}`;


### PR DESCRIPTION
## **User description**
Closes #2877, closes #2878.

Two verified low-impact findings from the 2026-07-03 Svelte 5 hot-path audit, both touching Rack.svelte, on one branch with separate commits.

## #2877 - equality-guard setDropPreview

`resolveDropTarget` mints a fresh `{ position, height, feedback }` object on every pointermove/dragover. Both `setDropPreview` closures in Rack.svelte (handler context and the Safari pointer-drag listener) assigned it unconditionally, so ~21 of 22 within-slot moves wrote a new reference and woke `activePreview` plus every per-slot `isDropTarget` derived on each pixel.

Added `setDropPreviewIfChanged`: skip the write when position, height, and feedback all match the current preview; null clears always pass through. Wired to both closures. A referential no-op filter; no new tests.

## #2878 - memoise slug-to-device Map

Three render-path sites each ran `deviceLibrary.find((d) => d.slug === ...)` over a deep-proxied array: `getDeviceBySlug`, the `visibleDevices` filter, and `containerChildren`. Memoised `bySlug = $derived(new Map(deviceLibrary.map((dt) => [dt.slug, dt])))` (rebuilt only when deviceLibrary changes, same pattern as AnnotationColumn.svelte) and switched all three sites to `.get()`. The same proxy objects come out of the map, so downstream identity comparisons are unaffected.

### Side cleanup: getContainerContext was dead

The issue flagged the `getContainerContext` call in the keyed each as apparently dead. Verified and confirmed:

- `visibleDevices` filters out any device with a truthy `container_id` (`if (placedDevice.container_id) return false`), so in `{#each visibleDevices}` the ternary `placedDevice.container_id ? getContainerContext(placedDevice) : undefined` always took the false branch.
- `getContainerContext` had exactly one call site (that ternary), so the function itself was orphaned.
- `<RackDevice>` is instantiated in exactly one place, and `containerContext={containerCtx}` was always `undefined` there, so the `containerContext` prop and its `if (containerContext)` aria branch in RackDevice.svelte never ran. Container children are rendered inline via `containerChildDevices`, not as nested `<RackDevice>` components with a `containerContext` prop.

Per the project rule (delete dead code completely), removed: the `getContainerContext` function, the `containerCtx` const and ternary, the `containerContext` prop pass, the now-unused `toHumanUnits` import in Rack.svelte, and the `containerContext` prop definition, destructure, and aria branch in RackDevice.svelte. No behaviour change (the branch was unreachable); no test referenced `containerContext`.

## Verification

- `npm run check`: 0 errors, 0 warnings (5488 files)
- `npm run lint` on both files: clean
- `prettier --write` on both files: applied (Rack.svelte reformatted)
- Targeted suites green (540 total across both commits): rack-row, rack-undo, container-collision, carrier-placement, chassis-child-placement, device-movement, layout-device-actions, selection-move-announcements, dragdrop, dnd-within-rack, dnd-between-racks, placement-pointer, placement-keyboard, layout-preview-cache, touch-drag-threshold, MobileRacksSheet

Both issues decline new tests; existing suites are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Speed up rack rendering and avoid repeated drag preview updates**

### What Changed
- Rack lookups now use a cached device index, so rack items and container contents are found without repeated list scans
- Drag previews now update only when the hovered slot actually changes, which reduces extra redraws while moving across a slot
- Child device container details were removed from the device label, so those devices are announced the same way as other rack items

### Impact
`✅ Smoother rack dragging`
`✅ Fewer unnecessary rack redraws`
`✅ Faster rack rendering with large device lists`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
