### PR TITLE
fix: delete confirm acts on the object it names, not live selection (#2918)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -54,7 +54,7 @@
   import { parseDeviceLibraryImport } from "$lib/utils/import";
   import { registerImportDevicesTrigger } from "$lib/actions/import-devices-trigger";
   import { hapticTap } from "$lib/utils/haptics";
-  import { appDebug, dialogDebug, layoutDebug } from "$lib/utils/debug";
+  import { appDebug, dialogDebug } from "$lib/utils/debug";
   import type { ImageData } from "$lib/types/images";
   import type { DisplayMode, Layout, RackWidth } from "$lib/types";
   import type { ImportResult } from "$lib/utils/netbox-import";
@@ -69,7 +69,11 @@
     duplicateSelection,
     canMoveSelectedDeviceSlot,
   } from "$lib/actions/selection-actions";
-  import { handleDelete, handleNewRack } from "$lib/utils/dialog-actions";
+  import {
+    handleDelete,
+    handleConfirmDelete,
+    handleNewRack,
+  } from "$lib/utils/dialog-actions";
   import {
     findNextValidPosition,
     canMoveUp,
@@ -217,41 +221,6 @@
   }
 
   // --- Delete handlers ---
-
-  function handleConfirmDelete() {
-    if (deleteTarget?.type === "rack" && selectionStore.selectedRackId) {
-      const rackId = selectionStore.selectedRackId;
-      // A bay member removal closes the row and dissolves a 1-member bay; a
-      // standalone rack deletes plainly (#2741).
-      const group = layoutStore.getRackGroupForRack(rackId);
-      if (group?.layout_preset === "bayed") {
-        const { error } = layoutStore.removeRackFromBay(rackId);
-        if (error) {
-          layoutDebug.group(
-            "removeRackFromBay failed for %s: %s",
-            rackId,
-            error,
-          );
-        } else {
-          selectionStore.clearSelection();
-        }
-      } else {
-        layoutStore.deleteRack(rackId);
-        selectionStore.clearSelection();
-      }
-    } else if (deleteTarget?.type === "device") {
-      const rackId = selectionStore.selectedRackId;
-      const rack = rackId ? layoutStore.getRackById(rackId) : null;
-      const deviceIndex = selectionStore.getSelectedDeviceIndex(
-        rack?.devices ?? [],
-      );
-      if (rackId !== null && deviceIndex !== null) {
-        layoutStore.removeDeviceFromRack(rackId, deviceIndex);
-        selectionStore.clearSelection();
-      }
-    }
-    dialogStore.close();
-  }
 
   function handleCancelDelete() {
     dialogStore.close();

--- a/src/lib/stores/dialogs.svelte.ts
+++ b/src/lib/stores/dialogs.svelte.ts
@@ -37,6 +37,15 @@ export type SheetId =
 export interface DeleteTarget {
   type: "rack" | "device";
   name: string;
+  /**
+   * Rack/device identity captured at dialog-open time (#2918). Confirming the
+   * dialog must act on this snapshot, not the live selectionStore, so a
+   * selection change between open and confirm can't delete a different
+   * object than the one named in the dialog.
+   */
+  rackId: string;
+  /** Only set when type is "device". */
+  deviceIndex?: number;
 }
 
 // Dialog state

--- a/src/lib/stores/dialogs.svelte.ts
+++ b/src/lib/stores/dialogs.svelte.ts
@@ -44,8 +44,13 @@ export interface DeleteTarget {
    * object than the one named in the dialog.
    */
   rackId: string;
-  /** Only set when type is "device". */
-  deviceIndex?: number;
+  /**
+   * Stable device id, only set when type is "device". Confirm resolves the
+   * current array index from this id, so a reorder between open and confirm
+   * (e.g. an arrow-key move, or a device removed above it) can't shift a
+   * captured index onto the wrong device.
+   */
+  deviceId?: string;
 }
 
 // Dialog state

--- a/src/lib/utils/dialog-actions.ts
+++ b/src/lib/utils/dialog-actions.ts
@@ -71,7 +71,7 @@ export function handleDelete(): void {
           type: "device",
           name: deviceDef?.model ?? deviceDef?.slug ?? "Device",
           rackId: rack.id,
-          deviceIndex,
+          deviceId: device.id,
         };
         dialogStore.open("confirmDelete");
       }
