### PR TITLE
fix(api): Workers deployment fails open when Cloudflare Access is fully unconfigured (#2913)

### DIFF
--- a/api/.dev.vars
+++ b/api/.dev.vars
@@ -1,0 +1,10 @@
+# Local `wrangler dev` only. This file is read by `wrangler dev` but is never
+# bundled or uploaded by `wrangler deploy` (Cloudflare's dev-only var
+# mechanism), so it cannot accidentally ship this opt-out to a deployed Worker
+# (#2913). Do not add real secrets here; CF_ACCESS_* production values are set
+# by the dev cutover (#2675 / #2134) via `wrangler secret` / CI, not this file.
+
+# Cloudflare Access is intentionally unconfigured in local dev (no Access in
+# front of `wrangler dev`). Explicitly opt out of the fail-closed default so
+# the smoke endpoints keep returning 200 locally.
+CF_ACCESS_DISABLED=true

--- a/api/src/security/access-jwt.test.ts
+++ b/api/src/security/access-jwt.test.ts
@@ -69,8 +69,21 @@ function requestWithToken(token?: string): Request {
 }
 
 describe("resolveAccessJwtConfig", () => {
-  it("returns null when no Access env vars are set", () => {
-    expect(resolveAccessJwtConfig({})).toBeNull();
+  it("throws (fails closed) when no Access env vars are set and there is no explicit opt-out", () => {
+    // A deployed Worker that forgot to configure Access must not fail open
+    // (#2913).
+    expect(() => resolveAccessJwtConfig({})).toThrow(/not configured/);
+  });
+
+  it("returns null when no Access env vars are set and CF_ACCESS_DISABLED=true is explicitly set", () => {
+    // The local `wrangler dev` opt-out.
+    expect(resolveAccessJwtConfig({ CF_ACCESS_DISABLED: "true" })).toBeNull();
+  });
+
+  it("throws (fails closed) when CF_ACCESS_DISABLED is set to anything other than 'true'", () => {
+    expect(() => resolveAccessJwtConfig({ CF_ACCESS_DISABLED: "1" })).toThrow(
+      /not configured/,
+    );
   });
 
   it("throws (fails closed) when Access config is only partially set", () => {

--- a/api/src/security/access-jwt.ts
+++ b/api/src/security/access-jwt.ts
@@ -8,18 +8,20 @@
  * signature, issuer, and audience (AUD tag). Service tokens (used by CI smoke
  * and machine clients) carry the same assertion, so they pass the same check.
  *
- * Validation is conditional. It is only enforced when the three inputs are
- * configured via environment variables:
+ * Validation is enforced when the three inputs are configured via environment
+ * variables:
  *
  *   CF_ACCESS_JWKS_URL  the Access application's JWKS endpoint
  *   CF_ACCESS_ISSUER    the expected `iss` (the team domain, e.g.
  *                       https://<team>.cloudflareaccess.com)
  *   CF_ACCESS_AUD       the Access application AUD tag (the expected `aud`)
  *
- * When any of these is absent (for example local `wrangler dev` with
- * AUTH_MODE=none and no Access in front), validation is skipped so the smoke
- * endpoints return 200. When configured, a missing or invalid assertion yields
- * 401 (missing) or 403 (present but invalid).
+ * A deployed Worker must never silently fail open, so an absent config is
+ * fail-closed by default (#2913): every request is denied. Validation is only
+ * skipped (smoke endpoints return 200) when the config is absent AND
+ * `CF_ACCESS_DISABLED=true` is explicitly set, which opts out for local
+ * `wrangler dev`. When configured, a missing or invalid assertion yields 401
+ * (missing) or 403 (present but invalid).
  *
  * No values are hardcoded; all three are read from env. The real values are set
  * later by the dev cutover (#2675 / #2134).
@@ -34,6 +36,19 @@ import type { EnvMap } from "./types";
 
 /** The header Cloudflare Access uses to carry the signed assertion. */
 export const CF_ACCESS_JWT_HEADER = "Cf-Access-Jwt-Assertion";
+
+/**
+ * The env var that explicitly opts out of Access enforcement when
+ * `CF_ACCESS_*` is fully unconfigured. Intended for local `wrangler dev`
+ * only; a deployed Worker that forgets to set the three `CF_ACCESS_*`
+ * variables must fail closed, not fail open (#2913).
+ */
+export const CF_ACCESS_DISABLED_ENV = "CF_ACCESS_DISABLED";
+
+/** True when the explicit local-dev opt-out is set. */
+function isAccessDisabledOptOut(env: EnvMap): boolean {
+  return env[CF_ACCESS_DISABLED_ENV]?.trim().toLowerCase() === "true";
+}
 
 /** Resolved, validated Access configuration. */
 export interface AccessJwtConfig {
@@ -53,8 +68,9 @@ export type AccessJwtResult =
  * Resolve the Access JWT config from env.
  *
  * @param env - Environment map (defaults to `process.env`).
- * @returns The config when all three inputs are set and non-empty; otherwise
- *   `null`, which means validation is skipped.
+ * @returns The config when all three inputs are set and non-empty; `null`
+ *   only when unset AND `CF_ACCESS_DISABLED=true` is explicitly set (local
+ *   `wrangler dev`). Otherwise throws, so the caller fails closed.
  */
 export function resolveAccessJwtConfig(
   env: EnvMap = typeof process !== "undefined" ? process.env : {},
@@ -65,12 +81,20 @@ export function resolveAccessJwtConfig(
 
   const present = [jwksUrl, issuer, audience].filter(Boolean).length;
 
-  // None set: Access is not configured. This is the local `wrangler dev` /
-  // AUTH_MODE=none mode where validation is skipped so the smoke endpoints
-  // return 200. Production Access enforcement config is wired by the dev
-  // cutover (#2134).
+  // None set: Access is not configured. This is either a deliberate local
+  // `wrangler dev` skip (opted out via CF_ACCESS_DISABLED=true) or a deployed
+  // Worker that forgot to configure Access. A deployed Worker must never
+  // silently fail open (#2913), so treat "absent, no opt-out" the same as a
+  // partial config: fail closed by throwing.
   if (present === 0) {
-    return null;
+    if (isAccessDisabledOptOut(env)) {
+      return null;
+    }
+    throw new Error(
+      "Cloudflare Access is not configured: set all of CF_ACCESS_JWKS_URL, " +
+        "CF_ACCESS_ISSUER, and CF_ACCESS_AUD, or set CF_ACCESS_DISABLED=true " +
+        "to explicitly skip validation (local `wrangler dev` only).",
+    );
   }
 
   // Partially set: an incomplete config must never silently disable the auth

--- a/api/src/security/access-jwt.ts
+++ b/api/src/security/access-jwt.ts
@@ -33,6 +33,7 @@ import {
   type JWTPayload,
 } from "jose";
 import type { EnvMap } from "./types";
+import { parseBoolean } from "./config";
 
 /** The header Cloudflare Access uses to carry the signed assertion. */
 export const CF_ACCESS_JWT_HEADER = "Cf-Access-Jwt-Assertion";
@@ -47,7 +48,7 @@ export const CF_ACCESS_DISABLED_ENV = "CF_ACCESS_DISABLED";
 
 /** True when the explicit local-dev opt-out is set. */
 function isAccessDisabledOptOut(env: EnvMap): boolean {
-  return env[CF_ACCESS_DISABLED_ENV]?.trim().toLowerCase() === "true";
+  return parseBoolean(env[CF_ACCESS_DISABLED_ENV]);
 }
 
 /** Resolved, validated Access configuration. */

--- a/api/src/security/config.ts
+++ b/api/src/security/config.ts
@@ -24,8 +24,10 @@ const MIN_AUTH_SESSION_TIMEOUT_SECONDS = 60;
 const MAX_AUTH_SESSION_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
 const DEFAULT_AUTH_SESSION_SAME_SITE: AuthSessionSameSite = "Lax";
 
-function parseBoolean(value: string | undefined): boolean {
-  return value?.toLowerCase() === "true";
+/** Parse a "true"/"false" style env var. Only the literal "true" (after
+ * trimming and case-folding) is truthy; everything else, including unset. */
+export function parseBoolean(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
 }
 
 function deriveAuthLogHashKey(authSessionSecret: string): string {

--- a/api/src/worker.test.ts
+++ b/api/src/worker.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import { createWorkerHandler, type WorkerEnv } from "./worker";
+import type { R2BucketLike, R2ListResult } from "./storage/r2-driver";
+
+/**
+ * A minimal in-memory R2 bucket stand-in. The tests below never touch storage
+ * (the smoke endpoint is unauthenticated and storage-free), but `WorkerEnv`
+ * requires a `LAYOUTS` binding to construct the app.
+ */
+function fakeBucket(): R2BucketLike {
+  const empty: R2ListResult = {
+    objects: [],
+    truncated: false,
+    delimitedPrefixes: [],
+  };
+  return {
+    head: async () => null,
+    get: async () => null,
+    put: async () => null,
+    delete: async () => {},
+    list: async () => empty,
+  };
+}
+
+/** Build a WorkerEnv with a fake LAYOUTS binding plus string env overrides. */
+function buildEnv(overrides: Record<string, string> = {}): WorkerEnv {
+  return {
+    NODE_ENV: "test",
+    LAYOUTS: fakeBucket(),
+    ...overrides,
+  };
+}
+
+function smokeRequest(headers: Record<string, string> = {}): Request {
+  return new Request("https://worker.example/api/version", { headers });
+}
+
+describe("Worker fetch: Cloudflare Access gate", () => {
+  it("denies the request (does not route to the app) when Access config is fully absent and no opt-out is set", async () => {
+    const worker = createWorkerHandler();
+    const env = buildEnv();
+
+    const res = await worker.fetch(smokeRequest(), env);
+
+    // Denied, not the version JSON the open app would have returned.
+    expect(res.status).not.toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty("version");
+  });
+
+  it("restores the skip path (200 on the smoke endpoint) when CF_ACCESS_DISABLED=true is explicitly set", async () => {
+    const worker = createWorkerHandler();
+    const env = buildEnv({ CF_ACCESS_DISABLED: "true" });
+
+    const res = await worker.fetch(smokeRequest(), env);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("version");
+  });
+
+  it("still returns 503 (unchanged) when Access config is only partially set", async () => {
+    const worker = createWorkerHandler();
+    const env = buildEnv({
+      CF_ACCESS_JWKS_URL:
+        "https://team.cloudflareaccess.com/cdn-cgi/access/certs",
+      CF_ACCESS_ISSUER: "https://team.cloudflareaccess.com",
+      // CF_ACCESS_AUD intentionally missing
+    });
+
+    const res = await worker.fetch(smokeRequest(), env);
+
+    expect(res.status).toBe(503);
+  });
+
+  it("still requires a token (401) when Access is fully configured", async () => {
+    const worker = createWorkerHandler();
+    const env = buildEnv({
+      CF_ACCESS_JWKS_URL:
+        "https://team.cloudflareaccess.com/cdn-cgi/access/certs",
+      CF_ACCESS_ISSUER: "https://team.cloudflareaccess.com",
+      CF_ACCESS_AUD: "test-aud",
+    });
+
+    const res = await worker.fetch(smokeRequest(), env);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/api/src/worker.test.ts
+++ b/api/src/worker.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { createWorkerHandler, type WorkerEnv } from "./worker";
 import type { R2BucketLike, R2ListResult } from "./storage/r2-driver";
 
@@ -85,5 +87,22 @@ describe("Worker fetch: Cloudflare Access gate", () => {
     const res = await worker.fetch(smokeRequest(), env);
 
     expect(res.status).toBe(401);
+  });
+});
+
+describe("wrangler.jsonc does not promote the dev-only opt-out to a deployed var", () => {
+  it("never sets CF_ACCESS_DISABLED in wrangler.jsonc (the fail-closed default must ship to every deployed Worker)", () => {
+    // The opt-out belongs only in api/.dev.vars, which `wrangler dev` reads
+    // but `wrangler deploy` never bundles. If CF_ACCESS_DISABLED is ever
+    // copied into wrangler.jsonc (e.g. into a "vars" block), it deploys with
+    // every Worker and silently reopens #2913. Strip `//` comment lines first
+    // so this only checks the actual JSONC content, not the doc comment that
+    // explains the mechanism.
+    const raw = readFileSync(join(__dirname, "..", "wrangler.jsonc"), "utf-8");
+    const jsoncOnly = raw
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"))
+      .join("\n");
+    expect(jsoncOnly).not.toContain("CF_ACCESS_DISABLED");
   });
 });

--- a/api/src/worker.test.ts
+++ b/api/src/worker.test.ts
@@ -4,6 +4,10 @@ import { join } from "node:path";
 import { createWorkerHandler, type WorkerEnv } from "./worker";
 import type { R2BucketLike, R2ListResult } from "./storage/r2-driver";
 
+// `import.meta.dir` (Bun) matches the sibling deploy-config.test.ts convention;
+// these specs run only under `bun test`.
+const THIS_DIR = import.meta.dir;
+
 /**
  * A minimal in-memory R2 bucket stand-in. The tests below never touch storage
  * (the smoke endpoint is unauthenticated and storage-free), but `WorkerEnv`
@@ -98,7 +102,7 @@ describe("wrangler.jsonc does not promote the dev-only opt-out to a deployed var
     // every Worker and silently reopens #2913. Strip `//` comment lines first
     // so this only checks the actual JSONC content, not the doc comment that
     // explains the mechanism.
-    const raw = readFileSync(join(__dirname, "..", "wrangler.jsonc"), "utf-8");
+    const raw = readFileSync(join(THIS_DIR, "..", "wrangler.jsonc"), "utf-8");
     const jsoncOnly = raw
       .split("\n")
       .filter((line) => !line.trim().startsWith("//"))

--- a/api/src/worker.ts
+++ b/api/src/worker.ts
@@ -8,9 +8,10 @@
  * reached and never enters the bundle (app.ts loads it via dynamic import).
  *
  * Cloudflare Access JWT validation (folded in from #2134) runs in front of the
- * app on `/api/*` and `/*` when configured (CF_ACCESS_* env vars). When those
- * are absent (local `wrangler dev`), validation is skipped so the smoke
- * endpoints return 200.
+ * app on `/api/*` and `/*` when configured (CF_ACCESS_* env vars). A deployed
+ * Worker with those absent fails closed (denies every request) unless
+ * CF_ACCESS_DISABLED=true is explicitly set, which restores the skip path
+ * (smoke endpoints return 200) for local `wrangler dev` (#2913).
  *
  * The self-host / Bun entry (src/index.ts) is separate and keeps its node:fs
  * imports; this module is the only one the Worker bundle ships.
@@ -35,8 +36,9 @@ export interface WorkerEnv {
 
 type FetchHandler = (request: Request) => Response | Promise<Response>;
 
-let appPromise: Promise<{ fetch: FetchHandler }> | null = null;
-let cachedValidator: AccessJwtValidator | null = null;
+export interface WorkerHandler {
+  fetch(request: Request, env: WorkerEnv): Promise<Response>;
+}
 
 /**
  * Narrow the Worker env to the string-keyed map the app/security code expects.
@@ -52,62 +54,83 @@ function toEnvMap(env: WorkerEnv): EnvMap {
   return out;
 }
 
-export default {
-  async fetch(request: Request, env: WorkerEnv): Promise<Response> {
-    const envMap = toEnvMap(env);
+/**
+ * Build a Worker fetch handler with its own cold-start caches (the resolved
+ * Access validator and the in-flight app-construction promise).
+ *
+ * A factory rather than a single module-level singleton so tests can build a
+ * fresh handler per case without one test's cached validator leaking into the
+ * next. The default export below calls this once per Worker isolate, which is
+ * the same lifetime the previous module-level `let`s had.
+ */
+export function createWorkerHandler(): WorkerHandler {
+  let appPromise: Promise<{ fetch: FetchHandler }> | null = null;
+  let cachedValidator: AccessJwtValidator | null = null;
 
-    // Cloudflare Access validation runs before the app when configured.
-    // Skipped (returns 200-eligible) when CF_ACCESS_* env vars are absent.
-    if (!cachedValidator) {
-      try {
-        cachedValidator = createAccessJwtValidator(
-          resolveAccessJwtConfig(envMap),
-        );
-      } catch (error) {
-        // Misconfigured Access (e.g. a partial CF_ACCESS_* set). Fail closed:
-        // deny the request and do not cache, so a corrected config takes effect
-        // on the next request without needing a redeploy.
-        logger.error(
-          { err: error },
-          "Cloudflare Access is misconfigured; denying request",
-        );
+  return {
+    async fetch(request: Request, env: WorkerEnv): Promise<Response> {
+      const envMap = toEnvMap(env);
+
+      // Cloudflare Access validation runs before the app when configured.
+      // Fails closed (denies) when CF_ACCESS_* env vars are absent and no
+      // explicit CF_ACCESS_DISABLED=true opt-out is set (#2913).
+      if (!cachedValidator) {
+        try {
+          cachedValidator = createAccessJwtValidator(
+            resolveAccessJwtConfig(envMap),
+          );
+        } catch (error) {
+          // Misconfigured Access: a partial CF_ACCESS_* set, or fully absent
+          // without the explicit opt-out. Fail closed: deny the request and
+          // do not cache, so a corrected config takes effect on the next
+          // request without needing a redeploy.
+          logger.error(
+            { err: error },
+            "Cloudflare Access is misconfigured; denying request",
+          );
+          return Response.json(
+            {
+              error: "Service Unavailable",
+              message: "Server authentication is misconfigured.",
+            },
+            { status: 503 },
+          );
+        }
+      }
+      const accessResult = await cachedValidator.validate(request);
+      if (accessResult.status === "missing") {
         return Response.json(
           {
-            error: "Service Unavailable",
-            message: "Server authentication is misconfigured.",
+            error: "Unauthorized",
+            message: "Cloudflare Access token required.",
           },
-          { status: 503 },
+          { status: 401 },
         );
       }
-    }
-    const accessResult = await cachedValidator.validate(request);
-    if (accessResult.status === "missing") {
-      return Response.json(
-        { error: "Unauthorized", message: "Cloudflare Access token required." },
-        { status: 401 },
-      );
-    }
-    if (accessResult.status === "invalid") {
-      return Response.json(
-        { error: "Forbidden", message: "Invalid Cloudflare Access token." },
-        { status: 403 },
-      );
-    }
+      if (accessResult.status === "invalid") {
+        return Response.json(
+          { error: "Forbidden", message: "Invalid Cloudflare Access token." },
+          { status: 403 },
+        );
+      }
 
-    // Build the app once and share the in-flight promise so concurrent
-    // cold-start requests await the same construction instead of each creating
-    // (and discarding) their own instance. Reset on failure so a transient
-    // construction error does not permanently wedge the Worker.
-    if (!appPromise) {
-      appPromise = createApp(envMap, {
-        storage: createR2Driver(env.LAYOUTS),
-      }).catch((error) => {
-        appPromise = null;
-        throw error;
-      });
-    }
-    const app = await appPromise;
+      // Build the app once and share the in-flight promise so concurrent
+      // cold-start requests await the same construction instead of each
+      // creating (and discarding) their own instance. Reset on failure so a
+      // transient construction error does not permanently wedge the Worker.
+      if (!appPromise) {
+        appPromise = createApp(envMap, {
+          storage: createR2Driver(env.LAYOUTS),
+        }).catch((error) => {
+          appPromise = null;
+          throw error;
+        });
+      }
+      const app = await appPromise;
 
-    return app.fetch(request);
-  },
-};
+      return app.fetch(request);
+    },
+  };
+}
+
+export default createWorkerHandler();

--- a/api/wrangler.jsonc
+++ b/api/wrangler.jsonc
@@ -47,6 +47,12 @@
   // Real values (account_id, vars, secrets, Access config) are added by the dev
   // cutover. RACKULA_AUTH_MODE is intentionally unset here, so the Worker runs
   // AUTH_MODE=none and the smoke endpoints are reachable under `wrangler dev`.
+  //
+  // Cloudflare Access validation fails closed (denies every request) when
+  // CF_ACCESS_* is unconfigured, unless CF_ACCESS_DISABLED=true is explicitly
+  // set (#2913). That opt-out lives in api/.dev.vars, which `wrangler dev`
+  // reads locally but `wrangler deploy` never bundles, so it cannot leak into
+  // a deployed Worker.
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
## **User description**
## Summary

- A deployed Cloudflare Workers API with `CF_ACCESS_*` fully absent now fails closed (denies every request) instead of silently skipping Access validation and routing to the open app.
- The skip path (local `wrangler dev`) is only reachable via an explicit `CF_ACCESS_DISABLED=true` opt-out, wired into `api/.dev.vars` (read by `wrangler dev`, never bundled by `wrangler deploy`).
- Partial-config behaviour (503, unchanged) and fully-configured behaviour (401/403 unchanged) are untouched.
- `worker.ts` is refactored from a module-level singleton to a `createWorkerHandler()` factory so tests can exercise each Access state without one test's cached validator leaking into the next.
- Local `/code-review` (CodeRabbit CLI was rate-limited both locally and on push) found two follow-ups, both addressed: `isAccessDisabledOptOut` now reuses the shared `parseBoolean` helper instead of duplicating it, and a regression guard test asserts `wrangler.jsonc` never promotes `CF_ACCESS_DISABLED` into a deployed var.

## Root cause

- `resolveAccessJwtConfig` (`api/src/security/access-jwt.ts`) returned `null` when all three `CF_ACCESS_*` vars were absent, and the validator built from that config reported `skipped`.
- `worker.ts` treated `skipped` as "proceed to the app" with no distinction from a deliberate local-dev skip, so a deployed Worker that forgot to set `CF_ACCESS_*` exposed full read/write/delete of every layout to the public internet.

## Fix

- Absent config with no `CF_ACCESS_DISABLED=true` opt-out now throws from `resolveAccessJwtConfig`, reusing the existing partial-config fail-closed path in `worker.ts` (already caught and turned into a 503).

## Files changed

- `api/src/security/access-jwt.ts`: fail-closed default + `CF_ACCESS_DISABLED` opt-out
- `api/src/security/config.ts`: exported `parseBoolean` (now also trims) for reuse
- `api/src/worker.ts`: `createWorkerHandler()` factory refactor (same production lifetime, testable)
- `api/src/security/access-jwt.test.ts`: updated/added unit tests for the new fail-closed default and opt-out
- `api/src/worker.test.ts`: new integration tests for the Worker's fetch handler across all four Access states, plus a guard test on `wrangler.jsonc`
- `api/wrangler.jsonc`: doc comment only
- `api/.dev.vars`: new, non-secret, explicit local-dev opt-out

## Test plan

- [x] `bun test` in `api/` (371 pass, including 5 new/changed tests directly covering this fix)
- [x] `npm run typecheck` in `api/`
- [x] `npm run lint` and `npm run build` at repo root
- [x] Absent config + no opt-out -> denied, not routed to the app
- [x] Absent config + `CF_ACCESS_DISABLED=true` -> skip path, 200 on `/api/version`
- [x] Partial config -> 503 (unchanged)
- [x] Fully configured, missing token -> 401 (unchanged, wiring regression check)
- [x] `wrangler.jsonc` never contains `CF_ACCESS_DISABLED`

Closes #2913


___

## **CodeAnt-AI Description**
**Fail closed when Cloudflare Access is missing in deployed Workers**

### What Changed
- Workers now deny requests when all Cloudflare Access settings are missing, instead of silently allowing access.
- Local `wrangler dev` keeps working only when `CF_ACCESS_DISABLED=true` is set explicitly.
- Partial Access setup still returns 503, and fully configured Access still returns 401 or 403 as before.
- Added checks so the dev-only opt-out stays out of deployed Worker settings.

### Impact
`✅ Fewer public API exposures from missing Access config`
`✅ Safer local development without changing production behavior`
`✅ Clearer misconfiguration failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
