### PR TITLE
test: fix stale device arming in responsive placement-banner e2e (#2697)

### DIFF
--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./helpers/base-test";
-import { gotoWithRack, locators } from "./helpers";
+import { gotoWithRack, locators, paletteItemByName } from "./helpers";
 
 test.describe("Responsive Layout", () => {
   test.describe("Desktop viewport (1200px)", () => {
@@ -64,9 +64,16 @@ test.describe("Responsive Layout", () => {
       // The placement banner is a full-width top overlay stacked above the
       // controls. The upper-left History group must drop below it so undo/redo
       // stays reachable while a device is armed.
-      const firstDevice = page.locator(locators.device.paletteItem).first();
-      await expect(firstDevice).toBeVisible();
-      await firstDevice.focus();
+      //
+      // Arm a named, full-width "Server" rather than the palette's positional
+      // first row: the alphabetized palette's first item is "Blade Server
+      // (Full-Height)", a chassis-child device that cannot rail-mount and only
+      // abandons placement with a screen-reader announcement, never arming the
+      // "Placing:" banner this test asserts on (#2851, matching the
+      // armServerForKeyboard convention in keyboard-placement.spec.ts).
+      const serverDevice = paletteItemByName(page, "Server").first();
+      await expect(serverDevice).toBeVisible();
+      await serverDevice.focus();
       await page.keyboard.press("Enter");
 
       const banner = page


### PR DESCRIPTION
## **User description**
## Summary

Fixes the nightly e2e failure in `e2e/responsive.spec.ts:61` ("history controls clear the placement banner during placement (#2697)"), failing on both chromium and webkit every nightly run since 2026-07-04. The test itself was stale, not the app.

## Root cause

The test armed the palette's positional first device via `page.locator(locators.device.paletteItem).first()`, then pressed Enter and expected a "Placing:" banner.

Since #2745 alphabetized the device palette (and the default view is brand mode with the Generic section expanded), the first row shown is the first category (`server`) sorted A-Z by model name, not by insertion order. "Blade Server (Full-Height)" sorts before "Server" alphabetically (B < S), so it is the actual first palette row, not a generic 1U server as the test assumed.

`blade-server-full` is a chassis child (`subdevice_role: "child"`, half-width). `requiresChassisBay()` (`src/lib/utils/collision.ts:505`) correctly returns `true` for it: it cannot rail-mount and no carrier can be synthesised for a chassis child. Under the honest-placement model (#2854/#2873), `primeKeyboardPlacement` abandons placement for such a device with only a screen-reader announcement ("Blade Server (Full-Height) must be placed in a chassis bay...") and never renders the "Placing:" banner.

This is not a regression: the abandon path is working exactly as designed. It is also not a new problem for this test file specifically: `dragDeviceToRack`, `armServerForKeyboard` (keyboard-placement.spec.ts), and the mouse/keyboard flows in ios-safari.spec.ts and mobile-placement-mouse.spec.ts already default to an explicitly-named "Server" device for this exact reason (see the comment at `e2e/helpers/device-actions.ts:39-43`, from #2851/#2755). This one test in responsive.spec.ts was the last holdout still using the fragile positional `.first()`.

## Evidence

- Reproduced locally on current `main` (chromium and webkit): both fail identically at `responsive.spec.ts:75` waiting on the "Placing:" banner, timeout, element never found.
- Captured the Playwright error-context snapshot at failure time: the palette's first `server` category listitem is literally `"Blade Server (Full-Height), 4U, server, half-width, half-depth"`.
- Captured the assertive announcer text at the moment of the failed Enter press: `"Blade Server (Full-Height) must be placed in a chassis bay. Drop it o[nto an existing bay]"` — the honest-placement abandon message, not an app error.
- Confirmed statically: `requiresCarrier(blade-server-full)` is `true` (half-width), `synthesizeCarrierForDevice(blade-server-full)` is `null` (chassis child never gets a synthesised rail carrier), so `requiresChassisBay()` is `true`.

## Fix

Arm the palette's named, full-width "Server" device via `paletteItemByName(page, "Server").first()` instead of the positional `.first()`, matching the established convention used by `keyboard-placement.spec.ts`, `ios-safari.spec.ts`, and `mobile-placement-mouse.spec.ts`. Added a comment explaining why, consistent with the existing `armServerForKeyboard` comment.

Checked the rest of `responsive.spec.ts` for the same fragile pattern: no other test in this file arms a device for placement via positional `.first()`, so no further changes were needed in this file. (Other spec files use positional `.first()` for non-arming purposes such as visibility checks, out of scope here.)

## Testing

- [x] E2E tests pass (`npm run test:e2e -- responsive.spec.ts --project=chromium`): 16/16 passed
- [x] E2E tests pass (`npm run test:e2e -- responsive.spec.ts --project=webkit`): 16/16 passed
- [x] `npx eslint e2e/responsive.spec.ts`: no issues
- [x] `prettier --check e2e/responsive.spec.ts` (main checkout's prettier): already formatted correctly

Local verification commands:

```bash
npm run test:e2e -- responsive.spec.ts --project=chromium
npm run test:e2e -- responsive.spec.ts --project=webkit
```

Note: one unrelated pre-existing flake was observed and self-resolved via the suite's built-in `retries: 1` config during these runs: `Panzoom at narrow viewport > reset view via keyboard shortcut` on webkit (a CSS transform-timing race, untouched by this change, in a different `describe` block). Re-running it in isolation with `--repeat-each=3` passed 3/3. Not addressed here as it is out of scope for this fix.

## Accessibility

Not applicable, this is a test-only change with no UI or behavioural changes.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Tests added for new functionality: n/a, existing test fixed to arm a valid device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3nXdhjPHsxnEwVpWyQefD


___

## **CodeAnt-AI Description**
Fix the responsive placement-banner test to arm a real Server device

### What Changed
- The responsive layout test now selects the named “Server” device instead of the first palette item
- This avoids a false failure caused by the first visible item being a chassis-only device that does not show the “Placing:” banner
- The test now matches the same device selection used by other placement flows

### Impact
`✅ Fewer nightly e2e failures`
`✅ Stable placement-banner test runs`
`✅ More reliable responsive layout checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
