### PR TITLE
fix: loadLayout rewrites cable endpoints when device ids are regenerated (#2923)

### DIFF
--- a/src/lib/stores/layout/layout-lifecycle.ts
+++ b/src/lib/stores/layout/layout-lifecycle.ts
@@ -100,7 +100,14 @@ export function loadLayout(
         nextId = generateUniqueDeviceId(seenDeviceIds, reserved);
         if (originalId) {
           deviceIdRemap.set(originalId, nextId);
-          layoutDeviceIdRemap.set(originalId, nextId);
+          // First regenerated mapping wins, matching the rack-id remap above
+          // (#2155). If the same original id is regenerated more than once
+          // (a duplicate id shared across racks that is also reserved, so no
+          // copy survives), keep the first so cable resolution is
+          // deterministic and independent of rack iteration order (#2923).
+          if (!layoutDeviceIdRemap.has(originalId)) {
+            layoutDeviceIdRemap.set(originalId, nextId);
+          }
         }
       } else {
         seenDeviceIds.add(nextId);

--- a/src/lib/stores/layout/layout-lifecycle.ts
+++ b/src/lib/stores/layout/layout-lifecycle.ts
@@ -64,6 +64,13 @@ export function loadLayout(
   // layout and every other open tab (#2182).
   const reserved = new Set<string>(reservedDeviceIds ?? []);
 
+  // Layout-global old -> new device-id map, accumulated across every rack.
+  // container_id resolution below stays scoped to its own rack's local map
+  // (unchanged from #2155); this global copy exists so the layout-level
+  // cable pass can rewrite an endpoint regardless of which rack its device
+  // was regenerated in (#2923).
+  const layoutDeviceIdRemap = new Map<string, string>();
+
   const racksFirstPass = layoutData.racks.map((r, index) => {
     const originalRackId = r.id;
     let rackId =
@@ -93,6 +100,7 @@ export function loadLayout(
         nextId = generateUniqueDeviceId(seenDeviceIds, reserved);
         if (originalId) {
           deviceIdRemap.set(originalId, nextId);
+          layoutDeviceIdRemap.set(originalId, nextId);
         }
       } else {
         seenDeviceIds.add(nextId);
@@ -137,12 +145,34 @@ export function loadLayout(
     ),
   }));
 
+  // Second pass (layout-level): rewrite cable endpoints through the
+  // layout-global device-id map so cables stay attached to their (possibly
+  // regenerated) devices. A cable can connect devices in different racks, so
+  // this runs after every rack's device ids are finalized rather than in the
+  // per-rack pass above. Only remap when the referenced id was renamed away
+  // (no surviving device anywhere in the layout still holds it); a reference
+  // to a surviving original id is preserved, mirroring the container_id and
+  // rack_groups precedence above (#2923).
+  const liveDeviceIds = new Set(
+    racksFirstPass.flatMap((r) => r.devices.map((d) => d.id)),
+  );
+  const cables = layoutData.cables?.map((cable) => ({
+    ...cable,
+    a_device_id: liveDeviceIds.has(cable.a_device_id)
+      ? cable.a_device_id
+      : (layoutDeviceIdRemap.get(cable.a_device_id) ?? cable.a_device_id),
+    b_device_id: liveDeviceIds.has(cable.b_device_id)
+      ? cable.b_device_id
+      : (layoutDeviceIdRemap.get(cable.b_device_id) ?? cable.b_device_id),
+  }));
+
   // Ensure runtime view is set, show_rear defaults, and all racks have valid IDs
   ctx.setLayout({
     ...layoutData,
     metadata,
     racks: racksFirstPass,
     ...(rackGroups !== undefined ? { rack_groups: rackGroups } : {}),
+    ...(cables !== undefined ? { cables } : {}),
   });
   ctx.resetBackupTracking();
 

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -6,6 +6,7 @@ import {
   createTestDeviceTypeInput,
   createTestDeviceType,
   createTestContainerType,
+  createTestCable,
 } from "./factories";
 
 describe("Layout Store", () => {
@@ -556,13 +557,11 @@ describe("Layout Store", () => {
             },
           ],
           cables: [
-            {
+            createTestCable({
               id: "cable-1",
               a_device_id: "dev-a",
-              a_interface: "eth0",
               b_device_id: "dev-b",
-              b_interface: "eth0",
-            },
+            }),
           ],
           settings: {
             display_mode: "label",
@@ -572,82 +571,89 @@ describe("Layout Store", () => {
         new Set(["dev-a", "dev-b"]),
       );
 
-      const devices = store.layout.racks.flatMap((r) => r.devices);
-      const liveIds = new Set(devices.map((d) => d.id));
+      // Exactly one device per rack, so each endpoint has one correct target.
+      const [rackA, rackB] = store.layout.racks;
+      const deviceA = rackA.devices[0];
+      const deviceB = rackB.devices[0];
       const cable = store.layout.cables?.[0];
       expect(cable).toBeDefined();
-      // Both original ids were reserved, so both were regenerated. Neither
-      // endpoint should still point at the dead original id.
-      expect(cable!.a_device_id).not.toBe("dev-a");
-      expect(cable!.b_device_id).not.toBe("dev-b");
-      // Every endpoint must resolve to a device that actually exists.
-      expect(liveIds.has(cable!.a_device_id)).toBe(true);
-      expect(liveIds.has(cable!.b_device_id)).toBe(true);
+      // Both original ids were reserved, so both were regenerated. Each
+      // endpoint must now resolve to the live device that replaced the id it
+      // originally referenced, not merely to some surviving device.
+      expect(deviceA.id).not.toBe("dev-a");
+      expect(deviceB.id).not.toBe("dev-b");
+      expect(cable!.a_device_id).toBe(deviceA.id);
+      expect(cable!.b_device_id).toBe(deviceB.id);
     });
 
-    it("keeps a cable endpoint on the surviving original id, remapping only removed references", () => {
+    it("preserves a surviving endpoint and remaps a regenerated one in the same cable", () => {
       const store = getLayoutStore();
-      store.loadLayout({
-        version: "0.7.0",
-        name: "Cable Surviving Id Test",
-        racks: [
-          {
-            id: "rack-1",
-            name: "Test Rack",
-            height: 42,
-            width: 19,
-            desc_units: false,
-            form_factor: "4-post-cabinet",
-            starting_unit: 1,
-            position: 0,
-            devices: [
-              // A keeps "X" (surviving original)
-              {
-                id: "X",
-                device_type: "server-c",
-                position: 100,
-                face: "front" as const,
-              },
-              // B duplicates "X" -> regenerated to a new id
-              {
-                id: "X",
-                device_type: "server-c",
-                position: 200,
-                face: "front" as const,
-              },
-            ],
+      // "keep-me" is not reserved, so it survives and its endpoint is left
+      // untouched (surviving-original precedence). "regen-me" collides with a
+      // reserved id, so it is regenerated and its endpoint must follow it.
+      store.loadLayout(
+        {
+          version: "0.7.0",
+          name: "Cable Surviving Id Test",
+          racks: [
+            {
+              id: "rack-1",
+              name: "Test Rack",
+              height: 42,
+              width: 19,
+              desc_units: false,
+              form_factor: "4-post-cabinet",
+              starting_unit: 1,
+              position: 0,
+              devices: [
+                {
+                  id: "keep-me",
+                  device_type: "server-c",
+                  position: 100,
+                  face: "front" as const,
+                },
+                {
+                  id: "regen-me",
+                  device_type: "server-c",
+                  position: 200,
+                  face: "front" as const,
+                },
+              ],
+            },
+          ],
+          device_types: [
+            {
+              slug: "server-c",
+              u_height: 1,
+              colour: "#4A90A4",
+              category: "server" as const,
+            },
+          ],
+          cables: [
+            createTestCable({
+              id: "cable-1",
+              a_device_id: "keep-me",
+              b_device_id: "regen-me",
+            }),
+          ],
+          settings: {
+            display_mode: "label",
+            show_labels_on_images: false,
           },
-        ],
-        device_types: [
-          {
-            slug: "server-c",
-            u_height: 1,
-            colour: "#4A90A4",
-            category: "server" as const,
-          },
-        ],
-        cables: [
-          {
-            id: "cable-1",
-            a_device_id: "X",
-            a_interface: "eth0",
-            b_device_id: "X",
-            b_interface: "eth1",
-          },
-        ],
-        settings: {
-          display_mode: "label",
-          show_labels_on_images: false,
         },
-      });
+        new Set(["regen-me"]),
+      );
 
       const devices = store.layout.racks[0].devices;
-      const finalIds = new Set(devices.map((d) => d.id));
+      const regenerated = devices.find((d) => d.id !== "keep-me")!;
       const cable = store.layout.cables?.[0];
       expect(cable).toBeDefined();
-      // "X" survives on the first device, so a reference to it is untouched.
-      expect(cable!.a_device_id).toBe("X");
-      expect(finalIds.has(cable!.b_device_id)).toBe(true);
+      // Surviving original id is preserved.
+      expect(cable!.a_device_id).toBe("keep-me");
+      // The reserved-id collision was regenerated, and the endpoint follows it
+      // to the new id rather than dangling at the dead original.
+      expect(regenerated.id).not.toBe("regen-me");
+      expect(cable!.b_device_id).toBe(regenerated.id);
     });
   });
 

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -498,6 +498,159 @@ describe("Layout Store", () => {
     });
   });
 
+  describe("loadLayout cable endpoint remapping (#2923)", () => {
+    it("rewrites cable endpoints across racks when device ids are regenerated", () => {
+      const store = getLayoutStore();
+      // Both devices collide with ids already reserved by another open tab
+      // (#2182 cross-tab dedup), so both get regenerated. The cable spans
+      // racks, so a per-rack remap map cannot fix both endpoints: the fix
+      // must accumulate a layout-global old -> new id map.
+      store.loadLayout(
+        {
+          version: "0.7.0",
+          name: "Cable Remap Test",
+          racks: [
+            {
+              id: "rack-a",
+              name: "Rack A",
+              height: 42,
+              width: 19,
+              desc_units: false,
+              form_factor: "4-post-cabinet",
+              starting_unit: 1,
+              position: 0,
+              devices: [
+                {
+                  id: "dev-a",
+                  device_type: "server-c",
+                  position: 1,
+                  face: "front" as const,
+                },
+              ],
+            },
+            {
+              id: "rack-b",
+              name: "Rack B",
+              height: 42,
+              width: 19,
+              desc_units: false,
+              form_factor: "4-post-cabinet",
+              starting_unit: 1,
+              position: 1,
+              devices: [
+                {
+                  id: "dev-b",
+                  device_type: "server-c",
+                  position: 1,
+                  face: "front" as const,
+                },
+              ],
+            },
+          ],
+          device_types: [
+            {
+              slug: "server-c",
+              u_height: 1,
+              colour: "#4A90A4",
+              category: "server" as const,
+            },
+          ],
+          cables: [
+            {
+              id: "cable-1",
+              a_device_id: "dev-a",
+              a_interface: "eth0",
+              b_device_id: "dev-b",
+              b_interface: "eth0",
+            },
+          ],
+          settings: {
+            display_mode: "label",
+            show_labels_on_images: false,
+          },
+        },
+        new Set(["dev-a", "dev-b"]),
+      );
+
+      const devices = store.layout.racks.flatMap((r) => r.devices);
+      const liveIds = new Set(devices.map((d) => d.id));
+      const cable = store.layout.cables?.[0];
+      expect(cable).toBeDefined();
+      // Both original ids were reserved, so both were regenerated. Neither
+      // endpoint should still point at the dead original id.
+      expect(cable!.a_device_id).not.toBe("dev-a");
+      expect(cable!.b_device_id).not.toBe("dev-b");
+      // Every endpoint must resolve to a device that actually exists.
+      expect(liveIds.has(cable!.a_device_id)).toBe(true);
+      expect(liveIds.has(cable!.b_device_id)).toBe(true);
+    });
+
+    it("keeps a cable endpoint on the surviving original id, remapping only removed references", () => {
+      const store = getLayoutStore();
+      store.loadLayout({
+        version: "0.7.0",
+        name: "Cable Surviving Id Test",
+        racks: [
+          {
+            id: "rack-1",
+            name: "Test Rack",
+            height: 42,
+            width: 19,
+            desc_units: false,
+            form_factor: "4-post-cabinet",
+            starting_unit: 1,
+            position: 0,
+            devices: [
+              // A keeps "X" (surviving original)
+              {
+                id: "X",
+                device_type: "server-c",
+                position: 100,
+                face: "front" as const,
+              },
+              // B duplicates "X" -> regenerated to a new id
+              {
+                id: "X",
+                device_type: "server-c",
+                position: 200,
+                face: "front" as const,
+              },
+            ],
+          },
+        ],
+        device_types: [
+          {
+            slug: "server-c",
+            u_height: 1,
+            colour: "#4A90A4",
+            category: "server" as const,
+          },
+        ],
+        cables: [
+          {
+            id: "cable-1",
+            a_device_id: "X",
+            a_interface: "eth0",
+            b_device_id: "X",
+            b_interface: "eth1",
+          },
+        ],
+        settings: {
+          display_mode: "label",
+          show_labels_on_images: false,
+        },
+      });
+
+      const devices = store.layout.racks[0].devices;
+      const finalIds = new Set(devices.map((d) => d.id));
+      const cable = store.layout.cables?.[0];
+      expect(cable).toBeDefined();
+      // "X" survives on the first device, so a reference to it is untouched.
+      expect(cable!.a_device_id).toBe("X");
+      expect(finalIds.has(cable!.b_device_id)).toBe(true);
+    });
+  });
+
   describe("dirty tracking", () => {
     it("markDirty sets isDirty to true", () => {
       const store = getLayoutStore();

--- a/src/tests/layout-store.test.ts
+++ b/src/tests/layout-store.test.ts
@@ -655,6 +655,93 @@ describe("Layout Store", () => {
       expect(regenerated.id).not.toBe("regen-me");
       expect(cable!.b_device_id).toBe(regenerated.id);
     });
+
+    it("resolves a cable referencing a duplicate id deterministically to the first device", () => {
+      const store = getLayoutStore();
+      // Degenerate input: the same id "dup" is shared across two racks and is
+      // also reserved by another tab, so no copy survives and both are
+      // regenerated. The layout-global remap keeps the first regenerated
+      // mapping (matching the #2155 rack-id remap), so the ambiguous cable
+      // endpoints resolve deterministically to the first device, independent
+      // of rack iteration order.
+      store.loadLayout(
+        {
+          version: "0.7.0",
+          name: "Duplicate Id Cable Test",
+          racks: [
+            {
+              id: "rack-a",
+              name: "Rack A",
+              height: 42,
+              width: 19,
+              desc_units: false,
+              form_factor: "4-post-cabinet",
+              starting_unit: 1,
+              position: 0,
+              devices: [
+                {
+                  id: "dup",
+                  device_type: "server-c",
+                  position: 1,
+                  face: "front" as const,
+                },
+              ],
+            },
+            {
+              id: "rack-b",
+              name: "Rack B",
+              height: 42,
+              width: 19,
+              desc_units: false,
+              form_factor: "4-post-cabinet",
+              starting_unit: 1,
+              position: 1,
+              devices: [
+                {
+                  id: "dup",
+                  device_type: "server-c",
+                  position: 1,
+                  face: "front" as const,
+                },
+              ],
+            },
+          ],
+          device_types: [
+            {
+              slug: "server-c",
+              u_height: 1,
+              colour: "#4A90A4",
+              category: "server" as const,
+            },
+          ],
+          cables: [
+            createTestCable({
+              id: "cable-1",
+              a_device_id: "dup",
+              b_device_id: "dup",
+            }),
+          ],
+          settings: {
+            display_mode: "label",
+            show_labels_on_images: false,
+          },
+        },
+        new Set(["dup"]),
+      );
+
+      const firstDevice = store.layout.racks[0].devices[0];
+      const secondDevice = store.layout.racks[1].devices[0];
+      const cable = store.layout.cables?.[0];
+      expect(cable).toBeDefined();
+      // Both copies were regenerated to distinct live ids.
+      expect(firstDevice.id).not.toBe("dup");
+      expect(secondDevice.id).not.toBe("dup");
+      expect(firstDevice.id).not.toBe(secondDevice.id);
+      // Both endpoints resolve to the first device (first-wins), so the result
+      // is deterministic rather than depending on which rack was processed last.
+      expect(cable!.a_device_id).toBe(firstDevice.id);
+      expect(cable!.b_device_id).toBe(firstDevice.id);
+    });
   });
 
   describe("dirty tracking", () => {


### PR DESCRIPTION
## **User description**
## Summary

On load, `loadLayout` regenerates device ids (duplicate-within-a-rack, or a reserved-id collision with another open tab per #2182) and rewrites `container_id` and `rack_groups`, but `layout.cables` was spread through untouched. Every cable touching a remapped device pointed at a dead id from the instant of load, then round-tripped into the next save. Fixes #2923.

## Changes

- `layout-lifecycle.ts`: accumulate a layout-global old to new device-id map (`layoutDeviceIdRemap`) across every rack during the first pass.
- Add a layout-level second pass, alongside the existing `rack_groups` pass, that rewrites cable `a_device_id`/`b_device_id` through that map. A cable can span racks, so this runs after every rack's device ids are finalized. A reference to a surviving original id is preserved, mirroring the `container_id`/`rack_groups` precedence established by #2155.
- Tests: two `loadLayout` cable-remap cases. One covers a cross-rack cable where both endpoints are regenerated (endpoints follow to the exact new device). One covers a single cable with a surviving endpoint (preserved) and a regenerated endpoint (remapped) to exercise both precedence branches. Both fail against pre-fix `loadLayout` and pass with the fix (verified).

## Testing

- [x] Unit tests pass (`npm run test:run`) - 3255 passed
- [x] Type check passes (`npm run check`) - 0 errors
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [ ] E2E tests pass (`npm run test:e2e`) - advisory self-hosted suite only

This is a data-layer fix with no UI surface; behaviour is covered by the new store-level unit tests.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2923


___

## **CodeAnt-AI Description**
**Keep cable connections pointing to the right devices after loading a layout**

### What Changed
- Cable endpoints are now rewritten when device IDs change during layout load, so cables stay attached instead of pointing at removed IDs
- If a device keeps its original ID, the cable keeps that endpoint unchanged
- If the same original ID appears more than once and must be regenerated, cable endpoints now follow the first regenerated device consistently
- Added tests for cross-rack cables, mixed preserved/remapped endpoints, and duplicate ID conflicts

### Impact
`✅ Fewer broken cables after reopening layouts`
`✅ Correct cable links across racks`
`✅ Consistent cable endpoints when duplicate device IDs are repaired`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
