### PR TITLE
fix: treat empty-string container_id as rack-level in storage migration paths (#2759)

### DIFF
--- a/src/lib/storage/adapt-legacy-layout.ts
+++ b/src/lib/storage/adapt-legacy-layout.ts
@@ -63,10 +63,24 @@ const KNOWN_CARRIER_SLUGS = new Set<string>([
   CARRIER_2U_2COL_SLUG,
 ]);
 
-/** A rack-level device has none of the child-placement markers set. */
+/**
+ * A rack-level device has none of the child-placement markers set.
+ *
+ * A falsy container_id (undefined or "") is rack-level here, matching how
+ * PlacedDeviceSchema, the carrier-first refine, and migrations.ts distinguish
+ * rail devices from container children (#2759, same class as #2699). A prior-
+ * release rack-level device can serialize container_id as "" (the schema's own
+ * default), so a strict `=== undefined` check misclassified it as a container
+ * child.
+ *
+ * parent_device and device_bay stay strict (`=== undefined`): they are
+ * schema-only fields (see PlacedDevice in types/index.ts) that no serializer
+ * in this codebase has ever written a value for, so there is no prior-release
+ * data that could carry an empty-string value for either.
+ */
 function isRackLevel(d: PlacedDevice): boolean {
   return (
-    d.container_id === undefined &&
+    !d.container_id &&
     d.parent_device === undefined &&
     d.device_bay === undefined
   );

--- a/src/tests/adapt-legacy-layout.test.ts
+++ b/src/tests/adapt-legacy-layout.test.ts
@@ -82,6 +82,40 @@ describe("adaptLegacyLayout", () => {
     });
   });
 
+  describe("empty-string container_id (#2759)", () => {
+    it("treats a rack-level device with an empty-string container_id as rack-level, snapping its fractional rail position", () => {
+      // A prior-release rack-level device can serialize container_id as ""
+      // (matching the class of bug fixed for the schema/storage position
+      // migration in #2699/#2756/#2931). isRackLevel's strict
+      // `=== undefined` check would misclassify this device as a container
+      // child, sending it to passthrough and skipping the fractional snap
+      // that every other rack-level device gets.
+      const dt = createTestDeviceType({ slug: "rb-1u-empty-cid", u_height: 1 });
+      const layout = createTestLayout({
+        device_types: [dt],
+        racks: [
+          createTestRack({
+            devices: [
+              createTestDevice({
+                id: "frac-empty-cid",
+                device_type: "rb-1u-empty-cid",
+                position: 32 / UNITS_PER_U, // factory re-applies toInternalUnits
+                container_id: "",
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const adapted = adaptLegacyLayout(layout);
+      const device = adapted.racks[0]!.devices.find(
+        (d) => d.id === "frac-empty-cid",
+      );
+      // Same snap as a rack-level device without container_id: round(32/6)=5 -> 30 internal == U5.
+      expect(device?.position).toBe(toInternalUnits(5));
+    });
+  });
+
   describe("half-width pair wrapping (legacy slot_position)", () => {
     it("wraps two co-located half-width devices into a carrier-1u-2col with two children", () => {
       const half = createTestDeviceType({


### PR DESCRIPTION
## **User description**
## Summary

Closes #2759

`adaptLegacyLayout`'s `isRackLevel` used a strict `container_id === undefined` check, so a prior-release rack-level device serialized with `container_id: ""` was misclassified as a container child: sent to passthrough instead of the rack-level path, skipping fractional-rail snapping and half-width carrier wrapping. Same class of bug as #2699 (PR #2756), which fixed the equivalent checks in `schemas/migrations.ts`.

## Investigation notes

The issue named two sites. Evidence changed the plan for both:

- **`src/lib/storage/adapt-legacy-layout.ts:66` (`isRackLevel`)**: fixed here. `d.container_id === undefined` -> `!d.container_id`.
- **`src/lib/storage/migrate-layout.ts:69`**: already fixed on `main`, as a side effect of #2931 (PR #2967, merged 2026-07-11, after this issue was filed). That PR routed `migrateLayout` through the shared `needsPositionMigration` / `migrateDevicePositions` helpers in `schemas/migrations.ts` (which already carry the falsy `container_id` check from #2756), and it added the exact regression test this issue asks for (`src/tests/migrate-layout.test.ts:85`, "migrates a rack-level device with an empty-string container_id the same as migrateDevicePositions"). No code change needed there; I re-ran that test to confirm it still passes.

**`parent_device` / `device_bay`**: left strict (`=== undefined`), not switched to falsy. Checked every write site in the codebase (`git log -S "parent_device"`, `grep` across `src/lib`) and the only places either field is ever assigned are the optional Zod schema declaration and a pass-through copy in `yaml-field-order.ts` that only copies a value when it is already defined. No serializer anywhere in this codebase has ever written a value to either field, so there is no prior-release data that could carry an empty string for them. `types/index.ts` marks them "(schema-only)". Applying the falsy treatment here would have no evidence behind it, so they stay as-is.

## Test plan

- Added a unit test in `src/tests/adapt-legacy-layout.test.ts` ("empty-string container_id (#2759)") that a rack-level device with `container_id: ""` still gets its fractional rail position snapped through `adaptLegacyLayout`. Verified it fails against the pre-fix code (32 vs expected 30 internal units) and passes with the fix.
- Re-ran the existing `migrate-layout.ts` parity test suite, including the empty-string `container_id` case already covered by #2967, to confirm no regression.
- Ran the upgrade-corpus harness tests (`upgrade-corpus.test.ts`, `upgrade-corpus-loadlayout.test.ts`, `upgrade-corpus-helpers.test.ts`, `browser-upgrade.test.ts`): all green.

```
VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/adapt-legacy-layout.test.ts src/tests/migrate-layout.test.ts src/tests/upgrade-corpus.test.ts src/tests/upgrade-corpus-loadlayout.test.ts src/tests/upgrade-corpus-helpers.test.ts src/tests/browser-upgrade.test.ts
# 6 files, 50 tests, all passed

npm run lint    # no issues
npm run check   # 0 errors, 0 warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Treat empty-string container IDs as rack-level devices during legacy storage migration**

### What Changed
- Devices saved with `container_id: ""` are now handled like rack-level devices instead of being treated as child devices
- These devices now go through the same rack-level snapping and wrapping rules as other top-level devices
- Added a regression test to confirm the empty-string case follows the rack-level path

### Impact
`✅ Correct migration for older saved layouts`
`✅ Fewer misplaced devices after import`
`✅ Consistent rack-level positioning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
