### PR TITLE
fix: align slugify truncation between frontend and API (#2932)

### DIFF
--- a/api/src/schemas/layout.test.ts
+++ b/api/src/schemas/layout.test.ts
@@ -13,6 +13,19 @@ describe("slugify (api)", () => {
   it("falls back to untitled when the name has no slug characters", () => {
     expect(slugify("...")).toBe("untitled");
   });
+
+  // The frontend's slugifyForFilename (src/lib/utils/slug.ts) truncates to
+  // the same SLUG_MAX_LENGTH (100 chars) so the two implementations agree on
+  // long names (#2932). This name is chosen so the 100-char cut lands on a
+  // hyphen, exercising the post-truncation trailing-hyphen trim both
+  // implementations apply. Mirrors the frontend test in src/tests/slug.test.ts.
+  it("truncates to the shared 100-character limit, matching the frontend slugifyForFilename", () => {
+    const name =
+      "Rack Layout Name With Words Of Various Length To Find A Boundary Hyphen Case For Truncation Testing Purposes";
+    expect(slugify(name)).toBe(
+      "rack-layout-name-with-words-of-various-length-to-find-a-boundary-hyphen-case-for-truncation-testing",
+    );
+  });
 });
 
 describe("buildYamlFilename (api)", () => {

--- a/api/src/schemas/layout.ts
+++ b/api/src/schemas/layout.ts
@@ -43,6 +43,15 @@ export function extractUuidFromFolderName(folderName: string): string | null {
 }
 
 /**
+ * Maximum length of a filename slug.
+ *
+ * This api package can't import the frontend's src/lib/utils/slug.ts (it's a
+ * separate Bun package), so this value is duplicated as SLUG_MAX_LENGTH there
+ * too, applied by slugifyForFilename. Keep both in sync (#2932).
+ */
+const SLUG_MAX_LENGTH = 100;
+
+/**
  * Sanitize a string for safe use in filesystem paths
  * Removes path separators and other dangerous characters while keeping readability
  */
@@ -72,10 +81,12 @@ export function buildFolderName(name: string, uuid: string): string {
  * Slugify a layout name to create a safe filename
  * Handles Unicode names by returning "untitled" if result is empty
  *
- * Behaviour mirrors the frontend slugify (src/lib/utils/slug.ts): a "+" becomes
- * "-plus" before other processing so "DS920+" maps to "ds920-plus", and hyphens
- * are trimmed and collapsed consistently. The api is a separate Bun package and
- * cannot import the frontend module, so the rules are kept in sync here.
+ * Behaviour mirrors the frontend's slugifyForFilename (src/lib/utils/slug.ts):
+ * a "+" becomes "-plus" before other processing so "DS920+" maps to
+ * "ds920-plus", hyphens are trimmed and collapsed consistently, and the result
+ * is truncated to SLUG_MAX_LENGTH (see #2932, where the two had drifted). The
+ * api is a separate Bun package and cannot import the frontend module, so the
+ * rules are kept in sync here.
  */
 export function slugify(name: string): string {
   const slug = name
@@ -89,7 +100,7 @@ export function slugify(name: string): string {
     .replace(/^-+|-+$/g, "")
     // Collapse multiple hyphens
     .replace(/-+/g, "-")
-    .slice(0, 100)
+    .slice(0, SLUG_MAX_LENGTH)
     .replace(/-+$/g, ""); // Remove trailing hyphens after truncation
 
   // Handle empty results (e.g., all-Unicode names like "...")

--- a/src/lib/utils/slug.ts
+++ b/src/lib/utils/slug.ts
@@ -9,6 +9,17 @@
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 /**
+ * Maximum length of a filename slug. Applied by slugifyForFilename, not by
+ * slugify itself (device slugs and NetBox slug mapping are not filenames and
+ * are intentionally left untruncated).
+ *
+ * The api package can't import this module (it's a separate Bun package), so
+ * this value is duplicated as SLUG_MAX_LENGTH in api/src/schemas/layout.ts.
+ * Keep both in sync (#2932).
+ */
+const SLUG_MAX_LENGTH = 100;
+
+/**
  * Convert any string to a valid slug
  *
  * @example
@@ -43,7 +54,9 @@ export function slugify(input: string): string {
  *
  * Built on slugify so the "+" rule and trim/collapse behaviour stay consistent
  * (e.g. "DS920+" becomes "ds920-plus", leading/trailing/repeated separators are
- * trimmed and collapsed).
+ * trimmed and collapsed). Truncated to SLUG_MAX_LENGTH to match the API's
+ * slugify (api/src/schemas/layout.ts), which is the other producer of
+ * layout filenames (#2932).
  *
  * @param name - The human-readable name to sanitize
  * @param fallback - Value returned when the name slugifies to an empty string
@@ -53,7 +66,8 @@ export function slugify(input: string): string {
  * slugifyForFilename('!!!', 'rack') // 'rack'
  */
 export function slugifyForFilename(name: string, fallback: string): string {
-  return slugify(name) || fallback;
+  const slug = slugify(name).slice(0, SLUG_MAX_LENGTH).replace(/-+$/, ""); // Remove trailing hyphens exposed by truncation
+  return slug || fallback;
 }
 
 /**

--- a/src/tests/slug.test.ts
+++ b/src/tests/slug.test.ts
@@ -93,6 +93,18 @@ describe("Slug Utilities", () => {
       expect(slugifyForFilename("!!!", "rack")).toBe("rack");
       expect(slugifyForFilename("", "layout")).toBe("layout");
     });
+
+    // The API's slugify (api/src/schemas/layout.ts) truncates to
+    // SLUG_MAX_LENGTH (100 chars) since it can't import this module (#2932).
+    // This name is chosen so the 100-char cut lands on a hyphen, exercising
+    // the post-truncation trailing-hyphen trim both implementations apply.
+    it("truncates to the shared 100-character limit, matching the API slugify", () => {
+      const name =
+        "Rack Layout Name With Words Of Various Length To Find A Boundary Hyphen Case For Truncation Testing Purposes";
+      expect(slugifyForFilename(name, "layout")).toBe(
+        "rack-layout-name-with-words-of-various-length-to-find-a-boundary-hyphen-case-for-truncation-testing",
+      );
+    });
   });
 
   describe("filename consistency across export paths", () => {


### PR DESCRIPTION
## **User description**
## Summary

The frontend and API each define `slugify` (the API can't import the frontend module, it's a separate Bun package) and they had drifted: the API truncated to 100 characters, the frontend did not. A layout/rack name over 100 characters slugified differently in exported filenames depending on which side produced it.

## Changes

- Added `SLUG_MAX_LENGTH = 100` in `src/lib/utils/slug.ts`, applied by `slugifyForFilename` (the frontend's actual filename-producing counterpart to the API's `slugify`). The raw `slugify()` used for device slugs and NetBox slug mapping is left untouched since those aren't filenames.
- Added the matching `SLUG_MAX_LENGTH = 100` constant in `api/src/schemas/layout.ts`, replacing the magic-number `.slice(0, 100)` in its `slugify()`.
- Cross-referencing doc comments on both constants so a future change to one is a visible prompt to update the other.
- Added a pinned regression test in each package's test file asserting the exact same expected output for the exact same >100-char input name (chosen so the truncation boundary lands on a hyphen, exercising the post-truncation trailing-hyphen trim both implementations apply).

## Testing

- [x] Unit tests pass (`npm run test:run`) - 3283 passed
- [x] API tests pass (`bun test` in `api/`) - includes new pinned truncation test
- [x] `npm run lint` clean
- [x] `npm run check` (svelte-check) clean
- [x] API `tsc --noEmit` clean
- [x] `npm run build` succeeds
- [ ] E2E tests (not applicable, no UI surface changed)
- [x] Self-review via `/code-review` (correctness + cleanup angles, no blocking findings)

## Accessibility

Not applicable, no UI changes.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality

Closes #2932

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
**Keep long export filenames consistent across frontend and API**

### What Changed
- Long layout and rack names now produce the same filename slug in both the frontend and API
- Slugs used for exported filenames are trimmed to 100 characters in both places, with trailing hyphens removed after truncation
- The fallback name still appears when a name turns into an empty slug
- New tests cover the long-name case to keep the two outputs aligned

### Impact
`✅ Consistent export filenames`
`✅ Fewer mismatched layout downloads`
`✅ Fewer filename edge-case errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
