### PR TITLE
fix: NetBox import maps inventory_items and warns on unsupported console ports (#2941)

### DIFF
--- a/src/lib/utils/netbox-import.test.ts
+++ b/src/lib/utils/netbox-import.test.ts
@@ -709,6 +709,42 @@ model: Some Device
 
       expect(result.deviceType.notes).toBe("This is a test device");
     });
+
+    it("maps inventory items", () => {
+      const netbox: NetBoxDeviceType = {
+        manufacturer: "Dell",
+        model: "PowerEdge R640",
+        slug: "dell-poweredge-r640",
+        inventory_items: [
+          { name: "PSU 1", manufacturer: "Dell", part_id: "450-AEBM" },
+        ],
+      };
+
+      const result = convertOk(netbox);
+
+      expect(result.deviceType.inventory_items).toContainEqual({
+        name: "PSU 1",
+        manufacturer: "Dell",
+        part_id: "450-AEBM",
+      });
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("warns that console ports have no Rackula representation", () => {
+      const netbox: NetBoxDeviceType = {
+        manufacturer: "Opengear",
+        model: "IM7208",
+        slug: "opengear-im7208",
+        console_ports: [{ name: "Console 1" }],
+        console_server_ports: [{ name: "Serial 1" }, { name: "Serial 2" }],
+      };
+
+      const result = convertOk(netbox);
+
+      expect(result.warnings).toContain(
+        "3 console port(s) are not yet supported by Rackula and were not imported",
+      );
+    });
   });
 
   describe("convertToDeviceType validation gate", () => {

--- a/src/lib/utils/netbox-import.test.ts
+++ b/src/lib/utils/netbox-import.test.ts
@@ -711,14 +711,14 @@ model: Some Device
     });
 
     it("maps inventory items", () => {
-      const netbox: NetBoxDeviceType = {
+      const netbox = createTestNetBoxDeviceType({
         manufacturer: "Dell",
         model: "PowerEdge R640",
         slug: "dell-poweredge-r640",
         inventory_items: [
           { name: "PSU 1", manufacturer: "Dell", part_id: "450-AEBM" },
         ],
-      };
+      });
 
       const result = convertOk(netbox);
 
@@ -731,13 +731,13 @@ model: Some Device
     });
 
     it("warns that console ports have no Rackula representation", () => {
-      const netbox: NetBoxDeviceType = {
+      const netbox = createTestNetBoxDeviceType({
         manufacturer: "Opengear",
         model: "IM7208",
         slug: "opengear-im7208",
         console_ports: [{ name: "Console 1" }],
         console_server_ports: [{ name: "Serial 1" }, { name: "Serial 2" }],
-      };
+      });
 
       const result = convertOk(netbox);
 

--- a/src/lib/utils/netbox-import.ts
+++ b/src/lib/utils/netbox-import.ts
@@ -558,6 +558,26 @@ export function convertToDeviceType(
     }));
   }
 
+  // Map inventory items
+  if (netbox.inventory_items && netbox.inventory_items.length > 0) {
+    deviceType.inventory_items = netbox.inventory_items.map((item) => ({
+      name: item.name,
+      manufacturer: item.manufacturer,
+      part_id: item.part_id,
+    }));
+  }
+
+  // Console ports have no Rackula representation yet. Note the gap in
+  // warnings rather than silently dropping the data.
+  const consolePortCount =
+    (netbox.console_ports?.length ?? 0) +
+    (netbox.console_server_ports?.length ?? 0);
+  if (consolePortCount > 0) {
+    warnings.push(
+      `${consolePortCount} console port(s) are not yet supported by Rackula and were not imported`,
+    );
+  }
+
   // Validate the built DeviceType against the schema before it can enter the
   // library. NetBox values pass through as-is, so an out-of-range u_height
   // (2.7, 0, -1, 99999) or a slug that could not be normalised must be refused


### PR DESCRIPTION
## **User description**
## Summary

NetBox import parsed `inventory_items` and console ports into the `NetBoxDeviceType` input interface but `convertToDeviceType` never mapped them, so imported devices silently lost that data.

- Map `inventory_items` (name, manufacturer, part_id) through to the resulting `DeviceType`. Rackula already has `InventoryItemSchema`, the `DeviceType` type carries the field, and the YAML serializer preserves it, so mapped items round-trip and persist.
- Console ports (`console_ports`, `console_server_ports`) have no Rackula representation yet. Instead of dropping them silently, add a non-fatal warning noting how many were not imported, following the same `warnings[]` mechanism the converter already uses for unknown airflow, poe, feed_leg, weight_unit, and subdevice_role values.

## Files changed

- `src/lib/utils/netbox-import.ts`: map `inventory_items`; warn on console port count.
- `src/lib/utils/netbox-import.test.ts`: add coverage for inventory item mapping and the console port warning.

## Test plan

- [x] `npm run test:run` (3272 passed)
- [x] `npm run check` (0 errors)
- [x] `npm run lint` (clean)
- [x] `npm run build` (clean)
- [x] CodeRabbit CLI local review

Closes #2941

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
**Preserve imported inventory items and warn when console ports are skipped**

### What Changed
- NetBox inventory items now import into device records instead of being dropped.
- Console ports and console server ports are still not supported, but imports now show a warning with the number skipped instead of failing silently.
- Added test coverage for both the inventory item mapping and the new warning message.

### Impact
`✅ Fewer lost device details`
`✅ Clearer NetBox import warnings`
`✅ Safer imports with visible unsupported data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
