### PR TITLE
fix: gate rack undo active-rack restore on whether execute activated (#2976)

### DIFF
--- a/src/lib/stores/commands/rack.ts
+++ b/src/lib/stores/commands/rack.ts
@@ -109,7 +109,12 @@ export function createAddRackCommand(
     },
     undo() {
       store.deleteRackRaw(rackCopy.id);
-      store.setActiveRackId(previousActiveRackId);
+      // Only restore the active rack if execute() actually changed it
+      // (setActive: true); otherwise the snapshot is stale and would
+      // clobber whatever is active now (#2976).
+      if (setActive) {
+        store.setActiveRackId(previousActiveRackId);
+      }
       if (layoutNameSync) {
         const { previousLayoutName, previousMetadataName } =
           layoutNameSync.snapshot;
@@ -138,6 +143,10 @@ export function createDeleteRackCommand(
   // Captured on each execute() so undo restores whichever rack was active
   // immediately before this delete ran (#2940).
   let previousActiveRackId: string | null = null;
+  // Tracks whether this rack was the active one at execute() time, i.e.
+  // whether execute() actually changed the active selection (deleteRackRaw
+  // falls back to another rack when the deleted rack was active).
+  let wasActiveAtExecute = false;
 
   return {
     type: "DELETE_RACK",
@@ -145,6 +154,7 @@ export function createDeleteRackCommand(
     timestamp: Date.now(),
     execute() {
       previousActiveRackId = store.getActiveRackId();
+      wasActiveAtExecute = previousActiveRackId === rackSnapshot.id;
       const result = store.deleteRackRaw(rackSnapshot.id);
       if (result && originalIndex === undefined) {
         originalIndex = result.index;
@@ -152,7 +162,13 @@ export function createDeleteRackCommand(
     },
     undo() {
       store.restoreRackRaw(rackSnapshot, groupSnapshots, originalIndex);
-      store.setActiveRackId(previousActiveRackId);
+      // Only restore the active rack if execute() actually changed it
+      // (this rack was active and deleteRackRaw fell back to another one);
+      // otherwise the snapshot is stale and would clobber whatever is
+      // active now (#2976).
+      if (wasActiveAtExecute) {
+        store.setActiveRackId(previousActiveRackId);
+      }
     },
   };
 }

--- a/src/tests/rack-undo.test.ts
+++ b/src/tests/rack-undo.test.ts
@@ -469,6 +469,31 @@ describe("Rack Add/Delete Undo/Redo", () => {
       store.undo();
       expect(store.activeRackId).toBe(bay2!.id);
     });
+
+    it("undo of a non-active rack delete leaves the current active rack unchanged", () => {
+      const store = getLayoutStore();
+      const rackA = store.addRack("Rack A", 42)!;
+      const rackB = store.addRack("Rack B", 42)!;
+      const rackC = store.addRack("Rack C", 42)!;
+      store.setActiveRack(rackA.id);
+      store.clearHistory();
+      expect(store.activeRackId).toBe(rackA.id);
+
+      // Deleting a non-active rack (C) does not change the active rack,
+      // so the delete command's wasActiveAtExecute flag stays false.
+      store.deleteRack(rackC.id);
+      expect(store.activeRackId).toBe(rackA.id);
+
+      // User selects a different, pre-existing rack before undoing.
+      store.setActiveRack(rackB.id);
+      expect(store.activeRackId).toBe(rackB.id);
+
+      store.undo();
+
+      // The delete never changed the active rack on execute, so its undo
+      // must not restore the stale snapshot and clobber this selection.
+      expect(store.activeRackId).toBe(rackB.id);
+    });
   });
 
   describe("undo/redo state consistency", () => {

--- a/src/tests/rack-undo.test.ts
+++ b/src/tests/rack-undo.test.ts
@@ -415,6 +415,62 @@ describe("Rack Add/Delete Undo/Redo", () => {
     });
   });
 
+  describe("undo does not clobber active rack for non-activating commands (#2976)", () => {
+    it("undo of a non-activating rack add leaves the current active rack unchanged", () => {
+      const store = getLayoutStore();
+      const group = store.addBayedRackGroup("Test Bay", 2, 42, 19)!;
+      const [bay1, bay2] = group.racks;
+      store.clearHistory();
+      expect(store.activeRackId).toBe(bay1!.id);
+
+      // addBayToGroup adds a new rack without activating it.
+      const addResult = store.addBayToGroup(group.group.id);
+      expect(addResult.error).toBeUndefined();
+      expect(store.activeRackId).toBe(bay1!.id);
+
+      // User selects an unrelated, pre-existing rack before undoing.
+      store.setActiveRack(bay2!.id);
+      expect(store.activeRackId).toBe(bay2!.id);
+
+      store.undo();
+
+      // The undone command never activated anything on execute, so its
+      // undo must not restore its stale pre-execute snapshot either.
+      expect(store.activeRackId).toBe(bay2!.id);
+    });
+
+    it("undoing an earlier non-activating command does not clobber a later selection change in a compound undo sequence", () => {
+      const store = getLayoutStore();
+      const group = store.addBayedRackGroup("Test Bay", 2, 42, 19)!;
+      const [bay1, bay2] = group.racks;
+      store.clearHistory();
+      expect(store.activeRackId).toBe(bay1!.id);
+
+      // Earlier command: non-activating add (history entry #1).
+      const addResult = store.addBayToGroup(group.group.id);
+      expect(addResult.error).toBeUndefined();
+      expect(store.activeRackId).toBe(bay1!.id);
+
+      // Later command: activating add (history entry #2).
+      const extraRack = store.addRack("Extra Rack", 42)!;
+      expect(store.activeRackId).toBe(extraRack.id);
+
+      // Undo the later, activating command - this correctly restores
+      // the rack that was active before it ran.
+      store.undo();
+      expect(store.activeRackId).toBe(bay1!.id);
+
+      // User selects a different, unrelated rack before continuing to undo.
+      store.setActiveRack(bay2!.id);
+      expect(store.activeRackId).toBe(bay2!.id);
+
+      // Undo the earlier, non-activating command. It never touched the
+      // active rack on execute, so it must not clobber this selection.
+      store.undo();
+      expect(store.activeRackId).toBe(bay2!.id);
+    });
+  });
+
   describe("undo/redo state consistency", () => {
     it("marks layout as dirty after undo", () => {
       const store = getLayoutStore();


### PR DESCRIPTION
## **User description**
## Summary

Fixes the residual CodeAnt finding from #2940 (merged via PR #2961): `createAddRackCommand.undo()` and `createDeleteRackCommand.undo()` restored the execute-time active-rack snapshot unconditionally, even when the command never changed the active selection on execute. In batch/bay/group compound-undo flows this could overwrite a selection made after the command ran with a stale snapshot.

## Changes

- `createAddRackCommand.undo()`: only restore the active rack when `setActive` was true on execute (the only case where execute actually changed the selection).
- `createDeleteRackCommand`: track `wasActiveAtExecute` (whether the deleted rack was the active one when execute ran, i.e. whether `deleteRackRaw`'s fallback actually moved the selection); `undo()` restores the active rack only when that flag is set.
- Both flags/snapshots are recomputed on every `execute()`, so redo cycles stay correct (mirrors the existing #2940 `previousActiveRackId` pattern).

## Testing

- [x] Unit tests pass (`npm run test:run`) - 3304 passed
- [ ] E2E tests pass (`npm run test:e2e`)
- [x] Manual testing completed - via new TDD tests

Two new failing-first tests in `src/tests/rack-undo.test.ts` under "undo does not clobber active rack for non-activating commands (#2976)":
1. Undo of a non-activating rack add (`addBayToGroup`) leaves the current active rack unchanged.
2. In a compound undo sequence, undoing an earlier non-activating command does not clobber a later selection change.

Also ran `npm run lint` (clean), `npm run check` (0 errors), `npm run build` (success).

Closes #2976


___

## **CodeAnt-AI Description**
**Undo no longer resets the active rack after commands that never changed it**

### What Changed
- Undo now keeps the currently selected rack when reversing a rack add that did not activate the new rack.
- Undo now keeps the currently selected rack when reversing a delete that never changed the active rack during execution.
- Added coverage for undoing a non-activating rack add and for compound undo flows where a later selection should stay in place.

### Impact
`✅ Fewer unexpected selection changes`
`✅ Safer undo in multi-step rack edits`
`✅ Clearer rack selection behavior after undo`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
