### PR TITLE
fix: roving key bubbling and starting_unit display positions

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -369,7 +369,7 @@
           (dt) => dt.slug === d.device_type,
         );
         const name = d.label || deviceType?.model || d.device_type;
-        return `${formatDisplayPosition(d.position, activeRack.height, activeRack.desc_units)}: ${name}`;
+        return `${formatDisplayPosition(d.position, activeRack.height, activeRack.desc_units, activeRack.starting_unit)}: ${name}`;
       });
     return `Active rack devices from top to bottom: ${deviceNames.join(", ")}`;
   });

--- a/src/lib/components/DevicePaletteItem.svelte
+++ b/src/lib/components/DevicePaletteItem.svelte
@@ -134,6 +134,16 @@
   function handleRovingKeyDown(event: KeyboardEvent) {
     const mappedKey = ROVING_KEY_MAP[event.key];
     if (!mappedKey) return;
+    // Any mapped roving key belongs to this list, even when it turns out to
+    // be a no-op (Home already on the first row, End already on the last
+    // row, or any mapped key in a single-item list): cancel unconditionally
+    // here, before the boundary checks below can return early. CodeAnt
+    // (PR #3017, comment 3566106209) found the previous version only
+    // cancelled when focus actually moved, so a boundary no-op let the key
+    // bubble to window-level shortcuts (e.g. arrow-key device move) even
+    // though the palette had focus.
+    event.preventDefault();
+    event.stopPropagation();
     const row = event.currentTarget as HTMLElement;
     const list = row.closest('[role="list"]');
     if (!list) return;
@@ -144,8 +154,6 @@
     if (currentIndex === -1) return;
     const nextIndex = nextRovingIndex(currentIndex, mappedKey, items.length);
     if (nextIndex === currentIndex) return;
-    event.preventDefault();
-    event.stopPropagation();
     items[nextIndex]?.focus();
   }
 

--- a/src/lib/components/EditPanelPosition.svelte
+++ b/src/lib/components/EditPanelPosition.svelte
@@ -31,9 +31,18 @@
   );
 
   // Format an internal-unit position for display, honouring the rack's U
-  // numbering direction. Delegates to the shared helper (position.ts).
+  // numbering direction and starting_unit offset. Delegates to the shared
+  // helper (position.ts). Previously omitted starting_unit, so a rack whose
+  // numbering starts above U1 showed a label that diverged from the ruler;
+  // passing it through here brings this display in line with the ruler for
+  // those racks (CodeAnt, PR #3018, comment 3566108076).
   function formatDisplayPosition(position: number, rack: Rack): string {
-    return formatDisplayPositionShared(position, rack.height, rack.desc_units);
+    return formatDisplayPositionShared(
+      position,
+      rack.height,
+      rack.desc_units,
+      rack.starting_unit,
+    );
   }
 
   // Whether the selected device can move up/down. Delegates to the shared

