### PR TITLE
fix: make handleNewRack selection transactional (#3033)

### DIFF
--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -53,7 +53,7 @@ import {
   getRackById as getRackByIdImpl,
   setActiveRack as setActiveRackImpl,
   getTargetRack as getTargetRackImpl,
-  type RackDuplicateSelectionSync,
+  type RackSelectionSync,
 } from "./layout/rack-actions";
 import {
   createRackGroup as createRackGroupImpl,
@@ -441,6 +441,14 @@ export function createLayoutStore(
   // Rack Actions — delegated to layout/rack-actions.ts
   // =============================================================================
 
+  /**
+   * @param selectionSync - Optional bridge to the UI selection store. Pass it
+   * when the caller tracks a separate "selected" rack (distinct from
+   * "active") that should follow the new rack and stay coherent with
+   * activeRackId through undo/redo (#3033, mirroring duplicateRack's #3003
+   * fix); without it, the caller must sync selection itself after the call
+   * returns.
+   */
   function addRack(
     name: string,
     height: number,
@@ -448,6 +456,7 @@ export function createLayoutStore(
     form_factor?: FormFactor,
     desc_units?: boolean,
     starting_unit?: number,
+    selectionSync?: RackSelectionSync,
   ) {
     return addRackImpl(
       stateAccess,
@@ -457,6 +466,7 @@ export function createLayoutStore(
       form_factor,
       desc_units,
       starting_unit,
+      selectionSync,
     );
   }
 
@@ -523,10 +533,7 @@ export function createLayoutStore(
    * selection itself after the call returns.
    * @returns The duplicated rack, or an error message if duplication failed
    */
-  function duplicateRack(
-    id: string,
-    selectionSync?: RackDuplicateSelectionSync,
-  ) {
+  function duplicateRack(id: string, selectionSync?: RackSelectionSync) {
     return duplicateRackImpl(stateAccess, id, selectionSync);
   }
 

--- a/src/lib/stores/layout/rack-actions.ts
+++ b/src/lib/stores/layout/rack-actions.ts
@@ -288,6 +288,11 @@ export function getTargetRack(
  * @param form_factor - Rack form factor
  * @param desc_units - Whether units are numbered top-down
  * @param starting_unit - First U number
+ * @param selectionSync - Optional selection-store bridge (#3033, mirroring
+ * duplicateRack's #3003 fix). When provided, the caller's post-create
+ * selection change is folded into this command so undo/redo keep selection
+ * transactionally coherent with activeRackId; without it, the caller must
+ * sync selection itself outside the command/history system.
  * @returns The created rack object with ID, or null if at max capacity
  */
 export function addRack(
@@ -298,6 +303,7 @@ export function addRack(
   form_factor?: FormFactor,
   desc_units?: boolean,
   starting_unit?: number,
+  selectionSync?: RackSelectionSync,
 ): (Rack & { id: string }) | null {
   const layout = ctx.getLayout();
 
@@ -334,7 +340,25 @@ export function addRack(
   // setActive: true ensures redo also restores the active rack selection
   const history = ctx.getHistory();
   const adapter = getRackLifecycleCommandAdapter(ctx);
-  const command = createAddRackCommand(newRack, adapter, true, layoutNameSync);
+  // When a caller wants selection to follow this new rack transactionally
+  // (#3033, mirroring #3003), layer the bridge onto the shared adapter for
+  // just this command; other callers of getRackLifecycleCommandAdapter
+  // (duplicateRack, createRackGroup, etc.) are unaffected since
+  // syncSelection stays false.
+  const commandStore: RackLifecycleCommandStore = selectionSync
+    ? {
+        ...adapter,
+        getSelectedRackId: selectionSync.getSelectedRackId,
+        setSelectedRackId: selectionSync.setSelectedRackId,
+      }
+    : adapter;
+  const command = createAddRackCommand(
+    newRack,
+    commandStore,
+    true,
+    layoutNameSync,
+    Boolean(selectionSync),
+  );
   history.execute(command);
   ctx.markDirty();
 
@@ -538,13 +562,14 @@ export function moveRackInRow(
 
 /**
  * Optional bridge to the UI selection store, passed by a caller that wants
- * duplicateRack's post-duplicate selection change to be transactionally
- * coherent with activeRackId across undo/redo (#3003 fix round 1). Without
- * it, duplicateRack only manages activeRackId; the caller is responsible for
- * selecting the copy itself (and for any undo/redo coherence, which it then
- * cannot get for free).
+ * a rack-creating action's post-creation selection change to be
+ * transactionally coherent with activeRackId across undo/redo (#3003 fix
+ * round 1, extended to addRack by #3033). Without it, the action only
+ * manages activeRackId; the caller is responsible for selecting the new
+ * rack itself (and for any undo/redo coherence, which it then cannot get
+ * for free). Shared by addRack and duplicateRack.
  */
-export interface RackDuplicateSelectionSync {
+export interface RackSelectionSync {
   getSelectedRackId(): string | null;
   setSelectedRackId(id: string | null): void;
 }
@@ -560,7 +585,7 @@ export interface RackDuplicateSelectionSync {
 export function duplicateRack(
   ctx: LayoutStateAccess,
   id: string,
-  selectionSync?: RackDuplicateSelectionSync,
+  selectionSync?: RackSelectionSync,
 ): {
   error?: string;
   rack?: Rack & { id: string };
@@ -625,8 +650,8 @@ export function duplicateRack(
   const adapter = getRackLifecycleCommandAdapter(ctx);
   // When a caller wants selection to follow this duplicate transactionally
   // (#3003 fix round 1), layer the bridge onto the shared adapter for just
-  // this command; other callers of getRackLifecycleCommandAdapter (addRack,
-  // createRackGroup, etc.) are unaffected since syncSelection stays false.
+  // this command; other callers of getRackLifecycleCommandAdapter
+  // (createRackGroup, etc.) are unaffected since syncSelection stays false.
   const commandStore: RackLifecycleCommandStore = selectionSync
     ? {
         ...adapter,

--- a/src/lib/utils/dialog-actions.ts
+++ b/src/lib/utils/dialog-actions.ts
@@ -49,6 +49,13 @@ function nextAvailableRackName(
  * the schema default form factor. It is appended to the end of the row. Warns
  * when the rack limit is reached. The default name is disambiguated against
  * existing racks' names (#3002); see nextAvailableRackName.
+ *
+ * The selection change is routed through addRack's selection-sync bridge
+ * (#3033, mirroring #3003's fix for duplicateRack) rather than a bare
+ * selectionStore.selectRack() call after the fact: a bare call sits outside
+ * the command/history system, so undo restores activeRackId but leaves
+ * selectedRackId dangling on the just-removed rack's id. The bridge folds
+ * the selection change into the same undo/redo step as the rack itself.
  */
 export function handleNewRack(): void {
   const layoutStore = getLayoutStore();
@@ -62,9 +69,25 @@ export function handleNewRack(): void {
     layoutStore.racks.map((rack) => rack.name),
     NEW_RACK_DEFAULT_NAME,
   );
-  const rack = layoutStore.addRack(name, NEW_RACK_DEFAULT_HEIGHT);
+  const rack = layoutStore.addRack(
+    name,
+    NEW_RACK_DEFAULT_HEIGHT,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      getSelectedRackId: () => selectionStore.selectedRackId,
+      setSelectedRackId: (id) => {
+        if (id) {
+          selectionStore.selectRack(id);
+        } else {
+          selectionStore.clearSelection();
+        }
+      },
+    },
+  );
   if (!rack) return;
-  selectionStore.selectRack(rack.id);
   requestAnimationFrame(() => handleFitAll());
 }
 

--- a/src/tests/dialog-actions.test.ts
+++ b/src/tests/dialog-actions.test.ts
@@ -410,6 +410,36 @@ describe("handleNewRack", () => {
       false,
     );
   });
+
+  // #3033: handleNewRack selected the new rack via a bare
+  // selectionStore.selectRack() call outside the command/history system,
+  // the same non-transactional gap #3003 fixed for duplicateRack. Undo
+  // restored activeRackId (#2940/#2976) but left selectedRackId dangling on
+  // the just-removed rack's id. addRack's selection-sync bridge folds the
+  // selection change into the same undo/redo step as the rack itself, so
+  // undo and redo must keep active and selected coherent throughout.
+  it("keeps active and selected coherent through new-rack undo and redo", () => {
+    const layoutStore = getLayoutStore();
+    const selectionStore = getSelectionStore();
+    const existing = layoutStore.addRack("Existing Rack", 42)!;
+    layoutStore.setActiveRack(existing.id);
+    selectionStore.selectRack(existing.id);
+
+    handleNewRack();
+    const created = layoutStore.racks.find((rack) => rack.id !== existing.id);
+    expect(created).toBeDefined();
+    expect(layoutStore.activeRackId).toBe(created!.id);
+    expect(selectionStore.selectedRackId).toBe(created!.id);
+
+    layoutStore.undo();
+    expect(layoutStore.activeRackId).toBe(existing.id);
+    expect(selectionStore.selectedRackId).toBe(existing.id);
+    expect(layoutStore.getRackById(created!.id)).toBeUndefined();
+
+    layoutStore.redo();
+    expect(layoutStore.activeRackId).toBe(created!.id);
+    expect(selectionStore.selectedRackId).toBe(created!.id);
+  });
 });
 
 describe("seedStarterRack (#3007/R6a)", () => {


### PR DESCRIPTION
## **User description**
## Summary

handleNewRack (src/lib/utils/dialog-actions.ts) called addRack and then a bare selectionStore.selectRack() outside the command/history system, the same non-transactional pattern #3003 fixed for duplicateRack. Undo right after creating a rack via handleNewRack restored activeRackId through the command but left selectedRackId dangling on the removed rack's id (benign, null-guarded, but the same active/selected disagreement class in the undo path).

This mirrors #3003's fix exactly rather than inventing a new mechanism: addRack (src/lib/stores/layout/rack-actions.ts) now accepts an optional selectionSync bridge, threaded through to createAddRackCommand's existing syncSelection flag. The RackDuplicateSelectionSync interface is renamed to RackSelectionSync since it is now shared by both addRack and duplicateRack (same shape, no behaviour change to duplicateRack's existing call sites). handleNewRack now passes the bridge instead of a bare selectRack() call, so undo and redo keep active and selected coherent in the same history step.

## Changes

- `src/lib/stores/commands/rack.ts`: unchanged (syncSelection mechanism already existed from #3003)
- `src/lib/stores/layout/rack-actions.ts`: addRack takes an optional `selectionSync` param, wires it into the command adapter the same way duplicateRack does; renamed `RackDuplicateSelectionSync` to `RackSelectionSync`
- `src/lib/stores/layout.svelte.ts`: facade forwards the new param
- `src/lib/utils/dialog-actions.ts`: handleNewRack passes a selection-sync bridge instead of a bare `selectionStore.selectRack()` call

## Testing

Added "keeps active and selected coherent through new-rack undo and redo" to `src/tests/dialog-actions.test.ts`, mirroring the equivalent test #3003 added for duplicateRack in `src/tests/rack-context-duplicate.test.ts`. Seeds an existing active/selected rack, creates a new rack via handleNewRack, then asserts undo restores both activeRackId and selectedRackId to the existing rack (not just null) and redo puts both back on the created rack.

- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/dialog-actions.test.ts src/tests/rack-context-duplicate.test.ts src/tests/layout-rack-actions.test.ts src/tests/rack-actions-undo.test.ts`: 85/85 passed
- Pre-commit hook ran the full suite: 158 files / 2203 tests passed
- `npm run lint`: clean
- `npm run check` (svelte-check): 0 errors, 0 warnings

Closes #3033

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Keep new-rack selection undoable and redoable**

### What Changed
- Creating a new rack now keeps the “active” rack and the selected rack in sync through undo and redo
- Undoing a new rack creation now restores the previous selection instead of leaving it pointing at the removed rack
- The new-rack flow now uses the same selection behavior already used when duplicating a rack

### Impact
`✅ No stale rack selection after undo`
`✅ Consistent rack selection after redo`
`✅ Fewer confusing selection mismatches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
