### PR TITLE
fix: validate ZIP-extracted images by magic bytes and size cap (#2933)

### DIFF
--- a/src/lib/utils/archive-extract.ts
+++ b/src/lib/utils/archive-extract.ts
@@ -16,6 +16,11 @@ import { parseLayoutYaml, parseLayoutYamlWithImages } from "./yaml";
 import { extractUuidFromFolderName } from "./folder-structure";
 import { placementKey } from "./placement-key";
 import { archiveDebug } from "./debug";
+import { detectImageMime } from "./image-encoding";
+import {
+  SUPPORTED_IMAGE_FORMATS,
+  MAX_IMAGE_SIZE_BYTES,
+} from "$lib/types/constants";
 
 /**
  * Lazily load JSZip library
@@ -110,9 +115,14 @@ export async function getJSZip(): Promise<JSZipConstructor> {
 }
 
 /**
- * Supported image file extensions
+ * Supported image file extensions.
+ *
+ * SECURITY: gif/svg are intentionally excluded, matching SUPPORTED_IMAGE_FORMATS
+ * (the raster-only allowlist enforced by detectImageMime). SVG can carry
+ * embedded scripts; excluding it here means an entry named `front.svg` is never
+ * even considered a candidate image (#2933).
  */
-const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "webp", "gif", "svg"];
+const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "webp"];
 
 /**
  * Archive extraction limits (guardrails)
@@ -551,7 +561,28 @@ async function extractImageFromZip(
   if (!imageFile) return { error: true };
 
   try {
-    const imageBlob = await imageFile.async("blob");
+    // Never trust the file extension or JSZip's extension-inferred blob type:
+    // decode the real bytes and validate them the same way the YAML
+    // embedded-image path does (detectImageMime + allowlist + size cap, #2933).
+    const bytes = await imageFile.async("uint8array");
+
+    if (bytes.byteLength > MAX_IMAGE_SIZE_BYTES) {
+      archiveDebug.extract("Image exceeds size cap: %s", imagePath);
+      return { error: true };
+    }
+
+    const detected = detectImageMime(bytes);
+    if (!detected || !SUPPORTED_IMAGE_FORMATS.includes(detected)) {
+      archiveDebug.extract(
+        "Rejected image with unsupported or unrecognised format: %s",
+        imagePath,
+      );
+      return { error: true };
+    }
+
+    // Re-wrap into a fresh, plain-ArrayBuffer-backed view: JSZip's uint8array
+    // output type is too loose (ArrayBufferLike) for BlobPart.
+    const imageBlob = new Blob([new Uint8Array(bytes)], { type: detected });
     const dataUrl = await blobToDataUrl(imageBlob);
 
     // Graceful degradation: skip images that fail to convert

--- a/src/tests/archive-format.test.ts
+++ b/src/tests/archive-format.test.ts
@@ -10,6 +10,7 @@ import JSZip from "jszip";
 import { extractFolderArchive } from "$lib/utils/archive";
 import { serializeLayoutToYaml } from "$lib/utils/yaml";
 import { createTestLayout, createTestRack } from "./factories";
+import { MAX_IMAGE_SIZE_BYTES } from "$lib/types/constants";
 
 // Create a valid layout YAML using factories
 let SAMPLE_LAYOUT_YAML: string;
@@ -127,6 +128,77 @@ describe("extractFolderArchive", () => {
       await expect(extractFolderArchive(blob)).rejects.toThrow(
         "No valid layout file found",
       );
+    });
+  });
+
+  describe("image validation (magic bytes + size cap, #2933)", () => {
+    it("rejects a ZIP-extracted image whose bytes don't match its extension", async () => {
+      const zip = new JSZip();
+      const folderName = "My Layout-550e8400-e29b-41d4-a716-446655440000";
+      const folder = zip.folder(folderName);
+      folder?.file("my-layout.rackula.yaml", SAMPLE_LAYOUT_YAML);
+
+      // Extension claims PNG; content is SVG text. Extension/blob-type alone
+      // would accept this, but magic-byte sniffing must catch the mismatch.
+      const assetsFolder = folder?.folder("assets")?.folder("test-device");
+      const svgBytes = new TextEncoder().encode(
+        "<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>",
+      );
+      assetsFolder?.file("front.png", svgBytes);
+
+      const blob = await zip.generateAsync({ type: "blob" });
+      const result = await extractFolderArchive(blob);
+
+      expect(result.layout.name).toBe("Test Layout");
+      expect(result.images.has("test-device")).toBe(false);
+      expect(result.failedImages).toContain(
+        `${folderName}/assets/test-device/front.png`,
+      );
+    });
+
+    it("rejects a ZIP-extracted image exceeding the per-image size cap", async () => {
+      const zip = new JSZip();
+      const folderName = "My Layout-550e8400-e29b-41d4-a716-446655440000";
+      const folder = zip.folder(folderName);
+      folder?.file("my-layout.rackula.yaml", SAMPLE_LAYOUT_YAML);
+
+      // Real PNG header, but the total size pushes past MAX_IMAGE_SIZE_BYTES.
+      const assetsFolder = folder?.folder("assets")?.folder("test-device");
+      const oversizedPng = new Uint8Array(MAX_IMAGE_SIZE_BYTES + 1024);
+      oversizedPng.set([137, 80, 78, 71, 13, 10, 26, 10], 0);
+      assetsFolder?.file("front.png", oversizedPng);
+
+      const blob = await zip.generateAsync({ type: "blob" });
+      const result = await extractFolderArchive(blob);
+
+      expect(result.images.has("test-device")).toBe(false);
+      expect(result.failedImages).toContain(
+        `${folderName}/assets/test-device/front.png`,
+      );
+    });
+
+    it("excludes .svg and .gif entries entirely, even with valid magic bytes", async () => {
+      const zip = new JSZip();
+      const folderName = "My Layout-550e8400-e29b-41d4-a716-446655440000";
+      const folder = zip.folder(folderName);
+      folder?.file("my-layout.rackula.yaml", SAMPLE_LAYOUT_YAML);
+
+      const assetsFolder = folder?.folder("assets")?.folder("test-device");
+      assetsFolder?.file(
+        "front.svg",
+        "<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+      );
+      // Real GIF magic bytes ("GIF89a"), still must be excluded by extension.
+      assetsFolder?.file(
+        "rear.gif",
+        new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]),
+      );
+
+      const blob = await zip.generateAsync({ type: "blob" });
+      const result = await extractFolderArchive(blob);
+
+      expect(result.images.has("test-device")).toBe(false);
+      expect(result.failedImages).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## **User description**
## Summary

- The YAML embedded-image path sniffs magic bytes, rejects SVG, and enforces a per-image size cap. The ZIP archive path trusted the file extension and JSZip's extension-inferred blob type, and `IMAGE_EXTENSIONS` still listed `gif`/`svg`.
- `extractImageFromZip` now decodes each entry's bytes and runs them through the same `detectImageMime()` + `SUPPORTED_IMAGE_FORMATS` allowlist + `MAX_IMAGE_SIZE_BYTES` cap that `decodeYamlImages` already uses for the YAML path.
- `gif`/`svg` dropped from `IMAGE_EXTENSIONS` so those entries are never even considered candidate images.
- Rejected entries still fall through the existing `failedImages` mechanism (the "N images couldn't be read" toast); a bad image never rejects the whole layout.

## Files changed

- `src/lib/utils/archive-extract.ts`: magic-byte + size-cap validation in `extractImageFromZip`; `IMAGE_EXTENSIONS` narrowed to raster formats.
- `src/tests/archive-format.test.ts`: 3 new tests (magic-byte mismatch rejected, oversized image rejected, `.svg`/`.gif` entries excluded entirely).

## Test plan

- [x] `npm run lint`
- [x] `npm run check` (svelte-check, typed change)
- [x] `npm run test:run` (3285 tests pass)
- [x] `npm run build`
- [x] New tests written first, watched fail (RED), then implementation made them pass (GREEN)
- [x] Self-reviewed with `/code-review`

Closes #2933

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
**Reject unsafe ZIP images by checking the actual file contents**

### What Changed
- ZIP-imported images are now accepted only when their real bytes match a supported raster image type and stay under the per-image size limit
- `.svg` and `.gif` entries are no longer treated as valid image candidates, even if their file names look correct
- Bad images are skipped during import instead of breaking the whole layout, and they still show up in the failed-image count

### Impact
`✅ Safer ZIP imports`
`✅ Fewer broken image uploads`
`✅ Clearer import warnings for invalid images`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
