### PR TITLE
fix: migrateLayout and schema position-migration diverge on version-less bodies (#2931)

### DIFF
--- a/src/lib/storage/migrate-layout.ts
+++ b/src/lib/storage/migrate-layout.ts
@@ -1,32 +1,14 @@
 import type { Layout } from "$lib/types";
-import { UNITS_PER_U } from "$lib/types/constants";
 import { VERSION } from "$lib/version";
 import { sessionDebug } from "$lib/utils/debug";
+import {
+  needsPositionMigration,
+  migrateDevicePositions,
+} from "$lib/schemas/migrations";
 
 const log = sessionDebug.storage;
 
-/**
- * Compare semver versions (simplified).
- * Handles pre-release suffixes like -dev, -alpha.1, etc.
- * @returns -1 if a < b, 0 if a === b, 1 if a > b
- */
-function compareVersions(a: string, b: string): number {
-  // Strip pre-release (-dev, -alpha.1, etc.) and build metadata (+build)
-  const stripSuffix = (v: string) => v.split(/[-+]/)[0] ?? v;
-  const cleanA = stripSuffix(a.trim());
-  const cleanB = stripSuffix(b.trim());
-
-  const partsA = cleanA.split(".").map((p) => parseInt(p) || 0);
-  const partsB = cleanB.split(".").map((p) => parseInt(p) || 0);
-
-  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-    const partA = partsA[i] ?? 0;
-    const partB = partsB[i] ?? 0;
-    if (partA < partB) return -1;
-    if (partA > partB) return 1;
-  }
-  return 0;
-}
+type RawDevice = { position: number; container_id?: string };
 
 /**
  * Migrate legacy layout formats to current schema.
@@ -36,6 +18,11 @@ function compareVersions(a: string, b: string): number {
  *
  * Shared by the legacy single-slot working copy and the multi-layout browser
  * store so every persisted body is normalised through one code path.
+ *
+ * Position migration (#2931) routes through the same needsPositionMigration +
+ * migrateDevicePositions helpers the schema transform uses (schemas/
+ * migrations.ts), so this path and the schema path can never diverge: both
+ * apply the version/heuristic decision and the whole-U snap identically.
  *
  * @param raw - Raw parsed JSON object from localStorage
  * @returns Migrated Layout object, or null if migration fails
@@ -53,27 +40,24 @@ export function migrateLayout(raw: Record<string, unknown>): Layout | null {
     }
 
     // Migration 2: Position units (U-values → internal units)
-    // Layouts before 0.7.0 used U-values (1, 2, 3...)
-    // New format uses internal units (6, 12, 18...) where 1U = UNITS_PER_U units
-    const version = (raw.version as string) || "0.0.0";
-    const needsPositionMigration = compareVersions(version, "0.7.0") < 0;
-
     let migratedAnyPosition = false;
-    if (needsPositionMigration && Array.isArray(raw.racks)) {
-      for (const rack of raw.racks as Record<string, unknown>[]) {
-        if (Array.isArray(rack.devices)) {
-          for (const device of rack.devices as Record<string, unknown>[]) {
-            // Only migrate rack-level devices (not container children)
-            // Container children have container_id set and use 0-indexed positions
-            if (
-              device.container_id === undefined &&
-              typeof device.position === "number"
-            ) {
-              device.position = Math.round(device.position * UNITS_PER_U);
-              migratedAnyPosition = true;
-            }
+    if (Array.isArray(raw.racks)) {
+      const racks = raw.racks as Record<string, unknown>[];
+      const allDevices = racks.flatMap((rack) =>
+        Array.isArray(rack.devices) ? (rack.devices as RawDevice[]) : [],
+      );
+
+      const version = raw.version as string | undefined;
+      if (needsPositionMigration(version, allDevices)) {
+        for (const rack of racks) {
+          if (Array.isArray(rack.devices)) {
+            rack.devices = migrateDevicePositions(rack.devices as RawDevice[]);
           }
         }
+        // Only stamp the version when a rack-level device actually existed to
+        // rescale; an empty or container-children-only body has no position
+        // data to protect from double-migration, so leave its version as is.
+        migratedAnyPosition = allDevices.some((d) => !d.container_id);
       }
     }
 

--- a/src/tests/migrate-layout.test.ts
+++ b/src/tests/migrate-layout.test.ts
@@ -15,10 +15,23 @@ import { migrateLayout } from "$lib/storage/migrate-layout";
 import { migrateDevicePositions } from "$lib/schemas/migrations";
 import { UNITS_PER_U } from "$lib/types/constants";
 
-function rawLayoutWithPosition(position: number): Record<string, unknown> {
-  // No `version` field: the exact "version-less body" shape from the issue
-  // (e.g. a share-decoded layout that lost its version metadata).
-  return {
+/**
+ * Build a raw localStorage layout body for the parity tests.
+ *
+ * Version-less by default (the "share-decoded layout that lost its version
+ * metadata" shape from the issue); pass `version` only when a test needs one.
+ * Pass `devices` to override the single default device (e.g. an empty rack).
+ */
+function rawLayout(
+  overrides: {
+    position?: number;
+    container_id?: string;
+    version?: string;
+    devices?: Record<string, unknown>[];
+  } = {},
+): Record<string, unknown> {
+  const { position = 0, container_id, version, devices } = overrides;
+  const raw: Record<string, unknown> = {
     name: "Parity",
     racks: [
       {
@@ -30,101 +43,60 @@ function rawLayoutWithPosition(position: number): Record<string, unknown> {
         form_factor: "4-post-cabinet",
         starting_unit: 1,
         position: 0,
-        devices: [
-          { id: "d1", device_type: "server-1u", position, face: "front" },
+        devices: devices ?? [
+          {
+            id: "d1",
+            device_type: "server-1u",
+            position,
+            ...(container_id !== undefined ? { container_id } : {}),
+            face: "front",
+          },
         ],
       },
     ],
     device_types: [],
     settings: { display_mode: "label", show_labels_on_images: false },
   };
+  if (version !== undefined) raw.version = version;
+  return raw;
+}
+
+function firstDevicePosition(result: unknown): number {
+  return (result as { racks: { devices: { position: number }[] }[] }).racks[0]!
+    .devices[0]!.position;
 }
 
 describe("migrateLayout / schema position-migration parity (#2931)", () => {
   it("snaps a version-less body's fractional legacy-U position to the same whole-U value as migrateDevicePositions", () => {
-    const raw = rawLayoutWithPosition(1.5);
-    const result = migrateLayout(raw);
+    const result = migrateLayout(rawLayout({ position: 1.5 }));
     expect(result).not.toBeNull();
-
-    const migratedPosition = (
-      result as unknown as { racks: { devices: { position: number }[] }[] }
-    ).racks[0]!.devices[0]!.position;
 
     // What schemas/migrations.ts produces for the identical raw position.
     const [expectedDevice] = migrateDevicePositions([
       { position: 1.5, container_id: undefined },
     ]);
 
-    expect(migratedPosition).toBe(expectedDevice!.position);
+    expect(firstDevicePosition(result)).toBe(expectedDevice!.position);
     // Whole-U snap: must land on a UNITS_PER_U boundary, never a sub-U
     // position the carrier-first refine would reject.
-    expect(migratedPosition % UNITS_PER_U).toBe(0);
+    expect(firstDevicePosition(result) % UNITS_PER_U).toBe(0);
   });
 
   it("migrates a rack-level device with an empty-string container_id the same as migrateDevicePositions", () => {
     // Empty-string container_id is rack-level, matching PlacedDeviceSchema,
     // the carrier-first refine, and clampOverRackPositions.
-    const raw = {
-      name: "Parity",
-      racks: [
-        {
-          id: "rack-1",
-          name: "Main",
-          height: 42,
-          width: 19,
-          desc_units: false,
-          form_factor: "4-post-cabinet",
-          starting_unit: 1,
-          position: 0,
-          devices: [
-            {
-              id: "d1",
-              device_type: "server-1u",
-              position: 5,
-              container_id: "",
-              face: "front",
-            },
-          ],
-        },
-      ],
-      device_types: [],
-      settings: { display_mode: "label", show_labels_on_images: false },
-    };
-
-    const result = migrateLayout(raw);
+    const result = migrateLayout(rawLayout({ position: 5, container_id: "" }));
     expect(result).not.toBeNull();
-    const migratedPosition = (
-      result as unknown as { racks: { devices: { position: number }[] }[] }
-    ).racks[0]!.devices[0]!.position;
 
-    expect(migratedPosition).toBe(5 * UNITS_PER_U);
+    expect(firstDevicePosition(result)).toBe(5 * UNITS_PER_U);
   });
 
   it("does not stamp the current version when a rack has no rack-level devices to migrate", () => {
     // An old-versioned body with an empty rack has no position data to
     // protect from double-migration, so its version must be left untouched.
-    const raw = {
-      version: "0.6.0",
-      name: "Empty Rack",
-      racks: [
-        {
-          id: "rack-1",
-          name: "Main",
-          height: 42,
-          width: 19,
-          desc_units: false,
-          form_factor: "4-post-cabinet",
-          starting_unit: 1,
-          position: 0,
-          devices: [],
-        },
-      ],
-      device_types: [],
-      settings: { display_mode: "label", show_labels_on_images: false },
-    };
-
-    const result = migrateLayout(raw);
+    const result = migrateLayout(rawLayout({ version: "0.6.0", devices: [] }));
     expect(result).not.toBeNull();
-    expect((result as unknown as { version: string }).version).toBe("0.6.0");
+
+    expect((result as { version: string }).version).toBe("0.6.0");
   });
 });

--- a/src/tests/migrate-layout.test.ts
+++ b/src/tests/migrate-layout.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Parity between migrateLayout (browser localStorage read door) and the
+ * schema transform's position-migration helpers (schemas/migrations.ts).
+ *
+ * migrateLayout used to decide "needs migration" on version alone and scale
+ * every rack-level position by UNITS_PER_U with no whole-U snap, diverging
+ * from the schema path's needsPositionMigration + migrateDevicePositions
+ * (which snaps to the nearest whole U before scaling). A version-less body
+ * with a fractional legacy-U position produced a sub-U internal position via
+ * migrateLayout that the carrier-first refine rejects, while the schema path
+ * produced a valid whole-U position for the identical input (#2931).
+ */
+import { describe, it, expect } from "vitest";
+import { migrateLayout } from "$lib/storage/migrate-layout";
+import { migrateDevicePositions } from "$lib/schemas/migrations";
+import { UNITS_PER_U } from "$lib/types/constants";
+
+function rawLayoutWithPosition(position: number): Record<string, unknown> {
+  // No `version` field: the exact "version-less body" shape from the issue
+  // (e.g. a share-decoded layout that lost its version metadata).
+  return {
+    name: "Parity",
+    racks: [
+      {
+        id: "rack-1",
+        name: "Main",
+        height: 42,
+        width: 19,
+        desc_units: false,
+        form_factor: "4-post-cabinet",
+        starting_unit: 1,
+        position: 0,
+        devices: [
+          { id: "d1", device_type: "server-1u", position, face: "front" },
+        ],
+      },
+    ],
+    device_types: [],
+    settings: { display_mode: "label", show_labels_on_images: false },
+  };
+}
+
+describe("migrateLayout / schema position-migration parity (#2931)", () => {
+  it("snaps a version-less body's fractional legacy-U position to the same whole-U value as migrateDevicePositions", () => {
+    const raw = rawLayoutWithPosition(1.5);
+    const result = migrateLayout(raw);
+    expect(result).not.toBeNull();
+
+    const migratedPosition = (
+      result as unknown as { racks: { devices: { position: number }[] }[] }
+    ).racks[0]!.devices[0]!.position;
+
+    // What schemas/migrations.ts produces for the identical raw position.
+    const [expectedDevice] = migrateDevicePositions([
+      { position: 1.5, container_id: undefined },
+    ]);
+
+    expect(migratedPosition).toBe(expectedDevice!.position);
+    // Whole-U snap: must land on a UNITS_PER_U boundary, never a sub-U
+    // position the carrier-first refine would reject.
+    expect(migratedPosition % UNITS_PER_U).toBe(0);
+  });
+
+  it("migrates a rack-level device with an empty-string container_id the same as migrateDevicePositions", () => {
+    // Empty-string container_id is rack-level, matching PlacedDeviceSchema,
+    // the carrier-first refine, and clampOverRackPositions.
+    const raw = {
+      name: "Parity",
+      racks: [
+        {
+          id: "rack-1",
+          name: "Main",
+          height: 42,
+          width: 19,
+          desc_units: false,
+          form_factor: "4-post-cabinet",
+          starting_unit: 1,
+          position: 0,
+          devices: [
+            {
+              id: "d1",
+              device_type: "server-1u",
+              position: 5,
+              container_id: "",
+              face: "front",
+            },
+          ],
+        },
+      ],
+      device_types: [],
+      settings: { display_mode: "label", show_labels_on_images: false },
+    };
+
+    const result = migrateLayout(raw);
+    expect(result).not.toBeNull();
+    const migratedPosition = (
+      result as unknown as { racks: { devices: { position: number }[] }[] }
+    ).racks[0]!.devices[0]!.position;
+
+    expect(migratedPosition).toBe(5 * UNITS_PER_U);
+  });
+});

--- a/src/tests/migrate-layout.test.ts
+++ b/src/tests/migrate-layout.test.ts
@@ -99,4 +99,32 @@ describe("migrateLayout / schema position-migration parity (#2931)", () => {
 
     expect(migratedPosition).toBe(5 * UNITS_PER_U);
   });
+
+  it("does not stamp the current version when a rack has no rack-level devices to migrate", () => {
+    // An old-versioned body with an empty rack has no position data to
+    // protect from double-migration, so its version must be left untouched.
+    const raw = {
+      version: "0.6.0",
+      name: "Empty Rack",
+      racks: [
+        {
+          id: "rack-1",
+          name: "Main",
+          height: 42,
+          width: 19,
+          desc_units: false,
+          form_factor: "4-post-cabinet",
+          starting_unit: 1,
+          position: 0,
+          devices: [],
+        },
+      ],
+      device_types: [],
+      settings: { display_mode: "label", show_labels_on_images: false },
+    };
+
+    const result = migrateLayout(raw);
+    expect(result).not.toBeNull();
+    expect((result as unknown as { version: string }).version).toBe("0.6.0");
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

- `migrateLayout` (browser localStorage read door) duplicated the schema transform's position-migration logic instead of sharing it, so the two paths could diverge on the same input.
- A fractional legacy-U position (e.g. `1.5`) went through `migrateLayout` as `Math.round(position * UNITS_PER_U)` with no whole-U snap, landing on a sub-U internal position that the carrier-first schema refine rejects. The schema path (`needsPositionMigration` + `migrateDevicePositions`) snapped the same input to a valid whole-U value.
- A device with an empty-string `container_id` was skipped by `migrateLayout`'s strict `=== undefined` check but correctly migrated by the schema path (falsy `container_id` is rack-level everywhere else in the schema).

## Changes

- `migrateLayout` now calls the shared `needsPositionMigration` and `migrateDevicePositions` helpers from `schemas/migrations.ts` directly instead of re-implementing version comparison and position scaling, so the two paths can never diverge again.
- The version-stamp-for-idempotency logic now only fires when an actual rack-level device existed to migrate (guards against prematurely stamping the version on an empty or container-children-only rack).
- Removed the now-unused local `compareVersions` duplicate.

## Testing

- [x] Unit tests pass (`npm run test:run`) - 207 files, 3285 tests
- [x] `npm run lint` clean
- [x] `npm run check` (svelte-check/TypeScript) clean, 0 errors
- [x] `npm run build` succeeds
- New tests in `src/tests/migrate-layout.test.ts` cover: fractional legacy-U whole-U snap parity, empty-string `container_id` migration parity, and the version-stamp-only-when-needed guard.

Closes #2931


___

## **CodeAnt-AI Description**
**Keep legacy layout migration consistent for version-less and old layouts**

### What Changed
- Layouts without version data now migrate positions the same way as schema-based migration, including snapping fractional legacy positions to whole units before scaling.
- Rack-level devices with an empty `container_id` are now migrated instead of being skipped.
- Empty racks or racks with only container children no longer get stamped as already migrated when there was nothing to rescale.
- Added tests covering these migration cases and the version-stamping guard.

### Impact
`✅ Fewer broken imported layouts`
`✅ Consistent position migration across saved and shared layouts`
`✅ Fewer double-migration issues on reload`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
