### PR TITLE
fix: re-anchor roving tabindex when virtualized palette rows unmount (#3015)

### DIFF
--- a/src/lib/components/DevicePalette.svelte
+++ b/src/lib/components/DevicePalette.svelte
@@ -619,10 +619,14 @@
 
   <!-- Device List -->
   <div class="device-list" class:fill-flat={flatFill}>
-    {#snippet deviceRow(device: DeviceType, index = 0)}
+    <!-- isAnchor marks this row as the list's single roving tab stop
+         (tabindex 0). It is the first mounted row of the list, not a fixed
+         absolute index, so a virtualized list re-anchors to the nearest
+         mounted row when scrolling unmounts the rows above it (#3015). -->
+    {#snippet deviceRow(device: DeviceType, isAnchor = true)}
       <DevicePaletteItem
         {device}
-        tabindex={index === 0 ? 0 : -1}
+        tabindex={isAnchor ? 0 : -1}
         searchQuery={isSearchActive ? searchQuery : ""}
         isCompatible={isCompatible(device)}
         incompatibilityReason={incompatibilityReason(device)}
@@ -651,15 +655,15 @@
             key={(device) => device.slug}
             ariaLabel={label}
           >
-            {#snippet row(device, index)}
-              {@render deviceRow(device, index)}
+            {#snippet row(device, _index, isFirst)}
+              {@render deviceRow(device, isFirst)}
             {/snippet}
           </VirtualList>
         </div>
       {:else}
         <div class="section-devices" role="list" aria-label={label}>
           {#each devices as device, index (device.slug)}
-            {@render deviceRow(device, index)}
+            {@render deviceRow(device, index === 0)}
           {/each}
         </div>
       {/if}

--- a/src/lib/components/VirtualList.svelte
+++ b/src/lib/components/VirtualList.svelte
@@ -19,8 +19,12 @@
     itemHeight: number;
     /** Rows rendered beyond the viewport on each side. */
     overscan?: number;
-    /** Renders a single row. Receives the item and its absolute index. */
-    row: Snippet<[T, number]>;
+    /** Renders a single row. Receives the item, its absolute index, and
+     *  whether it is the first row of the currently mounted window. The last
+     *  flag lets a roving-tabindex list re-anchor its single tab stop to the
+     *  nearest mounted row as scrolling unmounts rows above it (#3015), so a
+     *  keyboard user tabbing in is never stranded with no tabindex=0 row. */
+    row: Snippet<[T, number, boolean]>;
     /** Stable identity for an item, used as the {#each} key so the same DOM
      *  node is never reused for a different item when the slice shifts. */
     key: (item: T) => string | number;
@@ -78,7 +82,7 @@
       style:transform="translateY({visibleWindow.offsetY}px)"
     >
       {#each visibleItems as item, i (key(item))}
-        {@render row(item, visibleWindow.startIndex + i)}
+        {@render row(item, visibleWindow.startIndex + i, i === 0)}
       {/each}
     </div>
   </div>

--- a/src/tests/device-palette-tab-order.test.ts
+++ b/src/tests/device-palette-tab-order.test.ts
@@ -4,7 +4,7 @@
  * must use roving tabindex so the whole list is a single outer Tab stop.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, within } from "@testing-library/svelte";
+import { render, screen, within, fireEvent } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import TestDevicePalette from "./helpers/TestDevicePalette.svelte";
 import { resetLayoutStore } from "$lib/stores/layout.svelte";
@@ -155,5 +155,42 @@ describe("device palette tab order", () => {
     expect(tabbable()).toHaveLength(1);
     expect(tabbable()[0]).toBe(lastRow);
     expect(lastRow).toHaveFocus();
+  });
+
+  // #3015: the roving anchor is the first mounted row, not a fixed absolute
+  // index. In a virtualized long list the index-0 anchor row unmounts when the
+  // user mouse-wheel scrolls without focusing anything; without re-anchoring
+  // there would be no tabindex=0 row left and a keyboard user tabbing in would
+  // be stranded. A-Z mode renders every device in one windowed list, so it is
+  // the simplest way to drive real mount/unmount here.
+  it("keeps a tab-stop anchor after the anchor row unmounts during virtualized scroll", async () => {
+    const user = userEvent.setup();
+    render(TestDevicePalette);
+
+    await user.click(screen.getByRole("button", { name: "A-Z" }));
+    const list = screen.getByRole("list", { name: "All Devices" });
+
+    const tabbable = () =>
+      within(list)
+        .getAllByRole("listitem")
+        .filter((row) => row.getAttribute("tabindex") === "0");
+
+    // Before scrolling: the first mounted row is the single tab stop.
+    const firstRowBefore = within(list).getAllByRole("listitem")[0];
+    // eslint-disable-next-line no-restricted-syntax -- roving tabindex invariant: exactly one row is ever in the tab order
+    expect(tabbable()).toHaveLength(1);
+    expect(tabbable()[0]).toBe(firstRowBefore);
+
+    // Scroll far enough to unmount the original anchor row, without focusing
+    // anything (mouse-wheel scroll). happy-dom reports clientHeight 0, so the
+    // window is a fixed row count and this scrollTop pushes index 0 out of it.
+    await fireEvent.scroll(list, { target: { scrollTop: 1200 } });
+    expect(firstRowBefore).not.toBeInTheDocument();
+
+    // Re-anchored: exactly one currently-mounted row is still the tab stop, and
+    // it is the new first mounted row, so tabbing into the list still lands.
+    // eslint-disable-next-line no-restricted-syntax -- roving tabindex invariant: exactly one row is ever in the tab order
+    expect(tabbable()).toHaveLength(1);
+    expect(tabbable()[0]).toBe(within(list).getAllByRole("listitem")[0]);
   });
 });

--- a/src/tests/device-palette-tab-order.test.ts
+++ b/src/tests/device-palette-tab-order.test.ts
@@ -170,16 +170,19 @@ describe("device palette tab order", () => {
     await user.click(screen.getByRole("button", { name: "A-Z" }));
     const list = screen.getByRole("list", { name: "All Devices" });
 
-    const tabbable = () =>
-      within(list)
-        .getAllByRole("listitem")
-        .filter((row) => row.getAttribute("tabindex") === "0");
+    // Verifies the roving invariant: the first mounted row is the single tab
+    // stop and every other mounted row is out of the tab order.
+    const verifySingleTabStop = () => {
+      const items = within(list).getAllByRole("listitem");
+      expect(items[0]).toHaveAttribute("tabindex", "0");
+      items.slice(1).forEach((row) => {
+        expect(row).toHaveAttribute("tabindex", "-1");
+      });
+    };
 
     // Before scrolling: the first mounted row is the single tab stop.
     const firstRowBefore = within(list).getAllByRole("listitem")[0];
-    // eslint-disable-next-line no-restricted-syntax -- roving tabindex invariant: exactly one row is ever in the tab order
-    expect(tabbable()).toHaveLength(1);
-    expect(tabbable()[0]).toBe(firstRowBefore);
+    verifySingleTabStop();
 
     // Scroll far enough to unmount the original anchor row, without focusing
     // anything (mouse-wheel scroll). happy-dom reports clientHeight 0, so the
@@ -187,10 +190,8 @@ describe("device palette tab order", () => {
     await fireEvent.scroll(list, { target: { scrollTop: 1200 } });
     expect(firstRowBefore).not.toBeInTheDocument();
 
-    // Re-anchored: exactly one currently-mounted row is still the tab stop, and
-    // it is the new first mounted row, so tabbing into the list still lands.
-    // eslint-disable-next-line no-restricted-syntax -- roving tabindex invariant: exactly one row is ever in the tab order
-    expect(tabbable()).toHaveLength(1);
-    expect(tabbable()[0]).toBe(within(list).getAllByRole("listitem")[0]);
+    // Re-anchored: the new first mounted row is the single tab stop, so tabbing
+    // into the list still lands and the keyboard user is never stranded.
+    verifySingleTabStop();
   });
 });


### PR DESCRIPTION
## **User description**
Closes #3015

## Problem

The device palette's roving tabindex (from #2998) anchors the single tab stop (`tabindex="0"`) to the row at absolute index 0. In a virtualized long list (over the 30-row threshold, e.g. Dell/HPE or A-Z mode), mouse-wheel scrolling without focusing anything unmounts that index-0 row. With no focus event to move the anchor imperatively, no mounted row carries `tabindex="0"`, so a keyboard user tabbing into the list is stranded with no tab stop until a row is focused again. Narrow WCAG 2.4.3/2.4.7-adjacent edge case, flagged as a deliberate follow-up by #2998's task review.

## Fix

Re-anchor the roving tab stop to the first mounted row instead of a fixed absolute index.

- `VirtualList` now passes each row snippet a third argument: whether the row is the first of the currently mounted window (`i === 0`).
- `DevicePalette`'s `deviceRow` takes an explicit `isAnchor` flag. The plain-DOM branch anchors index 0 as before; the virtualized branch anchors the first mounted row.

The anchor now follows the mounted window reactively as rows scroll in and out, so there is always exactly one `tabindex="0"` row. No focus is stolen during scroll; only the tab-stop anchor moves.

## Tests

Added a behavioural test in `device-palette-tab-order.test.ts` that drives A-Z (flat) mode, scrolls the virtualized list far enough to unmount the original anchor row (mouse-wheel scroll, no focus), and asserts a mounted row is still the single tab stop. Verified it fails without the fix (`expected [] to have a length of 1`, i.e. zero tab stops) and passes with it. Uses `getAllByRole`/`fireEvent.scroll` only, no `querySelector`.

- `npm run lint`: clean
- `npm run check`: 0 errors, 0 warnings
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/device-palette-tab-order.test.ts src/tests/virtual-list.test.ts src/tests/device-palette-item-roving-boundary.test.ts src/tests/roving-index.test.ts`: 29 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Keep the device palette keyboard-focusable while scrolling long lists

### What Changed
- Long, virtualized device lists now keep one row in the tab order even after the original top row scrolls out of view
- Scrolling no longer leaves the list with no `Tab` stop, so keyboard users can still enter the list after mouse-wheel or touchpad scrolling
- Added a test that scrolls a long list until the original anchor row unmounts and verifies a mounted row still remains the single tab stop

### Impact
`✅ Fewer keyboard dead ends in long device lists`
`✅ More reliable tab navigation after scrolling`
`✅ Clearer focus behavior in virtualized palettes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
