### PR TITLE
fix(api): global argon2 concurrency cap for login flood resistance (#2921)

### DIFF
--- a/api/src/local-auth.test.ts
+++ b/api/src/local-auth.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
+  ARGON2_MAX_CONCURRENT_VERIFICATIONS,
+  argon2VerificationGate,
   bootstrapLocalCredentials,
   createLoginRateLimiter,
   hashPassword,
@@ -117,6 +119,36 @@ describe("hashPassword / verifyPasswordHash", () => {
 
   it("returns false for malformed hash", async () => {
     expect(await verifyPasswordHash("not-a-hash", "anything")).toBe(false);
+  });
+});
+
+describe("verifyPasswordHash global concurrency cap", () => {
+  it("bounds concurrent argon2 verifications regardless of how many requests arrive at once", async () => {
+    const password = "concurrency-cap-password12";
+    const hashed = await hashPassword(password);
+    const totalCalls = ARGON2_MAX_CONCURRENT_VERIFICATIONS + 3;
+
+    const inFlight = Array.from({ length: totalCalls }, () =>
+      verifyPasswordHash(hashed, password),
+    );
+
+    // Synchronously (before any verification has had a chance to complete),
+    // the gate must have admitted no more than the configured cap and queued
+    // the rest — proving the bound holds regardless of how many verifications
+    // were requested simultaneously, independent of any per-IP identity.
+    expect(argon2VerificationGate.active).toBe(
+      ARGON2_MAX_CONCURRENT_VERIFICATIONS,
+    );
+    expect(argon2VerificationGate.pending).toBe(
+      totalCalls - ARGON2_MAX_CONCURRENT_VERIFICATIONS,
+    );
+
+    const results = await Promise.all(inFlight);
+    expect(results.every((result) => result === true)).toBe(true);
+
+    // The gate is fully drained once every verification settles.
+    expect(argon2VerificationGate.active).toBe(0);
+    expect(argon2VerificationGate.pending).toBe(0);
   });
 });
 

--- a/api/src/local-auth.ts
+++ b/api/src/local-auth.ts
@@ -1,6 +1,7 @@
 import { hash, verify, Algorithm } from "@node-rs/argon2";
 import { timingSafeEqual } from "node:crypto";
 import type { EnvMap } from "./security";
+import { createSemaphore } from "./security/semaphore";
 
 export interface LocalCredentials {
   username: string;
@@ -12,6 +13,41 @@ const ARGON2_MEMORY_COST = 65536; // 64 MiB
 const ARGON2_TIME_COST = 3;
 const ARGON2_PARALLELISM = 4;
 const MIN_PASSWORD_LENGTH = 12;
+
+/**
+ * Maximum Argon2id verifications allowed to run concurrently across the whole
+ * process.
+ *
+ * Each verify() call allocates ARGON2_MEMORY_COST (64 MiB) regardless of the
+ * caller's identity. The per-IP login limiter throttles a single source, but a
+ * flood distributed across many source IPs can still drive unbounded concurrent
+ * 64 MiB allocations. Capping concurrency bounds worst-case argon2 memory use
+ * to this many * 64 MiB regardless of how the flood is spread across sources.
+ */
+export const ARGON2_MAX_CONCURRENT_VERIFICATIONS = 4;
+
+/**
+ * Maximum verifications allowed to wait for a concurrency slot before the gate
+ * sheds load.
+ *
+ * Serializing argon2 lowers throughput, so under a sustained flood the wait
+ * queue would otherwise grow without bound and re-introduce memory exhaustion
+ * via parked login handlers. Once this many callers are queued, further
+ * verifications are rejected immediately (surfaced as a failed login) instead
+ * of being enqueued, keeping worst-case memory and latency bounded. The bound
+ * is generous relative to any legitimate self-hosted concurrent-login load.
+ */
+export const ARGON2_MAX_QUEUED_VERIFICATIONS = 64;
+
+/**
+ * Global, IP-agnostic semaphore bounding concurrent Argon2id verifications and
+ * shedding excess load. Shared by every password verification so the bound
+ * holds regardless of how many distinct sources request verification.
+ */
+export const argon2VerificationGate = createSemaphore(
+  ARGON2_MAX_CONCURRENT_VERIFICATIONS,
+  ARGON2_MAX_QUEUED_VERIFICATIONS,
+);
 export const MAX_PASSWORD_LENGTH = 1024;
 const MAX_USERNAME_LENGTH = 255;
 
@@ -50,17 +86,24 @@ export async function hashPassword(password: string): Promise<string> {
 
 /**
  * Verify a plaintext password against an Argon2id hash.
+ *
+ * Verification runs through {@link argon2VerificationGate}, a global concurrency
+ * cap. When the gate is saturated (flood), the call is rejected without
+ * allocating argon2 memory and is treated as a non-match, shedding load rather
+ * than exhausting memory.
  * @param hashed - The stored Argon2id hash string.
  * @param password - The plaintext password to verify.
- * @returns `true` if the password matches; `false` otherwise (including invalid hashes).
+ * @returns `true` if the password matches; `false` otherwise (including invalid
+ *   hashes and gate saturation).
  */
 export async function verifyPasswordHash(
   hashed: string,
   password: string,
 ): Promise<boolean> {
   try {
-    return await verify(hashed, password);
+    return await argon2VerificationGate.run(() => verify(hashed, password));
   } catch {
+    // Invalid hash or gate saturation: treat as a non-match (load shedding).
     return false;
   }
 }

--- a/api/src/security/semaphore.test.ts
+++ b/api/src/security/semaphore.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "bun:test";
+import { createSemaphore, SemaphoreSaturatedError } from "./semaphore";
+
+/** A controllable async task: resolves only when `release()` is called. */
+function deferredTask(): { promise: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+describe("createSemaphore", () => {
+  it("throws when maxConcurrent is less than 1", () => {
+    expect(() => createSemaphore(0)).toThrow();
+  });
+
+  it("throws when maxConcurrent is not an integer", () => {
+    expect(() => createSemaphore(1.5)).toThrow();
+    expect(() => createSemaphore(Number.NaN)).toThrow();
+    expect(() => createSemaphore(Number.POSITIVE_INFINITY)).toThrow();
+  });
+
+  it("throws when maxQueued is negative or not an integer", () => {
+    expect(() => createSemaphore(1, -1)).toThrow();
+    expect(() => createSemaphore(1, 1.5)).toThrow();
+    expect(() => createSemaphore(1, Number.NaN)).toThrow();
+  });
+
+  it("runs a single task immediately", async () => {
+    const semaphore = createSemaphore(2);
+    const result = await semaphore.run(async () => "done");
+    expect(result).toBe("done");
+  });
+
+  it("allows up to maxConcurrent tasks to run at once", () => {
+    const semaphore = createSemaphore(2);
+    const tasks = [deferredTask(), deferredTask(), deferredTask()];
+
+    for (const task of tasks) {
+      void semaphore.run(() => task.promise);
+    }
+
+    // Only the first 2 should have acquired a slot; the 3rd queues.
+    expect(semaphore.active).toBe(2);
+    expect(semaphore.pending).toBe(1);
+  });
+
+  it("runs a queued task once a slot frees up", async () => {
+    const semaphore = createSemaphore(1);
+    const first = deferredTask();
+    const second = deferredTask();
+
+    const firstRun = semaphore.run(() => first.promise);
+    const secondRun = semaphore.run(() => second.promise);
+
+    expect(semaphore.active).toBe(1);
+    expect(semaphore.pending).toBe(1);
+
+    first.release();
+    await firstRun;
+
+    // Releasing the first slot should immediately hand it to the queued task.
+    expect(semaphore.active).toBe(1);
+    expect(semaphore.pending).toBe(0);
+
+    second.release();
+    await secondRun;
+
+    expect(semaphore.active).toBe(0);
+    expect(semaphore.pending).toBe(0);
+  });
+
+  it("releases the slot even when the task throws", async () => {
+    const semaphore = createSemaphore(1);
+
+    await expect(
+      semaphore.run(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(semaphore.active).toBe(0);
+    expect(semaphore.pending).toBe(0);
+
+    // A slot must still be available after the failure.
+    const result = await semaphore.run(async () => "ok");
+    expect(result).toBe("ok");
+  });
+
+  it("rejects immediately when the queue is full (load shedding)", async () => {
+    // 1 slot + room for 1 queued task; a 3rd concurrent caller is shed.
+    const semaphore = createSemaphore(1, 1);
+    const running = deferredTask();
+    const queued = deferredTask();
+
+    const runningTask = semaphore.run(() => running.promise); // takes the slot
+    const queuedTask = semaphore.run(() => queued.promise); // fills the queue
+
+    expect(semaphore.active).toBe(1);
+    expect(semaphore.pending).toBe(1);
+
+    // Third caller has nowhere to go: rejected synchronously, no slot consumed.
+    await expect(semaphore.run(async () => "shed")).rejects.toBeInstanceOf(
+      SemaphoreSaturatedError,
+    );
+    expect(semaphore.active).toBe(1);
+    expect(semaphore.pending).toBe(1);
+
+    running.release();
+    queued.release();
+    await Promise.all([runningTask, queuedTask]);
+
+    expect(semaphore.active).toBe(0);
+    expect(semaphore.pending).toBe(0);
+  });
+
+  it("runs queued tasks in FIFO order", async () => {
+    const semaphore = createSemaphore(1);
+    const order: number[] = [];
+    const blocker = deferredTask();
+
+    const holdRun = semaphore.run(() => blocker.promise);
+    const secondRun = semaphore.run(async () => {
+      order.push(2);
+    });
+    const thirdRun = semaphore.run(async () => {
+      order.push(3);
+    });
+
+    blocker.release();
+    await Promise.all([holdRun, secondRun, thirdRun]);
+
+    expect(order).toEqual([2, 3]);
+  });
+});

--- a/api/src/security/semaphore.ts
+++ b/api/src/security/semaphore.ts
@@ -1,0 +1,109 @@
+/**
+ * Counting semaphore bounding concurrent execution of async work.
+ *
+ * Used to cap globally expensive operations (e.g. Argon2id verification)
+ * independent of any per-client identity, so a bound holds regardless of how
+ * many distinct sources the work is requested from.
+ *
+ * @module semaphore
+ */
+
+/**
+ * Error thrown by {@link Semaphore.run} when the wait queue is full.
+ *
+ * A full queue means the semaphore is shedding load: callers beyond the
+ * configured `maxQueued` are rejected immediately rather than parked
+ * indefinitely, which bounds worst-case memory and latency under a flood.
+ */
+export class SemaphoreSaturatedError extends Error {
+  constructor(message = "Semaphore queue is full") {
+    super(message);
+    this.name = "SemaphoreSaturatedError";
+  }
+}
+
+/**
+ * A semaphore instance limiting how many callers of `run` execute at once.
+ */
+export interface Semaphore {
+  /** Number of callers currently holding a slot and running. */
+  readonly active: number;
+  /** Number of callers waiting for a slot to free up. */
+  readonly pending: number;
+  /**
+   * Run `fn` once a slot is available. Additional callers beyond the
+   * configured concurrency limit queue in FIFO order and run as slots free up.
+   * When the queue is already at `maxQueued`, the call is rejected immediately
+   * with a {@link SemaphoreSaturatedError} instead of being enqueued. The slot
+   * is always released, whether `fn` resolves or rejects.
+   */
+  run<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Create a semaphore that allows at most `maxConcurrent` callers to run
+ * concurrently, queueing up to `maxQueued` additional callers.
+ *
+ * @param maxConcurrent - Maximum concurrent executions. Must be an integer >= 1.
+ * @param maxQueued - Maximum callers allowed to wait for a slot. Must be an
+ *   integer >= 0, or `Infinity` (the default) for an unbounded queue. When the
+ *   queue is full, `run` rejects with {@link SemaphoreSaturatedError}.
+ */
+export function createSemaphore(
+  maxConcurrent: number,
+  maxQueued: number = Number.POSITIVE_INFINITY,
+): Semaphore {
+  if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1) {
+    throw new Error("maxConcurrent must be an integer of at least 1");
+  }
+  if (
+    maxQueued !== Number.POSITIVE_INFINITY &&
+    (!Number.isInteger(maxQueued) || maxQueued < 0)
+  ) {
+    throw new Error("maxQueued must be a non-negative integer or Infinity");
+  }
+
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  function acquire(): Promise<void> {
+    if (active < maxConcurrent) {
+      active++;
+      return Promise.resolve();
+    }
+    if (queue.length >= maxQueued) {
+      return Promise.reject(new SemaphoreSaturatedError());
+    }
+    return new Promise((resolve) => {
+      queue.push(() => {
+        active++;
+        resolve();
+      });
+    });
+  }
+
+  function release(): void {
+    active--;
+    const next = queue.shift();
+    if (next) {
+      next();
+    }
+  }
+
+  return {
+    get active() {
+      return active;
+    },
+    get pending() {
+      return queue.length;
+    },
+    async run<T>(fn: () => Promise<T>): Promise<T> {
+      await acquire();
+      try {
+        return await fn();
+      } finally {
+        release();
+      }
+    },
+  };
+}


### PR DESCRIPTION
## **User description**
## Summary

Login POST is exempt from the global write limiter and relied solely on the per-IP login limiter (5/60s). Each argon2id verify allocates 64 MiB (`ARGON2_MEMORY_COST = 65536`, parallelism 4) with no global concurrency cap, so a flood distributed across many source IPs could drive simultaneous 64 MiB allocations and exhaust memory on the single-process API.

This adds a global, IP-agnostic concurrency cap around argon2 verification, independent of the per-IP limiter (which is left intact).

## Changes

- `api/src/security/semaphore.ts`: new counting semaphore primitive (`createSemaphore`). Caps concurrent executions and bounds its FIFO wait queue; when the queue is full it sheds load by rejecting with `SemaphoreSaturatedError` rather than parking callers indefinitely.
- `api/src/local-auth.ts`: route `verifyPasswordHash` through a shared, process-global `argon2VerificationGate` capped at `ARGON2_MAX_CONCURRENT_VERIFICATIONS` (4). Worst-case argon2 memory is bounded to 4 x 64 MiB regardless of how many source IPs the flood is spread across. The queue is bounded (`ARGON2_MAX_QUEUED_VERIFICATIONS`, 64); once saturated, excess verifications are shed and surfaced as a failed login, so the wait queue cannot itself re-introduce memory exhaustion via parked handlers.
- Tests for the semaphore primitive (concurrency bound, FIFO order, slot release on throw, integer validation, load-shedding) and for the global argon2 cap.

## Why the queue is also bounded

Serializing argon2 to 4 concurrent verifications lowers throughput. Under a sustained distributed flood the incoming rate can exceed the drain rate, so an unbounded wait queue would grow without limit and re-introduce memory exhaustion via parked login handlers. Bounding the queue with fast-reject load-shedding keeps worst-case memory and latency bounded.

## Testing

- [x] API unit + integration tests pass (`bun test` in `api/`, 381 passing)
- [x] API typecheck passes (`tsc --noEmit`)
- [x] Repo lint passes (`npm run lint`)
- [x] Repo build passes (`npm run build`)

## Acceptance criteria

- [x] Concurrent argon2 verifications are globally bounded regardless of source IP spread

Closes #2921


___

## **CodeAnt-AI Description**
**Limit login password checks so a flood cannot exhaust server memory**

### What Changed
- Password verification now runs through a shared process-wide limit, so only a small number of Argon2 checks can run at the same time
- Extra login attempts wait in a short queue, and once that queue is full they are rejected immediately instead of piling up
- Failed, malformed, or overloaded verification attempts all return a normal login failure response
- Added tests for the concurrency limit, queue order, and load shedding behavior

### Impact
`✅ Fewer login-related memory spikes`
`✅ Lower risk of API slowdown during password floods`
`✅ Clearer overload handling for failed login attempts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
