### PR TITLE
refactor: remove orphaned leftDrawerOpen state from ui store (#3032)

### DIFF
--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -112,7 +112,6 @@ function handleEscape(): void {
   }
   selectionStore.clearSelection();
   layoutStore.setActiveRack(null);
-  uiStore.closeLeftDrawer();
   uiStore.closeRightDrawer();
 }
 

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -211,7 +211,6 @@ const initialEnableBayedRacks = loadEnableBayedRacksFromStorage();
 
 // Module-level state (using $state rune)
 let zoom = $state(100);
-let leftDrawerOpen = $state(false);
 let rightDrawerOpen = $state(false);
 let displayMode = $state<DisplayMode>("label");
 let showAnnotations = $state(false);
@@ -250,7 +249,6 @@ const showLabelsOnImages = $derived(displayMode === "image-label");
  */
 export function resetUIStore(): void {
   zoom = 100;
-  leftDrawerOpen = false;
   rightDrawerOpen = false;
   displayMode = "label";
   showAnnotations = false;
@@ -289,9 +287,6 @@ export function getUIStore() {
     },
 
     // Drawer state getters
-    get leftDrawerOpen() {
-      return leftDrawerOpen;
-    },
     get rightDrawerOpen() {
       return rightDrawerOpen;
     },
@@ -360,10 +355,7 @@ export function getUIStore() {
     resetZoom,
 
     // Drawer actions
-    toggleLeftDrawer,
     toggleRightDrawer,
-    openLeftDrawer,
-    closeLeftDrawer,
     openRightDrawer,
     closeRightDrawer,
 
@@ -446,31 +438,10 @@ function resetZoom(): void {
 }
 
 /**
- * Toggle left drawer visibility
- */
-function toggleLeftDrawer(): void {
-  leftDrawerOpen = !leftDrawerOpen;
-}
-
-/**
  * Toggle right drawer visibility
  */
 function toggleRightDrawer(): void {
   rightDrawerOpen = !rightDrawerOpen;
-}
-
-/**
- * Open left drawer
- */
-function openLeftDrawer(): void {
-  leftDrawerOpen = true;
-}
-
-/**
- * Close left drawer
- */
-function closeLeftDrawer(): void {
-  leftDrawerOpen = false;
 }
 
 /**

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -325,9 +325,9 @@ describe("actions registry", () => {
     });
 
     it("the bare 'd' key no longer resolves to any action", () => {
-      // toggle-sidebar flipped leftDrawerOpen, a flag no component read; it was
-      // removed rather than wired up, per the no-dead-code policy. Nothing else
-      // in the registry claims the bare 'd' key.
+      // toggle-sidebar drove a flag no component read; it was removed rather
+      // than wired up, per the no-dead-code policy. Nothing else in the
+      // registry claims the bare 'd' key.
       const event = new KeyboardEvent("keydown", { key: "d" });
       expect(findActionForEvent(event)).toBeUndefined();
     });

--- a/src/tests/ui-store.test.ts
+++ b/src/tests/ui-store.test.ts
@@ -126,23 +126,9 @@ describe("UI Store", () => {
   });
 
   describe("Drawers", () => {
-    it("leftDrawerOpen starts false", () => {
-      const store = getUIStore();
-      expect(store.leftDrawerOpen).toBe(false);
-    });
-
     it("rightDrawerOpen starts false", () => {
       const store = getUIStore();
       expect(store.rightDrawerOpen).toBe(false);
-    });
-
-    it("toggleLeftDrawer toggles leftDrawerOpen", () => {
-      const store = getUIStore();
-      store.toggleLeftDrawer();
-      expect(store.leftDrawerOpen).toBe(true);
-
-      store.toggleLeftDrawer();
-      expect(store.leftDrawerOpen).toBe(false);
     });
 
     it("toggleRightDrawer toggles rightDrawerOpen", () => {
@@ -152,19 +138,6 @@ describe("UI Store", () => {
 
       store.toggleRightDrawer();
       expect(store.rightDrawerOpen).toBe(false);
-    });
-
-    it("openLeftDrawer sets leftDrawerOpen to true", () => {
-      const store = getUIStore();
-      store.openLeftDrawer();
-      expect(store.leftDrawerOpen).toBe(true);
-    });
-
-    it("closeLeftDrawer sets leftDrawerOpen to false", () => {
-      const store = getUIStore();
-      store.openLeftDrawer();
-      store.closeLeftDrawer();
-      expect(store.leftDrawerOpen).toBe(false);
     });
 
     it("openRightDrawer sets rightDrawerOpen to true", () => {


### PR DESCRIPTION
## **User description**
Closes #3032

## Summary

Removes the orphaned `leftDrawerOpen` drawer state from `src/lib/stores/ui.svelte.ts`, left dead after #2995 removed the toggle-sidebar command and its keyboard shortcut.

- Deletes `leftDrawerOpen` ($state), its getter/export, and `toggleLeftDrawer` / `openLeftDrawer` / `closeLeftDrawer`
- Deletes the reset-line for `leftDrawerOpen` in `resetUIStore`
- Deletes the stale `uiStore.closeLeftDrawer()` call in `handleEscape` (`src/lib/actions/dispatch.ts`), a fourth call site the issue text missed: grep confirmed it was the only remaining writer outside the store and tests, and it would have been a compile error once the store method was removed
- Deletes the four `ui-store.test.ts` blocks that only exercised the deleted symbols (`leftDrawerOpen starts false`, `toggleLeftDrawer toggles leftDrawerOpen`, `openLeftDrawer`, `closeLeftDrawer`)
- Rewords a stale comment in `actions-registry.test.ts` that referenced `leftDrawerOpen` by name; the test itself (bare 'd' key no longer resolves to an action) is still valid and was kept

`rightDrawerOpen` and its actions are untouched: it still has real readers in `rack-actions.ts` and `app-actions.ts` (canvas offset calculation) and is not part of this issue.

## Test plan

- `npm run lint` clean
- `npm run check` (svelte-check): 0 errors, 0 warnings
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/ui-store.test.ts src/tests/actions-registry.test.ts`: 102 passed
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/dispatch.test.ts`: 9 passed (covers `handleEscape`)
- Repo-wide grep for `leftDrawerOpen|toggleLeftDrawer|openLeftDrawer|closeLeftDrawer` under `src/`: no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Remove unused left drawer state from the UI**

### What Changed
- Removed the unused left drawer state and its open/close/toggle actions from the UI store
- Escape no longer tries to close a left drawer; it still closes the right drawer and clears selection as before
- Updated tests and comments to match the removed left drawer behavior

### Impact
`✅ No visible change for users`
`✅ Fewer stale UI controls in the app`
`✅ Lower risk of broken drawer behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
