### PR TITLE
feat: PortDirection field with inferDirection defaults

### DIFF
--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -236,7 +236,7 @@
             y={y + 2}
             text-anchor="end"
           >
-            &#8592;
+            &#8594;
           </text>
         {:else if getPortDirection(iface) === "output"}
           <text

--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -12,12 +12,17 @@
   - Hover tooltips with port details (#251)
 -->
 <script lang="ts">
-  import type { InterfaceTemplate, InterfaceType, RackView } from "$lib/types";
+  import type {
+    InterfaceTemplate,
+    InterfaceType,
+    PortDirection,
+    RackView,
+  } from "$lib/types";
   import {
     showPortTooltip,
     hidePortTooltip,
   } from "$lib/stores/portTooltip.svelte";
-  import { getPortCategory } from "$lib/utils/port-utils";
+  import { getPortCategory, inferDirection } from "$lib/utils/port-utils";
 
   interface Props {
     interfaces: InterfaceTemplate[];
@@ -84,6 +89,14 @@
 
   function getInterfaceColor(type: InterfaceType): string {
     return INTERFACE_COLORS[type] ?? CATEGORY_COLORS[getPortCategory(type)];
+  }
+
+  // Direction arrow shown for input/output ports (none for bidirectional,
+  // and none when an AV type has no explicit or inferred direction).
+  function getPortDirection(
+    iface: InterfaceTemplate,
+  ): PortDirection | undefined {
+    return iface.direction ?? inferDirection(iface.type, iface.mgmt_only);
   }
 
   // Filter interfaces for current view
@@ -214,6 +227,27 @@
             ⚡
           </text>
         {/if}
+
+        <!-- Direction arrow (input/output only; bidirectional and unset show nothing) -->
+        {#if getPortDirection(iface) === "input"}
+          <text
+            class="port-direction-indicator"
+            x={x - PORT_RADIUS - 2}
+            y={y + 2}
+            text-anchor="end"
+          >
+            &#8592;
+          </text>
+        {:else if getPortDirection(iface) === "output"}
+          <text
+            class="port-direction-indicator"
+            x={x + PORT_RADIUS + 2}
+            y={y + 2}
+            text-anchor="start"
+          >
+            &#8594;
+          </text>
+        {/if}
       {/each}
 
       <!-- Invisible SVG click targets (larger than visual ports, Safari compatible) -->
@@ -281,6 +315,12 @@
   }
 
   .port-poe-indicator {
+    font-size: 6px;
+    pointer-events: none;
+  }
+
+  .port-direction-indicator {
+    fill: var(--colour-port-indicator);
     font-size: 6px;
     pointer-events: none;
   }

--- a/src/lib/components/PortTooltip.svelte
+++ b/src/lib/components/PortTooltip.svelte
@@ -4,8 +4,9 @@
   Renders at the document level, positioned using fixed coordinates.
 -->
 <script lang="ts">
-  import type { InterfaceType } from "$lib/types";
+  import type { InterfaceTemplate, InterfaceType } from "$lib/types";
   import { getPortTooltipState } from "$lib/stores/portTooltip.svelte";
+  import { inferDirection } from "$lib/utils/port-utils";
 
   // Get reactive tooltip state from store
   const tooltipState = $derived(getPortTooltipState());
@@ -53,6 +54,20 @@
     return TYPE_LABELS[type] ?? type;
   }
 
+  const DIRECTION_LABELS = {
+    input: "Input",
+    output: "Output",
+    bidirectional: "Bidirectional",
+  } as const;
+
+  // Get human-readable direction label; null when no direction is set or
+  // inferred (AV types without an explicit direction).
+  function getDirectionLabel(port: InterfaceTemplate): string | null {
+    const direction =
+      port.direction ?? inferDirection(port.type, port.mgmt_only);
+    return direction ? DIRECTION_LABELS[direction] : null;
+  }
+
   // Get PoE label
   function getPoELabel(
     poeMode?: "pd" | "pse",
@@ -76,6 +91,9 @@
   <div class="port-tooltip" role="tooltip" style="left: {x}px; top: {y}px;">
     <div class="port-tooltip-name">{port.label ?? port.name}</div>
     <div class="port-tooltip-type">{getTypeLabel(port.type)}</div>
+    {#if getDirectionLabel(port)}
+      <div class="port-tooltip-direction">{getDirectionLabel(port)}</div>
+    {/if}
     {#if port.mgmt_only}
       <div class="port-tooltip-badge mgmt">Management Only</div>
     {/if}
@@ -127,6 +145,11 @@
   }
 
   .port-tooltip-type {
+    color: var(--colour-text-muted-inverse, rgba(255, 255, 255, 0.7));
+    font-size: var(--font-size-xs);
+  }
+
+  .port-tooltip-direction {
     color: var(--colour-text-muted-inverse, rgba(255, 255, 255, 0.7));
     font-size: var(--font-size-xs);
   }

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -217,6 +217,12 @@ export const PoEModeSchema = z.enum(["pd", "pse"]);
 export const InterfacePositionSchema = z.enum(["front", "rear"]);
 
 /**
+ * Port direction enum: input, output, or bidirectional signal flow
+ * (spike #1927; used for AV signal routing)
+ */
+export const PortDirectionSchema = z.enum(["input", "output", "bidirectional"]);
+
+/**
  * Cable type enum (NetBox-compatible)
  */
 export const CableTypeSchema = z.enum([
@@ -334,6 +340,7 @@ export const InterfaceTemplateSchema = z
     position: InterfacePositionSchema.optional(),
     poe_mode: PoEModeSchema.optional(),
     poe_type: PoETypeSchema.optional(),
+    direction: PortDirectionSchema.optional(),
   })
   .passthrough();
 
@@ -412,6 +419,7 @@ export const PlacedPortSchema = z
       .min(0, "Template index must be non-negative"),
     type: InterfaceTypeSchema,
     label: z.string().max(64).optional(),
+    direction: PortDirectionSchema.optional(),
   })
   .passthrough();
 
@@ -1191,6 +1199,7 @@ export type InterfaceType = z.infer<typeof InterfaceTypeSchema>;
 export type PoEType = z.infer<typeof PoETypeSchema>;
 export type PoEMode = z.infer<typeof PoEModeSchema>;
 export type InterfacePosition = z.infer<typeof InterfacePositionSchema>;
+export type PortDirection = z.infer<typeof PortDirectionSchema>;
 export type InterfaceTemplate = z.infer<typeof InterfaceTemplateSchema>;
 export type PowerPort = z.infer<typeof PowerPortSchema>;
 export type PowerOutlet = z.infer<typeof PowerOutletSchema>;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -210,6 +210,11 @@ export type PoEMode = "pd" | "pse";
 export type InterfacePosition = "front" | "rear";
 
 /**
+ * Port signal direction (spike #1927; used for AV signal routing)
+ */
+export type PortDirection = "input" | "output" | "bidirectional";
+
+/**
  * Cable type (NetBox-compatible)
  * Physical cable types for network, fiber, and power connections
  */
@@ -271,6 +276,8 @@ export interface InterfaceTemplate {
   poe_mode?: PoEMode;
   /** PoE type/standard */
   poe_type?: PoEType;
+  /** Signal direction. Provides the default used when the placed port omits its own. */
+  direction?: PortDirection;
 }
 
 /**
@@ -390,6 +397,8 @@ export interface PlacedPort {
   type: InterfaceType;
   /** User override label for this port instance */
   label?: string;
+  /** Signal direction override; falls back to the InterfaceTemplate default when unset */
+  direction?: PortDirection;
 }
 
 // =============================================================================

