### PR TITLE
feat: cascade delete connections on device removal

### DIFF
--- a/src/lib/stores/layout/recorded-device-actions.ts
+++ b/src/lib/stores/layout/recorded-device-actions.ts
@@ -15,7 +15,10 @@ import { canPlaceDevice, requiresCarrier } from "$lib/utils/collision";
 import { effectiveFace } from "$lib/utils/effective-face";
 import { findDeviceType as findDeviceTypeInArray } from "$lib/stores/layout-helpers";
 import { findDeviceType } from "$lib/utils/device-lookup";
-import { findCablesForDevices } from "./recorded-device-type-actions";
+import {
+  findCablesForDevices,
+  findConnectionsForDevices,
+} from "./recorded-device-type-actions";
 import { debug } from "$lib/utils/debug";
 import { generateId } from "$lib/utils/device";
 import { instantiatePorts } from "$lib/utils/port-utils";
@@ -32,6 +35,7 @@ import {
   createDetachContainerCommand,
   createUpdateDeviceNotesCommand,
   createUpdateDeviceIpCommand,
+  createRemoveConnectionCommand,
   createBatchCommand,
   type Command,
 } from "../commands";
@@ -443,7 +447,18 @@ export function removeDeviceRecorded(
     ...children.map((child) => ({ rackId, device: child })),
   ]);
 
-  const command =
+  // Connections reference placed devices' ports by id. Deleting a device (or
+  // a carrier and its children) without cleaning up its connections leaves
+  // dangling port references, saved as-is on the next autosave (#639).
+  // Gather them here and fold their removal into the same undo step as the
+  // device removal below, so undo restores the device and its connections
+  // together.
+  const connectedConnections = findConnectionsForDevices(ctx, [
+    { rackId, device },
+    ...children.map((child) => ({ rackId, device: child })),
+  ]);
+
+  const removeCommand =
     children.length > 0
       ? createRemoveDeviceWithChildrenCommand(
           device,
@@ -460,8 +475,41 @@ export function removeDeviceRecorded(
           layout.metadata?.id ?? "",
           connectedCables,
         );
+
+  // Connections don't need the id-remap handling cables need: they key off
+  // PlacedPort.id, and port ids never change across a remove/restore cycle
+  // (unlike device ids, which placeDeviceRaw can remap on collision), so a
+  // plain REMOVE_CONNECTION per connection is enough. Compose them ahead of
+  // the device removal so execute() clears connections before the device
+  // disappears, and undo (which runs in reverse) restores the device before
+  // the connections that reference its ports.
+  const connectionCommands: Command[] = connectedConnections.map((connection) =>
+    createRemoveConnectionCommand(
+      connection,
+      adapter,
+      `Remove connection ${connection.label ?? connection.id}`,
+    ),
+  );
+
+  const command =
+    connectionCommands.length > 0
+      ? createBatchCommand(`Remove ${deviceName}`, [
+          ...connectionCommands,
+          removeCommand,
+        ])
+      : removeCommand;
+
   history.execute(command);
   ctx.markDirty();
+
+  if (connectedConnections.length > 0) {
+    debug.deviceRemove({
+      deviceName,
+      connectionsRemoved: connectedConnections.length,
+      connectionIds: connectedConnections.map((c) => c.id),
+    });
+  }
+
   return deviceName;
 }
 

--- a/src/lib/stores/layout/recorded-device-type-actions.ts
+++ b/src/lib/stores/layout/recorded-device-type-actions.ts
@@ -6,7 +6,7 @@
  * wrapping raw mutators, then executes it through the history system.
  */
 
