### PR TITLE
fix: undo of add/duplicate/delete rack restores previously active rack (#2940)

### DIFF
--- a/src/lib/stores/commands/rack.ts
+++ b/src/lib/stores/commands/rack.ts
@@ -53,6 +53,7 @@ export interface RackLifecycleCommandStore {
     id: string,
   ): { rack: Rack; index: number; groups: RackGroup[] } | undefined;
   restoreRackRaw(rack: Rack, groups: RackGroup[], originalIndex?: number): void;
+  getActiveRackId(): string | null;
   setActiveRackId(id: string | null): void;
   /**
    * Write both `layout.name` and `layout.metadata.name` directly (bypasses
@@ -86,12 +87,16 @@ export function createAddRackCommand(
 ): Command {
   // Deep copy to avoid mutation issues
   const rackCopy = JSON.parse(JSON.stringify(rack)) as Rack;
+  // Captured on each execute() so undo (and a subsequent redo) restores
+  // whichever rack was active immediately before this command ran (#2940).
+  let previousActiveRackId: string | null = null;
 
   return {
     type: "ADD_RACK",
     description: `Add rack "${rack.name}"`,
     timestamp: Date.now(),
     execute() {
+      previousActiveRackId = store.getActiveRackId();
       store.addRackRaw(rackCopy);
       if (setActive) {
         store.setActiveRackId(rackCopy.id);
@@ -104,6 +109,7 @@ export function createAddRackCommand(
     },
     undo() {
       store.deleteRackRaw(rackCopy.id);
+      store.setActiveRackId(previousActiveRackId);
       if (layoutNameSync) {
         const { previousLayoutName, previousMetadataName } =
           layoutNameSync.snapshot;
@@ -129,12 +135,16 @@ export function createDeleteRackCommand(
   ) as RackGroup[];
   // Capture original index on first execute so undo restores to the correct position
   let originalIndex: number | undefined;
+  // Captured on each execute() so undo restores whichever rack was active
+  // immediately before this delete ran (#2940).
+  let previousActiveRackId: string | null = null;
 
   return {
     type: "DELETE_RACK",
     description: `Delete rack "${rack.name}"`,
     timestamp: Date.now(),
     execute() {
+      previousActiveRackId = store.getActiveRackId();
       const result = store.deleteRackRaw(rackSnapshot.id);
       if (result && originalIndex === undefined) {
         originalIndex = result.index;
@@ -142,6 +152,7 @@ export function createDeleteRackCommand(
     },
     undo() {
       store.restoreRackRaw(rackSnapshot, groupSnapshots, originalIndex);
+      store.setActiveRackId(previousActiveRackId);
     },
   };
 }

--- a/src/lib/stores/layout/rack-actions.ts
+++ b/src/lib/stores/layout/rack-actions.ts
@@ -173,6 +173,7 @@ export function getRackLifecycleCommandAdapter(
     deleteRackRaw: (id: string) => deleteRackRaw(ctx, id),
     restoreRackRaw: (rack: Rack, groups: RackGroup[], originalIndex?: number) =>
       restoreRackRaw(ctx, rack, groups, originalIndex),
+    getActiveRackId: () => ctx.getActiveRackId(),
     setActiveRackId: (id: string | null) => ctx.setActiveRackId(id),
     setLayoutNamesRaw: (name: string, metadataName: string | undefined) =>
       setLayoutNamesRaw(ctx, name, metadataName),

--- a/src/tests/rack-undo.test.ts
+++ b/src/tests/rack-undo.test.ts
@@ -360,6 +360,61 @@ describe("Rack Add/Delete Undo/Redo", () => {
     });
   });
 
+  describe("active rack restoration on undo (#2940)", () => {
+    it("restores the previously active rack after undoing addRack", () => {
+      const store = getLayoutStore();
+      // Rack A occupies index 0; without a fix, deleteRackRaw's naive
+      // racks[0] fallback would land on A even when Z was really active,
+      // masking the bug. Rack Z must be active (and not index 0) to prove
+      // undo restores the *previously active* rack, not just "some" rack.
+      store.addRack("Rack A", 42);
+      const rackZ = store.addRack("Rack Z", 42)!;
+      store.clearHistory();
+      expect(store.activeRackId).toBe(rackZ.id);
+
+      const rackB = store.addRack("Rack B", 42)!;
+      expect(store.activeRackId).toBe(rackB.id);
+
+      store.undo();
+
+      expect(store.activeRackId).toBe(rackZ.id);
+    });
+
+    it("restores the previously active rack after undoing duplicateRack", () => {
+      const store = getLayoutStore();
+      // Same rationale as above: rack Z must be active and not index 0.
+      store.addRack("Rack A", 42);
+      const rackZ = store.addRack("Rack Z", 42)!;
+      store.clearHistory();
+      expect(store.activeRackId).toBe(rackZ.id);
+
+      const result = store.duplicateRack(rackZ.id);
+      expect(result.rack).toBeDefined();
+      expect(store.activeRackId).toBe(result.rack!.id);
+
+      store.undo();
+
+      expect(store.activeRackId).toBe(rackZ.id);
+    });
+
+    it("restores the previously active rack after undoing deleteRack", () => {
+      const store = getLayoutStore();
+      const rackA = store.addRack("Rack A", 42)!;
+      store.addRack("Rack B", 42);
+      store.setActiveRack(rackA.id);
+      store.clearHistory();
+      expect(store.activeRackId).toBe(rackA.id);
+
+      // Deleting the active rack falls back to another rack internally.
+      store.deleteRack(rackA.id);
+      expect(store.activeRackId).not.toBe(rackA.id);
+
+      store.undo();
+
+      expect(store.activeRackId).toBe(rackA.id);
+    });
+  });
+
   describe("undo/redo state consistency", () => {
     it("marks layout as dirty after undo", () => {
       const store = getLayoutStore();


### PR DESCRIPTION
## **User description**
## Summary

- `createAddRackCommand.undo()` deleted the added/duplicated rack copy but never restored whichever rack was active before the command ran. `deleteRackRaw`'s internal `racks[0]` fallback (triggered when the deleted rack was active) left an arbitrary rack active after undo instead of the one the user had selected.
- `createDeleteRackCommand.undo()` restored the deleted rack but never reactivated it (or the previously active rack), so a delete-undo of the active rack left the wrong rack selected.
- `duplicateRack` and `addRack` both route through `createAddRackCommand`, so the fix covers add, duplicate, and delete undo in one change.

Fix: snapshot the active rack id via `getActiveRackId()` on each `execute()` and restore it with `setActiveRackId()` in `undo()`, mirroring the existing pattern already used in `commands/device.ts` and `commands/device-type.ts`.

## Files changed

- `src/lib/stores/commands/rack.ts`: added `getActiveRackId()` to `RackLifecycleCommandStore`; snapshot/restore active rack id in `createAddRackCommand` and `createDeleteRackCommand`.
- `src/lib/stores/layout/rack-actions.ts`: wired `getActiveRackId` into `getRackLifecycleCommandAdapter`.
- `src/tests/rack-undo.test.ts`: added failing-first tests proving undo of add/duplicate/delete restores the previously active rack (constructed with a non-index-0 previously-active rack so the naive `racks[0]` fallback can't coincidentally pass).

## Test plan

- [x] `npm run lint`
- [x] `npm run check` (svelte-check, typed change)
- [x] `npm run test:run` (3273 tests)
- [x] `npm run build`

Closes #2940


___

## **CodeAnt-AI Description**
**Undo now restores the rack that was active before add, duplicate, or delete actions**

### What Changed
- Undoing an added or duplicated rack now brings back the rack that was selected before the action, instead of leaving a different rack active
- Undoing a rack delete now restores the deleted rack and reselects the rack that was active before the delete
- Added tests to cover all three undo cases and prevent the wrong rack from staying selected

### Impact
`✅ Restored rack selection after undo`
`✅ Fewer wrong-context rack edits`
`✅ Safer add, duplicate, and delete undo`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
