### PR TITLE
fix: container-child devices announce their container hierarchy

### DIFF
--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -295,6 +295,14 @@
     return deviceLibrary.find((d) => d.slug === slug);
   }
 
+  // Slot display name for a container child, falling back to the raw slot id
+  // when the slot has no display name (mirrors EditPanelPosition's
+  // containerContext.slotName precedence).
+  function getSlotName(slotId: string | undefined): string {
+    const slot = device.slots?.find((s) => s.id === slotId);
+    return slot?.name ?? slotId ?? "Unknown";
+  }
+
   // Calculate child device position within container
   // Position is 0-indexed from bottom of container, Y is SVG coordinate (origin at top)
   function getChildY(childPosition: number, childUHeight: number): number {
@@ -869,10 +877,14 @@
             "var(--colour-device-default)"}
           {@const childName = child.name ?? childType.model ?? childType.slug}
           {@const isChildSelected = selectedChildId === child.id}
+          {@const slotName = getSlotName(child.slot_id)}
+          {@const childAriaLabel = `${childName}, ${childType.u_height}U ${childType.category} in ${slotName} of ${displayName} at U${positionHuman}`}
           <g
             class="container-child"
             class:selected={isChildSelected}
             transform="translate({childX}, {childY})"
+            role="img"
+            aria-label={childAriaLabel}
           >
             <!-- Child device rectangle -->
             <rect