-import type { Cable, DeviceType, PlacedDevice } from "$lib/types";
+import type { Cable, Connection, DeviceType, PlacedDevice } from "$lib/types";
 import {
   createDeviceType as createDeviceTypeHelper,
   findDeviceType as findDeviceTypeInArray,
@@ -17,7 +17,9 @@ import {
   createAddDeviceTypeCommand,
   createUpdateDeviceTypeCommand,
   createDeleteDeviceTypeCommand,
+  createRemoveConnectionCommand,
   createBatchCommand,
+  type Command,
 } from "../commands";
 import type { LayoutStateAccess } from "./types";
 import { getCommandStoreAdapter } from "./command-adapters";
@@ -93,6 +95,30 @@ export function findCablesForDevices(
 }
 
 /**
+ * Find connections attached to any port on the given placed devices.
+ * Used so REMOVE_DEVICE / REMOVE_DEVICE_WITH_CHILDREN (#639) and
+ * DELETE_DEVICE_TYPE can clean up dangling connection endpoints, mirroring
+ * findCablesForDevices above. Unlike cables, connections reference
+ * PlacedPort.id (not device id), and port ids never change across a
+ * remove/restore cycle, so no id-remap bookkeeping is needed on undo.
+ */
+export function findConnectionsForDevices(
+  ctx: LayoutStateAccess,
+  placedDevices: { rackId: string; device: PlacedDevice }[],
+): Connection[] {
+  const layout = ctx.getLayout();
+  const connections = layout.connections;
+  if (!connections || connections.length === 0) return [];
+  const portIds = new Set(
+    placedDevices.flatMap((p) => (p.device.ports ?? []).map((port) => port.id)),
+  );
+  if (portIds.size === 0) return [];
+  return connections.filter(
+    (c) => portIds.has(c.a_port_id) || portIds.has(c.b_port_id),
+  );
+}
+
+/**
  * Delete a device type with undo/redo support
  * @param ctx - Layout state access
  * @param slug - Device type slug
@@ -107,16 +133,37 @@ export function deleteDeviceTypeRecorded(
 
   const placedDevices = getPlacedDevicesWithRackForType(ctx, slug);
   const connectedCables = findCablesForDevices(ctx, placedDevices);
+  const connectedConnections = findConnectionsForDevices(ctx, placedDevices);
   const history = ctx.getHistory();
   const adapter = getCommandStoreAdapter(ctx);
 
-  const command = createDeleteDeviceTypeCommand(
+  const deleteCommand = createDeleteDeviceTypeCommand(
     existing,
     placedDevices,
     adapter,
     connectedCables,
     layout.metadata?.id ?? "",
   );
+
+  // Connections reference PlacedPort.id, which DELETE_DEVICE_TYPE's device
+  // restore never remaps, so a plain REMOVE_CONNECTION per connection is
+  // enough (#639, mirrors the cable handling above).
+  const connectionCommands: Command[] = connectedConnections.map((connection) =>
+    createRemoveConnectionCommand(
+      connection,
+      adapter,
+      `Remove connection ${connection.label ?? connection.id}`,
+    ),
+  );
+
+  const command =
+    connectionCommands.length > 0
+      ? createBatchCommand(`Delete ${existing.model ?? existing.slug}`, [
+          ...connectionCommands,
+          deleteCommand,
+        ])
+      : deleteCommand;
+
   history.execute(command);
   ctx.markDirty();
 }
@@ -151,6 +198,10 @@ export function deleteMultipleDeviceTypesRecorded(
   // A cable connecting devices of two different types would otherwise be
   // snapshotted by both per-type delete commands, restoring it twice on undo.
   const claimedCableIds = new Set<string>();
+  // Same double-restore risk for a connection spanning two of the deleted
+  // types (#639).
+  const claimedConnectionIds = new Set<string>();
+  const connectionCommands: Command[] = [];
 
   for (const slug of slugs) {
     const existing = findDeviceTypeInArray(layout.device_types, slug);
@@ -164,6 +215,23 @@ export function deleteMultipleDeviceTypesRecorded(
         return true;
       },
     );
+    const connectedConnections = findConnectionsForDevices(
+      ctx,
+      placedDevices,
+    ).filter((connection) => {
+      if (claimedConnectionIds.has(connection.id)) return false;
+      claimedConnectionIds.add(connection.id);
+      return true;
+    });
+    for (const connection of connectedConnections) {
+      connectionCommands.push(
+        createRemoveConnectionCommand(
+          connection,
+          adapter,
+          `Remove connection ${connection.label ?? connection.id}`,
+        ),
+      );
+    }
     const command = createDeleteDeviceTypeCommand(
       existing,
       placedDevices,
@@ -191,7 +259,10 @@ export function deleteMultipleDeviceTypesRecorded(
     description,
   );
 
-  const batchCommand = createBatchCommand(description, commands);
+  const batchCommand = createBatchCommand(description, [
+    ...connectionCommands,
+    ...commands,
+  ]);
   history.execute(batchCommand);
   ctx.markDirty();
 

--- a/src/lib/utils/debug.ts
+++ b/src/lib/utils/debug.ts
@@ -107,6 +107,16 @@ export const debug = {
     toPosition: number;
     result: string;
   }) => layoutDebug.device("move %O", data),
+  /**
+   * Warn that removing a device cascaded into deleting its connections
+   * (#639), so a layout that looked fully wired can silently lose links
+   * without a trace unless this is surfaced.
+   */
+  deviceRemove: (data: {
+    deviceName: string;
+    connectionsRemoved: number;
+    connectionIds: string[];
+  }) => layoutDebug.device("remove %O", data),
 };
 
 // Auto-enable in development (browser only)

