### PR TITLE
fix: netbox import writes device definitions and image manifest entries

### DIFF
--- a/docs/guides/NETBOX-IMPORT.md
+++ b/docs/guides/NETBOX-IMPORT.md
@@ -7,17 +7,22 @@ This guide explains how to import devices from the [NetBox community devicetype-
 ### Complete Import Workflow
 
 ```bash
-# 1. Import devices (downloads YAML + images automatically)
+# 1. Import devices: downloads YAML + images, writes device definitions to
+#    src/lib/data/brandPacks/<vendor>.ts, and (when any imported device has
+#    an image) processes that vendor's images and regenerates
+#    bundledImages.ts automatically
 npx tsx scripts/import-netbox-devices.ts --vendor HPE --all
 
-# 2. Process images (convert to optimized WebP)
-npm run process-images
-
-# 3. Generate bundled images manifest (register images for bundling)
-npm run generate-bundled-images
-
-# 4. Verify build works
+# 2. Verify build works
 npm run build
+```
+
+Re-running the same command is safe: devices already present in the brand pack file are skipped, so nothing is duplicated. If a new brand pack file was created (a vendor imported for the first time), register it per [BRAND-PACKS.md](BRAND-PACKS.md#step-2-register-the-pack); the script prints a reminder when this happens. To process images or regenerate `bundledImages.ts` by hand (for example after manually editing a brand pack file), the underlying commands are still available:
+
+```bash
+npm run process-images                                    # all vendors
+npx tsx scripts/process-images.ts --vendor hpe             # one vendor only
+npm run generate-bundled-images
 ```
 
 ### Using the Import Script

--- a/scripts/import-netbox-devices.ts
+++ b/scripts/import-netbox-devices.ts
@@ -375,9 +375,13 @@ ${newEntries}
   return { filePath, added, skipped, created: true };
 }
 
+// npx ships as a .cmd shim on Windows, which spawnSync can't exec directly
+// without a shell; select the shim there and the plain binary everywhere else.
+const NPX_COMMAND = process.platform === "win32" ? "npx.cmd" : "npx";
+
 /** Best-effort prettier formatting; a formatting failure should not abort the import. */
 function formatWithPrettier(relativePath: string): boolean {
-  const result = spawnSync("npx", ["prettier", "--write", relativePath], {
+  const result = spawnSync(NPX_COMMAND, ["prettier", "--write", relativePath], {
     cwd: ROOT_DIR,
     stdio: "inherit",
   });
@@ -387,7 +391,7 @@ function formatWithPrettier(relativePath: string): boolean {
 /** Runs scripts/process-images.ts scoped to one vendor, so unrelated vendors' images are untouched. */
 function runProcessImagesForVendor(vendor: string): boolean {
   const result = spawnSync(
-    "npx",
+    NPX_COMMAND,
     ["tsx", "scripts/process-images.ts", "--vendor", vendor],
     { cwd: ROOT_DIR, stdio: "inherit" },
   );
@@ -397,7 +401,7 @@ function runProcessImagesForVendor(vendor: string): boolean {
 /** Runs scripts/generate-bundled-images.ts to regenerate bundledImages.ts from the processed images on disk. */
 function runGenerateBundledImages(): boolean {
   const result = spawnSync(
-    "npx",
+    NPX_COMMAND,
     ["tsx", "scripts/generate-bundled-images.ts"],
     { cwd: ROOT_DIR, stdio: "inherit" },
   );

--- a/scripts/import-netbox-devices.ts
+++ b/scripts/import-netbox-devices.ts
@@ -19,12 +19,21 @@
  *   --list-vendors    List all available vendors
  *   --dry-run         Show what would be imported without making changes
  *   --images-only     Only download images, don't update TypeScript files
+ *
+ * On a real (non-dry-run, non-images-only) import, the script writes new
+ * device definitions to src/lib/data/brandPacks/<vendor>.ts (creating the
+ * file if it does not exist yet) and, when any imported device has an image,
+ * runs the image pipeline for that vendor only: scripts/process-images.ts
+ * --vendor <vendor> followed by scripts/generate-bundled-images.ts, so
+ * bundledImages.ts is regenerated in the same run. Devices whose slug is
+ * already present in the brand pack file are skipped (idempotent re-runs).
  */
 
-import { writeFile, mkdir } from "fs/promises";
+import { writeFile, mkdir, readFile } from "fs/promises";
 import { existsSync } from "fs";
-import { join, dirname } from "path";
+import { join, dirname, relative } from "path";
 import { fileURLToPath } from "url";
+import { spawnSync } from "child_process";
 import yaml from "js-yaml";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -215,17 +224,6 @@ async function fetchDeviceYaml(
   }
 }
 
-function slugToVarName(slug: string): string {
-  // Convert slug to camelCase variable name
-  // ubiquiti-usw-pro-24 -> ubiquitiUswPro24
-  return slug
-    .split("-")
-    .map((part, i) =>
-      i === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1),
-    )
-    .join("");
-}
-
 function inferCategory(device: NetBoxDevice): string {
   const model = device.model.toLowerCase();
   const slug = device.slug.toLowerCase();
@@ -250,7 +248,13 @@ function inferCategory(device: NetBoxDevice): string {
 
 function deviceToTypeScript(device: NetBoxDevice): string {
   const category = inferCategory(device);
-  const categoryColour = `CATEGORY_COLOURS.${category.replace("-", "_")}`;
+  // Category keys with a hyphen (e.g. "patch-panel") are not valid dot-access
+  // identifiers, so CATEGORY_COLOURS must be indexed with bracket notation for
+  // those and dot notation otherwise, matching the convention used across the
+  // brand pack files (see e.g. kws.ts's CATEGORY_COLOURS["patch-panel"]).
+  const categoryColour = category.includes("-")
+    ? `CATEGORY_COLOURS["${category}"]`
+    : `CATEGORY_COLOURS.${category}`;
 
   const lines = [
     "\t{",
@@ -260,20 +264,21 @@ function deviceToTypeScript(device: NetBoxDevice): string {
     `\t\tmodel: '${device.model}',`,
     `\t\tis_full_depth: ${device.is_full_depth ?? true},`,
     `\t\tcolour: ${categoryColour},`,
-    `\t\tcategory: '${category}'`,
+    `\t\tcategory: '${category}',`,
   ];
 
   if (device.front_image) {
     lines.push(`\t\tfront_image: true,`);
   }
   if (device.rear_image) {
-    lines.push(`\t\trear_image: true`);
+    lines.push(`\t\trear_image: true,`);
   }
   if (device.airflow) {
     lines.push(`\t\tairflow: '${device.airflow}',`);
   }
 
-  // Clean up trailing comma on last property
+  // Clean up trailing comma on the last property (whichever field ends up
+  // last depends on which optional fields are present above).
   const lastLine = lines[lines.length - 1];
   if (lastLine.endsWith(",")) {
     lines[lines.length - 1] = lastLine.slice(0, -1);
@@ -281,6 +286,122 @@ function deviceToTypeScript(device: NetBoxDevice): string {
 
   lines.push("\t}");
   return lines.join("\n");
+}
+
+const BRAND_PACKS_DIR = join(ROOT_DIR, "src", "lib", "data", "brandPacks");
+
+function brandPackFilePath(vendor: string): string {
+  return join(BRAND_PACKS_DIR, `${vendor.toLowerCase()}.ts`);
+}
+
+/**
+ * Extract every device slug already present in a brand pack file's source
+ * text. Used to make writes idempotent: a slug found here is skipped rather
+ * than appended again on a re-run.
+ */
+function extractExistingSlugs(content: string): Set<string> {
+  const slugs = new Set<string>();
+  const slugPattern = /slug:\s*['"]([^'"]+)['"]/g;
+  let match: RegExpExecArray | null;
+  while ((match = slugPattern.exec(content)) !== null) {
+    const slug = match[1];
+    if (slug) {
+      slugs.add(slug);
+    }
+  }
+  return slugs;
+}
+
+interface WriteBrandPackResult {
+  filePath: string;
+  added: NetBoxDevice[];
+  skipped: NetBoxDevice[];
+  created: boolean;
+}
+
+/**
+ * Write newly imported devices into the vendor's brand pack file, creating
+ * the file if it doesn't exist yet. Devices whose slug is already present are
+ * skipped so re-running the import is a no-op for devices already added.
+ */
+async function writeBrandPackDevices(
+  vendor: string,
+  devices: NetBoxDevice[],
+): Promise<WriteBrandPackResult> {
+  const filePath = brandPackFilePath(vendor);
+  const fileExists = existsSync(filePath);
+  const existingContent = fileExists ? await readFile(filePath, "utf-8") : "";
+  const existingSlugs = extractExistingSlugs(existingContent);
+
+  const added = devices.filter((d) => !existingSlugs.has(d.slug));
+  const skipped = devices.filter((d) => existingSlugs.has(d.slug));
+
+  if (added.length === 0) {
+    return { filePath, added, skipped, created: false };
+  }
+
+  const newEntries = added.map((d) => deviceToTypeScript(d)).join(",\n");
+
+  if (fileExists) {
+    const trimmed = existingContent.replace(/\s+$/, "");
+    if (!trimmed.endsWith("];")) {
+      throw new Error(
+        `Could not safely append to ${filePath}: expected the file to end with "];"`,
+      );
+    }
+    const before = trimmed.slice(0, -2).replace(/,\s*$/, "");
+    const updated = `${before},\n${newEntries},\n];\n`;
+    await writeFile(filePath, updated, "utf-8");
+    return { filePath, added, skipped, created: false };
+  }
+
+  const vendorLower = vendor.toLowerCase();
+  const arrayName = `${vendorLower}Devices`;
+  const newFile = `/**
+ * ${vendor} Brand Pack
+ * Pre-defined device types for ${vendor} equipment
+ * Source: NetBox community devicetype-library
+ */
+
+import type { DeviceType } from '$lib/types';
+import { CATEGORY_COLOURS } from '$lib/types/constants';
+
+export const ${arrayName}: DeviceType[] = [
+${newEntries}
+];
+`;
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, newFile, "utf-8");
+  return { filePath, added, skipped, created: true };
+}
+
+/** Best-effort prettier formatting; a formatting failure should not abort the import. */
+function formatWithPrettier(relativePath: string): boolean {
+  const result = spawnSync("npx", ["prettier", "--write", relativePath], {
+    cwd: ROOT_DIR,
+    stdio: "inherit",
+  });
+  return result.status === 0;
+}
+
+/** Runs scripts/process-images.ts scoped to one vendor, so unrelated vendors' images are untouched. */
+function runProcessImagesForVendor(vendor: string): boolean {
+  const result = spawnSync(
+    "npx",
+    ["tsx", "scripts/process-images.ts", "--vendor", vendor],
+    { cwd: ROOT_DIR, stdio: "inherit" },
+  );
+  return result.status === 0;
+}
+
+/** Runs scripts/generate-bundled-images.ts to regenerate bundledImages.ts from the processed images on disk. */
+function runGenerateBundledImages(): boolean {
+  const result = spawnSync(
+    "npx",
+    ["tsx", "scripts/generate-bundled-images.ts"],
+    { cwd: ROOT_DIR, stdio: "inherit" },
+  );
+  return result.status === 0;
 }
 
 async function importDevice(
@@ -426,60 +547,76 @@ async function main(): Promise<void> {
   console.log(`Imported ${importedDevices.length} rack-mountable device(s)`);
 
   if (importedDevices.length > 0 && !options.dryRun && !options.imagesOnly) {
-    // Generate TypeScript for imported devices
-    console.log(`\n📝 Generated TypeScript:`);
-    console.log(`\nAdd these to your brand pack file:\n`);
-    console.log(`import type { DeviceType } from '$lib/types';`);
-    console.log(`import { CATEGORY_COLOURS } from '$lib/types/constants';\n`);
-    console.log(
-      `export const ${options.vendor.toLowerCase()}Devices: DeviceType[] = [`,
-    );
-    importedDevices.forEach((device, i) => {
-      console.log(
-        deviceToTypeScript(device) +
-          (i < importedDevices.length - 1 ? "," : ""),
-      );
-    });
-    console.log(`];`);
+    const vendorLower = options.vendor.toLowerCase();
 
-    // Generate bundledImages.ts entries
-    const devicesWithImages = importedDevices.filter(
+    console.log(`\n📝 Writing device definitions...`);
+    const { filePath, added, skipped, created } = await writeBrandPackDevices(
+      options.vendor,
+      importedDevices,
+    );
+    const relFilePath = relative(ROOT_DIR, filePath);
+
+    if (added.length > 0) {
+      console.log(
+        `  ✅ ${created ? "Created" : "Updated"} ${relFilePath}: added ${added.length} device(s)`,
+      );
+      added.forEach((d) => console.log(`    + ${d.slug}`));
+      formatWithPrettier(relFilePath);
+    } else {
+      console.log(`  ⏭️  ${relFilePath}: no new devices (all already present)`);
+    }
+    if (skipped.length > 0) {
+      console.log(
+        `  ⏭️  Skipped ${skipped.length} device(s) already in the brand pack:`,
+      );
+      skipped.forEach((d) => console.log(`    - ${d.slug}`));
+    }
+    if (created) {
+      console.log(
+        `\n⚠️  New brand pack file created. It still needs to be registered manually (see docs/guides/BRAND-PACKS.md):`,
+      );
+      console.log(
+        `  1. Import ${vendorLower}Devices in src/lib/data/brandPacks/index.ts`,
+      );
+      console.log(`  2. Add one BRAND_PACK_REGISTRY entry`);
+      console.log(`  3. Wire up the brand icon in BrandIcon.svelte`);
+    }
+
+    const devicesWithImages = added.filter(
       (d) => d.front_image || d.rear_image,
     );
     if (devicesWithImages.length > 0) {
-      console.log(`\n📸 Add to bundledImages.ts:\n`);
-      console.log(`// Imports:`);
-      const vendorLower = options.vendor.toLowerCase();
-      devicesWithImages.forEach((device) => {
-        const varBase = slugToVarName(device.slug);
-        if (device.front_image) {
+      console.log(`\n📸 Processing images for ${options.vendor}...`);
+      const processOk = runProcessImagesForVendor(vendorLower);
+      if (!processOk) {
+        console.log(
+          `  ⚠️  Image processing failed; run 'npm run process-images' manually.`,
+        );
+      } else {
+        console.log(`\n📸 Regenerating bundledImages.ts...`);
+        const generateOk = runGenerateBundledImages();
+        if (!generateOk) {
           console.log(
-            `import ${varBase}Front from '$lib/assets/device-images/${vendorLower}/${device.slug}.front.webp';`,
+            `  ⚠️  bundledImages.ts regeneration failed; run 'npm run generate-bundled-images' manually.`,
           );
+        } else {
+          formatWithPrettier(join("src", "lib", "data", "bundledImages.ts"));
         }
-        if (device.rear_image) {
-          console.log(
-            `import ${varBase}Rear from '$lib/assets/device-images/${vendorLower}/${device.slug}.rear.webp';`,
-          );
-        }
-      });
-
-      console.log(`\n// Manifest entries:`);
-      devicesWithImages.forEach((device) => {
-        const varBase = slugToVarName(device.slug);
-        const parts = [];
-        if (device.front_image) parts.push(`front: ${varBase}Front`);
-        if (device.rear_image) parts.push(`rear: ${varBase}Rear`);
-        console.log(`'${device.slug}': { ${parts.join(", ")} },`);
-      });
+      }
     }
   }
 
   if (!options.dryRun) {
     console.log(`\n📋 Next steps:`);
-    console.log(`1. Run: npm run process-images`);
-    console.log(`2. Update src/lib/data/bundledImages.ts with new imports`);
-    console.log(`3. Add devices to brand pack file if not already present`);
+    console.log(
+      `1. Review the diff (brand pack file, bundledImages.ts, images)`,
+    );
+    console.log(`2. Run: npm run build`);
+    if (options.imagesOnly) {
+      console.log(
+        `3. Images only were downloaded; re-run without --images-only to write device definitions`,
+      );
+    }
   }
 }
 

--- a/scripts/process-images.ts
+++ b/scripts/process-images.ts
@@ -18,7 +18,7 @@
 import sharp from "sharp";
 import { readdir, mkdir, stat } from "fs/promises";
 import { join, parse, relative } from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { dirname } from "path";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -202,10 +202,13 @@ async function main(): Promise<void> {
 }
 
 // Only run when invoked directly (e.g. `npx tsx scripts/process-images.ts`), not
-// when imported as a module (e.g. by scripts/import-netbox-devices.ts).
+// when imported as a module (e.g. by scripts/import-netbox-devices.ts). Compares
+// via pathToFileURL rather than a raw `file://` template, since a plain
+// concatenation doesn't URL-encode spaces/non-ASCII characters or normalise
+// Windows path separators, so it can silently mismatch and never run.
 const isMainModule =
   process.argv[1] !== undefined &&
-  import.meta.url === `file://${process.argv[1]}`;
+  import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMainModule) {
   main().catch(console.error);

--- a/scripts/process-images.ts
+++ b/scripts/process-images.ts
@@ -6,7 +6,13 @@
  * - Converts to WebP format
  * - Preserves directory structure
  *
- * Usage: npm run process-images
+ * Usage:
+ *   npm run process-images                    # process every vendor
+ *   npx tsx scripts/process-images.ts --vendor mikrotik   # process one vendor only
+ *
+ * Scoping to a vendor avoids re-encoding unrelated vendors' images (each
+ * encode is lossy, so an unscoped run churns every vendor's webp output even
+ * when only one vendor changed, e.g. during a NetBox import).
  */
 
 import sharp from "sharp";
@@ -29,6 +35,12 @@ const OUTPUT_DIR = join(
 );
 const MAX_WIDTH = 400;
 const SUPPORTED_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp"];
+
+function parseVendorArg(argv: string[]): string | undefined {
+  const index = argv.indexOf("--vendor");
+  if (index === -1) return undefined;
+  return argv[index + 1];
+}
 
 interface ProcessResult {
   file: string;
@@ -119,32 +131,36 @@ async function processImage(sourcePath: string): Promise<ProcessResult> {
   }
 }
 
-async function main(): Promise<void> {
+async function processImages(vendor?: string): Promise<ProcessResult[]> {
+  const scanDir = vendor ? join(SOURCE_DIR, vendor.toLowerCase()) : SOURCE_DIR;
+
   console.log("🖼️  Device Image Processor");
   console.log("========================\n");
-  console.log(`Source: ${SOURCE_DIR}`);
+  console.log(`Source: ${scanDir}`);
   console.log(`Output: ${OUTPUT_DIR}`);
   console.log(`Max width: ${MAX_WIDTH}px`);
   console.log(`Output format: WebP\n`);
 
   // Check if source directory exists
   try {
-    await stat(SOURCE_DIR);
+    await stat(scanDir);
   } catch {
     console.log("⚠️  Source directory does not exist. Nothing to process.");
     console.log(
-      "   Place images in assets-source/device-images/ and run again.\n",
+      vendor
+        ? `   No images found for vendor "${vendor}" in assets-source/device-images/.\n`
+        : "   Place images in assets-source/device-images/ and run again.\n",
     );
-    return;
+    return [];
   }
 
   // Get all image files
-  const files = await getFiles(SOURCE_DIR);
+  const files = await getFiles(scanDir);
 
   if (files.length === 0) {
     console.log("⚠️  No images found in source directory.");
     console.log("   Supported formats: PNG, JPG, JPEG, WebP\n");
-    return;
+    return [];
   }
 
   console.log(`Found ${files.length} image(s) to process...\n`);
@@ -176,6 +192,23 @@ async function main(): Promise<void> {
     console.log(`❌ Errors: ${errors}`);
   }
   console.log("Done!\n");
+
+  return results;
 }
 
-main().catch(console.error);
+async function main(): Promise<void> {
+  const vendor = parseVendorArg(process.argv.slice(2));
+  await processImages(vendor);
+}
+
+// Only run when invoked directly (e.g. `npx tsx scripts/process-images.ts`), not
+// when imported as a module (e.g. by scripts/import-netbox-devices.ts).
+const isMainModule =
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isMainModule) {
+  main().catch(console.error);
+}
+
+export { processImages };


### PR DESCRIPTION
## **User description**
## Summary

`scripts/import-netbox-devices.ts` downloaded elevation images to disk but only `console.log`'d the generated device definitions and `bundledImages.ts` manifest entries. The import workflow could fetch data and download images but could never actually add a device without a maintainer hand-copying the console output into the right files. This is why #1581's MikroTik CSS326-24G-2S+RM and CSS610-8G-2S+IN had to be hand-authored.

Closes #2595

## Before / after data flow

**Before:**

```
fetch YAML -> download images -> console.log("Add these to your brand pack file: ...")
                                -> console.log("Add to bundledImages.ts: ...")
```

Nothing was written. The script's own final output even said "Next steps: 1. Run process-images 2. Update bundledImages.ts with new imports 3. Add devices to brand pack file if not already present" - i.e. it printed instructions for a manual job it could have done itself.

**After**, on a real (non-dry-run, non-`--images-only`) import:

```
fetch YAML -> download images -> writeBrandPackDevices()
                                     -> writes/creates src/lib/data/brandPacks/<vendor>.ts
                                     -> skips devices whose slug already exists
                                     -> prettier --write on the file it touched
                                  -> if any newly-added device has an image:
                                       -> runs scripts/process-images.ts --vendor <vendor> (scoped)
                                       -> runs scripts/generate-bundled-images.ts (regenerates bundledImages.ts)
                                       -> prettier --write on bundledImages.ts
```

If the vendor's brand pack file doesn't exist yet, the script creates it and prints a reminder to register it in `src/lib/data/brandPacks/index.ts` and wire up the brand icon (per `docs/guides/BRAND-PACKS.md`) - registration and icon wiring are the one part of adding a *new vendor* that stays a deliberate manual/reviewed step, matching how `index.ts` documents itself ("the one thing that does not derive... is the icon artwork").

## Idempotency

`writeBrandPackDevices` reads the target brand pack file's existing content and extracts every `slug: '...'` it finds via regex before writing. Devices whose slug is already present are skipped and reported separately from newly-added ones. Re-running the same import is therefore a no-op for anything already added: the file isn't modified and no image processing/regeneration runs a second time for those devices.

## process-images vendor scoping (secondary issue)

`npm run process-images` walked and re-encoded every vendor's images via `readdir`, even during an import for a single vendor - this is why the orphaned `import/MikroTik-devices` branch had re-encoded ~76 unrelated images for Ubiquiti, Palo Alto, HPE, Fortinet, etc.

`scripts/process-images.ts` now accepts an optional `--vendor <name>` flag that scopes the scan to `assets-source/device-images/<vendor>/` instead of the whole tree. The default (no flag) behaviour is unchanged - byte-identical output, same set of files touched - so `npm run process-images` and any other caller is unaffected. `import-netbox-devices.ts` uses the scoped form internally.

## Bugs found and fixed along the way

Actually writing `deviceToTypeScript`'s output to disk (instead of only printing it) surfaced two latent bugs that had never been exercised for real:

1. **Missing comma**: the `category` field's line had no trailing comma, and neither did `rear_image`'s. If a device had `rear_image` and/or `airflow` set after `category`, the generated object literal was invalid TypeScript (`category: 'network'` directly followed by `front_image: true,` with no separator). Fixed by giving every field a trailing comma and letting the existing "strip the trailing comma off whichever line ends up last" cleanup handle it, regardless of which optional fields are present.
2. **Broken colour lookup for `patch-panel`**: `CATEGORY_COLOURS.${category.replace("-", "_")}` produced `CATEGORY_COLOURS.patch_panel`, which doesn't exist (the real key is the hyphenated `"patch-panel"`, only reachable via bracket notation, e.g. `kws.ts`'s `CATEGORY_COLOURS["patch-panel"]`). Fixed to use bracket notation for hyphenated categories.

## Evidence

All testing was done in an isolated worktree; test artefacts were `git checkout`/`rm`'d afterward so this diff is exactly the two scripts plus a doc update.

**Real network, idempotent no-op on a fully-imported vendor** (`--vendor Netgate --all`, run twice): both runs reported `Skipped 8 device(s) already in the brand pack`, `added: []`, and `git status` showed zero changes to `netgate.ts` after either run.

**Real network, end-to-end new-vendor import** (`--vendor Bastion --all`, a small NetBox vendor not previously in this repo): first run created `src/lib/data/brandPacks/bastion.ts` with 8 rack-mountable devices (1 of the 9 NetBox entries is 0U and correctly excluded), auto-prettier-formatted, plus the "register this in index.ts" reminder since it's a brand-new file. `npm run check` reported 0 errors with the file present. Second run reported all 8 as skipped with zero further changes - confirmed idempotent through the real CLI, not just the underlying function.

**Real, scoped image pipeline**: with MikroTik's 28 already-committed raw source images, `npx tsx scripts/process-images.ts --vendor mikrotik` processed only those 28 files and `git status` showed no diff (deterministic re-encode). Running the full unscoped `npm run process-images` (994 files) touched the same files it would touch on `main` today (unrelated to this change - some pre-existing sharp version drift); confirms default behaviour is unchanged.

**Full pipeline, fixture-driven** (a throwaway `aten-cl1308` device + copied source image, since no real ungated NetBox device+image combo was findable in the time available that wasn't already imported): confirmed `process-images --vendor aten` produced a webp, `generate-bundled-images` added the entry to `bundledImages.ts`, and `prettier --write` normalized the generator's single-quoted output to the project's double-quoted style so the diff stays CI-clean. Re-running both steps a second time produced zero further changes.

**Typecheck/lint**: `npm run check` (svelte-check) - 0 errors, 0 warnings, both before and with fixture-written brand pack files present. `npm run lint` (full repo eslint) - no issues. A standalone `tsc --noEmit` project scoped to the three touched/related scripts (scripts aren't in the app's `tsconfig.json` `include`, so `npm run check` doesn't type-check them directly) - no errors.

## Remaining gap (out of scope)

`.github/workflows/import-netbox.yml`'s final step uses `peter-evans/create-pull-request` with the default `GITHUB_TOKEN`, which this org disallows for PR creation. That step will still fail even with this fix - the workflow can now run the import and (thanks to this PR) actually produce a real diff including the brand pack file and `bundledImages.ts`, but it still cannot open the resulting PR itself. This needs a maintainer decision (e.g. a PAT/GitHub App token with `pull-requests: write` scoped for this workflow) and is left untouched here, per the issue's own scope note. In the meantime the script is fully usable locally: `npx tsx scripts/import-netbox-devices.ts --vendor <name> --all`, then push/PR by hand.

## Test plan

- [x] `npm run check` - 0 errors
- [x] `npm run lint` - no issues
- [x] Standalone `tsc --noEmit` on touched scripts - no errors
- [x] Real network dry-run/idempotency test against an existing vendor (Netgate)
- [x] Real network end-to-end test against a brand-new vendor (Bastion)
- [x] Real scoped vs. unscoped `process-images` comparison (MikroTik)
- [x] Fixture-driven full pipeline test (process-images -> generate-bundled-images -> prettier)
- [x] All test artefacts reverted; diff is exactly `scripts/import-netbox-devices.ts`, `scripts/process-images.ts`, `docs/guides/NETBOX-IMPORT.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**NetBox imports now write device definitions and update images in one run**

### What Changed
- Imported devices are now added directly to the vendor brand pack file instead of being printed for manual copy-paste
- Re-running the same import skips devices that are already present, so repeated imports do not duplicate entries
- When imported devices include images, the import now processes only that vendor’s images and regenerates `bundledImages.ts` automatically
- Two device definition issues are fixed when entries are written to disk: patch-panel colors now resolve correctly, and devices with both rear image and airflow data keep valid formatting
- Image processing can now be limited to one vendor, which avoids touching unrelated vendors’ image files

### Impact
`✅ One-step NetBox imports`
`✅ No duplicate device entries on repeat imports`
`✅ Fewer unnecessary image updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