@@ -81,10 +81,12 @@ export function handleDelete(): void {
 
 /**
  * Apply the delete confirmed by the confirm-delete dialog. Acts on the
- * rackId/deviceIndex snapshot captured in deleteTarget at open time, not the
- * live selectionStore, so a selection change between opening the dialog and
+ * rackId/deviceId snapshot captured in deleteTarget at open time, not the live
+ * selectionStore, so a selection change between opening the dialog and
  * confirming it can't delete a different object than the one named in the
- * dialog (#2918).
+ * dialog (#2918). The device's array index is resolved from its stable id at
+ * confirm time, so a reorder while the dialog is open (an arrow-key move, or a
+ * device removed above it) can't misroute the removal onto the wrong device.
  */
 export function handleConfirmDelete(): void {
   const layoutStore = getLayoutStore();
@@ -107,9 +109,14 @@ export function handleConfirmDelete(): void {
       layoutStore.deleteRack(rackId);
       selectionStore.clearSelection();
     }
-  } else if (target?.type === "device" && target.deviceIndex !== undefined) {
-    layoutStore.removeDeviceFromRack(target.rackId, target.deviceIndex);
-    selectionStore.clearSelection();
+  } else if (target?.type === "device" && target.deviceId !== undefined) {
+    const rack = layoutStore.getRackById(target.rackId);
+    const deviceIndex =
+      rack?.devices.findIndex((d) => d.id === target.deviceId) ?? -1;
+    if (deviceIndex >= 0) {
+      layoutStore.removeDeviceFromRack(target.rackId, deviceIndex);
+      selectionStore.clearSelection();
+    }
   }
 
   dialogStore.close();

--- a/src/lib/utils/dialog-actions.ts
+++ b/src/lib/utils/dialog-actions.ts
@@ -9,6 +9,7 @@ import { getToastStore } from "$lib/stores/toast.svelte";
 import { getViewportStore } from "$lib/utils/viewport.svelte";
 import { dialogStore } from "$lib/stores/dialogs.svelte";
 import { handleFitAll } from "$lib/utils/app-actions";
+import { layoutDebug } from "$lib/utils/debug";
 
 /** Stage-1 default height for a directly-created rack (#2732). */
 const NEW_RACK_DEFAULT_HEIGHT = 24;
@@ -45,7 +46,11 @@ export function handleDelete(): void {
   if (selectionStore.isRackSelected && selectionStore.selectedRackId) {
     const rack = layoutStore.getRackById(selectionStore.selectedRackId);
     if (rack) {
-      dialogStore.deleteTarget = { type: "rack", name: rack.name };
+      dialogStore.deleteTarget = {
+        type: "rack",
+        name: rack.name,
+        rackId: rack.id,
+      };
       dialogStore.open("confirmDelete");
     }
   } else if (selectionStore.isDeviceSelected) {
@@ -65,11 +70,49 @@ export function handleDelete(): void {
         dialogStore.deleteTarget = {
           type: "device",
           name: deviceDef?.model ?? deviceDef?.slug ?? "Device",
+          rackId: rack.id,
+          deviceIndex,
         };
         dialogStore.open("confirmDelete");
       }
     }
   }
+}
+
+/**
+ * Apply the delete confirmed by the confirm-delete dialog. Acts on the
+ * rackId/deviceIndex snapshot captured in deleteTarget at open time, not the
+ * live selectionStore, so a selection change between opening the dialog and
+ * confirming it can't delete a different object than the one named in the
+ * dialog (#2918).
+ */
+export function handleConfirmDelete(): void {
+  const layoutStore = getLayoutStore();
+  const selectionStore = getSelectionStore();
+  const target = dialogStore.deleteTarget;
+
+  if (target?.type === "rack") {
+    const rackId = target.rackId;
+    // A bay member removal closes the row and dissolves a 1-member bay; a
+    // standalone rack deletes plainly (#2741).
+    const group = layoutStore.getRackGroupForRack(rackId);
+    if (group?.layout_preset === "bayed") {
+      const { error } = layoutStore.removeRackFromBay(rackId);
+      if (error) {
+        layoutDebug.group("removeRackFromBay failed for %s: %s", rackId, error);
+      } else {
+        selectionStore.clearSelection();
+      }
+    } else {
+      layoutStore.deleteRack(rackId);
+      selectionStore.clearSelection();
+    }
+  } else if (target?.type === "device" && target.deviceIndex !== undefined) {
+    layoutStore.removeDeviceFromRack(target.rackId, target.deviceIndex);
+    selectionStore.clearSelection();
+  }
+
+  dialogStore.close();
 }
 
 /** Open the keyboard-shortcuts help dialog. */