--- a/src/lib/utils/position.ts
+++ b/src/lib/utils/position.ts
@@ -70,32 +70,40 @@ export function formatPosition(internal: number): string {
 
 /**
  * Format an internal rail position as a whole-U label, honouring the rack's
- * U-numbering direction (`desc_units`, "U1 at top").
+ * U-numbering direction (`desc_units`, "U1 at top") and starting offset
+ * (`starting_unit`).
  *
  * The rail position (`position`) is always measured from the physical
  * bottom of the rack regardless of `desc_units` (#2158); only the label
- * shown on the ruler flips. This mirrors the flip the ruler itself applies
- * (Rack.svelte's `uLabels`): ascending numbering (`desc_units` false)
- * labels a position directly, while descending numbering mirrors it across
- * the rack height so the label matches the row the device physically
- * occupies.
+ * shown on the ruler flips and offsets. This mirrors the formula the ruler
+ * itself applies (Rack.svelte's `uLabels`): for row index `i` counted from
+ * the top (`i = height - wholeU`), the ruler labels a descending rack
+ * `starting_unit + i` and an ascending rack
+ * `starting_unit + (height - 1) - i`. Without `starting_unit`, a rack whose
+ * numbering starts above 1 (e.g. a continuation rack) would show a label
+ * that diverges from the ruler.
  *
  * @param position - Internal position (e.g., 6 = U1, 12 = U2)
  * @param height - Rack height in U
  * @param desc_units - Whether the rack numbers U1 at the top (descending)
+ * @param starting_unit - The rack's first U number (default: 1)
  * @returns Formatted position string matching the ruler's label
  *
  * @example
- * formatDisplayPosition(6, 42, false)  // "U1" (ascending, U1 at bottom)
- * formatDisplayPosition(6, 42, true)   // "U42" (descending, U1 at top)
+ * formatDisplayPosition(6, 42, false)      // "U1" (ascending, U1 at bottom)
+ * formatDisplayPosition(6, 42, true)       // "U42" (descending, U1 at top)
+ * formatDisplayPosition(6, 42, false, 25)  // "U25" (ascending, starts at U25)
  */
 export function formatDisplayPosition(
   position: number,
   height: number,
   desc_units?: boolean,
+  starting_unit?: number,
 ): string {
-  if (!desc_units) return formatPosition(position);
+  const startUnit = starting_unit ?? 1;
   const wholeU = Math.round(toHumanUnits(position));
-  const displayWholeU = height - wholeU + 1;
+  const displayWholeU = desc_units
+    ? startUnit + height - wholeU
+    : startUnit + wholeU - 1;
   return formatPosition(toInternalUnits(displayWholeU));
 }

--- a/src/tests/Canvas.device-list-position.test.ts
+++ b/src/tests/Canvas.device-list-position.test.ts
@@ -92,4 +92,64 @@ describe("Canvas device-list description position (#2999)", () => {
     expect(description.textContent).toContain("U26:");
     expect(description.textContent).not.toContain("U17:");
   });
+
+  it("announces the ruler's label for an ascending rack with an offset starting_unit", () => {
+    const layoutStore = getLayoutStore();
+    // starting_unit: 25, ascending (desc_units false). Ruler formula:
+    // uNumber = startUnit + (height - 1) - i, i = height - positionHuman.
+    // positionHuman 17 in a 42U rack -> i = 25 -> uNumber = 25 + 41 - 25 = 41.
+    const rack = layoutStore.addRack(
+      "Offset Ascending Rack",
+      42,
+      undefined,
+      undefined,
+      false,
+      25,
+    );
+    const rackId = rack!.id;
+
+    const deviceType = layoutStore.addDeviceType({
+      name: "Server Type",
+      u_height: 1,
+      category: "server",
+      colour: "#4A90D9",
+    });
+
+    layoutStore.placeDevice(rackId, deviceType.slug, 17, "front");
+
+    const { getByText } = render(Canvas);
+
+    const description = getByText(/Active rack devices from top to bottom/);
+    expect(description.textContent).toContain("U41:");
+  });
+
+  it("announces the ruler's label for a descending rack with an offset starting_unit", () => {
+    const layoutStore = getLayoutStore();
+    // starting_unit: 25, descending (desc_units true). Ruler formula:
+    // uNumber = startUnit + i, i = height - positionHuman.
+    // positionHuman 17 in a 42U rack -> i = 25 -> uNumber = 25 + 25 = 50.
+    const rack = layoutStore.addRack(
+      "Offset Descending Rack",
+      42,
+      undefined,
+      undefined,
+      true,
+      25,
+    );
+    const rackId = rack!.id;
+
+    const deviceType = layoutStore.addDeviceType({
+      name: "Server Type",
+      u_height: 1,
+      category: "server",
+      colour: "#4A90D9",
+    });
+
+    layoutStore.placeDevice(rackId, deviceType.slug, 17, "front");
+
+    const { getByText } = render(Canvas);
+
+    const description = getByText(/Active rack devices from top to bottom/);
+    expect(description.textContent).toContain("U50:");
+  });
 });

