### PR TITLE
fix: replace raw parser and schema errors with plain-language messages (#2989)

### DIFF
--- a/src/lib/utils/debug.ts
+++ b/src/lib/utils/debug.ts
@@ -69,6 +69,11 @@ export const sessionDebug = {
   storage: Debug("rackula:session:storage"),
 };
 
+/** Debug logger for the shared plain-language import/decode failure path (#2989): file-import (yaml.ts) and share-link decode (share.ts) route their raw parse/validation detail here instead of console.warn. */
+export const importDebug = {
+  validation: Debug("rackula:import:validation"),
+};
+
 // Create shared instances for reuse
 const generalLog = Debug("rackula:general");
 const infoLog = Debug("rackula:info");

--- a/src/lib/utils/import-errors.ts
+++ b/src/lib/utils/import-errors.ts
@@ -129,6 +129,14 @@ const INVALID_FORMAT_DEFAULT_LABELS = [
 ];
 
 /**
+ * A single Zod-generated `values` token: a double-quoted string (from
+ * `z.enum(...)`) or a bare number (from `z.literal(<number>)`). Used to
+ * match `invalid_value`'s default message, which lists one or more of these
+ * joined by `|`.
+ */
+const INVALID_VALUE_TOKEN = String.raw`(?:"[^"]*"|-?\d+(?:\.\d+)?)`;
+
+/**
  * Zod 4's built-in English error map (node_modules/zod/src/v4/locales/en.ts,
  * verified against the installed zod@4.4.3) produces a fixed, recognizable
  * message shape for a field with no custom message on the schema. Each
@@ -136,20 +144,29 @@ const INVALID_FORMAT_DEFAULT_LABELS = [
  * template for that issue code, not just its leading words, so a custom
  * message that merely starts with "Invalid " or "Too big: " is not
  * misdetected as machine-generated (verified against every bare
- * `.min()`/`.max()`/`.url()`/etc. in src/lib/schemas/index.ts and share.ts,
- * and against a set of custom messages that share those prefixes).
+ * `.min()`/`.max()`/`.url()`/`.enum()`/`.union()`/`.literal()`/etc. in
+ * src/lib/schemas/index.ts and share.ts, and against a set of custom
+ * messages that share those prefixes).
+ *
+ * `invalid_value` covers both `z.enum(...)` failures ("Invalid option:
+ * expected one of ...") and a standalone `z.literal(...)` failure ("Invalid
+ * input: expected ..."). `invalid_union` covers `z.union([z.literal(...),
+ * ...])` failures (e.g. `RackWidthSchema`, `SlotWidthSchema`, the share
+ * format's `w`): Zod reports these as a single top-level issue whose message
+ * is the fixed string "Invalid input" (no discriminator info, since none of
+ * this codebase's unions are `z.discriminatedUnion`).
  *
  * ImportValidationIssue deliberately does not carry the extra fields
- * (`origin`, `minimum`, `maximum`, `inclusive`, `received`) the real error
- * map needs to regenerate these messages exactly, so detection matches the
- * template's fixed structure (words, punctuation, comparison operators)
- * around a `\S+`/`\d+` placeholder for the variable parts, instead of
- * reconstructing and comparing the default text field-by-field. Trade-off: a
- * future custom message that happens to fully match one of these templates
- * (e.g. a custom `too_big` message literally shaped like "Too big: expected
- * string to have <=5 characters") would be misdetected as machine-generated.
- * That shape is specific enough that no current schema message collides
- * with it.
+ * (`origin`, `minimum`, `maximum`, `inclusive`, `received`, `values`) the
+ * real error map needs to regenerate these messages exactly, so detection
+ * matches the template's fixed structure (words, punctuation, comparison
+ * operators) around a `\S+`/`\d+` placeholder for the variable parts,
+ * instead of reconstructing and comparing the default text field-by-field.
+ * Trade-off: a future custom message that happens to fully match one of
+ * these templates (e.g. a custom `too_big` message literally shaped like
+ * "Too big: expected string to have <=5 characters") would be misdetected
+ * as machine-generated. That shape is specific enough that no current
+ * schema message collides with it.
  */
 const ZOD_DEFAULT_MESSAGE_PATTERNS: Partial<Record<string, RegExp>> = {
   invalid_type: /^Invalid input: expected \S+, received \S+$/,
@@ -160,6 +177,10 @@ const ZOD_DEFAULT_MESSAGE_PATTERNS: Partial<Record<string, RegExp>> = {
   invalid_format: new RegExp(
     `^Invalid (?:${INVALID_FORMAT_DEFAULT_LABELS.map(escapeRegExp).join("|")}|string: must (?:start with|end with|include) ".*"|string: must match pattern .+)$`,
   ),
+  invalid_value: new RegExp(
+    String.raw`^Invalid (?:option: expected one of ${INVALID_VALUE_TOKEN}(?:\|${INVALID_VALUE_TOKEN})+|input: expected ${INVALID_VALUE_TOKEN})$`,
+  ),
+  invalid_union: /^Invalid input$/,
 };
 
 /** Plain-language clause appended after the humanized field name (e.g. "Name is invalid") for a field that has no custom schema message. */
@@ -167,6 +188,8 @@ const PLAIN_CODE_CLAUSES: Partial<Record<string, string>> = {
   too_small: "does not meet the minimum requirement",
   too_big: "exceeds the maximum allowed",
   invalid_format: "is not formatted correctly",
+  invalid_value: "must be one of the supported options",
+  invalid_union: "must be one of the supported options",
 };
 
 const DEFAULT_ISSUE_CLAUSE = "is invalid";

--- a/src/lib/utils/import-errors.ts
+++ b/src/lib/utils/import-errors.ts
@@ -1,0 +1,111 @@
+/**
+ * Plain-language copy for import/decode failures (#2989).
+ *
+ * The file-import path (yaml.ts, loading a .yaml/.zip layout) and the
+ * share-link decode path (share.ts, the `?l=` URL) hit the same three
+ * failure shapes: the payload cannot be parsed at all, it parses but is not
+ * a layout, or it parses as a layout with one invalid field. Both doors
+ * route their failure copy through this module so they cannot drift apart
+ * again (R4, docs/research/ui-friction-review-2026-07-11.md).
+ */
+
+export type ImportSource = "file" | "share-link";
+
+/**
+ * Shown when the payload cannot be parsed at all (a corrupt or binary file,
+ * malformed compression, invalid JSON). Raw detail belongs on the console,
+ * never in this copy.
+ */
+export function unreadableImportMessage(source: ImportSource): string {
+  return source === "file"
+    ? "Could not read layout file"
+    : "Could not decode share link";
+}
+
+/**
+ * Shown when the payload parses but does not resolve to a valid layout.
+ * This is the share-link path's original curated copy, reused verbatim so a
+ * user gets the same words for the same underlying problem through either
+ * door.
+ */
+export const INVALID_LAYOUT_FORMAT_MESSAGE =
+  "Layout format is invalid or outdated";
+
+/**
+ * The subset of a Zod issue this module reads. Kept independent of Zod's own
+ * issue type so callers (and tests) can pass a plain object shaped like one.
+ */
+export interface ImportValidationIssue {
+  path: PropertyKey[];
+  message: string;
+  code?: string;
+  expected?: string;
+}
+
+/** Plain-language names for the Zod `expected` type strings used by the schema. */
+const PLAIN_TYPE_NAMES: Record<string, string> = {
+  number: "a number",
+  string: "text",
+  boolean: "true or false",
+  array: "a list",
+  object: "an object",
+};
+
+function humanizeSegment(segment: PropertyKey): string {
+  return String(segment).replace(/_/g, " ");
+}
+
+function singularize(word: string): string {
+  return word.endsWith("s") && word.length > 1 ? word.slice(0, -1) : word;
+}
+
+/**
+ * Turn a Zod issue path (e.g. `["racks", 0, "devices", 0, "position"]`) into
+ * a short plain-language field label (e.g. "device position"). Array indices
+ * are dropped; only the field and its immediate named parent are kept so the
+ * label stays short.
+ */
+function humanizeFieldPath(path: PropertyKey[]): string {
+  const named = path.filter((segment) => typeof segment !== "number");
+  if (named.length === 0) return "value";
+  const field = humanizeSegment(named[named.length - 1]!);
+  if (named.length === 1) return field;
+  const parent = singularize(humanizeSegment(named[named.length - 2]!));
+  return `${parent} ${field}`;
+}
+
+function capitalize(text: string): string {
+  return text.length > 0 ? text[0]!.toUpperCase() + text.slice(1) : text;
+}
+
+/**
+ * Format a single Zod validation issue as plain language, with no dotted
+ * path prefix. An existing custom schema message (e.g. "Height cannot
+ * exceed 100U") is already human-authored text, so it is preserved as-is; a
+ * generic type-mismatch issue has no such message, so a plain-language
+ * sentence is built from the field name instead.
+ */
+function describeSingleIssue(issue: ImportValidationIssue): string {
+  if (issue.code === "invalid_type") {
+    const expected = issue.expected
+      ? (PLAIN_TYPE_NAMES[issue.expected] ?? `a ${issue.expected}`)
+      : "a different value";
+    return `${capitalize(humanizeFieldPath(issue.path))} must be ${expected}`;
+  }
+  return issue.message;
+}
+
+/**
+ * Map a list of Zod validation issues to one plain-language toast message.
+ * A single issue gets a field-aware message (see {@link describeSingleIssue}).
+ * Zero or multiple issues fall back to {@link INVALID_LAYOUT_FORMAT_MESSAGE}:
+ * a comma-joined raw issue list is never shown to the user.
+ */
+export function describeValidationIssues(
+  issues: ImportValidationIssue[],
+): string {
+  if (issues.length === 1) {
+    return describeSingleIssue(issues[0]!);
+  }
+  return INVALID_LAYOUT_FORMAT_MESSAGE;
+}

--- a/src/lib/utils/import-errors.ts
+++ b/src/lib/utils/import-errors.ts
@@ -49,7 +49,13 @@ const PLAIN_TYPE_NAMES: Record<string, string> = {
   boolean: "true or false",
   array: "a list",
   object: "an object",
+  int: "a whole number",
 };
+
+/** Prefixes an unrecognized `expected` type name with "a"/"an" (e.g. "an int", "a bigint") for the {@link PLAIN_TYPE_NAMES} fallback. */
+function withIndefiniteArticle(word: string): string {
+  return /^[aeiou]/i.test(word) ? `an ${word}` : `a ${word}`;
+}
 
 function humanizeSegment(segment: PropertyKey): string {
   return String(segment).replace(/_/g, " ");
@@ -68,7 +74,7 @@ function singularize(word: string): string {
 function humanizeFieldPath(path: PropertyKey[]): string {
   const named = path.filter((segment) => typeof segment !== "number");
   if (named.length === 0) return "value";
-  const field = humanizeSegment(named[named.length - 1]!);
+  const field = singularize(humanizeSegment(named[named.length - 1]!));
   if (named.length === 1) return field;
   const parent = singularize(humanizeSegment(named[named.length - 2]!));
   return `${parent} ${field}`;
@@ -79,18 +85,67 @@ function capitalize(text: string): string {
 }
 
 /**
+ * Zod 4's built-in English error map (node_modules/zod/src/v4/locales/en.ts,
+ * verified against the installed zod@4.4.3) produces a fixed, recognizable
+ * message shape for a field with no custom message on the schema. A schema
+ * author's own message is free-form text and never happens to start with
+ * these machine-generated prefixes in this codebase (checked every bare
+ * `.min()`/`.max()`/`.url()` in src/lib/schemas/index.ts and share.ts).
+ *
+ * ImportValidationIssue deliberately does not carry the extra fields
+ * (`origin`, `minimum`, `maximum`, `inclusive`) the real error map needs to
+ * regenerate these messages exactly, so detection matches by prefix/shape
+ * instead of reconstructing and comparing the default text. Trade-off: a
+ * future custom message that happens to start with the same words (e.g.
+ * "Too big: this file cannot be shared") would be misdetected as
+ * machine-generated and replaced with the generic clause below.
+ */
+const ZOD_DEFAULT_MESSAGE_PATTERNS: Partial<Record<string, RegExp>> = {
+  too_small: /^Too small: /,
+  too_big: /^Too big: /,
+  invalid_format: /^Invalid /,
+};
+
+/** Plain-language clause appended after the humanized field name (e.g. "Name is invalid") for a field that has no custom schema message. */
+const PLAIN_CODE_CLAUSES: Partial<Record<string, string>> = {
+  too_small: "does not meet the minimum requirement",
+  too_big: "exceeds the maximum allowed",
+  invalid_format: "is not formatted correctly",
+};
+
+const DEFAULT_ISSUE_CLAUSE = "is invalid";
+
+function isZodDefaultMessage(issue: ImportValidationIssue): boolean {
+  const pattern = issue.code
+    ? ZOD_DEFAULT_MESSAGE_PATTERNS[issue.code]
+    : undefined;
+  return pattern ? pattern.test(issue.message) : false;
+}
+
+/**
  * Format a single Zod validation issue as plain language, with no dotted
  * path prefix. An existing custom schema message (e.g. "Height cannot
- * exceed 100U") is already human-authored text, so it is preserved as-is; a
- * generic type-mismatch issue has no such message, so a plain-language
- * sentence is built from the field name instead.
+ * exceed 100U") is already human-authored text, so it is preserved as-is.
+ * A generic type-mismatch issue has no such message, so a plain-language
+ * sentence is built from the field name instead. Other bare constraints
+ * (`.min()`, `.max()`, `.url()`, etc. with no message argument) ship Zod's
+ * own internal wording (e.g. "Too small: expected string to have >=1
+ * characters") - {@link isZodDefaultMessage} detects that case and swaps in
+ * plain copy instead of leaking it to the user.
  */
 function describeSingleIssue(issue: ImportValidationIssue): string {
   if (issue.code === "invalid_type") {
     const expected = issue.expected
-      ? (PLAIN_TYPE_NAMES[issue.expected] ?? `a ${issue.expected}`)
+      ? (PLAIN_TYPE_NAMES[issue.expected] ??
+        withIndefiniteArticle(issue.expected))
       : "a different value";
     return `${capitalize(humanizeFieldPath(issue.path))} must be ${expected}`;
+  }
+  if (isZodDefaultMessage(issue)) {
+    const clause = issue.code
+      ? (PLAIN_CODE_CLAUSES[issue.code] ?? DEFAULT_ISSUE_CLAUSE)
+      : DEFAULT_ISSUE_CLAUSE;
+    return `${capitalize(humanizeFieldPath(issue.path))} ${clause}`;
   }
   return issue.message;
 }

--- a/src/lib/utils/import-errors.ts
+++ b/src/lib/utils/import-errors.ts
@@ -84,26 +84,82 @@ function capitalize(text: string): string {
   return text.length > 0 ? text[0]!.toUpperCase() + text.slice(1) : text;
 }
 
+/** Escapes regex metacharacters so a literal string can be embedded in a larger pattern. */
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The exact set of format labels Zod 4's default English error map emits for
+ * `invalid_format` (node_modules/zod/src/v4/locales/en.ts `FormatDictionary`,
+ * verified against the installed zod@4.4.3). Only formats this codebase's
+ * schemas use bare (no custom message) matter in practice - currently just
+ * `.url()` ("Invalid URL") - but the full dictionary is listed so this stays
+ * correct if a future bare `.email()`/`.uuid()`/etc. is added.
+ */
+const INVALID_FORMAT_DEFAULT_LABELS = [
+  "input",
+  "email address",
+  "URL",
+  "emoji",
+  "UUID",
+  "UUIDv4",
+  "UUIDv6",
+  "nanoid",
+  "GUID",
+  "cuid",
+  "cuid2",
+  "ULID",
+  "XID",
+  "KSUID",
+  "ISO datetime",
+  "ISO date",
+  "ISO time",
+  "ISO duration",
+  "IPv4 address",
+  "IPv6 address",
+  "MAC address",
+  "IPv4 range",
+  "IPv6 range",
+  "base64-encoded string",
+  "base64url-encoded string",
+  "JSON string",
+  "E.164 number",
+  "JWT",
+];
+
 /**
  * Zod 4's built-in English error map (node_modules/zod/src/v4/locales/en.ts,
  * verified against the installed zod@4.4.3) produces a fixed, recognizable
- * message shape for a field with no custom message on the schema. A schema
- * author's own message is free-form text and never happens to start with
- * these machine-generated prefixes in this codebase (checked every bare
- * `.min()`/`.max()`/`.url()` in src/lib/schemas/index.ts and share.ts).
+ * message shape for a field with no custom message on the schema. Each
+ * pattern below is anchored (`^...$`) and matches the *full* generated
+ * template for that issue code, not just its leading words, so a custom
+ * message that merely starts with "Invalid " or "Too big: " is not
+ * misdetected as machine-generated (verified against every bare
+ * `.min()`/`.max()`/`.url()`/etc. in src/lib/schemas/index.ts and share.ts,
+ * and against a set of custom messages that share those prefixes).
  *
  * ImportValidationIssue deliberately does not carry the extra fields
- * (`origin`, `minimum`, `maximum`, `inclusive`) the real error map needs to
- * regenerate these messages exactly, so detection matches by prefix/shape
- * instead of reconstructing and comparing the default text. Trade-off: a
- * future custom message that happens to start with the same words (e.g.
- * "Too big: this file cannot be shared") would be misdetected as
- * machine-generated and replaced with the generic clause below.
+ * (`origin`, `minimum`, `maximum`, `inclusive`, `received`) the real error
+ * map needs to regenerate these messages exactly, so detection matches the
+ * template's fixed structure (words, punctuation, comparison operators)
+ * around a `\S+`/`\d+` placeholder for the variable parts, instead of
+ * reconstructing and comparing the default text field-by-field. Trade-off: a
+ * future custom message that happens to fully match one of these templates
+ * (e.g. a custom `too_big` message literally shaped like "Too big: expected
+ * string to have <=5 characters") would be misdetected as machine-generated.
+ * That shape is specific enough that no current schema message collides
+ * with it.
  */
 const ZOD_DEFAULT_MESSAGE_PATTERNS: Partial<Record<string, RegExp>> = {
-  too_small: /^Too small: /,
-  too_big: /^Too big: /,
-  invalid_format: /^Invalid /,
+  invalid_type: /^Invalid input: expected \S+, received \S+$/,
+  too_small:
+    /^Too small: expected \S+ to (?:have [<>]=?\d+(?:\.\d+)? (?:characters|bytes|items|entries)|be [<>]=?\d+(?:\.\d+)?)$/,
+  too_big:
+    /^Too big: expected \S+ to (?:have [<>]=?\d+(?:\.\d+)? (?:characters|bytes|items|entries)|be [<>]=?\d+(?:\.\d+)?)$/,
+  invalid_format: new RegExp(
+    `^Invalid (?:${INVALID_FORMAT_DEFAULT_LABELS.map(escapeRegExp).join("|")}|string: must (?:start with|end with|include) ".*"|string: must match pattern .+)$`,
+  ),
 };
 
 /** Plain-language clause appended after the humanized field name (e.g. "Name is invalid") for a field that has no custom schema message. */
@@ -115,6 +171,14 @@ const PLAIN_CODE_CLAUSES: Partial<Record<string, string>> = {
 
 const DEFAULT_ISSUE_CLAUSE = "is invalid";
 
+/**
+ * True when `issue.message` is exactly the machine-generated default text
+ * Zod 4 ships for `issue.code` (see {@link ZOD_DEFAULT_MESSAGE_PATTERNS}).
+ * False for any issue code this module has no default template for, and for
+ * any message that doesn't fully match the template - including an
+ * author-written custom message, even one that happens to start with the
+ * same words as a default.
+ */
 function isZodDefaultMessage(issue: ImportValidationIssue): boolean {
   const pattern = issue.code
     ? ZOD_DEFAULT_MESSAGE_PATTERNS[issue.code]
@@ -124,16 +188,20 @@ function isZodDefaultMessage(issue: ImportValidationIssue): boolean {
 
 /**
  * Format a single Zod validation issue as plain language, with no dotted
- * path prefix. An existing custom schema message (e.g. "Height cannot
- * exceed 100U") is already human-authored text, so it is preserved as-is.
- * A generic type-mismatch issue has no such message, so a plain-language
- * sentence is built from the field name instead. Other bare constraints
- * (`.min()`, `.max()`, `.url()`, etc. with no message argument) ship Zod's
- * own internal wording (e.g. "Too small: expected string to have >=1
- * characters") - {@link isZodDefaultMessage} detects that case and swaps in
- * plain copy instead of leaking it to the user.
+ * path prefix. Any message that is not Zod's own machine-generated default
+ * for its issue code - including a custom `invalid_type` message - is
+ * already human-authored text, so it is preserved as-is (see
+ * {@link isZodDefaultMessage}). A generic type-mismatch issue with no
+ * custom message has a plain-language sentence built from the field name
+ * instead. Other bare constraints (`.min()`, `.max()`, `.url()`, etc. with
+ * no message argument) ship Zod's own internal wording (e.g. "Too small:
+ * expected string to have >=1 characters") that is swapped for plain copy
+ * the same way.
  */
 function describeSingleIssue(issue: ImportValidationIssue): string {
+  if (!isZodDefaultMessage(issue)) {
+    return issue.message;
+  }
   if (issue.code === "invalid_type") {
     const expected = issue.expected
       ? (PLAIN_TYPE_NAMES[issue.expected] ??
@@ -141,13 +209,10 @@ function describeSingleIssue(issue: ImportValidationIssue): string {
       : "a different value";
     return `${capitalize(humanizeFieldPath(issue.path))} must be ${expected}`;
   }
-  if (isZodDefaultMessage(issue)) {
-    const clause = issue.code
-      ? (PLAIN_CODE_CLAUSES[issue.code] ?? DEFAULT_ISSUE_CLAUSE)
-      : DEFAULT_ISSUE_CLAUSE;
-    return `${capitalize(humanizeFieldPath(issue.path))} ${clause}`;
-  }
-  return issue.message;
+  const clause = issue.code
+    ? (PLAIN_CODE_CLAUSES[issue.code] ?? DEFAULT_ISSUE_CLAUSE)
+    : DEFAULT_ISSUE_CLAUSE;
+  return `${capitalize(humanizeFieldPath(issue.path))} ${clause}`;
 }
 
 /**

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -35,6 +35,10 @@ import {
 import { generateId } from "./device";
 import { createDefaultRack } from "./serialization";
 import { toHumanUnits, toInternalUnits } from "./position";
+import {
+  INVALID_LAYOUT_FORMAT_MESSAGE,
+  unreadableImportMessage,
+} from "./import-errors";
 
 // =============================================================================
 // Helper Functions
@@ -512,7 +516,7 @@ export function decodeLayout(encoded: string): DecodeResult {
       const result = MinimalLayoutV2Schema.safeParse(parsed);
       if (!result.success) {
         console.warn("Share link v2 validation failed:", result.error);
-        return { layout: null, error: "Layout format is invalid or outdated" };
+        return { layout: null, error: INVALID_LAYOUT_FORMAT_MESSAGE };
       }
       return { layout: fromMinimalLayoutV2(result.data) };
     }
@@ -521,12 +525,12 @@ export function decodeLayout(encoded: string): DecodeResult {
     const result = MinimalLayoutSchema.safeParse(parsed);
     if (!result.success) {
       console.warn("Share link v1 validation failed:", result.error);
-      return { layout: null, error: "Layout format is invalid or outdated" };
+      return { layout: null, error: INVALID_LAYOUT_FORMAT_MESSAGE };
     }
     return { layout: fromMinimalLayoutV1(result.data) };
   } catch (error) {
     console.warn("Share link decode failed:", error);
-    return { layout: null, error: "Could not decode share link" };
+    return { layout: null, error: unreadableImportMessage("share-link") };
   }
 }
 

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -35,6 +35,7 @@ import {
 import { generateId } from "./device";
 import { createDefaultRack } from "./serialization";
 import { toHumanUnits, toInternalUnits } from "./position";
+import { importDebug } from "$lib/utils/debug";
 import {
   describeValidationIssues,
   unreadableImportMessage,
@@ -511,11 +512,18 @@ export function decodeLayout(encoded: string): DecodeResult {
     }
     const parsed = JSON.parse(json);
 
-    // Detect v1 vs v2 by field presence
-    if ("rs" in parsed) {
+    // Detect v1 vs v2 by field presence. Guard against JSON primitives
+    // (null, a string, a number, a boolean): `"rs" in parsed` throws for
+    // those, but they decoded successfully and are simply the wrong shape,
+    // so route them to the v1 schema's invalid-layout message instead of
+    // misreporting them as an unreadable/undecodable payload.
+    if (parsed !== null && typeof parsed === "object" && "rs" in parsed) {
       const result = MinimalLayoutV2Schema.safeParse(parsed);
       if (!result.success) {
-        console.warn("Share link v2 validation failed:", result.error);
+        importDebug.validation(
+          "Share link v2 validation failed: %O",
+          result.error,
+        );
         return {
           layout: null,
           error: describeValidationIssues(result.error.issues),
@@ -527,7 +535,10 @@ export function decodeLayout(encoded: string): DecodeResult {
     // v1 fallback
     const result = MinimalLayoutSchema.safeParse(parsed);
     if (!result.success) {
-      console.warn("Share link v1 validation failed:", result.error);
+      importDebug.validation(
+        "Share link v1 validation failed: %O",
+        result.error,
+      );
       return {
         layout: null,
         error: describeValidationIssues(result.error.issues),
@@ -535,7 +546,7 @@ export function decodeLayout(encoded: string): DecodeResult {
     }
     return { layout: fromMinimalLayoutV1(result.data) };
   } catch (error) {
-    console.warn("Share link decode failed:", error);
+    importDebug.validation("Share link decode failed: %O", error);
     return { layout: null, error: unreadableImportMessage("share-link") };
   }
 }

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -39,6 +39,8 @@ import { importDebug } from "$lib/utils/debug";
 import {
   describeValidationIssues,
   unreadableImportMessage,
+  INVALID_LAYOUT_FORMAT_MESSAGE,
+  type ImportValidationIssue,
 } from "./import-errors";
 
 // =============================================================================
@@ -366,6 +368,27 @@ function fromMinimalLayoutV2(minimal: MinimalLayoutV2): Layout {
   };
 }
 
+/**
+ * Share-link validation issues carry Zod paths built from the minimal
+ * format's abbreviated transport keys (`rs`, `dt`, `f`, ... - see the
+ * key-mapping comment at the top of this file), not the user-facing field
+ * names {@link describeValidationIssues}'s field-humanizer expects. Passing
+ * a nested issue straight through would surface wire-format internals like
+ * "R n must be text" instead of plain language (#2989 follow-up). A
+ * root-level type mismatch (empty path - the whole decoded payload isn't an
+ * object) has no transport key to leak, so it still gets the shared
+ * helper's specific message; any issue nested under a transport key falls
+ * back to the generic invalid-layout copy instead.
+ */
+function describeShareValidationIssues(
+  issues: ImportValidationIssue[],
+): string {
+  if (issues.length === 1 && issues[0]!.path.length > 0) {
+    return INVALID_LAYOUT_FORMAT_MESSAGE;
+  }
+  return describeValidationIssues(issues);
+}
+
 // =============================================================================
 // Encoding/Decoding Functions
 // =============================================================================
@@ -526,7 +549,7 @@ export function decodeLayout(encoded: string): DecodeResult {
         );
         return {
           layout: null,
-          error: describeValidationIssues(result.error.issues),
+          error: describeShareValidationIssues(result.error.issues),
         };
       }
       return { layout: fromMinimalLayoutV2(result.data) };
@@ -541,7 +564,7 @@ export function decodeLayout(encoded: string): DecodeResult {
       );
       return {
         layout: null,
-        error: describeValidationIssues(result.error.issues),
+        error: describeShareValidationIssues(result.error.issues),
       };
     }
     return { layout: fromMinimalLayoutV1(result.data) };

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -36,7 +36,7 @@ import { generateId } from "./device";
 import { createDefaultRack } from "./serialization";
 import { toHumanUnits, toInternalUnits } from "./position";
 import {
-  INVALID_LAYOUT_FORMAT_MESSAGE,
+  describeValidationIssues,
   unreadableImportMessage,
 } from "./import-errors";
 
@@ -516,7 +516,10 @@ export function decodeLayout(encoded: string): DecodeResult {
       const result = MinimalLayoutV2Schema.safeParse(parsed);
       if (!result.success) {
         console.warn("Share link v2 validation failed:", result.error);
-        return { layout: null, error: INVALID_LAYOUT_FORMAT_MESSAGE };
+        return {
+          layout: null,
+          error: describeValidationIssues(result.error.issues),
+        };
       }
       return { layout: fromMinimalLayoutV2(result.data) };
     }
@@ -525,7 +528,10 @@ export function decodeLayout(encoded: string): DecodeResult {
     const result = MinimalLayoutSchema.safeParse(parsed);
     if (!result.success) {
       console.warn("Share link v1 validation failed:", result.error);
-      return { layout: null, error: INVALID_LAYOUT_FORMAT_MESSAGE };
+      return {
+        layout: null,
+        error: describeValidationIssues(result.error.issues),
+      };
     }
     return { layout: fromMinimalLayoutV1(result.data) };
   } catch (error) {

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -15,7 +15,7 @@ import {
   type LayoutZod,
 } from "$lib/schemas";
 import { adaptLegacyLayout } from "$lib/storage";
-import { layoutDebug } from "$lib/utils/debug";
+import { layoutDebug, importDebug } from "$lib/utils/debug";
 import {
   decodeYamlImages,
   type SerializedImages,
@@ -92,14 +92,14 @@ export async function parseYaml<T = unknown>(yamlString: string): Promise<T> {
  * Parse YAML for the file-import path, replacing a js-yaml parse failure
  * (a code-frame exception painting raw file bytes into its message, e.g. for
  * binary content renamed .yaml) with the shared plain-language copy (#2989).
- * The raw exception is logged to the console, matching the share-link
- * decode path's existing console.warn convention.
+ * The raw exception is logged via the namespace-filtered debug logger,
+ * matching the share-link decode path's equivalent logging.
  */
 async function parseYamlForImport(yamlString: string): Promise<unknown> {
   try {
     return await parseYaml(yamlString);
   } catch (error) {
-    console.warn("Layout file parse failed:", error);
+    importDebug.validation("Layout file parse failed: %O", error);
     throw new Error(unreadableImportMessage("file"), { cause: error });
   }
 }
@@ -355,7 +355,7 @@ function validateParsedLayout(parsed: unknown): {
   // idempotent, so loadLayout re-running it after this parse is a no-op.
   const baseResult = LayoutSchemaBase.safeParse(parsed);
   if (!baseResult.success) {
-    console.warn("Layout validation failed:", baseResult.error);
+    importDebug.validation("Layout validation failed: %O", baseResult.error);
     throw new Error(describeValidationIssues(baseResult.error.issues), {
       cause: baseResult.error,
     });
@@ -366,7 +366,7 @@ function validateParsedLayout(parsed: unknown): {
   const result = LayoutSchema.safeParse(adapted);
 
   if (!result.success) {
-    console.warn("Layout validation failed:", result.error);
+    importDebug.validation("Layout validation failed: %O", result.error);
     throw new Error(describeValidationIssues(result.error.issues), {
       cause: result.error,
     });

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -22,6 +22,10 @@ import {
 } from "$lib/utils/image-encoding";
 import { orderLayoutFields } from "$lib/utils/yaml-field-order";
 import type { ImageStoreMap } from "$lib/types/images";
+import {
+  describeValidationIssues,
+  unreadableImportMessage,
+} from "$lib/utils/import-errors";
 
 /**
  * Warn if any rack contains duplicate device IDs before serialization (#1363)
@@ -82,6 +86,22 @@ export async function serializeToYaml(data: unknown): Promise<string> {
 export async function parseYaml<T = unknown>(yamlString: string): Promise<T> {
   const yaml = await getYaml();
   return yaml.load(yamlString, { schema: yaml.JSON_SCHEMA }) as T;
+}
+
+/**
+ * Parse YAML for the file-import path, replacing a js-yaml parse failure
+ * (a code-frame exception painting raw file bytes into its message, e.g. for
+ * binary content renamed .yaml) with the shared plain-language copy (#2989).
+ * The raw exception is logged to the console, matching the share-link
+ * decode path's existing console.warn convention.
+ */
+async function parseYamlForImport(yamlString: string): Promise<unknown> {
+  try {
+    return await parseYaml(yamlString);
+  } catch (error) {
+    console.warn("Layout file parse failed:", error);
+    throw new Error(unreadableImportMessage("file"), { cause: error });
+  }
 }
 
 /**
@@ -335,10 +355,10 @@ function validateParsedLayout(parsed: unknown): {
   // idempotent, so loadLayout re-running it after this parse is a no-op.
   const baseResult = LayoutSchemaBase.safeParse(parsed);
   if (!baseResult.success) {
-    const errors = baseResult.error.issues
-      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
-      .join(", ");
-    throw new Error(`Invalid layout: ${errors}`);
+    console.warn("Layout validation failed:", baseResult.error);
+    throw new Error(describeValidationIssues(baseResult.error.issues), {
+      cause: baseResult.error,
+    });
   }
 
   const adapted = adaptLegacyLayout(baseResult.data as unknown as Layout);
@@ -346,14 +366,10 @@ function validateParsedLayout(parsed: unknown): {
   const result = LayoutSchema.safeParse(adapted);
 
   if (!result.success) {
-    const errors = result.error.issues
-      .map((issue) => {
-        const path = issue.path.join(".");
-        return `${path}: ${issue.message}`;
-      })
-      .join(", ");
-
-    throw new Error(`Invalid layout: ${errors}`);
+    console.warn("Layout validation failed:", result.error);
+    throw new Error(describeValidationIssues(result.error.issues), {
+      cause: result.error,
+    });
   }
 
   return { layout: toRuntimeLayout(result.data), rawImages };
@@ -366,7 +382,7 @@ function validateParsedLayout(parsed: unknown): {
  * parseLayoutYamlWithImages to recover them).
  */
 export async function parseLayoutYaml(yamlString: string): Promise<Layout> {
-  const parsed = await parseYaml(yamlString);
+  const parsed = await parseYamlForImport(yamlString);
   return validateParsedLayout(parsed).layout;
 }
 
@@ -384,7 +400,7 @@ export async function parseLayoutYamlWithImages(yamlString: string): Promise<{
   failedImagesCount: number;
   failedKeys: string[];
 }> {
-  const parsed = await parseYaml(yamlString);
+  const parsed = await parseYamlForImport(yamlString);
   const { layout, rawImages } = validateParsedLayout(parsed);
   const { images, failedImagesCount, failedKeys } = decodeYamlImages(rawImages);
 

--- a/src/tests/import-errors.test.ts
+++ b/src/tests/import-errors.test.ts
@@ -12,6 +12,7 @@ import {
 } from "$lib/utils/import-errors";
 import { parseLayoutYaml } from "$lib/utils/yaml";
 import { decodeLayout } from "$lib/utils/share";
+import { PowerPortSchema, SlotSchema, DeviceLinkSchema } from "$lib/schemas";
 
 describe("unreadableImportMessage", () => {
   it("names the file for a file-import parse failure", () => {
@@ -78,6 +79,61 @@ describe("describeValidationIssues", () => {
     expect(message).toBe("Device position must be a number");
     expect(message).not.toContain("racks.0.devices.0.position");
   });
+
+  it("replaces Zod's default too-small wording for a bare .min() field with no custom message", () => {
+    // PowerPortSchema.name is `z.string().min(1)` with no custom message
+    // (src/lib/schemas/index.ts ~319), so Zod 4 ships its own internal
+    // wording ("Too small: expected string to have >=1 characters") here.
+    const result = PowerPortSchema.safeParse({ name: "" });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: an otherwise-valid PowerPortSchema payload with only `name` invalid must fail with exactly one issue
+    expect(result.error.issues).toHaveLength(1);
+
+    const message = describeValidationIssues(result.error.issues);
+
+    expect(message).not.toContain("Too small");
+    expect(message).not.toContain(">=1");
+    expect(message.toLowerCase()).toContain("name");
+  });
+
+  it("replaces Zod's default too-big wording for a bare .max() field with no custom message", () => {
+    // SlotSchema.name is `z.string().max(100)` with no custom message
+    // (src/lib/schemas/index.ts ~251).
+    const result = SlotSchema.safeParse({
+      id: "slot-1",
+      name: "x".repeat(101),
+      position: { row: 0, col: 0 },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: an otherwise-valid SlotSchema payload with only `name` invalid must fail with exactly one issue
+    expect(result.error.issues).toHaveLength(1);
+
+    const message = describeValidationIssues(result.error.issues);
+
+    expect(message).not.toContain("Too big");
+    expect(message).not.toContain("<=100");
+    expect(message.toLowerCase()).toContain("name");
+  });
+
+  it("replaces Zod's default invalid-URL wording for a bare .url() field with no custom message", () => {
+    // DeviceLinkSchema.url is `z.string().url()` with no custom message
+    // (src/lib/schemas/index.ts ~367).
+    const result = DeviceLinkSchema.safeParse({
+      label: "docs",
+      url: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: an otherwise-valid DeviceLinkSchema payload with only `url` invalid must fail with exactly one issue
+    expect(result.error.issues).toHaveLength(1);
+
+    const message = describeValidationIssues(result.error.issues);
+
+    expect(message).not.toContain("Invalid URL");
+    expect(message.toLowerCase()).toContain("url");
+  });
 });
 
 describe("shared helper unifies file-import and share-link copy (#2989 AC4)", () => {
@@ -98,5 +154,28 @@ describe("shared helper unifies file-import and share-link copy (#2989 AC4)", ()
 
     expect(fileMessage).toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
     expect(shareMessage).toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+  });
+
+  it("resolves the equivalent single-field failure to the same message on both doors", async () => {
+    // File-import: the parsed document is a list, not an object at all, so
+    // schema validation reports exactly one issue (root type mismatch).
+    let fileMessage = "";
+    try {
+      await parseLayoutYaml("- 1\n- 2\n");
+    } catch (error) {
+      fileMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    // Share-link: same underlying failure shape - a JSON array at the root,
+    // which is not an object either MinimalLayoutSchema or
+    // MinimalLayoutV2Schema can validate.
+    const encoded = LZString.compressToEncodedURIComponent(
+      JSON.stringify([1, 2, 3]),
+    );
+    const { error: shareMessage } = decodeLayout(encoded);
+
+    expect(fileMessage).not.toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+    expect(shareMessage).not.toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+    expect(fileMessage).toBe(shareMessage);
   });
 });

--- a/src/tests/import-errors.test.ts
+++ b/src/tests/import-errors.test.ts
@@ -12,7 +12,14 @@ import {
 } from "$lib/utils/import-errors";
 import { parseLayoutYaml } from "$lib/utils/yaml";
 import { decodeLayout } from "$lib/utils/share";
-import { PowerPortSchema, SlotSchema, DeviceLinkSchema } from "$lib/schemas";
+import {
+  PowerPortSchema,
+  SlotSchema,
+  DeviceLinkSchema,
+  DeviceFaceSchema,
+  RackWidthSchema,
+} from "$lib/schemas";
+import { z } from "$lib/zod";
 
 describe("unreadableImportMessage", () => {
   it("names the file for a file-import parse failure", () => {
@@ -153,6 +160,39 @@ describe("describeValidationIssues", () => {
 
     expect(message).not.toContain("Invalid URL");
     expect(message.toLowerCase()).toContain("url");
+  });
+
+  it("replaces Zod's default invalid-option wording for a real schema enum field", () => {
+    // DeviceFaceSchema is `z.enum(["front", "rear", "both"])`
+    // (src/lib/schemas/index.ts ~87), used unmodified (no custom message) at
+    // PlacedDeviceSchema.face.
+    const result = z
+      .object({ face: DeviceFaceSchema })
+      .safeParse({ face: "side" });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const message = describeValidationIssues(result.error.issues);
+
+    expect(message).not.toContain("Invalid option");
+    expect(message).not.toContain('"front"');
+    expect(message.toLowerCase()).toContain("face");
+  });
+
+  it("replaces Zod's default invalid-input wording for a real schema literal union field", () => {
+    // RackWidthSchema is `z.union([z.literal(10), z.literal(19), ...])`
+    // (src/lib/schemas/index.ts ~126), used unmodified (no custom message)
+    // at RackSchema.width.
+    const result = z
+      .object({ width: RackWidthSchema })
+      .safeParse({ width: 15 });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const message = describeValidationIssues(result.error.issues);
+
+    expect(message).not.toBe("Invalid input");
+    expect(message.toLowerCase()).toContain("width");
   });
 });
 

--- a/src/tests/import-errors.test.ts
+++ b/src/tests/import-errors.test.ts
@@ -80,6 +80,32 @@ describe("describeValidationIssues", () => {
     expect(message).not.toContain("racks.0.devices.0.position");
   });
 
+  it("preserves a custom message on an invalid_type field instead of rewriting it from the expected type", () => {
+    const message = describeValidationIssues([
+      {
+        path: ["racks", 0, "width"],
+        message: "Width must be 10 or 19 inches",
+        code: "invalid_type",
+        expected: "number",
+      },
+    ]);
+
+    expect(message).toBe("Width must be 10 or 19 inches");
+    expect(message).not.toContain("must be a number");
+  });
+
+  it("preserves a custom message that starts with the same words as a Zod default without matching its full shape", () => {
+    const message = describeValidationIssues([
+      {
+        path: ["racks", 0, "devices", 0, "device_type"],
+        message: "Invalid device type: unknown slug",
+        code: "invalid_format",
+      },
+    ]);
+
+    expect(message).toBe("Invalid device type: unknown slug");
+  });
+
   it("replaces Zod's default too-small wording for a bare .min() field with no custom message", () => {
     // PowerPortSchema.name is `z.string().min(1)` with no custom message
     // (src/lib/schemas/index.ts ~319), so Zod 4 ships its own internal
@@ -87,8 +113,6 @@ describe("describeValidationIssues", () => {
     const result = PowerPortSchema.safeParse({ name: "" });
     expect(result.success).toBe(false);
     if (result.success) return;
-    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: an otherwise-valid PowerPortSchema payload with only `name` invalid must fail with exactly one issue
-    expect(result.error.issues).toHaveLength(1);
 
     const message = describeValidationIssues(result.error.issues);
 
@@ -107,8 +131,6 @@ describe("describeValidationIssues", () => {
     });
     expect(result.success).toBe(false);
     if (result.success) return;
-    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: an otherwise-valid SlotSchema payload with only `name` invalid must fail with exactly one issue
-    expect(result.error.issues).toHaveLength(1);
 
     const message = describeValidationIssues(result.error.issues);
 
@@ -126,8 +148,6 @@ describe("describeValidationIssues", () => {
     });
     expect(result.success).toBe(false);
     if (result.success) return;
-    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: an otherwise-valid DeviceLinkSchema payload with only `url` invalid must fail with exactly one issue
-    expect(result.error.issues).toHaveLength(1);
 
     const message = describeValidationIssues(result.error.issues);
 

--- a/src/tests/import-errors.test.ts
+++ b/src/tests/import-errors.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the shared import/decode failure copy (#2989).
+ */
+
+import { describe, it, expect } from "vitest";
+import LZString from "lz-string";
+import {
+  describeValidationIssues,
+  unreadableImportMessage,
+  INVALID_LAYOUT_FORMAT_MESSAGE,
+  type ImportValidationIssue,
+} from "$lib/utils/import-errors";
+import { parseLayoutYaml } from "$lib/utils/yaml";
+import { decodeLayout } from "$lib/utils/share";
+
+describe("unreadableImportMessage", () => {
+  it("names the file for a file-import parse failure", () => {
+    expect(unreadableImportMessage("file")).toBe("Could not read layout file");
+  });
+
+  it("matches the share-link path's existing curated copy", () => {
+    expect(unreadableImportMessage("share-link")).toBe(
+      "Could not decode share link",
+    );
+  });
+});
+
+describe("describeValidationIssues", () => {
+  it("falls back to the shared invalid-format message for multiple issues, with no comma-joined list", () => {
+    const issues: ImportValidationIssue[] = [
+      {
+        path: ["name"],
+        message: "Invalid input: expected string, received undefined",
+        code: "invalid_type",
+        expected: "string",
+      },
+      {
+        path: ["settings"],
+        message: "Invalid input: expected object, received undefined",
+        code: "invalid_type",
+        expected: "object",
+      },
+    ];
+
+    const message = describeValidationIssues(issues);
+
+    expect(message).toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+    expect(message).not.toContain(",");
+  });
+
+  it("falls back to the shared invalid-format message for zero issues", () => {
+    expect(describeValidationIssues([])).toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+  });
+
+  it("preserves an existing custom schema message without the dotted path prefix", () => {
+    const message = describeValidationIssues([
+      {
+        path: ["racks", 0, "height"],
+        message: "Height cannot exceed 100U",
+        code: "too_big",
+      },
+    ]);
+
+    expect(message).toBe("Height cannot exceed 100U");
+    expect(message).not.toContain("racks.0");
+  });
+
+  it("names the field in plain language for a generic type-mismatch issue", () => {
+    const message = describeValidationIssues([
+      {
+        path: ["racks", 0, "devices", 0, "position"],
+        message: "Invalid input: expected number, received string",
+        code: "invalid_type",
+        expected: "number",
+      },
+    ]);
+
+    expect(message).toBe("Device position must be a number");
+    expect(message).not.toContain("racks.0.devices.0.position");
+  });
+});
+
+describe("shared helper unifies file-import and share-link copy (#2989 AC4)", () => {
+  it("resolves the equivalent underlying failure to the same message on both doors", async () => {
+    // File-import: valid YAML, but not shaped like a layout at all.
+    let fileMessage = "";
+    try {
+      await parseLayoutYaml("foo: bar\nbaz: 123\n");
+    } catch (error) {
+      fileMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    // Share-link: valid JSON, but not a recognized share format.
+    const encoded = LZString.compressToEncodedURIComponent(
+      JSON.stringify({ rs: "not-an-array" }),
+    );
+    const { error: shareMessage } = decodeLayout(encoded);
+
+    expect(fileMessage).toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+    expect(shareMessage).toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+  });
+});

--- a/src/tests/share.test.ts
+++ b/src/tests/share.test.ts
@@ -23,7 +23,10 @@ import {
   createTestDevice,
 } from "./factories";
 import { toInternalUnits } from "$lib/utils/position";
-import { unreadableImportMessage } from "$lib/utils/import-errors";
+import {
+  unreadableImportMessage,
+  INVALID_LAYOUT_FORMAT_MESSAGE,
+} from "$lib/utils/import-errors";
 import type { Layout } from "$lib/types";
 
 // pako 3.x exports a frozen, read-only ESM namespace, so vi.spyOn cannot
@@ -306,6 +309,28 @@ describe("decodeLayout", () => {
     expect(layout).toBeNull();
     expect(error).toBeDefined();
     expect(error).not.toBe(unreadableImportMessage("share-link"));
+  });
+
+  it("does not surface a raw share-format transport key in a v2 single-field failure", () => {
+    // Otherwise-valid MinimalLayoutV2 payload with one broken field (rack
+    // height, the `h` transport key) nested under `rs`. The Zod issue path
+    // is ["rs", 0, "h"] - if passed straight through the field-humanizer
+    // this would leak abbreviated wire-format keys (e.g. "R h must be...").
+    const payload = {
+      v: "1.0",
+      n: "Test Layout",
+      rs: [{ i: "0", n: "Rack 1", h: "not-a-number", w: 19, d: [] }],
+      dt: [],
+    };
+    const encoded = LZString.compressToEncodedURIComponent(
+      JSON.stringify(payload),
+    );
+    const { layout, error } = decodeLayout(encoded);
+
+    expect(layout).toBeNull();
+    expect(error).toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+    expect(error).not.toMatch(/\brs\b/i);
+    expect(error).not.toMatch(/\bh\b/i);
   });
 
   it("round-trips layout through encode/decode", () => {

--- a/src/tests/share.test.ts
+++ b/src/tests/share.test.ts
@@ -23,6 +23,7 @@ import {
   createTestDevice,
 } from "./factories";
 import { toInternalUnits } from "$lib/utils/position";
+import { unreadableImportMessage } from "$lib/utils/import-errors";
 import type { Layout } from "$lib/types";
 
 // pako 3.x exports a frozen, read-only ESM namespace, so vi.spyOn cannot
@@ -282,6 +283,29 @@ describe("decodeLayout", () => {
     expect(decodeLayout("invalid").error).toBeDefined();
     expect(decodeLayout("").layout).toBeNull();
     expect(decodeLayout("!!!").layout).toBeNull();
+  });
+
+  it("routes a decoded JSON null payload to the invalid-layout message, not the unreadable-payload message", () => {
+    // `"rs" in parsed` throws for a JSON primitive; a null payload decoded
+    // successfully but is the wrong shape, so it must not be misreported as
+    // an undecodable share link.
+    const encoded = LZString.compressToEncodedURIComponent("null");
+    const { layout, error } = decodeLayout(encoded);
+
+    expect(layout).toBeNull();
+    expect(error).toBeDefined();
+    expect(error).not.toBe(unreadableImportMessage("share-link"));
+  });
+
+  it("routes a decoded JSON string payload to the invalid-layout message, not the unreadable-payload message", () => {
+    const encoded = LZString.compressToEncodedURIComponent(
+      JSON.stringify("just a string"),
+    );
+    const { layout, error } = decodeLayout(encoded);
+
+    expect(layout).toBeNull();
+    expect(error).toBeDefined();
+    expect(error).not.toBe(unreadableImportMessage("share-link"));
   });
 
   it("round-trips layout through encode/decode", () => {

--- a/src/tests/yaml-archive-regression.test.ts
+++ b/src/tests/yaml-archive-regression.test.ts
@@ -21,6 +21,7 @@ import {
   serializeLayoutToYamlWithMetadata,
 } from "$lib/utils/yaml";
 import { toInternalUnits } from "$lib/utils/position";
+import { INVALID_LAYOUT_FORMAT_MESSAGE } from "$lib/utils/import-errors";
 import type { Cable, Layout, RackGroup } from "$lib/types";
 import {
   createTestDevice,
@@ -279,7 +280,8 @@ describe("legacy ZIP load compatibility (#1114)", () => {
 describe("invalid YAML load error paths (#1114)", () => {
   it("rejects a ZIP whose YAML fails schema validation", async () => {
     // A corrupt or hand-edited file with a missing required rack field must be
-    // rejected loudly, not silently loaded as a broken layout.
+    // rejected loudly, not silently loaded as a broken layout. The rejection is
+    // plain language (#2989): no raw Zod path/issue list reaches the user.
     const zip = new JSZip();
     const folder = zip.folder(`Broken-${UUID}`);
     folder?.file(
@@ -288,6 +290,8 @@ describe("invalid YAML load error paths (#1114)", () => {
     );
     const blob = await zip.generateAsync({ type: "blob" });
 
-    await expect(extractFolderArchive(blob)).rejects.toThrow(/Invalid layout/);
+    await expect(extractFolderArchive(blob)).rejects.toThrow(
+      INVALID_LAYOUT_FORMAT_MESSAGE,
+    );
   });
 });

--- a/src/tests/yaml.test.ts
+++ b/src/tests/yaml.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   parseYaml,
   parseLayoutYaml,
@@ -9,6 +9,7 @@ import {
   unreadableImportMessage,
   INVALID_LAYOUT_FORMAT_MESSAGE,
 } from "$lib/utils/import-errors";
+import { importDebug } from "$lib/utils/debug";
 import {
   createTestLayout,
   createTestRack,
@@ -47,6 +48,14 @@ async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
 }
 
 describe("plain-language import errors (#2989)", () => {
+  // Guarantees the debug spy below is restored even if an assertion in the
+  // test body throws first, so a failure here cannot leak a mock into
+  // later, unrelated tests (mirrors the console.warn -> debug logger move
+  // in yaml.ts/share.ts, #2989 fix round 3).
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("rejects a file that is not valid YAML at all with a plain message, no code frame, no raw bytes", async () => {
     // Mirrors "binary junk renamed .yaml": malformed syntax breaks js-yaml's
     // parser the same way corrupt file bytes do, producing a code-frame
@@ -61,14 +70,15 @@ describe("plain-language import errors (#2989)", () => {
     expect(message).not.toContain("nested");
   });
 
-  it("logs the raw parse failure to the console instead of showing it to the user", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("logs the raw parse failure via the debug logger instead of showing it to the user", async () => {
+    const debugSpy = vi
+      .spyOn(importDebug, "validation")
+      .mockImplementation(() => {});
     const notYaml = "name: Broken:\n  nested: value";
 
     await expect(parseLayoutYaml(notYaml)).rejects.toThrow();
 
-    expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
+    expect(debugSpy).toHaveBeenCalled();
   });
 
   it("rejects YAML that parses but is not a layout with the shared invalid-format message, no raw Zod issue list", async () => {
@@ -81,14 +91,15 @@ describe("plain-language import errors (#2989)", () => {
     expect(message).not.toContain(":");
   });
 
-  it("logs the raw validation failure to the console instead of showing it to the user", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("logs the raw validation failure via the debug logger instead of showing it to the user", async () => {
+    const debugSpy = vi
+      .spyOn(importDebug, "validation")
+      .mockImplementation(() => {});
     const notALayout = "foo: bar\nbaz: 123\n";
 
     await expect(parseLayoutYaml(notALayout)).rejects.toThrow();
 
-    expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
+    expect(debugSpy).toHaveBeenCalled();
   });
 
   it("names the field in plain language for a single invalid field", async () => {

--- a/src/tests/yaml.test.ts
+++ b/src/tests/yaml.test.ts
@@ -78,7 +78,10 @@ describe("plain-language import errors (#2989)", () => {
 
     await expect(parseLayoutYaml(notYaml)).rejects.toThrow();
 
-    expect(debugSpy).toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Layout file parse failed: %O",
+      expect.anything(),
+    );
   });
 
   it("rejects YAML that parses but is not a layout with the shared invalid-format message, no raw Zod issue list", async () => {
@@ -99,7 +102,10 @@ describe("plain-language import errors (#2989)", () => {
 
     await expect(parseLayoutYaml(notALayout)).rejects.toThrow();
 
-    expect(debugSpy).toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      "Layout validation failed: %O",
+      expect.anything(),
+    );
   });
 
   it("names the field in plain language for a single invalid field", async () => {

--- a/src/tests/yaml.test.ts
+++ b/src/tests/yaml.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   parseYaml,
   parseLayoutYaml,
   serializeLayoutToYaml,
+  serializeToYaml,
 } from "$lib/utils/yaml";
-import { createTestLayout } from "./factories";
+import {
+  unreadableImportMessage,
+  INVALID_LAYOUT_FORMAT_MESSAGE,
+} from "$lib/utils/import-errors";
+import {
+  createTestLayout,
+  createTestRack,
+  createTestDevice,
+  createTestDeviceType,
+} from "./factories";
 
 describe("parseYaml schema restriction (#2041)", () => {
   it("rejects dangerous non-JSON YAML function tags", async () => {
@@ -23,5 +33,109 @@ describe("parseYaml schema restriction (#2041)", () => {
     const yaml = await serializeLayoutToYaml(createTestLayout(), "");
     const layout = await parseLayoutYaml(yaml);
     expect(layout.name).toBeTruthy();
+  });
+});
+
+/** Resolves to the rejection message of a promise expected to reject. */
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("expected promise to reject");
+}
+
+describe("plain-language import errors (#2989)", () => {
+  it("rejects a file that is not valid YAML at all with a plain message, no code frame, no raw bytes", async () => {
+    // Mirrors "binary junk renamed .yaml": malformed syntax breaks js-yaml's
+    // parser the same way corrupt file bytes do, producing a code-frame
+    // exception (line/column marker plus the raw offending text).
+    const notYaml = "name: Broken:\n  nested: value";
+
+    const message = await rejectionMessage(parseLayoutYaml(notYaml));
+
+    expect(message).toBe(unreadableImportMessage("file"));
+    expect(message).not.toContain("\n");
+    expect(message).not.toContain("^");
+    expect(message).not.toContain("nested");
+  });
+
+  it("logs the raw parse failure to the console instead of showing it to the user", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const notYaml = "name: Broken:\n  nested: value";
+
+    await expect(parseLayoutYaml(notYaml)).rejects.toThrow();
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("rejects YAML that parses but is not a layout with the shared invalid-format message, no raw Zod issue list", async () => {
+    const notALayout = "foo: bar\nbaz: 123\n";
+
+    const message = await rejectionMessage(parseLayoutYaml(notALayout));
+
+    expect(message).toBe(INVALID_LAYOUT_FORMAT_MESSAGE);
+    expect(message).not.toContain(",");
+    expect(message).not.toContain(":");
+  });
+
+  it("logs the raw validation failure to the console instead of showing it to the user", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const notALayout = "foo: bar\nbaz: 123\n";
+
+    await expect(parseLayoutYaml(notALayout)).rejects.toThrow();
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("names the field in plain language for a single invalid field", async () => {
+    const deviceType = createTestDeviceType({ slug: "test-device" });
+    const device = createTestDevice({
+      device_type: "test-device",
+      position: 10,
+    });
+    const layout = createTestLayout({
+      racks: [createTestRack({ devices: [device] })],
+      device_types: [deviceType],
+    });
+
+    // Break only the device's position type; everything else stays valid so
+    // this hits the single-issue path, not the generic fallback.
+    const broken = {
+      ...layout,
+      racks: [
+        {
+          ...layout.racks[0],
+          devices: [{ ...device, position: "not-a-number" }],
+        },
+      ],
+    };
+    const yamlText = await serializeToYaml(broken);
+
+    const message = await rejectionMessage(parseLayoutYaml(yamlText));
+
+    expect(message).toBe("Device position must be a number");
+    expect(message).not.toContain("racks.0.devices.0.position");
+  });
+
+  it("preserves an existing custom schema message without the dotted path prefix", async () => {
+    const layout = createTestLayout({
+      racks: [createTestRack({ height: 42 })],
+    });
+
+    // Break only the rack height; everything else stays valid.
+    const broken = {
+      ...layout,
+      racks: [{ ...layout.racks[0], height: 150 }],
+    };
+    const yamlText = await serializeToYaml(broken);
+
+    const message = await rejectionMessage(parseLayoutYaml(yamlText));
+
+    expect(message).toBe("Height cannot exceed 100U");
+    expect(message).not.toContain("racks.0.height");
   });
 });


### PR DESCRIPTION
## **User description**
Closes #2989.

## Summary

Import failures no longer leak parser or schema internals into toasts. A shared helper (`src/lib/utils/import-errors.ts`) maps the three failure classes (not YAML, not a layout, single invalid field) to plain-language copy, used by both the file-import path (`yaml.ts`) and the share-link decode path (`share.ts`) so the two doors cannot drift.

Custom schema messages (like "Height cannot exceed 100U") are preserved without the dotted Zod path prefix. Zod default wording (Too small, Too big, Invalid URL) is replaced with plain copy, detected per issue code, with the tradeoff documented inline. Raw detail still reaches the console with `{ cause }`.

## Mobile acceptance criterion

Every new message is one short sentence, so the multi-line code-dump wrap can no longer occur. Visual spot-check welcome.

## Incidental

LayoutYamlPanel's rarely-hit Apply-button catch now also shows plain copy. Its live-validation display is untouched.

## Testing

TDD red-first for the three failure classes, custom-message preservation, and cross-path equivalence tests (multi-issue and single-field). Full unit suite green (3474+ tests). Lint and svelte-check clean.

## Note on push

Pushed with `--no-verify`: the pre-push hook's local CodeRabbit gate times out in this environment (documented project practice). PR-side CodeRabbit and CodeAnt gates apply as normal.


___

## **CodeAnt-AI Description**
**Replace raw import and share-link errors with plain-language messages**

### What Changed
- File imports now show short, user-friendly messages when a YAML file is unreadable or not a valid layout
- Share links use the same plain-language messages for the same failure cases, so both import paths behave the same
- Single-field validation errors now name the field in plain language, and existing custom schema messages are shown without technical path prefixes
- Raw parser and validation details are kept in the console instead of appearing in user-facing errors

### Impact
`✅ Clearer import error messages`
`✅ Fewer confusing parser details in toasts`
`✅ Consistent file and share-link failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
