### PR TITLE
fix: add management to InterfaceTypeSchema enum

### DIFF
--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -153,6 +153,7 @@ export const InterfaceTypeSchema = z.enum([
   "400gbase-x-qsfpdd",
   // Console & Management
   "console",
+  "management",
   "usb-a",
   "usb-b",
   "usb-c",


### PR DESCRIPTION
## **User description**
## Summary

`management` is a declared member of the `InterfaceType` union in `src/lib/types/index.ts` and has a UI label in `PortTooltip.svelte` ("Management"), but it was missing from `InterfaceTypeSchema` (the `z.enum` in `src/lib/schemas/index.ts`). That enum validates a port's `type` on both `InterfaceTemplate` and `PlacedPort`, so a port with `type: "management"` typechecked green in TypeScript but failed Zod validation at runtime (`InterfaceTypeSchema.safeParse("management").success === false`).

That inversion surfaces the moment a device, or an imported/hand-authored layout, uses `type: "management"`: import, YAML roundtrip, or the device-library schema test rejects a value TypeScript already accepted.

## Fix

The additive one-liner the issue prescribes: add `"management"` to the `InterfaceTypeSchema` `z.enum` in `src/lib/schemas/index.ts`, next to `"console"`.

The issue also notes a related smell: two separate `InterfaceType` definitions exist (the hand-written union in `types/index.ts` and `z.infer<typeof InterfaceTypeSchema>` in `schemas/index.ts`) that can drift like this again. Collapsing them into a single source of truth is explicitly called out as an optional maintainer's-call follow-up, out of scope here, and owned by the connectivity enablers (#3089/#3090). This PR does not touch that.

## Verification

- `VITEST_MAX_WORKERS=2 npm run test:run -- schemas` → 234 passed (1 file)
- `VITEST_MAX_WORKERS=2 npm run test:run -- brandpacks starterLibrary yaml-roundtrip` → 151 passed (3 files)
- `npm run check` (svelte-check + tsc) → 5504 files, 0 errors, 0 warnings
- `npx eslint src/lib/schemas/index.ts` → No issues found
- `prettier --check src/lib/schemas/index.ts` (main checkout binary) → All matched files use Prettier code style

No test changes: no existing test enumerates the `InterfaceTypeSchema` values exhaustively (unlike `DeviceCategorySchema`, which does use `it.each`), so nothing needed updating. Per the repo's testing policy ("Trust the Schema", don't duplicate Zod validation), a new test asserting `safeParse("management").success` would just be re-testing schema data, so none was added.

Closes #3085

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
Allow management ports to pass validation

### What Changed
- Ports marked as `management` now validate correctly during import and YAML round-trips
- This matches the existing label and type support already shown in the UI

### Impact
`✅ Fewer rejected device imports`
`✅ Successful YAML round-trips for management ports`
`✅ Clearer support for management interfaces`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
