### PR TITLE
fix: reduced-motion drag no longer snaps device to SVG origin

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -1072,10 +1072,6 @@
     .rack-device {
       transition: none;
     }
-
-    .rack-device.dragging {
-      transform: none;
-    }
   }
 
   /* Container child device styles */


### PR DESCRIPTION
## **User description**
## Root cause

`RackDevice.svelte` positions each device via the SVG presentation attribute `transform="translate(...)"` on the `<g class="rack-device">`. A reduced-motion CSS rule reset the CSS `transform` on the dragging element:

```css
@media (prefers-reduced-motion: reduce) {
  .rack-device.dragging {
    transform: none;
  }
}
```

CSS `transform` overrides the SVG `transform` presentation attribute, so `transform: none` cleared the positioning `translate()` while `.dragging` was applied, snapping the device to (0,0) for the duration of the drag. The normal-motion `.rack-device.dragging` rule deliberately uses only `opacity` and `filter` (no CSS transform, per the Issue #5 note already in the file), so this reset had nothing legitimate to reset and instead broke positioning.

## Fix

Removed the `.rack-device.dragging { transform: none; }` rule from the reduced-motion media query in `src/lib/components/RackDevice.svelte`. The sibling rule in the same media query, `.rack-device { transition: none; }`, only disables the `filter` transition and is unaffected; it stays. I checked the rest of the file for other reduced-motion rules resetting `transform` on SVG-positioned elements (e.g. container-child devices, which are also positioned via `transform="translate(...)"`) and found none, so no other rule needed the same fix.

## Verification

- `npm run check`: 5504 files, 0 errors, 0 warnings.
- `npx eslint src/lib/components/RackDevice.svelte`: no issues.
- Prettier: no formatting changes needed.
- Related unit suites (`VITEST_MAX_WORKERS=2 npm run test:run -- src/tests/dragdrop.test.ts src/tests/rack-pointer-drag.dragcancel.test.ts src/tests/RackDevice.port-indicators.test.ts src/tests/RackDevice.escape-cancel-drag.test.ts src/tests/RackDevice.placement-select-suppression.test.ts src/tests/RackDevice.aria-label-name.test.ts src/tests/RackDevice.placement-click-routing.test.ts src/tests/touch-drag-threshold.test.ts`): 8 files, 53 tests, all passing.
- Manual repro per the issue: enable OS "Reduce motion", open a rack with a placed device, drag it. Before the fix the device visibly jumped to the top-left SVG origin for the duration of the drag; after removing the rule the device stays under the pointer, matching normal-motion drag.

## Why no new automated test

This is a one-rule CSS deletion with no new logic. There's no existing Playwright drag spec in `e2e/` to extend, and per repo testing policy (no `querySelector`/class-name assertions, which are ESLint-blocked, and no low-value tests just because a fix touches the area), a dedicated e2e spec that emulates `prefers-reduced-motion: reduce`, performs a drag, and asserts the computed SVG position would be new test infrastructure for a single-line regression, not a cheap addition to an existing suite. Playwright does support `reducedMotion: 'reduce'` context emulation, so if a broader drag e2e suite is added later this scenario would be a natural fit, but adding one now for this fix alone isn't warranted. The manual verification above plus the existing green drag/RackDevice unit suites are the coverage for this change.

Closes #2883

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Keep dragged devices in place when reduced motion is on**

### What Changed
- Dragged rack devices no longer snap to the top-left corner when reduced motion is enabled.
- The reduced-motion setting still removes motion effects, but it no longer clears the device’s position while dragging.

### Impact
`✅ Correct drag position with reduced motion`
`✅ Fewer visual jumps during dragging`
`✅ Clearer accessibility behavior for motion-sensitive users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
