### PR TITLE
fix: open redirect via backslash bypass in login next param (#2917)

### DIFF
--- a/src/lib/components/LoginForm.svelte
+++ b/src/lib/components/LoginForm.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { getSafeNextPath } from "$lib/utils/safe-redirect";
+
   let username = $state("");
   let password = $state("");
   let error = $state("");
@@ -7,19 +9,6 @@
   const canSubmit = $derived(
     username.trim() !== "" && password !== "" && !loading,
   );
-
-  function getNextPath(): string {
-    const params = new URLSearchParams(window.location.search);
-    const next = params.get("next") ?? "/";
-    const trimmed = next.trim();
-
-    // Prevent open redirect: must start with / and not // or protocol
-    if (!trimmed.startsWith("/")) return "/";
-    if (trimmed.startsWith("//")) return "/";
-    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return "/";
-
-    return trimmed;
-  }
 
   async function handleSubmit(event: SubmitEvent) {
     event.preventDefault();
@@ -39,7 +28,10 @@
       });
 
       if (response.ok) {
-        window.location.href = getNextPath();
+        window.location.href = getSafeNextPath(
+          window.location.search,
+          window.location.origin,
+        );
         return;
       }
 

--- a/src/lib/utils/safe-redirect.test.ts
+++ b/src/lib/utils/safe-redirect.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { getSafeNextPath } from "./safe-redirect";
+
+const ORIGIN = "https://app.example.com";
+
+describe("getSafeNextPath", () => {
+  it("blocks backslash bypass (raw)", () => {
+    expect(getSafeNextPath("?next=/\\evil.com", ORIGIN)).toBe("/");
+  });
+
+  it("blocks backslash bypass (percent-encoded, matches issue repro)", () => {
+    expect(getSafeNextPath("?next=%2F%5Cevil.com", ORIGIN)).toBe("/");
+  });
+
+  it("blocks backslash bypass (uppercase and lowercase encoded backslash)", () => {
+    expect(getSafeNextPath("?next=%2F%5cevil.com", ORIGIN)).toBe("/");
+    expect(getSafeNextPath("?next=%2F%5Cevil.com", ORIGIN)).toBe("/");
+  });
+
+  it("blocks protocol-relative //evil.com", () => {
+    expect(getSafeNextPath("?next=//evil.com", ORIGIN)).toBe("/");
+  });
+
+  it("blocks an absolute URL with a scheme", () => {
+    expect(getSafeNextPath("?next=https%3A%2F%2Fevil.com", ORIGIN)).toBe("/");
+  });
+
+  it("blocks a path that does not start with /", () => {
+    expect(getSafeNextPath("?next=evil.com", ORIGIN)).toBe("/");
+  });
+
+  it("allows a legitimate same-origin relative path", () => {
+    expect(getSafeNextPath("?next=%2Fdashboard", ORIGIN)).toBe("/dashboard");
+  });
+
+  it("allows a legitimate same-origin path with query and hash", () => {
+    expect(
+      getSafeNextPath("?next=%2Frack%2F123%3Ftab%3Ddevices%23top", ORIGIN),
+    ).toBe("/rack/123?tab=devices#top");
+  });
+
+  it("defaults to / when next is missing", () => {
+    expect(getSafeNextPath("", ORIGIN)).toBe("/");
+  });
+
+  it("defaults to / when next is empty", () => {
+    expect(getSafeNextPath("?next=", ORIGIN)).toBe("/");
+  });
+});

--- a/src/lib/utils/safe-redirect.test.ts
+++ b/src/lib/utils/safe-redirect.test.ts
@@ -12,9 +12,15 @@ describe("getSafeNextPath", () => {
     expect(getSafeNextPath("?next=%2F%5Cevil.com", ORIGIN)).toBe("/");
   });
 
