### PR TITLE
chore(ci): gate fixable HIGH/CRITICAL Trivy findings and surface skipped smoke tests

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -537,6 +537,18 @@ jobs:
             tag: ${{ inputs.version }}
 
     steps:
+      # Needed so trivy-action can read the reviewed exceptions file below.
+      # Pinned to the release tag being scanned, not the ref that triggered
+      # the workflow, so promote decisions use the tag's own exceptions.
+      - name: Checkout .trivyignore
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+          sparse-checkout: |
+            .trivyignore
+          sparse-checkout-cone-mode: false
+
       - name: Log in to Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -563,9 +575,15 @@ jobs:
           limit-severities-for-sarif: true
           severity: HIGH,CRITICAL
           ignore-unfixed: true
-          exit-code: 0
+          # Fail closed: a fixable HIGH/CRITICAL CVE blocks promote (#2720).
+          # Unfixable/accepted findings are excluded via .trivyignore, not by
+          # loosening this exit code.
+          exit-code: 1
+          trivyignores: .trivyignore
           version: "v0.70.0"
 
+      # Runs even when the scan step above fails the job, so a blocked
+      # release still lands its findings in the Security tab for triage.
       - name: Upload scan results
         if: always()
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -180,17 +180,48 @@ jobs:
           # dangling. Prune so untagged images don't accumulate on the VPS.
           docker image prune -f
 
