### PR TITLE
fix: full-depth placement preview/keyboard validate effective face, not raw view face (#2925)

### DIFF
--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -68,7 +68,10 @@
   } from "$lib/utils/rack-interaction-handlers";
   import { attachPointerDragListeners } from "$lib/utils/rack-pointer-drag";
   import { createContextMenuHandlers } from "$lib/utils/rack-context-menu-handlers";
-  import { effectiveFace, pendingCollisionFace } from "$lib/utils/effective-face";
+  import {
+    effectiveFace,
+    pendingCollisionFace,
+  } from "$lib/utils/effective-face";
 
   const canvasStore = getCanvasStore();
   const viewportStore = getViewportStore();

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -68,7 +68,7 @@
   } from "$lib/utils/rack-interaction-handlers";
   import { attachPointerDragListeners } from "$lib/utils/rack-pointer-drag";
   import { createContextMenuHandlers } from "$lib/utils/rack-context-menu-handlers";
-  import { effectiveFace } from "$lib/utils/effective-face";
+  import { effectiveFace, pendingCollisionFace } from "$lib/utils/effective-face";
 
   const canvasStore = getCanvasStore();
   const viewportStore = getViewportStore();
@@ -331,7 +331,9 @@
         deviceHeight,
         position,
         undefined,
-        effectiveFaceFilter,
+        // Widen a full-depth pending device to both faces so the keyboard
+        // preview matches the store's placement (#2925); see pendingCollisionFace.
+        pendingCollisionFace(placementStore.pendingDevice, effectiveFaceFilter),
       ),
     };
   });

--- a/src/lib/utils/effective-face.ts
+++ b/src/lib/utils/effective-face.ts
@@ -20,3 +20,29 @@ export function effectiveFace(
   }
   return placedDevice.face;
 }
+
+/**
+ * The face a *pending* (not yet placed) device should be checked against for
+ * collision purposes, given the raw view/target face the caller is trying to
+ * place onto. Mirrors `effectiveFace` for a device already in the rack: a
+ * full-depth device always collides on "both" faces regardless of which
+ * sub-view (front/rear) the cursor or keyboard cursor is over, so its
+ * collision face can never be narrowed to a single face. Half-depth devices
+ * collide only on the given view face.
+ *
+ * Shared by the drag/tap preview (resolveDropTarget, resolveDropAction) and
+ * the keyboard cursor (validStartPositions, keyboardCursorPreview) so all
+ * three agree with the store (placeDeviceRecorded) on whether a full-depth
+ * device would collide with an existing device on the opposite face (#2925).
+ *
+ * is_full_depth undefined or true means full-depth; false means half-depth.
+ */
+export function pendingCollisionFace(
+  deviceType: Pick<DeviceType, "is_full_depth"> | undefined,
+  viewFace: DeviceFace | undefined,
+): DeviceFace | undefined {
+  if (deviceType && deviceType.is_full_depth !== false) {
+    return "both";
+  }
+  return viewFace;
+}

--- a/src/lib/utils/placement-keyboard.ts
+++ b/src/lib/utils/placement-keyboard.ts
@@ -16,6 +16,7 @@
 import type { Rack, DeviceType, DeviceFace } from "$lib/types";
 import { getDropFeedback } from "./dragdrop";
 import { requiresChassisBay } from "./collision";
