### PR TITLE
fix: preserve unknown/legacy fields in nested YAML serializers (#2927)

### DIFF
--- a/src/lib/utils/yaml-field-order.ts
+++ b/src/lib/utils/yaml-field-order.ts
@@ -36,6 +36,8 @@ function orderDeviceTypeFields(dt: DeviceType): Record<string, unknown> {
   // --- Physical Properties ---
   ordered.u_height = dt.u_height;
   if (dt.slot_width !== undefined) ordered.slot_width = dt.slot_width;
+  if (dt.rack_widths !== undefined && dt.rack_widths.length > 0)
+    ordered.rack_widths = dt.rack_widths;
   if (dt.is_full_depth !== undefined) ordered.is_full_depth = dt.is_full_depth;
   if (dt.is_powered !== undefined) ordered.is_powered = dt.is_powered;
   if (dt.weight !== undefined) ordered.weight = dt.weight;
@@ -79,6 +81,8 @@ function orderDeviceTypeFields(dt: DeviceType): Record<string, unknown> {
 
   // --- Power Device Properties ---
   if (dt.va_rating !== undefined) ordered.va_rating = dt.va_rating;
+
+  appendUnknownKeys(ordered, dt, KNOWN_DEVICE_TYPE_KEYS);
 
   return ordered;
 }
@@ -135,6 +139,8 @@ function orderPlacedDeviceFields(
   if (device.custom_fields !== undefined)
     ordered.custom_fields = device.custom_fields;
 
+  appendUnknownKeys(ordered, device, KNOWN_PLACED_DEVICE_KEYS);
+
   return ordered;
 }
 
@@ -159,6 +165,8 @@ function orderRackFields(rack: Rack): Record<string, unknown> {
   ordered.position = rack.position;
   ordered.devices = rack.devices.map(orderPlacedDeviceFields);
   if (rack.notes !== undefined) ordered.notes = rack.notes;
+
+  appendUnknownKeys(ordered, rack, KNOWN_RACK_KEYS);
 
   return ordered;
 }
@@ -188,6 +196,8 @@ function orderCableFields(cable: Cable): Record<string, unknown> {
   if (cable.length !== undefined) ordered.length = cable.length;
   if (cable.length_unit !== undefined) ordered.length_unit = cable.length_unit;
   if (cable.status !== undefined) ordered.status = cable.status;
+
+  appendUnknownKeys(ordered, cable, KNOWN_CABLE_KEYS);
 
   return ordered;
 }
@@ -252,6 +262,120 @@ function appendUnknownSections(
     if (UNSAFE_KEYS.has(key)) continue;
     if (KNOWN_TOP_LEVEL_KEYS.has(key)) continue;
     if (key in target) continue;
+    target[key] = value;
+  }
+}
+
+/**
+ * Fields each nested orderer below explicitly handles, whether or not it ends
+ * up writing them (e.g. an empty array skipped for tidiness, or `Rack.view`,
+ * which is runtime-only and deliberately never persisted). Kept separate from
+ * "did the orderer write this key" so appendUnknownKeys can tell an
+ * intentional omission apart from a field the allowlist never learned about.
+ */
+const KNOWN_DEVICE_TYPE_KEYS = new Set<string>([
+  "slug",
+  "manufacturer",
+  "model",
+  "part_number",
+  "u_height",
+  "slot_width",
+  "rack_widths",
+  "is_full_depth",
+  "is_powered",
+  "weight",
+  "weight_unit",
+  "airflow",
+  "front_image",
+  "rear_image",
+  "colour",
+  "category",
+  "tags",
+  "notes",
+  "serial_number",
+  "asset_tag",
+  "links",
+  "custom_fields",
+  "interfaces",
+  "power_ports",
+  "power_outlets",
+  "device_bays",
+  "inventory_items",
+  "subdevice_role",
+  "slots",
+  "va_rating",
+]);
+
+const KNOWN_PLACED_DEVICE_KEYS = new Set<string>([
+  "id",
+  "device_type",
+  "name",
+  "label",
+  "position",
+  "face",
+  "ports",
+  "front_image",
+  "rear_image",
+  "colour_override",
+  "parent_device",
+  "device_bay",
+  "container_id",
+  "slot_id",
+  "auto_created",
+  "notes",
+  "custom_fields",
+]);
+
+const KNOWN_RACK_KEYS = new Set<string>([
+  "id",
+  "name",
+  "height",
+  "width",
+  "depth_mm",
+  "base_weight",
+  "desc_units",
+  "show_rear",
+  "form_factor",
+  "starting_unit",
+  "position",
+  "devices",
+  "notes",
+  // Runtime-only current-face-filter state; never persisted to YAML.
+  "view",
+]);
+
+const KNOWN_CABLE_KEYS = new Set<string>([
+  "id",
+  "a_device_id",
+  "a_interface",
+  "b_device_id",
+  "b_interface",
+  "type",
+  "color",
+  "label",
+  "length",
+  "length_unit",
+  "status",
+]);
+
+/**
+ * Copy any unrecognised keys from a nested source object (a DeviceType,
+ * PlacedDevice, Rack, or Cable parsed by its `.passthrough()` Zod schema)
+ * onto the ordered output, after the known fields, so unknown fields from a
+ * newer schema or legacy declared fields not yet wired into the orderer (e.g.
+ * `comments`, `outlet_count`) survive a load and resave (#2927).
+ */
+function appendUnknownKeys(
+  target: Record<string, unknown>,
+  source: object,
+  knownKeys: ReadonlySet<string>,
+): void {
+  for (const [key, value] of Object.entries(
+    source as Record<string, unknown>,
+  )) {
+    if (value === undefined) continue;
+    if (UNSAFE_KEYS.has(key)) continue;
+    if (knownKeys.has(key)) continue;
     target[key] = value;
   }
 }

--- a/src/lib/utils/yaml-field-order.ts
+++ b/src/lib/utils/yaml-field-order.ts
@@ -36,8 +36,9 @@ function orderDeviceTypeFields(dt: DeviceType): Record<string, unknown> {
   // --- Physical Properties ---
   ordered.u_height = dt.u_height;
   if (dt.slot_width !== undefined) ordered.slot_width = dt.slot_width;
-  if (dt.rack_widths !== undefined && dt.rack_widths.length > 0)
-    ordered.rack_widths = dt.rack_widths;
+  // Preserve rack_widths whenever defined, including an explicitly-empty array,
+  // so an author's `rack_widths: []` survives save/load losslessly (#2927).
+  if (dt.rack_widths !== undefined) ordered.rack_widths = dt.rack_widths;
   if (dt.is_full_depth !== undefined) ordered.is_full_depth = dt.is_full_depth;
   if (dt.is_powered !== undefined) ordered.is_powered = dt.is_powered;
   if (dt.weight !== undefined) ordered.weight = dt.weight;

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -456,4 +456,23 @@ describe("YAML nested unknown-field round-trip (#2927)", () => {
     );
     expect(restoredType?.rack_widths).toEqual([10]);
   });
+
+  it("preserves an explicitly-empty rack_widths array on a device type through a round-trip", async () => {
+    const deviceType = createTestDeviceType({
+      slug: "explicit-empty-device",
+      rack_widths: [],
+    });
+    const layout = createTestLayout({ device_types: [deviceType] });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    expect(yaml).toContain("rack_widths");
+
+    const restored = await parseLayoutYaml(yaml);
+    const restoredType = restored.device_types.find(
+      (dt) => dt.slug === "explicit-empty-device",
+    );
+    // An explicitly-set empty array must survive save/load, not be silently
+    // dropped to `undefined`.
+    expect(restoredType?.rack_widths).toEqual([]);
+  });
 });

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -422,9 +422,7 @@ describe("YAML nested unknown-field round-trip (#2927)", () => {
     } as unknown as Cable;
 
     const layout = createTestLayout({
-      racks: [
-        createTestRack({ id: "rack-1", devices: [deviceA, deviceB] }),
-      ],
+      racks: [createTestRack({ id: "rack-1", devices: [deviceA, deviceB] })],
       device_types: [deviceType],
       cables: [cable],
     });

--- a/src/tests/yaml-roundtrip.test.ts
+++ b/src/tests/yaml-roundtrip.test.ts
@@ -4,8 +4,9 @@ import {
   serializeLayoutToYamlWithMetadata,
   parseLayoutYaml,
 } from "$lib/utils/yaml";
-import type { DeviceType } from "$lib/types";
+import type { Cable, DeviceType, PlacedDevice, Rack } from "$lib/types";
 import {
+  createTestCable,
   createTestContainerChild,
   createTestDevice,
   createTestDeviceType,
@@ -335,5 +336,126 @@ describe("YAML unknown top-level section round-trip (#2208)", () => {
     // None of the reserved keys are emitted, and the global prototype is intact.
     expect(yaml).not.toContain("hacked");
     expect(({} as Record<string, unknown>).hacked).toBeUndefined();
+  });
+});
+
+describe("YAML nested unknown-field round-trip (#2927)", () => {
+  it("preserves an unknown field on a device type through a save/load/save round-trip", async () => {
+    const deviceType = {
+      ...createTestDeviceType({ slug: "future-device" }),
+      future_dt_field: "keep-me",
+    } as unknown as DeviceType;
+
+    const layout = createTestLayout({ device_types: [deviceType] });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    expect(yaml).toContain("future_dt_field");
+
+    const restored = await parseLayoutYaml(yaml);
+    const restoredType = restored.device_types.find(
+      (dt) => dt.slug === "future-device",
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(restoredType?.future_dt_field).toBe("keep-me");
+
+    // A second resave must not drop it now that it round-tripped once already.
+    const resaved = await serializeLayoutToYaml(restored);
+    expect(resaved).toContain("future_dt_field");
+  });
+
+  it("preserves an unknown field on a placed device through a save/load/save round-trip", async () => {
+    const deviceType = createTestDeviceType({ slug: "host-device" });
+    const device = {
+      ...createTestDevice({ id: "device-1", device_type: deviceType.slug }),
+      future_pd_field: "keep-me",
+    } as unknown as PlacedDevice;
+
+    const layout = createTestLayout({
+      racks: [createTestRack({ id: "rack-1", devices: [device] })],
+      device_types: [deviceType],
+    });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    expect(yaml).toContain("future_pd_field");
+
+    const restored = await parseLayoutYaml(yaml);
+    const restoredDevice = restored.racks[0]?.devices.find(
+      (d) => d.id === "device-1",
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(restoredDevice?.future_pd_field).toBe("keep-me");
+
+    const resaved = await serializeLayoutToYaml(restored);
+    expect(resaved).toContain("future_pd_field");
+  });
+
+  it("preserves an unknown field on a rack through a save/load/save round-trip", async () => {
+    const rack = {
+      ...createTestRack({ id: "rack-1" }),
+      future_rack_field: "keep-me",
+    } as unknown as Rack;
+
+    const layout = createTestLayout({ racks: [rack] });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    expect(yaml).toContain("future_rack_field");
+
+    const restored = await parseLayoutYaml(yaml);
+    const restoredRack = restored.racks.find(
+      (r) => r.id === "rack-1",
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(restoredRack?.future_rack_field).toBe("keep-me");
+
+    const resaved = await serializeLayoutToYaml(restored);
+    expect(resaved).toContain("future_rack_field");
+  });
+
+  it("preserves an unknown field on a cable through a save/load/save round-trip", async () => {
+    const deviceA = createTestDevice({ id: "device-a", position: 10 });
+    const deviceB = createTestDevice({ id: "device-b", position: 12 });
+    const deviceType = createTestDeviceType({ slug: "test-device" });
+    const cable = {
+      ...createTestCable({
+        id: "cable-1",
+        a_device_id: "device-a",
+        b_device_id: "device-b",
+      }),
+      future_cable_field: "keep-me",
+    } as unknown as Cable;
+
+    const layout = createTestLayout({
+      racks: [
+        createTestRack({ id: "rack-1", devices: [deviceA, deviceB] }),
+      ],
+      device_types: [deviceType],
+      cables: [cable],
+    });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    expect(yaml).toContain("future_cable_field");
+
+    const restored = await parseLayoutYaml(yaml);
+    const restoredCable = restored.cables?.find(
+      (c) => c.id === "cable-1",
+    ) as unknown as Record<string, unknown> | undefined;
+    expect(restoredCable?.future_cable_field).toBe("keep-me");
+
+    const resaved = await serializeLayoutToYaml(restored);
+    expect(resaved).toContain("future_cable_field");
+  });
+
+  it("preserves the known-but-unlisted rack_widths field on a device type through a round-trip", async () => {
+    const deviceType = createTestDeviceType({
+      slug: "mini-rack-device",
+      rack_widths: [10],
+    });
+    const layout = createTestLayout({ device_types: [deviceType] });
+
+    const yaml = await serializeLayoutToYaml(layout);
+    expect(yaml).toContain("rack_widths");
+
+    const restored = await parseLayoutYaml(yaml);
+    const restoredType = restored.device_types.find(
+      (dt) => dt.slug === "mini-rack-device",
+    );
+    expect(restoredType?.rack_widths).toEqual([10]);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

The nested YAML serializers (device-type, placed-device, rack, cable) each rebuilt a fresh object from a fixed key allowlist with no unknown-field passthrough, while every nested Zod schema is `.passthrough()`. Unknown fields survived load but were silently dropped on the next save: a standing forward-compat data-loss channel. A newer Rackula could write `device_types[].some_new_field`, an older Rackula opens and resaves, and the field is gone.

This also dropped legacy declared fields (`comments`, `outlet_count`) and, for device types, the known-but-unlisted `rack_widths` (the mechanism behind the rack_widths data-loss finding).

## Fix

- Add an `appendUnknownKeys(target, source, knownKeys)` helper that copies any own-enumerable key not in the type's allowlist onto the ordered output, reusing the shared `UNSAFE_KEYS` prototype-pollution guard.
- Call it at the end of `orderDeviceTypeFields`, `orderPlacedDeviceFields`, `orderRackFields`, and `orderCableFields`, each driven by a per-type `KNOWN_*_KEYS` allowlist.
- `KNOWN_RACK_KEYS` includes the runtime-only `view` field so it stays out of the serialized file.
- Wire `rack_widths` into the device-type orderer explicitly so it keeps its schema field order.

## Files changed

- `src/lib/utils/yaml-field-order.ts`: unknown-key sweep in each nested orderer + `rack_widths` ordering
- `src/tests/yaml-roundtrip.test.ts`: round-trip tests for unknown fields at each nested level + `rack_widths`

## Test plan

- [x] `npm run test:run` (3256 passed)
- [x] `npm run check` (0 errors)
- [x] `npm run lint` (clean)
- [x] `npm run build` (clean)
- [x] New tests fail before the fix (verified RED), pass after
- [x] Verified `rack.view` runtime-only field never leaks into serialized YAML
- [x] Verified legacy `comments` / `outlet_count` now survive a round-trip

Closes #2927


___

## **CodeAnt-AI Description**
**Keep nested YAML fields when saving and reloading layouts**

### What Changed
- Unknown fields inside device types, placed devices, racks, and cables now stay in the file after a save/load/save cycle
- Legacy fields that were being dropped, including rack widths and older rack/device fields, now survive round-trips
- Runtime-only rack view data still stays out of saved YAML

### Impact
`✅ Fewer lost custom fields in saved layouts`
`✅ Safer upgrades between older and newer app versions`
`✅ Preserved rack and device data after reload`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
