### PR TITLE
chore(ci): make gated release pipeline idempotent on re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,10 +158,22 @@ jobs:
           TAG: ${{ needs.validate.outputs.tag }}
           NOTES: ${{ steps.changelog.outputs.notes }}
         run: |
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes "$NOTES" \
-            --prerelease
+          # Idempotent on re-run: a prior partial attempt may have already staged
+          # this release (see #2709, the v26.6.5 incident, where a bare `gh release
+          # create` 422'd on re-run because the release already existed). Converge
+          # on the same end state either way instead of hard-failing.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; updating in place"
+            gh release edit "$TAG" \
+              --title "$TAG" \
+              --notes "$NOTES" \
+              --prerelease
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "$NOTES" \
+              --prerelease
+          fi
 
   # STAGE: build and push ONLY immutable Docker tags (:vX.Y.Z / :vX.Y.Z-persist /
   # api :vX.Y.Z). No :latest, no :year_month. Promote retags these by digest.


### PR DESCRIPTION
## **User description**
## Summary

Makes the gated release pipeline (`.github/workflows/release.yml`) safe to re-run after a partial failure or cancellation. Today, a re-run after `stage-release` has already succeeded once hard-fails with HTTP 422 because `Stage prerelease` does a bare `gh release create`, which the v26.6.5 incident hit directly: the run was cancelled mid-`stage-docker`, and the subsequent re-run failed at `Stage prerelease` because the release object already existed from the first attempt, stranding the pipeline until someone manually deleted the release.

Fix: `Stage prerelease` now checks whether the release already exists (`gh release view`) and edits it in place if so, otherwise creates it as before. Both paths converge on the same end state (prerelease, same title/notes). No other code paths in `release.yml` needed changes; the rest of the stage/promote chain was audited and is either already idempotent or was already fixed in an earlier PR.

Closes #2709.

## Per-step idempotency audit

| Step | Job / file | Hazard | Resolution |
| --- | --- | --- | --- |
| Create prerelease | `stage-release` (release.yml) | Bare `gh release create` returns 422 if the release already exists from an earlier partial run | Fixed here: create-or-update via `gh release view` then `gh release edit` or `gh release create` |
| Publish tarball to release (`gh release upload`) | `stage-lxc` -> `build-lxc.yml` publish job | Re-uploading an existing asset could error | Already fixed in #1898 (predates this issue): uses `gh release upload ... --clobber`. Confirmed present, no change needed here. |
| Promote frontend and API by digest | `promote-docker` | `docker buildx imagetools create --tag latest --tag YEAR_MONTH <digest>` could risk a duplicate-tag error on re-run | Verified idempotent by design: the digest is resolved fresh from the immutable `:vX.Y.Z` tag each run, and `imagetools create` repoints the destination tag to that digest rather than erroring if the tag already exists. No change needed. |
| Promote persist image by digest | `promote-docker` | Same digest-retag pattern as above | Same reasoning: idempotent by design. No change needed. |
| Mark release latest | `promote-github` | `gh release edit "$TAG" --prerelease=false --latest=true` | `gh release edit` sets absolute state; re-running with the same flags on an already-promoted release is a no-op success, not an error. No change needed. |
| Deploy to prod (`docker stop`/`rm`, `compose up`) | `promote-prod` -> `deploy-prod.yml` | Stopping/removing a container that doesn't exist (already deployed, or first deploy) could error | Already guarded: `docker stop rackula-app 2>/dev/null && docker rm rackula-app 2>/dev/null || true`, plus `docker compose pull` / `docker compose up -d --remove-orphans`, all naturally idempotent. No change needed. |
| Promote gate (approval) | `promote-gate` | None: the step is a single `echo`, gated by the `production` GitHub Environment | No hazard. Re-running just requires approval again, which is the intended human choke point, not a duplicate-create bug. |
| Notify on failure (alert issue) | `notify-failure` | Duplicate-create of the same `CI Alert` issue on repeated failures | Already idempotent: looks up an existing open issue by title and comments on it instead of creating a duplicate; label creation is wrapped in a try/catch that swallows only 422 (already-exists). Not a promote step, listed for completeness. |

