### PR TITLE
fix(api): apply YAML complexity guard to snapshot endpoint parse (#2944)

### DIFF
--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -70,8 +70,7 @@ function isValidSnapshotFilenameParam(filename: string): boolean {
 }
 
 type YamlComplexityGuardResult =
-  | { ok: true; value: unknown }
-  | { ok: false; status: 400; error: string };
+  { ok: true; value: unknown } | { ok: false; status: 400; error: string };
 
 /**
  * Parses YAML with JSON_SCHEMA and applies the bounded, cycle-safe complexity
@@ -94,10 +93,7 @@ function parseYamlWithComplexityGuard(
   }
 
   try {
-    assertYamlComplexityBounded(
-      parsed,
-      Buffer.byteLength(yamlContent, "utf8"),
-    );
+    assertYamlComplexityBounded(parsed, Buffer.byteLength(yamlContent, "utf8"));
   } catch (e) {
     if (
       e instanceof YamlCircularReferenceError ||

--- a/api/src/routes/layouts.ts
+++ b/api/src/routes/layouts.ts
@@ -69,6 +69,48 @@ function isValidSnapshotFilenameParam(filename: string): boolean {
   return SNAPSHOT_NAME_PATTERN.test(filename);
 }
 
+type YamlComplexityGuardResult =
+  | { ok: true; value: unknown }
+  | { ok: false; status: 400; error: string };
+
+/**
+ * Parses YAML with JSON_SCHEMA and applies the bounded, cycle-safe complexity
+ * guard (#2912) shared by every yaml.load reachable from request input. A
+ * naive JSON.stringify guard would throw on genuine cycles but *succeed*
+ * (while fully expanding shared references) on an acyclic nested-alias body
+ * -- the guard itself was the amplifier for a YAML alias-expansion DoS
+ * (#2912). This bounded, cycle-safe traversal follows each shared reference
+ * only once, so it stays fast and never materializes an expansion.
+ */
+function parseYamlWithComplexityGuard(
+  yamlContent: string,
+): YamlComplexityGuardResult {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { ok: false, status: 400, error: `Invalid YAML: ${message}` };
+  }
+
+  try {
+    assertYamlComplexityBounded(
+      parsed,
+      Buffer.byteLength(yamlContent, "utf8"),
+    );
+  } catch (e) {
+    if (
+      e instanceof YamlCircularReferenceError ||
+      e instanceof YamlTooComplexError
+    ) {
+      return { ok: false, status: 400, error: e.message };
+    }
+    throw e;
+  }
+
+  return { ok: true, value: parsed };
+}
+
 const layouts = new Hono<{ Variables: StorageVariables }>();
 
 // List all layouts
@@ -128,34 +170,11 @@ layouts.put("/:uuid", async (c) => {
     // Parse once, read metadata.id directly — no JSON.stringify round-trip,
     // which would throw on cyclic objects from YAML anchors and silently
     // bypass this guard (see #2067).
-    let parsed: unknown;
-    try {
-      parsed = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA });
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      return c.json({ error: `Invalid YAML: ${message}` }, 400);
+    const parseResult = parseYamlWithComplexityGuard(yamlContent);
+    if (!parseResult.ok) {
+      return c.json({ error: parseResult.error }, parseResult.status);
     }
-
-    // Reject circular and alias-bomb bodies. A naive JSON.stringify guard
-    // would throw on genuine cycles but *succeed* (while fully expanding
-    // shared references) on an acyclic nested-alias body -- the guard
-    // itself was the amplifier for a YAML alias-expansion DoS (#2912). This
-    // bounded, cycle-safe traversal follows each shared reference only
-    // once, so it stays fast and never materializes an expansion.
-    try {
-      assertYamlComplexityBounded(
-        parsed,
-        Buffer.byteLength(yamlContent, "utf8"),
-      );
-    } catch (e) {
-      if (
-        e instanceof YamlCircularReferenceError ||
-        e instanceof YamlTooComplexError
-      ) {
-        return c.json({ error: e.message }, 400);
-      }
-      throw e;
-    }
+    const parsed = parseResult.value;
 
     const layout = LayoutFileSchema.safeParse(parsed);
     if (layout.success && layout.data.metadata?.id) {
@@ -307,11 +326,14 @@ layouts.post("/:uuid/snapshots", async (c) => {
       return c.json({ error: "Request body is empty" }, 400);
     }
 
-    try {
-      yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA });
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      return c.json({ error: `Invalid YAML: ${message}` }, 400);
+    // Defense-in-depth: apply the same bounded, cycle-safe complexity guard
+    // as the layout PUT (#2912). The parse result is discarded below and the
+    // raw text is stored with no expansion, so this is not exploitable today,
+    // but a future restore-snapshot read-back could replay a stored alias
+    // bomb (#2944).
+    const parseResult = parseYamlWithComplexityGuard(yamlContent);
+    if (!parseResult.ok) {
+      return c.json({ error: parseResult.error }, parseResult.status);
     }
 
     const result = await c

--- a/api/src/snapshots.test.ts
+++ b/api/src/snapshots.test.ts
@@ -520,6 +520,50 @@ describe("POST /layouts/:uuid/snapshots", () => {
   });
 });
 