--- a/src/tests/layout-device-actions.test.ts
+++ b/src/tests/layout-device-actions.test.ts
@@ -9,6 +9,7 @@ import {
   createTestDevice,
   createTestDeviceType,
   createTestDeviceTypeInput,
+  createTestInterfaceTemplate,
 } from "./factories";
 
 describe("Layout Store", () => {
@@ -610,6 +611,210 @@ describe("Layout Store", () => {
 
       expect(reloaded).not.toBeNull();
       expect(reloaded?.cables ?? []).toEqual([]);
+    });
+  });
+
+  describe("removeDeviceFromRack (connection cleanup, #639)", () => {
+    /**
+     * Place two devices with one gigabit port each and connect them; return
+     * their ids plus the connecting Connection's id. Mirrors
+     * setupTwoDevicesWithCable above, but for the port-based Connection model
+     * (#369) rather than the deprecated Cable model.
+     */
+    function setupTwoDevicesWithConnection() {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42)!;
+
+      const deviceType = createTestDeviceType({ slug: "test-switch" });
+      deviceType.interfaces = [
+        createTestInterfaceTemplate({ name: "port-0", type: "1000base-t" }),
+      ];
+      store.addDeviceTypeRaw(deviceType);
+
+      store.placeDevice(rack.id, deviceType.slug, 5);
+      store.placeDevice(rack.id, deviceType.slug, 10);
+      const deviceA = store.rack.devices[0]!;
+      const deviceB = store.rack.devices[1]!;
+
+      const connection = {
+        id: "connection-1",
+        a_port_id: deviceA.ports![0]!.id,
+        b_port_id: deviceB.ports![0]!.id,
+      };
+      store.addConnectionRaw(connection);
+
+      return {
+        store,
+        rack,
+        deviceAId: deviceA.id,
+        deviceBId: deviceB.id,
+        connection,
+      };
+    }
+
+    it("removes connections attached to the deleted device's ports and keeps the layout schema-valid", () => {
+      const { store, rack, deviceAId } = setupTwoDevicesWithConnection();
+      const deviceAIndex = store.rack.devices.findIndex(
+        (d) => d.id === deviceAId,
+      );
+
+      store.removeDeviceFromRack(rack.id, deviceAIndex);
+
+      expect(store.layout.connections ?? []).toEqual([]);
+
+      const result = LayoutSchema.safeParse(store.layout);
+      expect(result.success).toBe(true);
+    });
+
+    it("undo restores the device and its connection in a single step", () => {
+      const { store, rack, deviceAId, deviceBId, connection } =
+        setupTwoDevicesWithConnection();
+      const deviceAIndex = store.rack.devices.findIndex(
+        (d) => d.id === deviceAId,
+      );
+
+      store.removeDeviceFromRack(rack.id, deviceAIndex);
+      expect(store.rack.devices.some((d) => d.id === deviceAId)).toBe(false);
+      expect(store.layout.connections ?? []).toEqual([]);
+
+      store.undo();
+
+      expect(store.rack.devices.some((d) => d.id === deviceAId)).toBe(true);
+      expect(store.layout.connections).toEqual([
+        expect.objectContaining({
+          id: connection.id,
+          a_port_id: connection.a_port_id,
+          b_port_id: connection.b_port_id,
+        }),
+      ]);
+      // Device restore also brought its ports back under the same id, so the
+      // restored connection still points at a real port on device B too.
+      const deviceB = store.rack.devices.find((d) => d.id === deviceBId)!;
+      expect(deviceB.ports!.some((p) => p.id === connection.b_port_id)).toBe(
+        true,
+      );
+    });
+
+    it("redo removes the device and its connection again", () => {
+      const { store, rack, deviceAId } = setupTwoDevicesWithConnection();
+      const deviceAIndex = store.rack.devices.findIndex(
+        (d) => d.id === deviceAId,
+      );
+
+      store.removeDeviceFromRack(rack.id, deviceAIndex);
+      store.undo();
+      store.redo();
+
+      expect(store.rack.devices.some((d) => d.id === deviceAId)).toBe(false);
+      expect(store.layout.connections ?? []).toEqual([]);
+    });
+
+    it("leaves connections between two other devices untouched", () => {
+      const { store, rack, deviceAId } = setupTwoDevicesWithConnection();
+
+      // A third, unrelated device connected to device B: removing device A
+      // must not disturb this connection.
+      const otherType = createTestDeviceType({ slug: "test-other" });
+      otherType.interfaces = [
+        createTestInterfaceTemplate({ name: "port-0", type: "1000base-t" }),
+      ];
+      store.addDeviceTypeRaw(otherType);
+      store.placeDevice(rack.id, otherType.slug, 20);
+      const deviceB = store.rack.devices.find(
+        (d) => d.device_type === "test-switch" && d.id !== deviceAId,
+      )!;
+      const deviceC = store.rack.devices.find(
+        (d) => d.device_type === otherType.slug,
+      )!;
+      const unrelatedConnection = {
+        id: "connection-2",
+        a_port_id: deviceB.ports![0]!.id,
+        b_port_id: deviceC.ports![0]!.id,
+      };
+      store.addConnectionRaw(unrelatedConnection);
+
+      const deviceAIndex = store.rack.devices.findIndex(
+        (d) => d.id === deviceAId,
+      );
+      store.removeDeviceFromRack(rack.id, deviceAIndex);
+
+      expect(store.layout.connections).toEqual([
+        expect.objectContaining({ id: "connection-2" }),
+      ]);
+    });
+
+    it("also cleans up connections when deleting a carrier with children", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test Rack", 42)!;
+
+      const containerType = store.addDeviceType(
+        createTestDeviceTypeInput({
+          name: "Test Carrier",
+          u_height: 1,
+          category: "server",
+          colour: "#8B4513",
+          slots: [
+            {
+              id: "slot-left",
+              position: { row: 0, col: 0 },
+              width_fraction: 0.5,
+            },
+          ],
+        }),
+      );
+      const childType = createTestDeviceType({ slug: "test-child" });
+      childType.slot_width = 1;
+      childType.is_full_depth = false;
+      childType.interfaces = [
+        createTestInterfaceTemplate({ name: "port-0", type: "1000base-t" }),
+      ];
+      store.addDeviceTypeRaw(childType);
+
+      const otherType = createTestDeviceType({ slug: "test-other" });
+      otherType.interfaces = [
+        createTestInterfaceTemplate({ name: "port-0", type: "1000base-t" }),
+      ];
+      store.addDeviceTypeRaw(otherType);
+
+      store.placeDevice(rack.id, containerType.slug, 10);
+      const carrierId = store.activeRack!.devices[0]!.id;
+      store.placeInContainer(
+        rack.id,
+        childType.slug,
+        carrierId,
+        "slot-left",
+        0,
+      );
+      const child = store.rack.devices.find(
+        (d) => d.container_id === carrierId,
+      )!;
+      store.placeDevice(rack.id, otherType.slug, 20);
+      const other = store.rack.devices.find(
+        (d) => d.device_type === otherType.slug,
+      )!;
+
+      // Connection hangs off the carrier's CHILD (not the carrier itself),
+      // mirroring the cable carrier-cascade test above.
+      const connection = {
+        id: "connection-1",
+        a_port_id: child.ports![0]!.id,
+        b_port_id: other.ports![0]!.id,
+      };
+      store.addConnectionRaw(connection);
+
+      const carrierIndex = store.rack.devices.findIndex(
+        (d) => d.id === carrierId,
+      );
+      store.removeDeviceFromRack(rack.id, carrierIndex);
+
+      expect(store.layout.connections ?? []).toEqual([]);
+      const result = LayoutSchema.safeParse(store.layout);
+      expect(result.success).toBe(true);
+
+      store.undo();
+      expect(store.layout.connections).toEqual([
+        expect.objectContaining({ id: "connection-1" }),
+      ]);
     });
   });
 

