### PR TITLE
chore(security): add fallback meta CSP to index.html and login.html (#2937)

### DIFF
--- a/deploy/lxc/security-headers.conf
+++ b/deploy/lxc/security-headers.conf
@@ -26,4 +26,8 @@ add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 # the GH-Pages redirect shim was the only inline script and was removed), so no
 # hashes are needed. If a build-emitted inline script ever returns, pin its hash
 # here and in the Docker variant together.
+#
+# CROSS-REF: index.html and login.html carry a fallback <meta> CSP for hosting
+# paths that bypass nginx (bare static serves). That meta tag mirrors this
+# policy minus frame-ancestors (meta CSP cannot express it). Keep both in sync.
 add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;

--- a/deploy/security-headers.conf
+++ b/deploy/security-headers.conf
@@ -35,4 +35,8 @@ add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
 # - base-uri 'self': Prevent injected <base> tags from redirecting relative URL resolution
 # - form-action 'self': Restrict form submission targets to same origin
 # - frame-ancestors 'self': Prevent framing by other sites (reinforces X-Frame-Options)
+#
+# CROSS-REF: index.html and login.html carry a fallback <meta> CSP for hosting
+# paths that bypass nginx (bare static serves). That meta tag mirrors this
+# policy minus frame-ancestors (meta CSP cannot express it). Keep both in sync.
 add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;

--- a/index.html
+++ b/index.html
@@ -2,6 +2,15 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
+    <!-- Fallback CSP for hosting paths that bypass the nginx headers (see
+         deploy/security-headers.conf, the single source of truth for the
+         server-sent policy). Meta CSP cannot carry frame-ancestors (browsers
+         ignore it on a <meta> element), so clickjacking protection there is
+         server-only; a bare static serve loses that layer but keeps the rest. -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self';"
+    />
     <link
       rel="icon"
       type="image/png"

--- a/login.html
+++ b/login.html
@@ -2,6 +2,15 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
+    <!-- Fallback CSP for hosting paths that bypass the nginx headers (see
+         deploy/security-headers.conf, the single source of truth for the
+         server-sent policy). Meta CSP cannot carry frame-ancestors (browsers
+         ignore it on a <meta> element), so clickjacking protection there is
+         server-only; a bare static serve loses that layer but keeps the rest. -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self';"
+    />
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
## **User description**
## Summary

- Neither `index.html` nor `login.html` carried a client-side CSP, so any hosting path that serves the static build without `deploy/security-headers.conf` (a bare static serve bypassing nginx) shipped with no CSP at all.
- Adds a `<meta http-equiv="Content-Security-Policy">` fallback to both entrypoints, mirroring the nginx policy exactly, minus `frame-ancestors` (unsupported on a `<meta>` element per spec; clickjacking protection stays server-only via nginx's `X-Frame-Options` + `frame-ancestors`).
- Adds cross-reference comments in `deploy/security-headers.conf` and `deploy/lxc/security-headers.conf` pointing at the HTML files so future policy edits keep both in sync.

## Meta CSP applied

```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; base-uri 'self'; form-action 'self';
```

When nginx is also present, the browser enforces the intersection of the two policies. Since the meta content is a subset of the nginx header content (nginx additionally adds `frame-ancestors 'self'`, which meta can't express), the meta tag never becomes the *stricter* policy and can't break the app when both are in effect.

## Files changed

- `index.html`: added fallback meta CSP
- `login.html`: added fallback meta CSP
- `deploy/security-headers.conf`: cross-ref comment
- `deploy/lxc/security-headers.conf`: cross-ref comment

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check` (svelte-check) clean, 0 errors
- [x] `npm run build` succeeds
- [x] Verified via Playwright against a plain `vite preview` server (no CSP header sent, simulating the bare-serve gap this issue describes):
  - `index.html` and `login.html` load with no CSP-related console errors
  - `config.js` loads under `script-src 'self'`
  - Svelte scoped styles apply under `style-src 'unsafe-inline'`
  - An injected inline `<script>` was blocked by the browser with a CSP violation message, confirming the meta tag is actively enforced (not a dead no-op)

Closes #2937


___

## **CodeAnt-AI Description**
**Add a fallback Content Security Policy for static hosting**

### What Changed
- `index.html` and `login.html` now include a browser-side Content Security Policy, so the app still has CSP protection even when served without nginx headers
- The fallback policy matches the server policy for script, style, image, font, connect, base, and form rules
- Clickjacking protection remains server-only; the fallback covers the rest of the policy for bare static serves

### Impact
`✅ CSP protection on plain static hosting`
`✅ Fewer XSS risks when nginx headers are missing`
`✅ Safer login and app entry pages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
