### PR TITLE
fix: pass group selection to BayedRackView for selected outline (#2764)

### DIFF
--- a/src/lib/components/RackCanvasView.svelte
+++ b/src/lib/components/RackCanvasView.svelte
@@ -763,6 +763,7 @@
             selectedRackId={selectionStore.selectedType === "rack"
               ? selectionStore.selectedRackId
               : null}
+            {selectedGroupId}
             displayMode={uiStore.displayMode}
             showLabelsOnImages={uiStore.showLabelsOnImages}
             showAnnotations={uiStore.showAnnotations}


### PR DESCRIPTION
## **User description**
## Summary

Closes #2764

When a bayed rack group is selected, `BayedRackView` never showed its selected outline. `RackCanvasView` already derives a `selectedGroupId` value (used for the bay resize handle), but only forwarded `selectedRackId` to `BayedRackView`, never `selectedGroupId`. `BayedRackView` computes `isGroupSelected = selectedGroupId === group.id || racks.some((r) => r.id === selectedRackId)`, so a `"group"` selection left both inbound props null and the outline never rendered.

## Fix

Forward the existing `selectedGroupId` derived value to `BayedRackView` alongside `selectedRackId`. One-line prop wiring, no restyling.

## Tests

No test added. The only observable effect of this fix is a CSS class (`.bayed-rack-view.selected`) on a DOM node, which this project's ESLint rules block asserting in tests (no `toHaveClass`/`querySelector`). Per the project's testing policy this is pure prop-wiring with no new logic to unit test; existing coverage (`RackCanvasView.escape-cancel-resize.test.ts`) still passes.

Verified:
- `npm run lint` clean
- `npm run check` clean (0 errors, 0 warnings)
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/RackCanvasView.escape-cancel-resize.test.ts` passes (2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show the selected outline for bayed rack groups**

### What Changed
- Bayed rack groups now show the selected outline when the group itself is selected
- Rack and group selections are both passed through, so the highlight matches the current selection
- The bay resize handle behavior remains unchanged

### Impact
`✅ Clearer selected bay highlights`
`✅ Fewer missing selection outlines`
`✅ More reliable rack group selection feedback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