--- a/src/tests/layout-device-actions.test.ts
+++ b/src/tests/layout-device-actions.test.ts
@@ -6,6 +6,7 @@ import { parseLayoutObject } from "$lib/utils/yaml";
 import {
   setupStoreWithDevice,
   createTestCable,
+  createTestConnection,
   createTestDevice,
   createTestDeviceType,
   createTestDeviceTypeInput,
@@ -636,11 +637,11 @@ describe("Layout Store", () => {
       const deviceA = store.rack.devices[0]!;
       const deviceB = store.rack.devices[1]!;
 
-      const connection = {
+      const connection = createTestConnection({
         id: "connection-1",
         a_port_id: deviceA.ports![0]!.id,
         b_port_id: deviceB.ports![0]!.id,
-      };
+      });
       store.addConnectionRaw(connection);
 
       return {
@@ -726,11 +727,11 @@ describe("Layout Store", () => {
       const deviceC = store.rack.devices.find(
         (d) => d.device_type === otherType.slug,
       )!;
-      const unrelatedConnection = {
+      const unrelatedConnection = createTestConnection({
         id: "connection-2",
         a_port_id: deviceB.ports![0]!.id,
         b_port_id: deviceC.ports![0]!.id,
-      };
+      });
       store.addConnectionRaw(unrelatedConnection);
 
       const deviceAIndex = store.rack.devices.findIndex(
@@ -795,11 +796,11 @@ describe("Layout Store", () => {
 
       // Connection hangs off the carrier's CHILD (not the carrier itself),
       // mirroring the cable carrier-cascade test above.
-      const connection = {
+      const connection = createTestConnection({
         id: "connection-1",
         a_port_id: child.ports![0]!.id,
         b_port_id: other.ports![0]!.id,
-      };
+      });
       store.addConnectionRaw(connection);
 
       const carrierIndex = store.rack.devices.findIndex(

--- a/src/tests/layout-device-type-actions.test.ts
+++ b/src/tests/layout-device-type-actions.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { getImageStore, resetImageStore } from "$lib/stores/images.svelte";
-import { createTestDeviceTypeInput } from "./factories";
+import {
+  createTestDeviceType,
+  createTestDeviceTypeInput,
+  createTestInterfaceTemplate,
+} from "./factories";
 
 describe("Layout Store", () => {
   beforeEach(() => {
@@ -181,6 +185,103 @@ describe("Layout Store", () => {
       // Images should be cleaned up
       expect(imageStore.hasImage(deviceType.slug, "front")).toBe(false);
       expect(imageStore.hasImage(deviceType.slug, "rear")).toBe(false);
+    });
+
+    it("also removes connections attached to the deleted placed devices' ports, undoably (#639)", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test", 42)!;
+
+      const deviceType = createTestDeviceType({ slug: "test-delete-type" });
+      deviceType.interfaces = [
+        createTestInterfaceTemplate({ name: "port-0", type: "1000base-t" }),
+      ];
+      store.addDeviceTypeRaw(deviceType);
+
+      const otherType = createTestDeviceType({ slug: "test-other-type" });
+      otherType.interfaces = [
+        createTestInterfaceTemplate({ name: "port-0", type: "1000base-t" }),
+      ];
+      store.addDeviceTypeRaw(otherType);
+
+      store.placeDevice(rack.id, deviceType.slug, 5);
+      store.placeDevice(rack.id, otherType.slug, 10);
+      const deleted = store.rack.devices.find(
+        (d) => d.device_type === deviceType.slug,
+      )!;
+      const survivor = store.rack.devices.find(
+        (d) => d.device_type === otherType.slug,
+      )!;
+
+      const connection = {
+        id: "connection-1",
+        a_port_id: deleted.ports![0]!.id,
+        b_port_id: survivor.ports![0]!.id,
+      };
+      store.addConnectionRaw(connection);
+
+      store.deleteDeviceType(deviceType.slug);
+
+      expect(store.layout.connections ?? []).toEqual([]);
+
+      store.undo();
+
+      expect(store.layout.connections).toEqual([
+        expect.objectContaining({ id: "connection-1" }),
+      ]);
+      expect(
+        store.rack.devices.some((d) => d.device_type === deviceType.slug),
+      ).toBe(true);
+    });
+  });
+
+  describe("deleteMultipleDeviceTypesRecorded", () => {
+    it("removes a connection spanning two of the deleted types exactly once, undoably (#639)", () => {
+      const store = getLayoutStore();
+      const rack = store.addRack("Test", 42)!;
+
+      const typeA = createTestDeviceType({ slug: "test-bulk-a" });
+      typeA.interfaces = [
+        createTestInterfaceTemplate({ name: "port-0", type: "1000base-t" }),
+      ];
+      store.addDeviceTypeRaw(typeA);
+
+      const typeB = createTestDeviceType({ slug: "test-bulk-b" });
+      typeB.interfaces = [
+        createTestInterfaceTemplate({ name: "port-0", type: "1000base-t" }),
+      ];
+      store.addDeviceTypeRaw(typeB);
+
+      store.placeDevice(rack.id, typeA.slug, 5);
+      store.placeDevice(rack.id, typeB.slug, 10);
+      const deviceA = store.rack.devices.find(
+        (d) => d.device_type === typeA.slug,
+      )!;
+      const deviceB = store.rack.devices.find(
+        (d) => d.device_type === typeB.slug,
+      )!;
+
+      const connection = {
+        id: "connection-1",
+        a_port_id: deviceA.ports![0]!.id,
+        b_port_id: deviceB.ports![0]!.id,
+      };
+      store.addConnectionRaw(connection);
+
+      const deletedCount = store.deleteMultipleDeviceTypesRecorded([
+        typeA.slug,
+        typeB.slug,
+      ]);
+
+      expect(deletedCount).toBe(2);
+      expect(store.layout.connections ?? []).toEqual([]);
+
+      store.undo();
+
+      // Single undo restores both device types, both placed devices, and the
+      // connection exactly once (not duplicated by both per-type commands).
+      expect(store.layout.connections).toEqual([
+        expect.objectContaining({ id: "connection-1" }),
+      ]);
     });
   });
 });

--- a/src/tests/layout-device-type-actions.test.ts
+++ b/src/tests/layout-device-type-actions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { getLayoutStore, resetLayoutStore } from "$lib/stores/layout.svelte";
 import { getImageStore, resetImageStore } from "$lib/stores/images.svelte";
 import {
+  createTestConnection,
   createTestDeviceType,
   createTestDeviceTypeInput,
   createTestInterfaceTemplate,
@@ -212,11 +213,11 @@ describe("Layout Store", () => {
         (d) => d.device_type === otherType.slug,
       )!;
 
-      const connection = {
+      const connection = createTestConnection({
         id: "connection-1",
         a_port_id: deleted.ports![0]!.id,
         b_port_id: survivor.ports![0]!.id,
-      };
+      });
       store.addConnectionRaw(connection);
 
       store.deleteDeviceType(deviceType.slug);
@@ -260,11 +261,11 @@ describe("Layout Store", () => {
         (d) => d.device_type === typeB.slug,
       )!;
 
-      const connection = {
+      const connection = createTestConnection({
         id: "connection-1",
         a_port_id: deviceA.ports![0]!.id,
         b_port_id: deviceB.ports![0]!.id,
-      };
+      });
       store.addConnectionRaw(connection);
 
       const deletedCount = store.deleteMultipleDeviceTypesRecorded([


### PR DESCRIPTION
## **User description**
## Summary

Removing a placed device now cascades to delete every `Connection` referencing one of its ports, in the same undoable operation as the device removal. Undoing the removal restores the device and its connections together in one history step.

## Design: command composition

`removeDeviceRecorded` (in `src/lib/stores/layout/recorded-device-actions.ts`) gathers connections for the device (and, for a carrier, its children) via a new `findConnectionsForDevices` helper, added next to the existing `findCablesForDevices` helper in `recorded-device-type-actions.ts` (`#2924` precedent). It then builds one `REMOVE_CONNECTION` command per connection and composes them with the existing device-removal command into a single `BATCH` command via `createBatchCommand`, the same pattern `placeDeviceRecorded` already uses for auto-imported device types.

Connections key off `PlacedPort.id`, and port ids never change across a remove/restore cycle (unlike device ids, which `placeDeviceRaw` can remap on an id collision). That means connection removal/restoration needs no id-remap bookkeeping, unlike the cable cleanup this mirrors, which has to rewrite `a_device_id`/`b_device_id` on undo. Connection removals are ordered ahead of the device removal in the batch, so `execute()` clears connections before the device disappears, and `undo()` (which runs in reverse) restores the device first, then the connections that reference its ports.

No changes were needed to `commands/device.ts`: the existing `getCommandStoreAdapter` already implements `ConnectionCommandStore` (`addConnectionRaw`/`updateConnectionRaw`/`removeConnectionRaw`), so the same adapter instance used for the device command also builds the connection commands.

## Undo/redo atomicity

A single `store.undo()` call restores both the device and its connections; a single `store.redo()` removes both again. Covered directly in tests (see below).

## Removal paths covered

- **`removeDeviceRecorded`** (single device removal, including the carrier-with-children case): cascades connections. This is the primary path from the issue (`removeDeviceFromRack -> removeDeviceRecorded`).
- **`deleteDeviceTypeRecorded`** (deleting a device type removes every placed instance across every rack): cascades connections the same way, reusing `findConnectionsForDevices`.
- **`deleteMultipleDeviceTypesRecorded`** (bulk device type deletion): cascades connections with a claimed-id guard, so a connection spanning two device types being bulk-deleted is snapshotted and restored exactly once, not duplicated. Mirrors the existing `claimedCableIds` guard for cables.

**Known gap, not addressed here:** `clearRackRecorded` (clear rack) and `deleteRack` (delete rack) also destroy placed devices, but neither already cleans up cables either (the older, established precedent for this kind of cascade). Fixing connections there would mean fixing a larger, pre-existing orphaning gap that predates this issue and is out of scope for it. Flagging as follow-up material rather than silently leaving it unmentioned.

## Log behavior

A `debug.deviceRemove` log fires under the `rackula:layout:device` namespace whenever a device removal cascades into deleted connections, reporting the device name, connection count, and connection ids. Enable via `localStorage.debug = "rackula:layout:*"`, consistent with how `devicePlace`/`deviceMove` already log in the same file.

## Test evidence

New tests in `src/tests/layout-device-actions.test.ts` (`removeDeviceFromRack (connection cleanup, #639)`) and `src/tests/layout-device-type-actions.test.ts`:

- Removing a device removes its connections and the layout stays `LayoutSchema`-valid.
- Undo restores the device and its connection in a single step (one `store.undo()` call).
- Redo removes both again.
- Connections between two other (unrelated) devices survive.
- Deleting a carrier also cleans up connections hanging off its children.
- Deleting a device type cascades connection cleanup, undoably.
- Bulk device-type deletion removes a connection spanning two deleted types exactly once (dedup guard), undoably.

Verification run in the worktree:

- `VITEST_MAX_WORKERS=2 npm run test:run`: 251 test files passed, 3691 tests passed, exit code 0.
- `npm run check` (svelte-check): 5508 files, 0 errors, 0 warnings.
- `npx eslint` on all touched files: no issues found.
- `prettier --check` on all touched files: all files use Prettier code style.

## Scope note

This PR touches only `mutators.ts`'s sibling files (`recorded-device-actions.ts`, `recorded-device-type-actions.ts`) and `debug.ts`, per the parallel work split with `#3090` (connection serialization), which stays in `yaml-field-order.ts` and `layout-lifecycle.ts`. `mutators.ts` itself is unchanged; no raw mutator needed adding since `addConnectionRaw`/`removeConnectionRaw` already existed from `#369`.

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Deleting a device now also removes any connections attached to its ports, and undo restores both together**

### What Changed
- Removing a device now clears any connections linked to that device’s ports instead of leaving broken links behind
- The same cleanup now happens when deleting a device type, including bulk deletion, so placed devices of that type do not leave stale connections in the layout
- Undo and redo now bring back or remove the device and its connections in one step
- Added tests for single-device removal, carrier removal with children, device type deletion, and bulk deletion to confirm connections are handled once and stay valid

### Impact
`✅ Fewer broken connections after device removal`
`✅ Single-step undo for device and connection cleanup`
`✅ Safer bulk device type deletion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
