### PR TITLE
fix: serialize browser workspace-index writes under a well-known lock (#2930)

### DIFF
--- a/src/lib/components/PersistenceEffects.svelte
+++ b/src/lib/components/PersistenceEffects.svelte
@@ -121,7 +121,11 @@
   // body is still serialised against a peer tab editing that same layout. Each
   // lock is keyed per layout id, so writing many bodies never nests one lock.
   // The tab-id stamp remains the real ping-pong guard; the lock only serialises
-  // concurrent writers when it can be taken.
+  // concurrent writers when it can be taken. The whole operation also runs
+  // under the single well-known workspace-index lock (#2930), so a peer tab
+  // persisting a DIFFERENT layout (and thus holding a different per-layout
+  // lock) cannot interleave its own read-modify-write of the shared
+  // `Rackula:workspace` index with this one.
   function persistWorkspaceGuarded(snapshot: {
     tabs: PersistTab[];
     activeLayoutId: string | null;
@@ -131,6 +135,8 @@
       isPaused: (layoutId) => twinTabGuard.isPaused(layoutId),
       withLayoutLock: (layoutId, write) =>
         twinTabGuard.withLayoutLock(layoutId, write),
+      withWorkspaceIndexLock: (write) =>
+        twinTabGuard.withWorkspaceIndexLock(write),
     });
   }
 
