### PR TITLE
chore: stop VerbBarOverlay's perpetual per-frame poll while a selection is idle (#2879)

### DIFF
--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -273,13 +273,24 @@
   const anchorSignal = $derived.by<string | null>(() => {
     if (selection.isDeviceSelected && selection.selectedDeviceId) {
       const id = selection.selectedDeviceId;
-      for (const rack of layout.racks) {
+      // Track the rack's row index, its bayed-group index, and its slot within
+      // that group's rack_ids so the signature changes on every reorder that
+      // moves the device's screen x. reorderRacks rewrites rack.position and
+      // the array order (row index catches it). reorderRacksInGroup swaps
+      // only group.rack_ids and leaves rack.position untouched, but bayed
+      // members render flush in rack_ids order (stable position sort when
+      // positions are equal), so an internal group reorder still moves the
+      // device; the slot index catches it. rack.position is included too as
+      // the persisted row-order field.
+      for (const [i, rack] of layout.racks.entries()) {
         for (const dev of rack.devices) {
           if (dev.id === id) {
-            // rack.position is the persisted row-order field (reorderRacks
-            // reassigns it), so including it wakes re-measurement when the
-            // rack containing the selected device is reordered in its row.
-            return `${rack.id}|${rack.position}|${rack.width}|${rack.height}|${dev.position}|${dev.device_type}`;
+            const group = layout.rack_groups.find((g) =>
+              g.rack_ids.includes(rack.id),
+            );
+            const gIdx = group ? layout.rack_groups.indexOf(group) : -1;
+            const slotInGroup = group ? group.rack_ids.indexOf(rack.id) : -1;
+            return `${rack.id}|${i}|${gIdx}|${slotInGroup}|${rack.position}|${rack.width}|${rack.height}|${dev.position}|${dev.device_type}`;
           }
         }
       }
@@ -310,7 +321,14 @@
     void canvas.isInteracting;
     void canvas.cameraMoveId;
     void anchorSignal;
-    if (verbs.length === 0) return;
+    if (verbs.length === 0) {
+      // The {#if verbs.length > 0} template unmounts the bar, so nothing is
+      // visible after selection clears. But pos retains its last value; reset
+      // it here so a subsequent re-select does not flash the stale position
+      // for a frame before the first measure() tick lands.
+      hide();
+      return;
+    }
 
     let raf = 0;
     // Stop the loop once this deadline expires with no motion in flight. Any

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -36,6 +36,13 @@
   import { getUIStore } from "$lib/stores/ui.svelte";
   import { getStorageMode } from "$lib/storage";
 
+  // How long the measure loop keeps running after the last detected motion
+  // before going idle. Motion in flight (a pan/zoom gesture, the camera tween,
+  // or the bar still moving) extends this every frame; it only needs to bridge
+  // the gap between a discrete wake (selection, camera, or layout commit) and
+  // the first frame that registers the resulting position change.
+  const SETTLE_MS = 200;
+
   interface Props {
     /** Screen-space canvas container the overlay measures and positions within. */
     canvasEl: HTMLElement | null;
@@ -258,22 +265,67 @@
     }
   }
 
+  // A reactive signature of the anchor's geometry. Reading it in the measure
+  // effect wakes the loop on committed moves (the 120ms settle tween), rack
+  // reorder, bayed-group reorder, and container resize, none of which produce a
+  // per-frame signal. Camera/pan/zoom motion is signalled separately via
+  // canvas.isInteracting / cameraMoveId.
+  const anchorSignal = $derived.by<string | null>(() => {
+    if (selection.isDeviceSelected && selection.selectedDeviceId) {
+      const id = selection.selectedDeviceId;
+      for (const rack of layout.racks) {
+        for (const dev of rack.devices) {
+          if (dev.id === id) {
+            return `${rack.id}|${rack.width}|${rack.height}|${dev.position}|${dev.device_type}`;
+          }
+        }
+      }
+      return null;
+    }
+    if (selection.isRackSelected || selection.isGroupSelected) {
+      const id = selection.selectedRackId ?? "";
+      const idx = layout.racks.findIndex((r) => r.id === id);
+      const rack = idx >= 0 ? layout.racks[idx] : null;
+      const gidx = layout.rack_groups.findIndex((g) => g.rack_ids.includes(id));
+      return `${idx}|${gidx}|${rack ? rack.width : 0}|${rack ? rack.height : 0}`;
+    }
+    return null;
+  });
+
   // Keep the bar pinned to the selected object. Pan has no reactive signal in
-  // the canvas store, so a requestAnimationFrame loop (running only while a bar
-  // is shown) tracks pan and zoom; a target or verb-set change re-runs this
-  // effect. measure() skips state writes when nothing moved, so an idle
-  // selection costs only a couple of getBoundingClientRect reads per frame and
-  // triggers no re-render.
+  // the canvas store (panzoom mutates the DOM transform directly) and the
+  // camera tween animates the transform without per-frame state, so a
+  // requestAnimationFrame loop tracks motion in flight. The loop is gated: it
+  // runs only while a motion signal is active (a pan/zoom gesture, the camera
+  // tween, or a layout commit that moves the anchor) and for the SETTLE_MS
+  // window after, then stops. An idle selection does zero per-frame work: no
+  // rAF tick, no querySelector, no getBoundingClientRect.
   $effect(() => {
     void selection.selectedDeviceId;
     void selection.selectedRackId;
     void verbs;
+    void canvas.isInteracting;
+    void canvas.cameraMoveId;
+    void anchorSignal;
     if (verbs.length === 0) return;
 
     let raf = 0;
+    // Stop the loop once this deadline expires with no motion in flight. Any
+    // wake (selection, verb, camera, or layout-commit change) resets it; an
+    // active gesture or tween, or the bar still moving, keeps extending it.
+    let deadline = performance.now() + SETTLE_MS;
     const tick = () => {
+      const prev = pos;
       measure();
-      raf = requestAnimationFrame(tick);
+      const moved = pos !== prev;
+      const interacting = canvas.isInteracting;
+      const now = performance.now();
+      if (interacting || moved) deadline = now + SETTLE_MS;
+      if (now < deadline) {
+        raf = requestAnimationFrame(tick);
+      } else {
+        raf = 0;
+      }
     };
     raf = requestAnimationFrame(tick);
 

--- a/src/lib/components/VerbBarOverlay.svelte
+++ b/src/lib/components/VerbBarOverlay.svelte
@@ -276,7 +276,10 @@
       for (const rack of layout.racks) {
         for (const dev of rack.devices) {
           if (dev.id === id) {
-            return `${rack.id}|${rack.width}|${rack.height}|${dev.position}|${dev.device_type}`;
+            // rack.position is the persisted row-order field (reorderRacks
+            // reassigns it), so including it wakes re-measurement when the
+            // rack containing the selected device is reordered in its row.
+            return `${rack.id}|${rack.position}|${rack.width}|${rack.height}|${dev.position}|${dev.device_type}`;
           }
         }
       }

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -62,6 +62,13 @@ let currentZoom = $state(1); // 1 = 100%
 let canvasElement = $state<HTMLElement | null>(null);
 let isPanning = $state(false);
 let isZooming = $state(false);
+// Bumped once at the start of each programmatic camera move (smoothMoveTo and
+// its callers: focusRack, zoomToDevice, ensureRacksVisible). Pan has no
+// reactive signal (panzoom mutates the DOM transform directly) and the tween
+// animates the transform without per-frame state, so consumers that must follow
+// camera motion (the verb bar overlay) read this to know when to re-measure.
+// Pan/zoom gestures are signalled separately via isInteracting.
+let cameraMoveId = $state(0);
 let zoomEndTimer: ReturnType<typeof setTimeout> | null = null;
 let viewportSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let suppressViewportSave = false;
@@ -138,6 +145,9 @@ export function getCanvasStore() {
     },
     get isInteracting() {
       return isPanning || isZooming;
+    },
+    get cameraMoveId() {
+      return cameraMoveId;
     },
 
     // Actions
@@ -428,6 +438,10 @@ function stepCameraAnimation(now: number): void {
  */
 function smoothMoveTo(x: number, y: number, scale: number): void {
   if (!panzoomInstance) return;
+
+  // Wake consumers that follow camera motion (the verb bar overlay) for both
+  // the animated tween and the reduced-motion instant landing below.
+  cameraMoveId++;
 
   // Reduced motion: land the camera instantly, cancelling any in-flight transition.
   if (prefersReducedMotion()) {

--- a/src/lib/stores/canvas.svelte.ts
+++ b/src/lib/stores/canvas.svelte.ts
@@ -62,11 +62,14 @@ let currentZoom = $state(1); // 1 = 100%
 let canvasElement = $state<HTMLElement | null>(null);
 let isPanning = $state(false);
 let isZooming = $state(false);
-// Bumped once at the start of each programmatic camera move (smoothMoveTo and
-// its callers: focusRack, zoomToDevice, ensureRacksVisible). Pan has no
-// reactive signal (panzoom mutates the DOM transform directly) and the tween
-// animates the transform without per-frame state, so consumers that must follow
-// camera motion (the verb bar overlay) read this to know when to re-measure.
+// Bumped once at the start of each programmatic camera move so consumers that
+// must follow camera motion (the verb bar overlay) re-measure. Covers the
+// animated tween (smoothMoveTo and its callers: focusRack, zoomToDevice,
+// ensureRacksVisible) and every direct viewport mutator (zoomIn, zoomOut,
+// setZoom, resetZoom, moveTo, fitAll, restoreViewport). moveTo in particular
+// fires no panstart/zoom event for programmatic calls, so the bump is required
+// there; the zoom mutators also bump for a deterministic signal rather than
+// relying on the transient isZooming window from the panzoom zoom event.
 // Pan/zoom gestures are signalled separately via isInteracting.
 let cameraMoveId = $state(0);
 let zoomEndTimer: ReturnType<typeof setTimeout> | null = null;
@@ -111,6 +114,7 @@ export function resetCanvasStore(): void {
   canvasElement = null;
   isPanning = false;
   isZooming = false;
+  cameraMoveId = 0;
   cancelZoomEnd();
   cancelViewportSave();
   cancelCameraAnimation();
@@ -235,6 +239,7 @@ function restoreViewport(): boolean {
       y: saved.y,
       scale,
     });
+    cameraMoveId++;
     cancelCameraAnimation();
     panzoomInstance.zoomAbs(0, 0, scale);
     panzoomInstance.moveTo(saved.x, saved.y);
@@ -307,6 +312,7 @@ function disposePanzoom(): void {
 function zoomIn(): void {
   if (!panzoomInstance || currentZoom >= ZOOM_MAX) return;
 
+  cameraMoveId++;
   cancelCameraAnimation();
   const newZoom = snapZoom(currentZoom, "in");
   const transform = panzoomInstance.getTransform();
@@ -321,6 +327,7 @@ function zoomIn(): void {
 function zoomOut(): void {
   if (!panzoomInstance || currentZoom <= ZOOM_MIN) return;
 
+  cameraMoveId++;
   cancelCameraAnimation();
   const newZoom = snapZoom(currentZoom, "out");
   const transform = panzoomInstance.getTransform();
@@ -335,6 +342,7 @@ function zoomOut(): void {
 function setZoom(scale: number): void {
   if (!panzoomInstance) return;
 
+  cameraMoveId++;
   cancelCameraAnimation();
   const clampedScale = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, scale));
   const transform = panzoomInstance.getTransform();
@@ -348,6 +356,7 @@ function setZoom(scale: number): void {
 function resetZoom(): void {
   if (!panzoomInstance) return;
 
+  cameraMoveId++;
   cancelCameraAnimation();
   suppressViewportSave = true;
   clearSavedViewport();
@@ -371,6 +380,9 @@ function getTransform(): { x: number; y: number; scale: number } {
  */
 function moveTo(x: number, y: number): void {
   if (!panzoomInstance) return;
+  // Pure pan: programmatic moveTo fires no panstart/zoom event, so without
+  // this bump the verb bar overlay would not re-measure after a moveTo.
+  cameraMoveId++;
   cancelCameraAnimation();
   panzoomInstance.moveTo(x, y);
 }
@@ -489,6 +501,7 @@ function fitAll(
 ): void {
   if (!panzoomInstance || !canvasElement || racks.length === 0) return;
 
+  cameraMoveId++;
   suppressViewportSave = true;
   cancelViewportSave();
   cancelCameraAnimation();


### PR DESCRIPTION
## **User description**
Closes #2879.

The 2026-07-03 hot-path audit's completeness critic flagged this as the single biggest standing rAF consumer in the app: whenever a selection is live (`verbs.length > 0`), `VerbBarOverlay` ran a perpetual `requestAnimationFrame` loop for the entire lifetime of the selection, each tick running `querySelector` + two `getBoundingClientRect` reads + position math. The state write was already guarded (no re-render churn), but the per-frame DOM query and layout reads ran while the selection sat idle.

This replaces it with the issue's gated-loop candidate: same measurement path, smallest diff, but the loop runs only while motion is in flight plus a 200ms SETTLE window, then stops. An idle selection does zero per-frame work.

## Wake signals (read in the measure `$effect`)

- `canvas.isInteracting` covers pan/zoom gestures. Pan has no reactive signal in the canvas store (panzoom mutates the DOM transform directly), so the loop must watch gestures.
- `canvas.cameraMoveId`, a new counter in the canvas store, bumped once at the start of each programmatic camera move (`smoothMoveTo`, covering `focusRack`/`zoomToDevice`/`ensureRacksVisible`), for both the animated tween and the reduced-motion instant landing. The camera tween animates the transform without per-frame state, so consumers that must follow camera motion read this.
- `anchorSignal`, a derived string signature of the anchor's geometry (rack id/width/height + device position/type for a device; rack index + group index + width/height for a rack/group). Reading it wakes the loop on committed moves (the 120ms settle tween from #2876), rack reorder, bayed-group reorder, and container resize, none of which produce a per-frame signal.
- existing selection/verb deps re-run the effect, resetting the loop.

The loop extends its deadline while `canvas.isInteracting` is true or `measure()` detects the anchor moved, so it stays alive through the full duration of any motion source; `SETTLE_MS` bridges the gap between a discrete wake and the first frame that registers the resulting position change. The effect cancels its rAF on cleanup so a new wake mid-motion does not leak loops. Window resize/scroll listeners kept as-is.

## Acceptance criteria

- [x] An idle selection (no camera motion, no layout change) performs zero per-frame work: no rAF tick, no querySelector, no getBoundingClientRect
- [x] Bar stays pinned during pan/zoom gestures, camera transitions, and committed device moves including the settle tween (covered by `isInteracting` + `cameraMoveId` + `anchorSignal`)
- [x] Bar still hides below `VERB_BAR_LOW_ZOOM_THRESHOLD` and while zoomed out, unchanged (the `measure()` visibility logic is untouched)
- [x] Existing suites pass: `verb-bar-overlay.test.ts` (23) and `verb-bar-position.test.ts` unchanged

## Known gap (flagged, not blocking)

A keyboard-initiated rack-row reorder with a **device** selected does not change `anchorSignal`: rack id/width/height and device position/type are all invariant under a rack-row reorder, so the derived returns an equal string and the effect does not re-run. An already-idle loop would not re-measure in that specific case. Drag-initiated reorder is covered by `isInteracting`. The bar self-corrects on the next wake (any selection/verb/camera change). Calling this out for reviewers rather than expanding scope without evidence it bites in practice.

## Verification

- `npm run check`: 0 errors, 0 warnings (5488 files)
- `npm run lint`: clean
- `prettier --check` on both files: clean
- `verb-bar-overlay.test.ts` + `verb-bar-position.test.ts`: 23 passed
- Full unit suite: 201 files, 3221 tests passed

Sequenced after #2874 and #2876 (both merged) per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop the verb bar from polling every frame when nothing is moving**

### What Changed
- The verb bar now stops its frame-by-frame position checks after motion ends, instead of running continuously while a selection stays active
- It still follows pan, zoom, camera moves, and layout changes while movement is happening, then goes idle after a short settle period
- Reduced-motion camera jumps also trigger the bar to re-measure so it stays attached to the selected item

### Impact
`✅ Lower CPU while a selection is idle`
`✅ Smoother pan and zoom`
`✅ Fewer unnecessary layout reads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
