### PR TITLE
chore: dev-env acceptance checklist for d.racku.la on Workers

### DIFF
--- a/docs/deployment/dev-acceptance-checklist.md
+++ b/docs/deployment/dev-acceptance-checklist.md
@@ -34,9 +34,9 @@ Items that hit `/api/*` authenticate the same way `deploy-dev.yml` and `soak-smo
 
 - [ ] Layout round-trip: PUT then GET returns the same body with an `X-Rackula-Updated-At` echo and a newer-or-equal `updatedAt` (R2 monotonic token).
 
-  Command: PUT a small YAML layout to `https://d.racku.la/api/layouts/<uuid>` with the same CF Access headers, then GET the same URL.
+  Command: PUT an initial YAML layout to `https://d.racku.la/api/layouts/<uuid>` with the CF Access headers and capture the `X-Rackula-Updated-At` value from the response; PUT a changed body to the same UUID with the same headers and capture the second `X-Rackula-Updated-At`; then GET the same URL.
 
-  Expected: the PUT returns 200 with an `X-Rackula-Updated-At` header (the header name is `UPDATED_AT_HEADER` in `api/src/routes/layouts.ts`); the GET returns the identical body and an `updatedAt` that is newer than or equal to the value echoed on PUT. The R2 driver issues a strictly newer `updatedAt` on every overwrite, covered by the shared storage contract in `api/src/storage/storage-contract.ts`.
+  Expected: both PUTs return 200 with an `X-Rackula-Updated-At` header (the header name is `UPDATED_AT_HEADER` in `api/src/routes/layouts.ts`); the second token is strictly newer than the first, which is what actually proves the R2 driver's monotonic-overwrite contract (covered by the shared storage contract in `api/src/storage/storage-contract.ts`) rather than just a single create-then-read; the GET returns the body and `updatedAt` from the second write.
 
 - [ ] Asset content-type: `/assets/<hashed>.js` returns `application/javascript` with an immutable cache-control.
 

