### PR TITLE
chore(lxc): verify Bun release checksum before install (#2943)

### DIFF
--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
+# build.func is sourced unpinned from ProxmoxVED@main by convention (every
+# community-scripts app does this; the branch is community-scripts-controlled).
+# An upstream compromise would run as root during CT creation. Accepted as a
+# residual supply-chain risk rather than pinned, to stay aligned with the
+# ecosystem norm. See issue #2943.
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: gVNS (ggfevans)
 # License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -39,8 +39,10 @@ BUN_ASSET="bun-linux-${BUN_VARIANT}.zip"
 curl_with_retry "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ASSET}" "$BUN_TMP/bun.zip"
 
 # Verify the downloaded zip against Bun's published SHASUMS256.txt before extracting.
+# Strip a leading '*' from the filename field so both text- and binary-mode
+# checksum formats (`<hash>  file` and `<hash> *file`) match.
 curl_with_retry "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" "$BUN_TMP/SHASUMS256.txt"
-BUN_EXPECTED_SHA=$(awk -v f="$BUN_ASSET" '$2 == f { print $1 }' "$BUN_TMP/SHASUMS256.txt")
+BUN_EXPECTED_SHA=$(awk -v f="$BUN_ASSET" '{ gsub(/^\*/, "", $2) } $2 == f { print $1 }' "$BUN_TMP/SHASUMS256.txt")
 if [[ -z "$BUN_EXPECTED_SHA" ]]; then
   msg_error "Checksum for ${BUN_ASSET} not found in Bun's SHASUMS256.txt (bun-v${BUN_VERSION})"
   rm -rf "$BUN_TMP"

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -35,7 +35,24 @@ case "$(uname -m)" in
     ;;
 esac
 BUN_TMP=$(mktemp -d)
-curl_with_retry "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_VARIANT}.zip" "$BUN_TMP/bun.zip"
+BUN_ASSET="bun-linux-${BUN_VARIANT}.zip"
+curl_with_retry "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ASSET}" "$BUN_TMP/bun.zip"
+
+# Verify the downloaded zip against Bun's published SHASUMS256.txt before extracting.
+curl_with_retry "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" "$BUN_TMP/SHASUMS256.txt"
+BUN_EXPECTED_SHA=$(awk -v f="$BUN_ASSET" '$2 == f { print $1 }' "$BUN_TMP/SHASUMS256.txt")
+if [[ -z "$BUN_EXPECTED_SHA" ]]; then
+  msg_error "Checksum for ${BUN_ASSET} not found in Bun's SHASUMS256.txt (bun-v${BUN_VERSION})"
+  rm -rf "$BUN_TMP"
+  exit 1
+fi
+BUN_ACTUAL_SHA=$(sha256sum "$BUN_TMP/bun.zip" | awk '{print $1}')
+if [[ "$BUN_EXPECTED_SHA" != "$BUN_ACTUAL_SHA" ]]; then
+  msg_error "Bun checksum verification failed for ${BUN_ASSET} (expected ${BUN_EXPECTED_SHA}, got ${BUN_ACTUAL_SHA})"
+  rm -rf "$BUN_TMP"
+  exit 1
+fi
+
 $STD unzip -o "$BUN_TMP/bun.zip" -d "$BUN_TMP"
 mkdir -p /usr/local/bun/bin
 install -m 755 "$BUN_TMP/bun-linux-${BUN_VARIANT}/bun" /usr/local/bun/bin/bun


### PR DESCRIPTION
## **User description**
## Summary

- Verify the downloaded Bun release zip against Bun's published `SHASUMS256.txt` before `unzip`/`install` in `deploy/lxc/community-scripts/install/rackula-install.sh`. Fails loudly (`msg_error` + `exit 1`) on a missing or mismatched checksum.
- Document `build.func`'s unpinned `ProxmoxVED@main` sourcing in `deploy/lxc/community-scripts/ct/rackula.sh` as an accepted residual supply-chain risk (community-scripts ecosystem convention), per maintainer decision on #2943. Sourcing itself is unchanged.

## Scope decision

Per maintainer direction, this PR does the Bun checksum verification only. `build.func` is intentionally left sourced from `ProxmoxVED@main` rather than pinned, to stay aligned with the convention every other community-scripts app follows; the residual risk is now documented explicitly instead of implicit.

## Files changed

- `deploy/lxc/community-scripts/install/rackula-install.sh`: fetch `SHASUMS256.txt` for the pinned `BUN_VERSION`, extract the expected hash for the resolved asset (`bun-linux-${BUN_VARIANT}.zip`), compare against `sha256sum` of the downloaded zip, abort on mismatch or missing entry.
- `deploy/lxc/community-scripts/ct/rackula.sh`: comment documenting the `build.func` residual-risk decision, no behavior change.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `shellcheck` on both modified scripts shows no new warnings (only pre-existing SC1090/SC1091 on the two `source` lines, unrelated to this change)
- [x] Verified end-to-end against Bun's real `bun-v1.3.14` release: downloaded the actual `bun-linux-x64.zip` and `SHASUMS256.txt`, confirmed the `awk` extraction and `sha256sum` comparison produce a correct match
- [x] Confirmed `catch_errors` (`set -Ee -o pipefail` + ERR trap, active earlier in the script) means a failed `curl_with_retry` for either the zip or `SHASUMS256.txt` already aborts the install
- No unit-test surface (shell script, deploy-only); this cannot affect the app's Vitest/E2E suites

Closes #2943


___

## **CodeAnt-AI Description**
**Verify Bun downloads before installing Rackula**

### What Changed
- Rackula now checks the downloaded Bun release zip against Bun's published checksum file before installing it.
- If the Bun checksum is missing or does not match, installation stops with a clear error instead of continuing.
- The LXC setup script now documents that one shared setup file is still loaded from the upstream community-scripts branch by design.

### Impact
`✅ Safer Rackula installs`
`✅ Fewer broken Bun installations`
`✅ Clearer install failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
