### PR TITLE
fix: add Escape-to-cancel for in-progress pointer drags (#2935)

### DIFF
--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -303,6 +303,15 @@
   function handleResizeCancel(event: PointerEvent) {
     const drag = resizeDrag;
     if (!drag || event.pointerId !== drag.pointerId) return;
+    cancelResizeDrag();
+  }
+
+  // Shared reset path for a pointercancel and an Escape-cancel (#2935): both
+  // abort an in-progress resize the same way, rewinding the live preview to
+  // the height the rack had before the drag started.
+  function cancelResizeDrag() {
+    const drag = resizeDrag;
+    if (!drag) return;
     const { rackIds, startHeight } = drag;
     resizeDrag = null;
     for (const id of rackIds) {
@@ -423,8 +432,31 @@
   function handleBayDragCancel(event: PointerEvent) {
     const drag = bayDrag;
     if (!drag || event.pointerId !== drag.pointerId) return;
+    cancelBayDrag();
+  }
+
+  // Shared reset path for a pointercancel and an Escape-cancel (#2935): a bay
+  // drag never mutates the store until release, so cancelling is just
+  // discarding the in-progress ghost.
+  function cancelBayDrag() {
     bayDrag = null;
   }
+
+  // Escape-to-cancel (#2935): a window Escape handler active only while a
+  // resize or bay drag is in progress, so it does not interfere with
+  // unrelated Escape presses (e.g. clearing selection).
+  $effect(() => {
+    if (!resizeDrag && !bayDrag) return;
+
+    function handleWindowKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      cancelResizeDrag();
+      cancelBayDrag();
+    }
+
+    window.addEventListener("keydown", handleWindowKeyDown);
+    return () => window.removeEventListener("keydown", handleWindowKeyDown);
+  });
 
   // Handle mobile tap-to-place (uses active rack)
   function handlePlacementTap(

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -527,9 +527,28 @@
 
   function handlePointerCancel(event: PointerEvent) {
     if (event.pointerId !== activePointerId) return;
+    cancelActiveDrag();
+  }
 
-    // Cancel any in-progress drag
+  // Shared reset path for a pointercancel and an Escape-cancel (#2935): both
+  // abort an in-progress drag the same way, restoring pre-drag state without
+  // committing a move. Escape can fire while the pointer is still physically
+  // down, so it also releases capture that a real pointercancel/pointerup
+  // would already have released.
+  function cancelActiveDrag() {
+    if (rectElement?.releasePointerCapture && activePointerId !== null) {
+      try {
+        rectElement.releasePointerCapture(activePointerId);
+      } catch {
+        // Already released - safe to ignore
+      }
+    }
+
     if (pointerState === "dragging") {
+      // Tell every Rack listening for the pointer-drag events (Safari #397
+      // workaround, see rack-pointer-drag.ts) to drop its local preview/hover
+      // state without resolving a drop (#2935).
+      document.dispatchEvent(new CustomEvent("rackula:dragcancel"));
       setCurrentDragData(null);
       isDragging = false;
       hideDragTooltip();
@@ -541,6 +560,21 @@
     pointerStartPos = null;
     activePointerId = null;
   }
+
+  // Escape-to-cancel (#2935): a window Escape handler active only while this
+  // device is being dragged, so it does not interfere with unrelated Escape
+  // presses (e.g. clearing selection).
+  $effect(() => {
+    if (!isDragging) return;
+
+    function handleWindowKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      cancelActiveDrag();
+    }
+
+    window.addEventListener("keydown", handleWindowKeyDown);
+    return () => window.removeEventListener("keydown", handleWindowKeyDown);
+  });
 
   function openDeviceContextMenu(x: number, y: number) {
     // If context menu handler is provided, use it; otherwise fall back to duplicate
@@ -638,6 +672,7 @@
        because Safari 18.x doesn't properly compute hit areas on transformed <g> elements -->
   <rect
     bind:this={rectElement}
+    data-testid="rack-device-hitbox"
     class="device-rect"
     class:rear-muted={isRearMuted}
     x="0"

--- a/src/lib/utils/rack-pointer-drag.ts
+++ b/src/lib/utils/rack-pointer-drag.ts
@@ -149,9 +149,16 @@ export function attachPointerDragListeners(
   // resolve or dispatch a drop, only discard whatever preview/hover state the
   // last dragmove left behind. Every rack clears its own local state; there is
   // no source/target rack distinction like dragend has.
+  //
+  // It must also arm the same click-suppression debounce dragend uses
+  // (onDragFinished). The browser synthesises a trailing click on the pointer
+  // release that follows the Escape cancel; without arming the debounce that
+  // click reaches handleClick and would select the rack or place a pending
+  // device. onDragFinished only arms suppression, it does not dispatch a drop.
   function handleDragCancel() {
     ctx.setDropPreview(null);
     ctx.setContainerHoverInfo(null);
+    ctx.onDragFinished();
   }
 
   document.addEventListener(

--- a/src/lib/utils/rack-pointer-drag.ts
+++ b/src/lib/utils/rack-pointer-drag.ts
@@ -145,11 +145,21 @@ export function attachPointerDragListeners(
     ctx.onDragFinished();
   }
 
+  // An Escape-cancelled drag (#2935) never reaches handleDragEnd: it must not
+  // resolve or dispatch a drop, only discard whatever preview/hover state the
+  // last dragmove left behind. Every rack clears its own local state; there is
+  // no source/target rack distinction like dragend has.
+  function handleDragCancel() {
+    ctx.setDropPreview(null);
+    ctx.setContainerHoverInfo(null);
+  }
+
   document.addEventListener(
     "rackula:dragmove",
     handleDragMove as EventListener,
   );
   document.addEventListener("rackula:dragend", handleDragEnd as EventListener);
+  document.addEventListener("rackula:dragcancel", handleDragCancel);
 
   return () => {
     document.removeEventListener(
@@ -160,5 +170,6 @@ export function attachPointerDragListeners(
       "rackula:dragend",
       handleDragEnd as EventListener,
     );
+    document.removeEventListener("rackula:dragcancel", handleDragCancel);
   };
 }

--- a/src/tests/RackCanvasView.escape-cancel-resize.test.ts
+++ b/src/tests/RackCanvasView.escape-cancel-resize.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression test for #2935: an in-progress canvas resize drag reset only on
+ * a browser-issued pointercancel, drop, or pointerup. Pressing Escape mid-drag
+ * had no handler and could not abort it. This asserts Escape aborts an active
+ * resize drag and restores the rack's pre-drag height, mirroring the
+ * pointercancel reset path (handleResizeCancel).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import RackCanvasView from "$lib/components/RackCanvasView.svelte";
+import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  getSelectionStore,
+  resetSelectionStore,
+} from "$lib/stores/selection.svelte";
+import { resetCanvasStore } from "$lib/stores/canvas.svelte";
+import { resetUIStore } from "$lib/stores/ui.svelte";
+import { resetPlacementStore } from "$lib/stores/placement.svelte";
+import { resetToastStore } from "$lib/stores/toast.svelte";
+import { resetViewportStore } from "$lib/utils/viewport.svelte";
+
+describe("RackCanvasView Escape-to-cancel resize drag (#2935)", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+    resetSelectionStore();
+    resetCanvasStore();
+    resetUIStore();
+    resetPlacementStore();
+    resetToastStore();
+    resetViewportStore();
+
+    vi.stubGlobal("matchMedia", (query: string): MediaQueryList => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => true,
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("aborts an active resize drag and restores the rack's pre-drag height", async () => {
+    const layoutStore = getLayoutStore();
+    const rack = layoutStore.addRack("Test Rack", 42);
+    if (!rack) throw new Error("addRack failed to create a rack");
+    getSelectionStore().selectRack(rack.id);
+
+    const { getByLabelText } = render(RackCanvasView);
+
+    const grip = getByLabelText("Resize rack height from bottom edge");
+
+    grip.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        pointerId: 1,
+        clientY: 0,
+      }),
+    );
+    grip.dispatchEvent(
+      new PointerEvent("pointermove", {
+        bubbles: true,
+        pointerId: 1,
+        clientY: 200,
+      }),
+    );
+    await tick();
+
+    // Precondition: the drag actually previewed a new height.
+    expect(layoutStore.getRackById(rack.id)?.height).not.toBe(42);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await tick();
+
+    expect(layoutStore.getRackById(rack.id)?.height).toBe(42);
+  });
+
+  it("does nothing when Escape is pressed while no resize drag is active", async () => {
+    const layoutStore = getLayoutStore();
+    const rack = layoutStore.addRack("Test Rack", 42);
+    if (!rack) throw new Error("addRack failed to create a rack");
+    getSelectionStore().selectRack(rack.id);
+
+    render(RackCanvasView);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await tick();
+
+    expect(layoutStore.getRackById(rack.id)?.height).toBe(42);
+  });
+});

--- a/src/tests/RackDevice.escape-cancel-drag.test.ts
+++ b/src/tests/RackDevice.escape-cancel-drag.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression test for #2935: an in-progress device drag reset only on a
+ * browser-issued pointercancel, drop, or pointerup. Pressing Escape mid-drag
+ * had no handler and could not abort it. This asserts Escape aborts an active
+ * device drag and clears the shared drag/tooltip state, mirroring the
+ * pointercancel reset path.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render } from "@testing-library/svelte";
+import { tick } from "svelte";
+import RackDevice from "$lib/components/RackDevice.svelte";
+import { createTestDeviceType } from "./factories";
+import { getCurrentDragData } from "$lib/utils/dragdrop";
+import {
+  getDragTooltipState,
+  hideDragTooltip,
+} from "$lib/stores/dragTooltip.svelte";
+
+describe("RackDevice Escape-to-cancel drag (#2935)", () => {
+  afterEach(() => {
+    // The tooltip store is a module-level singleton; clear it so a failed
+    // assertion in one test cannot leak visible state into the next.
+    hideDragTooltip();
+  });
+
+  it("aborts an active device drag and clears shared drag/tooltip state", async () => {
+    const device = createTestDeviceType({
+      slug: "test-server",
+      u_height: 1,
+    });
+    const ondragend = vi.fn();
+
+    const { getByTestId } = render(RackDevice, {
+      props: {
+        device,
+        position: 6,
+        rackHeight: 42,
+        rackId: "rack-1",
+        deviceIndex: 0,
+        selected: false,
+        uHeight: 30,
+        rackWidth: 300,
+        ondragend,
+      },
+    });
+
+    const hitbox = getByTestId("rack-device-hitbox");
+
+    hitbox.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        isPrimary: true,
+        pointerId: 1,
+        clientX: 0,
+        clientY: 0,
+      }),
+    );
+    hitbox.dispatchEvent(
+      new PointerEvent("pointermove", {
+        bubbles: true,
+        isPrimary: true,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 20,
+      }),
+    );
+    await tick();
+
+    // Precondition: the move crossed the drag threshold and the shared drag
+    // state reflects an active drag.
+    expect(getCurrentDragData()).not.toBeNull();
+    expect(getDragTooltipState().visible).toBe(true);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await tick();
+
+    expect(getCurrentDragData()).toBeNull();
+    expect(getDragTooltipState().visible).toBe(false);
+    expect(ondragend).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when Escape is pressed while no drag is active", async () => {
+    const device = createTestDeviceType({
+      slug: "test-server",
+      u_height: 1,
+    });
+    const ondragend = vi.fn();
+
+    render(RackDevice, {
+      props: {
+        device,
+        position: 6,
+        rackHeight: 42,
+        rackId: "rack-1",
+        deviceIndex: 0,
+        selected: false,
+        uHeight: 30,
+        rackWidth: 300,
+        ondragend,
+      },
+    });
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await tick();
+
+    expect(ondragend).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/rack-pointer-drag.dragcancel.test.ts
+++ b/src/tests/rack-pointer-drag.dragcancel.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test for #2935: aborting an in-progress device drag with Escape
+ * left a stale drop-target highlight behind. RackDevice's pointercancel/drop
+ * paths only clear a Rack's local preview via the "rackula:dragmove" /
+ * "rackula:dragend" document events; Escape had no equivalent, so the last
+ * computed drop preview (and container hover highlight) stayed rendered
+ * after the drag was aborted. attachPointerDragListeners must also listen
+ * for a "rackula:dragcancel" event that clears both without dispatching a
+ * drop action.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  attachPointerDragListeners,
+  type PointerDragContext,
+} from "$lib/utils/rack-pointer-drag";
+import type { Rack } from "$lib/types";
+
+function createContext(
+  overrides: Partial<PointerDragContext> = {},
+): PointerDragContext {
+  return {
+    getSvgElement: () => null,
+    getRack: () => ({ id: "rack-1" }) as Rack,
+    getDeviceLibrary: () => [],
+    getRackDims: () => ({
+      rackHeight: 0,
+      rackWidth: 0,
+      interiorWidth: 0,
+      uHeight: 0,
+      rackPadding: 0,
+      railWidth: 0,
+    }),
+    getFaceFilter: () => undefined,
+    getSelectedDeviceId: () => null,
+    getEventCallbacks: () => ({}),
+    setDropPreview: vi.fn(),
+    setContainerHoverInfo: vi.fn(),
+    onDragFinished: vi.fn(),
+    layoutStore: {} as PointerDragContext["layoutStore"],
+    toastStore: {} as PointerDragContext["toastStore"],
+    ...overrides,
+  };
+}
+
+describe("attachPointerDragListeners rackula:dragcancel (#2935)", () => {
+  it("clears the drop preview and container hover info without dispatching a drop", () => {
+    const setDropPreview = vi.fn();
+    const setContainerHoverInfo = vi.fn();
+    const onDragFinished = vi.fn();
+    const ctx = createContext({
+      setDropPreview,
+      setContainerHoverInfo,
+      onDragFinished,
+    });
+
+    const detach = attachPointerDragListeners(ctx);
+
+    document.dispatchEvent(new CustomEvent("rackula:dragcancel"));
+
+    expect(setDropPreview).toHaveBeenCalledWith(null);
+    expect(setContainerHoverInfo).toHaveBeenCalledWith(null);
+    // A cancelled drag never resolves or dispatches a drop action.
+    expect(onDragFinished).not.toHaveBeenCalled();
+
+    detach();
+  });
+
+  it("stops listening for rackula:dragcancel after detach", () => {
+    const setDropPreview = vi.fn();
+    const ctx = createContext({ setDropPreview });
+
+    const detach = attachPointerDragListeners(ctx);
+    detach();
+
+    document.dispatchEvent(new CustomEvent("rackula:dragcancel"));
+
+    expect(setDropPreview).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/rack-pointer-drag.dragcancel.test.ts
+++ b/src/tests/rack-pointer-drag.dragcancel.test.ts
@@ -5,8 +5,14 @@
  * "rackula:dragend" document events; Escape had no equivalent, so the last
  * computed drop preview (and container hover highlight) stayed rendered
  * after the drag was aborted. attachPointerDragListeners must also listen
- * for a "rackula:dragcancel" event that clears both without dispatching a
- * drop action.
+ * for a "rackula:dragcancel" event that clears both.
+ *
+ * It must also arm the click-suppression debounce (onDragFinished), the same
+ * one the dragend path uses: the browser synthesises a trailing click on the
+ * pointer release that follows the Escape cancel, and without arming the
+ * debounce that click would select the rack or place a pending device
+ * (CodeAnt review of PR #2970). onDragFinished arms suppression only; it does
+ * not resolve or dispatch a drop.
  */
 import { describe, it, expect, vi } from "vitest";
 import {
@@ -43,7 +49,7 @@ function createContext(
 }
 
 describe("attachPointerDragListeners rackula:dragcancel (#2935)", () => {
-  it("clears the drop preview and container hover info without dispatching a drop", () => {
+  it("clears the drop preview and container hover info and arms the click debounce", () => {
     const setDropPreview = vi.fn();
     const setContainerHoverInfo = vi.fn();
     const onDragFinished = vi.fn();
@@ -59,8 +65,10 @@ describe("attachPointerDragListeners rackula:dragcancel (#2935)", () => {
 
     expect(setDropPreview).toHaveBeenCalledWith(null);
     expect(setContainerHoverInfo).toHaveBeenCalledWith(null);
-    // A cancelled drag never resolves or dispatches a drop action.
-    expect(onDragFinished).not.toHaveBeenCalled();
+    // Arm the same debounce dragend uses so the browser's trailing synthetic
+    // click after the pointer release does not select the rack or place a
+    // pending device.
+    expect(onDragFinished).toHaveBeenCalledTimes(1);
 
     detach();
   });


### PR DESCRIPTION
## **User description**
## Summary

- In-progress device drags (`RackDevice.svelte`), canvas resize drags, and bay drags (`RackCanvasView.svelte`) previously reset only on a browser-issued `pointercancel`, drop, or `pointerup`. Pressing Escape mid-drag had no effect.
- Each drag now installs a window Escape listener while active, sharing the exact same cancel path as the existing `pointercancel` handler (`cancelActiveDrag` / `cancelResizeDrag` / `cancelBayDrag`) so the reset logic cannot drift between the two triggers.
- Cancelling a device drag also broadcasts a new `rackula:dragcancel` document event so every `Rack` listening for the pointer-drag events (the Safari #397 workaround, `rack-pointer-drag.ts`) clears its local drop-preview/hover highlight instead of leaving a stale highlight on screen after the abort. The same gap existed for a real browser `pointercancel`; fixed for both triggers together.

## Files changed

- `src/lib/components/RackDevice.svelte`: extracted `cancelActiveDrag()`, added an Escape-active-while-dragging window listener, dispatches `rackula:dragcancel`, added `data-testid="rack-device-hitbox"` for test targeting.
- `src/lib/components/RackCanvasView.svelte`: extracted `cancelResizeDrag()` / `cancelBayDrag()`, added an Escape-active-while-dragging window listener covering both.
- `src/lib/utils/rack-pointer-drag.ts`: added a `rackula:dragcancel` listener that clears drop-preview/container-hover state without dispatching a drop.
- `src/tests/RackDevice.escape-cancel-drag.test.ts` (new): Escape aborts an active device drag and clears shared drag/tooltip state.
- `src/tests/RackCanvasView.escape-cancel-resize.test.ts` (new): Escape aborts an active resize drag and restores the rack's pre-drag height.
- `src/tests/rack-pointer-drag.dragcancel.test.ts` (new): `rackula:dragcancel` clears preview/hover without dispatching a drop.

## Test plan

- [x] `npm run lint` - clean
- [x] `npm run check` - 0 errors
- [x] `npm run test:run` - 3288/3288 passing
- [x] `npm run build` - succeeds
- [x] New tests written first (TDD), watched RED, then GREEN after implementation

Closes #2935


___

## **CodeAnt-AI Description**
**Escape now cancels in-progress rack drags without leaving stale preview state**

### What Changed
- Pressing Escape now aborts an active device drag, resize drag, or bay drag
- Cancelled device drags clear the shared drag tooltip and remove any leftover drop or hover highlight
- Cancelled resize drags restore the rack to its height before the drag started
- Cancelled bay drags are discarded without applying the change

### Impact
`✅ Escape can stop accidental rack drags`
`✅ Fewer stuck drop highlights after drag aborts`
`✅ Restores the previous rack size after cancelled resizing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
