### PR TITLE
fix: muted device colours clear WCAG AA against label token (#3016)

### DIFF
--- a/docs/reference/BRAND.md
+++ b/docs/reference/BRAND.md
@@ -108,12 +108,14 @@ For device backgrounds and data visualization, use these muted variants. They ma
 | Category | Muted Colour | Original | Contrast | Rationale |
 | --- | --- | --- | --- | --- |
 | `server` | `#4A7A8A` | `#8BE9FD` | 4.8:1 | Core infrastructure — teal/cyan family |
-| `network` | `#7B6BA8` | `#BD93F9` | 4.6:1 | Primary accent — purple family |
+| `network` | `#7968A6` | `#BD93F9` | 4.6:1 | Primary accent — purple family |
 | `storage` | `#3D7A4A` | `#50FA7B` | 5.2:1 | Data/growth — green family |
 | `power` | `#A84A4A` | `#FF5555` | 5.1:1 | Critical/energy — red family |
-| `kvm` | `#A87A4A` | `#FFB86C` | 4.5:1 | Control/interactive — orange family |
+| `kvm` | `#926A40` | `#FFB86C` | 4.6:1 | Control/interactive — orange family |
 | `av-media` | `#A85A7A` | `#FF79C6` | 4.7:1 | Media/entertainment — pink family |
-| `cooling` | `#8A8A4A` | `#F1FA8C` | 4.6:1 | Environmental — yellow/olive family |
+| `cooling` | `#75753F` | `#F1FA8C` | 4.6:1 | Environmental — yellow/olive family |
+
+**Note:** `network`, `kvm`, and `cooling` were darkened slightly in issue #3016 after measuring their contrast against the actual device-label token (`--neutral-50`, `#fafafa`) rather than the previously assumed white: the prior hexes measured 4.46:1, 3.63:1, and 3.46:1, with `kvm` and `cooling` failing WCAG AA. Each new hex keeps the same hue and saturation, darkened only enough to clear 4.5:1 with margin.
 
 ### Passive Device Categories
 
@@ -132,12 +134,12 @@ For device backgrounds and data visualization, use these muted variants. They ma
 export const CATEGORY_COLOURS: Record<DeviceCategory, string> = {
   // Active — Muted Dracula
   server: "#4A7A8A",
-  network: "#7B6BA8",
+  network: "#7968A6",
   storage: "#3D7A4A",
   power: "#A84A4A",
-  kvm: "#A87A4A",
+  kvm: "#926A40",
   "av-media": "#A85A7A",
-  cooling: "#8A8A4A",
+  cooling: "#75753F",
 
   // Passive — Comment/Selection tones
   shelf: "#6272A4",

--- a/docs/reference/BRAND.md
+++ b/docs/reference/BRAND.md
@@ -99,7 +99,7 @@ Rackula uses a **three-tier colour hierarchy**:
 
 For device backgrounds and data visualization, use these muted variants. They maintain Dracula hue identity but are darkened/desaturated for:
 
-- WCAG AA contrast with white text (4.5:1 minimum)
+- WCAG AA contrast with the actual device-label token (`--neutral-50`, `#fafafa`) (4.5:1 minimum)
 - Reduced visual fatigue at scale
 - Professional appearance
 
@@ -108,12 +108,12 @@ For device backgrounds and data visualization, use these muted variants. They ma
 | Category | Muted Colour | Original | Contrast | Rationale |
 | --- | --- | --- | --- | --- |
 | `server` | `#4A7A8A` | `#8BE9FD` | 4.8:1 | Core infrastructure — teal/cyan family |
-| `network` | `#7968A6` | `#BD93F9` | 4.6:1 | Primary accent — purple family |
-| `storage` | `#3D7A4A` | `#50FA7B` | 5.2:1 | Data/growth — green family |
-| `power` | `#A84A4A` | `#FF5555` | 5.1:1 | Critical/energy — red family |
-| `kvm` | `#926A40` | `#FFB86C` | 4.6:1 | Control/interactive — orange family |
-| `av-media` | `#A85A7A` | `#FF79C6` | 4.7:1 | Media/entertainment — pink family |
-| `cooling` | `#75753F` | `#F1FA8C` | 4.6:1 | Environmental — yellow/olive family |
+| `network` | `#7968A6` | `#BD93F9` | 4.6:1 | Primary accent: purple family |
+| `storage` | `#3D7A4A` | `#50FA7B` | 5.2:1 | Data/growth: green family |
+| `power` | `#A84A4A` | `#FF5555` | 5.1:1 | Critical/energy: red family |
+| `kvm` | `#926A40` | `#FFB86C` | 4.6:1 | Control/interactive: orange family |
+| `av-media` | `#A85A7A` | `#FF79C6` | 4.7:1 | Media/entertainment: pink family |
+| `cooling` | `#75753F` | `#F1FA8C` | 4.6:1 | Environmental: yellow/olive family |
 
 **Note:** `network`, `kvm`, and `cooling` were darkened slightly in issue #3016 after measuring their contrast against the actual device-label token (`--neutral-50`, `#fafafa`) rather than the previously assumed white: the prior hexes measured 4.46:1, 3.63:1, and 3.46:1, with `kvm` and `cooling` failing WCAG AA. Each new hex keeps the same hue and saturation, darkened only enough to clear 4.5:1 with margin.
 

--- a/src/lib/types/constants.ts
+++ b/src/lib/types/constants.ts
@@ -15,13 +15,13 @@ import type { DeviceCategory, RackView, DeviceFace } from "./index";
 export const CATEGORY_COLOURS: Record<DeviceCategory, string> = {
   // Active categories - Muted Dracula (WCAG AA compliant)
   server: "#4A7A8A", // muted cyan (4.8:1)
-  network: "#7B6BA8", // muted purple (4.6:1)
+  network: "#7968A6", // muted purple (4.6:1, issue #3016)
   firewall: "#C0392B", // alert red (5.4:1) - distinct from muted power red
   storage: "#3D7A4A", // muted green (5.2:1)
   power: "#A84A4A", // muted red (5.1:1)
-  kvm: "#A87A4A", // muted orange (4.5:1)
+  kvm: "#926A40", // muted orange (4.6:1, issue #3016)
   "av-media": "#A85A7A", // muted pink (4.7:1)
-  cooling: "#8A8A4A", // muted yellow (4.6:1)
+  cooling: "#75753F", // muted yellow (4.6:1, issue #3016)
   chassis: "#5A6A8A", // muted blue-gray for blade chassis (4.5:1)
 
   // Passive categories - Dracula neutrals (unchanged)


### PR DESCRIPTION
## **User description**
## Summary

Closes #3016

`network`, `kvm`, and `cooling` muted device colours documented contrast ratios in BRAND.md (4.6, 4.5, 4.6) that did not hold against the actual device-label token (`--neutral-50`, `#fafafa`, rendered via `.device-name { fill: var(--neutral-50) }` in `RackDevice.svelte`). Measured against that real token:

| Category | Old hex | Documented ratio | Measured ratio | WCAG AA (4.5:1) |
| --- | --- | --- | --- | --- |
| `network` | `#7B6BA8` | 4.6:1 | 4.460:1 | pass (barely) |
| `kvm` | `#A87A4A` | 4.5:1 | 3.627:1 | **fail** |
| `cooling` | `#8A8A4A` | 4.6:1 | 3.460:1 | **fail** |

`kvm` and `cooling` fail WCAG AA on real rendered device labels, not just in the docs.

## Fix (option 1 from the issue)

Darkened all three hexes, keeping the same hue and saturation (only lightness reduced), so each clears 4.5:1 with a safety margin (target >= 4.55 so display rounding never dips below AA):

| Category | Old hex | New hex | New ratio vs `#fafafa` | Rounded (BRAND.md) |
| --- | --- | --- | --- | --- |
| `network` | `#7B6BA8` | `#7968A6` | 4.6318:1 | 4.6:1 |
| `kvm` | `#A87A4A` | `#926A40` | 4.6168:1 | 4.6:1 |
| `cooling` | `#8A8A4A` | `#75753F` | 4.6012:1 | 4.6:1 |

Each new value keeps the muted-vs-bright relationship intact (the bright Dracula accents for these categories still measure well under 2:1 against the label token, so muted stays the clearly-dimmer sibling). Updated:

- `src/lib/types/constants.ts`: `CATEGORY_COLOURS.network`, `.kvm`, `.cooling`
- `docs/reference/BRAND.md`: Active Device Categories table (hex + contrast columns) and the Implementation code sample, plus a short note explaining the correction and citing the old measured ratios

## Out of scope

#3005's `ColourPicker` presets (`src/lib/constants/colourPresets.ts`) already deliberately exclude `network`, `kvm`, and `cooling` because the old bright accents failed contrast. Re-including these three as presets now that the muted fills clear AA is a separate decision, left out of this fix.

## Test plan

- `npm run lint`: pass
- `npm run check` (svelte-check): 0 errors, 0 warnings
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/contrast.test.ts src/tests/colour-presets-contrast.test.ts`: 35/35 pass (no colour-value hardcoding added, per project ESLint rule)
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/carrier-enforcement.test.ts src/tests/carrier-placement.test.ts src/tests/slot-move-store.test.ts src/tests/baying-store.test.ts src/tests/placement-completion.test.ts src/tests/keyboard.test.ts`: 92/92 pass (these reference `CATEGORY_COLOURS.network` symbolically, so they picked up the new hex automatically)
- Full unit suite ran via the pre-commit hook: 182 files / 2621 tests, all pass
- Did not touch `src/tests/fixtures/upgrade-corpus/*.yaml`: those are frozen snapshots of prior-release data (per project policy) and intentionally still contain the old `#7B6BA8` value as historical device-type colour data, not a live default

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Adjust muted device colors so labels meet contrast requirements**

### What Changed
- Darkened the muted colors for network, KVM, and cooling devices so their labels stay readable against the actual label background.
- Updated the brand guide to match the new colors and note why the change was made.
- Kept the same color family for each category while making only the brightness lighter-to-darker adjustment.

### Impact
`✅ Clearer device labels`
`✅ Fewer low-contrast UI issues`
`✅ WCAG AA-compliant muted device colors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
