### PR TITLE
fix: align device library strings with unified surface name (#3062)

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -402,7 +402,7 @@
       imageStore.setDeviceImage(device.slug, "rear", data.rearImage);
     }
 
-    toastStore.showToast(`"${data.name}" added to device library`, "success");
+    toastStore.showToast(`"${data.name}" added to Devices`, "success");
     dialogStore.close();
   }
 
@@ -416,7 +416,7 @@
     layoutStore.addDeviceTypeRaw(result.deviceType);
     layoutStore.markDirty();
     toastStore.showToast(
-      `Imported "${result.deviceType.model}" to device library`,
+      `Imported "${result.deviceType.model}" to Devices`,
       "success",
     );
     dialogStore.close();
@@ -467,7 +467,7 @@
       toastStore.showToast(message, result.skipped > 0 ? "warning" : "success");
     } catch (error) {
       dialogDebug.import("Failed to import device library: %O", error);
-      toastStore.showToast("Failed to import device library", "error");
+      toastStore.showToast("Failed to import devices", "error");
     } finally {
       input.value = "";
     }
@@ -992,7 +992,7 @@
   accept=".json,application/json"
   onchange={handleDeviceImportFileChange}
   style="display: none;"
-  aria-label="Import device library file"
+  aria-label="Import devices file"
 />
 
 <!--


### PR DESCRIPTION
## **User description**
## Summary

Follow-up from #3007, which unified the device-library surface to the name "Devices" across the desktop tab, mobile sheet title, and onboarding hint. This PR sweeps the remaining stray user-facing strings in `src/lib/components/DialogOrchestrator.svelte` that still said "device library":

- Add-custom-device success toast: `"${name}" added to device library` -> `"${name}" added to Devices`
- NetBox import success toast: `Imported "${model}" to device library` -> `Imported "${model}" to Devices`
- JSON import failure toast: `Failed to import device library` -> `Failed to import devices` (matches the sibling success message in the same handler, which already reads `Imported N devices` with no "library" suffix)
- Hidden file input aria-label: `Import device library file` -> `Import devices file`

Debug-log strings (`dialogDebug.import(...)`) are left untouched; they are developer diagnostics, not user-facing.

## Excluded on purpose

`CleanupDialog.svelte`'s `"Clean Up Device Library"` title and `CleanupPromptDialog.svelte`'s `"Clean Up Device Library?"` title are left unchanged. Re-evaluated per the issue's instruction rather than blind-renamed: both name a distinct, specific feature (bulk review/delete of unused custom device types), not the Devices palette surface itself, and the two dialogs already use the phrase consistently with each other. Renaming them to reference "Devices" would blur a specific action with the general surface name, so they stay as-is.

## Test plan

Copy-only change, no new tests per project testing policy (no new behavior to cover).

- [x] `npm run lint` - no issues
- [x] `npm run check` - 0 errors, 0 warnings
- [x] Grepped `src/tests/` and `e2e/` for the exact strings changed - no test asserts on them, so nothing else needed updating

Closes #3062

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Align device import and add-device messages with the Devices name**

### What Changed
- Success messages now say “Devices” instead of “device library” when adding a custom device or importing from NetBox
- A failed JSON import now says “Failed to import devices”
- The hidden file picker label now says “Import devices file”

### Impact
`✅ Consistent Devices wording`
`✅ Clearer import errors`
`✅ Easier file picker labeling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
