### PR TITLE
feat: scheduled soak-smoke cron against count.racku.la and d.racku.la

### DIFF
--- a/.github/workflows/soak-smoke.yml
+++ b/.github/workflows/soak-smoke.yml
@@ -1,0 +1,94 @@
+name: Soak Smoke
+
+# Scheduled browser smoke check against the live prod and dev deployments,
+# independent of any deploy trigger. Each run is the 7-day soak signal that
+# #1986 (VPS decommission) reads before destroying the Linode instance: the
+# decommission gate is an unbroken 7-day streak of green runs on this
+# workflow, queryable with:
+#
+#   gh run list --workflow=soak-smoke.yml --limit 50
+#
+# A run's conclusion is a plain success/failure across both targets (matrix
+# fail-fast is off so both legs always run, but either leg failing marks the
+# whole run failed), so the streak query above is a straightforward read of
+# the "conclusion" column with no per-job digging required. See issue #2676.
+#
+# count.racku.la is public today (no CF Access token needed); d.racku.la sits
+# behind Cloudflare Access and authenticates via the same service-token
+# secrets deploy-dev.yml uses (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET,
+# added by #2346).
+
+on:
+  schedule:
+    # Every 6 hours at :43, off the top and bottom of the hour to avoid the
+    # scheduler's busiest minutes.
+    - cron: "43 */6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: soak-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Smoke (${{ matrix.target.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - name: prod
+            url: https://count.racku.la
+          - name: dev
+            url: https://d.racku.la
+    env:
+      SMOKE_TEST_URL: ${{ matrix.target.url }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-chromium-
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      # d.racku.la sits behind Cloudflare Access. The CF_ACCESS_* env vars are
+      # inherited by the smoke config (playwright.smoke.config.ts) and applied
+      # as headers on every request; without them the dev leg would hit the
+      # login wall instead of the app (#2346). count.racku.la is public today
+      # (#3094 tracks the pending Access decision), so the secrets are simply
+      # unused on the prod leg.
+      - name: Browser smoke test against deployed app
+        env:
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: npm run test:e2e:smoke
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: soak-smoke-report-${{ matrix.target.name }}
+          path: playwright-report/
+          retention-days: 7

--- a/docs/deployment/soak-smoke.md
+++ b/docs/deployment/soak-smoke.md
@@ -1,0 +1,32 @@
+# Soak Smoke
+
+The soak-smoke workflow (`.github/workflows/soak-smoke.yml`) runs the deployed-environment smoke suite (`e2e/deploy-smoke.spec.ts`, via `e2e/playwright.smoke.config.ts`) against both live Rackula deployments on a schedule, independent of any deploy trigger. It is the standing health signal used to prove a multi-day green streak.
+
+## What it checks
+
+- **prod**: `https://count.racku.la`, public today, no Cloudflare Access token needed.
+- **dev**: `https://d.racku.la`, behind Cloudflare Access. Authenticates with the same service-token secrets `deploy-dev.yml` uses: `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` (added by #2346), passed as env vars that `playwright.smoke.config.ts` applies as request headers.
+
+Each target runs as its own matrix leg with `fail-fast: false`, so both always run, but either leg failing marks the whole workflow run failed. That keeps the run's `conclusion` a single, unambiguous pass/fail per scheduled tick.
+
+## Schedule
+
+Every 6 hours at `:43` (`43 */6 * * *`), an off-peak minute chosen to avoid the `:00`/`:30` marks where most scheduled workflows across GitHub cluster.
+
+`workflow_dispatch` is also enabled for on-demand runs (for example, to re-check immediately after a deploy).
+
+Scheduled workflows only fire from the default branch, so the cron becomes active once this workflow merges to `main`; it does not run on pull requests.
+
+## Reading the streak
+
+Query recent runs directly:
+
+```bash
+gh run list --workflow=soak-smoke.yml --limit 50
+```
+
+A 7-day green streak is 7 days of consecutive runs (4 per day at the 6-hour cadence) with no `failure` conclusion in between. This is the decommission gate that issue #1986 (destroy the Linode VPS) reads before proceeding: the VPS stays up until this workflow has shown an unbroken 7-day green run since the relevant cutover, alongside #1986's other gate conditions (restorable image insurance, data disposition). The same soak window also satisfies issue #2029's rollback-runbook soak, so it is built once and shared.
+
+## On failure
+
+A failing leg uploads its Playwright HTML report as an artifact (`soak-smoke-report-prod` or `soak-smoke-report-dev`) for 7 days, the same pattern `deploy-dev.yml`'s post-deploy smoke job uses.

--- a/docs/deployment/soak-smoke.md
+++ b/docs/deployment/soak-smoke.md
@@ -4,8 +4,8 @@ The soak-smoke workflow (`.github/workflows/soak-smoke.yml`) runs the deployed-e
 
 ## What it checks
 
-- **prod**: `https://count.racku.la`, public today, no Cloudflare Access token needed.
-- **dev**: `https://d.racku.la`, behind Cloudflare Access. Authenticates with the same service-token secrets `deploy-dev.yml` uses: `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` (added by #2346), passed as env vars that `playwright.smoke.config.ts` applies as request headers.
+- prod: `https://count.racku.la`, public today, no Cloudflare Access token needed.
+- dev: `https://d.racku.la`, behind Cloudflare Access. Authenticates with the same service-token secrets `deploy-dev.yml` uses: `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` (added by #2346), passed as env vars that `playwright.smoke.config.ts` applies as request headers.
 
 Each target runs as its own matrix leg with `fail-fast: false`, so both always run, but either leg failing marks the whole workflow run failed. That keeps the run's `conclusion` a single, unambiguous pass/fail per scheduled tick.
 


### PR DESCRIPTION
## **User description**
## Summary

Adds `.github/workflows/soak-smoke.yml`, a scheduled workflow that runs the existing post-deploy smoke suite (`e2e/deploy-smoke.spec.ts` via `e2e/playwright.smoke.config.ts`) against both live deployments, independent of any deploy trigger. This is the standing green-streak signal that #1986 (VPS decommission) gates on.

## What runs and when

- Two matrix legs in one job, `fail-fast: false`: `prod` (`https://count.racku.la`) and `dev` (`https://d.racku.la`). Both always run; either leg failing marks the whole run failed, so `gh run list` gives an unambiguous per-run pass/fail with no per-job digging.
- Schedule: `43 */6 * * *`, every 6 hours at :43. That minute avoids :00 and :30, the hour marks where scheduled GitHub workflows cluster.
- Also has `workflow_dispatch` for on-demand runs.
- Runs on `ubuntu-latest` (hosted), not the self-hosted VPS runner: both targets are reached over the public internet, so there's no dependency on the VPS itself, and no path-filter or deploy coupling.

## How the dev target authenticates

d.racku.la sits behind Cloudflare Access. The workflow passes the same service-token secret pair `deploy-dev.yml`'s smoke job already uses: `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` (added by #2346). These are inherited by `playwright.smoke.config.ts`, which applies them as `CF-Access-Client-Id` / `CF-Access-Client-Secret` request headers. count.racku.la is public today (no token needed); the secrets are simply unused on that leg. No secret values appear in the workflow or this PR.

## How the smoke invocation mirrors deploy-dev.yml

Reused rather than forked: checkout, `actions/setup-node` (Node 22, npm cache), `npm ci`, cache + install Playwright chromium, then `npm run test:e2e:smoke` with `SMOKE_TEST_URL` pointing at the target and the CF Access env vars set the same way deploy-dev.yml's `smoke-test` job does. On failure, uploads the Playwright HTML report as an artifact per target (`soak-smoke-report-prod` / `soak-smoke-report-dev`), matching deploy-dev.yml's failure-artifact pattern.

## Reading the 7-day streak

```bash
gh run list --workflow=soak-smoke.yml --limit 50
```

A green streak is consecutive runs (4/day at this cadence) with no `failure` conclusion over 7 days. Documented in a comment block at the top of the workflow file and in `docs/deployment/soak-smoke.md`, including that #1986 (destroy the Linode VPS) reads this streak as one of its decommission gate conditions, and that the same soak window doubles as #2029's rollback-runbook soak.

## Activation

Scheduled workflows only fire from the default branch. The cron becomes active once this merges to `main`; it will not run on this PR.

Closes #2676

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Add a scheduled smoke check for the live prod and dev sites**

### What Changed
- Added a workflow that runs the existing browser smoke tests against both live deployments every 6 hours and on demand
- The prod check runs against `count.racku.la`; the dev check runs against `d.racku.la` and uses the existing Cloudflare Access credentials
- Both targets always run, and a failure in either one marks the whole scheduled run as failed
- Failed runs upload the Playwright report for 7 days so the failure can be reviewed later
- Added a doc page explaining the schedule, how to read the streak, and how the workflow supports the VPS decommission gate

### Impact
`✅ Continuous live-site health checks`
`✅ Clear pass/fail signal for deployment streaks`
`✅ Faster review of smoke-test failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
