### PR TITLE
fix: harden ZIP image validation (writer parity, pre-alloc cap, extension parity) (#2972)

### DIFF
--- a/src/lib/utils/archive-extract.ts
+++ b/src/lib/utils/archive-extract.ts
@@ -125,6 +125,18 @@ export async function getJSZip(): Promise<JSZipConstructor> {
 const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "webp"];
 
 /**
+ * File extension to expected image MIME type, for the extension-to-content
+ * parity check. Every key is an allowed raster extension (IMAGE_EXTENSIONS); the
+ * detected magic-byte MIME must match the extension's entry here (#2972).
+ */
+const EXTENSION_TO_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+};
+
+/**
  * Archive extraction limits (guardrails)
  */
 const LIMITS = {
@@ -299,15 +311,21 @@ export async function extractFolderArchive(
   // re-inflates only the YAML/image files it needs; that overlap is small and
   // bounded by the per-file caps below.
   let totalUncompressedSize = 0;
+  // Retain each entry's measured inflated size so image extraction can reject an
+  // oversized entry BEFORE inflating it into memory, reusing this streamed
+  // measurement instead of inflating a second time just to check the cap (#2972).
+  const uncompressedSizes = new Map<string, number>();
   for (const name of entries) {
     const file = zip.files[name];
     if (!file || file.dir) continue;
     // Pass the remaining global budget as this entry's cap so the stream aborts
     // as soon as the cumulative total would exceed the limit.
-    totalUncompressedSize += await measureUncompressedSize(
+    const size = await measureUncompressedSize(
       file,
       LIMITS.MAX_TOTAL_UNCOMPRESSED_BYTES - totalUncompressedSize,
     );
+    uncompressedSizes.set(name, size);
+    totalUncompressedSize += size;
   }
 
   const ratio = totalUncompressedSize / blob.size;
@@ -325,11 +343,11 @@ export async function extractFolderArchive(
   }
 
   if (format.type === "new-folder") {
-    return await extractNewFormatZip(zip, format);
+    return await extractNewFormatZip(zip, format, uncompressedSizes);
   }
 
   // Old flat format
-  return await extractOldFormatZip(zip, format);
+  return await extractOldFormatZip(zip, format, uncompressedSizes);
 }
 
 /**
@@ -339,6 +357,7 @@ export async function extractFolderArchive(
 async function extractNewFormatZip(
   zip: JSZipInstance,
   format: ZipFormat,
+  uncompressedSizes: Map<string, number>,
 ): Promise<{ layout: Layout; images: ImageStoreMap; failedImages: string[] }> {
   // Extract YAML
   const yamlPath = format.yamlPath;
@@ -395,6 +414,7 @@ async function extractNewFormatZip(
         deviceSlug,
         filename,
         layoutId,
+        uncompressedSizes,
       );
 
       if (result.error) {
@@ -419,6 +439,7 @@ async function extractNewFormatZip(
 async function extractOldFormatZip(
   zip: JSZipInstance,
   format: ZipFormat,
+  uncompressedSizes: Map<string, number>,
 ): Promise<{ layout: Layout; images: ImageStoreMap; failedImages: string[] }> {
   // Extract YAML from root
   const yamlPath = format.yamlPath;
@@ -473,6 +494,7 @@ async function extractOldFormatZip(
         deviceSlug,
         filename,
         layoutId,
+        uncompressedSizes,
       );
 
       if (result.error) {
@@ -501,6 +523,8 @@ async function extractOldFormatZip(
           imagePath,
           deviceSlug,
           filename,
+          "",
+          uncompressedSizes,
         );
 
         if (result.error) {
@@ -529,6 +553,7 @@ async function extractImageFromZip(
   deviceSlug: string,
   filename: string,
   layoutId: string = "",
+  uncompressedSizes?: Map<string, number>,
 ): Promise<{
   imageKey?: string;
   face?: "front" | "rear";
@@ -560,21 +585,43 @@ async function extractImageFromZip(
   const imageFile = zip.file(imagePath);
   if (!imageFile) return { error: true };
 
+  // Reject an oversized entry BEFORE inflating it into memory, using the
+  // inflated size already measured by the preflight guard so we do not stream or
+  // allocate the entry twice (#2972). The map is populated for every non-dir
+  // entry; a missing size falls through to the post-decode byteLength backstop.
+  const measuredSize = uncompressedSizes?.get(imagePath);
+  if (measuredSize !== undefined && measuredSize > MAX_IMAGE_SIZE_BYTES) {
+    archiveDebug.extract("Image exceeds size cap: %s", imagePath);
+    return { error: true };
+  }
+
   try {
     // Never trust the file extension or JSZip's extension-inferred blob type:
     // decode the real bytes and validate them the same way the YAML
     // embedded-image path does (detectImageMime + allowlist + size cap, #2933).
     const bytes = await imageFile.async("uint8array");
 
+    // Backstop the pre-decode size gate for any entry missing from the map.
     if (bytes.byteLength > MAX_IMAGE_SIZE_BYTES) {
       archiveDebug.extract("Image exceeds size cap: %s", imagePath);
       return { error: true };
     }
 
+    // Sniff the real bytes, require an allowlisted raster format, AND require the
+    // detected format to match the filename extension. That extension-to-content
+    // parity mirrors the YAML path's declared-vs-detected check, so a file named
+    // front.png carrying JPEG/WebP bytes is rejected rather than silently
+    // accepted (#2972).
     const detected = detectImageMime(bytes);
-    if (!detected || !SUPPORTED_IMAGE_FORMATS.includes(detected)) {
+    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+    const expected = EXTENSION_TO_MIME[ext];
+    if (
+      !detected ||
+      !SUPPORTED_IMAGE_FORMATS.includes(detected) ||
+      detected !== expected
+    ) {
       archiveDebug.extract(
-        "Rejected image with unsupported or unrecognised format: %s",
+        "Rejected image with unsupported, unrecognised, or mismatched format: %s",
         imagePath,
       );
       return { error: true };

--- a/src/lib/utils/archive.ts
+++ b/src/lib/utils/archive.ts
@@ -48,26 +48,26 @@ type JSZipConstructor = typeof import("jszip");
 type JSZipInstance = ReturnType<JSZipConstructor>;
 
 /**
- * MIME type to file extension mapping
+ * MIME type to file extension mapping.
+ *
+ * Raster-only, matching the reader's IMAGE_EXTENSIONS and SUPPORTED_IMAGE_FORMATS
+ * allowlist. gif/svg are deliberately absent so the writer never emits a
+ * `.gif`/`.svg` asset the reader would then reject on re-import (#2972).
  */
 const MIME_TO_EXTENSION: Record<string, string> = {
   "image/png": "png",
   "image/jpeg": "jpg",
   "image/webp": "webp",
-  "image/gif": "gif",
-  "image/svg+xml": "svg",
 };
 
 /**
- * File extension to MIME type mapping
+ * File extension to MIME type mapping (raster-only, see MIME_TO_EXTENSION).
  */
 const EXTENSION_TO_MIME: Record<string, string> = {
   png: "image/png",
   jpg: "image/jpeg",
   jpeg: "image/jpeg",
   webp: "image/webp",
-  gif: "image/gif",
-  svg: "image/svg+xml",
 };
 
 /**

--- a/src/tests/archive-format.test.ts
+++ b/src/tests/archive-format.test.ts
@@ -200,6 +200,46 @@ describe("extractFolderArchive", () => {
       expect(result.images.has("test-device")).toBe(false);
       expect(result.failedImages).toEqual([]);
     });
+
+    it("rejects a raster image whose content does not match its extension (#2972)", async () => {
+      const zip = new JSZip();
+      const folderName = "My Layout-550e8400-e29b-41d4-a716-446655440000";
+      const folder = zip.folder(folderName);
+      folder?.file("my-layout.rackula.yaml", SAMPLE_LAYOUT_YAML);
+
+      // Named front.png but the bytes are a real JPEG (FF D8 FF). Both are
+      // allowlisted raster formats, so the allowlist alone accepts it; only an
+      // extension-to-content parity check (like the YAML declared-vs-detected
+      // check) rejects the mismatch.
+      const assetsFolder = folder?.folder("assets")?.folder("test-device");
+      const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+      assetsFolder?.file("front.png", jpegBytes);
+
+      const blob = await zip.generateAsync({ type: "blob" });
+      const result = await extractFolderArchive(blob);
+
+      expect(result.images.has("test-device")).toBe(false);
+      expect(result.failedImages).toContain(
+        `${folderName}/assets/test-device/front.png`,
+      );
+    });
+
+    it("accepts a correctly-labelled JPEG (.jpg with JPEG bytes)", async () => {
+      const zip = new JSZip();
+      const folderName = "My Layout-550e8400-e29b-41d4-a716-446655440000";
+      const folder = zip.folder(folderName);
+      folder?.file("my-layout.rackula.yaml", SAMPLE_LAYOUT_YAML);
+
+      const assetsFolder = folder?.folder("assets")?.folder("test-device");
+      const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+      assetsFolder?.file("front.jpg", jpegBytes);
+
+      const blob = await zip.generateAsync({ type: "blob" });
+      const result = await extractFolderArchive(blob);
+
+      expect(result.images.get("test-device")?.front).toBeDefined();
+      expect(result.failedImages).toEqual([]);
+    });
   });
 
   describe("format precedence", () => {


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #2933 / PR #2968 addressing the three CodeAnt review findings raised on that PR. None reintroduced the SVG/GIF vulnerability #2933 closed, but all three are legitimate hardening gaps in the ZIP image path, so they are closed here rather than left open.

1. Writer/reader format parity. The reader dropped `gif`/`svg` from `IMAGE_EXTENSIONS`, but the writer's `MIME_TO_EXTENSION` / `EXTENSION_TO_MIME` (`archive.ts`) still mapped `image/gif` and `image/svg+xml`, so the exporter could emit `.gif`/`.svg` assets the reader now silently drops. Those mappings are removed so writer and reader share one raster-only policy.

2. Pre-allocation size cap. `extractImageFromZip` enforced the per-image cap only after inflating the whole entry via `async("uint8array")`. The preflight guard already streams each entry's real uncompressed size; those sizes are now retained in a map and an oversized image is rejected before the full allocation, reusing the existing measurement (no extra inflation). The post-decode `byteLength` check stays as a backstop.

3. Extension-to-content parity. A `front.png` carrying valid JPEG/WebP bytes was accepted because only the detected MIME was allowlist-checked. The detected magic-byte MIME must now also match the filename extension, mirroring the YAML path's declared-vs-detected check. Correctly labelled images (`.jpg` with JPEG bytes, etc.) still load.

## Files changed

- `src/lib/utils/archive-extract.ts`: pre-allocation size gate via retained preflight sizes; extension-to-content parity check; `EXTENSION_TO_MIME` map.
- `src/lib/utils/archive.ts`: writer MIME maps narrowed to raster-only.
- `src/tests/archive-format.test.ts`: parity rejection test (JPEG bytes in `.png`) plus a correctly-labelled-JPEG positive control.

## Test plan

- [x] `npm run lint`
- [x] `npm run check` (svelte-check, typed change, 0 errors)
- [x] `npm run test:run` (3293 tests pass)
- [x] `npm run build`
- [x] New parity test written first, watched fail (RED), then implementation made it pass (GREEN)

## Acceptance criteria

- [x] Writer never emits `.gif`/`.svg` extensions
- [x] Oversized ZIP image entries are rejected before full in-memory allocation
- [x] A raster image whose bytes do not match its filename extension is rejected

Closes #2972

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
**Harden ZIP image imports so invalid or mismatched images are rejected earlier**

### What Changed
- ZIP image imports now reject files whose content does not match their filename extension, so a `.png` that contains JPEG/WebP data is no longer accepted.
- Oversized images are now blocked before full decoding when their uncompressed size is already known, reducing wasted work on large archive entries.
- ZIP exports now avoid writing `.gif` and `.svg` images, keeping exported files aligned with what imports will accept.
- Added coverage for mismatched image extensions and a valid JPEG case.

### Impact
`✅ Fewer invalid images imported from ZIP files`
`✅ Lower chance of large-image memory spikes during archive import`
`✅ Fewer export/import mismatches for image files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