+import { pendingCollisionFace } from "./effective-face";
 
 /**
  * Whole-U start positions (1-indexed, human units, ascending) where `device`
@@ -34,6 +35,10 @@ export function validStartPositions(
   // announcing one would be dishonest and Enter would fail (#2854).
   if (requiresChassisBay(device)) return [];
 
+  // Widen a full-depth pending device to both faces so the keyboard cursor
+  // matches the store's placement (#2925); see pendingCollisionFace.
+  const collisionFace = pendingCollisionFace(device, face);
+
   const positions: number[] = [];
   const deviceHeight = device.u_height;
   const lastStart = rack.height - deviceHeight + 1;
@@ -45,7 +50,7 @@ export function validStartPositions(
         deviceHeight,
         startU,
         undefined,
-        face,
+        collisionFace,
       ) === "valid"
     ) {
       positions.push(startU);

--- a/src/lib/utils/rack-drop-coordinator.ts
+++ b/src/lib/utils/rack-drop-coordinator.ts
@@ -23,6 +23,7 @@ import {
 import { findDeviceType } from "$lib/utils/device-lookup";
 import { getDeviceDisplayName } from "$lib/utils/device";
 import { screenToSVG } from "$lib/utils/coordinates";
+import { pendingCollisionFace } from "$lib/utils/effective-face";
 
 /**
  * The rail height of a synthesised carrier, defaulting to 1U if the slug is
@@ -247,13 +248,15 @@ export function resolveDropTarget(
     // Requires a chassis bay but none is under the cursor: honestly invalid.
     feedback = "invalid";
   } else {
+    // Widen a full-depth pending device to both faces so the preview matches
+    // the store's placement (#2925); see pendingCollisionFace.
     feedback = getDropFeedback(
       rack,
       deviceLibrary,
       device.u_height,
       targetU,
       excludeIndex,
-      faceFilter,
+      pendingCollisionFace(device, faceFilter),
     );
   }
 
@@ -373,13 +376,15 @@ export function resolveDropAction(
     };
   }
 
+  // Widen a full-depth pending device to both faces so the resolved drop
+  // matches the store's placement (#2925); see pendingCollisionFace.
   const feedback = getDropFeedback(
     rack,
     deviceLibrary,
     dragData.device.u_height,
     targetU,
     excludeIndex,
-    faceFilter,
+    pendingCollisionFace(dragData.device, faceFilter),
   );
 
   if (feedback !== "valid") {

--- a/src/tests/full-depth-pending-collision-face.test.ts
+++ b/src/tests/full-depth-pending-collision-face.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Full-depth placement preview and keyboard cursor honesty (#2925).
+ *
+ * The store derives a pending (not-yet-placed) full-depth device's collision
+ * face as "both" regardless of which sub-view (front/rear) it is being placed
+ * from - a full-depth device physically spans the whole rack depth. The
+ * preview (resolveDropTarget), the drop-action resolver (resolveDropAction),
+ * and the keyboard cursor (validStartPositions) must derive the same
+ * collision face, or a full-depth device previews as valid over an existing
+ * device on the opposite face and then gets refused by the actual placement
+ * (same honesty class as #2854).
+ */
+import { describe, it, expect, vi } from "vitest";
+
+// Control the resolved SVG coordinate without a real DOM geometry. The
+// feedback decision under test is downstream of the coordinate math (which is
+// unchanged).
+vi.mock("$lib/utils/coordinates", async (importActual) => {
+  const actual = await importActual<typeof import("$lib/utils/coordinates")>();
+  return { ...actual, screenToSVG: vi.fn(() => ({ x: 100, y: 200 })) };
+});
+
+import { pendingCollisionFace } from "$lib/utils/effective-face";
+import { validStartPositions } from "$lib/utils/placement-keyboard";
+import {
+  resolveDropTarget,
+  resolveDropAction,
+  type RackDimensions,
+  type DropCoordinateInput,
+} from "$lib/utils/rack-drop-coordinator";
+import {
+  createTestRack,
+  createTestDevice,
+  createTestDeviceType,
+} from "./factories";
+
+describe("pendingCollisionFace", () => {
+  const fullDepth = createTestDeviceType({ slug: "srv", u_height: 1 }); // is_full_depth omitted -> full-depth
+  const halfDepth = createTestDeviceType({
+    slug: "shallow",
+    u_height: 1,
+    is_full_depth: false,
+  });
+
+  it("collapses a full-depth device's collision face to 'both' regardless of view face", () => {
+    expect(pendingCollisionFace(fullDepth, "front")).toBe("both");
+    expect(pendingCollisionFace(fullDepth, "rear")).toBe("both");
+  });
+
+  it("passes through the raw view face for a half-depth device", () => {
+    expect(pendingCollisionFace(halfDepth, "front")).toBe("front");
+    expect(pendingCollisionFace(halfDepth, "rear")).toBe("rear");
+  });
+});
+
+describe("validStartPositions excludes slots blocked on the opposite face for a full-depth pending device (#2925)", () => {
+  // The pending device being placed is full-depth: it physically spans both
+  // faces, so it must collide with a device explicitly mounted on the rear,
+  // even though the keyboard cursor is only scanning the front view.
+  const fullDepth = createTestDeviceType({ slug: "srv", u_height: 1 });
+  const halfDepthRearNeighbour = createTestDeviceType({
+    slug: "shallow",
+    u_height: 1,
+    is_full_depth: false,
+  });
+
+  it("excludes a U occupied by a rear-mounted half-depth device when placing a full-depth device from the front view", () => {
+    const rack = createTestRack({
+      height: 5,
+      devices: [
+        createTestDevice({ device_type: "shallow", position: 2, face: "rear" }),
+      ],
+    });
+    // Old (buggy) behaviour: raw "front" (the pending full-depth device's
+    // uncorrected view face) vs the rear neighbour's explicit "rear" never
+    // collide, so U2 would wrongly appear as a valid start.
+    expect(
+      validStartPositions(
+        rack,
+        [fullDepth, halfDepthRearNeighbour],
+        fullDepth,
+        "front",
+      ),
+    ).not.toContain(2);
+  });
+});
+
+describe("resolveDropTarget / resolveDropAction agree for a full-depth device over an occupied opposite face (#2925)", () => {
+  const dims: RackDimensions = {
+    rackHeight: 12, // matches Rack.svelte's rack.height
+    rackWidth: 220,
+    interiorWidth: 220 - 17 * 2,
+    uHeight: 22,
+    rackPadding: 0,
+    railWidth: 17,
+  };
+  const coords: DropCoordinateInput = {
+    svgElement: {} as SVGSVGElement,
+    clientX: 100,
+    clientY: 200,
+  };
+  const fullDepth = createTestDeviceType({ slug: "srv", u_height: 1 });
+  const halfDepthRearNeighbour = createTestDeviceType({
+    slug: "shallow",
+    u_height: 1,
+    is_full_depth: false,
+  });
+
+  // These dims/coords resolve to targetU 3 (mirrors chassis-child-placement.test.ts).
+  function rackWithRearNeighbourAtU3() {
+    return createTestRack({
+      height: 12,
+      devices: [
+        createTestDevice({ device_type: "shallow", position: 3, face: "rear" }),
+      ],
+    });
+  }
+
+  it("previews a full-depth device as blocked over a rear half-depth device at the same U, even from the front view", () => {
+    const result = resolveDropTarget(
+      coords,
+      dims,
+      rackWithRearNeighbourAtU3(),
+      [fullDepth, halfDepthRearNeighbour],
+      fullDepth,
+      "front",
+    );
+    // Old (buggy) behaviour: doFacesCollide("front", "rear") is false, so this
+    // would wrongly report "valid".
+    expect(result.feedback).toBe("blocked");
+  });
+
+  it("resolves the drop action to invalid for the same scenario, matching the preview", () => {
+    const action = resolveDropAction(
+      coords,
+      dims,
+      rackWithRearNeighbourAtU3(),
+      [fullDepth, halfDepthRearNeighbour],
+      { type: "palette", device: fullDepth },
+      "front",
+    );
+    // Old (buggy) behaviour: this would wrongly resolve to a "palette-drop",
+    // which the store then refuses (a refused drop after a green preview).
+    expect(action.kind).toBe("invalid");
+  });
+});