Only `stage-release`'s `Create prerelease` step required a code change. Everything else in the stage/promote chain was either already idempotent by construction (digest retagging, absolute-state edits, guarded shell operations) or already fixed by a prior PR (#1898, the LXC upload `--clobber`).

## Failure-scenario walkthrough (the v26.6.5 case)

Before this fix:

1. Run starts: `validate` and `corpus-guard` pass.
2. `stage-release` runs `gh release create "$TAG" ...` and succeeds: the prerelease now exists on GitHub.
3. `stage-lxc` (needs `stage-release`) builds the tarball and uploads it with `--clobber`: succeeds.
4. `stage-docker` (the arm64 build) hangs and the run is cancelled.
5. A fresh run is started for the same tag (workflow_dispatch or a re-run). `validate` and `corpus-guard` pass again.
6. `stage-release` runs `gh release create "$TAG" ...` again: **HTTP 422, `Release.tag_name already exists`.** The job fails, `stage-lxc` and every downstream gate/promote job is skipped. The release is stuck as a prerelease. Recovery required manually deleting the release object.

After this fix, step 6 becomes:

6. `stage-release` runs `gh release view "$TAG"`: succeeds (the release from step 2 is still there). The step logs "Release $TAG already exists; updating in place" and runs `gh release edit "$TAG" --title "$TAG" --notes "$NOTES" --prerelease`, which succeeds and leaves the release in the identical state it would have been in from a fresh create.
7. `stage-docker` re-runs and completes.
8. `stage-lxc` re-runs; the tarball upload re-uses `--clobber`, overwriting the assets from step 3 cleanly rather than erroring.
9. `gate-docker` and `gate-lxc` run against the freshly staged artifacts.
10. `promote-gate` waits for maintainer approval, then `promote-docker` retags images by digest (idempotent whether or not a previous partial run already retagged them), and `promote-github` flips the release to `--prerelease=false --latest=true` (idempotent), and `promote-prod` deploys (idempotent).

The pipeline now converges to a successful, fully promoted release on re-run instead of requiring manual intervention.

## Constraints preserved

- No pipeline semantics, gates, or job ordering changed. This is a pure convergence fix on `Stage prerelease`.
- Tag and notes values still reach the script exclusively via `env:` (`TAG`, `NOTES`), never inline `${{ }}` interpolation inside `run:`, matching the hardening from #1899.
- `permissions:` blocks are unchanged (still `contents: write` on `stage-release`, nothing broadened).
- Fail-closed: the new `gh release view || ...` branch only decides create-vs-edit. If `gh release view` fails for a reason other than "release doesn't exist" and the release actually does exist, the fallback `gh release create` will legitimately fail with 422 and the job fails loudly, same as before. No `|| true` was added to any create/upload/edit call.

## Verification

- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release.yml'))"` parses cleanly.
- `actionlint .github/workflows/release.yml` reports only the pre-existing `lxc-gate` self-hosted-runner-label false positive (present identically on `main`, unrelated to this change).
- Formatted with `prettier --write .github/workflows/release.yml` (no changes needed, already conformant).

## Test plan

- [ ] CI on this PR passes (validate, corpus-guard on the workflow file itself).
- [ ] On next real release, confirm a `workflow_dispatch` re-run of an already-staged tag converges: `Stage prerelease` logs "already exists; updating in place" and the pipeline proceeds through promote.


___

## **CodeAnt-AI Description**
**Make staged releases safe to re-run after a partial failure**

### What Changed
- If a staged release already exists, the release step now updates it instead of failing.
- On the first run, it still creates the prerelease as before.
- Re-running the pipeline after a cancelation or partial failure now keeps the same release state and continues without manual cleanup.

### Impact
`✅ Fewer release rerun failures`
`✅ No manual release deletion after partial runs`
`✅ Shorter recovery from cancelled release pipelines`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
