### PR TITLE
chore(ci): build arm64 Docker images on native arm64 runners

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -175,7 +175,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ inputs.version }}
         run: |
-          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}')"
+          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println (printf "%s/%s" .Platform.OS .Platform.Architecture)}}{{end}}')"
           echo "$platforms"
           echo "$platforms" | grep -qx 'linux/amd64' || { echo "::error::missing linux/amd64 manifest for ${IMAGE_TAG}"; exit 1; }
           echo "$platforms" | grep -qx 'linux/arm64' || { echo "::error::missing linux/arm64 manifest for ${IMAGE_TAG}"; exit 1; }
@@ -320,7 +320,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ inputs.version }}-persist
         run: |
-          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}')"
+          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println (printf "%s/%s" .Platform.OS .Platform.Architecture)}}{{end}}')"
           echo "$platforms"
           echo "$platforms" | grep -qx 'linux/amd64' || { echo "::error::missing linux/amd64 manifest for ${IMAGE_TAG}"; exit 1; }
           echo "$platforms" | grep -qx 'linux/arm64' || { echo "::error::missing linux/arm64 manifest for ${IMAGE_TAG}"; exit 1; }
@@ -472,7 +472,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:${{ inputs.version }}
         run: |
-          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}')"
+          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println (printf "%s/%s" .Platform.OS .Platform.Architecture)}}{{end}}')"
           echo "$platforms"
           echo "$platforms" | grep -qx 'linux/amd64' || { echo "::error::missing linux/amd64 manifest for ${IMAGE_TAG}"; exit 1; }
           echo "$platforms" | grep -qx 'linux/arm64' || { echo "::error::missing linux/arm64 manifest for ${IMAGE_TAG}"; exit 1; }

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,6 +4,14 @@ name: Build Images
 # No :latest and no :year_month tags are pushed here. Those are applied later
 # by the promote stage, by digest. Mirrors the build/scan jobs from
 # deploy-prod.yml, changed only for the immutable-tag policy plus digest outputs.
+#
+# Each image (frontend, persist, api) builds linux/amd64 and linux/arm64 as
+# separate per-arch jobs, amd64 on ubuntu-latest and arm64 on the native
+# GitHub-hosted arm64 runner (ubuntu-24.04-arm). No QEMU emulation is used
+# anywhere in this workflow: each runner only ever builds its own native
+# architecture. Every per-arch leg pushes its image by digest (no tag), then
+# a merge job assembles the tagged multi-arch manifest with
+# `docker buildx imagetools create`. See #2708 / #2707.
 
 on:
   workflow_call:
@@ -30,13 +38,18 @@ env:
 
 jobs:
   build-frontend:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -51,13 +64,6 @@ jobs:
         # Derive the commit from the checked-out tag (ref above), not github.sha.
         # Short hash to match the frontend's commit format (rev-parse --short).
         run: echo "BUILD_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          # Disable binfmt image caching to avoid post-job cache-save collisions
-          # across parallel build-* jobs that share the same cache key.
-          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -77,31 +83,118 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.version }}
 
-      - name: Build and push
+      - name: Build and push by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: deploy/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache,mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-${{ matrix.arch }},mode=max
           build-args: |
             VITE_ENV=production
             APP_COMMIT=${{ env.BUILD_COMMIT }}
             APK_CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
 
-  build-persist:
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-frontend-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-frontend:
+    name: "Merge frontend manifest"
+    needs: [build-frontend]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.verify.outputs.digest }}
+
+    steps:
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-frontend-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ inputs.version }}
+
+      - name: Create manifest list and push
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          cd "$RUNNER_TEMP/digests"
+          tag_args=()
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && tag_args+=(--tag "$tag")
+          done <<< "$TAGS"
+          digest_args=()
+          for digest in *; do
+            digest_args+=("${IMAGE_REF}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
+
+      - name: Verify multi-arch manifest
+        id: verify
+        env:
+          IMAGE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ inputs.version }}
+        run: |
+          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}')"
+          echo "$platforms"
+          echo "$platforms" | grep -qx 'linux/amd64' || { echo "::error::missing linux/amd64 manifest for ${IMAGE_TAG}"; exit 1; }
+          echo "$platforms" | grep -qx 'linux/arm64' || { echo "::error::missing linux/arm64 manifest for ${IMAGE_TAG}"; exit 1; }
+          digest="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{.Manifest.Digest}}')"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+  build-persist:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -116,11 +209,6 @@ jobs:
         # Derive the commit from the checked-out tag (ref above), not github.sha.
         # Short hash to match the frontend's commit format (rev-parse --short).
         run: echo "BUILD_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -140,31 +228,118 @@ jobs:
           tags: |
             type=raw,value=v${{ inputs.version }}-persist
 
