### PR TITLE
fix: gate undo/redo and restore-file under read-only mode (#2804)

### DIFF
--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -72,7 +72,11 @@ export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {
   );
 }
 
+// Mutating commands: guarded here like the other mutation verbs below, so the
+// read-only lock holds even if a caller reaches this entry outside the
+// palette's own enabledWhen gating (#2804, mirrors create-rack's #2995 guard).
 function performUndo(): void {
+  if (getUIStore().readOnly) return;
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
   if (!layoutStore.canUndo) return;
@@ -82,6 +86,7 @@ function performUndo(): void {
 }
 
 function performRedo(): void {
+  if (getUIStore().readOnly) return;
   const layoutStore = getLayoutStore();
   const toastStore = getToastStore();
   if (!layoutStore.canRedo) return;
@@ -164,7 +169,12 @@ export function createActionDispatch(): ActionDispatch {
     "export-all": () => {
       void handleExportAll();
     },
-    "restore-file": runRestoreFromFile,
+    // Mutating command: replaces the working copy, so the read-only lock is
+    // enforced here like undo/redo above (#2804).
+    "restore-file": () => {
+      if (getUIStore().readOnly) return;
+      runRestoreFromFile();
+    },
     export: maybeExport,
     share: handleShare,
     load: handleLoad,

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -451,6 +451,11 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
     label: "Restore from backup (.zip)",
     scope: "global",
     bindings: [],
+    // Mutating command: replaces the working copy with the restored file, so
+    // it is gated like undo/redo/create-rack rather than New layout/Open/
+    // imports, which do not mutate a locked layout (they replace or add via
+    // their own confirm dialogs) (#2804).
+    enabledWhen: (ctx) => !ctx.readOnly,
     appMenuGroup: "layout-data",
     keywords: [
       "restore",
@@ -594,7 +599,10 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
       { key: "z", ctrl: true },
       { key: "z", meta: true },
     ],
-    enabledWhen: (ctx) => ctx.canUndo,
+    // Mutating command: can undo past the point the layout was locked, so it
+    // is gated on !ctx.readOnly like the selection verbs, in addition to
+    // needing history to undo (#2804).
+    enabledWhen: (ctx) => !ctx.readOnly && ctx.canUndo,
     helpGroup: "File",
     keywords: ["revert", "back"],
   },
@@ -608,7 +616,7 @@ export const ACTION_REGISTRY: ActionDefinition[] = [
       { key: "y", ctrl: true },
       { key: "y", meta: true },
     ],
-    enabledWhen: (ctx) => ctx.canRedo,
+    enabledWhen: (ctx) => !ctx.readOnly && ctx.canRedo,
     helpGroup: "File",
     keywords: ["forward", "repeat"],
   },

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -418,9 +418,14 @@ describe("actions registry", () => {
         "import-netbox",
       ] as const) {
         const action = getActionById(id);
-        expect(action?.enabledWhen?.({ ...base, readOnly: true }) ?? true).toBe(
-          true,
-        );
+        expect(action).toBeDefined();
+        // Mirrors isRunnable in palette-commands.ts: no enabledWhen means the
+        // command is always runnable. Asserting the action exists first (above)
+        // stops this from trivially passing if the action were removed.
+        const enabled = action?.enabledWhen
+          ? action.enabledWhen({ ...base, readOnly: true })
+          : true;
+        expect(enabled).toBe(true);
       }
     });
   });

--- a/src/tests/actions-registry.test.ts
+++ b/src/tests/actions-registry.test.ts
@@ -368,6 +368,63 @@ describe("actions registry", () => {
     });
   });
 