--- a/src/tests/device-palette-item-roving-boundary.test.ts
+++ b/src/tests/device-palette-item-roving-boundary.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression test for CodeAnt finding (PR #3017, comment 3566106209):
+ * DevicePaletteItem's roving-key handler only called preventDefault /
+ * stopPropagation when focus actually moved to another row. The boundary
+ * no-ops that nextRovingIndex's own wrap-around math produces -- Home
+ * pressed while already on the first row, End pressed while already on the
+ * last row, and any mapped key in a single-item list (e.g. a lone pinned
+ * device, or a search/category section down to one result) -- returned
+ * early without cancelling the event, so the key bubbled past the palette
+ * to window-level shortcuts. With a device selected in the rack, that lets
+ * e.g. ArrowUp on a single-item palette section also trigger the global
+ * "move selected device" shortcut, even though keyboard focus never left
+ * the palette.
+ *
+ * Verified against src/lib/utils/roving-index.ts's own confirmed no-op
+ * cases (see roving-index.test.ts): nextRovingIndex(0, "Home", N) === 0,
+ * nextRovingIndex(N-1, "End", N) === N-1, and nextRovingIndex(0, key, 1)
+ * === 0 for every mapped key.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, within, cleanup } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import TestDevicePaletteItem from "./helpers/TestDevicePaletteItem.svelte";
+import { createTestDeviceType } from "./factories";
+
+const DEVICE_NAME = "roving-boundary-device";
+
+/** Builds a `[role="list"]` container -- matching DevicePalette's
+ * per-section list -- with the real DevicePaletteItem row mounted directly
+ * inside it via Svelte's `target` mount option, plus plain stand-in
+ * `[role="listitem"]` siblings so the roving index math sees a real list
+ * length. Only the row under test needs to be the full component; the
+ * siblings just need to exist for `querySelectorAll` inside the component. */
+function buildList({
+  before = 0,
+  after = 0,
+}: {
+  before?: number;
+  after?: number;
+} = {}): HTMLElement {
+  const list = document.createElement("div");
+  list.setAttribute("role", "list");
+  document.body.appendChild(list);
+
+  for (let i = 0; i < before; i++) {
+    const sibling = document.createElement("div");
+    sibling.setAttribute("role", "listitem");
+    sibling.tabIndex = -1;
+    list.appendChild(sibling);
+  }
+
+  render(TestDevicePaletteItem, {
+    target: list,
+    props: { device: createTestDeviceType({ model: DEVICE_NAME }) },
+  });
+
+  for (let i = 0; i < after; i++) {
+    const sibling = document.createElement("div");
+    sibling.setAttribute("role", "listitem");
+    sibling.tabIndex = -1;
+    list.appendChild(sibling);
+  }
+
+  return list;
+}
+
+describe("DevicePaletteItem roving key boundary handling", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not leak ArrowUp to a global handler on the sole row of a single-item list", async () => {
+    const user = userEvent.setup();
+    const list = buildList();
+    const row = within(list).getByRole("listitem", {
+      name: new RegExp(DEVICE_NAME),
+    });
+    const globalKeydown = vi.fn();
+    window.addEventListener("keydown", globalKeydown);
+
+    row.focus();
+    await user.keyboard("{ArrowUp}");
+
+    expect(globalKeydown).not.toHaveBeenCalled();
+    window.removeEventListener("keydown", globalKeydown);
+  });
+
+  it("does not leak Home to a global handler when already on the first row", async () => {
+    const user = userEvent.setup();
+    const list = buildList({ after: 2 });
+    const row = within(list).getByRole("listitem", {
+      name: new RegExp(DEVICE_NAME),
+    });
+    const globalKeydown = vi.fn();
+    window.addEventListener("keydown", globalKeydown);
+
+    row.focus();
+    await user.keyboard("{Home}");
+
+    expect(globalKeydown).not.toHaveBeenCalled();
+    window.removeEventListener("keydown", globalKeydown);
+  });
+
+  it("does not leak End to a global handler when already on the last row", async () => {
+    const user = userEvent.setup();
+    const list = buildList({ before: 2 });
+    const row = within(list).getByRole("listitem", {
+      name: new RegExp(DEVICE_NAME),
+    });
+    const globalKeydown = vi.fn();
+    window.addEventListener("keydown", globalKeydown);
+
+    row.focus();
+    await user.keyboard("{End}");
+
+    expect(globalKeydown).not.toHaveBeenCalled();
+    window.removeEventListener("keydown", globalKeydown);
+  });
+});

