### PR TITLE
test: scope delete-rack verb selector after edit-panel name unification (#2858)

### DIFF
--- a/e2e/multi-rack-gapfill.spec.ts
+++ b/e2e/multi-rack-gapfill.spec.ts
@@ -107,9 +107,13 @@ test.describe("Delete rack (#2858)", () => {
     // Delete "Rack Dos" via the verb bar, which opens the confirm dialog. The
     // trash verb reads "Delete rack" for a rack selection, not the
     // device-oriented "Remove selected" the shared delete-selection action
-    // defaults to (#2994).
+    // defaults to (#2994). Scoped to the canvas: the edit panel's own delete
+    // button shares this accessible name since #3036 unified the two labels.
     await selectRack(page, "Rack Dos");
-    await page.getByRole("button", { name: "Delete rack" }).click();
+    await page
+      .locator(locators.canvas.root)
+      .getByRole("button", { name: "Delete rack" })
+      .click();
 
     const confirm = page.getByRole("dialog", { name: "Delete Rack" });
     await expect(confirm).toBeVisible();


### PR DESCRIPTION
## **User description**
## Root cause

CI run 29636326318 failed `e2e/multi-rack-gapfill.spec.ts:99` ("Delete rack (#2858) > confirming the delete dialog removes one rack and keeps the other") on both chromium and webkit, consistently including retry.

Merged PR #3036 unified the accessible name of the edit-panel's rack delete button with the verb-bar's delete-selection label: both now read "Delete rack" for a standalone rack selection (see `src/lib/actions/registry.ts` `labelForContext` and `src/lib/components/EditPanelRack.svelte`'s `aria-label`). The test's own locator, `page.getByRole('button', { name: 'Delete rack' })`, was written against the old, unambiguous label and was never scoped, so once both buttons shared the name it became ambiguous.

## Evidence

```
Error: strict mode violation: getByRole('button', { name: 'Delete rack' }) resolved to 2 elements:
1) <button ...>Delete Rack</button> inside [data-testid="rack-canvas"] (verb bar)
2) <button ...>Delete Rack</button> inside [data-testid="side-panel-panel-edit"] (edit panel)
```

## Fix

Scoped the locator to the canvas so it resolves only to the verb-bar button, which is the path the test exercises (selecting a rack, then using the floating verb bar to delete it):

```ts
await page
  .locator(locators.canvas.root)
  .getByRole("button", { name: "Delete rack" })
  .click();
```

`locators.canvas.root` already maps to `[data-testid="rack-canvas"]` in `e2e/helpers/locators.ts`; this follows the same testid-scoping idiom already used elsewhere in the helpers (e.g. `displayNameInput()` in `e2e/helpers/device-actions.ts` scopes to `side-panel-panel-edit`).

Swept `e2e/` for other unscoped `getByRole('button', { name: 'Delete rack' })` (and the bayed-group variant "Delete bayed rack") that could hit the same collision. This was the only occurrence; no other sites needed changes.

## Verification

Ran the full spec file on both configured browser projects from a fresh worktree:

```
npm run test:e2e -- multi-rack-gapfill.spec.ts --project=chromium
  4 passed (6.0s)

npm run test:e2e -- multi-rack-gapfill.spec.ts --project=webkit
  4 passed (7.4s)
```

All 4 tests in the file pass on both projects (8/8 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3nXdhjPHsxnEwVpWyQefD


___

## **CodeAnt-AI Description**
**Scope the delete-rack test to the canvas so it clicks the intended button**

### What Changed
- The delete-rack end-to-end test now targets the button in the canvas, avoiding the matching delete button in the edit panel
- The test still confirms the delete dialog appears and removes only the selected rack

### Impact
`✅ Fewer flaky delete-rack tests`
`✅ Clearer button targeting in multi-rack flows`
`✅ More reliable coverage for rack deletion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
