### PR TITLE
fix(api): bounded, cycle-safe YAML complexity guard (alias-expansion DoS) (#2912)

### DIFF
--- a/api/src/routes/layouts.test.ts
+++ b/api/src/routes/layouts.test.ts
@@ -208,8 +208,9 @@ describe("PUT /layouts/:uuid YAML alias-expansion DoS guard (#2912)", () => {
    * a chain of anchors/aliases, each level referencing the previous level
    * twice. js-yaml resolves this to a shared-reference object graph in
    * O(input), but a naive expansion (the prior JSON.stringify guard) would
-   * materialize roughly 10 * 2^depth leaves -- at depth 20 that is ~10.5M
-   * leaves and ~138MB of JSON text from a body of a few hundred bytes.
+   * materialize roughly 10 * 2^depth leaves. At depth 24 that is ~168M leaves
+   * and gigabytes of JSON text from a body of a few hundred bytes, so the old
+   * guard would take multiple seconds or OOM before returning.
    */
   function aliasBombYaml(depth: number): string {
     const lines = [
@@ -229,7 +230,7 @@ describe("PUT /layouts/:uuid YAML alias-expansion DoS guard (#2912)", () => {
   }
 
   it("rejects a nested-alias alias-bomb body with a fast 400 and no runaway allocation", async () => {
-    const body = aliasBombYaml(20);
+    const body = aliasBombYaml(24);
     expect(Buffer.byteLength(body, "utf8")).toBeLessThan(1024 * 1024);
 
     const start = performance.now();
@@ -237,10 +238,12 @@ describe("PUT /layouts/:uuid YAML alias-expansion DoS guard (#2912)", () => {
     const elapsedMs = performance.now() - start;
 
     expect(res.status).toBe(400);
-    // Generous relative to the sub-millisecond bounded traversal, but two
-    // orders of magnitude below the ~1s/138MB the old JSON.stringify guard
-    // took to materialize the same body (see issue #2912 repro).
-    expect(elapsedMs).toBeLessThan(500);
+    // The bounded traversal rejects this in O(depth) work (single-digit ms).
+    // The bound is deliberately generous so a loaded CI runner cannot flake it,
+    // yet it is far below the multi-second/OOM the old JSON.stringify guard
+    // needed to materialize this body's ~168M-leaf expansion: a regression to
+    // full expansion fails this assertion by orders of magnitude.
+    expect(elapsedMs).toBeLessThan(2000);
 
     const data = await res.json();
     expect(data.error).toContain("too complex");

--- a/api/src/routes/layouts.test.ts
+++ b/api/src/routes/layouts.test.ts
@@ -202,6 +202,69 @@ describe("PUT /layouts/:uuid schema validation (#2449)", () => {
   });
 });
 
+describe("PUT /layouts/:uuid YAML alias-expansion DoS guard (#2912)", () => {
+  /**
+   * Builds a small YAML body (well under 1MB) whose metadata section carries
+   * a chain of anchors/aliases, each level referencing the previous level
+   * twice. js-yaml resolves this to a shared-reference object graph in
+   * O(input), but a naive expansion (the prior JSON.stringify guard) would
+   * materialize roughly 10 * 2^depth leaves -- at depth 20 that is ~10.5M
+   * leaves and ~138MB of JSON text from a body of a few hundred bytes.
+   */
+  function aliasBombYaml(depth: number): string {
+    const lines = [
+      'version: "1.0.0"',
+      "name: AliasBomb",
+      "metadata:",
+      `  id: "${URL_UUID}"`,
+      "  name: AliasBomb",
+      '  schema_version: "1.0.0"',
+      "  a0: &a0 [x, x, x, x, x, x, x, x, x, x]",
+    ];
+    for (let i = 1; i <= depth; i++) {
+      lines.push(`  a${i}: &a${i} [*a${i - 1}, *a${i - 1}]`);
+    }
+    lines.push("racks: []");
+    return lines.join("\n");
+  }
+
+  it("rejects a nested-alias alias-bomb body with a fast 400 and no runaway allocation", async () => {
+    const body = aliasBombYaml(20);
+    expect(Buffer.byteLength(body, "utf8")).toBeLessThan(1024 * 1024);
+
+    const start = performance.now();
+    const res = await putLayout(URL_UUID, body);
+    const elapsedMs = performance.now() - start;
+
+    expect(res.status).toBe(400);
+    // Generous relative to the sub-millisecond bounded traversal, but two
+    // orders of magnitude below the ~1s/138MB the old JSON.stringify guard
+    // took to materialize the same body (see issue #2912 repro).
+    expect(elapsedMs).toBeLessThan(500);
+
+    const data = await res.json();
+    expect(data.error).toContain("too complex");
+
+    // The alias-bomb body must not have been written to disk.
+    const entries = await readdir(testDir);
+    expect(
+      entries.find((e) => e.toLowerCase().includes(URL_UUID.toLowerCase())),
+    ).toBeUndefined();
+  });
+
+  it("still accepts and round-trips a normal layout body", async () => {
+    const body = layoutYaml("Normal Layout", URL_UUID);
+
+    const putRes = await putLayout(URL_UUID, body);
+    expect(putRes.status).toBe(201);
+
+    const getRes = await app.request(`/layouts/${URL_UUID}`);
+    expect(getRes.status).toBe(200);
+    const savedContent = await getRes.text();
+    expect(savedContent).toBe(body);
+  });
+});
+
 describe("createApp storage driver injection (#2624)", () => {
   it("routes resolve the storage driver provided via deps, not the filesystem", async () => {
     // A stub driver records which methods the routes call and returns a

--- a/api/src/routes/layouts.test.ts
+++ b/api/src/routes/layouts.test.ts
@@ -229,22 +229,17 @@ describe("PUT /layouts/:uuid YAML alias-expansion DoS guard (#2912)", () => {
     return lines.join("\n");
   }
 
-  it("rejects a nested-alias alias-bomb body with a fast 400 and no runaway allocation", async () => {
+  it("rejects a nested-alias alias-bomb body without expanding it", async () => {
     const body = aliasBombYaml(24);
     expect(Buffer.byteLength(body, "utf8")).toBeLessThan(1024 * 1024);
 
-    const start = performance.now();
+    // Boundedness is asserted structurally, not by wall-clock: a regression to
+    // full expansion of this ~168M-leaf body would return 201 (saving it) or
+    // OOM / blow past the runner's own timeout, so the status and no-disk-write
+    // checks below catch it without a flake-prone timing assertion.
     const res = await putLayout(URL_UUID, body);
-    const elapsedMs = performance.now() - start;
 
     expect(res.status).toBe(400);
-    // The bounded traversal rejects this in O(depth) work (single-digit ms).
-    // The bound is deliberately generous so a loaded CI runner cannot flake it,
-    // yet it is far below the multi-second/OOM the old JSON.stringify guard
-    // needed to materialize this body's ~168M-leaf expansion: a regression to
-    // full expansion fails this assertion by orders of magnitude.
-    expect(elapsedMs).toBeLessThan(2000);
-
     const data = await res.json();
     expect(data.error).toContain("too complex");
 

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -143,7 +143,7 @@ layouts.put("/:uuid", async (c) => {
     // bounded, cycle-safe traversal follows each shared reference only
     // once, so it stays fast and never materializes an expansion.
     try {
-      assertYamlComplexityBounded(parsed);
+      assertYamlComplexityBounded(parsed, yamlContent.length);
     } catch (e) {
       if (
         e instanceof YamlCircularReferenceError ||

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -145,10 +145,10 @@ layouts.put("/:uuid", async (c) => {
     try {
       assertYamlComplexityBounded(parsed);
     } catch (e) {
-      if (e instanceof YamlCircularReferenceError) {
-        return c.json({ error: e.message }, 400);
-      }
-      if (e instanceof YamlTooComplexError) {
+      if (
+        e instanceof YamlCircularReferenceError ||
+        e instanceof YamlTooComplexError
+      ) {
         return c.json({ error: e.message }, 400);
       }
       throw e;

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -143,7 +143,7 @@ layouts.put("/:uuid", async (c) => {
     // bounded, cycle-safe traversal follows each shared reference only
     // once, so it stays fast and never materializes an expansion.
     try {
-      assertYamlComplexityBounded(parsed, yamlContent.length);
+      assertYamlComplexityBounded(parsed, Buffer.byteLength(yamlContent, "utf8"));
     } catch (e) {
       if (
         e instanceof YamlCircularReferenceError ||

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -143,7 +143,10 @@ layouts.put("/:uuid", async (c) => {
     // bounded, cycle-safe traversal follows each shared reference only
     // once, so it stays fast and never materializes an expansion.
     try {
-      assertYamlComplexityBounded(parsed, Buffer.byteLength(yamlContent, "utf8"));
+      assertYamlComplexityBounded(
+        parsed,
+        Buffer.byteLength(yamlContent, "utf8"),
+      );
     } catch (e) {
       if (
         e instanceof YamlCircularReferenceError ||

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -32,6 +32,11 @@ import { UuidSchema, LayoutFileSchema } from "../schemas/layout";
 import type { StorageVariables } from "../storage/driver";
 import { SNAPSHOT_NAME_PATTERN } from "../storage/snapshot-name";
 import { logger } from "../logger";
+import {
+  assertYamlComplexityBounded,
+  YamlCircularReferenceError,
+  YamlTooComplexError,
+} from "../yaml-safety";
 
 /** Header carrying the layout's updatedAt for echo-based conflict detection. */
 export const UPDATED_AT_HEADER = "X-Rackula-Updated-At";
@@ -131,17 +136,22 @@ layouts.put("/:uuid", async (c) => {
       return c.json({ error: `Invalid YAML: ${message}` }, 400);
     }
 
-    // Reject non-serializable bodies (circular references from anchors)
+    // Reject circular and alias-bomb bodies. A naive JSON.stringify guard
+    // would throw on genuine cycles but *succeed* (while fully expanding
+    // shared references) on an acyclic nested-alias body -- the guard
+    // itself was the amplifier for a YAML alias-expansion DoS (#2912). This
+    // bounded, cycle-safe traversal follows each shared reference only
+    // once, so it stays fast and never materializes an expansion.
     try {
-      JSON.stringify(parsed);
-    } catch {
-      return c.json(
-        {
-          error:
-            "YAML body contains circular references and cannot be processed",
-        },
-        400,
-      );
+      assertYamlComplexityBounded(parsed);
+    } catch (e) {
+      if (e instanceof YamlCircularReferenceError) {
+        return c.json({ error: e.message }, 400);
+      }
+      if (e instanceof YamlTooComplexError) {
+        return c.json({ error: e.message }, 400);
+      }
+      throw e;
     }
 
     const layout = LayoutFileSchema.safeParse(parsed);

--- a/api/src/yaml-safety.test.ts
+++ b/api/src/yaml-safety.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Bounded YAML complexity traversal (#2912)
+ *
+ * js-yaml resolves anchors/aliases to shared object references in O(input).
+ * A naive tree walk (e.g. JSON.stringify) re-expands every alias, so a small,
+ * acyclic document with nested aliases can expand to gigabytes ("billion
+ * laughs"). assertYamlComplexityBounded must:
+ * - Detect genuine cycles (a node reachable from itself) and reject them.
+ * - Reject documents whose *would-be-expanded* size exceeds a bound, without
+ *   ever materializing that expansion (bounded CPU and memory).
+ * - Pass through legitimate documents, including ones with large but
+ *   non-exponential shared references, quickly.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  assertYamlComplexityBounded,
+  YamlCircularReferenceError,
+  YamlTooComplexError,
+} from "./yaml-safety";
+
+/**
+ * Builds a chain of arrays where each level references the previous level
+ * twice, mimicking a YAML anchor/alias "billion laughs" body. The compact
+ * (shared-reference) graph has O(depth) nodes and edges, but a naive
+ * expansion would have O(2^depth) leaves.
+ */
+function buildAliasBombChain(depth: number): unknown {
+  let level: unknown[] = ["x", "x", "x", "x", "x", "x", "x", "x", "x", "x"];
+  for (let i = 0; i < depth; i++) {
+    level = [level, level];
+  }
+  return level;
+}
+
+describe("assertYamlComplexityBounded", () => {
+  it("does not throw for a normal, unshared object", () => {
+    const value = {
+      version: "1.0.0",
+      name: "Test",
+      racks: [{ id: "rack-a", devices: [{ id: "dev-1" }, { id: "dev-2" }] }],
+    };
+    expect(() => assertYamlComplexityBounded(value)).not.toThrow();
+  });
+
+  it("does not throw for many non-exponential shared references to the same small object", () => {
+    // A legitimate pattern: the same small object referenced many times
+    // (e.g. a shared device-type lookup). Total size is linear, not
+    // exponential, so this must pass quickly.
+    const shared = { note: "shared" };
+    const value = { items: Array(5000).fill(shared) };
+    const start = performance.now();
+    expect(() => assertYamlComplexityBounded(value)).not.toThrow();
+    expect(performance.now() - start).toBeLessThan(200);
+  });
+
+  it("throws YamlCircularReferenceError for a genuinely circular object", () => {
+    const obj: Record<string, unknown> = { name: "circular" };
+    obj.self = obj;
+    expect(() => assertYamlComplexityBounded(obj)).toThrow(
+      YamlCircularReferenceError,
+    );
+  });
+
+  it("throws YamlCircularReferenceError for a cycle nested inside an array", () => {
+    const inner: Record<string, unknown> = {};
+    const outer = { list: [inner] };
+    inner.parent = outer;
+    expect(() => assertYamlComplexityBounded(outer)).toThrow(
+      YamlCircularReferenceError,
+    );
+  });
+
+  it("throws YamlTooComplexError for a nested-alias chain that would expand exponentially, without expanding it", () => {
+    // Depth 40 would expand to roughly 10 * 2^40 (~1.1e13) leaves if
+    // materialized -- infeasible to actually build. The bounded traversal
+    // must reject this in well under a second by tracking would-be-expanded
+    // size via memoized per-node totals, never walking an already-fully-sized
+    // node's children twice.
+    const bomb = buildAliasBombChain(40);
+    const start = performance.now();
+    expect(() => assertYamlComplexityBounded(bomb)).toThrow(
+      YamlTooComplexError,
+    );
+    expect(performance.now() - start).toBeLessThan(200);
+  });
+
+  it("does not throw for a large legitimate array under the node cap", () => {
+    const value = {
+      racks: Array.from({ length: 500 }, (_, i) => ({
+        id: `rack-${i}`,
+        devices: Array.from({ length: 10 }, (_, j) => ({
+          id: `dev-${i}-${j}`,
+          device_type: "switch-1u",
+          position: j,
+          face: "front",
+        })),
+      })),
+    };
+    expect(() => assertYamlComplexityBounded(value)).not.toThrow();
+  });
+});

--- a/api/src/yaml-safety.test.ts
+++ b/api/src/yaml-safety.test.ts
@@ -6,10 +6,18 @@
  * acyclic document with nested aliases can expand to gigabytes ("billion
  * laughs"). assertYamlComplexityBounded must:
  * - Detect genuine cycles (a node reachable from itself) and reject them.
- * - Reject documents whose *would-be-expanded* size exceeds a bound, without
- *   ever materializing that expansion (bounded CPU and memory).
+ * - Reject documents whose would-be-expanded size exceeds a bound, without
+ *   ever materializing that expansion (bounded CPU and memory). The bound
+ *   covers both node-heavy (nested aliases) and value-heavy (one large string
+ *   aliased many times) bombs.
  * - Pass through legitimate documents, including ones with large but
- *   non-exponential shared references, quickly.
+ *   non-exponential shared references.
+ *
+ * Boundedness is asserted structurally rather than by wall-clock: the depth-40
+ * alias bomb below has ~10 * 2^40 expanded leaves, so a regression to full
+ * expansion could not build or walk it within the test runner's timeout. A
+ * test that completes at all therefore proves the traversal stayed in the
+ * compact graph.
  */
 import { describe, it, expect } from "bun:test";
 import {
@@ -39,24 +47,22 @@ describe("assertYamlComplexityBounded", () => {
       name: "Test",
       racks: [{ id: "rack-a", devices: [{ id: "dev-1" }, { id: "dev-2" }] }],
     };
-    expect(() => assertYamlComplexityBounded(value)).not.toThrow();
+    expect(() => assertYamlComplexityBounded(value, 200)).not.toThrow();
   });
 
   it("does not throw for many non-exponential shared references to the same small object", () => {
     // A legitimate pattern: the same small object referenced many times
-    // (e.g. a shared device-type lookup). Total size is linear, not
-    // exponential, so this must pass quickly.
+    // (e.g. a shared device-type lookup). Total expanded size is linear, not
+    // exponential, so this must pass.
     const shared = { note: "shared" };
     const value = { items: Array(5000).fill(shared) };
-    const start = performance.now();
-    expect(() => assertYamlComplexityBounded(value)).not.toThrow();
-    expect(performance.now() - start).toBeLessThan(200);
+    expect(() => assertYamlComplexityBounded(value, 100)).not.toThrow();
   });
 
   it("throws YamlCircularReferenceError for a genuinely circular object", () => {
     const obj: Record<string, unknown> = { name: "circular" };
     obj.self = obj;
-    expect(() => assertYamlComplexityBounded(obj)).toThrow(
+    expect(() => assertYamlComplexityBounded(obj, 100)).toThrow(
       YamlCircularReferenceError,
     );
   });
@@ -65,26 +71,35 @@ describe("assertYamlComplexityBounded", () => {
     const inner: Record<string, unknown> = {};
     const outer = { list: [inner] };
     inner.parent = outer;
-    expect(() => assertYamlComplexityBounded(outer)).toThrow(
+    expect(() => assertYamlComplexityBounded(outer, 100)).toThrow(
       YamlCircularReferenceError,
     );
   });
 
   it("throws YamlTooComplexError for a nested-alias chain that would expand exponentially, without expanding it", () => {
     // Depth 40 would expand to roughly 10 * 2^40 (~1.1e13) leaves if
-    // materialized -- infeasible to actually build. The bounded traversal
-    // must reject this in well under a second by tracking would-be-expanded
-    // size via memoized per-node totals, never walking an already-fully-sized
-    // node's children twice.
+    // materialized -- infeasible to build. The bounded traversal must reject
+    // it by tracking would-be-expanded size via memoized per-node totals,
+    // never walking an already-fully-sized node's children twice. The input
+    // byte length is tiny, so the floor budget applies.
     const bomb = buildAliasBombChain(40);
-    const start = performance.now();
-    expect(() => assertYamlComplexityBounded(bomb)).toThrow(
+    expect(() => assertYamlComplexityBounded(bomb, 500)).toThrow(
       YamlTooComplexError,
     );
-    expect(performance.now() - start).toBeLessThan(200);
   });
 
-  it("does not throw for a large legitimate array under the node cap", () => {
+  it("throws YamlTooComplexError for a value-heavy bomb: one large string aliased many times", () => {
+    // A small source can define one ~50KB string via an anchor and alias it
+    // thousands of times. Node count stays tiny, but the would-be-expanded
+    // size is hundreds of MB. Counting string leaves by length catches this.
+    const big = "z".repeat(50_000);
+    const value = { arr: Array(5000).fill(big) };
+    expect(() => assertYamlComplexityBounded(value, 55_000)).toThrow(
+      YamlTooComplexError,
+    );
+  });
+
+  it("does not throw for a large legitimate layout whose expanded size tracks its input size", () => {
     const value = {
       racks: Array.from({ length: 500 }, (_, i) => ({
         id: `rack-${i}`,
@@ -96,6 +111,8 @@ describe("assertYamlComplexityBounded", () => {
         })),
       })),
     };
-    expect(() => assertYamlComplexityBounded(value)).not.toThrow();
+    // A body of this shape serializes to a few hundred KB; the cap scales with
+    // that, so a genuine (unaliased) layout of this size passes.
+    expect(() => assertYamlComplexityBounded(value, 300_000)).not.toThrow();
   });
 });

--- a/api/src/yaml-safety.ts
+++ b/api/src/yaml-safety.ts
@@ -1,0 +1,99 @@
+/**
+ * Bounded, cycle-safe complexity check for parsed YAML bodies (#2912).
+ *
+ * js-yaml resolves anchors/aliases to shared object references in O(input):
+ * a document with nested aliases (each level referencing the prior twice) is
+ * acyclic, but a naive tree walk that re-expands every alias -- including
+ * the prior `JSON.stringify(parsed)` guard -- does O(2^depth) work. A body
+ * a few hundred bytes long can expand to gigabytes, hanging the event loop
+ * or OOMing the process. The same risk exists in any other naive consumer
+ * of the parsed value downstream (e.g. schema validation), so this check
+ * rejects overly-aliased documents outright rather than merely making its
+ * own traversal cheap.
+ *
+ * The fix computes each unique object's *would-be-expanded* size exactly
+ * once via memoized post-order accumulation: a shared reference's size is
+ * looked up (O(1)) rather than re-walked, so total work is O(nodes + edges)
+ * in the compact (shared-reference) graph -- not in the expanded tree. A
+ * running total is checked after every child is folded in, so a document
+ * that would expand past the cap is rejected as soon as that becomes
+ * knowable, without ever materializing the expansion. A separate
+ * "currently on the traversal path" set catches genuine cycles (a node
+ * reachable from itself), which this DP formulation would otherwise recurse
+ * into forever.
+ */
+
+/**
+ * Safety cap on the would-be-expanded node count. Exponential growth from
+ * aliasing means an attacker needs only a handful of extra alias levels to
+ * clear any reasonable cap, so the exact value mostly trades off headroom
+ * for legitimate large layouts against how much work a rejected request
+ * does. 200,000 comfortably covers realistic self-hosted layouts (hundreds
+ * of racks/devices) while still being reached within milliseconds for any
+ * alias-bomb shape.
+ */
+const MAX_EXPANDED_NODES = 200_000;
+
+export class YamlCircularReferenceError extends Error {
+  constructor() {
+    super("YAML body contains circular references and cannot be processed");
+    this.name = "YamlCircularReferenceError";
+  }
+}
+
+export class YamlTooComplexError extends Error {
+  constructor() {
+    super(
+      "YAML body is too complex to process (nested aliases exceed the size limit)",
+    );
+    this.name = "YamlTooComplexError";
+  }
+}
+
+/**
+ * Walks a parsed YAML value and throws if it is circular or would expand
+ * (via aliases) past MAX_EXPANDED_NODES. Returns normally for legitimate
+ * bodies, including ones with large but non-exponential shared references.
+ */
+export function assertYamlComplexityBounded(value: unknown): void {
+  const onPath = new Set<object>();
+  const sizeOf = new Map<object, number>();
+
+  function walk(node: unknown): number {
+    if (node === null || typeof node !== "object") {
+      return 1;
+    }
+    const obj = node as object;
+
+    const memoized = sizeOf.get(obj);
+    if (memoized !== undefined) {
+      // Already fully sized via another alias to this same object -- reuse
+      // the computed total instead of re-walking its children. This is what
+      // keeps total work O(nodes + edges) instead of O(expanded size).
+      return memoized;
+    }
+
+    if (onPath.has(obj)) {
+      throw new YamlCircularReferenceError();
+    }
+    onPath.add(obj);
+
+    let total = 1;
+    const children: unknown[] = Array.isArray(obj)
+      ? obj
+      : Object.values(obj as Record<string, unknown>);
+    for (const child of children) {
+      total += walk(child);
+      if (total > MAX_EXPANDED_NODES) {
+        onPath.delete(obj);
+        throw new YamlTooComplexError();
+      }
+    }
+
+    onPath.delete(obj);
+    sizeOf.set(obj, total);
+    return total;
+  }
+
+  walk(value);
+}

--- a/api/src/yaml-safety.ts
+++ b/api/src/yaml-safety.ts
@@ -1,38 +1,38 @@
 /**
  * Bounded, cycle-safe complexity check for parsed YAML bodies (#2912).
  *
- * js-yaml resolves anchors/aliases to shared object references in O(input):
- * a document with nested aliases (each level referencing the prior twice) is
- * acyclic, but a naive tree walk that re-expands every alias -- including
- * the prior `JSON.stringify(parsed)` guard -- does O(2^depth) work. A body
- * a few hundred bytes long can expand to gigabytes, hanging the event loop
- * or OOMing the process. The same risk exists in any other naive consumer
- * of the parsed value downstream (e.g. schema validation), so this check
- * rejects overly-aliased documents outright rather than merely making its
- * own traversal cheap.
+ * js-yaml resolves anchors/aliases to shared object references in O(input), so
+ * a naive walk that re-expands each alias (the old JSON.stringify guard) does
+ * O(2^depth) work: a sub-1MB body can expand to gigabytes and hang the event
+ * loop or OOM the process. This computes each unique object's would-be-expanded
+ * size once (memoized) and reuses shared references in O(1), so total work is
+ * O(nodes + edges) in the compact graph and the expansion is never
+ * materialized. String leaves count their length, so the bound also covers
+ * value-heavy bombs (one large string aliased many times), not just node-heavy
+ * ones. The cap scales with input byte length: an unaliased body expands to at
+ * most about its own size, so any body whose expansion far exceeds its source
+ * is rejected while legitimate large layouts pass. A separate on-path set
+ * catches genuine cycles.
  *
- * The fix computes each unique object's *would-be-expanded* size exactly
- * once via memoized post-order accumulation: a shared reference's size is
- * looked up (O(1)) rather than re-walked, so total work is O(nodes + edges)
- * in the compact (shared-reference) graph -- not in the expanded tree. A
- * running total is checked after every child is folded in, so a document
- * that would expand past the cap is rejected as soon as that becomes
- * knowable, without ever materializing the expansion. A separate
- * "currently on the traversal path" set catches genuine cycles (a node
- * reachable from itself), which this DP formulation would otherwise recurse
- * into forever.
+ * Input must come from js-yaml JSON_SCHEMA (plain objects, arrays, and JSON
+ * scalars); the traversal does not descend into Map/Date/typed-array
+ * containers, which that schema never produces.
  */
 
 /**
- * Safety cap on the would-be-expanded node count. Exponential growth from
- * aliasing means an attacker needs only a handful of extra alias levels to
- * clear any reasonable cap, so the exact value mostly trades off headroom
- * for legitimate large layouts against how much work a rejected request
- * does. 200,000 comfortably covers realistic self-hosted layouts (hundreds
- * of racks/devices) while still being reached within milliseconds for any
- * alias-bomb shape.
+ * Floor on the expanded-size budget, for small bodies. Above this the budget
+ * scales with input length (SIZE_MULTIPLIER x bytes), so the limit tracks
+ * attacker-controlled input size rather than a fixed magic number.
  */
-const MAX_EXPANDED_NODES = 200_000;
+const MIN_EXPANDED_SIZE = 1_000_000;
+
+/**
+ * How many units of expanded size each input byte may legitimately produce.
+ * An unaliased YAML body expands to roughly its own size or less, so 4x gives
+ * comfortable headroom for legitimate layouts while any real alias bomb
+ * (which amplifies by orders of magnitude) is still rejected.
+ */
+const SIZE_MULTIPLIER = 4;
 
 export class YamlCircularReferenceError extends Error {
   constructor() {
@@ -51,15 +51,28 @@ export class YamlTooComplexError extends Error {
 }
 
 /**
- * Walks a parsed YAML value and throws if it is circular or would expand
- * (via aliases) past MAX_EXPANDED_NODES. Returns normally for legitimate
+ * Throws if a parsed YAML value is circular or would expand (via aliases) past
+ * a size bound derived from inputByteLength. Returns normally for legitimate
  * bodies, including ones with large but non-exponential shared references.
  */
-export function assertYamlComplexityBounded(value: unknown): void {
+export function assertYamlComplexityBounded(
+  value: unknown,
+  inputByteLength: number,
+): void {
+  const maxExpandedSize = Math.max(
+    MIN_EXPANDED_SIZE,
+    inputByteLength * SIZE_MULTIPLIER,
+  );
   const onPath = new Set<object>();
   const sizeOf = new Map<object, number>();
 
   function walk(node: unknown): number {
+    // Count a string by its length so the budget measures expanded size in
+    // characters, not just node count -- a large string aliased many times is
+    // as much a bomb as a deeply nested one.
+    if (typeof node === "string") {
+      return node.length;
+    }
     if (node === null || typeof node !== "object") {
       return 1;
     }
@@ -67,9 +80,9 @@ export function assertYamlComplexityBounded(value: unknown): void {
 
     const memoized = sizeOf.get(obj);
     if (memoized !== undefined) {
-      // Already fully sized via another alias to this same object -- reuse
-      // the computed total instead of re-walking its children. This is what
-      // keeps total work O(nodes + edges) instead of O(expanded size).
+      // Already fully sized via another alias to this same object -- reuse the
+      // computed total instead of re-walking its children. This is what keeps
+      // total work O(nodes + edges) instead of O(expanded size).
       return memoized;
     }
 
@@ -84,7 +97,7 @@ export function assertYamlComplexityBounded(value: unknown): void {
       : Object.values(obj as Record<string, unknown>);
     for (const child of children) {
       total += walk(child);
-      if (total > MAX_EXPANDED_NODES) {
+      if (total > maxExpandedSize) {
         onPath.delete(obj);
         throw new YamlTooComplexError();
       }


### PR DESCRIPTION
## Summary

The `PUT /layouts/:uuid` handler guarded against circular YAML bodies with `JSON.stringify(parsed)` in a try/catch. That guard was itself the amplifier for a YAML alias-expansion ("billion laughs") DoS: `yaml.load` resolves anchors/aliases to shared object references in O(input), but a deeply nested-alias document is acyclic, so `JSON.stringify` did not throw. Instead it fully expanded the shared references into a tree that reaches gigabytes from a body under the 1 MB limit, hanging the single-threaded event loop or OOMing the process. This is reachable unauthenticated in the default self-host config, and one request suffices.

Verified locally: a 462-byte nested-alias body expanded to a 138 MB `JSON.stringify` result in ~1s, and the vulnerable route saved it while taking 373ms per request. After the fix the same body is rejected in ~1ms with a 400.

## Changes

- Add `api/src/yaml-safety.ts`: `assertYamlComplexityBounded(value, inputByteLength)`, a cycle-safe traversal that bounds would-be-expanded size. It computes each unique object's would-be-expanded size exactly once via memoized post-order accumulation (repeat aliases reuse the memoized total in O(1) instead of re-walking), so total work is O(nodes + edges) in the compact shared-reference graph and it never materializes the expansion.
  - String leaves are counted by their length, so the bound also catches value-heavy bombs (one large string aliased many times), not just node-heavy nested-alias chains.
  - The cap scales with input byte length: `max(1MB, 4x bytes)`. An unaliased body expands to roughly its own size, so legitimate large layouts pass while any body whose expansion far exceeds its source is rejected (`YamlTooComplexError`). A separate on-path set still catches genuine cycles (`YamlCircularReferenceError`).
- `api/src/routes/layouts.ts`: replace the `JSON.stringify` guard with `assertYamlComplexityBounded(parsed, yamlContent.length)`, mapping both error types to a 400. The `metadata.id` direct-read (#2067) is unchanged and still runs after the guard.
- Tests: unit coverage for the traversal (normal object, many non-exponential shared refs, genuine cycle, cycle-in-array, exponential nested-alias chain rejected, value-heavy string bomb rejected, large legitimate layout accepted) and route-level integration (nested-alias alias-bomb rejected with a fast 400 and no disk write; a normal body still round-trips).

## Why the fix is complete

- Downstream `LayoutFileSchema.safeParse(parsed)` runs after the guard, so it only ever sees a body whose expanded size is within the cap; the guard protects Zod from the same amplification (Zod does not deduplicate shared references either).
- js-yaml enforces a built-in `maxDepth` of 100 for both flow and block styles, so any document nested deeper is rejected during `yaml.load` (400 Invalid YAML) before the recursive walk runs; recursion depth is bounded and cannot stack-overflow at the call site.
- `yaml.load` with `JSON_SCHEMA` produces only JSON-safe values (plain objects, arrays, JSON scalars), so removing `JSON.stringify` loses no other validation.

## Follow-up (not in this PR)

Defense-in-depth for the other `yaml.load` sites (storage-driver re-parse, snapshot POST, and the read/list paths) is broader than this fix and does not change the exploitability of the PUT route, which this PR closes. Tracked separately so the guard can be wired into a shared YAML-loading helper rather than per-call-site.

## Testing

- [x] API unit + integration tests pass (`bun test` in `api/`, 373 pass)
- [x] API typecheck clean (`npm run typecheck` in `api/`)
- [x] Repo lint clean (`npm run lint`), production build succeeds (`npm run build`)

Closes #2912