--- a/src/lib/utils/rack-actions.ts
+++ b/src/lib/utils/rack-actions.ts
@@ -51,7 +51,7 @@ export function handleRackContextDelete(rackId: string): void {
 
   layoutStore.setActiveRack(rackId);
   selectionStore.selectRack(rackId);
-  dialogStore.deleteTarget = { type: "rack", name: rack.name };
+  dialogStore.deleteTarget = { type: "rack", name: rack.name, rackId: rack.id };
   dialogStore.open("confirmDelete");
 }
 

--- a/src/tests/dialog-actions.test.ts
+++ b/src/tests/dialog-actions.test.ts
@@ -98,10 +98,10 @@ describe("handleDelete", () => {
 describe("handleConfirmDelete", () => {
   beforeEach(resetAll);
 
-  // #2918: deleteTarget must snapshot rackId/deviceIndex at open time and act
-  // on that snapshot, not the live selectionStore, so a selection change
-  // between opening the dialog and confirming can't delete a different
-  // object than the one named in the dialog (async/programmatic/mobile paths).
+  // #2918: deleteTarget must snapshot rackId/deviceId at open time and act on
+  // that snapshot, not the live selectionStore, so a selection change between
+  // opening the dialog and confirming can't delete a different object than the
+  // one named in the dialog (async/programmatic/mobile paths).
   it("deletes exactly the device named in the dialog, even if selection moves to a different device before confirm", () => {
     const layoutStore = getLayoutStore();
     const selectionStore = getSelectionStore();
@@ -127,6 +127,52 @@ describe("handleConfirmDelete", () => {
     const rack = layoutStore.getRackById(rackId)!;
     expect(rack.devices.some((d) => d.id === namedDeviceId)).toBe(false);
     expect(rack.devices.some((d) => d.id === otherDevice.id)).toBe(true);
+  });
+
+  // #2918 hardening: the device is identified by a stable id, not a captured
+  // array index, so a reorder that shifts the named device's index between
+  // open and confirm (here: a device removed above it) still deletes exactly
+  // the named device and nothing else.
+  it("deletes exactly the device named in the dialog even if its array index shifts before confirm", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const rack = layoutStore.addRack("Test Rack", 42);
+    if (!rack) throw new Error("addRack returned null");
+
+    const dt = createTestDeviceType({ slug: "test-server", u_height: 1 });
+    layoutStore.addDeviceTypeRaw(dt);
+
+    // Two devices: "above" is placed first (array index 0), "named" second
+    // (array index 1). placeDeviceRaw appends, so this order is deterministic.
+    expect(layoutStore.placeDevice(rack.id, dt.slug, 5, "front")).toBe(true);
+    expect(layoutStore.placeDevice(rack.id, dt.slug, 10, "front")).toBe(true);
+    const devicesAtOpen = layoutStore.getRackById(rack.id)!.devices;
+    const aboveDeviceId = devicesAtOpen[0]!.id;
+    const namedDeviceId = devicesAtOpen[1]!.id;
+
+    selectionStore.selectDevice(rack.id, namedDeviceId);
+    handleDelete();
+    expect(dialogStore.deleteTarget).toMatchObject({ type: "device" });
+
+    // Remove the device above the named one, shifting the named device from
+    // index 1 to index 0 after the dialog opened but before confirm.
+    layoutStore.removeDeviceFromRack(rack.id, 0);
+    expect(
+      layoutStore
+        .getRackById(rack.id)!
+        .devices.some((d) => d.id === namedDeviceId),
+    ).toBe(true);
+
+    handleConfirmDelete();
+
+    const after = layoutStore.getRackById(rack.id)!.devices;
+    // A stale-index delete would have removed index 1 (now out of bounds, a
+    // silent no-op) and left the named device in place; id resolution removes
+    // exactly the named device.
+    expect(after.some((d) => d.id === namedDeviceId)).toBe(false);
+    expect(after.some((d) => d.id === aboveDeviceId)).toBe(false);
+    expect(after.length).toBe(0);
   });
 
   it("deletes exactly the rack named in the dialog, even if selection moves to a different rack before confirm", () => {

--- a/src/tests/dialog-actions.test.ts
+++ b/src/tests/dialog-actions.test.ts
@@ -12,7 +12,11 @@
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { handleDelete, handleNewRack } from "$lib/utils/dialog-actions";
+import {
+  handleDelete,
+  handleConfirmDelete,
+  handleNewRack,
+} from "$lib/utils/dialog-actions";
 import { dialogStore } from "$lib/stores/dialogs.svelte";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import {
@@ -88,6 +92,66 @@ describe("handleDelete", () => {
 
     expect(dialogStore.isOpen("confirmDelete")).toBe(false);
     expect(dialogStore.deleteTarget).toBeNull();
+  });
+});
+
+describe("handleConfirmDelete", () => {
+  beforeEach(resetAll);
+
+  // #2918: deleteTarget must snapshot rackId/deviceIndex at open time and act
+  // on that snapshot, not the live selectionStore, so a selection change
+  // between opening the dialog and confirming can't delete a different
+  // object than the one named in the dialog (async/programmatic/mobile paths).
+  it("deletes exactly the device named in the dialog, even if selection moves to a different device before confirm", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const { rackId, deviceId: namedDeviceId } = placeAndSelectDevice();
+
+    handleDelete();
+    expect(dialogStore.deleteTarget).toMatchObject({ type: "device" });
+
+    // Selection moves to a different device after the dialog opened but
+    // before it's confirmed.
+    const dt2 = createTestDeviceType({ slug: "test-server-2", u_height: 1 });
+    layoutStore.addDeviceTypeRaw(dt2);
+    const placed = layoutStore.placeDevice(rackId, dt2.slug, 20, "front");
+    expect(placed).toBe(true);
+    const otherDevice = layoutStore
+      .getRackById(rackId)!
+      .devices.find((d) => d.device_type === dt2.slug)!;
+    selectionStore.selectDevice(rackId, otherDevice.id);
+
+    handleConfirmDelete();
+
+    const rack = layoutStore.getRackById(rackId)!;
+    expect(rack.devices.some((d) => d.id === namedDeviceId)).toBe(false);
+    expect(rack.devices.some((d) => d.id === otherDevice.id)).toBe(true);
+  });
+
+  it("deletes exactly the rack named in the dialog, even if selection moves to a different rack before confirm", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+
+    const rackA = layoutStore.addRack("Rack A", 12);
+    const rackB = layoutStore.addRack("Rack B", 12);
+    if (!rackA || !rackB) throw new Error("addRack returned null");
+    selectionStore.selectRack(rackA.id);
+
+    handleDelete();
+    expect(dialogStore.deleteTarget).toMatchObject({
+      type: "rack",
+      name: "Rack A",
+    });
+
+    // Selection moves to a different rack after the dialog opened but
+    // before it's confirmed.
+    selectionStore.selectRack(rackB.id);
+
+    handleConfirmDelete();
+
+    expect(layoutStore.getRackById(rackA.id)).toBeUndefined();
+    expect(layoutStore.getRackById(rackB.id)).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

The confirm-delete dialog named a captured object (`deleteTarget.name`) but `handleConfirmDelete` re-resolved the actual `rackId`/`deviceIndex` from the live `selectionStore` at confirm time. If selection changed between opening the dialog and confirming it (async, programmatic, or mobile paths), the dialog said "Delete Rack A?" but deleted whatever was currently selected.

This captures `rackId` (and `deviceIndex` for devices) into `deleteTarget` at open time, and makes the confirm handler act on that snapshot instead of the live selection, mirroring the pattern `RackList.svelte` already uses.

## Changes

- `dialogs.svelte.ts`: `DeleteTarget` now carries `rackId` (and optional `deviceIndex`) alongside `type`/`name`.
- `dialog-actions.ts`: both `handleDelete` openers set the identity snapshot; new exported `handleConfirmDelete` acts on that snapshot (bay-member removal vs standalone rack vs device removal) rather than reading `selectionStore` live.
- `rack-actions.ts`: context-menu `handleRackContextDelete` opener also sets `rackId`.
- `DialogOrchestrator.svelte`: removes the local `handleConfirmDelete` (moved to the testable action) and wires the imported one to the confirm dialog; drops the now-unused `layoutDebug` import.
- `dialog-actions.test.ts`: two new tests proving confirm deletes exactly the named object even when selection moves to a different device/rack after the dialog opens.

## Testing

- [x] Unit tests pass (`npm run test:run`) - 3223 passing
- [x] `npm run check` (svelte-check) - 0 errors
- [x] `npm run lint` - clean
- [x] `npm run build` - succeeds
- [ ] E2E tests pass (`npm run test:e2e`)
- [x] Manual reasoning: selection desync no longer misroutes the delete

## Accessibility

No UI/markup changes; behaviour-only fix to which object a confirmed delete acts on.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
**Delete confirmation now removes the item named in the dialog, even if selection changes before you confirm.**

### What Changed
- Delete prompts now keep the rack or device identity they were opened for, instead of relying on whatever is selected at confirm time
- Confirming a rack delete now removes that specific rack, including bay-member removal when applicable
- Confirming a device delete now removes that specific device from its original rack
- Added tests showing the confirm action still deletes the named rack or device after selection moves elsewhere

### Impact
`✅ Fewer accidental deletes`
`✅ Safer mobile and delayed confirmations`
`✅ Clearer delete results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
