### PR TITLE
fix(export): inline bundled images, fix QR/legend overlap, honour hidden rear (#2928, #2929, #2938)

### DIFF
--- a/src/lib/utils/app-actions.ts
+++ b/src/lib/utils/app-actions.ts
@@ -28,6 +28,7 @@ import {
   exportToCSV,
   downloadBlob,
   generateExportFilename,
+  inlineImageHrefs,
 } from "$lib/utils/export";
 import type { ExportFormat, ExportOptions, ExportView } from "$lib/types";
 
@@ -219,6 +220,11 @@ export async function handleExportSubmit(
 
     const handler = imageFormatHandlers[options.format];
     if (handler) {
+      // Bundled device images are url-based (never data URLs, see
+      // vite.config.ts assetsInlineLimit: 0). Inline them to data URLs before
+      // rasterizing or serializing so they survive outside the app's origin
+      // and inside a serialized-SVG-as-image rasterization (#2928).
+      await inlineImageHrefs(svg);
       await handler(svg, layoutStore.layout.name, exportViewOrDefault);
     } else if (options.format === "csv") {
       const firstRack = racksToExport[0];

--- a/src/lib/utils/export/index.ts
+++ b/src/lib/utils/export/index.ts
@@ -8,6 +8,7 @@
 export { generateExportSVG, generateSingleRackSVG } from "./svg";
 export { exportAsSVG, exportAsPDF, prepareSvgForPdf } from "./vector";
 export { exportAsPNG, exportAsJPEG } from "./raster";
+export { inlineImageHrefs } from "./inline-images";
 export { exportAsZip, exportAsMultiPagePDF } from "./multi";
 export type { ExportProgressCallback } from "./multi";
 export { exportToCSV } from "./data";

--- a/src/lib/utils/export/inline-images.ts
+++ b/src/lib/utils/export/inline-images.ts
@@ -1,0 +1,52 @@
+/**
+ * Inline url-based device image hrefs to data URLs (#2928)
+ *
+ * Bundled device photos are served as site-relative static asset URLs
+ * (vite.config.ts sets `assetsInlineLimit: 0`, so they are never data URLs).
+ * Two export consumers of a generated export SVG cannot resolve a url-based
+ * <image> href:
+ *  - Rasterizing to PNG/JPEG loads the serialized SVG through `new Image()`;
+ *    browsers block external resource loads inside an SVG used as an image
+ *    source, so the image silently fails to render.
+ *  - A standalone SVG file opened outside the app's origin has nothing to
+ *    resolve a site-relative href against.
+ *
+ * Call this on a generated export SVG before rasterizing or serializing it,
+ * to replace every url-based <image> href with a self-contained data URL.
+ * User-uploaded images (already data: URLs) are left untouched.
+ */
+import { appDebug } from "$lib/utils/debug";
+
+export async function inlineImageHrefs(svg: SVGElement): Promise<void> {
+  const imageElements = Array.from(svg.getElementsByTagName("image"));
+  await Promise.all(imageElements.map(inlineImageElement));
+}
+
+async function inlineImageElement(imageEl: SVGImageElement): Promise<void> {
+  const href = imageEl.getAttribute("href");
+  if (!href || href.startsWith("data:")) return;
+
+  try {
+    const response = await fetch(href);
+    if (!response.ok) {
+      throw new Error(`Fetch failed with status ${response.status}`);
+    }
+    const blob = await response.blob();
+    const dataUrl = await blobToDataUrl(blob);
+    imageEl.setAttribute("href", dataUrl);
+  } catch (error) {
+    // Leave the original href if inlining fails (offline, 404, CORS); the
+    // image simply won't render in the export rather than breaking it.
+    appDebug.export("failed to inline image href %s: %O", href, error);
+  }
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Failed to read blob"));
+    reader.readAsDataURL(blob);
+  });
+}

--- a/src/lib/utils/export/inline-images.ts
+++ b/src/lib/utils/export/inline-images.ts
@@ -19,13 +19,33 @@ import { appDebug } from "$lib/utils/debug";
 
 export async function inlineImageHrefs(svg: SVGElement): Promise<void> {
   const imageElements = Array.from(svg.getElementsByTagName("image"));
-  await Promise.all(imageElements.map(inlineImageElement));
+
+  // Group elements by href so each unique url is fetched once. A layout with
+  // many devices sharing one bundled image produces many <image> elements
+  // pointing at the same url; fetching per element would download it N times.
+  const elementsByHref = new Map<string, SVGImageElement[]>();
+  for (const imageEl of imageElements) {
+    const href = imageEl.getAttribute("href");
+    if (!href || href.startsWith("data:")) continue;
+    const group = elementsByHref.get(href);
+    if (group) {
+      group.push(imageEl);
+    } else {
+      elementsByHref.set(href, [imageEl]);
+    }
+  }
+
+  await Promise.all(
+    Array.from(elementsByHref, ([href, elements]) =>
+      inlineHref(href, elements),
+    ),
+  );
 }
 
-async function inlineImageElement(imageEl: SVGImageElement): Promise<void> {
-  const href = imageEl.getAttribute("href");
-  if (!href || href.startsWith("data:")) return;
-
+async function inlineHref(
+  href: string,
+  elements: SVGImageElement[],
+): Promise<void> {
   try {
     const response = await fetch(href);
     if (!response.ok) {
@@ -33,7 +53,9 @@ async function inlineImageElement(imageEl: SVGImageElement): Promise<void> {
     }
     const blob = await response.blob();
     const dataUrl = await blobToDataUrl(blob);
-    imageEl.setAttribute("href", dataUrl);
+    for (const imageEl of elements) {
+      imageEl.setAttribute("href", dataUrl);
+    }
   } catch (error) {
     // Leave the original href if inlining fails (offline, 404, CORS); the
     // image simply won't render in the export rather than breaking it.

--- a/src/lib/utils/export/multi.ts
+++ b/src/lib/utils/export/multi.ts
@@ -3,6 +3,7 @@ import type { ImageStoreMap } from "$lib/types/images";
 import { generateSingleRackSVG } from "./svg";
 import { exportAsSVG, prepareSvgForPdf } from "./vector";
 import { exportAsPNG, exportAsJPEG } from "./raster";
+import { inlineImageHrefs } from "./inline-images";
 
 /**
  * Progress callback for multi-rack exports
@@ -48,6 +49,10 @@ export async function exportAsZip(
       images,
       layoutId,
     );
+
+    // Bundled device images are url-based; inline them to data URLs before
+    // rasterizing or serializing (#2928).
+    await inlineImageHrefs(svg);
 
     // Convert to the requested format
     let blob: Blob;
@@ -124,6 +129,10 @@ export async function exportAsMultiPagePDF(
       images,
       layoutId,
     );
+
+    // Bundled device images are url-based; inline them to data URLs before
+    // svg2pdf converts the SVG to vector PDF content (#2928).
+    await inlineImageHrefs(svg);
 
     // Parse SVG to get dimensions
     const imgWidth = parseInt(svg.getAttribute("width") || "0", 10);

--- a/src/lib/utils/export/svg.ts
+++ b/src/lib/utils/export/svg.ts
@@ -547,12 +547,16 @@ export function generateExportSVG(
 
   const contentWidth =
     totalRackWidth + (hasSidebar ? LEGEND_PADDING + sidebarWidth : 0);
-  const contentHeight = Math.max(rackAreaHeight, legendHeight);
+  // The QR block sits below the legend in the same sidebar column, so the
+  // column height budget must reserve space for both, not just the taller of
+  // the two (#2929).
+  const contentHeight = Math.max(
+    rackAreaHeight,
+    legendHeight + (shouldRenderQR ? qrAreaHeight : 0),
+  );
 
   const svgWidth = contentWidth + EXPORT_PADDING * 2;
-  const svgHeight =
-    Math.max(contentHeight, shouldRenderQR ? qrAreaHeight : 0) +
-    EXPORT_PADDING * 2;
+  const svgHeight = contentHeight + EXPORT_PADDING * 2;
 
   // Determine colours based on background
   const isDark = background === "dark";
@@ -1266,10 +1270,17 @@ export function generateExportSVG(
         // Single view: render with optional face filter
         // Note: Rack name is handled inside renderRackView when no viewLabel is provided
         const rackX = currentX;
+        // A "both" export with a hidden rear falls into this single-view
+        // branch (effectiveDualView is false above). Without an explicit
+        // filter, filterDevicesByFace returns every device, so rear-face
+        // devices would draw on top of the front view. Default to "front" so
+        // the single view matches what show_rear: false actually shows (#2938).
         const faceFilter =
           exportView === "front" || exportView === "rear"
             ? exportView
-            : undefined;
+            : exportView === "both" && !shouldShowRear
+              ? "front"
+              : undefined;
         const rackGroup = renderRackView(rack, rackX, rackY, faceFilter);
 
         svg.appendChild(rackGroup);

--- a/src/lib/utils/export/svg.ts
+++ b/src/lib/utils/export/svg.ts
@@ -528,8 +528,14 @@ export function generateExportSVG(
 
   // Use the larger of bayed group height or standalone rack height
   const rackAreaHeight = Math.max(maxRackAreaHeight, standaloneRackHeight);
-  const legendWidth = includeLegend ? 180 : 0;
-  const legendHeight = includeLegend
+  // The legend group is only rendered when it has at least one item (see the
+  // `includeLegend && usedDevices.length > 0` guard below). Mirror that exact
+  // condition here so the layout budget never reserves legend space (width or
+  // height) for a legend that will not be drawn - otherwise an empty-rack
+  // export leaves a phantom gap above the QR block.
+  const hasLegend = includeLegend && usedDevices.length > 0;
+  const legendWidth = hasLegend ? 180 : 0;
+  const legendHeight = hasLegend
     ? usedDevices.length * LEGEND_ITEM_HEIGHT + LEGEND_PADDING * 2
     : 0;
 
@@ -539,11 +545,8 @@ export function generateExportSVG(
 
   // Calculate sidebar (legend + QR column) dimensions
   // QR code shares the same column as legend, positioned at the bottom
-  const hasSidebar = includeLegend || shouldRenderQR;
-  const sidebarWidth = Math.max(
-    includeLegend ? legendWidth : 0,
-    shouldRenderQR ? qrTotalSize : 0,
-  );
+  const hasSidebar = hasLegend || shouldRenderQR;
+  const sidebarWidth = Math.max(legendWidth, shouldRenderQR ? qrTotalSize : 0);
 
   const contentWidth =
     totalRackWidth + (hasSidebar ? LEGEND_PADDING + sidebarWidth : 0);

--- a/src/tests/export-face-filter.test.ts
+++ b/src/tests/export-face-filter.test.ts
@@ -121,3 +121,48 @@ describe("PNG export — face filtering (#1681)", () => {
     expect(rectsWithFill(frontSvg, deviceType.colour!)).toHaveLength(0);
   });
 });
+
+describe("exportView 'both' with show_rear false (#2938)", () => {
+  it("renders only front-face devices instead of superimposing both faces", () => {
+    const frontType = createTestDeviceType({
+      slug: "front-server",
+      u_height: 2,
+      is_full_depth: false,
+      colour: "#336699",
+    });
+    const rearType = createTestDeviceType({
+      slug: "rear-pdu",
+      u_height: 1,
+      is_full_depth: false,
+      colour: "#994422",
+    });
+
+    const rack = createTestRack({
+      show_rear: false,
+      devices: [
+        createTestDevice({
+          id: "front-1",
+          device_type: "front-server",
+          position: 10,
+          face: "front",
+        }),
+        createTestDevice({
+          id: "rear-1",
+          device_type: "rear-pdu",
+          position: 5,
+          face: "rear",
+        }),
+      ],
+    });
+
+    const svg = generateExportSVG([rack], [frontType, rearType], {
+      ...baseOptions,
+      exportView: "both",
+    });
+
+    // eslint-disable-next-line no-restricted-syntax -- a rear-only device must not draw when the rack hides its rear
+    expect(rectsWithFill(svg, rearType.colour!)).toHaveLength(0);
+    // eslint-disable-next-line no-restricted-syntax -- the front device must still render exactly once
+    expect(rectsWithFill(svg, frontType.colour!)).toHaveLength(1);
+  });
+});

--- a/src/tests/export-inline-images.test.ts
+++ b/src/tests/export-inline-images.test.ts
@@ -91,8 +91,7 @@ describe("inlineImageHrefs (#2928)", () => {
     const fetchMock = vi.fn((url: string) =>
       Promise.resolve({
         ok: true,
-        blob: () =>
-          Promise.resolve(new Blob([url], { type: "image/webp" })),
+        blob: () => Promise.resolve(new Blob([url], { type: "image/webp" })),
       }),
     );
     vi.stubGlobal("fetch", fetchMock);

--- a/src/tests/export-inline-images.test.ts
+++ b/src/tests/export-inline-images.test.ts
@@ -83,7 +83,7 @@ describe("inlineImageHrefs (#2928)", () => {
     expect(imageEl.getAttribute("href")).toBe(href);
   });
 
-  it("inlines multiple images independently", async () => {
+  it("inlines multiple distinct images independently", async () => {
     const imageA = createImageElement("/assets/devices/a.webp");
     const imageB = createImageElement("/assets/devices/b.webp");
     const svg = wrapInSvg(imageA, imageB);
@@ -101,5 +101,31 @@ describe("inlineImageHrefs (#2928)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(imageA.getAttribute("href")).toMatch(/^data:image\/webp;base64,/);
     expect(imageB.getAttribute("href")).toMatch(/^data:image\/webp;base64,/);
+  });
+
+  it("fetches a shared href only once and applies it to every element", async () => {
+    // A layout with N identical devices produces N <image> elements with the
+    // same bundled href; inlining must not fetch the same URL N times (#2952
+    // CodeAnt finding).
+    const sharedHref = "/assets/devices/shared.webp";
+    const imageA = createImageElement(sharedHref);
+    const imageB = createImageElement(sharedHref);
+    const imageC = createImageElement(sharedHref);
+    const svg = wrapInSvg(imageA, imageB, imageC);
+
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        blob: () => Promise.resolve(new Blob([url], { type: "image/webp" })),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await inlineImageHrefs(svg);
+
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(sharedHref);
+    for (const el of [imageA, imageB, imageC]) {
+      expect(el.getAttribute("href")).toMatch(/^data:image\/webp;base64,/);
+    }
   });
 });

--- a/src/tests/export-inline-images.test.ts
+++ b/src/tests/export-inline-images.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Export image inlining (#2928)
+ *
+ * Bundled device images are served as site-relative static asset URLs
+ * (vite.config.ts sets `assetsInlineLimit: 0`, so they are never data URLs).
+ * Two export consumers cannot resolve a url-based <image> href:
+ *  - Rasterizing to PNG/JPEG loads the serialized SVG through `new Image()`;
+ *    browsers block external resource loads inside an SVG used as an image
+ *    source.
+ *  - A standalone SVG file opened outside the app's origin has nothing to
+ *    resolve a relative href against.
+ *
+ * `inlineImageHrefs` walks a generated export SVG and replaces any url-based
+ * <image> href with a self-contained data URL before either consumer runs.
+ * User-uploaded images (already data: URLs) are left untouched.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { inlineImageHrefs } from "$lib/utils/export/inline-images";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function createImageElement(href: string) {
+  const imageEl = document.createElementNS(SVG_NS, "image");
+  imageEl.setAttribute("href", href);
+  return imageEl;
+}
+
+function wrapInSvg(...elements: SVGElement[]) {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  for (const el of elements) svg.appendChild(el);
+  return svg;
+}
+
+describe("inlineImageHrefs (#2928)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("replaces a url-based image href with a data URL", async () => {
+    const imageEl = createImageElement("/assets/devices/server.webp");
+    const svg = wrapInSvg(imageEl);
+
+    const blob = new Blob(["fake-image-bytes"], { type: "image/webp" });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(blob),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await inlineImageHrefs(svg);
+
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      "/assets/devices/server.webp",
+    );
+    expect(imageEl.getAttribute("href")).toMatch(/^data:image\/webp;base64,/);
+  });
+
+  it("leaves an already-inlined data URL untouched (no fetch)", async () => {
+    const dataUrl = "data:image/png;base64,USERUPLOADED";
+    const imageEl = createImageElement(dataUrl);
+    const svg = wrapInSvg(imageEl);
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await inlineImageHrefs(svg);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(imageEl.getAttribute("href")).toBe(dataUrl);
+  });
+
+  it("leaves the original href in place when the fetch fails", async () => {
+    const href = "/assets/devices/missing.webp";
+    const imageEl = createImageElement(href);
+    const svg = wrapInSvg(imageEl);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("network error")),
+    );
+
+    await expect(inlineImageHrefs(svg)).resolves.toBeUndefined();
+    expect(imageEl.getAttribute("href")).toBe(href);
+  });
+
+  it("inlines multiple images independently", async () => {
+    const imageA = createImageElement("/assets/devices/a.webp");
+    const imageB = createImageElement("/assets/devices/b.webp");
+    const svg = wrapInSvg(imageA, imageB);
+
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        blob: () =>
+          Promise.resolve(new Blob([url], { type: "image/webp" })),
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await inlineImageHrefs(svg);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(imageA.getAttribute("href")).toMatch(/^data:image\/webp;base64,/);
+    expect(imageB.getAttribute("href")).toMatch(/^data:image\/webp;base64,/);
+  });
+});

--- a/src/tests/export-qr-legend-layout.test.ts
+++ b/src/tests/export-qr-legend-layout.test.ts
@@ -10,7 +10,11 @@
 import { describe, it, expect } from "vitest";
 import { generateExportSVG } from "$lib/utils/export";
 import type { ExportOptions, DeviceType } from "$lib/types";
-import { createTestRack, createTestDeviceType, createTestDevice } from "./factories";
+import {
+  createTestRack,
+  createTestDeviceType,
+  createTestDevice,
+} from "./factories";
 
 const QR_DATA_URL = "data:image/png;base64,QRCODE";
 
@@ -87,7 +91,8 @@ describe("export QR / legend layout (#2929)", () => {
     const icons = Array.from(lastItem.getElementsByTagName("svg"));
     expect(icons.length).toBeGreaterThan(0);
     const icon = icons[0]!;
-    const rowBottom = Number(icon.getAttribute("y")) + Number(icon.getAttribute("height"));
+    const rowBottom =
+      Number(icon.getAttribute("y")) + Number(icon.getAttribute("height"));
 
     const legendBottom = translateY(legendGroup(svg)) + rowBottom;
     const qrTop = translateY(qrGroup(svg));

--- a/src/tests/export-qr-legend-layout.test.ts
+++ b/src/tests/export-qr-legend-layout.test.ts
@@ -99,4 +99,26 @@ describe("export QR / legend layout (#2929)", () => {
 
     expect(qrTop).toBeGreaterThanOrEqual(legendBottom);
   });
+
+  it("does not reserve phantom legend space above the QR when the legend has no items", () => {
+    // includeLegend is true but the rack has no devices, so no legend group is
+    // drawn. The height budget must not reserve legend space, or the QR block
+    // is pushed down by a phantom gap (#2952 CodeAnt finding).
+    const rack = createTestRack({ height: 2, devices: [] });
+
+    const svg = generateExportSVG([rack], [], baseOptions);
+
+    // No legend group is rendered for an empty rack.
+    expect(
+      Array.from(svg.getElementsByTagName("g")).some(
+        (g) => g.getAttribute("class") === "export-legend",
+      ),
+    ).toBe(false);
+
+    // With no legend and QR the tallest element, the QR sits at the top of the
+    // content area (clamped to EXPORT_PADDING), not offset by phantom legend
+    // height.
+    const EXPORT_PADDING = 20;
+    expect(translateY(qrGroup(svg))).toBe(EXPORT_PADDING);
+  });
 });

--- a/src/tests/export-qr-legend-layout.test.ts
+++ b/src/tests/export-qr-legend-layout.test.ts
@@ -1,0 +1,97 @@
+/**
+ * QR code / legend layout (#2929)
+ *
+ * The sidebar column stacks the legend above the QR block. The shared column
+ * height budget must account for both: when the legend is the tallest sidebar
+ * element (many device types, a short rack), the QR block still needs its own
+ * space below the last legend row, or the opaque QR background paints over
+ * the bottom legend entries.
+ */
+import { describe, it, expect } from "vitest";
+import { generateExportSVG } from "$lib/utils/export";
+import type { ExportOptions, DeviceType } from "$lib/types";
+import { createTestRack, createTestDeviceType, createTestDevice } from "./factories";
+
+const QR_DATA_URL = "data:image/png;base64,QRCODE";
+
+const baseOptions: ExportOptions = {
+  format: "png",
+  scope: "all",
+  includeNames: true,
+  includeLegend: true,
+  background: "dark",
+  exportView: "front",
+  displayMode: "label",
+  includeQR: true,
+  qrCodeDataUrl: QR_DATA_URL,
+};
+
+// Legend rows are grouped with class="legend-item"; each row's icon/swatch
+// child carries its own y/height attributes, so the last row's bottom edge
+// can be read directly off the rendered output (no private layout constants).
+function legendItemGroups(svg: SVGElement): SVGGElement[] {
+  return Array.from(svg.getElementsByTagName("g")).filter(
+    (g) => g.getAttribute("class") === "legend-item",
+  );
+}
+
+function legendGroup(svg: SVGElement): SVGGElement {
+  const group = Array.from(svg.getElementsByTagName("g")).find(
+    (g) => g.getAttribute("class") === "export-legend",
+  );
+  if (!group) throw new Error("export-legend group not found");
+  return group;
+}
+
+function qrGroup(svg: SVGElement): SVGGElement {
+  const group = Array.from(svg.getElementsByTagName("g")).find(
+    (g) => g.getAttribute("class") === "export-qr",
+  );
+  if (!group) throw new Error("export-qr group not found");
+  return group;
+}
+
+function translateY(el: SVGElement): number {
+  const transform = el.getAttribute("transform") ?? "";
+  const match = /translate\(\s*[^,]+,\s*([^)]+)\)/.exec(transform);
+  if (!match?.[1]) throw new Error(`no translate() Y in "${transform}"`);
+  return Number(match[1]);
+}
+
+describe("export QR / legend layout (#2929)", () => {
+  it("keeps the QR block below the last legend row when the legend is the tallest sidebar element", () => {
+    // Many device types (tall legend) on a very short rack (small rack area),
+    // so the legend, not the rack, drives the sidebar column height.
+    const deviceTypes: DeviceType[] = Array.from({ length: 12 }, (_, i) =>
+      createTestDeviceType({ slug: `device-${i}`, u_height: 1 }),
+    );
+    const rack = createTestRack({
+      height: 2,
+      devices: deviceTypes.map((deviceType, i) =>
+        createTestDevice({
+          id: `dev-${i}`,
+          device_type: deviceType.slug,
+          position: 1,
+        }),
+      ),
+    });
+
+    const svg = generateExportSVG([rack], deviceTypes, baseOptions);
+
+    const items = legendItemGroups(svg);
+    expect(items.length).toBeGreaterThan(0);
+    const lastItem = items[items.length - 1]!;
+    // Every test device type defaults to category "server", so each legend
+    // row renders a nested <svg> icon (not the colour-swatch fallback); its
+    // y + height give the row's bottom edge within the legend group.
+    const icons = Array.from(lastItem.getElementsByTagName("svg"));
+    expect(icons.length).toBeGreaterThan(0);
+    const icon = icons[0]!;
+    const rowBottom = Number(icon.getAttribute("y")) + Number(icon.getAttribute("height"));
+
+    const legendBottom = translateY(legendGroup(svg)) + rowBottom;
+    const qrTop = translateY(qrGroup(svg));
+
+    expect(qrTop).toBeGreaterThanOrEqual(legendBottom);
+  });
+});


### PR DESCRIPTION
## **User description**
Fixes three related export bugs, all in the SVG export renderer (`src/lib/utils/export/`). Grouped in one PR because they touch the same file (`svg.ts`) and would otherwise conflict.

## #2928 - bundled device images missing from PNG/JPEG, broken in standalone SVG

Bundled device images are served as site-relative static asset URLs (`vite.config.ts` sets `assetsInlineLimit: 0`, so they are never data URLs). Two export consumers cannot resolve a url-based `<image>` href:

- Rasterizing to PNG/JPEG loads the serialized SVG through `new Image()`; browsers block external resource loads inside an SVG used as an image source, so the image silently fails to render (user sees the colour rect + label, no error).
- A standalone SVG file opened outside the app origin has nothing to resolve a site-relative href against.

Fix: new `inlineImageHrefs(svg)` (`src/lib/utils/export/inline-images.ts`) walks every `<image>`, fetches non-`data:` hrefs, and replaces them with data URLs (via FileReader) before the SVG is rasterized or serialized. User-uploaded images (already `data:` URLs) are left untouched. Fetch/read failures are swallowed so a missing image degrades gracefully instead of hard-failing the export. Wired into `handleExportSubmit` (app-actions), `exportAsZip`, and `exportAsMultiPagePDF`.

## #2929 - QR code overlaps legend in single-SVG export

The sidebar column stacks the legend above the QR block, but the shared column height budget took `max(rackAreaHeight, legendHeight)` and ignored that the QR block needs its own space below the legend. Whenever the legend was the tallest sidebar element, the opaque QR background painted over the bottom legend rows.

Fix: `contentHeight = Math.max(rackAreaHeight, legendHeight + (shouldRenderQR ? qrAreaHeight : 0))`. `svgHeight` simplifies accordingly (the old outer `Math.max` against `qrAreaHeight` is now subsumed).

## #2938 - exportView "both" superimposes front+rear when show_rear is false

When `exportView === "both"` and `rack.show_rear === false`, the render fell into the single-view branch with `faceFilter = undefined`, so `filterDevicesByFace` returned every device: rear-face devices drew on top of front devices at the same U, and blocked-slot hatching was skipped. Rear devices can exist on a `show_rear: false` rack because toggling the flag does not evict them.

Fix: default the single-view face filter to `"front"` when `exportView === "both" && !shouldShowRear`.

## Tests (TDD - written first, confirmed failing pre-fix)

- `export-inline-images.test.ts` (new): url-based hrefs inline to data URLs; data URLs left untouched (no fetch); original href preserved on fetch failure; multiple images inline independently.
- `export-qr-legend-layout.test.ts` (new): tall legend + short rack + QR - QR block starts at or below the last legend row's bottom edge.
- `export-face-filter.test.ts` (extended): `exportView: "both"` on a `show_rear: false` rack renders only front-face devices.

## Verification

- `npm run lint` - clean
- `npm run check` (svelte-check) - 0 errors
- `npm run test:run` - 3257 passed
- `npm run build` - success

Closes #2928
Closes #2929
Closes #2938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
**Fix export images, QR layout, and rear-face rendering**

### What Changed
- Exported images are now embedded into the output so bundled device pictures show up in PNG, JPEG, PDF, and standalone SVG exports.
- QR codes no longer cover the bottom of the legend when the legend is taller than the rack area.
- When a rack hides its rear side, a “both” export now shows only the front view instead of drawing rear devices on top of it.

### Impact
`✅ Exported device images appear reliably`
`✅ Fewer legend overlaps in QR-enabled exports`
`✅ Correct front-only output for racks with hidden rear views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
