### PR TITLE
fix: make new-layout confirm guard storage-mode aware (#2801)

### DIFF
--- a/src/lib/actions/dispatch.ts
+++ b/src/lib/actions/dispatch.ts
@@ -50,7 +50,7 @@ import {
   handleRackContextFocus,
   handleRackContextExport,
 } from "$lib/utils/rack-actions";
-import { handleLoad, handleExportAll } from "$lib/storage";
+import { handleLoad, handleExportAll, shouldSaveToServer } from "$lib/storage";
 import { runImportDevices } from "$lib/actions/import-devices-trigger";
 import { runRestoreFromFile } from "$lib/actions/restore-file-trigger";
 import { openStarterById } from "$lib/stores/starter-templates.svelte";
@@ -169,12 +169,20 @@ export function createActionDispatch(): ActionDispatch {
     share: handleShare,
     load: handleLoad,
     "view-yaml": handleOpenYamlEditor,
-    // Resetting to a new layout replaces the working copy. Confirm first when
-    // there are changes not yet in any exported file (mirrors restore-file); the
-    // shared confirmReplace dialog offers to export first, then resets. A fully
-    // backed-up copy resets straight away (#2775).
+    // Resetting to a new layout replaces the working copy, so confirm first when
+    // the current layout is not durably persisted. The signal is storage-mode
+    // aware (#2801): in server mode a successful server save clears isDirty, so
+    // key on isDirty (edits not yet saved to the server); in file/browser mode
+    // key on changesSinceExport (edits not yet in any exported file). This
+    // mirrors what the confirm dialog's "Save First" button does per mode
+    // (handleSaveFirst also branches on shouldSaveToServer), so the guard and the
+    // save it offers never disagree. A durably-persisted copy resets straight away.
     "new-layout": () => {
-      if (getLayoutStore().changesSinceExport > 0) {
+      const layoutStore = getLayoutStore();
+      const hasUndurableChanges = shouldSaveToServer()
+        ? layoutStore.isDirty
+        : layoutStore.changesSinceExport > 0;
+      if (hasUndurableChanges) {
         dialogStore.open("confirmReplace");
       } else {
         resetAndCreateNewRack();

--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -154,6 +154,15 @@
 
   // --- Replace dialog handlers ---
 
+  // The new-layout confirm dialog offers to save before discarding the working
+  // copy. Name the button for what "Save First" actually does in this mode
+  // (#2801): a server save when the server is the durable home, a file save
+  // otherwise. handleSaveFirst branches on the same shouldSaveToServer signal,
+  // so the label and the action it triggers always agree.
+  const newLayoutSaveLabel = $derived(
+    shouldSaveToServer() ? "Save to server" : "Save to file",
+  );
+
   async function handleSaveFirst() {
     dialogStore.close();
     const saved = shouldSaveToServer()
@@ -808,6 +817,7 @@
 
 <ConfirmReplaceDialog
   open={showReplaceDialog}
+  saveFirstLabel={newLayoutSaveLabel}
   onSaveFirst={handleSaveFirst}
   onReplace={handleReplace}
   onCancel={handleCancelReplace}

--- a/src/tests/dispatch.test.ts
+++ b/src/tests/dispatch.test.ts
@@ -78,39 +78,80 @@ describe("createActionDispatch", () => {
     }
   });
 
-  // new-layout replaces the working copy. When there are changes not yet in any
-  // exported file it must confirm first (the shared confirmReplace dialog),
-  // mirroring restore-file; a backed-up copy resets straight away (#2775).
-  // Wrap the real store and override only changesSinceExport, so the mock stays
-  // a complete, type-sound LayoutStore: any other field the new-layout branch
-  // might read returns the real value rather than silently being undefined.
-  function stubLayoutChangesSinceExport(value: number) {
+  // new-layout replaces the working copy, so it confirms first when the current
+  // layout is not durably persisted. The guard is storage-mode aware (#2801): in
+  // server mode it keys on isDirty (edits not yet saved to the server), in
+  // file/browser mode on changesSinceExport (edits not yet in any exported
+  // file). shouldSaveToServer picks the mode, mirroring the dialog's "Save
+  // First" button so the guard and the offered save never disagree.
+  //
+  // Wrap the real store and override only the fields under test, so the mock
+  // stays a complete, type-sound LayoutStore: any other field the new-layout
+  // branch might read returns the real value rather than silently being
+  // undefined.
+  function stubLayoutStore(overrides: {
+    changesSinceExport?: number;
+    isDirty?: boolean;
+  }) {
     const real = layoutStore.getLayoutStore();
     const stub = new Proxy(real, {
       get(target, prop) {
-        if (prop === "changesSinceExport") return value;
+        if (typeof prop === "string" && prop in overrides) {
+          return overrides[prop as keyof typeof overrides];
+        }
         return Reflect.get(target, prop, target);
       },
     });
     vi.spyOn(layoutStore, "getLayoutStore").mockReturnValue(stub);
   }
 
-  it("new-layout confirms before resetting when there are unexported changes", () => {
-    stubLayoutChangesSinceExport(2);
-    const reset = vi
+  function spyReset() {
+    return vi
       .spyOn(appActions, "resetAndCreateNewRack")
       .mockReturnValue(undefined);
+  }
+
+  // --- server mode: key on isDirty (unsaved to the server) ---
+
+  // The over-prompt bug this issue fixes: a server user who has saved to the
+  // server (isDirty false) but never exported a file (changesSinceExport > 0)
+  // must NOT be prompted, because the layout is durably persisted.
+  it("new-layout resets straight away in server mode when saved to the server, even with unexported changes", () => {
+    vi.spyOn(storage, "shouldSaveToServer").mockReturnValue(true);
+    stubLayoutStore({ isDirty: false, changesSinceExport: 5 });
+    const reset = spyReset();
+    const dispatch = createActionDispatch();
+    dispatch["new-layout"]();
+    expect(reset).toHaveBeenCalledOnce();
+    expect(dialogStore.isOpen("confirmReplace")).toBe(false);
+  });
+
+  it("new-layout confirms first in server mode when there are unsaved server changes", () => {
+    vi.spyOn(storage, "shouldSaveToServer").mockReturnValue(true);
+    stubLayoutStore({ isDirty: true, changesSinceExport: 0 });
+    const reset = spyReset();
     const dispatch = createActionDispatch();
     dispatch["new-layout"]();
     expect(dialogStore.isOpen("confirmReplace")).toBe(true);
     expect(reset).not.toHaveBeenCalled();
   });
 
-  it("new-layout resets straight away when there are no unexported changes", () => {
-    stubLayoutChangesSinceExport(0);
-    const reset = vi
-      .spyOn(appActions, "resetAndCreateNewRack")
-      .mockReturnValue(undefined);
+  // --- file/browser mode: semantics unchanged (key on changesSinceExport) ---
+
+  it("new-layout confirms first in file mode when there are unexported changes", () => {
+    vi.spyOn(storage, "shouldSaveToServer").mockReturnValue(false);
+    stubLayoutStore({ changesSinceExport: 2, isDirty: true });
+    const reset = spyReset();
+    const dispatch = createActionDispatch();
+    dispatch["new-layout"]();
+    expect(dialogStore.isOpen("confirmReplace")).toBe(true);
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it("new-layout resets straight away in file mode when everything is exported, even if dirty", () => {
+    vi.spyOn(storage, "shouldSaveToServer").mockReturnValue(false);
+    stubLayoutStore({ changesSinceExport: 0, isDirty: true });
+    const reset = spyReset();
     const dispatch = createActionDispatch();
     dispatch["new-layout"]();
     expect(reset).toHaveBeenCalledOnce();


### PR DESCRIPTION
## **User description**
## Summary

Closes #2801.

Follow-up from #2775 (PR #2800). The new-layout confirm guard keyed on `changesSinceExport` (which tracks file exports), but in server storage mode the dialog's "Save First" performs a server save, not a file export. So the guard over-prompted server users whose layout was already durably saved to the server, and the backup it offered was mislabeled.

## What changed

- **Guard is now storage-mode aware** (`src/lib/actions/dispatch.ts`). The new-layout entry keys on a "not durably persisted" signal chosen by mode:
  - Server mode: `layoutStore.isDirty`. A successful server save clears `isDirty` (via `finalizeSuccessfulSave` -> `markClean()`), so a durably-saved layout no longer prompts even when it has never been exported to a file. This is the over-prompt fix.
  - File/browser mode: `changesSinceExport > 0`, unchanged.
  - Mode is picked with `shouldSaveToServer()`, the same signal `handleSaveFirst` in `DialogOrchestrator` uses to decide server-save vs file-save, so the guard and the save it offers can never disagree (including the degraded server-mode-with-API-down case, where both fall back to the file path).

- **Dialog action label is now per-mode** (`src/lib/components/DialogOrchestrator.svelte`). The confirm dialog's Save First button reads "Save to server" in server mode and "Save to file" otherwise, naming what the action actually does. Same verb ("Save") through the whole flow: Save persists layouts, Export is for derived artifacts (#2995/#3007/#3061 vocabulary axis). The `ConfirmReplaceDialog` instance in `DialogOrchestrator` is used only by the new-layout flow, so this label change is scoped to that path.

## Adjacent site left as-is (by design)

`OpenFileGuardDialog.svelte` and `RestoreFromFileDialog.svelte` render their own `ConfirmReplaceDialog` instances with a `saveFirstLabel="Export first"` that calls `handleSaveAsArchive`. Those are a genuinely separate flow: they own local confirm state and explicitly do not touch the shared `dialogStore` "confirmReplace" path this PR fixes (their own file comments say so). They are file-oriented "open/restore from a file" guards, not the new-layout replace guard. To keep this diff focused on the core deliverable, their label/verb alignment is out of scope here.

## Tests

`src/tests/dispatch.test.ts` now covers the guard per mode (server-saved -> no prompt even with unexported changes; server-unsaved -> prompt; file-mode semantics unchanged and independent of `isDirty`). The store stub was generalised to override `isDirty` alongside `changesSinceExport`.

## Local gates

- `npm run lint`: pass (no issues)
- `npm run check`: pass (0 errors, 0 warnings)
- `VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/dispatch.test.ts`: pass (11 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the new-layout confirmation match how layouts are saved**

### What Changed
- New layout now prompts only when the current work is not yet durably saved: in server mode it checks for unsaved server changes, and in file/browser mode it checks for unsaved exported changes.
- If a layout has already been saved to the server, users are no longer blocked by a file-export warning when starting a new layout.
- The confirm dialog now names the save action by what it will do in the current mode: “Save to server” or “Save to file.”

### Impact
`✅ Fewer unnecessary new-layout prompts`
`✅ Clearer save-before-replace dialogs`
`✅ Less confusion between server saves and file exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