--- a/docs/deployment/dev-acceptance-checklist.md
+++ b/docs/deployment/dev-acceptance-checklist.md
@@ -1,0 +1,83 @@
+# Dev-Env Acceptance Checklist
+
+This is the one executable acceptance checklist for d.racku.la once it is served by the Cloudflare Worker instead of the VPS. It consolidates verification steps that were previously scattered as prose across #1985 (dev-arc tracker), #2134 (dev cutover: d.racku.la re-point and deploy-dev rewrite), and #2626 (Workers entry and CF storage driver). See #2677 for the consolidation issue.
+
+## Status: not runnable yet
+
+d.racku.la still runs on the VPS today. The dev Worker cutover (#2134) has not happened, so most items below cannot pass yet and every checkbox starts unchecked. Run this checklist against d.racku.la after each dev cutover deploy, starting with the #2134 cutover itself.
+
+## What this gates
+
+Passing this checklist is the acceptance gate for #2134's done-when. #2134 in turn gates prod cutover #2029: dev must be proven on Workers before prod cuts over.
+
+## Relationship to soak-smoke
+
+This checklist is a one-time (or per-deploy) manual acceptance gate. The scheduled soak-smoke workflow (`.github/workflows/soak-smoke.yml`, documented in `docs/deployment/soak-smoke.md`) is the automated ongoing complement: once dev is live on Workers, soak-smoke's dev leg runs the browser smoke suite against `https://d.racku.la` every 6 hours using the same Cloudflare Access service-token secrets referenced below, proving a standing green streak rather than a single pass.
+
+## Authentication
+
+Items that hit `/api/*` authenticate the same way `deploy-dev.yml` and `soak-smoke.yml` do: a Cloudflare Access service token sent as the `CF-Access-Client-Id` and `CF-Access-Client-Secret` headers, sourced from the `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` secrets.
+
+## Checklist
+
+- [ ] Unauthenticated request to `/api/layouts` returns a Cloudflare Access 302.
+
+  Command: `curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' https://d.racku.la/api/layouts`
+
+  Expected: HTTP 302, with `redirect_url` pointing at the Cloudflare Access login page.
+
+- [ ] Authenticated request (CF Access service token) to `/api/layouts` returns 200 JSON.
+
+  Command: `curl -sS -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" https://d.racku.la/api/layouts`
+
+  Expected: HTTP 200 with a JSON array body.
+
+- [ ] Layout round-trip: PUT then GET returns the same body with an `X-Rackula-Updated-At` echo and a newer-or-equal `updatedAt` (R2 monotonic token).
+
+  Command: PUT a small YAML layout to `https://d.racku.la/api/layouts/<uuid>` with the same CF Access headers, then GET the same URL.
+
+  Expected: the PUT returns 200 with an `X-Rackula-Updated-At` header (the header name is `UPDATED_AT_HEADER` in `api/src/routes/layouts.ts`); the GET returns the identical body and an `updatedAt` that is newer than or equal to the value echoed on PUT. The R2 driver issues a strictly newer `updatedAt` on every overwrite, covered by the shared storage contract in `api/src/storage/storage-contract.ts`.
+
+- [ ] Asset content-type: `/assets/<hashed>.js` returns `application/javascript` with an immutable cache-control.
+
+  Command: `curl -sI https://d.racku.la/assets/<hashed>.js` (substitute a real hashed filename from the deployed bundle)
+
+  Expected: `Content-Type: application/javascript` and a `Cache-Control` containing `immutable`. The self-host nginx config serves the same path as `public, immutable` (`deploy/nginx.conf.template`); the Worker's asset serving should match.
+
+- [ ] Headers by value on `/`: CSP, X-Frame-Options SAMEORIGIN, X-Content-Type-Options nosniff, HSTS, and dev-only `X-Robots-Tag: noindex`.
+
+  Command: `curl -sI https://d.racku.la/`
+
+  Expected: a `Content-Security-Policy` matching the shared policy (source of truth: `deploy/security-headers.conf`, do not hand-duplicate the full string here), `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, a `Strict-Transport-Security` header, and `X-Robots-Tag: noindex`. The `X-Robots-Tag` header is dev-only and must not appear on prod.
+
+- [ ] `config.js` reports `storage: "server"`.
+
+  Command: `curl -sS https://d.racku.la/config.js`
+
+  Expected: the body contains `window.__RACKULA_CONFIG__ = { storage: "server" }`. The build-time default is `storage: "browser"` (`static/config.js`); the dev deploy step must overwrite it.
+
+- [ ] `version.json` matches the deployed version and commit.
+
+  Command: `curl -sS https://d.racku.la/version.json`
+
+  Expected: `.version` equals the version being verified and `.commit` equals the short commit hash of the deployed build, the same shape `scripts/verify-version-alignment.sh` checks for self-host images.
+
+- [ ] `vps-rackula` is absent from `.github/workflows/deploy-dev.yml`.
+
+  Command: `grep -c vps-rackula .github/workflows/deploy-dev.yml`
+
+  Expected: `0`. This item is intentionally unchecked today: `vps-rackula` is still the self-hosted runner label for the current VPS-based deploy and smoke-test jobs in `deploy-dev.yml`. It flips to checked only once the VPS deploy leg of that workflow is removed as part of the dev cutover; this checklist does not modify that workflow itself.
+
+- [ ] This checklist is wired into #2134's done-when.
+
+  This item is about the consolidation, not a runtime check against d.racku.la. It is satisfied once #2134's issue body references this document as its acceptance gate.
+
+## Related
+
+- #2677: the consolidation issue this checklist implements.
+- #2134: dev cutover (d.racku.la re-point and deploy-dev rewrite); consumes this checklist as its acceptance gate.
+- #1985: dev-arc tracker.
+- #2626: Workers entry and CF storage driver; the local `wrangler dev` precursor to these live checks.
+- #2029: prod cutover, gated on #2134 (and therefore on this checklist) passing.
+- `docs/deployment/soak-smoke.md`: the scheduled ongoing health signal that complements this one-time gate.
+- `docs/plans/2026-06-29-cloudflare-migration-plan.md`: Appendix, per-issue smoketests, original source of the exact commands consolidated here.


### PR DESCRIPTION
## **User description**
## Summary

Adds `docs/deployment/dev-acceptance-checklist.md`, one executable acceptance checklist for d.racku.la once it is served by the Cloudflare Worker instead of the VPS. It consolidates the dev-env verification steps that were previously scattered as prose across #1985 (dev-arc tracker), #2134 (dev cutover: d.racku.la re-point and deploy-dev rewrite), and #2626 (Workers entry and CF storage driver), pulling the concrete curl commands from the migration plan appendix (`docs/plans/2026-06-29-cloudflare-migration-plan.md`) plus the header/version scripts already on main.

Each checklist item has an unchecked box, the exact command to run, and the expected observation:

- Unauthenticated `/api/layouts` returns a Cloudflare Access 302.
- Authenticated (CF Access service token) `/api/layouts` returns 200 JSON.
- Layout round-trip (PUT then GET) echoes `X-Rackula-Updated-At` with a newer-or-equal `updatedAt`.
- `/assets/<hashed>.js` returns `application/javascript` with an immutable cache-control.
- Headers by value on `/`: CSP, X-Frame-Options, X-Content-Type-Options, HSTS, dev-only `X-Robots-Tag: noindex`.
- `config.js` reports `storage: "server"`.
- `version.json` matches the deployed version and commit.
- `vps-rackula` is absent from `.github/workflows/deploy-dev.yml`.
- This checklist is wired into #2134's done-when.

The doc also cross-references the scheduled soak-smoke workflow (`docs/deployment/soak-smoke.md`) as the automated ongoing complement to this one-time acceptance gate.

## Intentionally-unchecked gate item

d.racku.la still runs on the VPS today; the dev Worker cutover (#2134) has not happened. Every checkbox in the new doc starts unchecked, including the `vps-rackula` absence item, which cannot pass until the VPS deploy leg is removed from `deploy-dev.yml` as part of that cutover. **This PR does not modify `.github/workflows/deploy-dev.yml` in any way** -- it only documents the future expected state and the command to verify it.

## #2134 wiring

Edited issue #2134's body via `gh issue edit` to point its existing "Done-when" clause at the new file, changing only this line:

```
Done-when: d.racku.la serves frontend+API from Workers; deploy-dev.yml has no vps-rackula reference; Access verified on UI and /api; the #2677 dev-env smoketest checklist (`docs/deployment/dev-acceptance-checklist.md`) is green (incl. /api/layouts via service token); VPS out of the dev serving path.
```

The rest of #2134's body is unchanged (verified with a diff before applying).

## Scope

Docs only. No code changes, no workflow changes.

Closes #2677

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Add a one-step acceptance checklist for the d.racku.la Worker cutover**

### What Changed
- Added a single checklist for verifying d.racku.la after it moves from the VPS to the Cloudflare Worker
- Included exact commands and expected results for login protection, layout save/read flow, asset delivery, security headers, dev config, and version matching
- Clarified that this checklist is the acceptance gate for the dev cutover and that the VPS-based workflow item stays unchecked until that cutover happens
- Linked the checklist to the ongoing soak-smoke checks and the related migration issues

### Impact
`✅ Clearer dev cutover checks`
`✅ Fewer missed deployment steps`
`✅ Easier verification of Worker rollout`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
