### PR TITLE
chore(api): API security hardening (OIDC alg pin, path/schema caps, cookie enforcement) (#2942)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -320,14 +320,9 @@ export async function createApp(
     securityConfig.localCredentials = localCreds;
     // Scrub plaintext password from environment after hashing
     delete env.RACKULA_LOCAL_PASSWORD;
-    if (
-      securityConfig.isProduction &&
-      !securityConfig.authSessionCookieSecure
-    ) {
-      logger.warn(
-        "⚠ Local auth mode in production without Secure cookies. Set RACKULA_AUTH_SESSION_COOKIE_SECURE=true.",
-      );
-    }
+    // Insecure cookies in production are refused at config resolution
+    // (resolveApiSecurityConfig), not just warned about, so no check is
+    // needed here (#2942).
   }
 
   if (securityConfig.isProduction && securityConfig.allowInsecureCors) {

--- a/api/src/auth/config.ts
+++ b/api/src/auth/config.ts
@@ -13,6 +13,49 @@ const OIDC_DISCOVERY_PATH = "/.well-known/openid-configuration";
 interface OidcDiscoveryDocument {
   issuer: string;
   jwksUri: string;
+  /**
+   * The asymmetric ID-token signing algorithms the provider advertises. Used
+   * to pin `jwtVerify` so an attacker cannot substitute a weaker algorithm,
+   * while still working with any provider (not just RS256). See
+   * {@link resolveIdTokenSigningAlgs}.
+   */
+  idTokenSigningAlgs: string[];
+}
+
+// OIDC providers MUST support RS256 (OpenID Connect Core 1.0, section 15.1), so
+// it is the safe fallback when discovery omits
+// id_token_signing_alg_values_supported.
+const DEFAULT_ID_TOKEN_SIGNING_ALGS = ["RS256"];
+
+/**
+ * Resolve the ID-token signing algorithms to pin `jwtVerify` to, from the
+ * discovery document's `id_token_signing_alg_values_supported`.
+ *
+ * Pinning prevents algorithm-substitution attacks (e.g. `alg: none`). We keep
+ * only asymmetric algorithms: the ID token is verified with the provider's
+ * public JWKS, so symmetric (`HS*`) and `none` can never be legitimate here and
+ * are exactly the confusion vectors to exclude. When the provider advertises no
+ * usable asymmetric algorithm (or omits the field), fall back to RS256, which
+ * OIDC requires every provider to support (#2942).
+ */
+function resolveIdTokenSigningAlgs(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [...DEFAULT_ID_TOKEN_SIGNING_ALGS];
+  }
+
+  const algs = [
+    ...new Set(
+      value
+        .filter((alg): alg is string => typeof alg === "string")
+        .map((alg) => alg.trim())
+        .filter((alg) => alg.length > 0),
+    ),
+  ].filter((alg) => {
+    const upper = alg.toUpperCase();
+    return upper !== "NONE" && !upper.startsWith("HS");
+  });
+
+  return algs.length > 0 ? algs : [...DEFAULT_ID_TOKEN_SIGNING_ALGS];
 }
 
 interface VerifiedOidcUserInfo {
@@ -201,6 +244,9 @@ async function fetchOidcDiscoveryDocument(
       jwksUriValue,
       "OIDC discovery jwks_uri",
     ).toString(),
+    idTokenSigningAlgs: resolveIdTokenSigningAlgs(
+      parsed.id_token_signing_alg_values_supported,
+    ),
   };
 }
 
