### PR TITLE
fix: validateCable resolves endpoints against all racks (#2939)

### DIFF
--- a/src/lib/stores/cables.svelte.ts
+++ b/src/lib/stores/cables.svelte.ts
@@ -54,22 +54,27 @@ export function validateCable(
 ): CableValidationResult {
   const errors: string[] = [];
   const layoutStore = getLayoutStore();
-  const rack = layoutStore.rack;
-  if (!rack)
+  const racks = layoutStore.racks;
+  if (!racks.length)
     return {
       valid: false,
       errors: ["No rack is available in the current layout"],
     };
   const device_types = layoutStore.device_types;
 
+  // Cables are layout-level, device-id-keyed data: resolve endpoints against
+  // every rack's devices, not just the active rack (#2939).
+  const findDeviceById = (deviceId: string) =>
+    racks.flatMap((r) => r.devices).find((d) => d.id === deviceId);
+
   // Check A-side device exists
-  const aDevice = rack.devices.find((d) => d.id === cable.a_device_id);
+  const aDevice = findDeviceById(cable.a_device_id);
   if (!aDevice) {
     errors.push(`A-side device not found: ${cable.a_device_id}`);
   }
 
   // Check B-side device exists
-  const bDevice = rack.devices.find((d) => d.id === cable.b_device_id);
+  const bDevice = findDeviceById(cable.b_device_id);
   if (!bDevice) {
     errors.push(`B-side device not found: ${cable.b_device_id}`);
   }

--- a/src/tests/cables-store.test.ts
+++ b/src/tests/cables-store.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { validateCable } from "$lib/stores/cables.svelte";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import { createTestDeviceType } from "./factories";
+
+describe("validateCable", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+  });
+
+  it("resolves endpoints across all racks, not just the active rack", () => {
+    const store = getLayoutStore();
+    const deviceType = createTestDeviceType({ slug: "generic-server" });
+    store.addDeviceTypeRaw(deviceType);
+
+    const rackA = store.addRack("Rack A", 42)!;
+    store.placeDevice(rackA.id, deviceType.slug, 5);
+
+    const rackB = store.addRack("Rack B", 42)!;
+    store.placeDevice(rackB.id, deviceType.slug, 5);
+
+    // Rack B is the active rack (most recently added).
+    expect(store.rack!.id).toBe(rackB.id);
+
+    const deviceInA = store.layout.racks.find((r) => r.id === rackA.id)!
+      .devices[0]!;
+    const deviceInB = store.layout.racks.find((r) => r.id === rackB.id)!
+      .devices[0]!;
+
+    const result = validateCable(
+      {
+        a_device_id: deviceInA.id,
+        a_interface: "eth0",
+        b_device_id: deviceInB.id,
+        b_interface: "eth1",
+      },
+      [],
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
- `validateCable` (`src/lib/stores/cables.svelte.ts`) resolved cable endpoints against `layoutStore.rack` (the active rack) only, but cables are layout-level, device-id-keyed data.
- A cable referencing a device in a non-active rack would incorrectly fail validation with "device not found".
- Resolves endpoints against `layoutStore.racks` (all racks) instead.

## Files changed
- `src/lib/stores/cables.svelte.ts`: `findDeviceById` now searches across all racks' devices instead of just the active rack; the empty-layout guard checks `racks.length` instead of the single active rack.
- `src/tests/cables-store.test.ts`: new test placing devices in two different racks and validating a cable across them, failing before the fix (active-rack device reported as not found) and passing after.

## Test plan
- [x] New test written first, watched fail (RED) against old code
- [x] `npm run lint`
- [x] `npm run check` (typed change)
- [x] `npm run test:run` (3280 tests passed)
- [x] `npm run build`

Latent bug, no production callers yet (no cable UI ships). Related to F2/F3 cable reference-graph issues.

Closes #2939


___

## **CodeAnt-AI Description**
Validate cable endpoints against devices in any rack

### What Changed
- Cable validation now finds both endpoint devices anywhere in the layout, instead of checking only the active rack
- Cables that connect devices on different racks now validate successfully when both devices exist
- Added a test that covers a cable spanning two racks and confirms it no longer fails with “device not found”

### Impact
`✅ Fewer false cable validation errors`
`✅ Cross-rack cables validate correctly`
`✅ More reliable layout checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