--- a/src/tests/RackDevice.container-child-aria-label.test.ts
+++ b/src/tests/RackDevice.container-child-aria-label.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression test for #2890: PR #2882 added a container-hierarchy screen
+ * reader announcement, but placed it in Rack.svelte's `visibleDevices` each
+ * block, which filters out any device with a truthy container_id -- so the
+ * branch could never fire. PR #2888 removed the resulting dead code, leaving
+ * container child devices with no accessible name at all (they render as raw
+ * <rect>/<text> SVG in RackDevice.svelte's container-children block).
+ *
+ * This test asserts the accessible name directly at the reachable site: the
+ * child <g> in RackDevice.svelte's container-children rendering.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import RackDevice from "$lib/components/RackDevice.svelte";
+import {
+  createTestDeviceType,
+  createTestContainerType,
+  createTestContainerChild,
+} from "./factories";
+
+describe("RackDevice container-child accessible name (#2890)", () => {
+  it("announces device, height, category, slot, container, and container position", () => {
+    const containerType = createTestContainerType({
+      slug: "blade-chassis",
+      model: "Blade Chassis",
+      u_height: 4,
+      slots: [
+        {
+          id: "slot-left",
+          name: "Left Bay",
+          position: { row: 0, col: 0 },
+          width_fraction: 0.5,
+        },
+        {
+          id: "slot-right",
+          name: "Right Bay",
+          position: { row: 0, col: 1 },
+          width_fraction: 0.5,
+        },
+      ],
+    });
+
+    const childType = createTestDeviceType({
+      slug: "blade-server",
+      model: "Blade Server",
+      u_height: 1,
+      category: "server",
+    });
+
+    const child = createTestContainerChild({
+      id: "child-1",
+      device_type: childType.slug,
+      container_id: "container-1",
+      slot_id: "slot-left",
+      position: 0,
+    });
+
+    const { getByRole } = render(RackDevice, {
+      props: {
+        device: containerType,
+        position: 30, // internal units (6/U) -> U5
+        rackHeight: 42,
+        rackId: "rack-1",
+        deviceIndex: 0,
+        selected: false,
+        uHeight: 30,
+        rackWidth: 300,
+        deviceLibrary: [containerType, childType],
+        containerChildDevices: [{ placedDevice: child, originalIndex: 0 }],
+      },
+    });
+
+    const childElement = getByRole("img", {
+      name: "Blade Server, 1U server in Left Bay of Blade Chassis at U5",
+    });
+    expect(childElement).toBeInTheDocument();
+  });
+
+  it("falls back to the slot id when the slot has no display name", () => {
+    const containerType = createTestContainerType({
+      slug: "blade-chassis",
+      model: "Blade Chassis",
+      u_height: 4,
+      slots: [
+        {
+          id: "slot-left",
+          position: { row: 0, col: 0 },
+          width_fraction: 0.5,
+        },
+      ],
+    });
+
+    const childType = createTestDeviceType({
+      slug: "blade-server",
+      model: "Blade Server",
+      u_height: 1,
+      category: "server",
+    });
+
+    const child = createTestContainerChild({
+      id: "child-1",
+      device_type: childType.slug,
+      container_id: "container-1",
+      slot_id: "slot-left",
+      position: 0,
+    });
+
+    const { getByRole } = render(RackDevice, {
+      props: {
+        device: containerType,
+        position: 6, // U1
+        rackHeight: 42,
+        rackId: "rack-1",
+        deviceIndex: 0,
+        selected: false,
+        uHeight: 30,
+        rackWidth: 300,
+        deviceLibrary: [containerType, childType],
+        containerChildDevices: [{ placedDevice: child, originalIndex: 0 }],
+      },
+    });
+
+    const childElement = getByRole("img", {
+      name: "Blade Server, 1U server in slot-left of Blade Chassis at U1",
+    });
+    expect(childElement).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

PR #2882 (interaction feedback cluster) added a container-hierarchy screen-reader announcement for child devices per Epic #159, but placed it at a site where it could never fire. `Rack.svelte`'s `visibleDevices` filters out any device with a truthy `container_id`, so the `{@const containerCtx = placedDevice.container_id ? getContainerContext(placedDevice) : undefined}` added to the top-level `{#each visibleDevices}` block always saw `container_id` as falsy, `containerCtx` was always `undefined`, and the `containerContext` prop passed to `<RackDevice>` was always `undefined`. The announcement was unreachable for the entire time it shipped.

PR #2888 (hot-path memo cleanup) correctly removed the resulting dead code (`getContainerContext` and its call site), per the project's delete-dead-code rule. That exposed the underlying gap this issue tracks: container child devices had no accessible name at all. They render via a separate path in `RackDevice.svelte` (`{#if isContainer && containerChildDevices.length > 0}`) as raw `<rect>`/`<text>` SVG with no `aria-label` and no `<title>`.

## Fix

Move the announcement to the reachable site: the container-children rendering block in `RackDevice.svelte`, where the container's own name (`displayName`), position (`positionHuman`), and slot definitions (`device.slots`) are already in scope for that component instance.

- Added `getSlotName(slotId)`, mirroring `EditPanelPosition.svelte`'s existing `containerContext.slotName` precedence (slot's own `name`, falling back to the raw `slot_id`, falling back to `"Unknown"`).
- Each child `<g class="container-child">` now carries `role="img"` and an `aria-label` built as:

  ```
  <device>, <n>U <category> in <slotName> of <containerName> at U<containerPosition>
  ```

  e.g. `Blade Server, 1U server in Left Bay of Blade Chassis at U5`

This mirrors two existing conventions already in the file rather than inventing a new one:
- The rack-level device's own `ariaLabel` derived (`role="button"` + `aria-label`).
- The device image's `role="img"` + `aria-label={imageAccessibleName}` pattern, used because the child group is non-interactive (no click/keyboard handler exists on it), so `role="img"` (not `role="button"`) is the correct ARIA semantics. Per the ARIA spec, `role="img"` implies "Children Presentational: True", so the descendant `<rect>`/`<text>` don't leak a separate, redundant accessible name into the tree.

## Test evidence (TDD)

New file `src/tests/RackDevice.container-child-aria-label.test.ts`, written first and run to confirm it failed before the fix landed:

**RED** (before the fix, both assertions failed with `Unable to find an accessible element with the role "img" and name "..."`):
```
TestingLibraryElementError: Unable to find an accessible element with the role "img" and name "Blade Server, 1U server in Left Bay of Blade Chassis at U5"
TestingLibraryElementError: Unable to find an accessible element with the role "img" and name "Blade Server, 1U server in slot-left of Blade Chassis at U1"
```

**GREEN** (after the fix):
```
PASS (2) FAIL (0)
```

Two cases: the hierarchy announcement with a named slot, and the fallback to the raw `slot_id` when a slot has no display name.

This is a component-level automated accessible-name assertion via `@testing-library/svelte`'s `getByRole('img', { name })`, which satisfies the issue's "axe-core or an automated accessible-name assertion" acceptance criterion without needing the heavier e2e axe-core harness (`e2e/axe.spec.ts`) for a change this scoped.

## Verification

- `VITEST_MAX_WORKERS=2 npm run test:run`: 246 test files / 3577 tests passed (full suite, no regressions)
- `npm run check` (svelte-check): 0 errors, 0 warnings across 5504 files
- `npx eslint` on touched files: no issues
- `mcp__svelte__svelte-autofixer` on `RackDevice.svelte`: no new issues (only pre-existing suggestions about unrelated `$effect` patterns in the file)
- Formatted with the repo's pinned prettier binary; `--check` confirms clean

No regression to rack-level device announcements: the existing `ariaLabel` derived for the top-level device (`role="button"`) is untouched, and `RackDevice.aria-label-name.test.ts` still passes.

Closes #2890

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Give container child devices a readable screen-reader label**

### What Changed
- Container child devices now announce their name, size, category, slot, container, and position when focused by assistive tech
- If a slot has no display name, the slot ID is used instead
- Added coverage for both named and unnamed slots to prevent regressions

### Impact
`✅ Clearer screen-reader output for blade devices`
`✅ Fewer unlabeled devices in rack views`
`✅ Better accessibility for container-based hardware`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
