### PR TITLE
fix: clear toasts on sheet open, exempting undo affordances (#3030)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -541,7 +541,10 @@
     const { rackId } = event.detail;
     layoutStore.setActiveRack(rackId);
     selectionStore.selectRack(rackId);
-    dialogStore.closeSheet();
+    // openSheet("rackEdit") already replaces whatever sheet was open (sheets
+    // are mutually exclusive), so a preceding closeSheet() is redundant. It
+    // also used to make openSheet see a false closed-to-open transition and
+    // wrongly clear a lingering non-undo toast on this same-tick swap (#3030).
     dialogStore.openSheet("rackEdit");
   }
 

--- a/src/lib/components/mobile/MobileRacksSheet.svelte
+++ b/src/lib/components/mobile/MobileRacksSheet.svelte
@@ -35,12 +35,14 @@
 
   // Open the existing rack-edit sheet for the tapped rack. This routes through
   // the same verbs as the long-press flow (App.handleRackLongPress) so mobile
-  // does not fork rack-edit logic: the rack becomes active and selected, the
-  // racks sheet closes, and RackEditSheet renders the now-active rack.
+  // does not fork rack-edit logic: the rack becomes active and selected, and
+  // RackEditSheet renders the now-active rack. openSheet("rackEdit") already
+  // replaces this sheet (sheets are mutually exclusive), so onclose is not
+  // called here: doing so used to make openSheet see a false closed-to-open
+  // transition and wrongly clear a lingering non-undo toast (#3030).
   function openRack(rack: Rack) {
     layoutStore.setActiveRack(rack.id);
     selectionStore.selectRack(rack.id);
-    onclose?.();
     dialogStore.openSheet("rackEdit");
   }
 