+describe("POST /layouts/:uuid/snapshots YAML alias-expansion DoS guard (#2944)", () => {
+  /**
+   * Mirrors the PUT layout guard's alias-bomb body (routes/layouts.test.ts,
+   * #2912): a small YAML body whose metadata carries a chain of
+   * anchors/aliases, each level referencing the previous level twice. js-yaml
+   * resolves this to a shared-reference object graph in O(input); the guard
+   * this test exercises is the defense-in-depth application of the same
+   * complexity bound to the snapshot upload's syntax-validation parse.
+   */
+  function aliasBombYaml(depth: number): string {
+    const lines = [
+      'version: "1.0.0"',
+      "name: AliasBomb",
+      "metadata:",
+      `  id: "${TEST_UUID}"`,
+      "  name: AliasBomb",
+      '  schema_version: "1.0.0"',
+      "  a0: &a0 [x, x, x, x, x, x, x, x, x, x]",
+    ];
+    for (let i = 1; i <= depth; i++) {
+      lines.push(`  a${i}: &a${i} [*a${i - 1}, *a${i - 1}]`);
+    }
+    lines.push("racks: []");
+    return lines.join("\n");
+  }
+
+  it("rejects a nested-alias alias-bomb body without expanding it", async () => {
+    const app = await createApp(buildEnv());
+    await putLayout(app, TEST_UUID, createLayoutYaml("My Layout", "v1"));
+
+    const body = aliasBombYaml(24);
+    expect(Buffer.byteLength(body, "utf8")).toBeLessThan(1024 * 1024);
+
+    const response = await postSnapshot(app, TEST_UUID, body);
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toContain("too complex");
+
+    // The alias-bomb body must not have been written to disk as a snapshot.
+    expect(await snapshotFilesOnDisk(TEST_UUID)).toEqual([]);
+  });
+});
+
 describe("snapshot route auth gating", () => {
   it("rejects snapshot upload without write token when token auth is enabled", async () => {
     const app = await createApp(


### PR DESCRIPTION
## **User description**
## Summary

`POST /layouts/:uuid/snapshots` called `yaml.load` for syntax validation without the bounded, cycle-safe complexity guard that the layout PUT gained in #2912. Not exploitable today (the parse result is discarded and the raw text is stored with no expansion), but a future restore-snapshot read-back could replay a stored alias bomb. This applies the same `assertYamlComplexityBounded` guard so every `yaml.load` reachable from request input is bounded identically (defense-in-depth).

## Changes

- Extract the parse-plus-guard into a shared `parseYamlWithComplexityGuard` helper in `api/src/routes/layouts.ts`, returning a discriminated result (`ok` / `400 + message`).
- Route both the layout `PUT /:uuid` and the snapshot `POST /:uuid/snapshots` through the helper, so the two paths cannot drift.
- Add a snapshot-endpoint alias-bomb regression test mirroring the PUT guard test from #2912: a small nested-alias body is rejected `400` fast/bounded and never written to disk.

## Testing

- [x] API unit tests pass (`bun test` in `api/`, 381 passing)
- [x] `tsc --noEmit` clean (api)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] E2E tests pass (`npm run test:e2e`) - not run; API-only change

The failing test was written first (RED: got 201, expected 400), then the guard was applied (GREEN).

## Accessibility

Non-UI PR, skipped.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2944

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Reject complex YAML in layout snapshots before saving it**

### What Changed
- Snapshot uploads now use the same YAML safety check as layout saves, so nested alias bodies are rejected instead of being accepted
- Invalid or overly complex YAML in either path returns a 400 error with a clear message
- Snapshot uploads that fail this check are not written to disk

### Impact
`✅ Fewer YAML alias-bomb uploads`
`✅ Safer snapshot saves`
`✅ Clearer snapshot validation errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
