### PR TITLE
fix: auto-number default rack names to remove ambiguity (#3002)

### DIFF
--- a/src/lib/utils/dialog-actions.ts
+++ b/src/lib/utils/dialog-actions.ts
@@ -17,10 +17,38 @@ const NEW_RACK_DEFAULT_HEIGHT = 24;
 const NEW_RACK_DEFAULT_NAME = "Racky McRackface";
 
 /**
+ * Resolve the name for a newly-created default rack, appending the lowest
+ * free " N" suffix when baseName collides with an existing rack's name
+ * (#3002). Two default racks used to end up with the exact same name, which
+ * cascaded into ambiguity downstream: the delete confirm couldn't say which
+ * rack was about to die, the active-rack cycle toast was uninformative, and
+ * both mobile switch dots carried an identical aria-label. Only the
+ * collision case changes -- baseName itself is returned unmodified when it
+ * isn't already taken, so plain direct-create naming is untouched. Existing
+ * racks are read, never renamed: this only picks the new rack's own name.
+ * Numbers are searched from 2 upward and the first unused one wins, so a
+ * gap left by a deleted numbered rack is reused, and a name some other rack
+ * already holds (however it got that name) is skipped rather than
+ * collided with.
+ */
+function nextAvailableRackName(
+  existingNames: readonly string[],
+  baseName: string,
+): string {
+  if (!existingNames.includes(baseName)) return baseName;
+  let suffix = 2;
+  while (existingNames.includes(`${baseName} ${suffix}`)) {
+    suffix++;
+  }
+  return `${baseName} ${suffix}`;
+}
+
+/**
  * Create a 24U rack directly on the canvas and select it, skipping the wizard
  * (#2732). The rack uses stage-1 defaults: width 19, ascending U-numbering, and
  * the schema default form factor. It is appended to the end of the row. Warns
- * when the rack limit is reached.
+ * when the rack limit is reached. The default name is disambiguated against
+ * existing racks' names (#3002); see nextAvailableRackName.
  */
 export function handleNewRack(): void {
   const layoutStore = getLayoutStore();
@@ -30,10 +58,11 @@ export function handleNewRack(): void {
     toastStore.showToast("Maximum number of racks reached", "warning");
     return;
   }
-  const rack = layoutStore.addRack(
+  const name = nextAvailableRackName(
+    layoutStore.racks.map((rack) => rack.name),
     NEW_RACK_DEFAULT_NAME,
-    NEW_RACK_DEFAULT_HEIGHT,
   );
+  const rack = layoutStore.addRack(name, NEW_RACK_DEFAULT_HEIGHT);
   if (!rack) return;
   selectionStore.selectRack(rack.id);
   requestAnimationFrame(() => handleFitAll());

--- a/src/tests/dialog-actions.test.ts
+++ b/src/tests/dialog-actions.test.ts
@@ -442,6 +442,8 @@ describe("handleNewRack name collision (#3002)", () => {
     handleNewRack();
 
     const names = layoutStore.racks.map((r) => r.name);
+    // Justification: verifies the behavioral invariant that all generated
+    // names are distinct without asserting an exact count.
     expect(new Set(names).size).toBe(names.length);
   });
 
@@ -482,15 +484,13 @@ describe("handleNewRack name collision (#3002)", () => {
     handleNewRack();
     const second = layoutStore.racks.find((r) => r.id !== first.id)!;
     handleNewRack();
-    const third = layoutStore.racks.find(
-      (r) => r.id !== first.id && r.id !== second.id,
-    )!;
 
     layoutStore.deleteRack(second.id);
+    expect(layoutStore.getRackById(second.id)).toBeUndefined();
+
+    const idsBeforeFourth = new Set(layoutStore.racks.map((r) => r.id));
     handleNewRack();
-    const fourth = layoutStore.racks.find(
-      (r) => r.id !== first.id && r.id !== third.id,
-    )!;
+    const fourth = layoutStore.racks.find((r) => !idsBeforeFourth.has(r.id))!;
 
     expect(fourth.name).toBe(second.name);
   });

--- a/src/tests/dialog-actions.test.ts
+++ b/src/tests/dialog-actions.test.ts
@@ -411,6 +411,120 @@ describe("handleNewRack", () => {
   });
 });
 
+// #3002: every new rack used to be named "Racky McRackface" with no
+// numbering, so once two or more existed the delete confirm couldn't say
+// which rack was about to die, the active-rack cycle toast was
+// uninformative, and both mobile switch dots carried the identical
+// aria-label. Only the name-collision case changes here: direct-create
+// naming is untouched when there's no collision (see the "no collision"
+// test below), and existing racks are never renamed to make room for a new
+// one. Assertions stick to distinctness/collision-avoidance rather than the
+// exact numbering wording, per the issue's test requirements.
+describe("handleNewRack name collision (#3002)", () => {
+  beforeEach(resetAll);
+
+  it("gives a second default-named rack a name distinct from the first", () => {
+    const layoutStore = getLayoutStore();
+
+    handleNewRack();
+    const first = layoutStore.racks[0]!;
+    handleNewRack();
+    const second = layoutStore.racks.find((r) => r.id !== first.id)!;
+
+    expect(second.name).not.toBe(first.name);
+  });
+
+  it("gives a third default-named rack a name distinct from the first two", () => {
+    const layoutStore = getLayoutStore();
+
+    handleNewRack();
+    handleNewRack();
+    handleNewRack();
+
+    const names = layoutStore.racks.map((r) => r.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  // AC 3: the collision path must not change plain direct-create naming.
+  // Compares against a pristine-store baseline rather than hardcoding the
+  // default name, so this doesn't pin the exact copy either.
+  it("does not number the default rack when no name collision exists, even with other racks present", () => {
+    handleNewRack();
+    const baseline = getLayoutStore().racks[0]!.name;
+    resetAll();
+
+    getLayoutStore().addRack("My Custom Rack", 12);
+    handleNewRack();
+    const created = getLayoutStore().racks.find(
+      (r) => r.name !== "My Custom Rack",
+    );
+
+    expect(created?.name).toBe(baseline);
+  });
+
+  it("never renames an existing user-named rack when a default rack is added", () => {
+    const layoutStore = getLayoutStore();
+    const custom = layoutStore.addRack("My Custom Rack", 12);
+    if (!custom) throw new Error("addRack returned null");
+
+    handleNewRack();
+
+    expect(layoutStore.getRackById(custom.id)?.name).toBe("My Custom Rack");
+  });
+
+  // Deleting a numbered rack frees its name for reuse rather than the next
+  // default rack always incrementing past it.
+  it("reuses a freed number when a numbered rack is deleted, instead of always incrementing", () => {
+    const layoutStore = getLayoutStore();
+
+    handleNewRack();
+    const first = layoutStore.racks[0]!;
+    handleNewRack();
+    const second = layoutStore.racks.find((r) => r.id !== first.id)!;
+    handleNewRack();
+    const third = layoutStore.racks.find(
+      (r) => r.id !== first.id && r.id !== second.id,
+    )!;
+
+    layoutStore.deleteRack(second.id);
+    handleNewRack();
+    const fourth = layoutStore.racks.find(
+      (r) => r.id !== first.id && r.id !== third.id,
+    )!;
+
+    expect(fourth.name).toBe(second.name);
+  });
+
+  // A rack manually renamed to look like a numbered variant (not created via
+  // the collision path itself) must still block that number from being
+  // reused, and must be left untouched.
+  it("skips a number already taken by a manually-named rack", () => {
+    const layoutStore = getLayoutStore();
+
+    handleNewRack();
+    const first = layoutStore.racks[0]!;
+    handleNewRack();
+    const second = layoutStore.racks.find((r) => r.id !== first.id)!;
+    // Undo removes exactly the rack handleNewRack just created (see the
+    // "undo removes the rack it created" test above), freeing the numbered
+    // name `second` used without needing to pin the exact numbering scheme.
+    layoutStore.undo();
+    expect(layoutStore.getRackById(second.id)).toBeUndefined();
+
+    const manual = layoutStore.addRack(second.name, 12);
+    if (!manual) throw new Error("addRack returned null");
+
+    handleNewRack();
+    const third = layoutStore.racks.find(
+      (r) => r.id !== first.id && r.id !== manual.id,
+    )!;
+
+    expect(third.name).not.toBe(first.name);
+    expect(third.name).not.toBe(manual.name);
+    expect(layoutStore.getRackById(manual.id)?.name).toBe(manual.name);
+  });
+});
+
 describe("zero-rack add-rack affordance", () => {
   beforeEach(resetAll);
 


### PR DESCRIPTION
## **User description**
Closes #3002.

## Summary

New racks whose default name collides with an existing rack get the lowest free numbered variant ("Racky McRackface 2"). User-named racks are never renamed, and the no-collision path is unchanged.

Downstream consumers (delete-confirm dialog, active-rack cycle toast, mobile switch-dot labels) read rack.name live and were verified to need no changes.

## Testing

- TDD red-first collision tests (gap reuse after deletion, skip past manual numbered names)
- Full unit suite green (3522 tests)
- Lint and svelte-check clean

## Reviewer note

NewRackForm.svelte still carries an independent default-name literal but is orphaned since the wizard removal in #2747. Flagged for a cleanup pass, out of scope here.

---

Pushed with --no-verify: the pre-push hook's local CodeRabbit gate times out in this environment (documented project practice). PR-side CodeRabbit and CodeAnt gates apply as normal.


___

## **CodeAnt-AI Description**
**Make newly created racks get unique default names**

### What Changed
- New racks now keep the default name when it is unused, and automatically get the lowest free numbered version when that name already exists.
- Existing racks are left unchanged, including racks with custom names or manually entered numbered names.
- If a numbered rack is deleted, its number can be reused by the next new rack.

### Impact
`✅ Clearer rack delete confirmation`
`✅ Unambiguous active-rack switching`
`✅ Distinct mobile switch labels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
