### PR TITLE
fix: stale autosave rollback + uncleared dirty state on availability flip (#2926, #2936)

### DIFF
--- a/src/lib/storage/manager.svelte.ts
+++ b/src/lib/storage/manager.svelte.ts
@@ -44,10 +44,14 @@ let _errorToastId: string | undefined = undefined;
 let serverSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-// Bumped on every auto-save effect run. A debounced save captures the id at
-// schedule time; if a newer run bumps it while the save is in flight, the live
-// layout has edits this save did not persist, so its success must not clear the
-// dirty/session state for those newer edits.
+// Bumped only by an auto-save effect run that actually schedules a save (i.e.
+// one that reaches past all of the effect's early-return guards). A debounced
+// save captures the id at schedule time; if a newer run that also schedules a
+// save bumps it while the first save is in flight, the live layout has edits
+// that first save did not persist, so its success must not clear the
+// dirty/session state for those newer edits. A run that early-returns (e.g. a
+// transient availability flip with no new edit) must NOT bump the id, or it
+// falsely invalidates an in-flight save that never lost any edits (#2936).
 let _serverSaveScheduleId = 0;
 
 // After a durable save the pending session debounce must be cancelled, or it
@@ -104,12 +108,16 @@ export function getStorageChipState() {
  * leaves the layout in the same state as a manual one.
  *
  * Always (server is healthy): resets the consecutive-failure counter, marks the
- * API available, and dismisses any lingering error toast.
+ * API available, and dismisses any lingering error toast. Also always, when
+ * newUpdatedAt is present: records the server echo as the new base and
+ * re-stamps the working copy with it, independent of clearDirtyState. A save
+ * finalized "stale" still reached the server under this echo, so the base must
+ * advance immediately, or a reconcile before the follow-up save fires sees
+ * false divergence against this tab's own write and can discard newer local
+ * edits (#2926).
  *
- * When clearDirtyState is true (the default): also sets status to "saved", marks
- * the layout clean, cancels the pending session debounce, records the server
- * echo as the new base, and re-stamps the working copy with it. The copy is kept
- * (not cleared) so a reload can detect divergence against the echoed updatedAt.
+ * When clearDirtyState is true (the default): also sets status to "saved",
+ * marks the layout clean, and cancels the pending session debounce.
  *
  * @param clearDirtyState Pass false for a stale debounced save whose captured
  *   snapshot is older than the live layout (newer unsaved edits arrived while the
@@ -134,7 +142,11 @@ export function finalizeSuccessfulSave(
     _saveStatus = "saved";
     layoutStore.markClean();
     cancelSessionSave();
-    if (newUpdatedAt) setServerBaseUpdatedAt(newUpdatedAt);
+  }
+  if (newUpdatedAt) {
+    setServerBaseUpdatedAt(newUpdatedAt);
+  }
+  if (clearDirtyState || newUpdatedAt) {
     saveSession(
       layoutStore.layout,
       {
@@ -553,9 +565,6 @@ export function initPersistenceEffects(): void {
 
   // Effect 2: Auto-save to server when API is available
   $effect(() => {
-    // Capture this run's schedule id; a later run (e.g. an edit during the
-    // in-flight save) bumps it and marks an earlier save's success stale.
-    const scheduleId = ++_serverSaveScheduleId;
     // Server mode only, matching Effects 1 and 3. isApiAvailable() is the
     // server-mode reachability signal; this explicit mode guard keeps a future
     // browser-mode caller that sets apiAvailable (e.g. a misconfiguration probe)
@@ -570,6 +579,13 @@ export function initPersistenceEffects(): void {
     if (serverSaveTimer) {
       clearTimeout(serverSaveTimer);
     }
+    // Capture this run's schedule id only once the run has committed to
+    // scheduling a save. A run that early-returns above never schedules a
+    // replacement, so it must not bump the id and falsely invalidate an
+    // in-flight save (#2936). A later run that also reaches here (e.g. an
+    // edit during the in-flight save) bumps it and marks that earlier save's
+    // success stale, since the live layout now has edits it did not persist.
+    const scheduleId = ++_serverSaveScheduleId;
     const snapshot = structuredClone($state.snapshot(layout));
     const imagesSnapshot = getImageStore().getUserImages();
     _serverSavePending = true;

--- a/src/tests/helpers/TestPersistenceAutosave.svelte
+++ b/src/tests/helpers/TestPersistenceAutosave.svelte
@@ -1,0 +1,12 @@
+<!--
+  Minimal harness for testing initPersistenceEffects() in isolation, without
+  the rest of PersistenceEffects.svelte's unrelated wiring (workspace persist,
+  keyboard viewport, twin-tab guard, beforeunload). Registers only the three
+  $effects manager.svelte.ts owns: session autosave, server autosave, health
+  check polling.
+-->
+<script lang="ts">
+  import { initPersistenceEffects } from "$lib/storage/manager.svelte";
+
+  initPersistenceEffects();
+</script>

--- a/src/tests/persistence-manager-autosave.test.ts
+++ b/src/tests/persistence-manager-autosave.test.ts
@@ -82,6 +82,25 @@ describe("successful save epilogue", () => {
     expect(layoutStore.isDirty).toBe(true); // newer unsaved edits preserved
   });
 
+  it("advances the server base and re-stamps the session on a stale save (#2926)", () => {
+    const layoutStore = getLayoutStore();
+    layoutStore.loadLayout(createTestLayout());
+    layoutStore.markStarted();
+    layoutStore.markDirty();
+    setServerBaseUpdatedAt("2026-06-14T09:00:00.000Z");
+
+    // Stale completion: the PUT succeeded and the server echoed a new
+    // updatedAt, but newer edits arrived in flight (clearDirtyState=false).
+    // The echo is still this tab's own write and must become the new base,
+    // or the next reconcile sees false divergence against it and can
+    // discard the newer local edits (#2926).
+    finalizeSuccessfulSave(false, "2026-06-14T10:00:00.000Z");
+
+    expect(getServerBaseUpdatedAt()).toBe("2026-06-14T10:00:00.000Z");
+    const session = loadSessionWithTimestamp();
+    expect(session?.serverUpdatedAt).toBe("2026-06-14T10:00:00.000Z");
+  });
+
   it("keeps the working copy and records the server echo on a durable save", () => {
     const layoutStore = getLayoutStore();
     // A started layout with a rack: the conditions under which the working copy

--- a/src/tests/persistence-manager-autosave.test.ts
+++ b/src/tests/persistence-manager-autosave.test.ts
@@ -97,6 +97,9 @@ describe("successful save epilogue", () => {
     finalizeSuccessfulSave(false, "2026-06-14T10:00:00.000Z");
 
     expect(getServerBaseUpdatedAt()).toBe("2026-06-14T10:00:00.000Z");
+    // The stale path must still preserve the dirty flag for the newer
+    // in-flight edits; advancing the base must not clear it.
+    expect(layoutStore.isDirty).toBe(true);
     const session = loadSessionWithTimestamp();
     expect(session?.serverUpdatedAt).toBe("2026-06-14T10:00:00.000Z");
   });

--- a/src/tests/persistence-manager-schedule-id.test.ts
+++ b/src/tests/persistence-manager-schedule-id.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import TestPersistenceAutosave from "./helpers/TestPersistenceAutosave.svelte";
+import { resetPersistenceManager } from "$lib/storage/manager.svelte";
+import { saveLayoutToServer, type SaveLayoutResult } from "$lib/storage/api";
+import { setServerBaseUpdatedAt } from "$lib/storage/server-base";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+import { resetImageStore } from "$lib/stores/images.svelte";
+import { setApiAvailable } from "$lib/storage/availability.svelte";
+import { createTestLayout } from "./factories";
+
+vi.mock("$lib/storage/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/storage/api")>();
+  return {
+    ...actual,
+    saveLayoutToServer: vi.fn(),
+  };
+});
+
+/**
+ * #2936: the server auto-save effect captured its schedule id as its very
+ * first statement, before any of its early-return guards. A reactive rerun
+ * triggered only by an availability flip (no new edit, so the rerun's guard
+ * fails and it schedules no replacement save) still bumped the id. An
+ * in-flight save's completion check then compared its captured id against the
+ * bumped counter, saw a mismatch, and skipped markClean() even though the
+ * save had actually reached the server. The chip stayed "Unsaved" until the
+ * next edit or reconnect (self-healing, but a real staleness bug).
+ */
+describe("auto-save effect survives an availability flip mid-flight (#2936)", () => {
+  const UUID = "22222222-2222-4222-8222-222222222222";
+  const originalConfig = window.__RACKULA_CONFIG__;
+
+  beforeEach(() => {
+    resetLayoutStore();
+    resetToastStore();
+    resetImageStore();
+    resetPersistenceManager();
+    setServerBaseUpdatedAt(null);
+    window.__RACKULA_CONFIG__ = { storage: "server" };
+    setApiAvailable(true);
+    vi.mocked(saveLayoutToServer).mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    resetImageStore();
+    setServerBaseUpdatedAt(null);
+    setApiAvailable(false);
+    window.__RACKULA_CONFIG__ = originalConfig;
+  });
+
+  it("still clears dirty state when a save succeeds after availability flips mid-flight", async () => {
+    const layoutStore = getLayoutStore();
+    layoutStore.loadLayout(createTestLayout({ metadata: { id: UUID } }));
+    layoutStore.markStarted();
+    layoutStore.markDirty();
+
+    let resolveSave: ((result: SaveLayoutResult) => void) | null = null;
+    vi.mocked(saveLayoutToServer).mockImplementation(
+      () =>
+        new Promise<SaveLayoutResult>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    const view = render(TestPersistenceAutosave);
+    await tick();
+
+    // Mount schedules the debounced server auto-save; fire it.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(saveLayoutToServer).toHaveBeenCalledTimes(1);
+
+    // Transient availability flip while the save is in flight: no edit
+    // occurred, so the rerun's guard fails and no replacement save is
+    // scheduled. This must not invalidate the in-flight save's completion.
+    setApiAvailable(false);
+    await tick();
+
+    // The in-flight save now resolves successfully.
+    resolveSave?.({ id: UUID, updatedAt: "2026-06-20T00:00:00.000Z" });
+    await vi.waitFor(() => expect(layoutStore.isDirty).toBe(false));
+
+    view.unmount();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Two related server-mode autosave bugs, both localised to `src/lib/storage/manager.svelte.ts`. Fixing them together because they touch the same file and the same code path.

### #2926 - stale autosave discards server updatedAt, priming false-divergence rollback (the serious one)

`finalizeSuccessfulSave` recorded the server-echoed `updatedAt` and re-stamped the session copy only when `clearDirtyState` was true. A save finalized "stale" (its schedule id was bumped by an edit mid-flight) still reached the server under a new `updatedAt`, but the local `serverBaseUpdatedAt` stayed frozen at the previous echo. On next launch, `reconcileSession` saw `localServerUpdatedAt !== match.updatedAt` (false divergence) even though the server copy is this tab's own write, then `isServerNewer` compared client wall clock against server mtime. If the follow-up save never fired (tab closed), `load-server` could win and the local copy holding the newest edits was snapshotted and replaced.

Fix: always record `result.updatedAt` as the new base and re-stamp the session copy when an echo is present, independent of `clearDirtyState`.

### #2936 - autosave can leave dirty state uncleared if availability flips mid-flight (cosmetic, self-heals)

The server-autosave `$effect` captured `scheduleId = ++_serverSaveScheduleId` as its first statement, before the early-return guards. A reactive rerun triggered only by an unrelated dependency (`apiAvailable`, failure count) that then early-returned without scheduling a save still bumped the counter, so an in-flight save's success check saw a stale id and skipped `markClean()`. The data reached the server, but the chip stayed "Unsaved" until the next edit or reconnect.

Fix: capture `scheduleId` after the guards, so only a run that actually schedules a save bumps the counter.

## Changes

- `finalizeSuccessfulSave`: advance the server base and re-stamp the session whenever a `newUpdatedAt` echo is present, not just on the dirty-clearing path. The dirty flag and session-debounce cancellation stay gated on `clearDirtyState` as before.
- Server-autosave effect: move the `scheduleId` capture past the six early-return guards to just before the timer is scheduled.
- Tests: new stale-save regression in `persistence-manager-autosave.test.ts` (#2926); new `persistence-manager-schedule-id.test.ts` driving the effect through a real availability flip via a minimal `TestPersistenceAutosave.svelte` harness (#2936).

## Testing

- [x] Unit tests pass (`npm run test:run`) - 3272 passing (207 files)
- [x] `npm run check` (svelte-check) - 0 errors
- [x] `npm run lint` - clean
- [x] `npm run build` - succeeds
- [ ] E2E tests pass (`npm run test:e2e`) - not run locally; advisory self-hosted suite has known baseline failures (#2859)

Both new tests were confirmed to fail with the fix reverted and pass with it restored (non-vacuous).

Closes #2926
Closes #2936

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix autosave so it keeps the right save state after mid-flight changes and availability flips**

### What Changed
- A successful server save now updates the saved copy even when the save finishes stale, preventing the next reload from treating the app’s own latest write as a conflict and losing newer local edits.
- A transient API availability flip no longer causes an in-flight autosave to stay marked as unsaved when the save actually reached the server.
- Added tests that cover both cases: preserving the server echo after a stale save and clearing dirty state after an availability change during autosave.

### Impact
`✅ Fewer lost edits after autosave`
`✅ Fewer stuck "Unsaved" indicators`
`✅ Safer restore after reconnect or reload`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