-  it("blocks backslash bypass (uppercase and lowercase encoded backslash)", () => {
+  it("blocks backslash bypass (lowercase encoded backslash)", () => {
     expect(getSafeNextPath("?next=%2F%5cevil.com", ORIGIN)).toBe("/");
-    expect(getSafeNextPath("?next=%2F%5Cevil.com", ORIGIN)).toBe("/");
+  });
+
+  it("blocks backslash bypass smuggled past a control character", () => {
+    // A stray tab/CR between the leading slash and the backslash is
+    // stripped by URL parsing (same as a browser), so this still
+    // normalises to a protocol-relative //evil.com and must be blocked.
+    expect(getSafeNextPath("?next=%2F%09%5Cevil.com", ORIGIN)).toBe("/");
   });
 
   it("blocks protocol-relative //evil.com", () => {

--- a/src/lib/utils/safe-redirect.ts
+++ b/src/lib/utils/safe-redirect.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolves the post-login "next" redirect target from a query string,
+ * guarding against open redirect. Only same-origin relative paths are
+ * allowed; anything else (protocol-relative //, absolute URLs, or a
+ * backslash that the browser will normalise to a protocol-relative URL,
+ * e.g. `/\evil.com`) falls back to "/".
+ */
+export function getSafeNextPath(search: string, origin: string): string {
+  const params = new URLSearchParams(search);
+  const next = params.get("next") ?? "/";
+  const trimmed = next.trim();
+
+  if (!trimmed.startsWith("/")) return "/";
+
+  try {
+    const resolved = new URL(trimmed, origin);
+    if (resolved.origin !== origin) return "/";
+  } catch {
+    return "/";
+  }
+
+  return trimmed;
+}


### PR DESCRIPTION
## **User description**
## Summary

- The post-login redirect guard in `LoginForm.svelte` rejected `next` values not starting with `/`, starting with `//`, or carrying a `scheme:`, but missed the backslash. `login.html?next=%2F%5Cevil.com` decodes to `/\evil.com`, passes all three checks, and the browser normalises `/\` to `//` (protocol-relative), redirecting to an attacker origin after login.
- Extracted the guard into a new, unit-tested `getSafeNextPath()` (`src/lib/utils/safe-redirect.ts`) that resolves the candidate with `new URL(trimmed, origin)` and only allows it through when the resolved origin matches the app's origin. This runs the same WHATWG URL parsing a browser applies during `location.href = ...` navigation, so it subsumes the old blocklist (backslash, protocol-relative, scheme, and any other origin-changing normalisation such as embedded tab/CR control-char smuggling) without needing an ever-growing list of special cases.
- `LoginForm.svelte` now calls `getSafeNextPath(window.location.search, window.location.origin)` instead of the inline `getNextPath()`.

## Files changed

- `src/lib/utils/safe-redirect.ts` (new): the extracted, testable redirect guard.
- `src/lib/utils/safe-redirect.test.ts` (new): 11 unit tests covering the backslash bypass (raw, percent-encoded, upper/lowercase, control-char-smuggled), protocol-relative `//`, absolute-URL-with-scheme, non-`/`-prefixed values, legitimate same-origin paths (with query/hash), and missing/empty `next`.
- `src/lib/components/LoginForm.svelte`: replaced the inline `getNextPath()` with a call to the new `getSafeNextPath()`.

## Test plan

- [x] Wrote failing tests first (TDD), confirmed RED (`Failed to resolve import "./safe-redirect"`), implemented, confirmed GREEN (11/11 pass).
- [x] `npm run lint` clean.
- [x] `npm run check` (svelte-check) clean: 0 errors, 0 warnings.
- [x] `npm run test:run`: 202/202 test files, 3231/3231 tests pass.
- [x] `npm run build` succeeds.
- [x] `next=/\evil.com` and encoded variant `next=%2F%5Cevil.com` now redirect to `/`, not offsite (acceptance criterion 1).
- [x] Legitimate same-origin relative paths (`/dashboard`, `/rack/123?tab=devices#top`) still work (acceptance criterion 2).
- [x] Independent adversarial subagent review (fuzzed ~20 additional payloads: NUL, vertical tab, IDN, `@`-userinfo tricks, mixed encoding) found no bypass and no functional regression.

Closes #2917


___

## **CodeAnt-AI Description**
**Block unsafe login redirects after sign-in**

### What Changed
- Login now sends users only to same-origin paths from the `next` parameter.
- Redirects that could send users to another site, including backslash-based and protocol-relative values, now fall back to `/`.
- Legitimate same-site paths with query strings and hashes still work.

### Impact
`✅ Fewer account-takeover redirect attacks`
`✅ Safer post-login redirects`
`✅ Same-site login links keep working`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
