### PR TITLE
docs: add brand pack contribution guide (and simplify pack registration)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ Key documentation for contributors:
 - **Architecture overview:** `docs/ARCHITECTURE.md` (start here for orientation)
 - **Technical overview:** `docs/reference/SPEC.md` (design principles)
 - **Testing guide:** `docs/guides/TESTING.md` (testing patterns)
+- **Brand packs:** `docs/guides/BRAND-PACKS.md` (adding a vendor to the device library)
 - **AI instructions:** `CLAUDE.md` (Claude Code workflow)
 
 ### Svelte 5 Runes

--- a/docs/guides/BRAND-PACKS.md
+++ b/docs/guides/BRAND-PACKS.md
@@ -1,0 +1,142 @@
+# Brand Pack Contribution Guide
+
+A brand pack is one vendor section in Rackula's device library (Dell, Ubiquiti, Blackmagic Design, and so on). This guide walks through adding a new vendor and opening a PR.
+
+> Adding a device to a vendor that already exists? You do not need this guide. Open the matching file in `src/lib/data/brandPacks/`, add the device to its array, and see [NETBOX-IMPORT.md](NETBOX-IMPORT.md) for sourcing the data and images. The steps below are for creating a brand-new vendor section.
+
+This guide owns the mechanics of a new pack: the data file, registration, and the brand icon. Two neighbouring docs own the rest and are linked where they apply:
+
+- [NETBOX-IMPORT.md](NETBOX-IMPORT.md): sourcing device data, slug and category conventions, and the device-image pipeline.
+- [CONTRIBUTING.md](../../CONTRIBUTING.md): dev setup, formatting, and the PR and sign-off process.
+
+## What we accept
+
+Homelab, AV and broadcast, networking, power, storage, cooling, and enterprise gear are all welcome. There is no gate on the kind of hardware; the bar is accuracy:
+
+- Real, rack-mountable products (any rack width Rackula supports: 10, 19, 21, 23 inch).
+- Correct `u_height` and depth, taken from a spec sheet or measured.
+- The right `category` and a unique `slug` per device.
+- A brand icon (see Step 3).
+- A verifiable source. Manufacturer spec sheets are ideal. The [NetBox devicetype-library](https://github.com/netbox-community/devicetype-library) is a convenient CC0 source with dimensions and elevation images.
+
+## Step 1: Create the pack file
+
+Add `src/lib/data/brandPacks/<brand>.ts` exporting a `<brand>Devices` array. A real minimal pack to copy is [`zima.ts`](../../src/lib/data/brandPacks/zima.ts) (one device); [`netgate.ts`](../../src/lib/data/brandPacks/netgate.ts) shows several.
+
+```typescript
+import type { DeviceType } from "$lib/types";
+import { CATEGORY_COLOURS } from "$lib/types/constants";
+
+/**
+ * Acme device definitions
+ */
+export const acmeDevices: DeviceType[] = [
+  {
+    slug: "acme-sw24", // unique, lowercase, hyphenated
+    u_height: 1, // 0.5 to 50, in steps of 0.5
+    manufacturer: "Acme",
+    model: "SW24",
+    category: "network",
+    colour: CATEGORY_COLOURS.network,
+    is_full_depth: false,
+    airflow: "front-to-rear",
+  },
+];
+```
+
+Required on every device: `slug`, `u_height`, `category`, and `colour`. Everything else is optional. The full field list and its rules live in the Zod schema at [`src/lib/schemas/index.ts`](../../src/lib/schemas/index.ts) (`DeviceTypeSchema`), which validates every device at load and in tests.
+
+Field notes:
+
+- `slug`: lowercase letters, digits, and single hyphens, unique across all packs. Convention is `<manufacturer>-<product-line>-<model>` (a `+` becomes `-plus`). See the slug rules in [NETBOX-IMPORT.md](NETBOX-IMPORT.md#slug-naming-convention).
+- `category`: one of `server`, `network`, `firewall`, `patch-panel`, `power`, `storage`, `kvm`, `av-media`, `cooling`, `shelf`, `blank`, `cable-management`, `chassis`, `other`. Categories drive the default colour and behaviour.
+- `colour`: any 6-character hex, but use `CATEGORY_COLOURS.<category>` from [`src/lib/types/constants.ts`](../../src/lib/types/constants.ts) so packs stay consistent with the palette.
+- `airflow` (optional): `passive`, `front-to-rear`, `rear-to-front`, `left-to-right`, `right-to-left`, `side-to-rear`, or `mixed`. Defaults to `front-to-rear`.
+- `slot_width: 1` marks a half-width device; `u_height` below 1 marks sub-U gear. Both mount inside a carrier rather than directly on the rails, which Rackula handles at placement time.
+- `front_image` / `rear_image` (optional booleans): set these only after you have run the image pipeline in [NETBOX-IMPORT.md](NETBOX-IMPORT.md); images are optional and can come in a later PR.
+
+## Step 2: Register the pack
+
+Open [`src/lib/data/brandPacks/index.ts`](../../src/lib/data/brandPacks/index.ts) and make two edits: import the array, then add one entry to `BRAND_PACK_REGISTRY`.
+
+```typescript
+// 1. Import (with the other brand imports near the top)
+import { acmeDevices } from "./acme";
+
+// 2. One registry entry
+const BRAND_PACK_REGISTRY: ReadonlyArray<
+  Omit<BrandSection, "defaultExpanded">
+> = [
+  // ... existing packs
+  { id: "acme", title: "Acme", devices: acmeDevices, icon: "acme" },
+];
+```
+
+That is the whole registration. The palette sections, the merged device list, slug lookups, and the tests all derive from `BRAND_PACK_REGISTRY`, so there is nothing else to keep in sync in this file. Order in the array does not matter: sections render A-Z by `title` and devices sort A-Z within each section.
+
+- `id`: unique, matches your file name. It keys the palette accordion, so a duplicate breaks the library (a test enforces uniqueness).
+- `title`: the display name shown in the library.
+- `icon`: the brand-icon slug, wired up in Step 3.
+
+## Step 3: Add the brand icon
+
+The `icon` slug in your registry entry is looked up in an `iconMap` in [`src/lib/components/BrandIcon.svelte`](../../src/lib/components/BrandIcon.svelte). This is the one step the registry does not do for you. If the slug has no iconMap entry, the section renders a generic lightning-bolt fallback.
+
+First check whether the brand is in [simple-icons](https://simpleicons.org): search the site for the brand.
+
+If it is there, import its `si<PascalName>` export and map your slug to it:
+
+```svelte
+import { siAcme } from "simple-icons";
+
+const iconMap = {
+  // ... existing entries
+  acme: siAcme,
+};
+```
+
+If it is not in simple-icons, add a path to [`src/lib/components/customBrandIcons.ts`](../../src/lib/components/customBrandIcons.ts) (an SVG path normalised to a 24x24 viewBox) and map your slug to it with a hex colour:
+
+```typescript
+// customBrandIcons.ts
+export const acmePath = "M12 2L2 22h20L12 2z";
+```
+
+```svelte
+// BrandIcon.svelte
+import { acmePath } from "./customBrandIcons";
+
+const iconMap = {
+  // ... existing entries
+  acme: { path: acmePath, hex: "FFFFFF" },
+};
+```
+
+The iconMap key must match the `icon` value in your registry entry exactly. If you see a lightning bolt where your logo should be, they do not match.
+
+## Step 4: Verify and open a PR
+
+Run the checks locally:
+
+```bash
+npm run check       # types
+npm run lint        # ESLint
+npm run format      # Prettier (run this; a new .ts file often needs it)
+npm run test:run    # unit tests
+npm run build       # production build
+npm run dev         # then find your brand in the library and confirm the icon
+```
+
+You do not edit any test file. `src/tests/brandpacks.test.ts` is parameterised over the registry and validates every device against the schema, so a correct pack passes with zero test changes. Adding a device must never require touching a test.
+
+Then open the PR following [CONTRIBUTING.md](../../CONTRIBUTING.md#pull-request-process): branch `feat/<brand>-brand-pack`, a `feat:` commit signed off with `git commit -s` (DCO), and AI co-author attribution if you used assistance. CodeRabbit reviews every PR, so expect review comments before merge.
+
+## Checklist
+
+- [ ] New `src/lib/data/brandPacks/<brand>.ts` exporting `<brand>Devices`.
+- [ ] Each device has `slug`, `u_height`, `category`, `colour`; slugs unique.
+- [ ] Imported and added one `BRAND_PACK_REGISTRY` entry in `index.ts`.
+- [ ] Brand icon wired in `BrandIcon.svelte` (simple-icons or `customBrandIcons.ts`).
+- [ ] `npm run check`, `lint`, `format`, `test:run`, `build` all pass.
+- [ ] `npm run dev` shows the section with the correct icon.
+- [ ] PR branch, `feat:` commit, and DCO sign-off per CONTRIBUTING.md.

--- a/src/lib/data/brandPacks/index.ts
+++ b/src/lib/data/brandPacks/index.ts
@@ -1,6 +1,14 @@
 /**
  * Brand Pack Index
- * Exports all brand-specific device packs
+ *
+ * A brand pack is one vendor section in the device library. To add a new pack,
+ * add a single entry to BRAND_PACK_REGISTRY below (alongside its import). The
+ * palette sections, brand-icon slug lookups, the merged device list, and the
+ * tests all derive from that registry. The one thing that does not is the icon
+ * artwork: a new `icon` slug must also be added to the iconMap in
+ * BrandIcon.svelte (or it renders the generic fallback).
+ *
+ * See docs/guides/BRAND-PACKS.md for the full contribution walkthrough.
  */
 
 import type { DeviceType, Airflow } from "$lib/types";
@@ -17,7 +25,6 @@ import { apcDevices } from "./apc";
 import { dellDevices } from "./dell";
 import { supermicroDevices } from "./supermicro";
 import { hpeDevices } from "./hpe";
-// New brand packs
 import { fortinetDevices } from "./fortinet";
 import { eatonDevices } from "./eaton";
 import { netgearDevices } from "./netgear";
@@ -41,40 +48,6 @@ import { beelinkDevices } from "./beelink";
 import { raspberryPiDevices } from "./raspberry-pi";
 import { zimaDevices } from "./zima";
 
-export {
-  ubiquitiDevices,
-  mikrotikDevices,
-  tplinkDevices,
-  synologyDevices,
-  apcDevices,
-  dellDevices,
-  supermicroDevices,
-  hpeDevices,
-  // New brand packs
-  fortinetDevices,
-  eatonDevices,
-  netgearDevices,
-  paloaltoDevices,
-  qnapDevices,
-  lenovoDevices,
-  cyberpowerDevices,
-  netgateDevices,
-  blackmagicdesignDevices,
-  deskpiDevices,
-  kwsDevices,
-  acInfinityDevices,
-  appleDevices,
-  ciscoDevices,
-  aristaDevices,
-  juniperDevices,
-  vertivDevices,
-  fsDevices,
-  intelDevices,
-  beelinkDevices,
-  raspberryPiDevices,
-  zimaDevices,
-};
-
 /**
  * Brand section data structure
  */
@@ -86,6 +59,117 @@ export interface BrandSection {
   /** simple-icons slug for brand logo, undefined for fallback icon */
   icon?: string;
 }
+
+/**
+ * Single source of truth for brand packs. Each entry becomes one section in the
+ * device library, and getAllBrandDevices()/getBrandSlugs()/getBrandIconSlug()
+ * all derive from it. Adding a pack means adding one entry here (plus its
+ * import); the only separate step is registering the `icon` slug in
+ * BrandIcon.svelte's iconMap.
+ *
+ * Each `id` must be unique (it keys the palette's accordion sections); the
+ * brandpacks test enforces this. Order in this array does not matter:
+ * getBrandPacks() sorts sections A-Z by title and devices A-Z within each
+ * section (#2723). The comment groupings are for humans scanning the file only.
+ * defaultExpanded is false for every pack.
+ */
+const BRAND_PACK_REGISTRY: ReadonlyArray<
+  Omit<BrandSection, "defaultExpanded">
+> = [
+  // Network
+  {
+    id: "ubiquiti",
+    title: "Ubiquiti",
+    devices: ubiquitiDevices,
+    icon: "ubiquiti",
+  },
+  {
+    id: "mikrotik",
+    title: "MikroTik",
+    devices: mikrotikDevices,
+    icon: "mikrotik",
+  },
+  { id: "tp-link", title: "TP-Link", devices: tplinkDevices, icon: "tplink" },
+  {
+    id: "fortinet",
+    title: "Fortinet",
+    devices: fortinetDevices,
+    icon: "fortinet",
+  },
+  { id: "netgear", title: "Netgear", devices: netgearDevices, icon: "netgear" },
+  {
+    id: "palo-alto",
+    title: "Palo Alto",
+    devices: paloaltoDevices,
+    icon: "paloaltonetworks",
+  },
+  { id: "cisco", title: "Cisco", devices: ciscoDevices, icon: "cisco" },
+  { id: "arista", title: "Arista", devices: aristaDevices, icon: "arista" },
+  {
+    id: "juniper",
+    title: "Juniper",
+    devices: juniperDevices,
+    icon: "junipernetworks",
+  },
+  { id: "netgate", title: "Netgate", devices: netgateDevices, icon: "netgate" },
+  { id: "fs", title: "FS.COM", devices: fsDevices, icon: "fs" },
+  // Storage
+  {
+    id: "synology",
+    title: "Synology",
+    devices: synologyDevices,
+    icon: "synology",
+  },
+  { id: "qnap", title: "QNAP", devices: qnapDevices, icon: "qnap" },
+  // Power
+  { id: "apc", title: "APC", devices: apcDevices, icon: "schneiderelectric" },
+  { id: "eaton", title: "Eaton", devices: eatonDevices, icon: "eaton" },
+  { id: "vertiv", title: "Vertiv", devices: vertivDevices, icon: "vertiv" },
+  {
+    id: "cyberpower",
+    title: "CyberPower",
+    devices: cyberpowerDevices,
+    icon: "cyberpower",
+  },
+  // Servers
+  { id: "dell", title: "Dell", devices: dellDevices, icon: "dell" },
+  {
+    id: "supermicro",
+    title: "Supermicro",
+    devices: supermicroDevices,
+    icon: "supermicro",
+  },
+  { id: "hpe", title: "HPE", devices: hpeDevices, icon: "hp" },
+  { id: "lenovo", title: "Lenovo", devices: lenovoDevices, icon: "lenovo" },
+  { id: "apple", title: "Apple", devices: appleDevices, icon: "apple" },
+  // AV/Media
+  {
+    id: "blackmagicdesign",
+    title: "Blackmagic Design",
+    devices: blackmagicdesignDevices,
+    icon: "blackmagicdesign",
+  },
+  // Homelab Accessories
+  { id: "deskpi", title: "DeskPi", devices: deskpiDevices, icon: "deskpi" },
+  { id: "kws", title: "KWS", devices: kwsDevices, icon: "kws" },
+  // Cooling
+  {
+    id: "ac-infinity",
+    title: "AC Infinity",
+    devices: acInfinityDevices,
+    icon: "acinfinity",
+  },
+  // Mini PCs / SBCs
+  { id: "intel", title: "Intel", devices: intelDevices, icon: "intel" },
+  { id: "beelink", title: "Beelink", devices: beelinkDevices, icon: "beelink" },
+  {
+    id: "raspberry-pi",
+    title: "Raspberry Pi",
+    devices: raspberryPiDevices,
+    icon: "raspberrypi",
+  },
+  { id: "zima", title: "Zima", devices: zimaDevices, icon: "zima" },
+];
 
 /**
  * Cached, ordered brand pack sections. Brand packs are static data, so the
@@ -102,237 +186,14 @@ export function getBrandPacks(): BrandSection[] {
     return cachedBrandPacks;
   }
 
-  const sections: BrandSection[] = [
-    // Network Equipment
-    {
-      id: "ubiquiti",
-      title: "Ubiquiti",
-      devices: ubiquitiDevices,
-      defaultExpanded: false,
-      icon: "ubiquiti",
-    },
-    {
-      id: "mikrotik",
-      title: "MikroTik",
-      devices: mikrotikDevices,
-      defaultExpanded: false,
-      icon: "mikrotik",
-    },
-    {
-      id: "tp-link",
-      title: "TP-Link",
-      devices: tplinkDevices,
-      defaultExpanded: false,
-      icon: "tplink",
-    },
-    {
-      id: "fortinet",
-      title: "Fortinet",
-      devices: fortinetDevices,
-      defaultExpanded: false,
-      icon: "fortinet",
-    },
-    {
-      id: "netgear",
-      title: "Netgear",
-      devices: netgearDevices,
-      defaultExpanded: false,
-      icon: "netgear",
-    },
-    {
-      id: "palo-alto",
-      title: "Palo Alto",
-      devices: paloaltoDevices,
-      defaultExpanded: false,
-      icon: "paloaltonetworks",
-    },
-    {
-      id: "cisco",
-      title: "Cisco",
-      devices: ciscoDevices,
-      defaultExpanded: false,
-      icon: "cisco",
-    },
-    {
-      id: "arista",
-      title: "Arista",
-      devices: aristaDevices,
-      defaultExpanded: false,
-      icon: "arista",
-    },
-    {
-      id: "juniper",
-      title: "Juniper",
-      devices: juniperDevices,
-      defaultExpanded: false,
-      icon: "junipernetworks",
-    },
-    {
-      id: "netgate",
-      title: "Netgate",
-      devices: netgateDevices,
-      defaultExpanded: false,
-      icon: "netgate",
-    },
-    {
-      id: "fs",
-      title: "FS.COM",
-      devices: fsDevices,
-      defaultExpanded: false,
-      icon: "fs",
-    },
-    // Storage
-    {
-      id: "synology",
-      title: "Synology",
-      devices: synologyDevices,
-      defaultExpanded: false,
-      icon: "synology",
-    },
-    {
-      id: "qnap",
-      title: "QNAP",
-      devices: qnapDevices,
-      defaultExpanded: false,
-      icon: "qnap",
-    },
-    // Power
-    {
-      id: "apc",
-      title: "APC",
-      devices: apcDevices,
-      defaultExpanded: false,
-      icon: "schneiderelectric",
-    },
-    {
-      id: "eaton",
-      title: "Eaton",
-      devices: eatonDevices,
-      defaultExpanded: false,
-      icon: "eaton",
-    },
-    {
-      id: "vertiv",
-      title: "Vertiv",
-      devices: vertivDevices,
-      defaultExpanded: false,
-      icon: "vertiv",
-    },
-    {
-      id: "cyberpower",
-      title: "CyberPower",
-      devices: cyberpowerDevices,
-      defaultExpanded: false,
-      icon: "cyberpower",
-    },
-    // Servers
-    {
-      id: "dell",
-      title: "Dell",
-      devices: dellDevices,
-      defaultExpanded: false,
-      icon: "dell",
-    },
-    {
-      id: "supermicro",
-      title: "Supermicro",
-      devices: supermicroDevices,
-      defaultExpanded: false,
-      icon: "supermicro",
-    },
-    {
-      id: "hpe",
-      title: "HPE",
-      devices: hpeDevices,
-      defaultExpanded: false,
-      icon: "hp",
-    },
-    {
-      id: "lenovo",
-      title: "Lenovo",
-      devices: lenovoDevices,
-      defaultExpanded: false,
-      icon: "lenovo",
-    },
-    // AV/Media
-    {
-      id: "blackmagicdesign",
-      title: "Blackmagic Design",
-      devices: blackmagicdesignDevices,
-      defaultExpanded: false,
-      icon: "blackmagicdesign",
-    },
-    // Homelab Accessories
-    {
-      id: "deskpi",
-      title: "DeskPi",
-      devices: deskpiDevices,
-      defaultExpanded: false,
-      icon: "deskpi",
-    },
-    {
-      id: "kws",
-      title: "KWS",
-      devices: kwsDevices,
-      defaultExpanded: false,
-      icon: "kws",
-    },
-    // Cooling
-    {
-      id: "ac-infinity",
-      title: "AC Infinity",
-      devices: acInfinityDevices,
-      defaultExpanded: false,
-      icon: "acinfinity",
-    },
-    // Servers - Apple
-    {
-      id: "apple",
-      title: "Apple",
-      devices: appleDevices,
-      defaultExpanded: false,
-      icon: "apple",
-    },
-    // Mini PCs / SBCs
-    {
-      id: "intel",
-      title: "Intel",
-      devices: intelDevices,
-      defaultExpanded: false,
-      icon: "intel",
-    },
-    {
-      id: "beelink",
-      title: "Beelink",
-      devices: beelinkDevices,
-      defaultExpanded: false,
-      icon: "beelink",
-    },
-    {
-      id: "raspberry-pi",
-      title: "Raspberry Pi",
-      devices: raspberryPiDevices,
-      defaultExpanded: false,
-      icon: "raspberrypi",
-    },
-    {
-      id: "zima",
-      title: "Zima",
-      devices: zimaDevices,
-      defaultExpanded: false,
-      icon: "zima",
-    },
-  ];
-
   // Single source of truth for device-library ordering (#2723): brand sections
   // A-Z by title, devices A-Z (numeric-aware) within each section. The palette
   // consumes this pre-sorted, so it does not re-sort at render.
-  cachedBrandPacks = sections
-    .map((section) => ({
-      ...section,
-      devices: sortDevicesAlphabetically(section.devices),
-    }))
-    .sort((a, b) => compareNames(a.title, b.title));
+  cachedBrandPacks = BRAND_PACK_REGISTRY.map((section) => ({
+    ...section,
+    defaultExpanded: false,
+    devices: sortDevicesAlphabetically(section.devices),
+  })).sort((a, b) => compareNames(a.title, b.title));
 
   return cachedBrandPacks;
 }
@@ -352,76 +213,6 @@ export function getBrandIconSlug(deviceSlug?: string): string | undefined {
   )?.icon;
 }
 
-/**
- * Get devices for a specific brand
- */
-export function getBrandDevices(brandId: string): DeviceType[] {
-  switch (brandId) {
-    case "ubiquiti":
-      return ubiquitiDevices;
-    case "mikrotik":
-      return mikrotikDevices;
-    case "tp-link":
-      return tplinkDevices;
-    case "synology":
-      return synologyDevices;
-    case "apc":
-      return apcDevices;
-    case "dell":
-      return dellDevices;
-    case "supermicro":
-      return supermicroDevices;
-    case "hpe":
-      return hpeDevices;
-    case "fortinet":
-      return fortinetDevices;
-    case "eaton":
-      return eatonDevices;
-    case "netgear":
-      return netgearDevices;
-    case "palo-alto":
-      return paloaltoDevices;
-    case "qnap":
-      return qnapDevices;
-    case "lenovo":
-      return lenovoDevices;
-    case "cyberpower":
-      return cyberpowerDevices;
-    case "netgate":
-      return netgateDevices;
-    case "blackmagicdesign":
-      return blackmagicdesignDevices;
-    case "deskpi":
-      return deskpiDevices;
-    case "kws":
-      return kwsDevices;
-    case "ac-infinity":
-      return acInfinityDevices;
-    case "apple":
-      return appleDevices;
-    case "cisco":
-      return ciscoDevices;
-    case "arista":
-      return aristaDevices;
-    case "juniper":
-      return juniperDevices;
-    case "vertiv":
-      return vertivDevices;
-    case "fs":
-      return fsDevices;
-    case "intel":
-      return intelDevices;
-    case "beelink":
-      return beelinkDevices;
-    case "raspberry-pi":
-      return raspberryPiDevices;
-    case "zima":
-      return zimaDevices;
-    default:
-      return [];
-  }
-}
-
 // Cached merged array of all brand devices (built once on first access)
 let cachedBrandDevices: DeviceType[] | null = null;
 
@@ -432,38 +223,7 @@ let cachedBrandDevices: DeviceType[] | null = null;
  */
 export function getAllBrandDevices(): DeviceType[] {
   if (!cachedBrandDevices) {
-    cachedBrandDevices = [
-      ...ubiquitiDevices,
-      ...mikrotikDevices,
-      ...tplinkDevices,
-      ...synologyDevices,
-      ...apcDevices,
-      ...dellDevices,
-      ...supermicroDevices,
-      ...hpeDevices,
-      ...fortinetDevices,
-      ...eatonDevices,
-      ...netgearDevices,
-      ...paloaltoDevices,
-      ...qnapDevices,
-      ...lenovoDevices,
-      ...cyberpowerDevices,
-      ...netgateDevices,
-      ...blackmagicdesignDevices,
-      ...deskpiDevices,
-      ...kwsDevices,
-      ...acInfinityDevices,
-      ...appleDevices,
-      ...ciscoDevices,
-      ...aristaDevices,
-      ...juniperDevices,
-      ...vertivDevices,
-      ...fsDevices,
-      ...intelDevices,
-      ...beelinkDevices,
-      ...raspberryPiDevices,
-      ...zimaDevices,
-    ];
+    cachedBrandDevices = BRAND_PACK_REGISTRY.flatMap((pack) => pack.devices);
   }
   return cachedBrandDevices;
 }

--- a/src/tests/brandpacks.test.ts
+++ b/src/tests/brandpacks.test.ts
@@ -57,6 +57,22 @@ describe("Brand Packs", () => {
 });
 
 describe("Cross-Brand Validation", () => {
+  it("no duplicate section ids across brand packs", () => {
+    // Section id keys the palette's accordion (DevicePalette #each ... (section.id));
+    // a collision throws a Svelte each_key_duplicate error at runtime.
+    const ids = ALL_BRAND_PACKS.map((pack) => pack.id);
+    const uniqueIds = new Set(ids);
+    const duplicates = ids.filter((id, i) => ids.indexOf(id) !== i);
+    expect(duplicates).toEqual([]);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it("no duplicate titles across brand packs", () => {
+    const titles = ALL_BRAND_PACKS.map((pack) => pack.title);
+    const duplicates = titles.filter((t, i) => titles.indexOf(t) !== i);
+    expect(duplicates).toEqual([]);
+  });
+
   it("no duplicate slugs across all brand packs", () => {
     const allSlugs: string[] = [];
     for (const pack of ALL_BRAND_PACKS) {


### PR DESCRIPTION
Closes #3046
Closes #3047

## Summary

There was no guide for contributing a brand pack (a vendor section in the device library). This PR adds one, and first removes a footgun that guide would otherwise have to document: registering a pack took five separate edits to `index.ts`, and forgetting the `getBrandDevices()` switch case or the `getAllBrandDevices()` spread silently broke device lookups.

## Changes

- Refactor `src/lib/data/brandPacks/index.ts` to a single `BRAND_PACK_REGISTRY`. `getBrandPacks()`, `getAllBrandDevices()`, `getBrandSlugs()`, and `getBrandIconSlug()` all derive from it, so a new pack is now one registry entry plus its import.
- Remove the dead `getBrandDevices()` switch (no consumers repo-wide) and the unused per-brand re-export block (nothing imports the individual `<brand>Devices` arrays from the barrel).
- Add cross-pack `id` and `title` uniqueness tests. Section `id` keys the device-palette accordion, so a duplicate would throw at runtime; only slug uniqueness was previously covered.
- Add `docs/guides/BRAND-PACKS.md`: a triage-first walkthrough (data file, single registry entry, `BrandIcon.svelte` icon wiring, verification, PR) with a copy-paste checklist. It links out to `NETBOX-IMPORT.md` for device data and images and to `CONTRIBUTING.md` for the PR flow rather than restating them.
- Cross-link the new guide from `CONTRIBUTING.md`.

No change to the device library's contents or ordering: sections still render A-Z by title with devices A-Z within each.

## Related

- Closes #3046 (simplify brand pack registration to a single registry entry)
- Closes #3047 (document how to contribute a brand pack via PR)
- Follow-up #3045 (add missing brand icons: Juniper, Eaton, Vertiv, KWS) is intentionally out of scope; that gap is pre-existing.

## Testing

- [x] Unit tests pass (`npm run test:run`): brand-pack suites plus the pre-commit `vitest related` set for the changed files (which for `index.ts` is broad) passed; `svelte-check` reports 0 errors; ESLint and Prettier clean.
- [ ] E2E tests pass (`npm run test:e2e`): not run. This is a behavior-preserving data-module refactor plus docs, with no user-facing change.
- [x] Manual testing completed: full production build (`npm run build`) succeeds; verified no consumers of the removed exports (no namespace imports, no re-export chains).

## Screenshots

Not applicable (no visual change).

## Accessibility

Not applicable (non-UI change).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed (ran the code-review skill at extra-high effort; both findings addressed)
- [x] No new warnings introduced
- [x] Tests added for new functionality (id/title uniqueness invariant)