### PR TITLE
fix: rename Export all layouts to Save all layouts verb (#3061)

### DIFF
--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -412,27 +412,30 @@ test.describe("Command palette", () => {
   test("the device bridge stays available for a query that also fuzzy-matches a command, and Enter goes to the bridge, not the command (#2996)", async ({
     page,
   }) => {
-    // "xserve" is the issue's own repro: it fuzzy-matches "Export all layouts"
-    // via a stray character-jump (a coincidental, low-confidence hit), which
-    // previously hid the device bridge entirely and let a bare Enter silently
-    // fire the export command instead of surfacing a way to place a device.
+    // "xarchive" reproduces the issue's own repro (#2996's original hit was
+    // "xserve" against the label's pre-rename text "Export all layouts"; #3061
+    // renamed the label to "Save all layouts" so the stray jump moved to this
+    // string): it fuzzy-matches "Save all layouts (.zip)" via a stray
+    // character-jump (a coincidental, low-confidence hit), which previously hid
+    // the device bridge entirely and let a bare Enter silently fire the save
+    // command instead of surfacing a way to place a device.
     await page.keyboard.press(`${PLATFORM_MODIFIER}+k`);
     const input = page.getByTestId("command-palette-input");
-    await input.fill("xserve");
+    await input.fill("xarchive");
 
     const bridge = page.getByTestId("command-palette-create-device");
     await expect(bridge).toBeVisible();
 
     await page.keyboard.press("Enter");
 
-    // Enter went to the device bridge, not "Export all layouts": the palette
-    // is still open, in the device sub-page, carrying the typed query. Had the
-    // export command fired instead, the palette would have closed entirely.
+    // Enter went to the device bridge, not "Save all layouts": the palette is
+    // still open, in the device sub-page, carrying the typed query. Had the
+    // save-all command fired instead, the palette would have closed entirely.
     await expect(
       page.getByRole("dialog", { name: "Command palette" }),
     ).toBeVisible();
     await expect(page.getByTestId("command-palette-device-back")).toBeVisible();
-    await expect(input).toHaveValue("xserve");
+    await expect(input).toHaveValue("xarchive");
   });
 
   test("the device bridge stays available for a device-category word that also fuzzy-matches a command (#2996)", async ({

--- a/src/lib/actions/palette-commands.ts
+++ b/src/lib/actions/palette-commands.ts
@@ -261,7 +261,7 @@ export function getPaletteSearchCommands(
  * case) lands at ~0.99 even after the keyword-string-length penalty; a query
  * that only hits an interior word or a keyword ("device" inside "Toggle
  * device sidebar", "server" inside "...Media Server") lands at ~0.89; a stray
- * character-jump coincidence ("xserve" against "Export all layouts") lands
+ * character-jump coincidence ("xarchive" against "Save all layouts") lands
  * near 0. 0.95 sits cleanly between the first two bands, so only a genuine,
  * intentional command-name match counts as "confident" here. Exported so
  * CommandPalette.svelte and its test can share one source of truth instead of

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -410,7 +410,10 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
   },
   {
     id: "export-all",
-    label: "Export all layouts (.zip)",
+    // Backs up the whole workspace to a ZIP: persisting layouts, so it leads
+    // with "Save" like export-backup and save-as above, not the derived-
+    // artifact "Export" export/export-rack use below (#3061, #2995/#3007).
+    label: "Save all layouts (.zip)",
     scope: "global",
     bindings: [],
     appMenuGroup: "workspace",

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -314,7 +314,7 @@
   //   8 for anything else: no other row can fire from an empty query.
   // - Non-empty query with no *confident* command match: bits-ui would still
   //   auto-select and fire whatever row scored above zero, including a stray
-  //   coincidental hit ("xserve" -> "Export all layouts"). Routing Enter to
+  //   coincidental hit ("xarchive" -> "Save all layouts"). Routing Enter to
   //   the device bridge here - the same condition that renders it - means a
   //   device-like query can no longer silently run an unrelated command
   //   instead of surfacing the bridge. A confident command match (the query
@@ -647,7 +647,7 @@
                    *confident* match for the query - a true zero-match, or a
                    query that only coincidentally brushes a command's keyword
                    or an interior word (see noConfidentCommandMatch) - so a
-                   device-like query ("server", "switch", "xserve") always
+                   device-like query ("server", "switch", "xarchive") always
                    keeps a route into device search even if it also brushes an
                    unrelated command. It lives in its OWN forceMounted group,
                    NOT the command group above: bits-ui culls a group whose

--- a/src/tests/palette-command-routing-threshold.test.ts
+++ b/src/tests/palette-command-routing-threshold.test.ts
@@ -44,7 +44,7 @@ describe("noConfidentCommandMatch routing bands (#2996)", () => {
   });
 
   describe("device/category queries stay below the threshold (bridge available)", () => {
-    it.each(["xserve", "switch", "server", "device", "rack"])(
+    it.each(["xarchive", "switch", "server", "device", "rack"])(
       "%s does not confidently match any registry command",
       (query) => {
         expect(noConfidentCommandMatch(query, commands)).toBe(true);


### PR DESCRIPTION
## **User description**
Closes #3061

## Summary

The command palette's "Export all layouts (.zip)" label predates the Save/Export vocabulary axis settled in #2995/#3007: Save means persisting layouts, Export means derived artifacts (images, etc). This command backs up the whole workspace to a ZIP (a file-persistence flow), so its label now leads with "Save" like the other persistence commands (`export-backup` = "Save layout (.yaml)", `save-as` = "Save As (ZIP)").

The `#2996` fuzzy-match repro in `e2e/command-palette.spec.ts` pinned the exact old string (`"xserve"` coincidentally fuzzy-matching `"Export all layouts"`), so per the issue, the label and the e2e string change together in this one PR.

## What changed

- `src/lib/actions/registry.ts`: `export-all` action's `label` renamed to `"Save all layouts (.zip)"`. `id` and `keywords` (including `"export all"`) are unchanged, matching the established pattern where `export-backup`/`save-as` keep `"export"` as a keyword synonym for discoverability even though their labels say Save.
- `e2e/command-palette.spec.ts`: the `#2996` repro test's query moves from `"xserve"` to `"xarchive"`, the new coincidental low-confidence hit against the renamed label.
- `src/tests/palette-command-routing-threshold.test.ts`: same string swap in the `it.each` case that locks the routing-band boundary against the real registry.
- `src/lib/actions/palette-commands.ts`, `src/lib/components/CommandPalette.svelte`: doc-comment examples referencing the old string/label updated to match.

## Why "xarchive" preserves the test's substance

I read `docs` around `#2996` and the scorer (`bits-ui`'s `computeCommandScore`, a subsequence-with-penalties fuzzy matcher, same function used both by our `noConfidentCommandMatch` gate and by bits-ui's own `Command.Root` default filter) before picking a replacement, rather than just swapping the literal string:

- The original `"xserve"` scored ~0.0007 against the old label + keywords (a genuine "near zero" stray character-jump: `x` from "Export", `s` from "layouts", `e/r/v/e` jumping into the "export all"/"archive" keywords). Once the label changes to "Save all layouts (.zip)", `"xserve"` no longer matches *anything* in the registry (score 0 everywhere) — it would silently turn this test into a vacuous zero-match case instead of the coincidental-hit scenario it's meant to protect.
- I wrote a small script using the actual `computeCommandScore` import from `node_modules/bits-ui` against the full action registry (post-rename) to search for a replacement that reproduces the same shape of bug: a query that (a) is *not* a confident match for anything (stays below the `0.95` `CONFIDENT_COMMAND_MATCH` threshold) but (b) *does* register a real, non-zero, top-ranked fuzzy hit against `export-all`'s new label, so bits-ui would still auto-select and (absent the fix) fire it on Enter.
- `"xarchive"` scores `~0.151` against `"Save all layouts (.zip)"` + its keywords, is the highest-scoring command across the entire registry for that query, and stays comfortably under `0.95`. This keeps the test's actual behavioural guarantee (a device-like stray query must route Enter to the device bridge, never to the coincidentally-matched command) intact, not just its shape.

## Grep check (AC3: no other export-centric labels on file-persistence flows)

Checked the full `ACTION_REGISTRY` (the single source of truth every surface — palette, app menu, verb bars, help overlay — reads from) plus a broader `grep -rn "Export"` across `src/lib`:

- `export-backup` -> "Save layout (.yaml)" — already Save-verbed (#2995/#3007).
- `save-as` -> "Save As (ZIP)" — already Save-verbed.
- `export-all` -> now "Save all layouts (.zip)" — fixed here.
- `export` -> "Export image" and `export-rack` -> "Export" — correctly stay Export: both open the image/SVG/PDF export dialog (derived artifacts), not a persistence flow.
- `LayoutContextMenu.svelte` / `RackContextMenu.svelte` "Export..." context-menu items route to the same image-export dialog (`handleLayoutExport` -> `maybeExport()`), so they're derived-artifact exports too and correctly stay "Export".
- Found one adjacent, pre-existing item that reads Export-flavoured but is actually a Save flow: `OpenFileGuardDialog.svelte` / `RestoreFromFileDialog.svelte`'s "Export first" button (which calls `handleSaveAsArchive()`, a server-mode save) and the `changesSinceExport` guard naming. This is already tracked as a deliberately-deferred, separate concern in #2801 ("reconcile server-mode 'Save First' with the changesSinceExport guard"), so I left it out of this PR's scope rather than expanding it.

## Test plan

- `npm run lint` — clean.
- `npm run check` (svelte-check) — 0 errors, 0 warnings.
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/palette-command-routing-threshold.test.ts src/tests/palette-commands.test.ts src/tests/dispatch.test.ts` — 55 passed.
- Broader palette-adjacent unit sweep (13 files) — 97 passed.
- `npm run test:e2e -- command-palette.spec.ts` (Chromium + WebKit) — 50 passed, including the `#2996` repro at the new string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Rename the all-layout backup command and keep device search available for near-miss queries**

### What Changed
- The command palette now shows **“Save all layouts (.zip)”** instead of **“Export all layouts (.zip)”** for the workspace backup action.
- The device-search bridge still appears when a typed query only loosely matches a command, so pressing Enter opens device search instead of running the command by mistake.
- The matching test cases and help text were updated to use the new label and example query.

### Impact
`✅ Clearer backup naming in the command palette`
`✅ Fewer accidental command runs from near-miss searches`
`✅ More reliable access to device search from fuzzy queries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
