### PR TITLE
fix: pin c-ares>=1.34.8-r0 to resolve CVE-2026-33630 (#91)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -29,16 +29,17 @@ RUN npm run build
 # Production stage - non-root nginx
 FROM nginxinc/nginx-unprivileged:alpine
 # Patch system packages to resolve known CVEs (e.g. libpng, libxml2 CVE-2026-6732,
-# libssl3/libcrypto3 CVE-2026-45447, libexpat CVE-2026-45186). APK_CACHEBUST is
-# fed a per-build value (release version / date) so this layer's buildcache is
-# invalidated each build and apk upgrade re-fetches current Alpine secfixes instead
-# of reusing a stale cached layer. Packages are pinned explicitly so tracked CVE
-# fixes are force-applied even if a future base ships them pinned to older versions.
+# libssl3/libcrypto3 CVE-2026-45447, libexpat CVE-2026-45186, c-ares CVE-2026-33630).
+# APK_CACHEBUST is fed a per-build value (release version / date) so this layer's
+# buildcache is invalidated each build and apk upgrade re-fetches current Alpine
+# secfixes instead of reusing a stale cached layer. Packages are pinned explicitly so
+# tracked CVE fixes are force-applied even if a future base ships them pinned to older
+# versions.
 ARG APK_CACHEBUST=0
 USER root
 RUN echo "apk-cachebust=${APK_CACHEBUST}" && \
     apk upgrade --no-cache && \
-    apk add --no-cache --upgrade "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0" "libexpat>=2.8.1-r0"
+    apk add --no-cache --upgrade "libssl3>=3.5.7-r0" "libcrypto3>=3.5.7-r0" "libexpat>=2.8.1-r0" "c-ares>=1.34.8-r0"
 USER nginx
 
 # OCI labels


### PR DESCRIPTION
## Summary

Resolves code-scanning alert [#91](https://github.com/RackulaLives/Rackula/security/code-scanning/91): Trivy flagged **c-ares 1.34.6-r0** (HIGH, [CVE-2026-33630](https://avd.aquasec.com/nvd/cve-2026-33630) — use-after-free / double-free in DNS query-completion handling) in the published `rackula-persist` image. Fixed version is **1.34.8-r0**.

Adds an explicit forward-looking pin for `c-ares` to `deploy/Dockerfile`, alongside the existing `libssl3` / `libcrypto3` / `libexpat` pins, so release builds force-apply the fix even if a future base image ships c-ares held back.

## Why this is safe

- c-ares **1.34.8-r0** is present in Alpine **v3.23**, **v3.22**, and **edge** `main` (built 2026-07-08), so the `>=1.34.8-r0` constraint resolves and the existing `apk upgrade --no-cache` already pulls it. The pin will not fail the build.
- Mirrors the pattern used for the earlier libexpat alert #85.

## Alert clearing

Trivy **image** alerts are bound to the published image, not source, so this merge alone does not close #91. The alert clears after `rebuild-images.yml` rebuilds + rescans the rolling tags (triggered separately). This PR is the source-side, forward-looking half.

## Test plan

- Alpine repo availability for 1.34.8-r0 verified across v3.22/v3.23 main.
- No app/runtime behaviour change; single-line package pin plus comment.