### PR TITLE
fix: ConfirmDialog Enter guard covers close/X button (#2975)

### DIFF
--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -27,9 +27,6 @@
     oncancel,
   }: Props = $props();
 
-  let cancelButtonEl: HTMLButtonElement | undefined = $state();
-  let confirmButtonEl: HTMLButtonElement | undefined = $state();
-
   function handleConfirm() {
     onconfirm?.();
   }
@@ -39,14 +36,15 @@
   }
 
   // Enter confirms as a convenience shortcut, but only when focus isn't
-  // already on one of the dialog's own buttons. When Cancel or Confirm is
-  // focused, native button activation (Enter -> click) decides which action
-  // fires; intercepting unconditionally here suppressed that native
-  // activation and always confirmed, even with Cancel focused.
+  // already on a button within the dialog (Cancel, Confirm, or the Dialog's
+  // own close/X control). When a button is focused, native button activation
+  // (Enter -> click) decides which action fires; intercepting unconditionally
+  // here suppressed that native activation and always confirmed, even with
+  // Cancel or the close button focused (#2919, #2975).
   function handleKeyDown(event: KeyboardEvent) {
     if (event.key !== "Enter") return;
     const active = document.activeElement;
-    if (active === cancelButtonEl || active === confirmButtonEl) return;
+    if (active instanceof HTMLButtonElement) return;
 
     event.preventDefault();
     handleConfirm();
@@ -71,7 +69,6 @@
 
     <div class="actions">
       <button
-        bind:this={cancelButtonEl}
         type="button"
         class="btn btn-secondary"
         data-testid="btn-cancel-confirm"
@@ -80,7 +77,6 @@
         {cancelLabel}
       </button>
       <button
-        bind:this={confirmButtonEl}
         type="button"
         class="btn {destructive ? 'btn-destructive' : 'btn-primary'}"
         data-testid="btn-confirm-action"

--- a/src/tests/ConfirmDialog.test.ts
+++ b/src/tests/ConfirmDialog.test.ts
@@ -44,6 +44,31 @@ describe("ConfirmDialog keyboard behaviour", () => {
     expect(onconfirm).not.toHaveBeenCalled();
   });
 
+  it("does not confirm when Enter is pressed while the close/X button is focused (#2975)", async () => {
+    const user = userEvent.setup();
+    const onconfirm = vi.fn();
+    const oncancel = vi.fn();
+
+    render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: "Delete Device Type",
+        message: 'Delete "Test Device"? This will remove it from your library.',
+        onconfirm,
+        oncancel,
+      },
+    });
+
+    // The dialog auto-focuses the close button on open; wait for that to
+    // settle so the Enter below targets it deterministically.
+    const closeButton = screen.getByRole("button", { name: "Close dialog" });
+    await waitFor(() => expect(closeButton).toHaveFocus());
+
+    await user.keyboard("{Enter}");
+
+    expect(onconfirm).not.toHaveBeenCalled();
+  });
+
   it("does not react to Enter while closed, and stops reacting once closed again", async () => {
     const onconfirm = vi.fn();
     const oncancel = vi.fn();


### PR DESCRIPTION
## **User description**
## Summary

Fixes the residual of #2919: pressing Enter while focus was on the ConfirmDialog's close ("X") button still fell through to `handleConfirm()` and fired the destructive confirm.

The Enter-confirm shortcut guard only exempted the Cancel and Confirm buttons by reference (`active === cancelButtonEl || active === confirmButtonEl`). The Dialog's close/X control (rendered by the child `Dialog.svelte` via bits-ui's `Dialog.Close`, a native `<button>`) was neither, so Enter on it confirmed.

## Fix

Replace the two-button reference check with `document.activeElement instanceof HTMLButtonElement`. Enter now defers to native button activation for any focused button in the dialog, covering the close/X control and any future buttons, while keeping the intent that Enter confirms only when focus is not on a button.

The `cancelButtonEl` / `confirmButtonEl` `$state` refs became unused (only ever written via `bind:this`, never read) and are removed along with their bindings, per the no-dead-code policy.

## Files changed

- `src/lib/components/ConfirmDialog.svelte`: generalize the Enter guard; drop the now-dead button refs and `bind:this` bindings.
- `src/tests/ConfirmDialog.test.ts`: add a regression test (Enter while the close/X button is focused does not confirm).

## Test plan

- [x] New failing test written first, watched fail (confirm fired once), then passes after the fix.
- [x] `npm run test:run` (3303 tests pass), `npm run lint` (clean), `npm run check` (svelte-check 0 errors), `npm run build` (clean).
- [x] Pre-existing #2919 tests untouched and still passing (Enter cancels when Cancel focused; Enter is a no-op while closed).

Closes #2975


___

## **CodeAnt-AI Description**
**Pressing Enter on the dialog’s close button no longer triggers delete**

### What Changed
- Enter now follows the focused button’s normal action in the confirm dialog, including the close/X button
- Pressing Enter still confirms only when focus is not on a button in the dialog
- Added a regression test to cover the close/X button case

### Impact
`✅ Fewer accidental deletes from keyboard use`
`✅ Safer confirm dialogs`
`✅ Clearer keyboard behavior in dialogs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
