### PR TITLE
refactor: expose PlacedPort identity and geometry from port rendering

### DIFF
--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -206,7 +206,11 @@
   <g class="port-indicators">
     {#if !isHighDensity}
       <!-- Individual port circles for low-density devices -->
-      {#each portPositions as { iface, port, x, y, color } (port?.id ?? iface.name)}
+      <!-- Keyed by PlacedPort.id when available; falls back to the loop
+           index, not iface.name, since duplicate interface names are legal
+           (see port-geometry.ts) and legacy layouts can leave every port
+           undefined, which would make an iface.name-only fallback collide. -->
+      {#each portPositions as { iface, port, x, y, color }, i (port?.id ?? i)}
         <circle
           class="port-circle"
           cx={x}
@@ -257,7 +261,7 @@
       {/each}
 
       <!-- Invisible SVG click targets (larger than visual ports, Safari compatible) -->
-      {#each portPositions as { iface, port, x, y } (port?.id ?? iface.name)}
+      {#each portPositions as { iface, port, x, y }, i (port?.id ?? i)}
         <circle
           class="port-hit-target"
           cx={x}

--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -15,6 +15,8 @@
   import type {
     InterfaceTemplate,
     InterfaceType,
+    PlacedPort,
+    PortClickInfo,
     PortDirection,
     RackView,
   } from "$lib/types";
@@ -23,18 +25,26 @@
     hidePortTooltip,
   } from "$lib/stores/portTooltip.svelte";
   import { getPortCategory, inferDirection } from "$lib/utils/port-utils";
+  import {
+    computeVisiblePortLayout,
+    HIGH_DENSITY_THRESHOLD,
+    PORT_Y_OFFSET,
+  } from "$lib/utils/port-geometry";
 
   interface Props {
     interfaces: InterfaceTemplate[];
+    /** Placed port instances for this device, keyed to `interfaces` by template_index (#3089). */
+    ports?: PlacedPort[];
     deviceWidth: number;
     deviceHeight: number;
     rackView: RackView;
     showPorts?: boolean;
-    onPortClick?: (iface: InterfaceTemplate) => void;
+    onPortClick?: (info: PortClickInfo) => void;
   }
 
   let {
     interfaces,
+    ports = [],
     deviceWidth,
     deviceHeight,
     rackView,
@@ -76,11 +86,6 @@
 
   // Constants for port rendering
   const PORT_RADIUS = 3;
-  const PORT_SPACING = 8;
-  const PORT_Y_OFFSET = 8; // Distance from bottom of device
-
-  // High-density threshold
-  const HIGH_DENSITY_THRESHOLD = 24;
 
   // Badge dimensions for high-density mode
   const BADGE_WIDTH = 24;
@@ -112,24 +117,22 @@
     visibleInterfaces.length > HIGH_DENSITY_THRESHOLD,
   );
 
-  // Calculate port positions (centered horizontally)
-  const portPositions = $derived.by(() => {
-    if (isHighDensity) return [];
-
-    const count = visibleInterfaces.length;
-    if (count === 0) return [];
-
-    const totalWidth = (count - 1) * PORT_SPACING;
-    const startX = (deviceWidth - totalWidth) / 2;
-    const y = deviceHeight - PORT_Y_OFFSET;
-
-    return visibleInterfaces.map((iface, i) => ({
-      iface,
-      x: startX + i * PORT_SPACING,
-      y,
-      color: getInterfaceColor(iface.type),
-    }));
-  });
+  // Port positions (centered horizontally), keyed by PlacedPort.id where one
+  // exists. Delegates to the shared geometry helper (#3089) so this layout
+  // and the one ConnectionLayer (#1931) will look up an anchor from are
+  // always identical.
+  const portPositions = $derived(
+    computeVisiblePortLayout({
+      interfaces,
+      ports,
+      rackView,
+      deviceWidth,
+      deviceHeight,
+    }).map((entry) => ({
+      ...entry,
+      color: getInterfaceColor(entry.iface.type),
+    })),
+  );
 
   // Group ports by type for high-density mode
   const portGroups = $derived.by(() => {
@@ -168,8 +171,11 @@
     }));
   });
 
-  function handlePortClick(iface: InterfaceTemplate) {
-    onPortClick?.(iface);
+  function handlePortClick(
+    iface: InterfaceTemplate,
+    port: PlacedPort | undefined,
+  ) {
+    onPortClick?.({ portId: port?.id, iface });
   }
 
   function handlePortMouseEnter(event: MouseEvent, iface: InterfaceTemplate) {
@@ -200,7 +206,7 @@
   <g class="port-indicators">
     {#if !isHighDensity}
       <!-- Individual port circles for low-density devices -->
-      {#each portPositions as { iface, x, y, color } (iface.name)}
+      {#each portPositions as { iface, port, x, y, color } (port?.id ?? iface.name)}
         <circle
           class="port-circle"
           cx={x}
@@ -251,7 +257,7 @@
       {/each}
 
       <!-- Invisible SVG click targets (larger than visual ports, Safari compatible) -->
-      {#each portPositions as { iface, x, y } (iface.name)}
+      {#each portPositions as { iface, port, x, y } (port?.id ?? iface.name)}
         <circle
           class="port-hit-target"
           cx={x}
@@ -261,13 +267,13 @@
           role="button"
           tabindex="0"
           aria-label="{iface.label ?? iface.name} ({iface.type})"
-          onclick={() => handlePortClick(iface)}
+          onclick={() => handlePortClick(iface, port)}
           onmouseenter={(e) => handlePortMouseEnter(e, iface)}
           onmouseleave={handlePortMouseLeave}
           onkeydown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
-              handlePortClick(iface);
+              handlePortClick(iface, port);
             }
           }}
         >

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -562,6 +562,7 @@
               {showLabelsOnImages}
               placedDeviceName={placedDevice.name}
               placedDeviceId={placedDevice.id}
+              ports={placedDevice.ports}
               frontImageRef={placedDevice.front_image}
               rearImageRef={placedDevice.rear_image}
               colourOverride={placedDevice.colour_override}

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -6,8 +6,9 @@
   import type {
     DeviceType,
     DisplayMode,
-    InterfaceTemplate,
     PlacedDevice,
+    PlacedPort,
+    PortClickInfo,
     RackView,
   } from "$lib/types";
   import { SvelteMap } from "svelte/reactivity";
@@ -74,6 +75,8 @@
     }>;
     /** ID of currently selected child device (for highlighting) */
     selectedChildId?: string | null;
+    /** Instantiated port instances for this placement (PlacedDevice.ports), passed alongside device.interfaces (#3089) */
+    ports?: PlacedPort[];
     /** Whether a device is being dragged over this container (shows slot overlay) */
     isDragOverContainer?: boolean;
     /** The slot ID currently targeted during drag (null if none) */
@@ -104,7 +107,7 @@
         y: number;
       }>,
     ) => void;
-    onPortClick?: (iface: InterfaceTemplate) => void;
+    onPortClick?: (info: PortClickInfo) => void;
   }
 
   let {
@@ -127,6 +130,7 @@
     deviceLibrary = [],
     containerChildDevices = [],
     selectedChildId = null,
+    ports = [],
     isDragOverContainer = false,
     dragTargetSlotId = null,
     isDragTargetValid = false,
@@ -839,6 +843,7 @@
   {#if device.interfaces?.length}
     <PortIndicators
       interfaces={device.interfaces}
+      {ports}
       {deviceWidth}
       {deviceHeight}
       {rackView}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -401,6 +401,22 @@ export interface PlacedPort {
   direction?: PortDirection;
 }
 
+/**
+ * Payload emitted when a rendered port is clicked. Carries the PlacedPort.id
+ * so callers (e.g. click-to-connect, #1932) can identify which port instance
+ * was targeted, not just which interface template it renders from.
+ */
+export interface PortClickInfo {
+  /**
+   * PlacedPort.id, when this port has an instantiated placement. Undefined
+   * for a layout placed before PlacedPort/instantiatePorts() existed, or for
+   * a template added to the device type after this device was placed.
+   */
+  portId: string | undefined;
+  /** The interface template this port renders from. */
+  iface: InterfaceTemplate;
+}
+
 // =============================================================================
 // Connection Types (Port-based - MVP)
 // =============================================================================

--- a/src/lib/utils/port-geometry.ts
+++ b/src/lib/utils/port-geometry.ts
@@ -1,0 +1,174 @@
+/**
+ * Port Geometry Utilities
+ *
+ * Pure functions for locating a PlacedPort's SVG anchor point in the
+ * individually-rendered (low-density) port layout. Shared by PortIndicators,
+ * which owns the click/hover targets, and, later, ConnectionLayer (#1931),
+ * which needs the same coordinates to draw a cable between two PlacedPort
+ * endpoints identified by Connection.a_port_id / b_port_id.
+ *
+ * No DOM access: callers supply device dimensions and an optional SVG-space
+ * offset (the device's own <g transform="translate(x, y)"> within the Rack
+ * SVG) so this module is unit-testable without mounting a component.
+ *
+ * Multi-row layout (#356) belongs here: swap the single-row math in
+ * computeVisiblePortLayout() below for a row-aware algorithm without
+ * changing the public API (lookup by PlacedPort.id, same PortAnchor shape).
+ */
+
+import type { InterfaceTemplate, PlacedPort, RackView } from "$lib/types";
+
+/** Horizontal spacing between port centres, in device-local SVG units. */
+export const PORT_SPACING = 8;
+
+/** Vertical distance of a port's centre from the bottom of the device. */
+export const PORT_Y_OFFSET = 8;
+
+/**
+ * Ports stop rendering individually beyond this count; PortIndicators falls
+ * back to grouped badges. Grouped badges have no per-port anchor: click-to-
+ * connect (#1932) cannot target an individual port on a high-density device
+ * until multi-row layout (#356) replaces this threshold.
+ */
+export const HIGH_DENSITY_THRESHOLD = 24;
+
+/** A single visible port position, paired with the template it renders from. */
+export interface PortLayoutEntry {
+  /** The interface template this position was computed for. */
+  iface: InterfaceTemplate;
+  /**
+   * The matching PlacedPort instance, when one exists. Undefined for a
+   * layout placed before PlacedPort/instantiatePorts() existed, or for a
+   * template added to the device type's interfaces after this device was
+   * placed - both leave the port template-identified only, same as
+   * PortIndicators' original rendering.
+   */
+  port: PlacedPort | undefined;
+  x: number;
+  y: number;
+}
+
+/** A PlacedPort's SVG anchor coordinate. */
+export interface PortAnchor {
+  portId: string;
+  x: number;
+  y: number;
+}
+
+/** SVG-space translation to add to device-local coordinates. */
+export interface PortGeometryOffset {
+  x: number;
+  y: number;
+}
+
+export interface PortGeometryOptions {
+  /** Interface templates from the owning DeviceType, in declaration order. */
+  interfaces: InterfaceTemplate[];
+  /** Placed port instances for this device (device-actions instantiatePorts()). */
+  ports: PlacedPort[];
+  /** Rack face currently in view; filters out ports mounted on the other face. */
+  rackView: RackView;
+  /** Rendered device width, matching RackDevice's deviceWidth. */
+  deviceWidth: number;
+  /** Rendered device height, matching RackDevice's deviceHeight. */
+  deviceHeight: number;
+  /**
+   * SVG-space translation of the device's own <g> within the Rack SVG, e.g.
+   * (RAIL_WIDTH + slotXOffset, RACK_PADDING + RAIL_WIDTH + yPosition) as
+   * computed by RackDevice.svelte. Omit for device-local coordinates (what
+   * PortIndicators itself renders in, since it is already nested inside that
+   * transform).
+   */
+  offset?: PortGeometryOffset;
+}
+
+/**
+ * Pair each PlacedPort with the InterfaceTemplate it was instantiated from.
+ * Matches by template_index (the position in DeviceType.interfaces at
+ * instantiation time), not template_name: duplicate interface names are
+ * legal (e.g. two ports both named "SFP+") and only template_index
+ * disambiguates them.
+ */
+function portByTemplateIndex(ports: PlacedPort[]): Map<number, PlacedPort> {
+  const byIndex = new Map<number, PlacedPort>();
+  for (const port of ports) {
+    byIndex.set(port.template_index, port);
+  }
+  return byIndex;
+}
+
+/**
+ * Interface templates visible on the current rack face, each paired with its
+ * PlacedPort when one exists. Position defaults to "front" (matching
+ * DEFAULT_RACK_VIEW), mirroring PortIndicators' visibleInterfaces filter.
+ */
+function visiblePorts(
+  interfaces: InterfaceTemplate[],
+  ports: PlacedPort[],
+  rackView: RackView,
+): Array<{ iface: InterfaceTemplate; port: PlacedPort | undefined }> {
+  const byIndex = portByTemplateIndex(ports);
+  return interfaces
+    .map((iface, index) => ({ iface, port: byIndex.get(index) }))
+    .filter(({ iface }) => (iface.position ?? "front") === rackView);
+}
+
+/**
+ * Computes the centred, single-row layout PortIndicators renders for
+ * individual (low-density) ports. Returns an empty array once the visible
+ * port count exceeds HIGH_DENSITY_THRESHOLD: grouped-badge mode has no
+ * per-port position, by design (see module docs and #1932).
+ */
+export function computeVisiblePortLayout(
+  options: PortGeometryOptions,
+): PortLayoutEntry[] {
+  const { interfaces, ports, rackView, deviceWidth, deviceHeight, offset } =
+    options;
+  const visible = visiblePorts(interfaces, ports, rackView);
+
+  if (visible.length === 0 || visible.length > HIGH_DENSITY_THRESHOLD) {
+    return [];
+  }
+
+  const offsetX = offset?.x ?? 0;
+  const offsetY = offset?.y ?? 0;
+  const totalWidth = (visible.length - 1) * PORT_SPACING;
+  const startX = (deviceWidth - totalWidth) / 2;
+  const y = deviceHeight - PORT_Y_OFFSET;
+
+  return visible.map(({ iface, port }, i) => ({
+    iface,
+    port,
+    x: offsetX + startX + i * PORT_SPACING,
+    y: offsetY + y,
+  }));
+}
+
+/**
+ * Anchor coordinates for every individually-rendered port that has a
+ * PlacedPort.id, in Rack SVG space when `offset` is supplied. This is the
+ * lookup ConnectionLayer (#1931) uses to locate a Connection's a_port_id /
+ * b_port_id endpoints; entries with no matching PlacedPort (legacy layouts,
+ * or grouped/high-density devices) are simply absent.
+ */
+export function getPortAnchors(options: PortGeometryOptions): PortAnchor[] {
+  const anchors: PortAnchor[] = [];
+  for (const entry of computeVisiblePortLayout(options)) {
+    if (entry.port) {
+      anchors.push({ portId: entry.port.id, x: entry.x, y: entry.y });
+    }
+  }
+  return anchors;
+}
+
+/**
+ * Anchor coordinates for a single PlacedPort, or undefined when it is not
+ * individually rendered: it belongs to the other rack face, the device is in
+ * grouped/high-density mode, or it has no matching PlacedPort.
+ */
+export function getPortAnchor(
+  portId: string,
+  options: PortGeometryOptions,
+): PortAnchor | undefined {
+  return getPortAnchors(options).find((anchor) => anchor.portId === portId);
+}

--- a/src/tests/RackDevice.port-key-collision.test.ts
+++ b/src/tests/RackDevice.port-key-collision.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression test for PR #3112 review findings (CodeAnt, CodeRabbit): the
+ * keyed #each in PortIndicators.svelte fell back to `iface.name` when a port
+ * has no matching PlacedPort. Duplicate interface names are explicitly legal
+ * (template_index exists specifically to disambiguate them, see
+ * port-geometry.ts), and a legacy layout saved before PlacedPort existed has
+ * every port undefined (PlacedDevice.ports defaults to [] via the schema).
+ * Combined, those two facts made the fallback key collide, and Svelte's
+ * keyed #each silently drops/reuses DOM nodes for colliding keys.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/svelte";
+import RackDevice from "$lib/components/RackDevice.svelte";
+import type { DeviceType } from "$lib/types";
+import { createTestDeviceType } from "./factories";
+
+describe("PortIndicators keyed #each (duplicate names, no PlacedPort)", () => {
+  it("renders one hit target per interface even when names collide and no ports are instantiated", () => {
+    const device: DeviceType = {
+      ...createTestDeviceType({ slug: "test-switch", u_height: 1 }),
+      interfaces: [
+        { name: "SFP+", type: "10gbase-x-sfpp" },
+        { name: "SFP+", type: "25gbase-x-sfp28" },
+      ],
+    };
+
+    // No `ports` prop passed: mirrors a layout placed before PlacedPort
+    // existed, so both interfaces resolve with port undefined.
+    const { getAllByRole } = render(RackDevice, {
+      props: {
+        device,
+        position: 6,
+        rackHeight: 42,
+        rackId: "rack-1",
+        deviceIndex: 0,
+        selected: false,
+        uHeight: 30,
+        rackWidth: 300,
+      },
+    });
+
+    // Every interface must get its own hit target, distinguishable by its
+    // accessible name (type-suffixed even though both share the "SFP+"
+    // name): a colliding key would drop or misattribute one.
+    const portTargets = getAllByRole("button", { name: /^SFP\+/ });
+    expect(portTargets.length).toBe(device.interfaces?.length);
+    expect(
+      getAllByRole("button", { name: "SFP+ (10gbase-x-sfpp)" }).length,
+    ).toBe(1);
+    expect(
+      getAllByRole("button", { name: "SFP+ (25gbase-x-sfp28)" }).length,
+    ).toBe(1);
+  });
+});

--- a/src/tests/port-geometry.test.ts
+++ b/src/tests/port-geometry.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the port geometry helper (#3089): a pure, DOM-free function that
+ * locates a PlacedPort's SVG anchor coordinate. Covers the two invariants
+ * the issue calls out explicitly: rear-face filtering and template_index
+ * disambiguation of duplicate interface names, plus the grouped/high-density
+ * "no per-port target" behaviour that #1932 needs documented.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeVisiblePortLayout,
+  getPortAnchor,
+  getPortAnchors,
+  HIGH_DENSITY_THRESHOLD,
+} from "$lib/utils/port-geometry";
+import { createTestInterfaceTemplate, createTestPlacedPort } from "./factories";
+
+describe("computeVisiblePortLayout", () => {
+  it("centres ports horizontally along the bottom edge, keyed to their PlacedPort", () => {
+    const interfaces = [
+      createTestInterfaceTemplate({ name: "eth0" }),
+      createTestInterfaceTemplate({ name: "eth1" }),
+    ];
+    const ports = [
+      createTestPlacedPort({ id: "port-a", template_index: 0 }),
+      createTestPlacedPort({ id: "port-b", template_index: 1 }),
+    ];
+
+    const layout = computeVisiblePortLayout({
+      interfaces,
+      ports,
+      rackView: "front",
+      deviceWidth: 100,
+      deviceHeight: 30,
+    });
+
+    expect(layout).toEqual([
+      { iface: interfaces[0], port: ports[0], x: 46, y: 22 },
+      { iface: interfaces[1], port: ports[1], x: 54, y: 22 },
+    ]);
+  });
+
+  it("applies the supplied SVG-space offset (Rack SVG space) on top of the device-local position", () => {
+    const interfaces = [createTestInterfaceTemplate()];
+    const ports = [createTestPlacedPort({ id: "port-a", template_index: 0 })];
+
+    const local = computeVisiblePortLayout({
+      interfaces,
+      ports,
+      rackView: "front",
+      deviceWidth: 100,
+      deviceHeight: 30,
+    });
+    const offsetted = computeVisiblePortLayout({
+      interfaces,
+      ports,
+      rackView: "front",
+      deviceWidth: 100,
+      deviceHeight: 30,
+      offset: { x: 17, y: 60 },
+    });
+
+    expect(offsetted[0].x).toBe(local[0].x + 17);
+    expect(offsetted[0].y).toBe(local[0].y + 60);
+  });
+
+  it("keeps an interface with no matching PlacedPort in the layout (legacy data), with port undefined", () => {
+    // Simulates a layout saved before PlacedPort/instantiatePorts existed:
+    // PlacedDevice.ports defaults to [] (see PlacedDeviceSchema), so the
+    // template renders positioned but with no port identity to click/connect.
+    const interfaces = [
+      createTestInterfaceTemplate({ name: "eth0" }),
+      createTestInterfaceTemplate({ name: "eth1" }),
+    ];
+
+    const layout = computeVisiblePortLayout({
+      interfaces,
+      ports: [],
+      rackView: "front",
+      deviceWidth: 100,
+      deviceHeight: 30,
+    });
+
+    expect(layout.length).toBe(interfaces.length);
+    expect(layout.every((entry) => entry.port === undefined)).toBe(true);
+  });
+
+  it("returns no layout once the visible port count exceeds the high-density threshold", () => {
+    const interfaces = Array.from(
+      { length: HIGH_DENSITY_THRESHOLD + 1 },
+      (_, i) => createTestInterfaceTemplate({ name: `eth${i}` }),
+    );
+    const ports = interfaces.map((_, i) =>
+      createTestPlacedPort({ id: `port-${i}`, template_index: i }),
+    );
+
+    const layout = computeVisiblePortLayout({
+      interfaces,
+      ports,
+      rackView: "front",
+      deviceWidth: 400,
+      deviceHeight: 30,
+    });
+
+    // Grouped/badge mode has no individual port position: #1932 (click-to-
+    // connect) cannot target a single port on a high-density device until
+    // multi-row layout (#356) replaces this threshold.
+    expect(layout).toEqual([]);
+  });
+});
+
+describe("rear-face filtering", () => {
+  const interfaces = [
+    createTestInterfaceTemplate({ name: "front-port" }), // position defaults to "front"
+    createTestInterfaceTemplate({ name: "rear-port", position: "rear" }),
+  ];
+  const ports = [
+    createTestPlacedPort({ id: "front-id", template_index: 0 }),
+    createTestPlacedPort({ id: "rear-id", template_index: 1 }),
+  ];
+
+  it("shows only front-positioned ports when viewing the front", () => {
+    const anchors = getPortAnchors({
+      interfaces,
+      ports,
+      rackView: "front",
+      deviceWidth: 100,
+      deviceHeight: 30,
+    });
+
+    expect(anchors.map((a) => a.portId)).toEqual(["front-id"]);
+  });
+
+  it("shows only rear-positioned ports when viewing the rear", () => {
+    const anchors = getPortAnchors({
+      interfaces,
+      ports,
+      rackView: "rear",
+      deviceWidth: 100,
+      deviceHeight: 30,
+    });
+
+    expect(anchors.map((a) => a.portId)).toEqual(["rear-id"]);
+  });
+});
+
+describe("template_index disambiguation", () => {
+  it("matches duplicate-named interfaces to the correct PlacedPort via template_index, not name", () => {
+    // Two SFP+ cages sharing a display name; only template_index tells them apart.
+    const interfaces = [
+      createTestInterfaceTemplate({ name: "SFP+", type: "10gbase-x-sfpp" }),
+      createTestInterfaceTemplate({ name: "SFP+", type: "10gbase-x-sfpp" }),
+    ];
+    const ports = [
+      createTestPlacedPort({ id: "second-cage", template_index: 1 }),
+      createTestPlacedPort({ id: "first-cage", template_index: 0 }),
+    ];
+
+    const layout = computeVisiblePortLayout({
+      interfaces,
+      ports,
+      rackView: "front",
+      deviceWidth: 100,
+      deviceHeight: 30,
+    });
+
+    expect(layout[0].port?.id).toBe("first-cage");
+    expect(layout[1].port?.id).toBe("second-cage");
+  });
+});
+
+describe("getPortAnchor", () => {
+  const interfaces = [
+    createTestInterfaceTemplate({ name: "eth0" }),
+    createTestInterfaceTemplate({ name: "eth1" }),
+  ];
+  const ports = [
+    createTestPlacedPort({ id: "port-a", template_index: 0 }),
+    createTestPlacedPort({ id: "port-b", template_index: 1 }),
+  ];
+  const options = {
+    interfaces,
+    ports,
+    rackView: "front" as const,
+    deviceWidth: 100,
+    deviceHeight: 30,
+  };
+
+  it("looks up a single PlacedPort's anchor by id", () => {
+    expect(getPortAnchor("port-b", options)).toEqual({
+      portId: "port-b",
+      x: 54,
+      y: 22,
+    });
+  });
+
+  it("returns undefined for a port id that has no rendered anchor (wrong face, unknown id, or grouped mode)", () => {
+    expect(getPortAnchor("does-not-exist", options)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Adds a shared, pure geometry helper that positions ports keyed by `PlacedPort.id` instead of `InterfaceTemplate` alone, and updates `onPortClick` to surface that identity. This is a prerequisite for connection rendering (#1931) and click-to-connect (#1932); it changes no visual output.

## The geometry helper

New module: `src/lib/utils/port-geometry.ts`.

```ts
export function computeVisiblePortLayout(options: PortGeometryOptions): PortLayoutEntry[]
export function getPortAnchors(options: PortGeometryOptions): PortAnchor[]
export function getPortAnchor(portId: string, options: PortGeometryOptions): PortAnchor | undefined
```

`PortGeometryOptions` takes `interfaces`, `ports`, `rackView`, `deviceWidth`, `deviceHeight`, and an optional `offset: { x, y }`.

- **Pure and DOM-free**: no Svelte runes, no component mounting required. It is exactly the single-row centred layout `PortIndicators` already computed (`PORT_SPACING`, `PORT_Y_OFFSET`), factored out and now the single source of truth for both rendering and future connection-endpoint lookup.
- **Rack SVG space via `offset`**: `PortIndicators` calls it with no offset (device-local coordinates, since it already renders inside the device's own `<g transform>`). `ConnectionLayer` (#1931), which will render at the Rack SVG root, can pass the same offset `RackDevice.svelte` computes today (`RAIL_WIDTH + slotXOffset`, `RACK_PADDING + RAIL_WIDTH + yPosition`) to get absolute Rack SVG coordinates for a `Connection.a_port_id`/`b_port_id` endpoint.
- **template_index disambiguation**: ports are paired to interfaces by `template_index` (position in `DeviceType.interfaces` at instantiation time), not by name, since duplicate interface names are legal.
- **Rear-face filtering**: unchanged from current behaviour, `iface.position ?? "front"` compared to `rackView`.
- **Legacy data**: `PlacedDevice.ports` defaults to `[]` via the schema (`ports: z.array(PlacedPortSchema).default([])`), so a layout saved before `PlacedPort`/`instantiatePorts()` existed, or a device type with an interface template added after the device was placed, has no matching `PlacedPort` for some or all interfaces. `computeVisiblePortLayout` still returns a position for every visible interface (`port: undefined` when unmatched) so rendering is unaffected; `getPortAnchors`/`getPortAnchor` only return entries that do have a `PlacedPort.id`, since there's nothing to key a connection endpoint by otherwise.
- **Grouped/high-density mode** (more than `HIGH_DENSITY_THRESHOLD` = 24 visible ports): `computeVisiblePortLayout` returns `[]`, so `getPortAnchors`/`getPortAnchor` never produce an anchor for a badge-grouped device. This is the documented limitation for #1932: badges have no per-port target until multi-row layout (#356) replaces the single-row threshold. #356 is also why the layout algorithm lives behind this function boundary rather than inline in the component: swapping it for a row-aware algorithm later doesn't change the public API (lookup by `PlacedPort.id`, same `PortAnchor` shape).

## onPortClick payload change

Before:

```ts
onPortClick?: (iface: InterfaceTemplate) => void;
```

After (new `PortClickInfo` type in `src/lib/types/index.ts`):

```ts
export interface PortClickInfo {
  portId: string | undefined; // PlacedPort.id, undefined for legacy/unmatched ports
  iface: InterfaceTemplate;
}

onPortClick?: (info: PortClickInfo) => void;
```

Call sites updated:

- `src/lib/components/PortIndicators.svelte`: added `ports?: PlacedPort[]` prop (default `[]`); `portPositions` now delegates to `computeVisiblePortLayout`; `handlePortClick` now takes `(iface, port)` and emits `{ portId: port?.id, iface }`.
- `src/lib/components/RackDevice.svelte`: added `ports?: PlacedPort[]` prop, forwarded to `PortIndicators`; `onPortClick` type updated to `(info: PortClickInfo) => void`.
- `src/lib/components/Rack.svelte`: now passes `ports={placedDevice.ports}` down to `RackDevice`, alongside the existing `placedDeviceId`/`placedDeviceName` props.

No other call site consumed `onPortClick` before this change (confirmed by search), so there was nothing else to update.

## No visual change

- Grouped/badge-mode rendering (`portGroups`, `badgePositions`) is untouched, still computed locally in `PortIndicators.svelte`.
- Individual port positions come from the exact formula that was inline before (`totalWidth = (count - 1) * PORT_SPACING`, `startX = (deviceWidth - totalWidth) / 2`, `y = deviceHeight - PORT_Y_OFFSET`), just moved into `computeVisiblePortLayout` and imported back. `PORT_SPACING`/`PORT_Y_OFFSET`/`HIGH_DENSITY_THRESHOLD` are now defined once in `port-geometry.ts` and imported by `PortIndicators.svelte`, instead of duplicated, so there's no way for the two to drift.
- The rendered dot/circle markup, colours, mgmt/PoE/direction indicators, and keying (`port?.id ?? iface.name`, falling back to the prior `iface.name` key when no port exists) are unchanged.
- The existing regression test `src/tests/RackDevice.port-indicators.test.ts` (#3009, no `ports` prop passed) still passes unmodified, confirming interface-driven rendering still works with `ports` absent.
- The visual-regression CI job is the backstop if any of this reasoning is wrong.

## Test evidence

New: `src/tests/port-geometry.test.ts` (9 tests, pure unit tests, no DOM):

- centred single-row layout math, keyed by `PlacedPort.id`
- `offset` applied on top of device-local coordinates (Rack SVG space)
- legacy data: interface with no matching `PlacedPort` still gets a layout position, with `port: undefined`
- grouped/high-density mode returns no layout (`[]`) once visible count exceeds `HIGH_DENSITY_THRESHOLD`
- rear-face filtering: front/rear ports resolve independently by `rackView`
- template_index disambiguation: duplicate-named interfaces matched to the correct `PlacedPort` via `template_index`, not name
- `getPortAnchor` single-id lookup, including the not-found case

No `querySelector`/`toHaveClass`/exact-length-literal assertions.

Verification run:

```
VITEST_MAX_WORKERS=2 npm run test:run   # 249 files, 3662 tests, all passed
npm run check                            # svelte-check: 0 errors, 0 warnings
npx eslint <touched files>               # no issues
svelte-autofixer on PortIndicators.svelte and RackDevice.svelte  # no issues
npx prettier --check <touched files>     # all pass (types/index.ts pre-existing local-toolchain
                                          # mismatch unrelated to this change, confirmed present
                                          # on unmodified main under the same local prettier 3.8.4)
```

Closes #3089

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Let port clicks identify the exact port instance**

### What Changed
- Port clicks now include the specific port ID along with the interface name, so actions like connect-from-click can target the right port instance
- Port positions are now calculated from a shared layout rule, keeping the visible port placement and future cable anchor points aligned
- Devices with many ports still switch to grouped badges, and those grouped ports do not expose individual click targets
- Added tests for port placement, rear-face filtering, duplicate interface names, offset positioning, legacy devices without stored ports, and high-density behavior

### Impact
`✅ Click-to-connect can target the correct port`
`✅ Fewer wrong-port connections on devices with duplicate port names`
`✅ Reliable port behavior on front and rear rack views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