-      - name: Build and push persist image
+      - name: Build and push persist image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: deploy/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-persist
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-persist,mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-persist-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:buildcache-persist-${{ matrix.arch }},mode=max
           build-args: |
             VITE_ENV=production
             APP_COMMIT=${{ env.BUILD_COMMIT }}
             APK_CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
 
-  build-api:
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-persist-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-persist:
+    name: "Merge persist manifest"
+    needs: [build-persist]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.verify.outputs.digest }}
+
+    steps:
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME_LC=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-persist-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=v${{ inputs.version }}-persist
+
+      - name: Create manifest list and push
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          cd "$RUNNER_TEMP/digests"
+          tag_args=()
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && tag_args+=(--tag "$tag")
+          done <<< "$TAGS"
+          digest_args=()
+          for digest in *; do
+            digest_args+=("${IMAGE_REF}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
+
+      - name: Verify multi-arch manifest
+        id: verify
+        env:
+          IMAGE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ inputs.version }}-persist
+        run: |
+          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}')"
+          echo "$platforms"
+          echo "$platforms" | grep -qx 'linux/amd64' || { echo "::error::missing linux/amd64 manifest for ${IMAGE_TAG}"; exit 1; }
+          echo "$platforms" | grep -qx 'linux/arm64' || { echo "::error::missing linux/arm64 manifest for ${IMAGE_TAG}"; exit 1; }
+          digest="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{.Manifest.Digest}}')"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+  build-api:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 12
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -182,11 +357,6 @@ jobs:
           echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
           # Short hash to match the frontend's commit format (rev-parse --short).
           echo "BUILD_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          cache-image: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -206,18 +376,17 @@ jobs:
           tags: |
             type=raw,value=${{ inputs.version }}
 
-      - name: Build and push API image
+      - name: Build and push API image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./api
           file: ./api/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:buildcache,mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:buildcache-${{ matrix.arch }},mode=max
           # Inject the release version so the API reports it at GET /version.
           # The git tag is the single source of truth; api/package.json is only a
           # local-dev fallback.