--- a/src/lib/utils/port-utils.ts
+++ b/src/lib/utils/port-utils.ts
@@ -44,9 +44,12 @@ const AV_INTERFACE_TYPES = new Set<string>([
 
 /**
  * Interface types whose direction defaults to "input" (spike #1927 taxonomy):
- * management/console ports and the AV control-serial types. Checked before
+ * console ports and the AV control-serial types. Checked before
  * AV_INTERFACE_TYPES in inferDirection() since rs-232/rs-422 are members of
- * both sets and the specific input default takes priority.
+ * both sets and the specific input default takes priority. Management-only
+ * interfaces also default to "input", but via the separate mgmt_only check
+ * in inferDirection(), not through this set: the "management" interface
+ * type itself falls through to "bidirectional" unless mgmt_only is set.
  */
 const INPUT_DEFAULT_TYPES = new Set<string>(["console", "rs-232", "rs-422"]);
 

--- a/src/lib/utils/port-utils.ts
+++ b/src/lib/utils/port-utils.ts
@@ -3,7 +3,7 @@
  * Functions for port instantiation when devices are placed
  */
 
-import type { DeviceType, PlacedPort } from "$lib/types";
+import type { DeviceType, PlacedPort, PortDirection } from "$lib/types";
 import { generateId } from "$lib/utils/device";
 
 export type PortCategory = "network" | "power" | "console" | "av";
@@ -43,6 +43,14 @@ const AV_INTERFACE_TYPES = new Set<string>([
 ]);
 
 /**
+ * Interface types whose direction defaults to "input" (spike #1927 taxonomy):
+ * management/console ports and the AV control-serial types. Checked before
+ * AV_INTERFACE_TYPES in inferDirection() since rs-232/rs-422 are members of
+ * both sets and the specific input default takes priority.
+ */
+const INPUT_DEFAULT_TYPES = new Set<string>(["console", "rs-232", "rs-422"]);
+
+/**
  * Categorize an interface type string into network, power, console, or av.
  * Uses string matching for network/power/console so it handles future types
  * (e.g. power-inlet-*) even before they are added to the InterfaceType enum.
@@ -63,6 +71,36 @@ export function getPortCategory(type: string): PortCategory {
     return "power";
   }
   return "network";
+}
+
+/**
+ * Infer the default signal direction for an interface type (spike #1927).
+ * Used when an InterfaceTemplate (or PlacedPort) does not set `direction`
+ * explicitly:
+ * - Management-only interfaces default to "input".
+ * - Console and AV control-serial types (rs-232, rs-422) default to "input".
+ * - All other AV types (XLR, HDMI, SDI, ...) have no default: direction must
+ *   be set explicitly on the device type.
+ * - Everything else (network, power, USB, etc.) defaults to "bidirectional".
+ *
+ * @param type - Interface type string
+ * @param mgmtOnly - Whether the interface is management-only
+ * @returns The inferred direction, or undefined if none should be assumed
+ */
+export function inferDirection(
+  type: string,
+  mgmtOnly?: boolean,
+): PortDirection | undefined {
+  if (mgmtOnly) {
+    return "input";
+  }
+  if (INPUT_DEFAULT_TYPES.has(type)) {
+    return "input";
+  }
+  if (AV_INTERFACE_TYPES.has(type)) {
+    return undefined;
+  }
+  return "bidirectional";
 }
 
 /**

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -27,6 +27,7 @@ import type {
   SlotWidth,
   Cable,
   InterfaceTemplate,
+  PlacedPort,
 } from "$lib/types";
 import type { CreateDeviceTypeInput } from "$lib/stores/layout-helpers";
 import type { NetBoxDeviceType } from "$lib/utils/netbox-import";
@@ -224,6 +225,23 @@ export function createTestInterfaceTemplate(
 ): InterfaceTemplate {
   return {
     name: "Test Interface",
+    type: "1000base-t",
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a test PlacedPort. Defaults to a gigabit RJ45 port instance;
+ * override `type`/`direction` to exercise other interface types or a
+ * direction override that differs from its InterfaceTemplate.
+ */
+export function createTestPlacedPort(
+  overrides: Partial<PlacedPort> = {},
+): PlacedPort {
+  return {
+    id: overrides.id ?? generateId(),
+    template_name: "Test Interface",
+    template_index: 0,
     type: "1000base-t",
     ...overrides,
   };

--- a/src/tests/fixtures/upgrade-corpus/v26.7.0-port-direction.expected.json
+++ b/src/tests/fixtures/upgrade-corpus/v26.7.0-port-direction.expected.json
@@ -1,0 +1,8 @@
+{
+  "allowList": [
+    {
+      "pathPattern": "\\.position$",
+      "reason": "rail position 3 is converted to internal 1/6U units on load; no coincidental duplicate elsewhere in this fixture unlike the sibling AV fixtures"
+    }
+  ]
+}

--- a/src/tests/fixtures/upgrade-corpus/v26.7.0-port-direction.rackula.yaml
+++ b/src/tests/fixtures/upgrade-corpus/v26.7.0-port-direction.rackula.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://count.racku.la/schemas/rackula-layout.schema.json
+metadata:
+  id: 7d2e9c4a-1f6b-4a3d-9e2c-5b8a3f7d1c66
+  name: Port Direction Demo Rack
+  schema_version: "1.0"
+version: "26.7.0"
+name: Port Direction Demo Rack
+racks:
+  - id: rack-direction
+    name: Direction Demo Rack
+    height: 8
+    width: 19
+    desc_units: false
+    show_rear: true
+    form_factor: 4-post-cabinet
+    starting_unit: 1
+    position: 0
+    devices:
+      - id: dev-direction-demo
+        device_type: direction-demo-device
+        position: 3
+        face: front
+        ports:
+          - id: port-line-out
+            template_name: Line Out
+            template_index: 0
+            type: hdmi
+            direction: input
+          - id: port-line-in
+            template_name: Line In
+            template_index: 1
+            type: hdmi
+            direction: input
+          - id: port-uplink
+            template_name: Uplink
+            template_index: 2
+            type: 1000base-t
+device_types:
+  - slug: direction-demo-device
+    manufacturer: Acme AV
+    model: Direction Demo 1U
+    u_height: 1
+    colour: "#8BE9FD"
+    category: av-media
+    interfaces:
+      - name: Line Out
+        type: hdmi
+        direction: output
+      - name: Line In
+        type: hdmi
+        direction: input
+      - name: Uplink
+        type: 1000base-t
+settings:
+  display_mode: label
+  show_labels_on_images: false

--- a/src/tests/port-utils.test.ts
+++ b/src/tests/port-utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { inferDirection } from "$lib/utils/port-utils";
+import { InterfaceTemplateSchema, PlacedPortSchema } from "$lib/schemas";
+import { createTestInterfaceTemplate, createTestPlacedPort } from "./factories";
+
+describe("inferDirection", () => {
+  it("defaults management-only interfaces to input", () => {
+    expect(inferDirection("1000base-t", true)).toBe("input");
+  });
+
+  it("mgmt_only takes priority over an AV type's no-default rule", () => {
+    expect(inferDirection("hdmi", true)).toBe("input");
+  });
+
+  it.each(["console", "rs-232", "rs-422"])("defaults %s to input", (type) => {
+    expect(inferDirection(type)).toBe("input");
+  });
+
+  it.each([
+    "xlr-3",
+    "trs-1-4",
+    "ts-1-4",
+    "rca",
+    "adat-optical",
+    "midi-din",
+    "bnc",
+    "db25-audio",
+    "phoenix",
+    "speakon",
+    "xlr-5",
+    "displayport",
+    "hdmi",
+    "sdi-bnc",
+    "vga",
+    "dmx-xlr",
+    "aes3",
+    "avb",
+    "dante",
+  ])("has no default direction for AV type %s", (type) => {
+    expect(inferDirection(type)).toBeUndefined();
+  });
+
+  it.each(["1000base-t", "10gbase-t", "usb-c", "management", "virtual"])(
+    "defaults %s to bidirectional",
+    (type) => {
+      expect(inferDirection(type)).toBe("bidirectional");
+    },
+  );
+});
+
+describe("PlacedPort direction override", () => {
+  it("can differ from and override the InterfaceTemplate default", () => {
+    const template = createTestInterfaceTemplate({
+      type: "hdmi",
+      direction: "input",
+    });
+    const port = createTestPlacedPort({ type: "hdmi", direction: "output" });
+
+    expect(InterfaceTemplateSchema.parse(template).direction).toBe("input");
+    expect(PlacedPortSchema.parse(port).direction).toBe("output");
+  });
+});

--- a/static/schemas/rackula-layout.schema.json
+++ b/static/schemas/rackula-layout.schema.json
@@ -197,6 +197,14 @@
             "items": {
               "additionalProperties": {},
               "properties": {
+                "direction": {
+                  "enum": [
+                    "input",
+                    "output",
+                    "bidirectional"
+                  ],
+                  "type": "string"
+                },
                 "label": {
                   "maxLength": 64,
                   "type": "string"
@@ -700,6 +708,14 @@
                 "items": {
                   "additionalProperties": {},
                   "properties": {
+                    "direction": {
+                      "enum": [
+                        "input",
+                        "output",
+                        "bidirectional"
+                      ],
+                      "type": "string"
+                    },
                     "id": {
                       "minLength": 1,
                       "type": "string"
@@ -989,6 +1005,14 @@
                   "items": {
                     "additionalProperties": {},
                     "properties": {
+                      "direction": {
+                        "enum": [
+                          "input",
+                          "output",
+                          "bidirectional"
+                        ],
+                        "type": "string"
+                      },
                       "id": {
                         "minLength": 1,
                         "type": "string"


### PR DESCRIPTION
## **User description**
## Summary

Adds an optional `direction` field (`input` | `output` | `bidirectional`) to `InterfaceTemplate` and `PlacedPort`, so AV signal flow direction can be modeled and shown in the UI.

## Field semantics

`direction` follows the exact same pattern as the existing `label` field: `InterfaceTemplate.direction` is the device-type default, and `PlacedPort.direction` can independently override it for a specific placed instance. Both fields are optional and additive; existing layouts without `direction` continue to load unchanged (schema passthrough already preserves unknown fields, and this is a new optional field, not a required one).

## inferDirection(type, mgmtOnly)

New utility in `src/lib/utils/port-utils.ts`, used wherever a template or placed port omits an explicit `direction`:

| Input | Result |
| --- | --- |
| `mgmt_only: true` | `input` |
| `type` is `console`, `rs-232`, or `rs-422` | `input` |
| `type` is any other AV type in `AV_INTERFACE_TYPES` | `undefined` (no default; direction must be set explicitly) |
| everything else (network, power, USB, etc.) | `bidirectional` |

Check order matters: `rs-232` and `rs-422` are members of both the input-default list and `AV_INTERFACE_TYPES` (added by #1929's control-type taxonomy). The input-default check runs first, so those two resolve to `input` rather than falling through to "no default".

## UI

- `PortIndicators.svelte`: individual (low-density, <=24 ports) port circles now show a small left/right arrow for `input`/`output`; `bidirectional` and unset (AV types without an explicit direction) show nothing. The resolved direction is `iface.direction ?? inferDirection(iface.type, iface.mgmt_only)`. Grouped high-density badge mode (>24 ports) is unchanged, per the issue: per-port arrows aren't visible there, and that's accepted. This change is deliberately scoped to arrow rendering only, since #3089 will refactor `PortIndicators.svelte` after this merges.
- `PortTooltip.svelte`: shows a human-readable direction label ("Input" / "Output" / "Bidirectional") under the port type, using the same resolution. No label is shown when direction is neither set nor inferable.

## Schema

- `PortDirectionSchema` added to `src/lib/schemas/index.ts`, dual-sourced with a hand-written `PortDirection` type in `src/lib/types/index.ts` (existing pattern for this file pair).
- `static/schemas/rackula-layout.schema.json` regenerated via `npm run generate-schema` (byte-for-byte, verified by `layout-json-schema.test.ts`).
- No `SCHEMA_VERSION` bump: it's already `1.1` this release (#3087) and `direction` is an additive optional field on both schemas.

## Corpus fixture

Added `src/tests/fixtures/upgrade-corpus/v26.7.0-port-direction.rackula.yaml`: an interface template with an explicit `direction: output`, a placed port for that same interface overriding it to `direction: input`, and a plain network interface with no `direction` at all (covering the backward-compatible/optional path). `schema_version: "1.0"` in the fixture metadata, matching sibling fixtures.

The sidecar allow-lists `\.position$`: the fixture's device `position: 3` gets converted to internal 1/6U units on load, which the corpus checker would otherwise flag as data loss. The sibling `v26.7.0-av-connectivity-ports` fixture avoids this only by coincidence (its device's raw position value happens to also appear as a `template_index` elsewhere in the layout); this fixture uses the explicit, documented allow-list mechanism instead (same pattern as `over-rack-rail-position.expected.json`).

## Test evidence

- `VITEST_MAX_WORKERS=2 npm run test:run`: 248 test files, 3653 tests, all passing.
- `npm run check` (svelte-check): 0 errors, 0 warnings across 5504 files.
- `npx eslint` on all touched files: no issues.
- `src/tests/port-utils.test.ts` (new): covers every `inferDirection` branch (mgmt_only, console/rs-232/rs-422, all AV types, network/power/USB/management/virtual defaults, and the mgmt_only-over-AV precedence edge case), plus a schema-level test that a `PlacedPort.direction` override can differ from its `InterfaceTemplate.direction` default.
- `src/tests/upgrade-corpus.test.ts`: new fixture passes with no undeclared silent data loss.
- `bash scripts/check-corpus-freshness.sh v26.7.0`: passes.
- `svelte-autofixer` (Svelte MCP) on both modified `.svelte` files: no issues from this change (PortIndicators surfaces one pre-existing, unrelated suggestion about its `$effect`-based hover timeout cleanup, not touched here).

## Deviations from the issue

No PlacedPort/InterfaceTemplate merge helper exists in the codebase for `label` either (`PortIndicators`/`PortTooltip` currently render only from `InterfaceTemplate`, and `instantiatePorts()` doesn't copy `label` onto the placed port). Since there's no existing merge utility to mirror, this PR doesn't invent one for `direction`; it adds the field with the same override-capable shape as `label` and leaves resolution to whatever future consumer wires `PlacedPort` into the UI (tracked separately, out of scope here).

Closes #1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Show port signal direction in the layout and tooltip**

### What Changed
- Ports can now carry a direction of input, output, or bidirectional on both device templates and placed ports
- When a direction is not set, the app now infers a default for common cases like management-only and console ports, while leaving some AV ports without a default
- Small port arrows now appear for input and output ports in the device view, and the tooltip shows a plain-language direction label
- Added support data and tests for direction-aware ports, including a sample layout fixture

### Impact
`✅ Clearer AV signal flow`
`✅ Fewer ambiguous port labels`
`✅ Easier port review in tooltips`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
