### PR TITLE
fix: deleting a placed device leaves its cables dangling (#2924)

### DIFF
--- a/src/lib/stores/commands/device.ts
+++ b/src/lib/stores/commands/device.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Command } from "./types";
-import type { PlacedDevice, DeviceFace } from "$lib/types";
+import type { Cable, PlacedDevice, DeviceFace } from "$lib/types";
 import type { DeviceImageData } from "$lib/types/images";
 import { getImageStore } from "../images.svelte";
 import { placementKey } from "$lib/utils/placement-key";
@@ -87,6 +87,16 @@ export interface CrossRackMoveStore extends DeviceCommandStore {
 }
 
 /**
+ * Cable operations needed by remove commands to clean up dangling cable
+ * endpoints when a placed device is deleted (#2924, mirrors the
+ * DELETE_DEVICE_TYPE cleanup from #1483).
+ */
+export interface CableCleanupStore {
+  addCableRaw(cable: Cable): void;
+  removeCableRaw(id: string): void;
+}
+
+/**
  * Create a command to place a device
  */
 export function createPlaceDeviceCommand(
@@ -158,13 +168,24 @@ export function createMoveDeviceCommand(
  */
 export function createRemoveDeviceCommand(
   device: PlacedDevice,
-  store: DeviceCommandStore,
+  store: DeviceCommandStore & CableCleanupStore,
   deviceName: string = "device",
   layoutId: string = "",
+  connectedCables: Cable[] = [],
 ): Command {
   // Store a deep copy of the device for restoration
   // structuredClone handles nested objects like ports and custom_fields
   const deviceCopy = structuredClone(device);
+  // Snapshot cables connected to this device so undo can restore them
+  // (#2924, mirrors the DELETE_DEVICE_TYPE cleanup from #1483). Cables read
+  // off the live layout are still Svelte 5 $state proxies here (unlike
+  // `device`, which the caller already ran through $state.snapshot() before
+  // this factory ever sees it) — structuredClone can't clone those, so use
+  // the same JSON round-trip createDeleteDeviceTypeCommand uses for its
+  // placed-device snapshots.
+  const cableData = connectedCables.map(
+    (c) => JSON.parse(JSON.stringify(c)) as Cable,
+  );
 
   // Track the target device by ID, not by a fixed creation-time index (#2656,
   // generalized in #2665). undo() re-appends the device to the end (mutators.ts
@@ -196,6 +217,11 @@ export function createRemoveDeviceCommand(
       getImageStore().removeAllDeviceImages(
         placementKey(layoutId, currentImageId),
       );
+      // Clean up cables connected to this device before removing it, otherwise
+      // their endpoint device ID becomes an orphan reference (#2924, #1483).
+      for (const cable of cableData) {
+        store.removeCableRaw(cable.id);
+      }
       store.removeDeviceAtIndexRaw(targetIndex);
     },
     undo() {
@@ -212,6 +238,17 @@ export function createRemoveDeviceCommand(
           imgStore.setDeviceImage(actualKey, "front", snapshotCopy.front);
         if (snapshotCopy.rear)
           imgStore.setDeviceImage(actualKey, "rear", snapshotCopy.rear);
+      }
+      // Restore cables, rewriting the endpoint that referenced this device
+      // through its (possibly remapped) id.
+      for (const cable of cableData) {
+        store.addCableRaw({
+          ...cable,
+          a_device_id:
+            cable.a_device_id === deviceCopy.id ? actualId : cable.a_device_id,
+          b_device_id:
+            cable.b_device_id === deviceCopy.id ? actualId : cable.b_device_id,
+        });
       }
     },
   };
@@ -233,12 +270,23 @@ export function createRemoveDeviceCommand(
 export function createRemoveDeviceWithChildrenCommand(
   parentDevice: PlacedDevice,
   children: PlacedDevice[],
-  store: DeviceCommandStore,
+  store: DeviceCommandStore & CableCleanupStore,
   deviceName: string = "device",
   layoutId: string = "",
+  connectedCables: Cable[] = [],
 ): Command {
   const parentCopy = structuredClone(parentDevice);
   const childrenCopies = children.map((c) => structuredClone(c));
+  // Snapshot cables connected to the parent or any child so undo can restore
+  // them (#2924, mirrors the DELETE_DEVICE_TYPE cleanup from #1483). JSON
+  // round-trip, not structuredClone: these cables are still live Svelte 5
+  // $state proxies (see createRemoveDeviceCommand for the full explanation).
+  const cableData = connectedCables.map(
+    (c) => JSON.parse(JSON.stringify(c)) as Cable,
+  );
+  // Populated by undo() so cable endpoints can be rewritten through the
+  // (possibly remapped) ids of whichever devices were just restored.
+  const restoredDeviceIdMap = new Map<string, string>();
 
   // Track live IDs so removal/restore resolve by id at runtime, and stay in
   // sync across execute/undo when placeDeviceRaw remaps an id on collision (#1363).
@@ -280,6 +328,16 @@ export function createRemoveDeviceWithChildrenCommand(
       }
       targets.sort((a, b) => b.index - a.index);
       const imgStore = getImageStore();
+      // Clean up cables connected to the parent or any child before removing
+      // them, otherwise their endpoint device IDs become orphan references
+      // (#2924, #1483). Gated on an actual removal happening this pass so a
+      // no-op redo never touches a cable already restored by an intervening
+      // undo.
+      if (targets.length > 0) {
+        for (const cable of cableData) {
+          store.removeCableRaw(cable.id);
+        }
+      }
       for (const { id, index } of targets) {
         imgStore.removeAllDeviceImages(placementKey(layoutId, id));
         store.removeDeviceAtIndexRaw(index);
@@ -293,6 +351,8 @@ export function createRemoveDeviceWithChildrenCommand(
       const actualParentId = actualParent?.id ?? parentCopy.id;
       currentParentId = actualParentId;
       restoreImage(actualParentId, parentImageCopy);
+      restoredDeviceIdMap.clear();
+      restoredDeviceIdMap.set(parentCopy.id, actualParentId);
 
       childrenCopies.forEach((child, i) => {
         const childToPlace: PlacedDevice =
@@ -304,7 +364,20 @@ export function createRemoveDeviceWithChildrenCommand(
         const actualChildId = actualChild?.id ?? childToPlace.id;
         currentChildIds[i] = actualChildId;
         restoreImage(actualChildId, childImageCopies[i]);
+        restoredDeviceIdMap.set(child.id, actualChildId);
       });
+
+      // Restore cables, rewriting each endpoint that referenced the parent or
+      // a child through its (possibly remapped) id.
+      for (const cable of cableData) {
+        store.addCableRaw({
+          ...cable,
+          a_device_id:
+            restoredDeviceIdMap.get(cable.a_device_id) ?? cable.a_device_id,
+          b_device_id:
+            restoredDeviceIdMap.get(cable.b_device_id) ?? cable.b_device_id,
+        });
+      }
     },
   };
 }

--- a/src/lib/stores/layout/recorded-device-actions.ts
+++ b/src/lib/stores/layout/recorded-device-actions.ts
@@ -15,6 +15,7 @@ import { canPlaceDevice, requiresCarrier } from "$lib/utils/collision";
 import { effectiveFace } from "$lib/utils/effective-face";
 import { findDeviceType as findDeviceTypeInArray } from "$lib/stores/layout-helpers";
 import { findDeviceType } from "$lib/utils/device-lookup";
+import { findCablesForDevices } from "./recorded-device-type-actions";
 import { debug } from "$lib/utils/debug";
 import { generateId } from "$lib/utils/device";
 import { instantiatePorts } from "$lib/utils/port-utils";
@@ -427,6 +428,16 @@ export function removeDeviceRecorded(
     .filter((d) => d.container_id === device.id)
     .map((child) => snapshotDevice(child));
 
+  // Cables reference placed devices by id. Deleting a device (or a carrier
+  // and its children) without cleaning up its cables leaves dangling
+  // endpoint references, saved as-is on the next autosave (#2924). Gather and
+  // remove them in the same undoable command, mirroring the #1483 pattern
+  // used for device-type deletion.
+  const connectedCables = findCablesForDevices(ctx, [
+    { rackId, device },
+    ...children.map((child) => ({ rackId, device: child })),
+  ]);
+
   const command =
     children.length > 0
       ? createRemoveDeviceWithChildrenCommand(
@@ -435,12 +446,14 @@ export function removeDeviceRecorded(
           adapter,
           deviceName,
           layout.metadata?.id ?? "",
+          connectedCables,
         )
       : createRemoveDeviceCommand(
           device,
           adapter,
           deviceName,
           layout.metadata?.id ?? "",
+          connectedCables,
         );
   history.execute(command);
   ctx.markDirty();

--- a/src/lib/stores/layout/recorded-device-type-actions.ts
+++ b/src/lib/stores/layout/recorded-device-type-actions.ts
@@ -75,9 +75,10 @@ export function updateDeviceTypeRecorded(
 
 /**
  * Find cables connected to any of the given placed devices.
- * Used so DELETE_DEVICE_TYPE can clean up dangling cable endpoints (#1483).
+ * Used so DELETE_DEVICE_TYPE (#1483) and REMOVE_DEVICE (#2924) can clean up
+ * dangling cable endpoints.
  */
-function findCablesForDevices(
+export function findCablesForDevices(
   ctx: LayoutStateAccess,
   placedDevices: { rackId: string; device: PlacedDevice }[],
 ): Cable[] {

--- a/src/tests/commands-device-type.test.ts
+++ b/src/tests/commands-device-type.test.ts
@@ -6,7 +6,11 @@ import {
   type DeviceTypeCommandStore,
 } from "$lib/stores/commands/device-type";
 import type { DeviceType } from "$lib/types";
-import { createTestDeviceType, createTestDevice } from "./factories";
+import {
+  createTestCable,
+  createTestDeviceType,
+  createTestDevice,
+} from "./factories";
 import { toInternalUnits } from "$lib/utils/position";
 
 function createMockStore(): DeviceTypeCommandStore & {
@@ -331,13 +335,11 @@ describe("Device Type Commands", () => {
         { rackId: "rack-1", device: devB },
       ];
       const cables = [
-        {
+        createTestCable({
           id: "cable-1",
           a_device_id: devA.id,
-          a_interface: "eth0",
           b_device_id: devB.id,
-          b_interface: "eth1",
-        },
+        }),
       ];
 
       const command = createDeleteDeviceTypeCommand(

--- a/src/tests/commands-device.test.ts
+++ b/src/tests/commands-device.test.ts
@@ -11,7 +11,11 @@ import {
   type DeviceTypeCommandStore,
 } from "$lib/stores/commands/device-type";
 import { createBatchCommand } from "$lib/stores/commands/types";
-import { createTestDevice, createTestDeviceType } from "./factories";
+import {
+  createTestCable,
+  createTestDevice,
+  createTestDeviceType,
+} from "./factories";
 import { toInternalUnits } from "$lib/utils/position";
 import type { PlacedDevice, DeviceFace } from "$lib/types";
 
@@ -247,13 +251,11 @@ describe("Device Commands", () => {
       const device = createTestDevice({ id: "device-with-cable" });
       const otherDevice = createTestDevice({ id: "other-device" });
       const cables = [
-        {
+        createTestCable({
           id: "cable-1",
           a_device_id: device.id,
-          a_interface: "eth0",
           b_device_id: otherDevice.id,
-          b_interface: "eth1",
-        },
+        }),
       ];
 
       const command = createRemoveDeviceCommand(
@@ -293,13 +295,11 @@ describe("Device Commands", () => {
       const store = createMockStore();
       const device = createTestDevice({ id: "device-with-cable" });
       const cables = [
-        {
+        createTestCable({
           id: "cable-1",
           a_device_id: device.id,
-          a_interface: "eth0",
           b_device_id: "other-device",
-          b_interface: "eth1",
-        },
+        }),
       ];
 
       const command = createRemoveDeviceCommand(

--- a/src/tests/commands-device.test.ts
+++ b/src/tests/commands-device.test.ts
@@ -22,6 +22,8 @@ function createMockStore(): DeviceCommandStore & {
   updateDeviceFaceRaw: ReturnType<typeof vi.fn>;
   updateDeviceNameRaw: ReturnType<typeof vi.fn>;
   getDeviceAtIndex: ReturnType<typeof vi.fn>;
+  addCableRaw: ReturnType<typeof vi.fn>;
+  removeCableRaw: ReturnType<typeof vi.fn>;
 } {
   return {
     placeDeviceRaw: vi.fn().mockReturnValue(0),
@@ -43,6 +45,8 @@ function createMockStore(): DeviceCommandStore & {
         ? createTestDevice({ id: `mock-${index}` })
         : undefined,
     ),
+    addCableRaw: vi.fn(),
+    removeCableRaw: vi.fn(),
   };
 }
 
@@ -237,6 +241,78 @@ describe("Device Commands", () => {
         expect.objectContaining({ position: toInternalUnits(15) }),
       );
     });
+
+    it("removes connected cables on execute and restores them (with remapped endpoint id) on undo (#2924)", () => {
+      const store = createMockStore();
+      const device = createTestDevice({ id: "device-with-cable" });
+      const otherDevice = createTestDevice({ id: "other-device" });
+      const cables = [
+        {
+          id: "cable-1",
+          a_device_id: device.id,
+          a_interface: "eth0",
+          b_device_id: otherDevice.id,
+          b_interface: "eth1",
+        },
+      ];
+
+      const command = createRemoveDeviceCommand(
+        device,
+        store,
+        "Switch",
+        "",
+        cables,
+      );
+
+      // Resolve-by-id (#2665): execute() looks up the device's current index
+      // via getDeviceAtIndex. Put it at index 0 so resolution succeeds.
+      store.getDeviceAtIndex.mockImplementation((i: number) =>
+        i === 0 ? device : undefined,
+      );
+
+      command.execute();
+      expect(store.removeCableRaw).toHaveBeenCalledWith("cable-1");
+
+      // placeDeviceRaw remaps the id on collision (#1363) — simulate that here.
+      store.placeDeviceRaw.mockReturnValueOnce(0);
+      store.getDeviceAtIndex.mockImplementationOnce(() =>
+        createTestDevice({ id: "device-with-cable-remapped" }),
+      );
+
+      command.undo();
+      expect(store.addCableRaw).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "cable-1",
+          a_device_id: "device-with-cable-remapped",
+          b_device_id: otherDevice.id,
+        }),
+      );
+    });
+
+    it("does not restore cables until undo is called", () => {
+      const store = createMockStore();
+      const device = createTestDevice({ id: "device-with-cable" });
+      const cables = [
+        {
+          id: "cable-1",
+          a_device_id: device.id,
+          a_interface: "eth0",
+          b_device_id: "other-device",
+          b_interface: "eth1",
+        },
+      ];
+
+      const command = createRemoveDeviceCommand(
+        device,
+        store,
+        "Switch",
+        "",
+        cables,
+      );
+      command.execute();
+
+      expect(store.addCableRaw).not.toHaveBeenCalled();
+    });
   });
 
   describe("batch auto-import + placement", () => {
@@ -378,6 +454,8 @@ describe("Device Commands", () => {
         getDeviceAtIndex(index: number): PlacedDevice | undefined {
           return devices[index];
         },
+        addCableRaw: vi.fn(),
+        removeCableRaw: vi.fn(),
       };
     }
 
@@ -505,6 +583,8 @@ describe("Device Commands", () => {
         getDeviceAtIndex(index: number): PlacedDevice | undefined {
           return devices[index];
         },
+        addCableRaw: vi.fn(),
+        removeCableRaw: vi.fn(),
       };
     }
 

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -25,6 +25,7 @@ import type {
   Slot,
   RackWidth,
   SlotWidth,
+  Cable,
 } from "$lib/types";
 import type { CreateDeviceTypeInput } from "$lib/stores/layout-helpers";
 import type { NetBoxDeviceType } from "$lib/utils/netbox-import";
@@ -208,6 +209,22 @@ export function createTestDevice(
     ...(overrides.position !== undefined
       ? { position: toInternalUnits(overrides.position) }
       : {}),
+  };
+}
+
+/**
+ * Creates a test Cable connecting two devices.
+ * Defaults connect "device-a":eth0 to "device-b":eth1; override the endpoint
+ * ids/interfaces to match the placed devices under test.
+ */
+export function createTestCable(overrides: Partial<Cable> = {}): Cable {
+  return {
+    id: overrides.id ?? generateId(),
+    a_device_id: "device-a",
+    a_interface: "eth0",
+    b_device_id: "device-b",
+    b_interface: "eth1",
+    ...overrides,
   };
 }
 

--- a/src/tests/image-undo.test.ts
+++ b/src/tests/image-undo.test.ts
@@ -59,6 +59,8 @@ function createMockDeviceStore(devices: PlacedDevice[]): DeviceCommandStore {
     getDeviceAtIndex(index: number) {
       return devices[index];
     },
+    addCableRaw() {},
+    removeCableRaw() {},
   };
 }
 

--- a/src/tests/layout-device-actions.test.ts
+++ b/src/tests/layout-device-actions.test.ts
@@ -412,6 +412,166 @@ describe("Layout Store", () => {
     });
   });
 
+  describe("removeDeviceFromRack (cable cleanup, #2924)", () => {
+    /** Place two devices and connect a cable between them; return their ids. */
+    function setupTwoDevicesWithCable() {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42)!;
+
+      const deviceType = store.addDeviceType(
+        createTestDeviceTypeInput({
+          name: "Test Switch",
+          u_height: 1,
+          category: "network",
+          colour: "#4A90D9",
+        }),
+      );
+
+      store.placeDevice(rack.id, deviceType.slug, 5);
+      store.placeDevice(rack.id, deviceType.slug, 10);
+      const deviceAId = store.rack.devices[0]!.id;
+      const deviceBId = store.rack.devices[1]!.id;
+
+      store.addCableRaw({
+        id: "cable-1",
+        a_device_id: deviceAId,
+        a_interface: "eth0",
+        b_device_id: deviceBId,
+        b_interface: "eth1",
+      });
+
+      return { store, rack, deviceAId, deviceBId };
+    }
+
+    it("removes cables connected to the deleted device and keeps the layout schema-valid", () => {
+      const { store, rack, deviceAId } = setupTwoDevicesWithCable();
+      const deviceAIndex = store.rack.devices.findIndex(
+        (d) => d.id === deviceAId,
+      );
+
+      store.removeDeviceFromRack(rack.id, deviceAIndex);
+
+      expect(store.layout.cables ?? []).toEqual([]);
+
+      const result = LayoutSchema.safeParse(store.layout);
+      expect(result.success).toBe(true);
+    });
+
+    it("undo restores the cable", () => {
+      const { store, rack, deviceAId } = setupTwoDevicesWithCable();
+      const deviceAIndex = store.rack.devices.findIndex(
+        (d) => d.id === deviceAId,
+      );
+
+      store.removeDeviceFromRack(rack.id, deviceAIndex);
+      expect(store.layout.cables ?? []).toEqual([]);
+
+      store.undo();
+
+      expect(store.layout.cables).toEqual([
+        expect.objectContaining({ id: "cable-1" }),
+      ]);
+    });
+
+    it("also cleans up cables when deleting a carrier with children", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42)!;
+
+      const containerType = store.addDeviceType(
+        createTestDeviceTypeInput({
+          name: "Test Carrier",
+          u_height: 1,
+          category: "server",
+          colour: "#8B4513",
+          slots: [
+            {
+              id: "slot-left",
+              position: { row: 0, col: 0 },
+              width_fraction: 0.5,
+            },
+          ],
+        }),
+      );
+      const childType = store.addDeviceType(
+        createTestDeviceTypeInput({
+          name: "Mini PC",
+          u_height: 1,
+          category: "server",
+          colour: "#4A90D9",
+          slot_width: 1,
+          is_full_depth: false,
+        }),
+      );
+      const otherType = store.addDeviceType(
+        createTestDeviceTypeInput({
+          name: "Other Server",
+          u_height: 1,
+          category: "server",
+          colour: "#4A90D9",
+        }),
+      );
+
+      store.placeDevice(rack.id, containerType.slug, 10);
+      const carrierId = store.activeRack!.devices[0]!.id;
+      store.placeInContainer(
+        rack.id,
+        childType.slug,
+        carrierId,
+        "slot-left",
+        0,
+      );
+      const childId = store.rack.devices.find(
+        (d) => d.container_id === carrierId,
+      )!.id;
+      store.placeDevice(rack.id, otherType.slug, 20);
+      const otherId = store.rack.devices.find(
+        (d) => d.device_type === otherType.slug,
+      )!.id;
+
+      // Cable connects the carrier's CHILD (not the carrier itself) to an
+      // unrelated device, mirroring how a real cabled peripheral hangs off a
+      // contained device.
+      store.addCableRaw({
+        id: "cable-1",
+        a_device_id: childId,
+        a_interface: "eth0",
+        b_device_id: otherId,
+        b_interface: "eth1",
+      });
+
+      const carrierIndex = store.rack.devices.findIndex(
+        (d) => d.id === carrierId,
+      );
+      store.removeDeviceFromRack(rack.id, carrierIndex);
+
+      expect(store.layout.cables ?? []).toEqual([]);
+      const result = LayoutSchema.safeParse(store.layout);
+      expect(result.success).toBe(true);
+
+      store.undo();
+      expect(store.layout.cables).toEqual([
+        expect.objectContaining({ id: "cable-1" }),
+      ]);
+    });
+
+    it("loads cleanly through the browser reload path after a device delete with cables (no dangling endpoints)", () => {
+      const { store, rack, deviceAId } = setupTwoDevicesWithCable();
+      const deviceAIndex = store.rack.devices.findIndex(
+        (d) => d.id === deviceAId,
+      );
+
+      store.removeDeviceFromRack(rack.id, deviceAIndex);
+
+      // Simulate a save-to-localStorage-and-reload round trip: JSON strips
+      // Svelte 5 $state proxies the same way JSON.stringify does on write.
+      const serialized = JSON.parse(JSON.stringify(store.layout));
+      const reloaded = parseLayoutObject(serialized);
+
+      expect(reloaded).not.toBeNull();
+      expect(reloaded?.cables ?? []).toEqual([]);
+    });
+  });
+
   describe("updateDeviceName", () => {
     it("updates placed device name", () => {
       const store = getLayoutStore();

--- a/src/tests/layout-device-actions.test.ts
+++ b/src/tests/layout-device-actions.test.ts
@@ -5,6 +5,7 @@ import { LayoutSchema } from "$lib/schemas";
 import { parseLayoutObject } from "$lib/utils/yaml";
 import {
   setupStoreWithDevice,
+  createTestCable,
   createTestDevice,
   createTestDeviceType,
   createTestDeviceTypeInput,
@@ -432,13 +433,13 @@ describe("Layout Store", () => {
       const deviceAId = store.rack.devices[0]!.id;
       const deviceBId = store.rack.devices[1]!.id;
 
-      store.addCableRaw({
-        id: "cable-1",
-        a_device_id: deviceAId,
-        a_interface: "eth0",
-        b_device_id: deviceBId,
-        b_interface: "eth1",
-      });
+      store.addCableRaw(
+        createTestCable({
+          id: "cable-1",
+          a_device_id: deviceAId,
+          b_device_id: deviceBId,
+        }),
+      );
 
       return { store, rack, deviceAId, deviceBId };
     }
@@ -537,13 +538,13 @@ describe("Layout Store", () => {
       // Cable connects the carrier's CHILD (not the carrier itself) to an
       // unrelated device, mirroring how a real cabled peripheral hangs off a
       // contained device.
-      store.addCableRaw({
-        id: "cable-1",
-        a_device_id: childId,
-        a_interface: "eth0",
-        b_device_id: otherId,
-        b_interface: "eth1",
-      });
+      store.addCableRaw(
+        createTestCable({
+          id: "cable-1",
+          a_device_id: childId,
+          b_device_id: otherId,
+        }),
+      );
 
       const carrierIndex = store.rack.devices.findIndex(
         (d) => d.id === carrierId,

--- a/src/tests/layout-device-actions.test.ts
+++ b/src/tests/layout-device-actions.test.ts
@@ -457,8 +457,8 @@ describe("Layout Store", () => {
       expect(result.success).toBe(true);
     });
 
-    it("undo restores the cable", () => {
-      const { store, rack, deviceAId } = setupTwoDevicesWithCable();
+    it("undo restores the cable with both endpoints intact", () => {
+      const { store, rack, deviceAId, deviceBId } = setupTwoDevicesWithCable();
       const deviceAIndex = store.rack.devices.findIndex(
         (d) => d.id === deviceAId,
       );
@@ -468,8 +468,14 @@ describe("Layout Store", () => {
 
       store.undo();
 
+      // Restored cable must point at the same two devices it originally
+      // connected, otherwise the remap logic silently broke the topology.
       expect(store.layout.cables).toEqual([
-        expect.objectContaining({ id: "cable-1" }),
+        expect.objectContaining({
+          id: "cable-1",
+          a_device_id: deviceAId,
+          b_device_id: deviceBId,
+        }),
       ]);
     });
 
@@ -549,8 +555,14 @@ describe("Layout Store", () => {
       expect(result.success).toBe(true);
 
       store.undo();
+      // The cable hung off the carrier's CHILD; undo must restore it pointing
+      // back at that child (and the unrelated device), not a dangling id.
       expect(store.layout.cables).toEqual([
-        expect.objectContaining({ id: "cable-1" }),
+        expect.objectContaining({
+          id: "cable-1",
+          a_device_id: childId,
+          b_device_id: otherId,
+        }),
       ]);
     });
 


### PR DESCRIPTION
## **User description**
## Summary

Deleting a placed device did no cable cleanup, so a cable connecting that device to another (typically from a NetBox import) survived the delete as a dangling endpoint reference and was persisted that way on the next autosave. This was asymmetric with device-*type* deletion, which already cleans up connected cables via `findCablesForDevices` (the #1483 pattern, with undo restore).

This builds on the #2911 carrier child-cascade in the same `removeDeviceRecorded` function: cable cleanup is layered alongside the child cascade, not as a parallel path.

## Changes

- `findCablesForDevices` in `recorded-device-type-actions.ts` is now exported (was private) so placed-device deletion can reuse it.
- `removeDeviceRecorded` gathers cables connected to the deleted device (and, for a carrier, its children) and passes them into the remove command.
- `createRemoveDeviceCommand` and `createRemoveDeviceWithChildrenCommand` remove those cables on execute and restore them on undo, rewriting any endpoint through the device's possibly-remapped id (the #1363 dedup guard), mirroring the existing `createDeleteDeviceTypeCommand` behaviour.
- Cables read off the live layout are still Svelte 5 `$state` proxies, so they are snapshotted with the same JSON round-trip `createDeleteDeviceTypeCommand` uses for its placed-device snapshots (`structuredClone` cannot clone those proxies directly).

## Testing

How was this tested?

- [x] Unit tests pass (`npm run test:run`) - 3246 passing
- [ ] E2E tests pass (`npm run test:e2e`)
- [x] Manual testing completed - via new integration tests

New tests (TDD, written failing first):

- `commands-device.test.ts`: `createRemoveDeviceCommand` removes connected cables on execute and restores them (with remapped endpoint id) on undo; does not restore until undo.
- `layout-device-actions.test.ts` (`removeDeviceFromRack (cable cleanup, #2924)`): deleting a cabled device removes the cable and keeps `LayoutSchema` valid; undo restores it; carrier-with-children delete also cleans up a child's cable; the layout loads cleanly through the browser reload path with no dangling endpoints.

Also ran `npm run lint`, `npm run check` (svelte-check, 0 errors), and `npm run build` clean.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2924


___

## **CodeAnt-AI Description**
**Deleting a placed device now also removes any cables attached to it, and brings them back on undo.**

### What Changed
- Deleting a device now cleans up its connected cables instead of leaving dangling endpoint references behind.
- If the deleted device is a carrier, cables attached to any of its children are cleaned up too.
- Undo restores the removed cables and keeps their links correct even if the device gets a new id when restored.
- Layouts stay valid after delete, save, and reload instead of persisting broken cable references.

### Impact
`✅ Fewer dangling cable references`
`✅ Safer device deletion`
`✅ Clean reload after deleting cabled devices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