@@ -227,9 +396,92 @@ jobs:
             APP_BUILD_TIME=${{ env.BUILD_TIME }}
             APK_CACHEBUST=${{ github.run_id }}-${{ github.run_attempt }}
 
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-api-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-api:
+    name: "Merge API manifest"
+    needs: [build-api]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.verify.outputs.digest }}
+
+    steps:
+      - name: Set lowercase image name
+        run: echo "API_IMAGE_NAME=${GITHUB_REPOSITORY,,}-api" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-api-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ inputs.version }}
+
+      - name: Create manifest list and push
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          cd "$RUNNER_TEMP/digests"
+          tag_args=()
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && tag_args+=(--tag "$tag")
+          done <<< "$TAGS"
+          digest_args=()
+          for digest in *; do
+            digest_args+=("${IMAGE_REF}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
+
+      - name: Verify multi-arch manifest
+        id: verify
+        env:
+          IMAGE_TAG: ${{ env.REGISTRY }}/${{ env.API_IMAGE_NAME }}:${{ inputs.version }}
+        run: |
+          platforms="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{range .Manifest.Manifests}}{{println .Platform.OS "/" .Platform.Architecture}}{{end}}')"
+          echo "$platforms"
+          echo "$platforms" | grep -qx 'linux/amd64' || { echo "::error::missing linux/amd64 manifest for ${IMAGE_TAG}"; exit 1; }
+          echo "$platforms" | grep -qx 'linux/arm64' || { echo "::error::missing linux/arm64 manifest for ${IMAGE_TAG}"; exit 1; }
+          digest="$(docker buildx imagetools inspect "$IMAGE_TAG" --format '{{.Manifest.Digest}}')"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
   verify-version-alignment:
     name: "Verify Version Alignment"
-    needs: [build-frontend, build-persist, build-api]
+    needs: [merge-frontend, merge-persist, merge-api]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -266,7 +518,7 @@ jobs:
             scripts/verify-version-alignment.sh "$VERSION"
 
   scan-images:
-    needs: [build-frontend, build-persist, build-api]
+    needs: [merge-frontend, merge-persist, merge-api]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## **User description**
## Summary

Closes #2708. Closes #2707.

The `linux/arm64` legs of the frontend, persist, and api Docker images now build on native GitHub-hosted arm64 runners (`ubuntu-24.04-arm`) instead of QEMU-emulated on `ubuntu-latest`. This removes the root cause of the flaky release-blocking failure: QEMU's arm64 translator hitting SIGILL (signal 4) during `RUN npm ci` in the frontend build, then buildkit hanging instead of failing, stalling the pipeline for up to the 30 minute job timeout.

## What changed

`.github/workflows/build-images.yml`, all three image builds (`build-frontend`, `build-persist`, `build-api`):

- Before: one job per image, `runs-on: ubuntu-latest`, QEMU set up, `platforms: linux/amd64,linux/arm64` built and pushed together in a single `docker/build-push-action` invocation.
- After: each image build is now a matrix job with one leg per architecture (`amd64` on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm`). Each leg builds only its own native architecture, no QEMU anywhere, and pushes by digest (untagged). A new merge job per image (`merge-frontend`, `merge-persist`, `merge-api`) downloads both digests and assembles the tagged multi-arch manifest with `docker buildx imagetools create`, then verifies both `linux/amd64` and `linux/arm64` are present in the manifest before the job succeeds (fails closed if either arch is missing).

Job topology:

- `build-frontend` (matrix: amd64/arm64) -> `merge-frontend` -> `verify-version-alignment`, `scan-images`
- `build-persist` (matrix: amd64/arm64) -> `merge-persist` -> `verify-version-alignment`, `scan-images`
- `build-api` (matrix: amd64/arm64) -> `merge-api` -> `verify-version-alignment`, `scan-images`

`verify-version-alignment` and `scan-images` now depend on the three merge jobs instead of the three build jobs, since the tagged image only exists after the merge step.

Registry cache refs are now arch-scoped (e.g. `buildcache-amd64` / `buildcache-arm64` instead of a single shared `buildcache`) so the two legs of a matrix build don't race writes to the same registry cache tag.

Timeouts are tightened for fail-fast behaviour: per-arch build legs are 15 minutes (frontend, persist) or 12 minutes (api), down from 30/30/20 for the old combined multi-arch jobs. Merge jobs are 10 minutes (registry-only operations, no build). These are initial estimates with headroom; native arm64 should be well under the old emulated combined timeout, but the numbers will get tuned after a few real releases.

## Decision recorded (per #2707 AC)

`linux/arm64` frontend, persist, and api Docker images are still published, now built natively instead of emulated. No `Set up QEMU` step remains anywhere in `build-images.yml`.

## release.yml

No changes needed. `stage-docker` calls `build-images.yml` via `workflow_call` and only consumes the `tag`/`version`/`year_month` inputs; `gate-docker` and `promote-docker` resolve images by tag directly against the registry (`docker compose pull`, `docker buildx imagetools inspect`), not via workflow_call outputs, so the internal job rename/restructure is fully contained inside `build-images.yml`. Verified with `actionlint` and by grepping `release.yml` for the old job names (no hits).

## Verification

- `actionlint .github/workflows/build-images.yml` passes clean.
- `python3 -c "import yaml; yaml.safe_load(...)"` parses the file and confirms every `needs:` reference resolves to an existing job.
- Manually traced every `needs:`/output reference in the diff.
- `ubuntu-24.04-arm` is a recognized GitHub-hosted runner label (confirmed via actionlint's known-labels list); this repo is public, so arm64 runner minutes are free.

Not yet verified: actual release-time behaviour (arm64 wall-clock time, and "no QEMU SIGILL across 2-3 release-equivalent runs") can only be confirmed by running real releases through this pipeline, since GitHub Actions workflow execution isn't available locally. That AC will be verified over the next 2-3 releases after this merges.

## Out of scope

`rebuild-images.yml` (the monthly OS-patch rebuild workflow) has a similar QEMU-based multi-arch pattern but is a separate file not covered by #2708/#2707; left as-is, worth a follow-up issue if it also proves flaky.


___

## **CodeAnt-AI Description**
**Build release images on native arm64 runners and publish complete multi-arch manifests**

### What Changed
- Frontend, persist, and API images now build arm64 on native GitHub-hosted arm64 runners instead of emulated builds, which removes the flaky release failures and long hangs seen during arm64 image creation
- Each image is published only after its amd64 and arm64 builds are combined into a single tagged manifest, and the workflow now checks that both platforms are present before it succeeds
- Image verification and scanning now run after the final published manifest exists, so they test the same release artifact users will pull

### Impact
`✅ Fewer release-blocking arm64 build failures`
`✅ Shorter waits during image publishing`
`✅ Reliable amd64 and arm64 images for every release`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
