### PR TITLE
fix: ConfirmDialog Enter fires destructive confirm even when Cancel is focused (#2919)

### DIFF
--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -4,7 +4,6 @@
 -->
 <script lang="ts">
   import Dialog from "./Dialog.svelte";
-  import { onMount } from "svelte";
 
   interface Props {
     open: boolean;
@@ -28,6 +27,9 @@
     oncancel,
   }: Props = $props();
 
+  let cancelButtonEl: HTMLButtonElement | undefined = $state();
+  let confirmButtonEl: HTMLButtonElement | undefined = $state();
+
   function handleConfirm() {
     onconfirm?.();
   }
@@ -36,21 +38,30 @@
     oncancel?.();
   }
 
-  // Handle keyboard shortcuts
+  // Enter confirms as a convenience shortcut, but only when focus isn't
+  // already on one of the dialog's own buttons. When Cancel or Confirm is
+  // focused, native button activation (Enter -> click) decides which action
+  // fires; intercepting unconditionally here suppressed that native
+  // activation and always confirmed, even with Cancel focused.
   function handleKeyDown(event: KeyboardEvent) {
-    if (!open) return;
+    if (event.key !== "Enter") return;
+    const active = document.activeElement;
+    if (active === cancelButtonEl || active === confirmButtonEl) return;
 
-    if (event.key === "Enter") {
-      event.preventDefault();
-      handleConfirm();
-    }
+    event.preventDefault();
+    handleConfirm();
   }
 
-  onMount(() => {
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
+  // Listen only while open. DevicePaletteItem renders one ConfirmDialog per
+  // deletable custom device, so an unconditional listener accumulated one
+  // idle document keydown listener per instance regardless of `open`.
+  $effect(() => {
+    if (open) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }
   });
 </script>
 
@@ -60,6 +71,7 @@
 
     <div class="actions">
       <button
+        bind:this={cancelButtonEl}
         type="button"
         class="btn btn-secondary"
         data-testid="btn-cancel-confirm"
@@ -68,6 +80,7 @@
         {cancelLabel}
       </button>
       <button
+        bind:this={confirmButtonEl}
         type="button"
         class="btn {destructive ? 'btn-destructive' : 'btn-primary'}"
         data-testid="btn-confirm-action"

--- a/src/tests/ConfirmDialog.test.ts
+++ b/src/tests/ConfirmDialog.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression tests for #2919: a document-level keydown handler ran the
+ * destructive confirm on Enter and called preventDefault(), which suppressed
+ * native activation of a focused Cancel button. The listener was also
+ * attached unconditionally on mount, so DevicePaletteItem (one ConfirmDialog
+ * per deletable custom device) accumulated idle document listeners.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import ConfirmDialog from "../lib/components/ConfirmDialog.svelte";
+
+describe("ConfirmDialog keyboard behaviour", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("cancels rather than confirms when Enter is pressed while Cancel is focused", async () => {
+    const user = userEvent.setup();
+    const onconfirm = vi.fn();
+    const oncancel = vi.fn();
+
+    render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: "Delete Device Type",
+        message: 'Delete "Test Device"? This will remove it from your library.',
+        onconfirm,
+        oncancel,
+      },
+    });
+
+    // Let the dialog's own initial focus management settle (it auto-focuses
+    // the close button) before taking over focus manually, so our explicit
+    // .focus() below doesn't lose a race with it.
+    const closeButton = screen.getByRole("button", { name: "Close dialog" });
+    await waitFor(() => expect(closeButton).toHaveFocus());
+
+    const cancelButton = screen.getByTestId("btn-cancel-confirm");
+    cancelButton.focus();
+    await user.keyboard("{Enter}");
+
+    expect(oncancel).toHaveBeenCalledTimes(1);
+    expect(onconfirm).not.toHaveBeenCalled();
+  });
+
+  it("does not react to Enter while closed, and stops reacting once closed again", async () => {
+    const onconfirm = vi.fn();
+    const oncancel = vi.fn();
+
+    const { rerender } = render(ConfirmDialog, {
+      props: {
+        open: false,
+        title: "Delete Device Type",
+        message: "Delete this device?",
+        onconfirm,
+        oncancel,
+      },
+    });
+
+    // Closed: no listener should be attached, so Enter is a no-op.
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onconfirm).not.toHaveBeenCalled();
+    expect(oncancel).not.toHaveBeenCalled();
+
+    // Open: the listener attaches, so Enter now confirms.
+    await rerender({
+      open: true,
+      title: "Delete Device Type",
+      message: "Delete this device?",
+      onconfirm,
+      oncancel,
+    });
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onconfirm).toHaveBeenCalledTimes(1);
+
+    // Closed again: the listener detaches, so a further Enter is a no-op.
+    await rerender({
+      open: false,
+      title: "Delete Device Type",
+      message: "Delete this device?",
+      onconfirm,
+      oncancel,
+    });
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onconfirm).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- The document-level keydown handler always confirmed on Enter and called `preventDefault()`, which suppressed native activation of a focused Cancel button, so a keyboard user who tabbed to Cancel and pressed Enter deleted instead of cancelling.
- The listener was also attached unconditionally in `onMount`, regardless of `open`. `DevicePaletteItem` renders one `ConfirmDialog` per deletable custom device, so this accumulated one idle document listener per instance.
- Enter now only triggers the confirm shortcut when focus isn't already on the Cancel or Confirm button; when one of those is focused, native button activation (Enter -> click) decides which action fires. The listener is registered in an `$effect` gated on `open`, so nothing is attached while the dialog is closed.

## Files changed

- `src/lib/components/ConfirmDialog.svelte`: replaced the unconditional `onMount` document listener with an `open`-gated `$effect`; `handleKeyDown` now checks `document.activeElement` against new `bind:this` refs on the Cancel/Confirm buttons before intercepting Enter.
- `src/tests/ConfirmDialog.test.ts` (new): regression tests for both acceptance criteria.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check` (svelte-check) clean
- [x] `npm run test:run` full suite passes (3223 tests)
- [x] `npm run build` succeeds
- [x] New test: Enter while Cancel is focused cancels, not confirms
- [x] New test: no reaction to Enter while closed; listener attaches/detaches as `open` toggles

## Follow-up (out of scope for this PR)

While tracing this, found that focusing the dialog's "X" close button (a third control, separate from Cancel/Confirm) and pressing Enter causes bits-ui's own `Dialog.Close` keydown handler to fire `oncancel` *and* our fallback shortcut to also fire `onconfirm` on the same keypress, since that button isn't one of the two tracked refs. Confirmed via trace this is pre-existing behavior (the old unconditional handler had the same double-fire for this specific focus state) and not something this fix introduces or that the issue's acceptance criteria cover. Will file a separate issue.

Closes #2919


___

## **CodeAnt-AI Description**
**Keep Enter from confirming when Cancel is focused, and only listen while the dialog is open**

### What Changed
- Pressing Enter now follows the focused button in the confirmation dialog, so Cancel is activated as Cancel instead of deleting by mistake
- The Enter shortcut no longer runs while the dialog is closed, and it stops running again after the dialog closes
- Added regression tests for both the Cancel-focused case and the open/closed keyboard behavior

### Impact
`✅ Fewer accidental deletes`
`✅ Safer keyboard cancellation`
`✅ Fewer background key handling issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
