### PR TITLE
feat: connection store with validation and undo support

### DIFF
--- a/src/lib/stores/commands/connection.ts
+++ b/src/lib/stores/commands/connection.ts
@@ -1,0 +1,88 @@
+/**
+ * Connection Commands for Undo/Redo
+ *
+ * Connections are addressed by stable `id` in a flat array
+ * (`Layout.connections`), so unlike device commands there is no
+ * index-shifting to resolve at undo time — raw mutators key directly off
+ * the connection id.
+ */
+
+import type { Command } from "./types";
+import type { Connection } from "$lib/types";
+
+/**
+ * Interface for layout store operations needed by connection commands
+ */
+export interface ConnectionCommandStore {
+  addConnectionRaw(connection: Connection): void;
+  updateConnectionRaw(id: string, updates: Partial<Connection>): void;
+  removeConnectionRaw(id: string): void;
+}
+
+/**
+ * Create a command to add a connection
+ */
+export function createAddConnectionCommand(
+  connection: Connection,
+  store: ConnectionCommandStore,
+  description: string = "Add connection",
+): Command {
+  return {
+    type: "ADD_CONNECTION",
+    description,
+    timestamp: Date.now(),
+    execute() {
+      store.addConnectionRaw(connection);
+    },
+    undo() {
+      store.removeConnectionRaw(connection.id);
+    },
+  };
+}
+
+/**
+ * Create a command to update a connection.
+ * `before` and `after` should contain only the keys being changed.
+ */
+export function createUpdateConnectionCommand(
+  id: string,
+  before: Partial<Connection>,
+  after: Partial<Connection>,
+  store: ConnectionCommandStore,
+  description: string = "Update connection",
+): Command {
+  return {
+    type: "UPDATE_CONNECTION",
+    description,
+    timestamp: Date.now(),
+    execute() {
+      store.updateConnectionRaw(id, after);
+    },
+    undo() {
+      store.updateConnectionRaw(id, before);
+    },
+  };
+}
+
+/**
+ * Create a command to remove a connection. Captures the full connection so
+ * undo can restore it exactly.
+ */
+export function createRemoveConnectionCommand(
+  connection: Connection,
+  store: ConnectionCommandStore,
+  description?: string,
+): Command {
+  const connectionCopy: Connection = { ...connection };
+  return {
+    type: "REMOVE_CONNECTION",
+    description: description ?? "Remove connection",
+    timestamp: Date.now(),
+    execute() {
+      store.removeConnectionRaw(connectionCopy.id);
+    },
+    undo() {
+      store.addConnectionRaw(connectionCopy);
+    },
+  };
+}

--- a/src/lib/stores/commands/connection.ts
+++ b/src/lib/stores/commands/connection.ts
@@ -15,7 +15,10 @@ import type { Connection } from "$lib/types";
  */
 export interface ConnectionCommandStore {
   addConnectionRaw(connection: Connection): void;
-  updateConnectionRaw(id: string, updates: Partial<Connection>): void;
+  updateConnectionRaw(
+    id: string,
+    updates: Partial<Omit<Connection, "id">>,
+  ): void;
   removeConnectionRaw(id: string): void;
 }
 