+  # Determines Cloudflare Access service-token availability up front so a
+  # missing secret (forks, some workflow_dispatch contexts) produces a
+  # distinct "skipped" conclusion on smoke-test instead of a job that runs
+  # to green having done nothing (#2720). Secrets cannot be read directly in
+  # a job-level `if:`, so the presence check runs as a step here and is
+  # published as this job's output.
+  check-cf-access:
+    name: "Check Cloudflare Access secrets"
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      available: ${{ steps.check.outputs.available }}
+    steps:
+      - name: Check secret availability
+        id: check
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          if [ -n "$CF_ACCESS_CLIENT_ID" ] && [ -n "$CF_ACCESS_CLIENT_SECRET" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Smoke test skipped: Cloudflare Access service token unavailable (fork or missing secret)"
+            {
+              echo "## Deploy Dev smoke test"
+              echo "Skipped: Cloudflare Access service token unavailable (fork or missing secret)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   smoke-test:
-    needs: deploy
+    needs: [deploy, check-cf-access]
+    # Same fork guard as before (#2346), now gating the whole job so a
+    # missing secret reports as skipped rather than a silent no-op success.
+    if: ${{ needs.check-cf-access.outputs.available == 'true' }}
     runs-on: [self-hosted, vps-rackula]
     timeout-minutes: 10
     permissions:
       contents: read
     env:
       # d.racku.la sits behind Cloudflare Access. Map the service-token secrets
-      # to env so the curl gate and the browser smoke can authenticate, and so
-      # the browser smoke can skip when they are absent (forks) instead of
-      # failing on the login wall (#2346).
+      # to env so the curl gate and the browser smoke can authenticate.
       CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
       CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
@@ -198,10 +229,6 @@ jobs:
       # Fast curl gate: fails immediately if the server or API is unreachable,
       # before we spend time spinning up a browser.
       - name: Verify deployment responds
-        # Same fork guard as the browser smoke below: without the CF Access
-        # service token these requests only reach the login wall, so skip rather
-        # than report a misleading pass (#2346).
-        if: ${{ env.CF_ACCESS_CLIENT_ID != '' && env.CF_ACCESS_CLIENT_SECRET != '' }}
         run: |
           sleep 5
           curl -sf --retry 5 --retry-delay 3 \
@@ -253,11 +280,10 @@ jobs:
         run: npx playwright install --with-deps chromium || npx playwright install chromium
 
       - name: Browser smoke test against deployed app
-        # Skip rather than fail when the Cloudflare Access service token is not
-        # configured (e.g. forks): without it every request lands on the login
-        # wall, which no timeout bump can fix (#2346). The CF_ACCESS_* env vars
-        # are inherited by the smoke config (playwright.smoke.config.ts).
-        if: ${{ env.CF_ACCESS_CLIENT_ID != '' && env.CF_ACCESS_CLIENT_SECRET != '' }}
+        # The CF_ACCESS_* env vars are inherited by the smoke config
+        # (playwright.smoke.config.ts). Without them every request lands on
+        # the login wall (#2346); the job-level check-cf-access gate above
+        # already keeps this job from running in that case.
         env:
           SMOKE_TEST_URL: https://d.racku.la
         run: npm run test:e2e:smoke

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,18 @@
+# Trivy exception list for release image scans (scan-images in
+# .github/workflows/build-images.yml). See issue #2720 and
+# docs/deployment/RELEASE-PIPELINE.md for the Trivy gate this file feeds.
+#
+# The scan gate is fail-closed: a fixable HIGH/CRITICAL CVE in a release
+# image blocks promote. This file is the only sanctioned escape hatch, and
+# only for findings that are unfixable upstream or an accepted risk.
+#
+# Every entry below must have:
+#   - the CVE id
+#   - a comment explaining why it is unfixable or accepted
+#   - a link to the accepted-risk discussion (GitHub issue or PR) that
+#     recorded the decision
+#
+# Do not add an entry to unblock a release without that discussion. If a fix
+# becomes available upstream, remove the entry instead of leaving it stale.
+#
+# No active entries at this time.

--- a/docs/deployment/RELEASE-PIPELINE.md
+++ b/docs/deployment/RELEASE-PIPELINE.md
@@ -12,6 +12,7 @@ Previously a tag push published `latest` everywhere (Docker `:latest`, GitHub la
    - `gh release create <tag> --prerelease`. Prereleases are excluded from `/releases/latest`, so LXC `fetch_and_deploy latest` does not pick them up yet.
    - Build the LXC tarball plus a matching `rackula-lxc-<tag>.tar.gz.sha256` and attach both to the prerelease. The `.sha256` file is `sha256sum -c` compatible (one line: hash, two spaces, bare filename) and is generated from the exact uploaded tarball.
    - Build and push Docker images with immutable tags only: `:X.Y.Z`, `:vX.Y.Z-persist`, and api `:X.Y.Z`. No `:latest`. No prod deploy.
+   - Scan every published image with Trivy (`scan-images` in `.github/workflows/build-images.yml`). A fixable HIGH or CRITICAL CVE fails the scan, which fails staging, which blocks gate and promote. See [Trivy image gate](#trivy-image-gate).
 2. Gate (automatic, fail closed)
    - Docker gate (GitHub-hosted): `docker compose up` the `:X.Y.Z` image, check `/` 200, then the persist profile (persist frontend + api sidecar) and check `/api/health` 200.
    - LXC gate (self-hosted `ci-runner` on the non-prod Proxmox host pve-rusty): download both the staged tarball and its `.sha256` from the release, verify integrity with `sha256sum -c` (the post-upload checksum check), then run `scripts/lxc-smoke-test.sh` on a throwaway unprivileged CT. A checksum mismatch fails the gate.
@@ -53,6 +54,30 @@ gh release edit vX.Y.Z --prerelease=false --latest=true
 ```
 
 Prefer fixing forward over overriding.
+
+## Trivy image gate
+
+`scan-images` in `.github/workflows/build-images.yml` scans every published release image (frontend, persist, api) for fixable HIGH and CRITICAL CVEs, with `ignore-unfixed: true` so findings with no available fix never block a release on their own. The scan runs `exit-code: 1`: a fixable finding fails the job, which fails `stage-docker`, which blocks `gate-docker` and every job downstream of it, so nothing promotes. This matches the fail-closed model the rest of the pipeline already follows for the docker and LXC gates.
+
+Findings still upload to the Security tab (`Upload scan results` runs with `if: always()`), so a blocked release leaves a normal SARIF trail for triage even though the job itself failed.
+
+### Exceptions: .trivyignore
+
+`.trivyignore` at the repo root is the only sanctioned way to exclude a finding from the gate. It is checked out at the release tag before the scan runs, so a release is evaluated against the exceptions committed at that tag, not against whatever is on `main` later.
+
+Every entry requires:
+
+- the CVE id
+- a comment explaining why it is unfixable upstream or an accepted risk
+- a link to the accepted-risk discussion (issue or PR) that recorded the decision
+
+Do not add an entry to unblock a release without that discussion first. If a fix becomes available upstream, remove the entry rather than leaving it stale; the weekly `trivy.yml` scan and the monthly `rebuild-images.yml` OS-patch rescan will keep surfacing it as a reminder if you don't.
+
+## Smoke test visibility
+
+`smoke-test` in `deploy-dev.yml` runs the deployed app through Playwright once the dev deploy completes. It needs a Cloudflare Access service token (`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`) because d.racku.la sits behind Cloudflare Access; without it every request only reaches the login wall (#2346). Rather than let those requests fail (or silently no-op inside a job that still reports success), a preceding `check-cf-access` job checks secret availability and publishes it as an output. `smoke-test` has a job-level `if:` on that output, so when the token is unavailable the job's conclusion is `skipped`, visibly distinct from a passed run in the Actions summary, and the gate step also emits an `::notice::` and a `$GITHUB_STEP_SUMMARY` line explaining why. This does not change when the smoke test is skipped, only how the skip is reported.
+
+`smoke-test` in `deploy-prod.yml` has no equivalent skip: it runs on the trusted self-hosted path during promote, count.racku.la is not behind Cloudflare Access, and the required secrets are always present there.
 
 ## Upgrade-gate baseline
 


### PR DESCRIPTION
## **User description**
## Summary

Closes #2720. Two release-gate gaps: Trivy image scanning was advisory only, and a deploy smoke test skipped for a missing secret read as a normal pass. Both are now visible/blocking as appropriate.

## Changes

- `.github/workflows/build-images.yml` (`scan-images`): `exit-code` flipped from `0` to `1`, so a fixable HIGH/CRITICAL CVE in a release image fails the job. `ignore-unfixed: true` is unchanged, so unfixable findings never trip the gate on their own. Added a `trivyignores: .trivyignore` input, plus a sparse checkout of `.trivyignore` pinned to the release tag being scanned (the job had no checkout step before this, since it only scans a remote image). The `Upload scan results` step already ran with `if: always()`, so SARIF still lands in the Security tab even when the scan step fails the job.
- `.trivyignore` (new, repo root): policy header only, no active entries. Documents that every entry needs a CVE id, a justification comment, and a link to the accepted-risk discussion, for unfixable/accepted findings only.
- `.github/workflows/deploy-dev.yml`: added a `check-cf-access` job that checks `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` availability and publishes it as a job output (secrets cannot be read directly in a job-level `if:`). `smoke-test` now has `needs: [deploy, check-cf-access]` and `if: needs.check-cf-access.outputs.available == 'true'`, so a missing secret makes the whole job report `skipped` instead of silently no-opping through to a green pass. The gate step also emits `::notice::Smoke test skipped: Cloudflare Access service token unavailable (fork or missing secret)` and a `$GITHUB_STEP_SUMMARY` line when skipping. The two step-level `if:` guards inside `smoke-test` that used to do this per-step are removed since the job-level gate now covers it; nothing about the trigger condition changed, only where it is evaluated and how it is reported.
- `docs/deployment/RELEASE-PIPELINE.md`: new "Trivy image gate" section documenting the blocking scan and the `.trivyignore` exception mechanism, and a new "Smoke test visibility" section documenting the `check-cf-access` pattern. Also a one-line addition to the Stage step of the pipeline flow.

## Gate graph: how this actually blocks promote

`stage-docker` in `release.yml` calls `build-images.yml` with `uses:`, so the reusable workflow's `scan-images` job is one of the jobs that must succeed for `stage-docker` itself to succeed. `gate-docker` has `needs: [validate, stage-docker]`, and `promote-gate`/`promote-docker`/`deploy-prod` chain off the gate jobs. A failed `scan-images` fails `stage-docker`, which fails `gate-docker` by dependency, which stops the whole chain before the `prod` Environment approval step is ever reached. No changes were needed to `release.yml` itself, only to `build-images.yml`.

`rebuild-images.yml` and `trivy.yml` each have their own separate `scan-images` job (not shared with `build-images.yml`) for post-release OS-patch rebuilds and scheduled/on-demand rescans respectively. Those are advisory triage surfaces feeding `security-triage.yml`, not the promote gate, so they are intentionally untouched here. Same for `deploy-prod.yml`'s `smoke-test`: it has no secret-gated skip today (count.racku.la is not behind Cloudflare Access and the job always runs on the trusted self-hosted promote path), so there was nothing to make visible there. Noted in the new doc section.

## Sanity check before flipping the gate

`trivy` CLI is not installed in this environment, so per the fallback instructions I checked GitHub's Code Scanning API instead:

```
gh api "repos/RackulaLives/Rackula/code-scanning/alerts?state=open&per_page=100"
```

Result: 0 open alerts total (not just Trivy) as of this PR. There are zero fixable HIGH/CRITICAL findings in the current release images, so flipping `exit-code` to `1` does not brick the next release.

## Deploy Dev trigger on merge

`deploy-dev.yml`'s own `paths:` filter is `api/**`, `src/**`, `deploy/**`, `assets/**`, `static/**`, `login.html`, `package.json`, `package-lock.json`, `docker-compose.yml`, `vite.config.*`, `svelte.config.*`, `tsconfig*.json`, `index.html`, with `!**/*.md` excluding markdown anywhere. This PR only touches `.github/workflows/*.yml`, `.trivyignore`, and a doc under `docs/`, none of which match those globs. **Merging this PR will not trigger a Deploy Dev run**, even though `deploy-dev.yml` itself is one of the changed files, because the trigger evaluates the paths changed in the push, not the location of the workflow file.

## Verification

- `actionlint` on all three touched workflows: no new findings. Pre-existing `vps-rackula`/self-hosted-runner-label warnings on unrelated lines are the known false positive (unknown custom runner label, not an actionlint config issue).
- `python3 -c "yaml.safe_load(...)"` on all three touched workflow files: parses clean.
- `needs:`/output references manually traced: `smoke-test` -> `needs.check-cf-access.outputs.available` resolves to the `check-cf-access` job's declared `outputs.available`, which resolves to `steps.check.outputs.available`. No downstream job in `deploy-dev.yml` or elsewhere depends on `smoke-test`'s conclusion, and there is no branch protection rule on `main` referencing it, so no `always()`/`!failure()` guard was needed anywhere.
- `prettier --write` on all touched files: no changes (already formatted).

## Not in scope

- `rebuild-images.yml` and `trivy.yml`'s own `scan-images` jobs (advisory rescans, separate from the promote gate).
- `deploy-prod.yml` (no secret-gated skip exists there to make visible).


___

## **CodeAnt-AI Description**
**Block release images with fixable critical vulnerabilities and show skipped dev smoke tests clearly**

### What Changed
- Release image scans now fail when they find a fixable HIGH or CRITICAL vulnerability, so vulnerable images block promotion instead of passing through.
- Approved exceptions are read from a reviewed `.trivyignore` file tied to the release tag, and scan results still upload for triage even when the scan fails.
- Dev smoke tests now show as skipped when Cloudflare Access secrets are missing, with a clear notice and summary message instead of a silent green pass.

### Impact
`✅ Fewer vulnerable releases`
`✅ Clearer security scan failures`
`✅ Visible skipped smoke tests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