@@ -167,8 +173,10 @@
     }
     const snapshot = snapshotWorkspaceTabs();
     if (snapshot.tabs.length > 0 && hasPersistableContent()) {
-      // Synchronous last-chance write: skip paused layouts but do not await the
-      // Web Lock (pagehide cannot wait on async work).
+      // Synchronous last-chance write: skip paused layouts but do not await
+      // either Web Lock (pagehide cannot wait on async work), including the
+      // workspace-index lock (#2930). A simultaneous pagehide flush across
+      // tabs remains a residual, accepted risk for the same reason.
       persistBrowserWorkspace({
         ...snapshot,
         isPaused: (layoutId) => twinTabGuard.isPaused(layoutId),

--- a/src/lib/storage/browser-workspace-persist.ts
+++ b/src/lib/storage/browser-workspace-persist.ts
@@ -56,6 +56,18 @@ export interface PersistWorkspaceArgs {
    * synchronous pagehide path, where async work cannot be awaited.
    */
   withLayoutLock?: <T>(layoutId: string, write: () => T) => Promise<T>;
+  /**
+   * Workspace-index lock wrapper (#2930): runs the ENTIRE persist body (every
+   * hydrated body write's own index update, plus the final open-set/library
+   * merge and write) under the single well-known `rackula:workspace-index`
+   * lock where available. `withLayoutLock` alone does not protect the shared
+   * `Rackula:workspace` key: two tabs editing different layouts hold different
+   * per-layout locks, so without this lock a peer's complete index write
+   * landing between this call's read and its overwrite is silently dropped.
+   * Omitted on the synchronous pagehide path, where async work cannot be
+   * awaited (same trade-off as withLayoutLock).
+   */
+  withWorkspaceIndexLock?: <T>(write: () => T | Promise<T>) => Promise<T>;
 }
 
 /**
@@ -64,82 +76,100 @@ export interface PersistWorkspaceArgs {
  * Returns a promise that resolves once every body write has run. When
  * `withLayoutLock` is supplied, each hydrated body write is taken under its own
  * per-layout lock; the index write that follows reflects the completed bodies.
+ * When `withWorkspaceIndexLock` is supplied, the WHOLE operation (every body's
+ * own index update, plus the final merge+write) runs under the single
+ * well-known workspace-index lock (#2930), so a peer tab persisting a
+ * different layout under the same lock can never interleave its own
+ * read-modify-write of the shared `Rackula:workspace` key with this one.
  */
 export async function persistBrowserWorkspace(
   args: PersistWorkspaceArgs,
 ): Promise<void> {
-  const { tabs, activeLayoutId, isPaused, withLayoutLock } = args;
+  const { tabs, activeLayoutId, isPaused, withLayoutLock, withWorkspaceIndexLock } =
+    args;
 
-  // Write each hydrated body first. saveLayoutBody also refreshes that layout's
-  // library entry in the index (updatedAt, durability); it returns false on
-  // quota, leaving the in-memory copy intact and surfacing the flag via the
-  // index. Shells have no body to write. A paused layout (twin-tab guard) is
-  // skipped so a foreign peer's copy is never clobbered. Each write runs under
-  // its own per-layout lock when one is supplied; the locks are distinct per
-  // layout id so writing many bodies in this loop cannot nest the same lock.
-  for (const tab of tabs) {
-    if (tab.hydrated && !isPaused?.(tab.layoutId)) {
-      const write = () =>
-        saveLayoutBody(tab.layoutId, tab.layout, {
+  const run = async (): Promise<void> => {
+    // Write each hydrated body first. saveLayoutBody also refreshes that layout's
+    // library entry in the index (updatedAt, durability); it returns false on
+    // quota, leaving the in-memory copy intact and surfacing the flag via the
+    // index. Shells have no body to write. A paused layout (twin-tab guard) is
+    // skipped so a foreign peer's copy is never clobbered. Each write runs under
+    // its own per-layout lock when one is supplied; the locks are distinct per
+    // layout id so writing many bodies in this loop cannot nest the same lock.
+    // saveLayoutBody's own index read-modify-write is not itself lock-aware, so
+    // when withWorkspaceIndexLock is supplied it relies on this whole `run`
+    // already executing under that lock (see below) for its index write to be
+    // safe against a peer tab persisting a different layout.
+    for (const tab of tabs) {
+      if (tab.hydrated && !isPaused?.(tab.layoutId)) {
+        const write = () =>
+          saveLayoutBody(tab.layoutId, tab.layout, {
+            changesSinceExport: tab.changesSinceExport,
+            hasEverExported: tab.hasEverExported,
+            lastExportedAt: tab.lastExportedAt,
+          });
+        if (withLayoutLock) {
+          await withLayoutLock(tab.layoutId, write);
+        } else {
+          write();
+        }
+      }
+    }
+
+    // Re-read the index after the body writes so hydrated entries are current,
+    // then layer in shell entries (carrying the shell name so the tab still
+    // renders next launch) and the final open set.
+    const current = loadWorkspaceIndex();
+    const library: Record<string, LibraryEntry> = current
+      ? { ...current.library }
+      : {};
+
+    for (const tab of tabs) {
+      const previous = library[tab.layoutId];
+      if (tab.hydrated) {
+        // A non-paused hydrated tab already wrote its library entry via
+        // saveLayoutBody above, so it is current and left alone. A paused tab
+        // (twin-tab guard) skipped its body write, so it has no fresh entry. Its
+        // id is still in openTabs below; without a library entry loadWorkspaceIndex
+        // would filter it out as dangling and drop the layout even though its body
+        // survives. Carry forward the existing entry (or a default named from the
+        // in-memory layout) so the paused tab survives a persist+reload round-trip.
+        if (!isPaused?.(tab.layoutId) || previous) continue;
+        library[tab.layoutId] = {
+          name: tab.layout.name,
+          updatedAt: "",
           changesSinceExport: tab.changesSinceExport,
           hasEverExported: tab.hasEverExported,
           lastExportedAt: tab.lastExportedAt,
-        });
-      if (withLayoutLock) {
-        await withLayoutLock(tab.layoutId, write);
-      } else {
-        write();
+          writeFailed: false,
+          storageMode: "browser",
+        };
+        continue;
       }
-    }
-  }
-
-  // Re-read the index after the body writes so hydrated entries are current,
-  // then layer in shell entries (carrying the shell name so the tab still
-  // renders next launch) and the final open set.
-  const current = loadWorkspaceIndex();
-  const library: Record<string, LibraryEntry> = current
-    ? { ...current.library }
-    : {};
-
-  for (const tab of tabs) {
-    const previous = library[tab.layoutId];
-    if (tab.hydrated) {
-      // A non-paused hydrated tab already wrote its library entry via
-      // saveLayoutBody above, so it is current and left alone. A paused tab
-      // (twin-tab guard) skipped its body write, so it has no fresh entry. Its
-      // id is still in openTabs below; without a library entry loadWorkspaceIndex
-      // would filter it out as dangling and drop the layout even though its body
-      // survives. Carry forward the existing entry (or a default named from the
-      // in-memory layout) so the paused tab survives a persist+reload round-trip.
-      if (!isPaused?.(tab.layoutId) || previous) continue;
       library[tab.layoutId] = {
-        name: tab.layout.name,
-        updatedAt: "",
-        changesSinceExport: tab.changesSinceExport,
-        hasEverExported: tab.hasEverExported,
-        lastExportedAt: tab.lastExportedAt,
-        writeFailed: false,
-        storageMode: "browser",
+        name: tab.name,
+        updatedAt: previous?.updatedAt ?? "",
+        changesSinceExport: previous?.changesSinceExport ?? 0,
+        hasEverExported: previous?.hasEverExported ?? false,
+        lastExportedAt: previous?.lastExportedAt ?? null,
+        writeFailed: previous?.writeFailed ?? false,
+        storageMode: previous?.storageMode ?? "browser",
       };
-      continue;
     }
-    library[tab.layoutId] = {
-      name: tab.name,
-      updatedAt: previous?.updatedAt ?? "",
-      changesSinceExport: previous?.changesSinceExport ?? 0,
-      hasEverExported: previous?.hasEverExported ?? false,
-      lastExportedAt: previous?.lastExportedAt ?? null,
-      writeFailed: previous?.writeFailed ?? false,
-      storageMode: previous?.storageMode ?? "browser",
-    };
+
+    saveWorkspaceIndex({
+      schemaVersion: 2,
+      activeId: activeLayoutId,
+      openTabs: tabs.map((tab) => tab.layoutId),
+      library,
+    });
+
+    if (tabs.length > 0) markEverHadLayouts();
+  };
+
+  if (withWorkspaceIndexLock) {
+    await withWorkspaceIndexLock(run);
+  } else {
+    await run();
   }
-
-  saveWorkspaceIndex({
-    schemaVersion: 2,
-    activeId: activeLayoutId,
-    openTabs: tabs.map((tab) => tab.layoutId),
-    library,
-  });
-
-  if (tabs.length > 0) markEverHadLayouts();
 }

--- a/src/lib/storage/browser-workspace-persist.ts
+++ b/src/lib/storage/browser-workspace-persist.ts
@@ -85,8 +85,13 @@ export interface PersistWorkspaceArgs {
 export async function persistBrowserWorkspace(
   args: PersistWorkspaceArgs,
 ): Promise<void> {
-  const { tabs, activeLayoutId, isPaused, withLayoutLock, withWorkspaceIndexLock } =
-    args;
+  const {
+    tabs,
+    activeLayoutId,
+    isPaused,
+    withLayoutLock,
+    withWorkspaceIndexLock,
+  } = args;
 
   const run = async (): Promise<void> => {
     // Write each hydrated body first. saveLayoutBody also refreshes that layout's

--- a/src/lib/storage/twin-tab-guard.ts
+++ b/src/lib/storage/twin-tab-guard.ts
@@ -224,18 +224,24 @@ export function createTwinTabGuard(
     // anyway. That is intentional here: the tab-id stamp is the real ping-pong
     // guard for same-layout writers, so this lock is only a best-effort
     // serialiser where it can be taken (#2044).
-    return withNamedLock(layoutLockName(layoutId), { ifAvailable: true }, write);
+    return withNamedLock(
+      layoutLockName(layoutId),
+      { ifAvailable: true },
+      write,
+    );
   }
 
-  function withWorkspaceIndexLock<T>(
-    write: () => T | Promise<T>,
-  ): Promise<T> {
+  function withWorkspaceIndexLock<T>(write: () => T | Promise<T>): Promise<T> {
     // Exclusive (blocking): the shared index has NO tab-id-stamp fallback, so
     // this lock must genuinely serialise. ifAvailable would hand a contended
     // peer a null lock and let it run its read-modify-write concurrently,
     // leaving the #2930 lost-update race open; an exclusive request queues the
     // peer behind the held lock so the two index RMWs never interleave.
-    return withNamedLock(WORKSPACE_INDEX_LOCK_NAME, { mode: "exclusive" }, write);
+    return withNamedLock(
+      WORKSPACE_INDEX_LOCK_NAME,
+      { mode: "exclusive" },
+      write,
+    );
   }
 
   return {

--- a/src/lib/storage/twin-tab-guard.ts
+++ b/src/lib/storage/twin-tab-guard.ts
@@ -20,6 +20,17 @@
  * Recovery is by design manual: a paused layout stays paused until the user
  * Reloads (a spurious foreign-write signal therefore leaves the tab paused, the
  * documented recovery, not an oversight).
+ *
+ * A second, single well-known lock (`rackula:workspace-index`, #2930) guards
+ * the shared `Rackula:workspace` index separately from the per-layout locks
+ * above: two tabs editing DIFFERENT layouts hold different per-layout locks,
+ * so those alone cannot serialise their read-modify-write of the one shared
+ * index key. The workspace autosave persist path (the high-frequency writer
+ * running in every tab) takes this lock as an exclusive, blocking request, so
+ * two tabs' concurrent persists cannot interleave their index read-modify-
+ * write and drop each other's entries. Lower-frequency, user-initiated index
+ * writers (library delete, first-run legacy adoption) do not yet take this
+ * lock and remain a smaller, separate race (follow-up).
  */
 
 import { generateId } from "$lib/utils/device";
@@ -29,6 +40,8 @@ const log = sessionDebug.storage;
 
 const LAYOUT_KEY_PREFIX = "Rackula:layout:";
 const LOCK_PREFIX = "rackula:layout:";
+/** The single well-known Web Lock name serialising the shared workspace index (#2930). */
+const WORKSPACE_INDEX_LOCK_NAME = "rackula:workspace-index";
 
 /**
  * The single source of truth for the writer-tab-id field name in a serialized
@@ -139,6 +152,17 @@ export interface TwinTabGuard {
    * only serialises concurrent writers when it can be acquired.
    */
   withLayoutLock<T>(layoutId: string, write: () => T): Promise<T>;
+  /**
+   * Run the full workspace-index read-modify-write cycle through the single
+   * well-known `rackula:workspace-index` Web Lock as a blocking exclusive
+   * request where available (#2930). A peer tab persisting a DIFFERENT layout
+   * holds a different per-layout lock, so `withLayoutLock` alone cannot
+   * serialise their shared index writes; both must go through this exclusive
+   * lock instead, which queues a contended peer behind the holder rather than
+   * letting it run concurrently. The write runs regardless when locks are
+   * unavailable, matching `withLayoutLock`'s fallback.
+   */
+  withWorkspaceIndexLock<T>(write: () => T | Promise<T>): Promise<T>;
 }
 
 function resolveLocks(
@@ -176,21 +200,50 @@ export function createTwinTabGuard(
     options.onForeignWrite?.(result.layoutId);
   }
 
-  async function withLayoutLock<T>(
-    layoutId: string,
-    write: () => T,
+  // Shared Web-Lock runner for both public wrappers below. Runs `write` under
+  // the named lock with the given request options where Web Locks exist, and
+  // runs it directly as the fallback where they do not. The callback always
+  // runs (with a null lock under ifAvailable when the lock is held), so
+  // `captured` is assigned before locks.request resolves; if `write` throws,
+  // the rejection propagates through locks.request and the lock is released.
+  async function withNamedLock<T>(
+    name: string,
+    options: LockOptions,
+    write: () => T | Promise<T>,
   ): Promise<T> {
     if (!locks) return write();
     let captured: T;
-    await locks.request(layoutLockName(layoutId), { ifAvailable: true }, () => {
-      captured = write();
+    await locks.request(name, options, async () => {
+      captured = await write();
     });
-    // The callback runs synchronously (own write) whether or not the lock was
-    // granted (ifAvailable yields a null lock when held), so captured is set.
     return captured!;
   }
 
-  return { isPaused, handleStorageEvent, withLayoutLock };
+  function withLayoutLock<T>(layoutId: string, write: () => T): Promise<T> {
+    // ifAvailable (try-lock): a held lock yields a null lock and the write runs
+    // anyway. That is intentional here: the tab-id stamp is the real ping-pong
+    // guard for same-layout writers, so this lock is only a best-effort
+    // serialiser where it can be taken (#2044).
+    return withNamedLock(layoutLockName(layoutId), { ifAvailable: true }, write);
+  }
+
+  function withWorkspaceIndexLock<T>(
+    write: () => T | Promise<T>,
+  ): Promise<T> {
+    // Exclusive (blocking): the shared index has NO tab-id-stamp fallback, so
+    // this lock must genuinely serialise. ifAvailable would hand a contended
+    // peer a null lock and let it run its read-modify-write concurrently,
+    // leaving the #2930 lost-update race open; an exclusive request queues the
+    // peer behind the held lock so the two index RMWs never interleave.
+    return withNamedLock(WORKSPACE_INDEX_LOCK_NAME, { mode: "exclusive" }, write);
+  }
+
+  return {
+    isPaused,
+    handleStorageEvent,
+    withLayoutLock,
+    withWorkspaceIndexLock,
+  };
 }
 
 /**

--- a/src/tests/browser-workspace-persist.test.ts
+++ b/src/tests/browser-workspace-persist.test.ts
@@ -217,4 +217,65 @@ describe("persistBrowserWorkspace", () => {
     expect(index!.library.b).toBeDefined();
     expect(loadLayoutBody("b").ok).toBe(true);
   });
+
+  // #2930: saveLayoutBody's index read-modify-write only runs under the
+  // per-layout Web Lock, and persistBrowserWorkspace's own final index merge
+  // (reading `current`, layering in this call's entries, then overwriting the
+  // whole index) previously ran completely unlocked. Two tabs editing
+  // different layouts hold different per-layout locks, so the shared
+  // `Rackula:workspace` key was unprotected: a peer's complete write landing
+  // between this call's stale read and its overwrite silently dropped the
+  // peer's library entry. True cross-tab interleaving (separate OS
+  // processes/IPC) cannot be reproduced by async/await timing tricks in a
+  // single-threaded test run, so these tests target the fix's actual
+  // mechanism instead: the entire read-modify-write (body writes and the
+  // index merge+write) must be gated behind one call to the single well-known
+  // workspace-index lock, so a peer holding that same lock can never observe
+  // a half-done state or interleave its own read-modify-write.
+  describe("workspace-index lock (#2930)", () => {
+    it("takes the workspace-index lock exactly once for the whole persist call (body writes plus index merge), not per body", async () => {
+      const acquisitions: number[] = [];
+      let count = 0;
+      const withWorkspaceIndexLock = async <T>(
+        write: () => T | Promise<T>,
+      ): Promise<T> => {
+        count += 1;
+        acquisitions.push(count);
+        return write();
+      };
+
+      await persistBrowserWorkspace({
+        tabs: [tab({ layoutId: "a" }), tab({ layoutId: "b" })],
+        activeLayoutId: "a",
+        withWorkspaceIndexLock,
+      });
+
+      // A single acquisition covering both hydrated bodies' index updates and
+      // the final merge+write: a peer tab serialised on the same well-known
+      // lock cannot interleave anywhere inside this call.
+      expect(acquisitions).toEqual([1]);
+      const index = loadWorkspaceIndex();
+      expect(index!.library.a).toBeDefined();
+      expect(index!.library.b).toBeDefined();
+    });
+
+    it("never writes a body or the index when the workspace-index lock is not granted, proving both are inside its scope", async () => {
+      const withWorkspaceIndexLock = async <T>(
+        _write: () => T | Promise<T>,
+      ): Promise<T> => {
+        throw new Error("lock never granted");
+      };
+
+      await expect(
+        persistBrowserWorkspace({
+          tabs: [tab({ layoutId: "a" })],
+          activeLayoutId: "a",
+          withWorkspaceIndexLock,
+        }),
+      ).rejects.toThrow("lock never granted");
+
+      expect(loadWorkspaceIndex()).toBeNull();
+      expect(loadLayoutBody("a").ok).toBe(false);
+    });
+  });
 });

--- a/src/tests/twin-tab-guard.test.ts
+++ b/src/tests/twin-tab-guard.test.ts
@@ -202,3 +202,62 @@ describe("createTwinTabGuard.withLayoutLock (Web Locks where available)", () => 
     expect(write).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("createTwinTabGuard.withWorkspaceIndexLock (#2930)", () => {
+  it("takes a blocking exclusive lock under the well-known workspace-index name, NOT ifAvailable, so contended writers truly serialise", async () => {
+    // The index lock must genuinely serialise: unlike the per-layout lock, it
+    // has no tab-id-stamp fallback, so ifAvailable (try-lock) would hand a
+    // contended peer a null lock and let it run its read-modify-write anyway,
+    // leaving the #2930 lost-update race open. An exclusive request queues the
+    // peer behind the held lock instead.
+    const request = vi.fn(
+      async (
+        _name: string,
+        _opts: { mode?: string; ifAvailable?: boolean },
+        cb: (lock: object | null) => unknown,
+      ) => cb({}),
+    );
+    const guard = createTwinTabGuard({
+      tabId: "this-tab",
+      locks: { request } as unknown as LockManager,
+    });
+
+    const write = vi.fn(() => true);
+    const result = await guard.withWorkspaceIndexLock(write);
+
+    expect(result).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "rackula:workspace-index",
+      { mode: "exclusive" },
+      expect.any(Function),
+    );
+  });
+
+  it("awaits an async write and returns its resolved value before releasing the lock", async () => {
+    const request = vi.fn(
+      async (
+        _name: string,
+        _opts: { mode?: string },
+        cb: (lock: object | null) => unknown,
+      ) => cb({}),
+    );
+    const guard = createTwinTabGuard({
+      tabId: "this-tab",
+      locks: { request } as unknown as LockManager,
+    });
+
+    const write = vi.fn(async () => "done");
+    const result = await guard.withWorkspaceIndexLock(write);
+    expect(result).toBe("done");
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("still runs the write when Web Locks are unavailable (fallback, same as withLayoutLock)", async () => {
+    const guard = createTwinTabGuard({ tabId: "this-tab", locks: undefined });
+    const write = vi.fn(() => true);
+    const result = await guard.withWorkspaceIndexLock(write);
+    expect(result).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

The browser workspace index (`Rackula:workspace`) read-modify-write in `persistBrowserWorkspace` ran under no lock. `saveLayoutBody`'s own index RMW is only guarded by the per-layout Web Lock (`rackula:layout:<id>`), so two tabs editing different layouts hold different locks and never serialize on the shared index key. A peer tab's complete write landing between this tab's stale read and its overwrite silently dropped the peer's library entry, orphaning that layout's body in localStorage (#2930).

## Fix

- Add a single well-known lock (`rackula:workspace-index`) to the twin-tab guard and run the entire `persistBrowserWorkspace` operation (every hydrated body write's own index update plus the final open-set/library merge and write) under it.
- The index lock is a blocking exclusive request, not `ifAvailable`. Unlike the per-layout lock it has no tab-id-stamp fallback, so a try-lock would hand a contended peer a null lock and let it run its RMW concurrently, leaving the race open. An exclusive request queues the peer behind the holder so the two index RMWs never interleave.
- Both public lock wrappers (`withLayoutLock`, `withWorkspaceIndexLock`) now delegate to a shared private `withNamedLock` helper.

## Scope notes

- The synchronous pagehide flush intentionally omits both locks (it cannot await async work); a simultaneous cross-tab pagehide flush remains a documented, accepted residual risk.
- Lower-frequency, user-initiated index writers (library delete via `deleteLayoutBody`, first-run legacy adoption via `adoptLegacyAutosave`) do not yet take this lock and are a smaller, separate race left as a follow-up.

## Files changed

- `src/lib/storage/twin-tab-guard.ts`: new `withWorkspaceIndexLock` (blocking exclusive) + shared `withNamedLock` helper; per-layout lock behaviour unchanged.
- `src/lib/storage/browser-workspace-persist.ts`: wrap the whole persist body in the workspace-index lock via an injectable `withWorkspaceIndexLock`.
- `src/lib/components/PersistenceEffects.svelte`: wire the guard's `withWorkspaceIndexLock` into the debounced persist path (not the sync pagehide path).
- `src/tests/twin-tab-guard.test.ts`, `src/tests/browser-workspace-persist.test.ts`: cover exclusive/blocking lock semantics, single acquisition per persist, and full-scope coverage of body + index writes.

## Test plan

- [x] `npm run check` (svelte-check, 0 errors)
- [x] `npm run lint` (ESLint, no issues)
- [x] `npm run test:run` (203 files, 3256 tests pass)
- [x] `npm run build` (succeeds)

Closes #2930


___

## **CodeAnt-AI Description**
**Prevent saved work from disappearing when two tabs edit different layouts**

### What Changed
- The workspace now saves its shared list of layouts under one dedicated lock, so one tab cannot overwrite another tab’s saved layout entry during autosave
- Saving now keeps the whole workspace update together: each layout body update and the final workspace list update happen as one protected save
- If browser locks are unavailable, saving still runs as before
- The fast page-close save still skips locking, so a rare cross-tab close race remains possible

### Impact
`✅ Fewer missing layouts after editing in multiple tabs`
`✅ Fewer lost changes in the workspace list`
`✅ Safer autosave for browser workspaces`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