+  describe("read-only gate for global mutators (#2804)", () => {
+    // undo/redo/restore-file can mutate a locked layout (undo past the point
+    // it was locked; restore-file replaces the working copy outright), so they
+    // are gated on !ctx.readOnly like create-rack (#2995). new-layout, open,
+    // and imports are deliberately NOT gated: they replace or add rather than
+    // mutate the locked layout, and route through their own confirm dialogs.
+    const base = {
+      hasSelection: false,
+      isDeviceSelected: false,
+      isRackSelected: false,
+      canUndo: true,
+      canRedo: true,
+      hasRacks: true,
+      mode: "browser" as const,
+      canMoveDeviceSlot: false,
+    };
+
+    it("disables undo when read-only, even with history to undo", () => {
+      const undo = getActionById("undo");
+      expect(undo?.enabledWhen?.({ ...base, readOnly: true })).toBe(false);
+      expect(undo?.enabledWhen?.({ ...base, readOnly: false })).toBe(true);
+    });
+
+    it("disables redo when read-only, even with history to redo", () => {
+      const redo = getActionById("redo");
+      expect(redo?.enabledWhen?.({ ...base, readOnly: true })).toBe(false);
+      expect(redo?.enabledWhen?.({ ...base, readOnly: false })).toBe(true);
+    });
+
+    it("disables restore-file when read-only", () => {
+      const restoreFile = getActionById("restore-file");
+      expect(restoreFile?.enabledWhen).toBeDefined();
+      expect(restoreFile?.enabledWhen?.({ ...base, readOnly: true })).toBe(
+        false,
+      );
+      expect(restoreFile?.enabledWhen?.({ ...base, readOnly: false })).toBe(
+        true,
+      );
+    });
+
+    it("leaves new-layout, open, and imports ungated in read-only mode", () => {
+      // These don't mutate the locked layout: they replace or add, and route
+      // through their own confirm dialogs, so read-only leaves them runnable.
+      for (const id of [
+        "new-layout",
+        "load",
+        "import-devices",
+        "import-netbox",
+      ] as const) {
+        const action = getActionById(id);
+        expect(action?.enabledWhen?.({ ...base, readOnly: true }) ?? true).toBe(
+          true,
+        );
+      }
+    });
+  });
+
   describe("export-backup relabel (#2995, R5)", () => {
     it("the displayed extension matches downloadYamlFile's real output", () => {
       // Regression guard: the label promised '.zip' while downloadYamlFile

--- a/src/tests/palette-commands.test.ts
+++ b/src/tests/palette-commands.test.ts
@@ -90,6 +90,26 @@ describe("getPaletteCommands", () => {
     expect(ids(multi)).toContain("cycle-rack-prev");
     expect(ids(multi)).toContain("cycle-rack-next");
   });
+
+  it("hides undo/redo/restore-file from browse when read-only, even with history available (#2804)", () => {
+    // canUndo/canRedo true would otherwise make these runnable; the lock wins.
+    const locked = { ...baseCtx, canUndo: true, canRedo: true, readOnly: true };
+    const list = ids(locked);
+    expect(list).not.toContain("undo");
+    expect(list).not.toContain("redo");
+    expect(list).not.toContain("restore-file");
+  });
+
+  it("keeps new-layout, open, and imports in browse when read-only (#2804)", () => {
+    // These don't mutate the locked layout: they replace or add via their own
+    // confirm dialogs, so the lock leaves them available.
+    const locked = { ...baseCtx, readOnly: true };
+    const list = ids(locked);
+    expect(list).toContain("new-layout");
+    expect(list).toContain("load");
+    expect(list).toContain("import-devices");
+    expect(list).toContain("import-netbox");
+  });
 });
 
 describe("getPaletteCommands unified grouping (#2775)", () => {
@@ -303,6 +323,27 @@ describe("getPaletteSearchCommands (#2778)", () => {
     // the reason is read-only rather than the selection one.
     const locked = { ...baseCtx, hasSelection: true, readOnly: true };
     expect(find(locked, "delete-selection")?.disabledReason).toBe("read-only");
+  });
+
+  it("greys undo/redo/restore-file with a read-only reason when the layout is locked (#2804)", () => {
+    // History/rack conditions alone would make these runnable; the lock is the
+    // actual blocker, so it must win over "nothing to undo"/"nothing to redo".
+    const locked = { ...baseCtx, canUndo: true, canRedo: true, readOnly: true };
+    expect(find(locked, "undo")?.disabledReason).toBe("read-only");
+    expect(find(locked, "redo")?.disabledReason).toBe("read-only");
+    expect(find(locked, "restore-file")?.disabledReason).toBe("read-only");
+  });
+
+  it("keeps new-layout, open, and imports runnable in search when read-only (#2804)", () => {
+    const locked = { ...baseCtx, readOnly: true };
+    for (const id of [
+      "new-layout",
+      "load",
+      "import-devices",
+      "import-netbox",
+    ] as const) {
+      expect(find(locked, id)?.disabledReason).toBeUndefined();
+    }
   });
 
   it("never includes the wrong-mode storage variant, even greyed", () => {

--- a/src/tests/palette-commands.test.ts
+++ b/src/tests/palette-commands.test.ts
@@ -342,7 +342,11 @@ describe("getPaletteSearchCommands (#2778)", () => {
       "import-devices",
       "import-netbox",
     ] as const) {
-      expect(find(locked, id)?.disabledReason).toBeUndefined();
+      const command = find(locked, id);
+      // Assert the command is present first, so a regression that drops it
+      // from the search list entirely can't hide behind an undefined match.
+      expect(command).toBeDefined();
+      expect(command?.disabledReason).toBeUndefined();
     }
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Undo, Redo, and Restore from backup had no read-only gate, so they stayed runnable from the palette (and via their keyboard shortcuts) on a presentation-locked layout even though they can mutate it. This extends the `enabledWhen`/availability mechanism #2778 built (browse hides unavailable commands, search greys them with a reason) to cover these three global mutators, matching the precedent already set for `create-rack` (#2995).

## What changed

- `src/lib/actions/registry.ts`: `undo` and `redo` now gate on `!ctx.readOnly && ctx.can{Undo,Redo}`; `restore-file` gains an `enabledWhen: (ctx) => !ctx.readOnly` (it previously had none).
- `src/lib/actions/dispatch.ts`: mirrors the guard in the dispatch spine (`if (getUIStore().readOnly) return;`) for `undo`, `redo`, and `restore-file`, so the lock holds even when a caller reaches these outside the palette's own gating (same pattern already used for `delete-selection`, `create-rack`, etc.).

## Allowed-list rationale

`new-layout`, `load` (Open), `import-devices`, and `import-netbox` are deliberately left **ungated**, per the issue's own recommendation: they don't mutate the locked layout, they replace or add to it, and they already route through their own confirm dialogs (`confirmReplace` for New layout with unsaved changes, file pickers for Open/imports). Gating them would be redundant with those dialogs and would block a legitimate "start fresh" or "add devices" flow that read-only mode isn't meant to prevent.

## Reason copy

Reuses the existing generic `"read-only"` reason string `unavailableReason` in `palette-commands.ts` already produces when an action's `enabledWhen` would pass minus the lock, so no new gating path or copy was needed there.

## Tests

Mirrors the #2778 test patterns:
- `src/tests/actions-registry.test.ts`: new `read-only gate for global mutators (#2804)` describe block, asserting undo/redo/restore-file disable under `readOnly: true` (even with history/no confirm needed) and that new-layout/load/import-devices/import-netbox stay ungated.
- `src/tests/palette-commands.test.ts`: browse hides undo/redo/restore-file when locked (even with history available); search greys them with `"read-only"`; the allowed set stays visible and runnable in both browse and search when locked.

## Local gates

- `npm run lint`: clean
- `npm run check`: 0 errors, 0 warnings
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/actions-registry.test.ts src/tests/palette-commands.test.ts src/tests/dispatch.test.ts`: 94 passed
- Pre-push hook: full unit suite (248 tests) + prettier + CodeRabbit local review, all clean

Closes #2804

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Undo, redo, and restore from backup are blocked in read-only layouts**

### What Changed
- Undo, redo, and restore from backup are no longer available when a layout is locked
- The command palette now hides these actions in read-only mode, and search shows them as unavailable
- New layout, Open, and import actions stay available in read-only mode

### Impact
`✅ Fewer accidental layout changes in read-only mode`
`✅ Clearer command palette availability`
`✅ Safer recovery actions during presentation-locked sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