--- a/src/tests/placement-keyboard.test.ts
+++ b/src/tests/placement-keyboard.test.ts
@@ -22,6 +22,15 @@ const twoU = createTestDeviceType({
   u_height: 2,
   is_full_depth: false,
 });
+// Half-depth pending device: only a half-depth device's collision face can be
+// narrowed to a single view face. A full-depth pending device always collides
+// on "both" faces regardless of view (#2925), so face-independence needs a
+// genuinely half-depth device under test here.
+const oneUHalfDepth = createTestDeviceType({
+  slug: "switch-half",
+  u_height: 1,
+  is_full_depth: false,
+});
 
 describe("validStartPositions", () => {
   it("lists every whole-U slot in an empty rack for a 1U device", () => {
@@ -52,16 +61,32 @@ describe("validStartPositions", () => {
     ]);
   });
 
-  it("treats the opposite face as free (face-aware collisions)", () => {
+  it("treats the opposite face as free for a half-depth pending device (face-aware collisions)", () => {
     const rack = createTestRack({
       height: 5,
       devices: [
         createTestDevice({ device_type: "server", position: 2, face: "rear" }),
       ],
     });
-    // The rear-mounted server does not block the front face.
+    // The rear-mounted server does not block the front face for a half-depth
+    // pending device.
+    expect(
+      validStartPositions(rack, [twoU, oneUHalfDepth], oneUHalfDepth, "front"),
+    ).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("collides a full-depth pending device with a rear-mounted device (#2925)", () => {
+    const rack = createTestRack({
+      height: 5,
+      devices: [
+        createTestDevice({ device_type: "server", position: 2, face: "rear" }),
+      ],
+    });
+    // oneU is full-depth (is_full_depth omitted): it spans both faces, so it
+    // collides with the rear-mounted server at U2-U3 even though the cursor
+    // is scanning the front view.
     expect(validStartPositions(rack, [twoU, oneU], oneU, "front")).toEqual([
-      1, 2, 3, 4, 5,
+      1, 4, 5,
     ]);
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Full-depth placement preview and the keyboard cursor validated collisions with the raw sub-view face (`front`/`rear`), while the store already widens a new full-depth device to `"both"` at placement time. The result: a full-depth device previewed as a valid drop (green over hatching, screen reader announces "available") over a device on the opposite face, then the actual drop refused it with a "Can't place device here" toast. Same honesty class as #2854.

The fix adds a shared `pendingCollisionFace(deviceType, viewFace)` helper next to `effectiveFace`, deriving the pending device's collision face once as `is_full_depth === false ? viewFace : "both"` (mirroring the store), and threads it through the four preview/keyboard call sites:

- `resolveDropTarget` / `resolveDropAction` (`rack-drop-coordinator.ts`) - drag/tap preview + drop resolution
- `validStartPositions` (`placement-keyboard.ts`) - keyboard cursor valid slots + tap-to-place highlight
- `keyboardCursorPreview` (`Rack.svelte`) - keyboard cursor preview rectangle

Carrier and chassis-bay branches already pass `"both"` and are untouched.

## Files changed

- `src/lib/utils/effective-face.ts`: new `pendingCollisionFace` helper
- `src/lib/utils/rack-drop-coordinator.ts`: preview + drop-action paths
- `src/lib/utils/placement-keyboard.ts`: keyboard valid-slot scan
- `src/lib/components/Rack.svelte`: keyboard cursor preview
- `src/tests/full-depth-pending-collision-face.test.ts`: new regression suite (preview/keyboard/drop agreement for a full-depth device over an occupied opposite face)
- `src/tests/placement-keyboard.test.ts`: pre-existing test had encoded the bug (asserted a full-depth device ignores the opposite face); split into a half-depth face-independence case + a full-depth collision case

## Test plan

- [x] `npm run test:run` (3257 tests pass)
- [x] `npm run lint` (no issues)
- [x] `npm run check` (svelte-check: 0 errors)
- [x] `npm run build`
- [x] New regression suite fails before the fix, passes after (verified TDD red -> green)

Closes #2925

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
Make full-depth placement previews and keyboard placement match the final drop result

### What Changed
- Full-depth devices now show blocked placement on the opposite face during drag, tap, and keyboard placement, matching the actual result after drop
- Keyboard valid-slot highlighting and cursor preview now agree with the same face rules as the placement result
- Half-depth devices keep face-specific collision behavior, and new tests cover both half-depth and full-depth cases

### Impact
`✅ Fewer “valid” previews that fail on drop`
`✅ Clearer keyboard placement feedback`
`✅ Fewer opposite-face placement surprises`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