--- a/src/lib/stores/dialogs.svelte.ts
+++ b/src/lib/stores/dialogs.svelte.ts
@@ -126,9 +126,21 @@ function isOpen(id: DialogId): boolean {
 }
 
 /**
- * Open a mobile sheet by ID.
+ * Open a mobile sheet by ID. Clears any lingering non-undo toast on the
+ * closed-to-open transition (#3030), so a toast left over from a prior
+ * action can't cover a nav sheet's controls (Layouts/Racks/Devices/View,
+ * deviceDetails), same as open()'s dialog-open clear (#3004/R27a). Only
+ * fires when no sheet was already open: nav sheets swap frequently (tab
+ * switches, selecting a different device while deviceDetails is already
+ * showing), and re-clearing on every one of those redundant/same-state
+ * calls would eat a toast the user still wants to see. Unlike open(), an
+ * isUndoAffordance toast is exempt, since sheets don't block it the way a
+ * modal dialog does and it already auto-dismisses on its own.
  */
 function openSheetById(id: SheetId, deviceIndex?: number) {
+  if (openSheet === null) {
+    getToastStore().clearNonUndoToasts();
+  }
   openSheet = id;
   if (deviceIndex !== undefined) {
     selectedDeviceIndex = deviceIndex;

--- a/src/lib/stores/toast.svelte.ts
+++ b/src/lib/stores/toast.svelte.ts
@@ -132,6 +132,24 @@ function dismissUndoToasts(): void {
 }
 
 /**
+ * Clear every toast except undo affordances (#3030). Used by the mobile
+ * bottom-nav sheets (Layouts/Racks/Devices/View, deviceDetails) on their
+ * closed-to-open transition, mirroring dialogStore.open()'s lingering-toast
+ * clear but carving out isUndoAffordance toasts: sheets open far more
+ * frequently than dialogs, and an unclicked, still-valid Undo toast must
+ * survive a nav-sheet open rather than being wiped mid-window. Safe because
+ * undo toasts already auto-dismiss at 5s and on the next history command
+ * (dismissUndoToasts()), so exempting them here can't leak one indefinitely.
+ */
+function clearNonUndoToasts(): void {
+  for (const toast of toasts) {
+    if (!toast.isUndoAffordance) {
+      dismissToast(toast.id);
+    }
+  }
+}
+
+/**
  * Dismiss a specific toast by ID
  */
 function dismissToast(id: string): void {
@@ -177,6 +195,7 @@ export function getToastStore() {
     showUndoToast,
     dismissToast,
     dismissUndoToasts,
+    clearNonUndoToasts,
     clearAllToasts,
   };
 }

--- a/src/tests/MobileRacksSheet.test.ts
+++ b/src/tests/MobileRacksSheet.test.ts
@@ -8,7 +8,7 @@ import {
 } from "$lib/stores/selection.svelte";
 import { dialogStore } from "$lib/stores/dialogs.svelte";
 import { resetHistoryStore } from "$lib/stores/history.svelte";
-import { resetToastStore } from "$lib/stores/toast.svelte";
+import { getToastStore, resetToastStore } from "$lib/stores/toast.svelte";
 
 function renderSheet(
   overrides: Partial<{ onnewrack: () => void; onclose: () => void }> = {},
@@ -70,15 +70,38 @@ describe("MobileRacksSheet", () => {
     expect(selection.selectedRackId).toBe(edge!.id);
   });
 
-  it("closes the racks sheet after opening rack properties", async () => {
+  it("implicitly closes the racks sheet by opening rack properties in its place", async () => {
+    // Sheets are mutually exclusive, so opening "rackEdit" replaces "racks"
+    // without an explicit close call in between (#3030): a preceding
+    // dialogStore.closeSheet() would make the open-sheet toast clear see a
+    // false closed-to-open transition on this same-tick swap.
     const layout = getLayoutStore();
     layout.addRack("Edge", 42);
+    dialogStore.openSheet("racks");
 
-    const props = renderSheet();
+    renderSheet();
 
     await fireEvent.click(screen.getByRole("button", { name: /Edge/ }));
 
-    expect(props.onclose).toHaveBeenCalledTimes(1);
+    expect(dialogStore.isSheetOpen("racks")).toBe(false);
+    expect(dialogStore.isSheetOpen("rackEdit")).toBe(true);
+  });
+
+  it("does not clear a lingering toast when tapping a rack swaps racks for rackEdit (#3030)", async () => {
+    const layout = getLayoutStore();
+    layout.addRack("Edge", 42);
+    dialogStore.openSheet("racks");
+    const toastStore = getToastStore();
+    toastStore.showToast("Rack duplicated", "success");
+
+    renderSheet();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Edge/ }));
+
+    expect(dialogStore.isSheetOpen("rackEdit")).toBe(true);
+    expect(toastStore.toasts.some((t) => t.message === "Rack duplicated")).toBe(
+      true,
+    );
   });
 
   it("raises the New Rack flow and closes the sheet from the New rack action", async () => {

--- a/src/tests/dialog-toast-coordination.test.ts
+++ b/src/tests/dialog-toast-coordination.test.ts
@@ -81,3 +81,76 @@ describe("dialog open dismisses lingering toasts", () => {
     );
   });
 });
+
+/**
+ * Sheet/toast coordination tests (#3030)
+ *
+ * Extends the dialog-open clear above to mobile bottom-nav sheets
+ * (Layouts/Racks/Devices/View, deviceDetails): a toast left over from a
+ * prior action must not linger and cover a nav sheet's controls either.
+ * Unlike a dialog, a sheet can reopen with a different ID or device index
+ * while already open (nav tab switches, selecting another device), so the
+ * clear only fires on the closed-to-open transition, not on every one of
+ * those. An isUndoAffordance toast is also exempt, since sheets open far
+ * more often than dialogs and an unclicked, still-valid Undo must survive.
+ */
+describe("sheet open dismisses lingering toasts", () => {
+  beforeEach(() => {
+    resetToastStore();
+    dialogStore.close();
+    dialogStore.closeSheet();
+  });
+
+  it("clears a plain toast on the closed-to-open transition", () => {
+    const toastStore = getToastStore();
+    toastStore.showToast("Device duplicated", "success");
+    expect(
+      toastStore.toasts.some((t) => t.message === "Device duplicated"),
+    ).toBe(true);
+
+    dialogStore.openSheet("racks");
+
+    expect(toastStore.toasts).toEqual([]);
+  });
+
+  it("does not clear an undo-affordance toast on the closed-to-open transition", () => {
+    const toastStore = getToastStore();
+    toastStore.showUndoToast("Removed switch", () => {});
+    expect(toastStore.toasts.some((t) => t.isUndoAffordance)).toBe(true);
+
+    dialogStore.openSheet("deviceDetails", 0);
+
+    expect(toastStore.toasts.some((t) => t.isUndoAffordance)).toBe(true);
+  });
+
+  it("does not clear toasts on a redundant openSheet call while already open", () => {
+    const toastStore = getToastStore();
+    dialogStore.openSheet("deviceDetails", 0);
+    toastStore.showToast("Device duplicated", "success");
+    expect(
+      toastStore.toasts.some((t) => t.message === "Device duplicated"),
+    ).toBe(true);
+
+    // Selecting a different device re-fires openSheet for the same sheet.
+    dialogStore.openSheet("deviceDetails", 1);
+
+    expect(
+      toastStore.toasts.some((t) => t.message === "Device duplicated"),
+    ).toBe(true);
+  });
+
+  it("does not clear toasts when switching directly from one open sheet to another", () => {
+    const toastStore = getToastStore();
+    dialogStore.openSheet("racks");
+    toastStore.showToast("Rack duplicated", "success");
+    expect(toastStore.toasts.some((t) => t.message === "Rack duplicated")).toBe(
+      true,
+    );
+
+    dialogStore.openSheet("layouts");
+
+    expect(toastStore.toasts.some((t) => t.message === "Rack duplicated")).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Closes #3030 (item 1 only; item 2, undo-affordance cap eviction, was already fixed in-PR on #3031/#3004).

`dialogStore.open()` clears lingering toasts on the open transition (#3004/R27a) so a toast can't cover a dialog's Cancel button, but `openSheet()` (mobile bottom-nav sheets: Layouts/Racks/Devices/View, deviceDetails) did not, so a toast could still cover a sheet control on mobile.

This extends the clear to `openSheet()`:

- Fires only on the closed-to-open transition, not on redundant `openSheet` calls while a sheet is already open (nav tab switches, or selecting a different device while `deviceDetails` is already showing re-fire `openSheet` with the same or a different id).
- Exempts `isUndoAffordance` toasts from the clear (unlike dialog-open's clear): nav sheets open far more often than dialogs, and an unclicked, still-valid Undo toast must survive one. It already auto-dismisses at 5s and on the next history command, so it can't leak indefinitely.
- Adds `toast.svelte.ts`'s `clearNonUndoToasts()`, shared by `openSheetById` rather than duplicating the undo-skip loop already used by `dismissUndoToasts()`.

## Test plan

- [x] `npm run lint`
- [x] `npm run check`
- [x] `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/dialog-toast-coordination.test.ts src/tests/toast-store.test.ts` (19 passed)
- [x] `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/MobileRacksSheet.test.ts src/tests/MobileLayoutsSheet.test.ts src/tests/dialog-actions.test.ts src/tests/storage-notice-consolidation.test.ts` (46 passed, no regressions)
- [x] Full unit suite ran via the pre-commit hook: 2224 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep mobile sheet controls clear of old toasts**

### What Changed
- Opening a mobile sheet now removes leftover non-undo toasts so they do not cover sheet controls
- Undo toasts stay visible when a sheet opens, so valid undo actions are not lost
- Toasts are not cleared again when switching between already-open sheets or reopening the same sheet

### Impact
`✅ Fewer mobile sheet controls hidden by toasts`
`✅ Undo actions stay available after opening a sheet`
`✅ Less toast flicker during sheet navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