@@ -285,6 +331,13 @@ function createOidcUserInfoResolver(options: {
       const { payload } = await jwtVerify(idToken, jwks, {
         issuer: discovery.issuer,
         audience: options.clientId,
+        // Pin the accepted signing algorithms to the asymmetric set the
+        // provider advertises in discovery (RS256 fallback). Without a pin,
+        // jose accepts any algorithm the JWKS key can verify (an RSA key
+        // validates RS256/RS384/RS512 alike) and, worse, `alg: none`; pinning
+        // closes that substitution gap while still supporting providers that
+        // sign with ES*/PS*/EdDSA rather than RS256 (#2942).
+        algorithms: discovery.idTokenSigningAlgs,
       });
 
       return mapVerifiedOidcPayload(payload);

--- a/api/src/auth/config.ts
+++ b/api/src/auth/config.ts
@@ -27,16 +27,33 @@ interface OidcDiscoveryDocument {
 // id_token_signing_alg_values_supported.
 const DEFAULT_ID_TOKEN_SIGNING_ALGS = ["RS256"];
 
+// Known asymmetric JWS signing algorithms accepted for ID tokens. The token is
+// verified with the provider's public JWKS, so only public-key algorithms are
+// valid here; symmetric (`HS*`) and `none` are excluded by their absence. An
+// exact allowlist (rather than "anything that is not none/HS*") is required so
+// that an unknown or non-JWS algorithm name in discovery cannot form a
+// non-empty pin set that suppresses the RS256 fallback and breaks login (#2942).
+const KNOWN_ASYMMETRIC_JWS_ALGS = new Set([
+  "RS256",
+  "RS384",
+  "RS512",
+  "ES256",
+  "ES384",
+  "ES512",
+  "PS256",
+  "PS384",
+  "PS512",
+]);
+
 /**
  * Resolve the ID-token signing algorithms to pin `jwtVerify` to, from the
  * discovery document's `id_token_signing_alg_values_supported`.
  *
- * Pinning prevents algorithm-substitution attacks (e.g. `alg: none`). We keep
- * only asymmetric algorithms: the ID token is verified with the provider's
- * public JWKS, so symmetric (`HS*`) and `none` can never be legitimate here and
- * are exactly the confusion vectors to exclude. When the provider advertises no
- * usable asymmetric algorithm (or omits the field), fall back to RS256, which
- * OIDC requires every provider to support (#2942).
+ * Pinning prevents algorithm-substitution attacks (e.g. `alg: none`). Only
+ * known asymmetric JWS algorithms ({@link KNOWN_ASYMMETRIC_JWS_ALGS}) are
+ * honoured; symmetric (`HS*`), `none`, and unrecognised names are dropped. When
+ * the provider advertises no usable asymmetric algorithm (or omits the field),
+ * fall back to RS256, which OIDC requires every provider to support (#2942).
  */
 function resolveIdTokenSigningAlgs(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -47,13 +64,9 @@ function resolveIdTokenSigningAlgs(value: unknown): string[] {
     ...new Set(
       value
         .filter((alg): alg is string => typeof alg === "string")
-        .map((alg) => alg.trim())
-        .filter((alg) => alg.length > 0),
+        .map((alg) => alg.trim()),
     ),
-  ].filter((alg) => {
-    const upper = alg.toUpperCase();
-    return upper !== "NONE" && !upper.startsWith("HS");
-  });
+  ].filter((alg) => KNOWN_ASYMMETRIC_JWS_ALGS.has(alg));
 
   return algs.length > 0 ? algs : [...DEFAULT_ID_TOKEN_SIGNING_ALGS];
 }

--- a/api/src/oidc.integration.test.ts
+++ b/api/src/oidc.integration.test.ts
@@ -274,6 +274,43 @@ describe("OIDC integration", () => {
     );
   }
 
+  // Runs the login -> callback flow and asserts the callback rejected the ID
+  // token: it redirects with user_info_is_missing and sets no session cookie.
+  // Shared by the algorithm-pinning regression tests.
+  async function expectOidcLoginRejected(
+    app: Awaited<ReturnType<typeof createApp>>,
+  ): Promise<void> {
+    const loginResponse = await app.request("/auth/login?next=%2Fdashboard");
+    expect(loginResponse.status).toBe(302);
+    const loginUrl = new URL(loginResponse.headers.get("location")!);
+    const state = loginUrl.searchParams.get("state");
+    expect(state).not.toBeNull();
+    const loginCookieHeader = cookieHeaderFromSetCookies(
+      readSetCookies(loginResponse.headers),
+    );
+
+    const callbackResponse = await app.request(
+      `/auth/callback?code=entra-code&state=${encodeURIComponent(state!)}`,
+      {
+        headers: {
+          Cookie: loginCookieHeader,
+        },
+      },
+    );
+
+    expect(callbackResponse.status).toBe(302);
+    expect(callbackResponse.headers.get("location")).toContain(
+      "user_info_is_missing",
+    );
+
+    const callbackCookies = readSetCookies(callbackResponse.headers);
+    expect(
+      callbackCookies.some((cookie) =>
+        cookie.includes("rackula_auth_session="),
+      ),
+    ).toBe(false);
+  }
+
   it("accepts Entra common issuer config when discovery returns tenant issuer", async () => {
     const mock = await installMockOidcFetch();
     try {
@@ -349,36 +386,7 @@ describe("OIDC integration", () => {
     });
     try {
       const app = await createApp(buildOidcEnv());
-
-      const loginResponse = await app.request("/auth/login?next=%2Fdashboard");
-      expect(loginResponse.status).toBe(302);
-      const loginUrl = new URL(loginResponse.headers.get("location")!);
-      const state = loginUrl.searchParams.get("state");
-      expect(state).not.toBeNull();
-      const loginCookieHeader = cookieHeaderFromSetCookies(
-        readSetCookies(loginResponse.headers),
-      );
-
-      const callbackResponse = await app.request(
-        `/auth/callback?code=entra-code&state=${encodeURIComponent(state!)}`,
-        {
-          headers: {
-            Cookie: loginCookieHeader,
-          },
-        },
-      );
-
-      expect(callbackResponse.status).toBe(302);
-      expect(callbackResponse.headers.get("location")).toContain(
-        "user_info_is_missing",
-      );
-
-      const callbackCookies = readSetCookies(callbackResponse.headers);
-      expect(
-        callbackCookies.some((cookie) =>
-          cookie.includes("rackula_auth_session="),
-        ),
-      ).toBe(false);
+      await expectOidcLoginRejected(app);
     } finally {
       mock.restore();
     }
@@ -446,36 +454,7 @@ describe("OIDC integration", () => {
     });
     try {
       const app = await createApp(buildOidcEnv());
-
-      const loginResponse = await app.request("/auth/login?next=%2Fdashboard");
-      expect(loginResponse.status).toBe(302);
-      const loginUrl = new URL(loginResponse.headers.get("location")!);
-      const state = loginUrl.searchParams.get("state");
-      expect(state).not.toBeNull();
-      const loginCookieHeader = cookieHeaderFromSetCookies(
-        readSetCookies(loginResponse.headers),
-      );
-
-      const callbackResponse = await app.request(
-        `/auth/callback?code=entra-code&state=${encodeURIComponent(state!)}`,
-        {
-          headers: {
-            Cookie: loginCookieHeader,
-          },
-        },
-      );
-
-      expect(callbackResponse.status).toBe(302);
-      expect(callbackResponse.headers.get("location")).toContain(
-        "user_info_is_missing",
-      );
-
-      const callbackCookies = readSetCookies(callbackResponse.headers);
-      expect(
-        callbackCookies.some((cookie) =>
-          cookie.includes("rackula_auth_session="),
-        ),
-      ).toBe(false);
+      await expectOidcLoginRejected(app);
     } finally {
       mock.restore();
     }

--- a/api/src/oidc.integration.test.ts
+++ b/api/src/oidc.integration.test.ts
@@ -67,12 +67,30 @@ async function createSignedIdToken(
   overrides: {
     audience?: string | string[];
     issuer?: string;
+    /**
+     * JWS algorithm used to sign the token (default "RS256"). Used by the
+     * algorithm-pinning test (#2942) to sign with a different-but-still-RSA
+     * algorithm (e.g. "RS384") that the same key material can verify.
+     */
+    algorithm?: "RS256" | "RS384";
+    /**
+     * Whether the exported JWKS entry declares its own `alg`. jose's
+     * RemoteJWKSet key-selection already filters candidates by a declared JWK
+     * `alg` when present, which would mask a missing `algorithms` pin in
+     * `jwtVerify`. Set to false to simulate a provider whose JWKS entries
+     * don't declare `alg` (common in the wild), which is the scenario where
+     * pinning actually matters.
+     */
+    includeJwkAlg?: boolean;
   } = {},
 ): Promise<{ token: string; publicJwk: JsonWebKey }> {
-  const { publicKey, privateKey } = await generateKeyPair("RS256");
+  const algorithm = overrides.algorithm ?? "RS256";
+  const { publicKey, privateKey } = await generateKeyPair(algorithm);
   const publicJwk = await exportJWK(publicKey);
   publicJwk.kid = "rackula-test-kid";
-  publicJwk.alg = "RS256";
+  if (overrides.includeJwkAlg ?? true) {
+    publicJwk.alg = algorithm;
+  }
   publicJwk.use = "sig";
 
   const nowSeconds = Math.floor(Date.now() / 1000);
@@ -82,7 +100,7 @@ async function createSignedIdToken(
     email_verified: true,
   })
     .setProtectedHeader({
-      alg: "RS256",
+      alg: algorithm,
       kid: "rackula-test-kid",
       typ: "JWT",
     })
@@ -100,6 +118,15 @@ async function installMockOidcFetch(
   options: {
     idTokenAudience?: string | string[];
     idTokenIssuer?: string;
+    idTokenAlgorithm?: "RS256" | "RS384";
+    idTokenIncludeJwkAlg?: boolean;
+    /**
+     * When set, adds `id_token_signing_alg_values_supported` to the mock
+     * discovery document so a test can exercise the discovery-driven algorithm
+     * pin (#2942). Omit to simulate a provider that does not advertise the
+     * field (which pins to the RS256 fallback).
+     */
+    discoverySigningAlgs?: string[];
     failTokenExchange?: boolean;
   } = {},
 ): Promise<{ restore: () => void }> {
@@ -107,6 +134,8 @@ async function installMockOidcFetch(
   const signedIdToken = await createSignedIdToken({
     audience: options.idTokenAudience,
     issuer: options.idTokenIssuer,
+    algorithm: options.idTokenAlgorithm,
+    includeJwkAlg: options.idTokenIncludeJwkAlg,
   });
 
   const mockFetch = async (
@@ -128,6 +157,12 @@ async function installMockOidcFetch(
           token_endpoint: ENTRA_TOKEN_URL,
           jwks_uri: ENTRA_JWKS_URL,
           userinfo_endpoint: "https://graph.microsoft.com/oidc/userinfo",
+          ...(options.discoverySigningAlgs
+            ? {
+                id_token_signing_alg_values_supported:
+                  options.discoverySigningAlgs,
+              }
+            : {}),
         }),
         {
           status: 200,
@@ -260,6 +295,128 @@ describe("OIDC integration", () => {
   it("rejects callback when token audience does not match client id", async () => {
     const mock = await installMockOidcFetch({
       idTokenAudience: "wrong-client-id",
+    });
+    try {
+      const app = await createApp(buildOidcEnv());
+
+      const loginResponse = await app.request("/auth/login?next=%2Fdashboard");
+      expect(loginResponse.status).toBe(302);
+      const loginUrl = new URL(loginResponse.headers.get("location")!);
+      const state = loginUrl.searchParams.get("state");
+      expect(state).not.toBeNull();
+      const loginCookieHeader = cookieHeaderFromSetCookies(
+        readSetCookies(loginResponse.headers),
+      );
+
+      const callbackResponse = await app.request(
+        `/auth/callback?code=entra-code&state=${encodeURIComponent(state!)}`,
+        {
+          headers: {
+            Cookie: loginCookieHeader,
+          },
+        },
+      );
+
+      expect(callbackResponse.status).toBe(302);
+      expect(callbackResponse.headers.get("location")).toContain(
+        "user_info_is_missing",
+      );
+
+      const callbackCookies = readSetCookies(callbackResponse.headers);
+      expect(
+        callbackCookies.some((cookie) =>
+          cookie.includes("rackula_auth_session="),
+        ),
+      ).toBe(false);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  // #2942: the OIDC id-token verification previously set no `algorithms`
+  // restriction on `jwtVerify`. An RSA key can validly sign RS256, RS384, or
+  // RS512, so an attacker able to influence the token's declared algorithm
+  // (or a compromised/misconfigured provider) could get a token accepted
+  // under an algorithm the operator never intended to trust. Here discovery
+  // omits id_token_signing_alg_values_supported, so the pin falls back to
+  // RS256; the mock JWKS entry omits its own `alg` field (as real-world JWKS
+  // often do) so the only thing that can reject the RS384-signed token is the
+  // pin, not jose's incidental JWK/header alg match.
+  it("rejects an ID token signed with an algorithm outside the pinned set", async () => {
+    const mock = await installMockOidcFetch({
+      idTokenAlgorithm: "RS384",
+      idTokenIncludeJwkAlg: false,
+    });
+    try {
+      const app = await createApp(buildOidcEnv());
+
+      const loginResponse = await app.request("/auth/login?next=%2Fdashboard");
+      expect(loginResponse.status).toBe(302);
+      const loginUrl = new URL(loginResponse.headers.get("location")!);
+      const state = loginUrl.searchParams.get("state");
+      expect(state).not.toBeNull();
+      const loginCookieHeader = cookieHeaderFromSetCookies(
+        readSetCookies(loginResponse.headers),
+      );
+
+      const callbackResponse = await app.request(
+        `/auth/callback?code=entra-code&state=${encodeURIComponent(state!)}`,
+        {
+          headers: {
+            Cookie: loginCookieHeader,
+          },
+        },
+      );
+
+      expect(callbackResponse.status).toBe(302);
+      expect(callbackResponse.headers.get("location")).toContain(
+        "user_info_is_missing",
+      );
+
+      const callbackCookies = readSetCookies(callbackResponse.headers);
+      expect(
+        callbackCookies.some((cookie) =>
+          cookie.includes("rackula_auth_session="),
+        ),
+      ).toBe(false);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  // #2942: pinning must not break a provider that signs with a non-RS256
+  // asymmetric algorithm (e.g. a Keycloak client configured for RS384). When
+  // discovery advertises the algorithm, the token verifies and login succeeds.
+  it("accepts an ID token whose non-RS256 algorithm the provider advertises", async () => {
+    const mock = await installMockOidcFetch({
+      idTokenAlgorithm: "RS384",
+      idTokenIncludeJwkAlg: false,
+      discoverySigningAlgs: ["RS384"],
+    });
+    try {
+      const app = await createApp(buildOidcEnv());
+      const authedCookieHeader = await completeOidcLogin(app);
+
+      const checkResponse = await app.request("/auth/check", {
+        headers: {
+          Cookie: authedCookieHeader,
+          Origin: "https://rack.example.com",
+        },
+      });
+      expect(checkResponse.status).toBe(204);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  // #2942: a discovery document advertising `none` (or an HS* symmetric alg)
+  // must not weaken the pin. Those are stripped, leaving the RS256 fallback, so
+  // an RS384 token is still rejected.
+  it("ignores a discovery-advertised insecure algorithm and keeps the RS256 fallback", async () => {
+    const mock = await installMockOidcFetch({
+      idTokenAlgorithm: "RS384",
+      idTokenIncludeJwkAlg: false,
+      discoverySigningAlgs: ["none", "HS256"],
     });
     try {
       const app = await createApp(buildOidcEnv());

--- a/api/src/oidc.integration.test.ts
+++ b/api/src/oidc.integration.test.ts
@@ -409,6 +409,32 @@ describe("OIDC integration", () => {
     }
   });
 
+  // #2942: a discovery document advertising only unknown / non-JWS algorithm
+  // names must not suppress the RS256 fallback. Only known asymmetric JWS
+  // algorithms are honoured; an unrecognised value is ignored, leaving the
+  // RS256 fallback so a valid RS256 token still verifies and login succeeds.
+  it("falls back to RS256 when discovery advertises only an unknown algorithm", async () => {
+    const mock = await installMockOidcFetch({
+      idTokenAlgorithm: "RS256",
+      idTokenIncludeJwkAlg: false,
+      discoverySigningAlgs: ["FOO256"],
+    });
+    try {
+      const app = await createApp(buildOidcEnv());
+      const authedCookieHeader = await completeOidcLogin(app);
+
+      const checkResponse = await app.request("/auth/check", {
+        headers: {
+          Cookie: authedCookieHeader,
+          Origin: "https://rack.example.com",
+        },
+      });
+      expect(checkResponse.status).toBe(204);
+    } finally {
+      mock.restore();
+    }
+  });
+
   // #2942: a discovery document advertising `none` (or an HS* symmetric alg)
   // must not weaken the pin. Those are stripped, leaving the RS256 fallback, so
   // an RS384 token is still rejected.

--- a/api/src/schemas/layout.test.ts
+++ b/api/src/schemas/layout.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { slugify, buildYamlFilename } from "./layout";
+import {
+  slugify,
+  buildYamlFilename,
+  buildFolderName,
+  LayoutFileSchema,
+} from "./layout";
+
+const TEST_UUID = "550e8400-e29b-41d4-a716-446655440000";
 
 describe("slugify (api)", () => {
   it("maps a trailing plus to -plus, matching the frontend slugify", () => {
@@ -33,5 +40,129 @@ describe("buildYamlFilename (api)", () => {
     expect(buildYamlFilename("Synology DS920+")).toBe(
       "synology-ds920-plus.rackula.yaml",
     );
+  });
+});
+
+// #2942: sanitizeForPath (invoked via buildFolderName) previously left control
+// characters like NUL untouched. A NUL byte survives to `path.join()` in the
+// filesystem storage driver, which throws `ERR_INVALID_ARG_VALUE` and turns a
+// bad layout name into a 500 rather than a clean rejection.
+describe("buildFolderName control-character safety (#2942)", () => {
+  it("strips control characters such as NUL before they reach the filesystem", () => {
+    const folderName = buildFolderName("My\x00Rack", TEST_UUID);
+    expect(folderName).toBe(`MyRack-${TEST_UUID}`);
+  });
+
+  it("strips other C0 control characters (tab, newline, escape)", () => {
+    const folderName = buildFolderName("My\t\n\x1bRack", TEST_UUID);
+    expect(folderName).toBe(`MyRack-${TEST_UUID}`);
+  });
+
+  it("strips leading and trailing dots so folder names cannot masquerade as hidden files", () => {
+    const folderName = buildFolderName(".hidden.", TEST_UUID);
+    expect(folderName.startsWith(".")).toBe(false);
+    expect(folderName).toBe(`hidden-${TEST_UUID}`);
+  });
+
+  // The 100-char truncation must run before the leading/trailing dot strip, or
+  // a dot sitting exactly at the truncation boundary is reintroduced as a new
+  // trailing dot. Name is >100 chars with a dot at index 99.
+  it("does not reintroduce a trailing dot when truncation lands on one", () => {
+    const name = "a".repeat(99) + "." + "b".repeat(50);
+    const sanitized = buildFolderName(name, TEST_UUID).slice(
+      0,
+      -`-${TEST_UUID}`.length,
+    );
+    expect(sanitized.endsWith(".")).toBe(false);
+    expect(sanitized).toBe("a".repeat(99));
+  });
+});
+
+// #2942: top-level `name`/`version` had no max length or charset restriction,
+// unlike `metadata.name`/`metadata.description`, which cap length. A NUL in a
+// name with no `metadata` section previously reached buildFolderName
+// unvalidated; it must now be rejected by schema validation with a clean 400.
+describe("LayoutFileSchema top-level name/version caps (#2942)", () => {
+  it("rejects a top-level name containing a NUL byte", () => {
+    const result = LayoutFileSchema.safeParse({
+      version: "1.0.0",
+      name: "My\x00Rack",
+      racks: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a top-level name longer than 100 characters", () => {
+    const result = LayoutFileSchema.safeParse({
+      version: "1.0.0",
+      name: "a".repeat(101),
+      racks: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a top-level name at the 100 character boundary", () => {
+    const result = LayoutFileSchema.safeParse({
+      version: "1.0.0",
+      name: "a".repeat(100),
+      racks: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a top-level version longer than 20 characters", () => {
+    const result = LayoutFileSchema.safeParse({
+      version: "1.".repeat(11), // 22 characters
+      name: "Test",
+      racks: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a top-level version containing a control character", () => {
+    const result = LayoutFileSchema.safeParse({
+      version: "1.0\x1b",
+      name: "Test",
+      racks: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("still accepts a normal versioned layout name", () => {
+    const result = LayoutFileSchema.safeParse({
+      version: "1.0.0",
+      name: "Homelab Rack",
+      racks: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // Backward compatibility: the prior schema was a bare `z.string()` that
+  // accepted an empty version, so the new max/charset caps must not start
+  // rejecting it (a prior-release layout must still load).
+  it("still accepts an empty top-level version", () => {
+    const result = LayoutFileSchema.safeParse({
+      version: "",
+      name: "Homelab Rack",
+      racks: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // metadata.name wins over the top-level name when a `metadata:` section is
+  // present (filesystem.ts derives layoutName as metadata?.name ?? name), so it
+  // feeds the same buildFolderName sink and must reject control characters too.
+  it("rejects a metadata.name containing a NUL byte", () => {
+    const result = LayoutFileSchema.safeParse({
+      version: "1.0.0",
+      name: "Homelab Rack",
+      metadata: {
+        id: TEST_UUID,
+        name: "Bad\x00Name",
+        schema_version: "1.0",
+      },
+      racks: [],
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/api/src/schemas/layout.ts
+++ b/api/src/schemas/layout.ts
@@ -52,18 +52,27 @@ export function extractUuidFromFolderName(folderName: string): string | null {
 const SLUG_MAX_LENGTH = 100;
 
 /**
+ * C0 control characters (0x00-0x1F) and DEL (0x7F). A NUL byte reaching
+ * `path.join()` throws `ERR_INVALID_ARG_VALUE`; other control characters are
+ * similarly unsafe or meaningless in filesystem paths (#2942).
+ */
+// eslint-disable-next-line no-control-regex -- intentionally matching control characters to strip them
+const CONTROL_CHAR_PATTERN = /[\x00-\x1f\x7f]/g;
+
+/**
  * Sanitize a string for safe use in filesystem paths
  * Removes path separators and other dangerous characters while keeping readability
  */
 function sanitizeForPath(name: string): string {
   return (
     name
+      .replace(CONTROL_CHAR_PATTERN, "") // Strip control characters (e.g. NUL) before they reach the filesystem
       .replace(/[/\\:*?"<>|]/g, "-") // Replace path separators and reserved chars
       .replace(/\.\./g, "-") // Prevent directory traversal
       .replace(/-+/g, "-") // Collapse multiple hyphens
-      .replace(/^-|-$/g, "") // Remove leading/trailing hyphens
       .trim()
-      .slice(0, 100) || // Limit length
+      .slice(0, 100) // Limit length
+      .replace(/^[-.]+|[-.]+$/g, "") || // Remove leading/trailing hyphens and dots AFTER truncation, so the slice can't reintroduce a boundary dot/hyphen
     "untitled"
   ); // Fallback for empty result
 }
@@ -120,6 +129,17 @@ export function buildYamlFilename(name: string): string {
 }
 
 /**
+ * Rejects C0 control characters (and DEL). Names (both the top-level `name` and
+ * `metadata.name`) feed `buildFolderName`/`buildYamlFilename`; `sanitizeForPath`
+ * also strips control characters as defense-in-depth, but a NUL byte reaching
+ * the filesystem layer unvalidated previously surfaced as a 500 instead of a
+ * clean 400. The `version` field never reaches the filesystem, so its check is
+ * purely about rejecting clearly-malformed data with a clean 400 (#2942).
+ */
+// eslint-disable-next-line no-control-regex -- intentionally rejecting control characters
+const NO_CONTROL_CHARS_PATTERN = /^[^\x00-\x1f\x7f]*$/;
+
+/**
  * Layout YAML metadata section schema.
  * Part of the data directory refactor (#570, #915).
  * This is the new `metadata:` section in YAML files.
@@ -135,7 +155,11 @@ export const LayoutYamlMetadataSchema = z
     name: z
       .string()
       .min(1, "Metadata name is required")
-      .max(100, "Metadata name must be 100 characters or less"),
+      .max(100, "Metadata name must be 100 characters or less")
+      .regex(
+        NO_CONTROL_CHARS_PATTERN,
+        "Metadata name must not contain control characters",
+      ),
     /** Format version for future migrations (e.g., "1.0") */
     schema_version: z.string().min(1, "Schema version is required"),
     /** Optional notes about the layout */
@@ -171,8 +195,24 @@ export const PlacedDeviceFileSchema = z
 // bodies before they are persisted (#2449). The full schema validation happens
 // in the SPA against the richer src/lib/schemas LayoutSchema.
 export const LayoutFileSchema = z.object({
-  version: z.string(),
-  name: z.string().min(1, "Layout name is required"),
+  // No `.min(1)`: the prior schema was a bare `z.string()` that accepted an
+  // empty version, so keep accepting it (backward compatibility). Only the
+  // upper bound and charset are new (#2942).
+  version: z
+    .string()
+    .max(20, "Layout version must be 20 characters or less")
+    .regex(
+      NO_CONTROL_CHARS_PATTERN,
+      "Layout version must not contain control characters",
+    ),
+  name: z
+    .string()
+    .min(1, "Layout name is required")
+    .max(100, "Layout name must be 100 characters or less")
+    .regex(
+      NO_CONTROL_CHARS_PATTERN,
+      "Layout name must not contain control characters",
+    ),
   /** Optional metadata section for new YAML format (#570, #915) */
   metadata: LayoutYamlMetadataSchema.optional(),
   racks: z

--- a/api/src/security.test.ts
+++ b/api/src/security.test.ts
@@ -215,6 +215,20 @@ describe("resolveApiSecurityConfig", () => {
     expect(config.csrfTrustedOrigins).toEqual(["https://rack.example.com"]);
   });
 
+  // #2942: an operator explicitly overriding RACKULA_AUTH_SESSION_COOKIE_SECURE=false
+  // in production previously only logged a warning (and only for local auth
+  // mode), letting the session cookie travel over plain HTTP. Refuse to start.
+  it("rejects an explicitly insecure auth session cookie in production", () => {
+    expect(() =>
+      resolveApiSecurityConfig(
+        buildAuthEnabledEnv({
+          NODE_ENV: "production",
+          RACKULA_AUTH_SESSION_COOKIE_SECURE: "false",
+        }),
+      ),
+    ).toThrow("insecure session cookie in production");
+  });
+
   it("derives auth log hash key from auth session secret by default", () => {
     const first = resolveApiSecurityConfig(buildAuthEnabledEnv());
     const second = resolveApiSecurityConfig(buildAuthEnabledEnv());

--- a/api/src/security/config.ts
+++ b/api/src/security/config.ts
@@ -395,6 +395,17 @@ export function resolveApiSecurityConfig(
     );
   }
 
+  // Refuse to start rather than merely warn: an insecure session cookie in
+  // production would travel over plain HTTP, exposing the session to network
+  // interception. Applies to every auth mode (local and OIDC both set the
+  // session cookie via this config), not just local auth (#2942).
+  if (authEnabled && isProduction && !authSessionCookieSecure) {
+    throw new Error(
+      "Refusing to run with an insecure session cookie in production. " +
+        "Set RACKULA_AUTH_SESSION_COOKIE_SECURE=true (or unset it to use the secure-by-default value).",
+    );
+  }
+
   const csrfProtectionEnabled = parseOptionalBoolean(
     "RACKULA_AUTH_CSRF_PROTECTION",
     env.RACKULA_AUTH_CSRF_PROTECTION,


### PR DESCRIPTION
## **User description**
## Summary

Closes 4 of the 5 defense-in-depth gaps in #2942. The fifth (in-memory session invalidation) is durable/distributed session storage and is deferred to #1269, out of scope here.

### 1. OIDC signing-algorithm pinning (`api/src/auth/config.ts`)

`jwtVerify` for the OIDC id-token set no `algorithms:` restriction, so jose would accept any algorithm the JWKS key can verify (an RSA key validates RS256/RS384/RS512 alike) and, without a pin, is exposed to `alg: none` substitution.

Rather than hardcode `["RS256"]` (which would break a provider configured for ES256/PS256/etc., e.g. a Keycloak client set to a non-default alg, listed as supported in the auth docs), the pin is derived from the discovery document's `id_token_signing_alg_values_supported`: keep only asymmetric algorithms (drop `none` and `HS*`, which can never be legitimate for JWKS/public-key verification and are the confusion vectors), falling back to RS256 (which every OIDC provider must support) when the field is absent. This hardens against substitution while still working with any compliant provider.

### 2. Control-character stripping in `sanitizeForPath` (`api/src/schemas/layout.ts`)

A NUL in a layout name reached `path.join()` and threw a 500. `sanitizeForPath` now strips C0 control characters (and DEL) and leading/trailing dots. The leading/trailing strip runs after the 100-char truncation so the slice cannot reintroduce a boundary dot.

### 3. Top-level `name`/`version` caps (`api/src/schemas/layout.ts`)

The top-level `name`/`version` fields were unbounded. They now have length caps (name 100, version 20) and a no-control-character charset, mirroring the `metadata.name`/`description` caps. `metadata.name` gains the same control-char guard because it wins over the top-level name when present (it feeds the same folder-name sink). `version` still accepts empty strings for backward compatibility (the prior schema was a bare `z.string()`).

### 4. Refuse insecure cookie in production (`api/src/security/config.ts`)

Production + `RACKULA_AUTH_SESSION_COOKIE_SECURE=false` previously only WARNED (and only for local auth). `resolveApiSecurityConfig` now THROWS at startup for every auth mode, matching how `SameSite=None`-without-Secure is already refused. The old warn-only block in `app.ts` is removed as dead code.

## Test plan

- [x] Alg-pin rejects a token signed outside the pinned set (RS384 with RS256 fallback)
- [x] Alg-pin accepts a non-RS256 token the provider advertises in discovery (RS384)
- [x] Discovery-advertised `none`/`HS256` are ignored and the RS256 fallback holds
- [x] Control-char name -> clean rejection (no 500); truncation cannot reintroduce a trailing dot
- [x] Over-long / control-char top-level `name`/`version` and `metadata.name` rejected
- [x] Empty top-level `version` still accepted (backward compat)
- [x] Production + insecure cookie -> startup throw
- [x] `bun test` (408 pass), `tsc --noEmit`, `npm run lint`, `npm run build` all green

Session durability (the fifth item) was intentionally left untouched, deferred to #1269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D2oqPsJpNzsvSFqPHDpAN


___

## **CodeAnt-AI Description**
Harden OIDC login, layout validation, and production cookie handling

### What Changed
- OIDC login now accepts only the signing algorithms the provider advertises, and falls back to RS256 when no safe algorithm is listed.
- Layout names and versions now reject control characters and oversized values before they reach file handling, preventing bad inputs from turning into server errors.
- Folder names now strip control characters and edge dots so they stay safe and predictable.
- Production startup now fails if session cookies are set to insecure mode, instead of continuing with a warning.
- Added regression tests covering the rejected and accepted cases for OIDC tokens, layout names, and cookie security.

### Impact
`✅ Fewer OIDC login bypass risks`
`✅ Fewer 500 errors from malformed layout names`
`✅ Safer production session cookies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