@@ -46,8 +49,8 @@ export function createAddConnectionCommand(
  */
 export function createUpdateConnectionCommand(
   id: string,
-  before: Partial<Connection>,
-  after: Partial<Connection>,
+  before: Partial<Omit<Connection, "id">>,
+  after: Partial<Omit<Connection, "id">>,
   store: ConnectionCommandStore,
   description: string = "Update connection",
 ): Command {

--- a/src/lib/stores/commands/index.ts
+++ b/src/lib/stores/commands/index.ts
@@ -7,3 +7,4 @@ export * from "./device-type";
 export * from "./device";
 export * from "./rack";
 export * from "./rack-group";
+export * from "./connection";

--- a/src/lib/stores/commands/types.ts
+++ b/src/lib/stores/commands/types.ts
@@ -33,6 +33,9 @@ export type CommandType =
   | "CREATE_RACK_GROUP"
   | "UPDATE_RACK_GROUP"
   | "DELETE_RACK_GROUP"
+  | "ADD_CONNECTION"
+  | "UPDATE_CONNECTION"
+  | "REMOVE_CONNECTION"
   | "BATCH";
 
 /**

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -1,0 +1,322 @@
+/**
+ * Connection Store
+ * CRUD operations and validation for port-to-port connections (#369)
+ *
+ * Structured after cables.svelte.ts, but unlike the deprecated Cable store
+ * (retiring in #3091), the mutating operations here go through the layout
+ * store's recorded/raw command pattern (src/lib/stores/layout/
+ * recorded-connection-actions.ts + src/lib/stores/commands/connection.ts),
+ * so add/update/remove are undoable via the existing history system.
+ *
+ * Connections reference PlacedPort.id directly (Connection.a_port_id /
+ * b_port_id). Serialization with stable port IDs across save/load is out of
+ * scope here — see #3090.
+ */
+
+import { SvelteSet } from "svelte/reactivity";
+import type { Connection, PlacedPort } from "$lib/types";
+import { generateId } from "$lib/utils/device";
+import { getPortCategory } from "$lib/utils/port-utils";
+import { getLayoutStore } from "./layout.svelte";
+
+/**
+ * Input for creating a new connection
+ */
+export interface CreateConnectionInput {
+  a_port_id: string;
+  b_port_id: string;
+  label?: string;
+  color?: string;
+}
+
+/**
+ * Validation result for connection operations. Errors block the operation;
+ * warnings are informational only (a mismatched connection is still allowed,
+ * e.g. bridging a network port to a console port for out-of-band access).
+ */
+export interface ConnectionValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Every PlacedPort across every rack. Connections reference ports by id
+ * only, and ports live on PlacedDevice.ports, so validation must search
+ * every rack, not just the active one (mirrors validateCable's cross-rack
+ * device lookup in cables.svelte.ts).
+ */
+function getAllPlacedPorts(): PlacedPort[] {
+  const layoutStore = getLayoutStore();
+  return layoutStore.racks.flatMap((rack) =>
+    rack.devices.flatMap((device) => device.ports ?? []),
+  );
+}
+
+/**
+ * Validate connection data against layout constraints.
+ *
+ * This function is exported for unit testing. Application code should use
+ * getConnectionStore().validateConnection(), which automatically supplies
+ * the current connection list and port index from the layout store.
+ *
+ * @param input - Connection data to validate
+ * @param connections - Existing connections (for duplicate/port-in-use checks)
+ * @param allPorts - Every placed port across every rack (for type/category lookups)
+ * @param excludeConnectionId - Connection ID to exclude from checks (for updates)
+ */
+export function validateConnection(
+  input: CreateConnectionInput,
+  connections: Connection[],
+  allPorts: PlacedPort[],
+  excludeConnectionId?: string,
+): ConnectionValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Self-connection
+  if (input.a_port_id === input.b_port_id) {
+    errors.push("Cannot connect a port to itself");
+  }
+
+  // Both ports must reference a placed port
+  const aPort = allPorts.find((p) => p.id === input.a_port_id);
+  const bPort = allPorts.find((p) => p.id === input.b_port_id);
+  if (!aPort) {
+    errors.push(`A-side port not found: ${input.a_port_id}`);
+  }
+  if (!bPort) {
+    errors.push(`B-side port not found: ${input.b_port_id}`);
+  }
+
+  // Single connection per port: most ports allow only one connection
+  const isPortInUse = (portId: string) =>
+    connections.some(
+      (c) =>
+        c.id !== excludeConnectionId &&
+        (c.a_port_id === portId || c.b_port_id === portId),
+    );
+  if (isPortInUse(input.a_port_id)) {
+    errors.push(`Port already has a connection: ${input.a_port_id}`);
+  }
+  if (input.b_port_id !== input.a_port_id && isPortInUse(input.b_port_id)) {
+    errors.push(`Port already has a connection: ${input.b_port_id}`);
+  }
+
+  // Duplicate connection between the same two ports, in either direction
+  const isDuplicate = connections.some((existing) => {
+    if (excludeConnectionId && existing.id === excludeConnectionId)
+      return false;
+    const matchesForward =
+      existing.a_port_id === input.a_port_id &&
+      existing.b_port_id === input.b_port_id;
+    const matchesReverse =
+      existing.a_port_id === input.b_port_id &&
+      existing.b_port_id === input.a_port_id;
+    return matchesForward || matchesReverse;
+  });
+  if (isDuplicate) {
+    errors.push("Connection already exists between these ports");
+  }
+
+  // Category/type compatibility (warning only). The Connection model has no
+  // class field: compatibility is always derived from the referenced ports'
+  // types via getPortCategory(), never stored. A category mismatch (e.g.
+  // network <-> power) is the stronger signal; only check exact type
+  // equality when the categories already agree, to avoid two warnings for
+  // the same underlying mismatch.
+  if (aPort && bPort) {
+    const aCategory = getPortCategory(aPort.type);
+    const bCategory = getPortCategory(bPort.type);
+    if (aCategory !== bCategory) {
+      warnings.push(
+        `Port categories do not match: ${aCategory} vs ${bCategory}`,
+      );
+    } else if (aPort.type !== bPort.type) {
+      warnings.push(`Port types do not match: ${aPort.type} vs ${bPort.type}`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Get access to the connection store.
+ * Provides CRUD operations, validation, and undo/redo-backed mutation for
+ * port-to-port connections within the current layout.
+ * @returns Store object with connection operations
+ */
+export function getConnectionStore() {
+  const layoutStore = getLayoutStore();
+
+  /**
+   * Get all connections from the current layout
+   */
+  function getConnections(): Connection[] {
+    return layoutStore.layout.connections ?? [];
+  }
+
+  /**
+   * Get a connection by ID
+   */
+  function getConnection(id: string): Connection | undefined {
+    return getConnections().find((c) => c.id === id);
+  }
+
+  /**
+   * Get connections attached to a specific port
+   */
+  function getConnectionsForPort(portId: string): Connection[] {
+    return getConnections().filter(
+      (c) => c.a_port_id === portId || c.b_port_id === portId,
+    );
+  }
+
+  /**
+   * Get connections attached to any port on a specific device
+   */
+  function getConnectionsForDevice(deviceId: string): Connection[] {
+    const device = layoutStore.racks
+      .flatMap((rack) => rack.devices)
+      .find((d) => d.id === deviceId);
+    if (!device?.ports || device.ports.length === 0) return [];
+    const portIds = new SvelteSet(device.ports.map((p) => p.id));
+    return getConnections().filter(
+      (c) => portIds.has(c.a_port_id) || portIds.has(c.b_port_id),
+    );
+  }
+
+  /**
+   * Add a new connection to the layout. Undoable via the layout store's
+   * history.
+   * @returns The created connection, or the validation errors that blocked it
+   */
+  function addConnection(
+    input: CreateConnectionInput,
+  ): { connection: Connection } | { errors: string[] } {
+    const validation = validateConnection(
+      input,
+      getConnections(),
+      getAllPlacedPorts(),
+    );
+    if (!validation.valid) {
+      return { errors: validation.errors };
+    }
+
+    const connection: Connection = {
+      id: generateId(),
+      a_port_id: input.a_port_id,
+      b_port_id: input.b_port_id,
+      label: input.label,
+      color: input.color,
+    };
+
+    layoutStore.addConnectionRecorded(connection);
+
+    return { connection };
+  }
+
+  /**
+   * Update an existing connection. Undoable via the layout store's history.
+   * @returns Success, or the validation errors that blocked the update
+   */
+  function updateConnection(
+    id: string,
+    updates: Partial<Connection>,
+  ): { success: true } | { errors: string[] } {
+    const existing = getConnection(id);
+    if (!existing) {
+      return { errors: ["Connection not found"] };
+    }
+
+    // Only revalidate endpoints if the update touches a port; label/color
+    // edits skip the port-based checks entirely.
+    if (updates.a_port_id !== undefined || updates.b_port_id !== undefined) {
+      const merged: CreateConnectionInput = {
+        a_port_id: updates.a_port_id ?? existing.a_port_id,
+        b_port_id: updates.b_port_id ?? existing.b_port_id,
+      };
+      const validation = validateConnection(
+        merged,
+        getConnections(),
+        getAllPlacedPorts(),
+        id,
+      );
+      if (!validation.valid) {
+        return { errors: validation.errors };
+      }
+    }
+
+    layoutStore.updateConnectionRecorded(id, updates);
+
+    return { success: true };
+  }
+
+  /**
+   * Remove a connection from the layout. Undoable via the layout store's
+   * history.
+   * @returns The removed connection, or undefined if not found
+   */
+  function removeConnection(id: string): Connection | undefined {
+    return layoutStore.removeConnectionRecorded(id);
+  }
+
+  /**
+   * Remove every connection attached to any port on a device, as a single
+   * undoable unit.
+   * @returns The number of connections removed
+   */
+  function removeConnectionsForDevice(deviceId: string): number {
+    const device = layoutStore.racks
+      .flatMap((rack) => rack.devices)
+      .find((d) => d.id === deviceId);
+    if (!device?.ports || device.ports.length === 0) return 0;
+    const portIds = new SvelteSet(device.ports.map((p) => p.id));
+    return layoutStore.removeConnectionsForPortsRecorded(portIds);
+  }
+
+  // =============================================================================
+  // Raw operations (bypass dirty tracking and history; used by the undo/redo
+  // command layer itself, exposed here for API symmetry with the CRUD ops)
+  // =============================================================================
+
+  function addConnectionRaw(connection: Connection): void {
+    layoutStore.addConnectionRaw(connection);
+  }
+
+  function updateConnectionRaw(
+    id: string,
+    updates: Partial<Connection>,
+  ): void {
+    layoutStore.updateConnectionRaw(id, updates);
+  }
+
+  function removeConnectionRaw(id: string): void {
+    layoutStore.removeConnectionRaw(id);
+  }
+
+  return {
+    // Getters
+    get connections() {
+      return getConnections();
+    },
+    getConnection,
+    getConnectionsForPort,
+    getConnectionsForDevice,
+
+    // CRUD operations (undo/redo-backed)
+    addConnection,
+    updateConnection,
+    removeConnection,
+    removeConnectionsForDevice,
+
+    // Raw operations (for undo/redo)
+    addConnectionRaw,
+    updateConnectionRaw,
+    removeConnectionRaw,
+
+    // Validation
+    validateConnection: (input: CreateConnectionInput) =>
+      validateConnection(input, getConnections(), getAllPlacedPorts()),
+  };
+}

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -179,7 +179,9 @@ export function getConnectionStore() {
    * in sync (plain Set is blocked here by the svelte/prefer-svelte-reactivity
    * ESLint rule, which applies to *.svelte.ts regardless of reactivity).
    */
-  function getPortIdsForDevice(deviceId: string): SvelteSet<string> | undefined {
+  function getPortIdsForDevice(
+    deviceId: string,
+  ): SvelteSet<string> | undefined {
     const device = layoutStore.racks
       .flatMap((rack) => rack.devices)
       .find((d) => d.id === deviceId);

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -173,14 +173,26 @@ export function getConnectionStore() {
   }
 
   /**
-   * Get connections attached to any port on a specific device
+   * Resolve a device across every rack and return the SvelteSet of its port
+   * ids, or undefined if the device is missing or has no ports. Shared by
+   * getConnectionsForDevice and removeConnectionsForDevice so the two stay
+   * in sync (plain Set is blocked here by the svelte/prefer-svelte-reactivity
+   * ESLint rule, which applies to *.svelte.ts regardless of reactivity).
    */
-  function getConnectionsForDevice(deviceId: string): Connection[] {
+  function getPortIdsForDevice(deviceId: string): SvelteSet<string> | undefined {
     const device = layoutStore.racks
       .flatMap((rack) => rack.devices)
       .find((d) => d.id === deviceId);
-    if (!device?.ports || device.ports.length === 0) return [];
-    const portIds = new SvelteSet(device.ports.map((p) => p.id));
+    if (!device?.ports || device.ports.length === 0) return undefined;
+    return new SvelteSet(device.ports.map((p) => p.id));
+  }
+
+  /**
+   * Get connections attached to any port on a specific device
+   */
+  function getConnectionsForDevice(deviceId: string): Connection[] {
+    const portIds = getPortIdsForDevice(deviceId);
+    if (!portIds) return [];
     return getConnections().filter(
       (c) => portIds.has(c.a_port_id) || portIds.has(c.b_port_id),
     );
@@ -222,22 +234,29 @@ export function getConnectionStore() {
    */
   function updateConnection(
     id: string,
-    updates: Partial<Connection>,
+    updates: Partial<Omit<Connection, "id">>,
   ): { success: true } | { errors: string[] } {
     const existing = getConnection(id);
     if (!existing) {
       return { errors: ["Connection not found"] };
     }
 
-    // Only revalidate endpoints if the update touches a port; label/color
-    // edits skip the port-based checks entirely.
-    if (updates.a_port_id !== undefined || updates.b_port_id !== undefined) {
-      const merged: CreateConnectionInput = {
-        a_port_id: updates.a_port_id ?? existing.a_port_id,
-        b_port_id: updates.b_port_id ?? existing.b_port_id,
-      };
+    // Revalidate whenever the payload touches an endpoint key at all, not
+    // just when its value is non-undefined: an explicit `{ a_port_id:
+    // undefined }` still has the key present and would otherwise skip this
+    // gate, then blank the endpoint when the raw mutator spreads it in.
+    const touchesAPort = "a_port_id" in updates;
+    const touchesBPort = "b_port_id" in updates;
+    if (touchesAPort || touchesBPort) {
+      const nextAPortId = touchesAPort ? updates.a_port_id : existing.a_port_id;
+      const nextBPortId = touchesBPort ? updates.b_port_id : existing.b_port_id;
+      // a_port_id/b_port_id are required strings on Connection; an explicit
+      // undefined/empty value here is itself invalid, not "no change".
+      if (!nextAPortId || !nextBPortId) {
+        return { errors: ["Connection endpoints cannot be cleared"] };
+      }
       const validation = validateConnection(
-        merged,
+        { a_port_id: nextAPortId, b_port_id: nextBPortId },
         getConnections(),
         getAllPlacedPorts(),
         id,
@@ -267,11 +286,8 @@ export function getConnectionStore() {
    * @returns The number of connections removed
    */
   function removeConnectionsForDevice(deviceId: string): number {
-    const device = layoutStore.racks
-      .flatMap((rack) => rack.devices)
-      .find((d) => d.id === deviceId);
-    if (!device?.ports || device.ports.length === 0) return 0;
-    const portIds = new SvelteSet(device.ports.map((p) => p.id));
+    const portIds = getPortIdsForDevice(deviceId);
+    if (!portIds) return 0;
     return layoutStore.removeConnectionsForPortsRecorded(portIds);
   }
 
@@ -284,7 +300,10 @@ export function getConnectionStore() {
     layoutStore.addConnectionRaw(connection);
   }
 
-  function updateConnectionRaw(id: string, updates: Partial<Connection>): void {
+  function updateConnectionRaw(
+    id: string,
+    updates: Partial<Omit<Connection, "id">>,
+  ): void {
     layoutStore.updateConnectionRaw(id, updates);
   }
 

--- a/src/lib/stores/connection.svelte.ts
+++ b/src/lib/stores/connection.svelte.ts
@@ -284,10 +284,7 @@ export function getConnectionStore() {
     layoutStore.addConnectionRaw(connection);
   }
 
-  function updateConnectionRaw(
-    id: string,
-    updates: Partial<Connection>,
-  ): void {
+  function updateConnectionRaw(id: string, updates: Partial<Connection>): void {
     layoutStore.updateConnectionRaw(id, updates);
   }
 

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -18,6 +18,7 @@ import type {
   RackView,
   DisplayMode,
   Cable,
+  Connection,
 } from "$lib/types";
 import { MAX_RACKS } from "$lib/types/constants";
 import { createLayout } from "$lib/utils/serialization";
@@ -96,6 +97,9 @@ import {
   updateCableRaw as updateCableRawImpl,
   removeCableRaw as removeCableRawImpl,
   removeCablesRaw as removeCablesRawImpl,
+  addConnectionRaw as addConnectionRawImpl,
+  updateConnectionRaw as updateConnectionRawImpl,
+  removeConnectionRaw as removeConnectionRawImpl,
 } from "./layout/mutators";
 import {
   addDeviceTypeRecorded as addDeviceTypeRecordedImpl,
@@ -119,6 +123,12 @@ import {
   updateRacksBatchRecorded as updateRacksBatchRecordedImpl,
   clearRackRecorded as clearRackRecordedImpl,
 } from "./layout/recorded-rack-actions";
+import {
+  addConnectionRecorded as addConnectionRecordedImpl,
+  updateConnectionRecorded as updateConnectionRecordedImpl,
+  removeConnectionRecorded as removeConnectionRecordedImpl,
+  removeConnectionsForPortsRecorded as removeConnectionsForPortsRecordedImpl,
+} from "./layout/recorded-connection-actions";
 import {
   duplicateDevice as duplicateDeviceImpl,
   placeInContainer as placeInContainerImpl,
@@ -382,6 +392,17 @@ export function createLayoutStore(
     updateCableRaw,
     removeCableRaw,
     removeCablesRaw,
+
+    // Connection raw actions
+    addConnectionRaw,
+    updateConnectionRaw,
+    removeConnectionRaw,
+
+    // Connection recorded actions (use undo/redo)
+    addConnectionRecorded,
+    updateConnectionRecorded,
+    removeConnectionRecorded,
+    removeConnectionsForPortsRecorded,
 
     // Utility
     getUsedDeviceTypeSlugs,
@@ -1074,6 +1095,44 @@ export function createLayoutStore(
 
   function removeCablesRaw(ids: Set<string>): void {
     removeCablesRawImpl(stateAccess, ids);
+  }
+
+  // Connection raw actions
+
+  function addConnectionRaw(connection: Connection): void {
+    addConnectionRawImpl(stateAccess, connection);
+  }
+
+  function updateConnectionRaw(
+    id: string,
+    updates: Partial<Connection>,
+  ): void {
+    updateConnectionRawImpl(stateAccess, id, updates);
+  }
+
+  function removeConnectionRaw(id: string): void {
+    removeConnectionRawImpl(stateAccess, id);
+  }
+
+  // Connection recorded actions (use undo/redo)
+
+  function addConnectionRecorded(connection: Connection): void {
+    addConnectionRecordedImpl(stateAccess, connection);
+  }
+
+  function updateConnectionRecorded(
+    id: string,
+    updates: Partial<Connection>,
+  ): boolean {
+    return updateConnectionRecordedImpl(stateAccess, id, updates);
+  }
+
+  function removeConnectionRecorded(id: string): Connection | undefined {
+    return removeConnectionRecordedImpl(stateAccess, id);
+  }
+
+  function removeConnectionsForPortsRecorded(portIds: Set<string>): number {
+    return removeConnectionsForPortsRecordedImpl(stateAccess, portIds);
   }
 
   // =============================================================================

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -1103,10 +1103,7 @@ export function createLayoutStore(
     addConnectionRawImpl(stateAccess, connection);
   }
 
-  function updateConnectionRaw(
-    id: string,
-    updates: Partial<Connection>,
-  ): void {
+  function updateConnectionRaw(id: string, updates: Partial<Connection>): void {
     updateConnectionRawImpl(stateAccess, id, updates);
   }
 

--- a/src/lib/stores/layout.svelte.ts
+++ b/src/lib/stores/layout.svelte.ts
@@ -1103,7 +1103,10 @@ export function createLayoutStore(
     addConnectionRawImpl(stateAccess, connection);
   }
 
-  function updateConnectionRaw(id: string, updates: Partial<Connection>): void {
+  function updateConnectionRaw(
+    id: string,
+    updates: Partial<Omit<Connection, "id">>,
+  ): void {
     updateConnectionRawImpl(stateAccess, id, updates);
   }
 
@@ -1119,7 +1122,7 @@ export function createLayoutStore(
 
   function updateConnectionRecorded(
     id: string,
-    updates: Partial<Connection>,
+    updates: Partial<Omit<Connection, "id">>,
   ): boolean {
     return updateConnectionRecordedImpl(stateAccess, id, updates);
   }

--- a/src/lib/stores/layout/command-adapters.ts
+++ b/src/lib/stores/layout/command-adapters.ts
@@ -109,8 +109,7 @@ export function getCommandStoreAdapter(
 
     // ConnectionCommandStore
     addConnectionRaw: (connection) => addConnectionRaw(ctx, connection),
-    updateConnectionRaw: (id, updates) =>
-      updateConnectionRaw(ctx, id, updates),
+    updateConnectionRaw: (id, updates) => updateConnectionRaw(ctx, id, updates),
     removeConnectionRaw: (id) => removeConnectionRaw(ctx, id),
 
     // DeviceCommandStore

--- a/src/lib/stores/layout/command-adapters.ts
+++ b/src/lib/stores/layout/command-adapters.ts
@@ -16,6 +16,7 @@ import type {
   DeviceTypeCommandStore,
   DeviceCommandStore,
   RackCommandStore,
+  ConnectionCommandStore,
 } from "../commands";
 import type { LayoutStateAccess } from "./types";
 import { getTargetRack } from "./rack-actions";
@@ -41,6 +42,9 @@ import {
   restoreRackDevicesRaw,
   addCableRaw,
   removeCableRaw,
+  addConnectionRaw,
+  updateConnectionRaw,
+  removeConnectionRaw,
 } from "./mutators";
 
 // =============================================================================
@@ -85,7 +89,10 @@ function resolveAdapterRackId(
  */
 export function getCommandStoreAdapter(
   ctx: LayoutStateAccess,
-): DeviceTypeCommandStore & DeviceCommandStore & RackCommandStore {
+): DeviceTypeCommandStore &
+  DeviceCommandStore &
+  RackCommandStore &
+  ConnectionCommandStore {
   return {
     // DeviceTypeCommandStore
     addDeviceTypeRaw: (deviceType) => addDeviceTypeRaw(ctx, deviceType),
@@ -99,6 +106,12 @@ export function getCommandStoreAdapter(
     getActiveRackId: () => ctx.getActiveRackId(),
     addCableRaw: (cable) => addCableRaw(ctx, cable),
     removeCableRaw: (id) => removeCableRaw(ctx, id),
+
+    // ConnectionCommandStore
+    addConnectionRaw: (connection) => addConnectionRaw(ctx, connection),
+    updateConnectionRaw: (id, updates) =>
+      updateConnectionRaw(ctx, id, updates),
+    removeConnectionRaw: (id) => removeConnectionRaw(ctx, id),
 
     // DeviceCommandStore
     moveDeviceRaw: (index, newPosition) =>

--- a/src/lib/stores/layout/mutators.ts
+++ b/src/lib/stores/layout/mutators.ts
@@ -709,13 +709,18 @@ export function addConnectionRaw(
 export function updateConnectionRaw(
   ctx: LayoutStateAccess,
   id: string,
-  updates: Partial<Connection>,
+  updates: Partial<Omit<Connection, "id">>,
 ): void {
   const layout = ctx.getLayout();
   ctx.setLayout({
     ...layout,
+    // `id: c.id` after the spread pins identity even if a caller with a wider
+    // (e.g. Partial<Connection>) or untyped payload smuggles an `id` key
+    // through — the type narrowing above blocks this at compile time for
+    // normal callers, but this is the single mutation choke point, so the
+    // invariant is enforced here regardless of how updates was constructed.
     connections: (layout.connections ?? []).map((c) =>
-      c.id === id ? { ...c, ...updates } : c,
+      c.id === id ? { ...c, ...updates, id: c.id } : c,
     ),
   });
 }

--- a/src/lib/stores/layout/mutators.ts
+++ b/src/lib/stores/layout/mutators.ts
@@ -12,6 +12,7 @@
 
 import type {
   Cable,
+  Connection,
   DeviceFace,
   DeviceType,
   PlacedDevice,
@@ -676,5 +677,58 @@ export function removeCablesRaw(
   ctx.setLayout({
     ...layout,
     cables: (layout.cables ?? []).filter((c) => !ids.has(c.id)),
+  });
+}
+
+// =============================================================================
+// Connection Raw Mutators
+// =============================================================================
+
+/**
+ * Add a connection directly (raw)
+ * @param ctx - Layout state access
+ * @param connection - Connection to add
+ */
+export function addConnectionRaw(
+  ctx: LayoutStateAccess,
+  connection: Connection,
+): void {
+  const layout = ctx.getLayout();
+  ctx.setLayout({
+    ...layout,
+    connections: [...(layout.connections ?? []), connection],
+  });
+}
+
+/**
+ * Update a connection directly (raw)
+ * @param ctx - Layout state access
+ * @param id - Connection ID to update
+ * @param updates - Properties to update
+ */
+export function updateConnectionRaw(
+  ctx: LayoutStateAccess,
+  id: string,
+  updates: Partial<Connection>,
+): void {
+  const layout = ctx.getLayout();
+  ctx.setLayout({
+    ...layout,
+    connections: (layout.connections ?? []).map((c) =>
+      c.id === id ? { ...c, ...updates } : c,
+    ),
+  });
+}
+
+/**
+ * Remove a connection directly (raw)
+ * @param ctx - Layout state access
+ * @param id - Connection ID to remove
+ */
+export function removeConnectionRaw(ctx: LayoutStateAccess, id: string): void {
+  const layout = ctx.getLayout();
+  ctx.setLayout({
+    ...layout,
+    connections: (layout.connections ?? []).filter((c) => c.id !== id),
   });
 }

--- a/src/lib/stores/layout/recorded-connection-actions.ts
+++ b/src/lib/stores/layout/recorded-connection-actions.ts
@@ -49,7 +49,7 @@ export function addConnectionRecorded(
 export function updateConnectionRecorded(
   ctx: LayoutStateAccess,
   id: string,
-  updates: Partial<Connection>,
+  updates: Partial<Omit<Connection, "id">>,
 ): boolean {
   const layout = ctx.getLayout();
   const existing = (layout.connections ?? []).find((c) => c.id === id);
@@ -57,8 +57,11 @@ export function updateConnectionRecorded(
 
   // Capture before-state for only the keys being changed, mirroring
   // updateRackRecorded in recorded-rack-actions.ts.
-  const before: Partial<Connection> = {};
-  for (const key of Object.keys(updates) as (keyof Connection)[]) {
+  const before: Partial<Omit<Connection, "id">> = {};
+  for (const key of Object.keys(updates) as (keyof Omit<
+    Connection,
+    "id"
+  >)[]) {
     before[key] = existing[key] as never;
   }
 

--- a/src/lib/stores/layout/recorded-connection-actions.ts
+++ b/src/lib/stores/layout/recorded-connection-actions.ts
@@ -58,10 +58,7 @@ export function updateConnectionRecorded(
   // Capture before-state for only the keys being changed, mirroring
   // updateRackRecorded in recorded-rack-actions.ts.
   const before: Partial<Omit<Connection, "id">> = {};
-  for (const key of Object.keys(updates) as (keyof Omit<
-    Connection,
-    "id"
-  >)[]) {
+  for (const key of Object.keys(updates) as (keyof Omit<Connection, "id">)[]) {
     before[key] = existing[key] as never;
   }
 

--- a/src/lib/stores/layout/recorded-connection-actions.ts
+++ b/src/lib/stores/layout/recorded-connection-actions.ts
@@ -1,0 +1,145 @@
+/**
+ * Recorded Connection Actions for Layout Store
+ *
+ * Connection-level operations with undo/redo support. Each function creates
+ * a Command wrapping the raw mutators in ./mutators.ts, then executes it
+ * through the history system. Mirrors the recorded/raw pattern used by
+ * recorded-device-actions.ts, but connections are id-keyed (no
+ * index-shifting to resolve at undo time).
+ */
+
+import type { Connection } from "$lib/types";
+import {
+  createAddConnectionCommand,
+  createUpdateConnectionCommand,
+  createRemoveConnectionCommand,
+  createBatchCommand,
+} from "../commands";
+import type { LayoutStateAccess } from "./types";
+import { getCommandStoreAdapter } from "./command-adapters";
+
+/**
+ * Add a connection with undo/redo support
+ * @param ctx - Layout state access
+ * @param connection - Connection to add
+ */
+export function addConnectionRecorded(
+  ctx: LayoutStateAccess,
+  connection: Connection,
+): void {
+  const history = ctx.getHistory();
+  const adapter = getCommandStoreAdapter(ctx);
+
+  const command = createAddConnectionCommand(
+    connection,
+    adapter,
+    `Add connection ${connection.label ?? connection.id}`,
+  );
+  history.execute(command);
+  ctx.markDirty();
+}
+
+/**
+ * Update a connection with undo/redo support
+ * @param ctx - Layout state access
+ * @param id - Connection ID to update
+ * @param updates - Properties to update
+ * @returns true if the connection existed and was updated
+ */
+export function updateConnectionRecorded(
+  ctx: LayoutStateAccess,
+  id: string,
+  updates: Partial<Connection>,
+): boolean {
+  const layout = ctx.getLayout();
+  const existing = (layout.connections ?? []).find((c) => c.id === id);
+  if (!existing) return false;
+
+  // Capture before-state for only the keys being changed, mirroring
+  // updateRackRecorded in recorded-rack-actions.ts.
+  const before: Partial<Connection> = {};
+  for (const key of Object.keys(updates) as (keyof Connection)[]) {
+    before[key] = existing[key] as never;
+  }
+
+  const history = ctx.getHistory();
+  const adapter = getCommandStoreAdapter(ctx);
+
+  const command = createUpdateConnectionCommand(
+    id,
+    before,
+    updates,
+    adapter,
+    `Update connection ${existing.label ?? id}`,
+  );
+  history.execute(command);
+  ctx.markDirty();
+  return true;
+}
+
+/**
+ * Remove a connection with undo/redo support
+ * @param ctx - Layout state access
+ * @param id - Connection ID to remove
+ * @returns The removed connection, or undefined if it did not exist
+ */
+export function removeConnectionRecorded(
+  ctx: LayoutStateAccess,
+  id: string,
+): Connection | undefined {
+  const layout = ctx.getLayout();
+  const existing = (layout.connections ?? []).find((c) => c.id === id);
+  if (!existing) return undefined;
+
+  const history = ctx.getHistory();
+  const adapter = getCommandStoreAdapter(ctx);
+
+  const command = createRemoveConnectionCommand(
+    existing,
+    adapter,
+    `Remove connection ${existing.label ?? id}`,
+  );
+  history.execute(command);
+  ctx.markDirty();
+  return existing;
+}
+
+/**
+ * Remove every connection referencing any of the given port IDs, as a single
+ * undoable unit. Used when a device (and its ports) is removed.
+ * @param ctx - Layout state access
+ * @param portIds - Port IDs whose connections should be removed
+ * @returns The number of connections removed
+ */
+export function removeConnectionsForPortsRecorded(
+  ctx: LayoutStateAccess,
+  portIds: Set<string>,
+): number {
+  if (portIds.size === 0) return 0;
+
+  const layout = ctx.getLayout();
+  const matching = (layout.connections ?? []).filter(
+    (c) => portIds.has(c.a_port_id) || portIds.has(c.b_port_id),
+  );
+  if (matching.length === 0) return 0;
+
+  const history = ctx.getHistory();
+  const adapter = getCommandStoreAdapter(ctx);
+
+  const commands = matching.map((connection) =>
+    createRemoveConnectionCommand(
+      connection,
+      adapter,
+      `Remove connection ${connection.label ?? connection.id}`,
+    ),
+  );
+
+  const command =
+    commands.length === 1
+      ? commands[0]!
+      : createBatchCommand(`Remove ${matching.length} connections`, commands);
+
+  history.execute(command);
+  ctx.markDirty();
+  return matching.length;
+}

--- a/src/tests/connection-store.test.ts
+++ b/src/tests/connection-store.test.ts
@@ -13,7 +13,7 @@ import {
   validateConnection,
 } from "$lib/stores/connection.svelte";
 import { getLayoutStore } from "$lib/stores/layout.svelte";
-import type { InterfaceType, PlacedPort } from "$lib/types";
+import type { Connection, InterfaceType, PlacedPort } from "$lib/types";
 import {
   createTestLayoutStore,
   createTestDeviceType,
@@ -43,6 +43,48 @@ function placeDeviceWithPorts(
   return { deviceId: device.id, ports: device.ports ?? [] };
 }
 
+/**
+ * Narrow an addConnection-style result to its success case, throwing with
+ * the validation errors if it failed. Removes the repeated
+ * `"connection"/"errors" in result` + manual cast pattern.
+ */
+function expectConnection(
+  result: { connection: Connection } | { errors: string[] },
+): Connection {
+  if (!("connection" in result)) {
+    throw new Error(
+      `Expected a connection, got errors: ${result.errors.join(", ")}`,
+    );
+  }
+  return result.connection;
+}
+
+/**
+ * Narrow an addConnection-style result to its failure case, throwing if it
+ * unexpectedly succeeded.
+ */
+function expectConnectionErrors(
+  result: { connection: Connection } | { errors: string[] },
+): string[] {
+  if (!("errors" in result)) {
+    throw new Error("Expected validation errors, got a connection");
+  }
+  return result.errors;
+}
+
+/**
+ * Narrow an updateConnection-style result to its failure case, throwing if
+ * it unexpectedly succeeded.
+ */
+function expectUpdateErrors(
+  result: { success: true } | { errors: string[] },
+): string[] {
+  if (!("errors" in result)) {
+    throw new Error("Expected validation errors, got success");
+  }
+  return result.errors;
+}
+
 describe("connection store", () => {
   let layoutStore: ReturnType<typeof getLayoutStore>;
   let rackId: string;
@@ -68,8 +110,7 @@ describe("connection store", () => {
         b_port_id: b.ports[0]!.id,
       });
 
-      expect("connection" in result).toBe(true);
-      const connection = (result as { connection: { id: string } }).connection;
+      const connection = expectConnection(result);
       expect(connection.id).toBeTruthy();
       expect(store.connections).toContainEqual(
         expect.objectContaining({
@@ -97,15 +138,14 @@ describe("connection store", () => {
         a_port_id: a.ports[0]!.id,
         b_port_id: b.ports[0]!.id,
       });
-      expect("connection" in first).toBe(true);
+      expectConnection(first);
 
       const second = store.addConnection({
         a_port_id: a.ports[0]!.id,
         b_port_id: c.ports[0]!.id,
       });
 
-      expect("errors" in second).toBe(true);
-      expect((second as { errors: string[] }).errors.length).toBeGreaterThan(0);
+      expect(expectConnectionErrors(second).length).toBeGreaterThan(0);
       // Only the first connection was created.
       expect(store.getConnectionsForPort(a.ports[0]!.id)).toContainEqual(
         expect.objectContaining({ b_port_id: b.ports[0]!.id }),
@@ -128,11 +168,8 @@ describe("connection store", () => {
         b_port_id: a.ports[0]!.id,
       });
 
-      expect("errors" in result).toBe(true);
       expect(
-        (result as { errors: string[] }).errors.some((e) =>
-          e.includes("itself"),
-        ),
+        expectConnectionErrors(result).some((e) => e.includes("itself")),
       ).toBe(true);
     });
   });
@@ -151,16 +188,15 @@ describe("connection store", () => {
         a_port_id: a.ports[0]!.id,
         b_port_id: b.ports[0]!.id,
       });
-      expect("connection" in first).toBe(true);
+      expectConnection(first);
 
       const duplicate = store.addConnection({
         a_port_id: a.ports[0]!.id,
         b_port_id: b.ports[0]!.id,
       });
 
-      expect("errors" in duplicate).toBe(true);
       expect(
-        (duplicate as { errors: string[] }).errors.some((e) =>
+        expectConnectionErrors(duplicate).some((e) =>
           e.toLowerCase().includes("already exists"),
         ),
       ).toBe(true);
@@ -268,7 +304,177 @@ describe("connection store", () => {
         b_port_id: b.ports[0]!.id,
       });
 
-      expect("connection" in result).toBe(true);
+      expectConnection(result);
+    });
+  });
+
+  describe("updateConnection", () => {
+    it("applies a successful endpoint update", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const c = placeDeviceWithPorts(layoutStore, rackId, "device-c", 15, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      const created = expectConnection(
+        store.addConnection({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
+
+      const result = store.updateConnection(created.id, {
+        b_port_id: c.ports[0]!.id,
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(store.getConnection(created.id)).toEqual(
+        expect.objectContaining({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: c.ports[0]!.id,
+        }),
+      );
+    });
+
+    it("rejects a port change that fails validation, leaving the connection unchanged", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const c = placeDeviceWithPorts(layoutStore, rackId, "device-c", 15, [
+        "1000base-t",
+      ]);
+      const d = placeDeviceWithPorts(layoutStore, rackId, "device-d", 20, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      const created = expectConnection(
+        store.addConnection({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
+      // c's port is already connected to d, so retargeting connection 1's
+      // a-side onto c's port should fail the single-connection-per-port
+      // check rather than silently succeeding.
+      store.addConnection({
+        a_port_id: c.ports[0]!.id,
+        b_port_id: d.ports[0]!.id,
+      });
+
+      const result = store.updateConnection(created.id, {
+        a_port_id: c.ports[0]!.id,
+      });
+
+      expect(expectUpdateErrors(result).length).toBeGreaterThan(0);
+      expect(store.getConnection(created.id)).toEqual(
+        expect.objectContaining({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
+    });
+
+    it("applies a label/color-only update without endpoint validation", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      const created = expectConnection(
+        store.addConnection({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
+
+      const result = store.updateConnection(created.id, {
+        label: "uplink",
+        color: "#ff5500",
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(store.getConnection(created.id)).toEqual(
+        expect.objectContaining({ label: "uplink", color: "#ff5500" }),
+      );
+    });
+  });
+
+  describe("update integrity: id cannot be overwritten", () => {
+    it("ignores an id field slipped into updateConnection's payload and leaves undo intact", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      const created = expectConnection(
+        store.addConnection({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
+      const originalId = created.id;
+      layoutStore.clearHistory();
+
+      // A caller with a loosely-typed payload (e.g. Partial<Connection> from
+      // elsewhere) smuggles an `id` field through the public update API.
+      // updateConnection's own signature now excludes `id`
+      // (Partial<Omit<Connection, "id">>), so this models a caller whose
+      // payload type is wider than that, cast away for the test.
+      const payload: Record<string, unknown> = {
+        id: "smuggled-id",
+        label: "renamed",
+      };
+      store.updateConnection(
+        originalId,
+        payload as Partial<Omit<Connection, "id">>,
+      );
+
+      // Identity must be untouched: still reachable by its original id, not
+      // reachable under the smuggled one.
+      expect(store.getConnection(originalId)?.label).toBe("renamed");
+      expect(store.getConnection("smuggled-id")).toBeUndefined();
+
+      // Undo must still find the connection by its original id.
+      expect(layoutStore.canUndo).toBe(true);
+      layoutStore.undo();
+      expect(store.getConnection(originalId)?.label).toBeUndefined();
+    });
+  });
+
+  describe("update integrity: endpoints cannot be blanked", () => {
+    it("rejects an explicit undefined a_port_id instead of skipping validation", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      const created = expectConnection(
+        store.addConnection({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
+
+      const result = store.updateConnection(created.id, {
+        a_port_id: undefined,
+        label: "x",
+      });
+
+      expect(expectUpdateErrors(result).length).toBeGreaterThan(0);
+      expect(store.getConnection(created.id)?.a_port_id).toBe(a.ports[0]!.id);
     });
   });
 
@@ -294,7 +500,19 @@ describe("connection store", () => {
         a_port_id: hub.ports[1]!.id,
         b_port_id: b.ports[0]!.id,
       });
-      expect(store.getConnectionsForDevice(hub.deviceId).length).toBe(2);
+      const beforeRemoval = store.getConnectionsForDevice(hub.deviceId);
+      expect(beforeRemoval).toContainEqual(
+        expect.objectContaining({
+          a_port_id: hub.ports[0]!.id,
+          b_port_id: a.ports[0]!.id,
+        }),
+      );
+      expect(beforeRemoval).toContainEqual(
+        expect.objectContaining({
+          a_port_id: hub.ports[1]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
 
       const removedCount = store.removeConnectionsForDevice(hub.deviceId);
 
@@ -353,17 +571,19 @@ describe("connection store", () => {
         "1000base-t",
       ]);
       const store = getConnectionStore();
-      const created = store.addConnection({
-        a_port_id: a.ports[0]!.id,
-        b_port_id: b.ports[0]!.id,
-      }) as { connection: { id: string } };
+      const created = expectConnection(
+        store.addConnection({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
       layoutStore.clearHistory();
 
-      store.removeConnection(created.connection.id);
-      expect(store.getConnection(created.connection.id)).toBeUndefined();
+      store.removeConnection(created.id);
+      expect(store.getConnection(created.id)).toBeUndefined();
 
       layoutStore.undo();
-      expect(store.getConnection(created.connection.id)).toEqual(
+      expect(store.getConnection(created.id)).toEqual(
         expect.objectContaining({
           a_port_id: a.ports[0]!.id,
           b_port_id: b.ports[0]!.id,
@@ -398,7 +618,19 @@ describe("connection store", () => {
       expect(layoutStore.canUndo).toBe(true);
 
       layoutStore.undo();
-      expect(store.getConnectionsForDevice(hub.deviceId).length).toBe(2);
+      const restored = store.getConnectionsForDevice(hub.deviceId);
+      expect(restored).toContainEqual(
+        expect.objectContaining({
+          a_port_id: hub.ports[0]!.id,
+          b_port_id: a.ports[0]!.id,
+        }),
+      );
+      expect(restored).toContainEqual(
+        expect.objectContaining({
+          a_port_id: hub.ports[1]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
       expect(layoutStore.canUndo).toBe(false);
     });
   });
@@ -430,14 +662,16 @@ describe("connection store", () => {
         "1000base-t",
       ]);
       const store = getConnectionStore();
-      const created = store.addConnection({
-        a_port_id: a.ports[0]!.id,
-        b_port_id: b.ports[0]!.id,
-      }) as { connection: { id: string } };
+      const created = expectConnection(
+        store.addConnection({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
       layoutStore.markClean();
       expect(layoutStore.isDirty).toBe(false);
 
-      store.removeConnection(created.connection.id);
+      store.removeConnection(created.id);
 
       expect(layoutStore.isDirty).toBe(true);
     });

--- a/src/tests/connection-store.test.ts
+++ b/src/tests/connection-store.test.ts
@@ -69,8 +69,7 @@ describe("connection store", () => {
       });
 
       expect("connection" in result).toBe(true);
-      const connection = (result as { connection: { id: string } })
-        .connection;
+      const connection = (result as { connection: { id: string } }).connection;
       expect(connection.id).toBeTruthy();
       expect(store.connections).toContainEqual(
         expect.objectContaining({
@@ -106,9 +105,7 @@ describe("connection store", () => {
       });
 
       expect("errors" in second).toBe(true);
-      expect((second as { errors: string[] }).errors.length).toBeGreaterThan(
-        0,
-      );
+      expect((second as { errors: string[] }).errors.length).toBeGreaterThan(0);
       // Only the first connection was created.
       expect(store.getConnectionsForPort(a.ports[0]!.id)).toContainEqual(
         expect.objectContaining({ b_port_id: b.ports[0]!.id }),
@@ -192,8 +189,11 @@ describe("connection store", () => {
 
       expect(validation.valid).toBe(false);
       expect(
-        validation.errors.some((e) => e.toLowerCase().includes("duplicate") ||
-          e.toLowerCase().includes("already exists")),
+        validation.errors.some(
+          (e) =>
+            e.toLowerCase().includes("duplicate") ||
+            e.toLowerCase().includes("already exists"),
+        ),
       ).toBe(true);
     });
   });
@@ -214,9 +214,9 @@ describe("connection store", () => {
       });
 
       expect(validation.valid).toBe(true);
-      expect(
-        validation.warnings.some((w) => w.includes("categories")),
-      ).toBe(true);
+      expect(validation.warnings.some((w) => w.includes("categories"))).toBe(
+        true,
+      );
     });
 
     it("warns on type mismatch within the same category (RJ45 vs SFP)", () => {

--- a/src/tests/connection-store.test.ts
+++ b/src/tests/connection-store.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Connection Store Tests (#369)
+ *
+ * Covers CRUD, validation rules, undo/redo integration, and dirty-state
+ * tracking for the port-to-port connection store. Ports come from placing
+ * real devices (DeviceType.interfaces -> PlacedPort via instantiatePorts),
+ * mirroring how the app generates port ids in practice.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getConnectionStore,
+  validateConnection,
+} from "$lib/stores/connection.svelte";
+import { getLayoutStore } from "$lib/stores/layout.svelte";
+import type { InterfaceType, PlacedPort } from "$lib/types";
+import {
+  createTestLayoutStore,
+  createTestDeviceType,
+  createTestInterfaceTemplate,
+} from "./factories";
+
+/**
+ * Place a device with the given interface types in a rack and return its id
+ * plus the resulting PlacedPort instances (real, store-generated ids).
+ */
+function placeDeviceWithPorts(
+  store: ReturnType<typeof getLayoutStore>,
+  rackId: string,
+  slug: string,
+  position: number,
+  interfaceTypes: InterfaceType[],
+): { deviceId: string; ports: PlacedPort[] } {
+  const deviceType = createTestDeviceType({ slug });
+  deviceType.interfaces = interfaceTypes.map((type, i) =>
+    createTestInterfaceTemplate({ name: `port-${i}`, type }),
+  );
+  store.addDeviceTypeRaw(deviceType);
+  store.placeDevice(rackId, slug, position);
+  const device = store.racks
+    .flatMap((r) => r.devices)
+    .find((d) => d.device_type === slug)!;
+  return { deviceId: device.id, ports: device.ports ?? [] };
+}
+
+describe("connection store", () => {
+  let layoutStore: ReturnType<typeof getLayoutStore>;
+  let rackId: string;
+
+  beforeEach(() => {
+    layoutStore = createTestLayoutStore();
+    const rack = layoutStore.addRack("Test Rack", 42)!;
+    rackId = rack.id;
+  });
+
+  describe("addConnection", () => {
+    it("creates a valid connection between two ports", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+
+      const result = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+
+      expect("connection" in result).toBe(true);
+      const connection = (result as { connection: { id: string } })
+        .connection;
+      expect(connection.id).toBeTruthy();
+      expect(store.connections).toContainEqual(
+        expect.objectContaining({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
+    });
+  });
+
+  describe("validation: single connection per port", () => {
+    it("errors when double-connecting an already-connected port", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const c = placeDeviceWithPorts(layoutStore, rackId, "device-c", 15, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+
+      const first = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+      expect("connection" in first).toBe(true);
+
+      const second = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: c.ports[0]!.id,
+      });
+
+      expect("errors" in second).toBe(true);
+      expect((second as { errors: string[] }).errors.length).toBeGreaterThan(
+        0,
+      );
+      // Only the first connection was created.
+      expect(store.getConnectionsForPort(a.ports[0]!.id)).toContainEqual(
+        expect.objectContaining({ b_port_id: b.ports[0]!.id }),
+      );
+      expect(store.getConnectionsForPort(a.ports[0]!.id)).not.toContainEqual(
+        expect.objectContaining({ b_port_id: c.ports[0]!.id }),
+      );
+    });
+  });
+
+  describe("validation: self-connection", () => {
+    it("errors when connecting a port to itself", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+
+      const result = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: a.ports[0]!.id,
+      });
+
+      expect("errors" in result).toBe(true);
+      expect(
+        (result as { errors: string[] }).errors.some((e) =>
+          e.includes("itself"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("validation: duplicate connection", () => {
+    it("errors when creating a duplicate connection between the same ports", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+
+      const first = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+      expect("connection" in first).toBe(true);
+
+      const duplicate = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+
+      expect("errors" in duplicate).toBe(true);
+      expect(
+        (duplicate as { errors: string[] }).errors.some((e) =>
+          e.toLowerCase().includes("already exists"),
+        ),
+      ).toBe(true);
+    });
+
+    it("errors on a reversed duplicate too (validated directly, isolated from the port-in-use check)", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+
+      const validation = validateConnection(
+        { a_port_id: b.ports[0]!.id, b_port_id: a.ports[0]!.id },
+        [
+          {
+            id: "existing",
+            a_port_id: a.ports[0]!.id,
+            b_port_id: b.ports[0]!.id,
+          },
+        ],
+        [...a.ports, ...b.ports],
+      );
+
+      expect(validation.valid).toBe(false);
+      expect(
+        validation.errors.some((e) => e.toLowerCase().includes("duplicate") ||
+          e.toLowerCase().includes("already exists")),
+      ).toBe(true);
+    });
+  });
+
+  describe("validation: category and type compatibility", () => {
+    it("warns on category mismatch (network vs console)", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "console",
+      ]);
+      const store = getConnectionStore();
+
+      const validation = store.validateConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+
+      expect(validation.valid).toBe(true);
+      expect(
+        validation.warnings.some((w) => w.includes("categories")),
+      ).toBe(true);
+    });
+
+    it("warns on type mismatch within the same category (RJ45 vs SFP)", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-x-sfp",
+      ]);
+      const store = getConnectionStore();
+
+      const validation = store.validateConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+
+      expect(validation.valid).toBe(true);
+      expect(validation.warnings.some((w) => w.includes("types"))).toBe(true);
+    });
+
+    it("raises no warning when both port type and category match", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+
+      const validation = store.validateConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+
+      expect(validation.warnings).toEqual([]);
+    });
+
+    it("does not block addConnection: warnings are non-blocking", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "console",
+      ]);
+      const store = getConnectionStore();
+
+      const result = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+
+      expect("connection" in result).toBe(true);
+    });
+  });
+
+  describe("removeConnectionsForDevice", () => {
+    it("removes every connection attached to any port on the device", () => {
+      const hub = placeDeviceWithPorts(layoutStore, rackId, "hub", 5, [
+        "1000base-t",
+        "1000base-t",
+      ]);
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 10, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 15, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+
+      store.addConnection({
+        a_port_id: hub.ports[0]!.id,
+        b_port_id: a.ports[0]!.id,
+      });
+      store.addConnection({
+        a_port_id: hub.ports[1]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+      expect(store.getConnectionsForDevice(hub.deviceId).length).toBe(2);
+
+      const removedCount = store.removeConnectionsForDevice(hub.deviceId);
+
+      expect(removedCount).toBe(2);
+      expect(store.getConnectionsForDevice(hub.deviceId)).toEqual([]);
+      expect(store.getConnectionsForPort(a.ports[0]!.id)).toEqual([]);
+      expect(store.getConnectionsForPort(b.ports[0]!.id)).toEqual([]);
+    });
+
+    it("returns 0 and records no history entry when the device has no connections", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      layoutStore.clearHistory();
+
+      const removedCount = getConnectionStore().removeConnectionsForDevice(
+        a.deviceId,
+      );
+
+      expect(removedCount).toBe(0);
+      expect(layoutStore.canUndo).toBe(false);
+    });
+  });
+
+  describe("undo/redo", () => {
+    it("undoes and redoes addConnection through the layout store history", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      layoutStore.clearHistory();
+
+      store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+      expect(store.connections.length).toBeGreaterThan(0);
+      expect(layoutStore.canUndo).toBe(true);
+
+      layoutStore.undo();
+      expect(store.connections).toEqual([]);
+      expect(layoutStore.canRedo).toBe(true);
+
+      layoutStore.redo();
+      expect(store.connections.length).toBeGreaterThan(0);
+    });
+
+    it("undoes removeConnection, restoring the connection", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      const created = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      }) as { connection: { id: string } };
+      layoutStore.clearHistory();
+
+      store.removeConnection(created.connection.id);
+      expect(store.getConnection(created.connection.id)).toBeUndefined();
+
+      layoutStore.undo();
+      expect(store.getConnection(created.connection.id)).toEqual(
+        expect.objectContaining({
+          a_port_id: a.ports[0]!.id,
+          b_port_id: b.ports[0]!.id,
+        }),
+      );
+    });
+
+    it("undoes removeConnectionsForDevice as a single step", () => {
+      const hub = placeDeviceWithPorts(layoutStore, rackId, "hub", 5, [
+        "1000base-t",
+        "1000base-t",
+      ]);
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 10, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 15, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      store.addConnection({
+        a_port_id: hub.ports[0]!.id,
+        b_port_id: a.ports[0]!.id,
+      });
+      store.addConnection({
+        a_port_id: hub.ports[1]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+      layoutStore.clearHistory();
+
+      store.removeConnectionsForDevice(hub.deviceId);
+      expect(store.getConnectionsForDevice(hub.deviceId)).toEqual([]);
+      expect(layoutStore.canUndo).toBe(true);
+
+      layoutStore.undo();
+      expect(store.getConnectionsForDevice(hub.deviceId).length).toBe(2);
+      expect(layoutStore.canUndo).toBe(false);
+    });
+  });
+
+  describe("dirty state", () => {
+    it("marks the layout dirty when a connection is added", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      layoutStore.markClean();
+      expect(layoutStore.isDirty).toBe(false);
+
+      getConnectionStore().addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      });
+
+      expect(layoutStore.isDirty).toBe(true);
+    });
+
+    it("marks the layout dirty when a connection is removed", () => {
+      const a = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const b = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const store = getConnectionStore();
+      const created = store.addConnection({
+        a_port_id: a.ports[0]!.id,
+        b_port_id: b.ports[0]!.id,
+      }) as { connection: { id: string } };
+      layoutStore.markClean();
+      expect(layoutStore.isDirty).toBe(false);
+
+      store.removeConnection(created.connection.id);
+
+      expect(layoutStore.isDirty).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Implements issue #369: a connection store with CRUD operations, validation, and undo/redo support for port-to-port connections.

## Store API

`src/lib/stores/connection.svelte.ts` (`getConnectionStore()`):

- `connections` (getter), `getConnection(id)`, `getConnectionsForPort(portId)`, `getConnectionsForDevice(deviceId)`
- `addConnection(input)` returns `{ connection }` or `{ errors }`
- `updateConnection(id, updates)` returns `{ success: true }` or `{ errors }`
- `removeConnection(id)` returns the removed `Connection` or `undefined`
- `removeConnectionsForDevice(deviceId)` returns the number removed, as a single undoable step
- `addConnectionRaw` / `updateConnectionRaw` / `removeConnectionRaw` (bypass history and dirty tracking, for API symmetry with the CRUD ops and for the undo/redo command layer)
- `validateConnection(input)` returns `{ valid, errors, warnings }`

## Validation rules

| Rule | Severity | Notes |
| --- | --- | --- |
| Self-connection (`a_port_id === b_port_id`) | error | |
| Port already connected | error | Most ports allow only one connection |
| Duplicate connection between the same two ports | error | Checked in both directions |
| Port category mismatch | warning | Derived via `getPortCategory(type)` from `src/lib/utils/port-utils.ts`; non-blocking |
| Port type mismatch within the same category | warning | e.g. RJ45 vs SFP, both `network`; only checked when categories already agree, to avoid double-reporting the same mismatch |

The Connection model has no `class` field. Compatibility is always derived from the referenced ports' `type`, never stored, per the issue's technical notes.

## Connection type/schema decision

`Connection` (in `src/lib/types/index.ts`) and `ConnectionSchema` (in `src/lib/schemas/index.ts`) already existed, added by #365 alongside `PlacedPort`. `Layout.connections?: Connection[]` is already a field on the schema. This PR reuses that type as-is rather than defining a new one; no type/schema changes were needed.

## Undo/redo integration

Wired into the existing recorded/raw command pattern (`src/lib/stores/layout/` + `src/lib/stores/history.svelte.ts`), not a standalone scheme:

- `src/lib/stores/commands/connection.ts`: new `ADD_CONNECTION` / `UPDATE_CONNECTION` / `REMOVE_CONNECTION` command types and `ConnectionCommandStore` interface, following the shape of `commands/device-type.ts` and `commands/rack.ts`. Connections are id-keyed in a flat array (`Layout.connections`), so unlike device commands there's no index-shifting to resolve at undo time.
- `src/lib/stores/layout/mutators.ts`: raw mutators (`addConnectionRaw` / `updateConnectionRaw` / `removeConnectionRaw`), mirroring the existing Cable raw mutators.
- `src/lib/stores/layout/command-adapters.ts`: `getCommandStoreAdapter()` now also implements `ConnectionCommandStore`.
- `src/lib/stores/layout/recorded-connection-actions.ts`: recorded wrappers (`addConnectionRecorded` / `updateConnectionRecorded` / `removeConnectionRecorded` / `removeConnectionsForPortsRecorded`) that build a `Command`, call `history.execute()`, then `ctx.markDirty()`, exactly mirroring `recorded-device-actions.ts`. `removeConnectionsForPortsRecorded` batches multiple removals into one `createBatchCommand` so `removeConnectionsForDevice` undoes as a single step.
- `src/lib/stores/layout.svelte.ts`: exposes the raw and recorded connection functions on the layout store facade, same as the existing Cable raw actions and the `placeDeviceRecorded`-style recorded actions.

`connection.svelte.ts`'s `addConnection` / `updateConnection` / `removeConnection` call the layout store's recorded functions (not the raw ones), so every mutation is undoable via `store.undo()` / `store.canUndo` on the shared layout store, and dirty state (`store.isDirty`) updates through the same `ctx.markDirty()` call every other recorded action uses.

Note: the deprecated `cables.svelte.ts` (`addCable`/`updateCable`/`removeCable`) does *not* go through this recorded pattern today, it calls raw mutators directly and is not undoable. That gap is inherited tech debt on the Cable store being retired in #3091; this PR does not touch `cables.svelte.ts`.

## Scope boundaries (explicitly out of scope)

- **Serialization** (stable port IDs across save/load, YAML round-trip, `KNOWN_TOP_LEVEL_KEYS`): deferred to #3090.
- **Port rendering / geometry**: untouched; this PR only reads `getPortCategory()` from `src/lib/utils/port-utils.ts`, and does not touch `PortIndicators`, `RackDevice`, or any rendering surface (in-flight in parallel via #3089).
- **Wiring `removeConnectionsForDevice` into device removal**: the method exists and is tested directly, but `removeDeviceRecorded` in `recorded-device-actions.ts` is not changed to call it automatically. Not requested by the issue's acceptance criteria; left for follow-up once connections are actually created through the UI.

## Test evidence

New `src/tests/connection-store.test.ts` (16 tests), covering every item in the issue's Test Requirements: `addConnection` creates a valid connection, double-connecting a port errors, type mismatch warns (both category mismatch and same-category type mismatch, plus a positive "no warning when matched" case), self-connection errors, duplicate connection errors (including the reversed-pair case), `removeConnectionsForDevice` removes every connection for a device, undo/redo works for add/remove/batch-remove, and dirty state updates on add and remove. Ports are set up by placing real devices with `DeviceType.interfaces` (so port ids come from the real `instantiatePorts` path, not hand-rolled fixtures).

```
VITEST_MAX_WORKERS=2 npm run test:run
Test Files  249 passed (249)
     Tests  3669 passed (3669)

npm run check
COMPLETED 5507 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

npx eslint <all touched files>
No issues found
```

## Deviations from the issue

None. The `ConnectionValidationResult` type name follows the repo's existing `<Domain>ValidationResult` convention (`CableValidationResult`, `RackValidationResult`, `ImageValidationResult`) rather than the bare `ValidationResult` used in the issue's pseudocode API.

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Add undoable port-to-port connections with validation**

### What Changed
- Added a connection store for creating, updating, removing, and listing connections between device ports
- Connections now block self-links, duplicate links, and ports that are already in use
- Connections between mismatched port categories or types are still allowed, but now show warnings
- Removing a device now removes all of its attached connections as one undoable action
- Connection changes now work with undo and redo, and mark the layout as changed

### Impact
`✅ Safer connection setup`
`✅ Fewer duplicate wiring mistakes`
`✅ Undoable connection edits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