--- a/src/tests/device-palette-item-roving-boundary.test.ts
+++ b/src/tests/device-palette-item-roving-boundary.test.ts
@@ -65,6 +65,13 @@ function buildList({
 }
 
 describe("DevicePaletteItem roving key boundary handling", () => {
+  const globalKeydown = vi.fn();
+
+  afterEach(() => {
+    window.removeEventListener("keydown", globalKeydown);
+    globalKeydown.mockClear();
+  });
+
   afterEach(() => {
     cleanup();
   });
@@ -75,14 +82,12 @@ describe("DevicePaletteItem roving key boundary handling", () => {
     const row = within(list).getByRole("listitem", {
       name: new RegExp(DEVICE_NAME),
     });
-    const globalKeydown = vi.fn();
     window.addEventListener("keydown", globalKeydown);
 
     row.focus();
     await user.keyboard("{ArrowUp}");
 
     expect(globalKeydown).not.toHaveBeenCalled();
-    window.removeEventListener("keydown", globalKeydown);
   });
 
   it("does not leak Home to a global handler when already on the first row", async () => {
@@ -91,14 +96,12 @@ describe("DevicePaletteItem roving key boundary handling", () => {
     const row = within(list).getByRole("listitem", {
       name: new RegExp(DEVICE_NAME),
     });
-    const globalKeydown = vi.fn();
     window.addEventListener("keydown", globalKeydown);
 
     row.focus();
     await user.keyboard("{Home}");
 
     expect(globalKeydown).not.toHaveBeenCalled();
-    window.removeEventListener("keydown", globalKeydown);
   });
 
   it("does not leak End to a global handler when already on the last row", async () => {
@@ -107,13 +110,11 @@ describe("DevicePaletteItem roving key boundary handling", () => {
     const row = within(list).getByRole("listitem", {
       name: new RegExp(DEVICE_NAME),
     });
-    const globalKeydown = vi.fn();
     window.addEventListener("keydown", globalKeydown);
 
     row.focus();
     await user.keyboard("{End}");
 
     expect(globalKeydown).not.toHaveBeenCalled();
-    window.removeEventListener("keydown", globalKeydown);
   });
 });

--- a/src/tests/edit-panel-position-starting-unit.test.ts
+++ b/src/tests/edit-panel-position-starting-unit.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for CodeAnt finding (PR #3018, comment 3566108076):
+ * formatDisplayPosition ignored a rack's starting_unit, so on a rack whose
+ * numbering starts above U1 (e.g. a continuation rack), the U label shown
+ * in the edit panel's Position row diverged from the ruler.
+ *
+ * EditPanelPosition's display previously showed the same result as if
+ * starting_unit were always 1 (a pre-existing gap, not introduced here).
+ * That is a genuine behaviour change for offset racks: the panel now
+ * matches the ruler, which is the correct outcome, but the displayed text
+ * for an offset rack is different from before this fix.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import EditPanelPosition from "$lib/components/EditPanelPosition.svelte";
+import { resetLayoutStore } from "$lib/stores/layout.svelte";
+import {
+  createTestRack,
+  createTestDevice,
+  createTestDeviceType,
+} from "./factories";
+import type { SelectedDeviceInfo } from "$lib/types";
+
+describe("EditPanelPosition starting_unit (offset racks)", () => {
+  beforeEach(() => {
+    resetLayoutStore();
+  });
+
+  it("matches the ruler's label for an ascending rack with an offset starting_unit", () => {
+    // starting_unit: 25, ascending. Ruler formula: uNumber = startUnit +
+    // (height - 1) - i, i = height - positionHuman. positionHuman 17 in a
+    // 42U rack -> i = 25 -> uNumber = 25 + 41 - 25 = 41.
+    const rack = createTestRack({ height: 42, starting_unit: 25 });
+    const device = createTestDeviceType({ slug: "server", u_height: 1 });
+    const placedDevice = createTestDevice({
+      device_type: "server",
+      position: 17,
+    });
+    rack.devices = [placedDevice];
+
+    const selectedDeviceInfo: SelectedDeviceInfo = {
+      device,
+      placedDevice,
+      rack,
+      deviceIndex: 0,
+    };
+
+    render(EditPanelPosition, { props: { selectedDeviceInfo } });
+
+    expect(screen.getByText("U41")).toBeInTheDocument();
+    // Would have shown "U17" before this fix (starting_unit ignored).
+    expect(screen.queryByText("U17")).not.toBeInTheDocument();
+  });
+
+  it("matches the ruler's label for a descending rack with an offset starting_unit", () => {
+    // starting_unit: 25, descending. Ruler formula: uNumber = startUnit + i,
+    // i = height - positionHuman. positionHuman 17 in a 42U rack -> i = 25
+    // -> uNumber = 25 + 25 = 50.
+    const rack = createTestRack({
+      height: 42,
+      starting_unit: 25,
+      desc_units: true,
+    });
+    const device = createTestDeviceType({ slug: "server", u_height: 1 });
+    const placedDevice = createTestDevice({
+      device_type: "server",
+      position: 17,
+    });
+    rack.devices = [placedDevice];
+
+    const selectedDeviceInfo: SelectedDeviceInfo = {
+      device,
+      placedDevice,
+      rack,
+      deviceIndex: 0,
+    };
+
+    render(EditPanelPosition, { props: { selectedDeviceInfo } });
+
+    expect(screen.getByText("U50")).toBeInTheDocument();
+    // Would have shown "U26" before this fix (starting_unit ignored: the
+    // desc_units-only formula height - wholeU + 1 = 42 - 17 + 1 = 26).
+    expect(screen.queryByText("U26")).not.toBeInTheDocument();
+  });
+
+  it("is unchanged for a rack starting at U1 (default)", () => {
+    const rack = createTestRack({ height: 42 });
+    const device = createTestDeviceType({ slug: "server", u_height: 1 });
+    const placedDevice = createTestDevice({
+      device_type: "server",
+      position: 17,
+    });
+    rack.devices = [placedDevice];
+
+    const selectedDeviceInfo: SelectedDeviceInfo = {
+      device,
+      placedDevice,
+      rack,
+      deviceIndex: 0,
+    };
+
+    render(EditPanelPosition, { props: { selectedDeviceInfo } });
+
+    expect(screen.getByText("U17")).toBeInTheDocument();
+  });
+});

--- a/src/tests/helpers/TestDevicePaletteItem.svelte
+++ b/src/tests/helpers/TestDevicePaletteItem.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { Tooltip } from "bits-ui";
+  import DevicePaletteItem from "$lib/components/DevicePaletteItem.svelte";
+  import type { DeviceType } from "$lib/types";
+
+  interface Props {
+    device: DeviceType;
+    tabindex?: number;
+  }
+
+  let { device, tabindex = 0 }: Props = $props();
+</script>
+
+<!-- DevicePaletteItem renders a favourite-pin button that uses Tooltip; the
+     app supplies the Tooltip.Provider context at the top level (App.svelte),
+     so mount it the same way here for isolated unit tests. -->
+<Tooltip.Provider>
+  <DevicePaletteItem {device} {tabindex} />
+</Tooltip.Provider>

--- a/src/tests/position.test.ts
+++ b/src/tests/position.test.ts
@@ -4,6 +4,7 @@ import {
   toInternalUnits,
   toHumanUnits,
   heightToInternalUnits,
+  formatDisplayPosition,
 } from "$lib/utils/position";
 
 describe("Position Conversion Utilities", () => {
@@ -88,6 +89,101 @@ describe("Position Conversion Utilities", () => {
     it("converts 1/2U device heights correctly", () => {
       expect(heightToInternalUnits(0.5)).toBe(3);
       expect(heightToInternalUnits(1.5)).toBe(9);
+    });
+  });
+
+  describe("formatDisplayPosition", () => {
+    // Independent cross-check against Rack.svelte's own ruler formula
+    // (uLabels, Rack.svelte ~L243-252), NOT a copy of position.ts's
+    // implementation: row index i counts down from the top (i=0), while
+    // position.ts's `position` is always measured from the physical
+    // bottom of the rack (SPEC: collision.ts's yToInternalPosition,
+    // "U=1 at bottom"). So humanU (bottom-up) = position / UNITS_PER_U,
+    // and the row index from the top is i = height - humanU. The ruler
+    // then labels that row `startUnit + i` (descending) or
+    // `startUnit + (height - 1) - i` (ascending). If formatDisplayPosition
+    // diverges from this, the announced/edit-panel U no longer matches
+    // what's drawn on the ruler.
+    function rulerLabel(
+      position: number,
+      height: number,
+      descUnits: boolean,
+      startingUnit: number,
+    ): string {
+      const humanU = position / UNITS_PER_U;
+      const i = height - humanU;
+      const uNumber = descUnits
+        ? startingUnit + i
+        : startingUnit + (height - 1) - i;
+      return `U${uNumber}`;
+    }
+
+    const height = 42;
+    // Physical rail positions (internal units) for U1 (bottom), U17, and U42 (top).
+    const bottomPosition = toInternalUnits(1);
+    const midPosition = toInternalUnits(17);
+    const topPosition = toInternalUnits(height);
+
+    it("matches the ruler for an ascending rack starting at U1 (default)", () => {
+      for (const position of [bottomPosition, midPosition, topPosition]) {
+        expect(formatDisplayPosition(position, height, false, 1)).toBe(
+          rulerLabel(position, height, false, 1),
+        );
+      }
+      // Matches the documented example: bottom rail position labels U1.
+      expect(formatDisplayPosition(bottomPosition, height, false, 1)).toBe(
+        "U1",
+      );
+    });
+
+    it("matches the ruler for a descending rack starting at U1 (default)", () => {
+      for (const position of [bottomPosition, midPosition, topPosition]) {
+        expect(formatDisplayPosition(position, height, true, 1)).toBe(
+          rulerLabel(position, height, true, 1),
+        );
+      }
+      // Matches the documented example: bottom rail position labels U42
+      // when desc_units flips U1 to the top.
+      expect(formatDisplayPosition(bottomPosition, height, true, 1)).toBe(
+        "U42",
+      );
+    });
+
+    it("matches the ruler for an ascending rack with an offset starting_unit", () => {
+      const startingUnit = 25;
+      for (const position of [bottomPosition, midPosition, topPosition]) {
+        expect(
+          formatDisplayPosition(position, height, false, startingUnit),
+        ).toBe(rulerLabel(position, height, false, startingUnit));
+      }
+      // The bottom rail position is the rack's first physical U, so it
+      // carries the starting_unit label directly.
+      expect(
+        formatDisplayPosition(bottomPosition, height, false, startingUnit),
+      ).toBe("U25");
+    });
+
+    it("matches the ruler for a descending rack with an offset starting_unit", () => {
+      const startingUnit = 25;
+      for (const position of [bottomPosition, midPosition, topPosition]) {
+        expect(
+          formatDisplayPosition(position, height, true, startingUnit),
+        ).toBe(rulerLabel(position, height, true, startingUnit));
+      }
+      // The top rail position is row i=0, so it carries the starting_unit
+      // label directly when descending.
+      expect(
+        formatDisplayPosition(topPosition, height, true, startingUnit),
+      ).toBe("U25");
+    });
+
+    it("defaults starting_unit to 1 when omitted, preserving prior callers", () => {
+      expect(formatDisplayPosition(bottomPosition, height, false)).toBe(
+        formatDisplayPosition(bottomPosition, height, false, 1),
+      );
+      expect(formatDisplayPosition(bottomPosition, height, true)).toBe(
+        formatDisplayPosition(bottomPosition, height, true, 1),
+      );
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

Fixes forward two verified CodeAnt post-merge findings from the M022 campaign. Both source PRs (#3017, #3018) were squash-merged before these findings were read (process miss), so this PR addresses them on top of current main.

- **CodeAnt finding, PR #3017, comment https://github.com/RackulaLives/Rackula/pull/3017#discussion_r3566106209**: `DevicePaletteItem`'s roving-key handler (`handleRovingKeyDown`) only called `preventDefault`/`stopPropagation` when focus actually moved to another row. Boundary no-ops that `nextRovingIndex`'s own wrap-around math produces (Home already on the first row, End already on the last row, or any mapped key in a single-item list, e.g. a lone pinned device) returned early without cancelling, so the key bubbled to window-level shortcuts. With a device selected in the rack, this let a boundary keypress in the palette also trigger the global move-device-in-rack shortcut. Verified with a red-first test proving the leak against the unfixed code. Fix: cancel unconditionally for any key in `ROVING_KEY_MAP` before the boundary checks that can return early.

- **CodeAnt finding, PR #3018, comment https://github.com/RackulaLives/Rackula/pull/3018#discussion_r3566108076**: `formatDisplayPosition` (`src/lib/utils/position.ts`) ignored a rack's `starting_unit`, so racks whose numbering starts above U1 (e.g. a continuation rack) showed a U label that diverged from the ruler (`Rack.svelte`'s `uLabels`). The helper now takes `starting_unit` and applies the same offset the ruler's formula uses, verified against an independent re-derivation of that formula across ascending/descending x default/offset starting_unit combinations. `Canvas.svelte`'s device-list description and `EditPanelPosition.svelte`'s Position readout now pass `rack.starting_unit` through.

  **Note:** `EditPanelPosition`'s pre-existing display also ignored `starting_unit` (not introduced by #3018 or this PR). Its Position row now shows a different value than before for racks with an offset `starting_unit` -- this is the correct outcome (it now matches the ruler), not a regression, and is covered by a new test asserting the changed value.

Refs #2998, #2999.

## Test plan

- [x] Red-first test proving the roving-key bubble against unfixed `DevicePaletteItem.svelte`, green after the fix (`src/tests/device-palette-item-roving-boundary.test.ts`)
- [x] Red-first test proving `formatDisplayPosition` diverges from the ruler for offset racks against unfixed `position.ts`, green after the fix (`src/tests/position.test.ts`)
- [x] Red-first test proving the `Canvas.svelte` and `EditPanelPosition.svelte` call sites propagate `starting_unit` correctly (`src/tests/Canvas.device-list-position.test.ts`, `src/tests/edit-panel-position-starting-unit.test.ts`)
- [x] `npx vitest run` (full suite, 3355 tests) passes
- [x] `npm run lint` clean
- [x] `npm run check` (svelte-check) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjQ86RRYi4MzfShss9VCCe


___

## **CodeAnt-AI Description**
Fix palette key handling and rack position labels on offset racks

### What Changed
- Arrow, Home, and End keys in the device palette no longer bubble up when focus stays on the same row, so palette navigation won’t also trigger global device-move shortcuts.
- Position labels now respect a rack’s starting U number, and the canvas and edit panel both show the same U label as the rack ruler.
- Added regression tests for boundary key presses and for ascending/descending racks that start above U1.

### Impact
`✅ Fewer accidental device moves while navigating the palette`
`✅ Matching rack labels in the canvas and edit panel`
`✅ Clearer position readouts for continuation racks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
