### PR TITLE
fix: defer URL.revokeObjectURL after YAML download click (#2934)

### DIFF
--- a/src/lib/components/LayoutYamlPanel.svelte
+++ b/src/lib/components/LayoutYamlPanel.svelte
@@ -222,7 +222,10 @@
     link.href = url;
     link.download = buildYamlFilename(layout.name);
     link.click();
-    URL.revokeObjectURL(url);
+    // Defer revocation so the URL stays valid while the browser starts the
+    // download. Revoking synchronously can race the download start and
+    // produce intermittent failed or empty downloads.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
   async function commitParsedLayout(parsed: ParsedYaml): Promise<void> {

--- a/src/tests/LayoutYamlPanel.test.ts
+++ b/src/tests/LayoutYamlPanel.test.ts
@@ -24,6 +24,53 @@ describe("LayoutYamlPanel", () => {
     vi.restoreAllMocks();
   });
 
+  describe("download", () => {
+    let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      revokeObjectURL = vi.fn();
+      vi.stubGlobal("URL", {
+        ...URL,
+        createObjectURL: vi.fn(() => "blob:mock-url"),
+        revokeObjectURL,
+      });
+      // happy-dom anchors throw on click navigation; suppress the no-op click.
+      vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+        () => {},
+      );
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it("defers revoking the download object URL to a later tick", async () => {
+      render(LayoutYamlPanel, {
+        props: { open: true, layout: baseLayout, onapply: vi.fn() },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("yaml-textarea")).toHaveDisplayValue(
+          /name: Baseline Layout/,
+        );
+      });
+
+      await fireEvent.click(
+        screen.getByRole("button", { name: "Download YAML" }),
+      );
+
+      // The download may begin asynchronously after click(); revoking now
+      // would invalidate the URL before the browser fetches it.
+      expect(revokeObjectURL).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+
+      expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:mock-url");
+    });
+  });
+
   it("blocks invalid YAML apply and applies once content is valid", async () => {
     const onApply = vi.fn();
     render(LayoutYamlPanel, {


### PR DESCRIPTION
## **User description**
## Summary

`URL.revokeObjectURL(url)` was called synchronously in the same frame as `link.click()` in `LayoutYamlPanel.handleDownload()`, which can cancel the download in some browsers by invalidating the blob URL before the browser starts fetching it. This defers the revoke with `setTimeout(..., 0)` to match the safe pattern already used in `export/utils.ts`'s `downloadBlob()`.

## Files changed

- `src/lib/components/LayoutYamlPanel.svelte`: defer `URL.revokeObjectURL(url)` via `setTimeout(..., 0)` after `link.click()`.
- `src/tests/LayoutYamlPanel.test.ts`: add a `download` describe block asserting the revoke is not called synchronously and fires on a later tick, with `beforeEach`/`afterEach` teardown for the fake timers and stubbed `URL`.

## Test plan

- [x] `npm run lint`
- [x] `npm run check`
- [x] `npm run test:run` (3283 tests pass)
- [x] `npm run build`

Closes #2934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
**Keep YAML downloads from failing in some browsers**

### What Changed
- YAML downloads now keep the download link valid long enough for the browser to start fetching the file, which prevents intermittent empty or failed downloads.
- Added a test that confirms the download URL is not revoked immediately and is cleared on a later tick.

### Impact
`✅ Fewer failed YAML downloads`
`✅ Fewer empty export files`
`✅ More reliable layout exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
