### PR TITLE
feat: ConnectionLayer and ConnectionPath rendering

### DIFF
--- a/src/lib/components/ConnectionLayer.svelte
+++ b/src/lib/components/ConnectionLayer.svelte
@@ -1,0 +1,81 @@
+<!--
+  ConnectionLayer SVG Component
+  Renders every Connection (#1931) whose ports both resolve to an anchor
+  within this rack/face as cubic bezier paths, routed via the external
+  channel algorithm (spike #262, src/lib/utils/connection-path.ts).
+
+  Rendered by Rack.svelte as a sibling layer AFTER the device each-block, so
+  it draws above every device body: PortIndicators renders mid-stack inside
+  RackDevice and cannot draw a line that crosses from one device to another,
+  which is why this layer lives at the rack level instead.
+
+  Anchors come exclusively from port-geometry.ts's getPortAnchors (#3089),
+  by way of connection-path.ts's buildPortAnchorMap - never recomputed here.
+  A connection whose port has no anchor (grouped/high-density device, wrong
+  rack face, cross-rack endpoint, or legacy data with no PlacedPort match)
+  is silently skipped rather than approximated; see buildRenderedConnections'
+  doc comment for the reasoning.
+-->
+<script lang="ts">
+  import type { DeviceType, PlacedDevice, RackView } from "$lib/types";
+  import { getConnectionStore } from "$lib/stores/connection.svelte";
+  import {
+    buildPortAnchorMap,
+    buildRenderedConnections,
+  } from "$lib/utils/connection-path";
+  import { type RackDimensions } from "$lib/utils/rack-drop-coordinator";
+  import ConnectionPath from "./ConnectionPath.svelte";
+
+  interface Props {
+    /** This rack's currently-visible, non-container-child devices (same set RackDevice renders). */
+    devices: PlacedDevice[];
+    deviceLibrary: DeviceType[];
+    /** Matches RackDevice's own rackView default: falls back to "front" when the rack has no view set. */
+    rackView?: RackView;
+    rackDims: RackDimensions;
+  }
+
+  let {
+    devices,
+    deviceLibrary,
+    rackView = "front",
+    rackDims,
+  }: Props = $props();
+
+  const connectionStore = getConnectionStore();
+
+  // Slug index rebuilt only when deviceLibrary changes, same pattern as
+  // Rack.svelte's own bySlug.
+  const bySlug = $derived(new Map(deviceLibrary.map((dt) => [dt.slug, dt])));
+
+  const portAnchors = $derived(
+    buildPortAnchorMap(devices, bySlug, rackView, rackDims),
+  );
+
+  const rackBounds = $derived({
+    x: 0,
+    y: 0,
+    width: rackDims.rackWidth,
+    height: rackDims.rackHeight * rackDims.uHeight,
+  });
+
+  const renderedConnections = $derived(
+    buildRenderedConnections(
+      connectionStore.connections,
+      portAnchors,
+      rackBounds,
+    ),
+  );
+</script>
+
+<g class="connection-layer">
+  {#each renderedConnections as { connection, geometry } (connection.id)}
+    <ConnectionPath {connection} {geometry} />
+  {/each}
+</g>
+
+<style>
+  .connection-layer {
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/components/ConnectionLayer.svelte
+++ b/src/lib/components/ConnectionLayer.svelte
@@ -12,9 +12,9 @@
   Anchors come exclusively from port-geometry.ts's getPortAnchors (#3089),
   by way of connection-path.ts's buildPortAnchorMap - never recomputed here.
   A connection whose port has no anchor (grouped/high-density device, wrong
-  rack face, cross-rack endpoint, or legacy data with no PlacedPort match)
-  is silently skipped rather than approximated; see buildRenderedConnections'
-  doc comment for the reasoning.
+  rack face, cross-rack endpoint, container-child device (#3117), or legacy
+  data with no PlacedPort match) is silently skipped rather than
+  approximated; see buildRenderedConnections' doc comment for the reasoning.
 -->
 <script lang="ts">
   import type { DeviceType, PlacedDevice, RackView } from "$lib/types";
@@ -27,7 +27,13 @@
   import ConnectionPath from "./ConnectionPath.svelte";
 
   interface Props {
-    /** This rack's currently-visible, non-container-child devices (same set RackDevice renders). */
+    /**
+     * This rack's currently-visible, non-container-child devices (same set
+     * RackDevice renders). Container-child ports have no rendered anchor
+     * anywhere yet (RackDevice's children block has no PortIndicators); a
+     * connection to one is skipped by buildRenderedConnections rather than
+     * approximated. Tracked as follow-up work: #3117.
+     */
     devices: PlacedDevice[];
     deviceLibrary: DeviceType[];
     /** Matches RackDevice's own rackView default: falls back to "front" when the rack has no view set. */

--- a/src/lib/components/ConnectionPath.svelte
+++ b/src/lib/components/ConnectionPath.svelte
@@ -1,0 +1,101 @@
+<!--
+  ConnectionPath SVG Component
+  Renders a single Connection (#1931) as an SVG cubic bezier path between two
+  already-resolved port anchors (see connection-path.ts / ConnectionLayer).
+
+  Hover affordance mirrors PortIndicators' hit-target idiom: a wide invisible
+  stroke owns pointer events and carries the label as a native SVG <title>
+  (a lightweight tooltip, per the issue's Testing Notes; hover/frame-rate
+  behaviour is verified manually / via E2E, not by unit tests), while a CSS
+  :hover on the shared group highlights the visible line and arrow.
+-->
+<script lang="ts">
+  import type { Connection } from "$lib/types";
+  import {
+    arrowPointsAttr,
+    type ConnectionGeometry,
+  } from "$lib/utils/connection-path";
+
+  interface Props {
+    connection: Connection;
+    geometry: ConnectionGeometry;
+  }
+
+  let { connection, geometry }: Props = $props();
+
+  // Connection.color is a user-chosen hex literal (schema: "Optional color
+  // for visualization (hex, e.g., '#FF5500')"), so it is used as-is when
+  // set; the fallback is a design token, not a hardcoded hex, matching the
+  // project's no-hex-literal-defaults convention.
+  const strokeColour = $derived(
+    connection.color ?? "var(--colour-port-default)",
+  );
+</script>
+
+<g class="connection">
+  <path
+    class="connection-hit"
+    d={geometry.path}
+    fill="none"
+    stroke="transparent"
+    stroke-width="12"
+  >
+    {#if connection.label}
+      <title>{connection.label}</title>
+    {/if}
+  </path>
+  <path
+    class="connection-line"
+    d={geometry.path}
+    fill="none"
+    stroke={strokeColour}
+  />
+  {#if geometry.arrow}
+    <polygon
+      class="connection-arrow"
+      points={arrowPointsAttr(geometry.arrow)}
+      fill={strokeColour}
+    />
+  {/if}
+</g>
+
+<style>
+  .connection {
+    pointer-events: none;
+  }
+
+  .connection-hit {
+    pointer-events: stroke;
+    cursor: pointer;
+  }
+
+  .connection-line {
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    opacity: 0.85;
+    transition:
+      stroke-width 150ms ease-out,
+      opacity 150ms ease-out;
+  }
+
+  .connection-arrow {
+    opacity: 0.85;
+    transition: opacity 150ms ease-out;
+  }
+
+  .connection:hover .connection-line {
+    stroke-width: 2.5;
+    opacity: 1;
+  }
+
+  .connection:hover .connection-arrow {
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .connection-line,
+    .connection-arrow {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/components/ConnectionPath.svelte
+++ b/src/lib/components/ConnectionPath.svelte
@@ -8,6 +8,19 @@
   (a lightweight tooltip, per the issue's Testing Notes; hover/frame-rate
   behaviour is verified manually / via E2E, not by unit tests), while a CSS
   :hover on the shared group highlights the visible line and arrow.
+
+  Interaction model: the hit-stroke uses geometry.hitPath, a version of the
+  curve trimmed away from both endpoints (see trimCubicBezier in
+  connection-path.ts), not the full geometry.path the visible line/arrow use.
+  ConnectionLayer renders after (visually above) the device layer, so an
+  untrimmed, pointer-events-enabled hit-stroke reaching all the way to a
+  connection's own port anchors would sit on top of those ports' own hit
+  targets. Since the hit-stroke has no click handler, a click landing on it
+  does not fall through to the port/device underneath - it bubbles past them
+  to whatever ancestor does handle clicks (the rack container), silently
+  doing the wrong thing instead of hitting the port. Trimming the ends keeps
+  the hover/tooltip target everywhere except right at the ports, where the
+  port's own hit target should win (#1931 PR review).
 -->
 <script lang="ts">
   import type { Connection } from "$lib/types";
@@ -35,10 +48,10 @@
 <g class="connection">
   <path
     class="connection-hit"
-    d={geometry.path}
+    d={geometry.hitPath}
     fill="none"
     stroke="transparent"
-    stroke-width="12"
+    stroke-width="8"
   >
     {#if connection.label}
       <title>{connection.label}</title>

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -24,6 +24,7 @@
     PlacedDevice,
   } from "$lib/types";
   import RackDevice from "./RackDevice.svelte";
+  import ConnectionLayer from "./ConnectionLayer.svelte";
   import RackFrame from "./RackFrame.svelte";
   import RackDropZone from "./RackDropZone.svelte";
   import RackChristmasHat from "./RackChristmasHat.svelte";
@@ -263,6 +264,14 @@
         );
         return ef === "both" || ef === effectiveFaceFilter;
       }),
+  );
+
+  // Devices this rack/face actually renders, for ConnectionLayer (#1931) to
+  // anchor connection endpoints against. Same set RackDevice renders from
+  // visibleDevices, kept as its own derived so ConnectionLayer only
+  // recomputes when the rendered device set itself changes.
+  const connectionDevices = $derived(
+    visibleDevices.map(({ placedDevice }) => placedDevice),
   );
 
   const containerChildren = $derived.by(() => {
@@ -589,6 +598,14 @@
         </g>
       {/each}
     </g>
+
+    <!-- Layer 2b: Connections, drawn above every device body (#1931) -->
+    <ConnectionLayer
+      devices={connectionDevices}
+      {deviceLibrary}
+      rackView={effectiveFaceFilter}
+      {rackDims}
+    />
 
     <!-- Empty-state hint: only in a face-filtered (dual) view, so an empty rear
          reads as "nothing rear-facing here" rather than looking broken. -->

--- a/src/lib/utils/connection-path.ts
+++ b/src/lib/utils/connection-path.ts
@@ -183,6 +183,77 @@ export function cubicBezierTangentAt(
   };
 }
 
+function lerpPoint(a: Point, b: Point, t: number): Point {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+}
+
+/** De Casteljau subdivision: control points either side of parameter t. */
+function splitCubic(
+  p0: Point,
+  p1: Point,
+  p2: Point,
+  p3: Point,
+  t: number,
+): { left: [Point, Point, Point, Point]; right: [Point, Point, Point, Point] } {
+  const a = lerpPoint(p0, p1, t);
+  const b = lerpPoint(p1, p2, t);
+  const c = lerpPoint(p2, p3, t);
+  const d = lerpPoint(a, b, t);
+  const e = lerpPoint(b, c, t);
+  const f = lerpPoint(d, e, t);
+  return { left: [p0, a, d, f], right: [f, e, c, p3] };
+}
+
+/**
+ * Fraction of the curve's parameter range trimmed off each end when building
+ * a connection's invisible hit-stroke (see ConnectionPath.svelte and
+ * trimCubicBezier below). Not applied to the visible line or arrow.
+ */
+export const HIT_PATH_TRIM = 0.1;
+
+/**
+ * The exact cubic bezier sub-segment spanning parameter range [t0, t1] of the
+ * original curve (De Casteljau subdivision, applied twice: once to keep
+ * [0, t1], then again on that result to keep [t0, t1]). Bezier curves are
+ * closed under sub-segment extraction, so this is exact, not an
+ * approximation.
+ *
+ * Used to trim ConnectionPath's invisible hit-stroke away from both curve
+ * endpoints. A connection's endpoints are exactly its own two port anchors;
+ * an untrimmed, pointer-events-enabled hit-stroke reaching all the way to
+ * them sits on top of (ConnectionLayer renders after the device layer) each
+ * port's own, smaller hit-circle. Since the hit-stroke has no click handler,
+ * a click there does not fall through to the port or device underneath - it
+ * bubbles past them entirely to whatever ancestor does handle it (the rack
+ * container's own click handler), silently doing the wrong thing instead of
+ * selecting/clicking the port. Trimming the ends keeps the fat, hover-
+ * friendly hit target everywhere else - which, per the external-channel
+ * routing, is nearly the curve's whole length, since it spends only a short
+ * span near each end inside the rack body at all (see #1931 PR review).
+ */
+export function trimCubicBezier(
+  source: Point,
+  control: CubicControlPoints,
+  target: Point,
+  t0: number,
+  t1: number,
+): { source: Point; control: CubicControlPoints; target: Point } {
+  if (t1 <= t0) {
+    const point = cubicBezierPointAt(source, control, target, t0);
+    return { source: point, control: { c1: point, c2: point }, target: point };
+  }
+
+  const { left } = splitCubic(source, control.c1, control.c2, target, t1);
+  const t0Relative = t0 / t1;
+  const { right } = splitCubic(left[0], left[1], left[2], left[3], t0Relative);
+
+  return {
+    source: right[0],
+    control: { c1: right[1], c2: right[2] },
+    target: right[3],
+  };
+}
+
 /**
  * Which way a direction arrow should point, or null when no arrow should be
  * drawn. Gating rule (#1931 AC): an arrow renders only when the two ports
@@ -277,6 +348,12 @@ export function arrowPointsAttr(triangle: ArrowTriangle): string {
 
 export interface ConnectionGeometry {
   path: string;
+  /**
+   * A trimmed sub-segment of `path` (see trimCubicBezier/HIT_PATH_TRIM),
+   * for the invisible hit-stroke only. Never used for the visible line or
+   * arrow, both of which use the full `path`.
+   */
+  hitPath: string;
   side: ChannelSide;
   midpoint: Point;
   arrow: ArrowTriangle | null;
@@ -309,6 +386,18 @@ export function computeConnectionGeometry(
     options.gutterOffset,
   );
   const path = buildCubicBezierPath(source, control, target);
+  const trimmed = trimCubicBezier(
+    source,
+    control,
+    target,
+    HIT_PATH_TRIM,
+    1 - HIT_PATH_TRIM,
+  );
+  const hitPath = buildCubicBezierPath(
+    trimmed.source,
+    trimmed.control,
+    trimmed.target,
+  );
   const midpoint = cubicBezierPointAt(source, control, target, 0.5);
   const arrow = computeArrowTriangle(
     source,
@@ -318,7 +407,7 @@ export function computeConnectionGeometry(
     options.arrowSize,
   );
 
-  return { path, side, midpoint, arrow };
+  return { path, hitPath, side, midpoint, arrow };
 }
 
 /**
@@ -392,6 +481,17 @@ export interface ResolvedPortAnchor {
  * contribute no entries for their ports - getPortAnchors returns [] for them
  * by design - which is what lets buildRenderedConnections below skip a
  * connection to such a port instead of guessing at a location for it.
+ *
+ * `devices` is expected to be top-level (non-container-child) placements
+ * only, same as what RackDevice actually renders a body for. Container
+ * children (PlacedDevice.container_id set) are deliberately out of scope
+ * here, not merely forgotten: RackDevice's own container-children block
+ * renders a plain rect + label with no PortIndicators call, so a child's
+ * ports have no rendered indicator or computed anchor anywhere in the app
+ * yet, independent of this module. A connection to a child's port therefore
+ * has no anchor to resolve and is skipped by buildRenderedConnections, the
+ * same graceful fallback used for grouped/high-density and wrong-face ports.
+ * Tracked as follow-up work: #3117.
  */
 export function buildPortAnchorMap(
   devices: PlacedDevice[],

--- a/src/lib/utils/connection-path.ts
+++ b/src/lib/utils/connection-path.ts
@@ -1,0 +1,491 @@
+/**
+ * Connection Path Geometry
+ * Spike #262: Cable Path Rendering Algorithm (issue #1931)
+ *
+ * Pure, DOM-free functions that turn two port anchors into renderable SVG
+ * connection geometry: a cubic bezier path routed through an external
+ * "channel" (gutter) to the left or right of the rack, and an optional
+ * direction arrow at the path midpoint.
+ *
+ * This is the production implementation of the algorithm explored in
+ * docs/research/connection-routing.ts (spike #262's externalChannelPath,
+ * scored 5/5: "never crosses devices, clean visual hierarchy, natural
+ * bundling"). The reference file is NOT imported from; the shape of the
+ * options and the routing math is reproduced here deliberately, adapted to
+ * this project's anchor/offset conventions (see port-geometry.ts) and split
+ * into independently testable steps rather than one calculateConnectionPath
+ * dispatcher.
+ *
+ * Anchor coordinates must come from port-geometry.ts's getPortAnchor(s) -
+ * this module never computes a port position itself, only what to draw once
+ * two anchors are known (buildPortAnchorMap below is the one exception: it
+ * is a thin per-device loop around getPortAnchors, not a re-implementation).
+ */
+
+import type {
+  Connection,
+  DeviceType,
+  InterfaceTemplate,
+  PlacedDevice,
+  PlacedPort,
+  PortDirection,
+  RackView,
+} from "$lib/types";
+import { inferDirection } from "$lib/utils/port-utils";
+import {
+  getPortAnchors,
+  type PortAnchor,
+  type PortGeometryOffset,
+} from "$lib/utils/port-geometry";
+import { toHumanUnits } from "$lib/utils/position";
+import type { RackDimensions } from "$lib/utils/rack-drop-coordinator";
+
+/** A 2D point in Rack SVG space. */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** The rack's bounding box in Rack SVG space, used to place the external gutter. */
+export interface RackBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Which side of the rack a connection's gutter/channel routes through. */
+export type ChannelSide = "left" | "right";
+
+/** Default horizontal distance the gutter sits outside the rack body, in px. */
+export const DEFAULT_GUTTER_OFFSET = 30;
+
+/** Total tip-to-base length of a direction arrow, in px. */
+export const ARROW_LENGTH = 7;
+
+/** Total base width of a direction arrow, in px. */
+export const ARROW_WIDTH = 5;
+
+export interface CubicControlPoints {
+  c1: Point;
+  c2: Point;
+}
+
+/**
+ * Alternate connections between the right and left gutter so that, absent
+ * any other signal, cabling load-balances visually across both sides of the
+ * rack instead of stacking every curve on one edge. Index is the position of
+ * a connection within the set actually being rendered (see
+ * buildRenderedConnections), not its position in the raw connections array,
+ * so a skipped (unanchored) connection does not "use up" a side.
+ */
+export function assignChannelSide(index: number): ChannelSide {
+  return index % 2 === 0 ? "right" : "left";
+}
+
+/**
+ * Control points for a cubic bezier that exits both endpoints horizontally
+ * toward a shared gutter line, then curves into the target. This is the
+ * "external channel" shape: the curve never crosses the rack body because
+ * both control points sit outside it on the same side.
+ */
+export function computeChannelControlPoints(
+  source: Point,
+  target: Point,
+  rackBounds: RackBounds,
+  side: ChannelSide,
+  gutterOffset: number = DEFAULT_GUTTER_OFFSET,
+): CubicControlPoints {
+  const gutterX =
+    side === "right"
+      ? rackBounds.x + rackBounds.width + gutterOffset
+      : rackBounds.x - gutterOffset;
+
+  return {
+    c1: { x: gutterX, y: source.y },
+    c2: { x: gutterX, y: target.y },
+  };
+}
+
+/** SVG path `d` attribute for a cubic bezier from source to target. */
+export function buildCubicBezierPath(
+  source: Point,
+  control: CubicControlPoints,
+  target: Point,
+): string {
+  return `M ${source.x},${source.y} C ${control.c1.x},${control.c1.y} ${control.c2.x},${control.c2.y} ${target.x},${target.y}`;
+}
+
+function cubicComponentAt(
+  p0: number,
+  p1: number,
+  p2: number,
+  p3: number,
+  t: number,
+): number {
+  const mt = 1 - t;
+  return (
+    mt * mt * mt * p0 +
+    3 * mt * mt * t * p1 +
+    3 * mt * t * t * p2 +
+    t * t * t * p3
+  );
+}
+
+/** Point on the cubic bezier at parameter t (De Casteljau / Bernstein form). */
+export function cubicBezierPointAt(
+  source: Point,
+  control: CubicControlPoints,
+  target: Point,
+  t: number,
+): Point {
+  return {
+    x: cubicComponentAt(source.x, control.c1.x, control.c2.x, target.x, t),
+    y: cubicComponentAt(source.y, control.c1.y, control.c2.y, target.y, t),
+  };
+}
+
+function cubicDerivativeComponentAt(
+  p0: number,
+  p1: number,
+  p2: number,
+  p3: number,
+  t: number,
+): number {
+  const mt = 1 - t;
+  return (
+    3 * mt * mt * (p1 - p0) + 6 * mt * t * (p2 - p1) + 3 * t * t * (p3 - p2)
+  );
+}
+
+/** Tangent (derivative) vector of the cubic bezier at parameter t, unnormalised. */
+export function cubicBezierTangentAt(
+  source: Point,
+  control: CubicControlPoints,
+  target: Point,
+  t: number,
+): Point {
+  return {
+    x: cubicDerivativeComponentAt(
+      source.x,
+      control.c1.x,
+      control.c2.x,
+      target.x,
+      t,
+    ),
+    y: cubicDerivativeComponentAt(
+      source.y,
+      control.c1.y,
+      control.c2.y,
+      target.y,
+      t,
+    ),
+  };
+}
+
+/**
+ * Which way a direction arrow should point, or null when no arrow should be
+ * drawn. Gating rule (#1931 AC): an arrow renders only when the two ports
+ * have unambiguous, opposite roles - one "output", the other "input". Any
+ * other combination (both bidirectional, both unset, both the same role, or
+ * either side "bidirectional"/unset) renders as a plain line.
+ */
+export type ArrowDirection = "a-to-b" | "b-to-a" | null;
+
+export function resolveArrowDirection(
+  aDirection: PortDirection | undefined,
+  bDirection: PortDirection | undefined,
+): ArrowDirection {
+  if (aDirection === "output" && bDirection === "input") return "a-to-b";
+  if (aDirection === "input" && bDirection === "output") return "b-to-a";
+  return null;
+}
+
+export interface ArrowTriangle {
+  tip: Point;
+  base1: Point;
+  base2: Point;
+}
+
+export interface ArrowSize {
+  length: number;
+  width: number;
+}
+
+const DEFAULT_ARROW_SIZE: ArrowSize = {
+  length: ARROW_LENGTH,
+  width: ARROW_WIDTH,
+};
+
+/**
+ * A small triangle centred on the path midpoint, pointing along the curve's
+ * tangent there (or against it, for "b-to-a"). Returns null when there is no
+ * direction to show, or when the tangent is degenerate (zero-length, e.g. a
+ * connection whose two anchors coincide) since no orientation can be drawn.
+ */
+export function computeArrowTriangle(
+  source: Point,
+  control: CubicControlPoints,
+  target: Point,
+  direction: ArrowDirection,
+  size: ArrowSize = DEFAULT_ARROW_SIZE,
+): ArrowTriangle | null {
+  if (direction === null) return null;
+
+  const midpoint = cubicBezierPointAt(source, control, target, 0.5);
+  const rawTangent = cubicBezierTangentAt(source, control, target, 0.5);
+  const tangent =
+    direction === "b-to-a"
+      ? { x: -rawTangent.x, y: -rawTangent.y }
+      : rawTangent;
+
+  const magnitude = Math.hypot(tangent.x, tangent.y);
+  if (magnitude === 0) return null;
+
+  const unit = { x: tangent.x / magnitude, y: tangent.y / magnitude };
+  const perp = { x: -unit.y, y: unit.x };
+  const halfLength = size.length / 2;
+  const halfWidth = size.width / 2;
+
+  const tip = {
+    x: midpoint.x + unit.x * halfLength,
+    y: midpoint.y + unit.y * halfLength,
+  };
+  const baseCentre = {
+    x: midpoint.x - unit.x * halfLength,
+    y: midpoint.y - unit.y * halfLength,
+  };
+
+  return {
+    tip,
+    base1: {
+      x: baseCentre.x + perp.x * halfWidth,
+      y: baseCentre.y + perp.y * halfWidth,
+    },
+    base2: {
+      x: baseCentre.x - perp.x * halfWidth,
+      y: baseCentre.y - perp.y * halfWidth,
+    },
+  };
+}
+
+/** SVG `points` attribute for an arrow triangle's `<polygon>`. */
+export function arrowPointsAttr(triangle: ArrowTriangle): string {
+  const { tip, base1, base2 } = triangle;
+  return `${tip.x},${tip.y} ${base1.x},${base1.y} ${base2.x},${base2.y}`;
+}
+
+export interface ConnectionGeometry {
+  path: string;
+  side: ChannelSide;
+  midpoint: Point;
+  arrow: ArrowTriangle | null;
+}
+
+export interface ConnectionGeometryOptions {
+  gutterOffset?: number;
+  arrowSize?: ArrowSize;
+}
+
+/**
+ * Full renderable geometry for one connection: the bezier path, which gutter
+ * it routed through, its midpoint, and (when direction is unambiguous) the
+ * direction arrow triangle.
+ */
+export function computeConnectionGeometry(
+  source: Point,
+  target: Point,
+  rackBounds: RackBounds,
+  index: number,
+  direction: ArrowDirection,
+  options: ConnectionGeometryOptions = {},
+): ConnectionGeometry {
+  const side = assignChannelSide(index);
+  const control = computeChannelControlPoints(
+    source,
+    target,
+    rackBounds,
+    side,
+    options.gutterOffset,
+  );
+  const path = buildCubicBezierPath(source, control, target);
+  const midpoint = cubicBezierPointAt(source, control, target, 0.5);
+  const arrow = computeArrowTriangle(
+    source,
+    control,
+    target,
+    direction,
+    options.arrowSize,
+  );
+
+  return { path, side, midpoint, arrow };
+}
+
+/**
+ * Effective signal direction for a connection endpoint: an explicit
+ * PlacedPort.direction override wins, then the InterfaceTemplate default,
+ * then the same inferDirection() fallback PortIndicators uses for the port's
+ * own direction glyph - so a connection between two ports shows an arrow
+ * under exactly the conditions those ports already display one individually.
+ * Falls back to PlacedPort.type when no InterfaceTemplate is available
+ * (matching PlacedPort.type's documented purpose: "avoids lookups for cable
+ * routing").
+ */
+export function resolveConnectionPortDirection(
+  port: PlacedPort | undefined,
+  iface: InterfaceTemplate | undefined,
+): PortDirection | undefined {
+  const explicit = port?.direction ?? iface?.direction;
+  if (explicit) return explicit;
+
+  const type = iface?.type ?? port?.type;
+  if (!type) return undefined;
+
+  return inferDirection(type, iface?.mgmt_only);
+}
+
+export interface DeviceOffsetParams {
+  /** PlacedDevice.position, in internal units (1/6U). */
+  position: number;
+  deviceUHeight: number;
+  rackHeight: number;
+  uHeight: number;
+  railWidth: number;
+  rackPadding: number;
+}
+
+/**
+ * The SVG-space offset of a device's own <g transform="translate(...)"> within
+ * the Rack SVG, reproducing the formula RackDevice.svelte and Rack.svelte
+ * apply together: RAIL_WIDTH (device g's own x translate, since a rail-mounted
+ * device always spans the full interior width - slotXOffset is always 0 at
+ * rack level) and RACK_PADDING + RAIL_WIDTH + yPosition (the devices layer's y
+ * translate plus the device g's own y translate). This is the same offset
+ * documented in port-geometry.ts's PortGeometryOptions.offset, computed here
+ * from a PlacedDevice + rack dimensions instead of read off a mounted
+ * component, so ConnectionLayer can locate every device's ports without
+ * depending on RackDevice internals.
+ */
+export function computeDeviceOffset(
+  params: DeviceOffsetParams,
+): PortGeometryOffset {
+  const positionHuman = toHumanUnits(params.position);
+  const yPosition =
+    (params.rackHeight - positionHuman - params.deviceUHeight + 1) *
+    params.uHeight;
+
+  return {
+    x: params.railWidth,
+    y: params.rackPadding + params.railWidth + yPosition,
+  };
+}
+
+export interface ResolvedPortAnchor {
+  anchor: PortAnchor;
+  direction: PortDirection | undefined;
+}
+
+/**
+ * Every individually-anchored port across a set of placed devices, keyed by
+ * PlacedPort.id, paired with its effective direction. Devices in
+ * grouped/high-density mode (see port-geometry.ts's HIGH_DENSITY_THRESHOLD)
+ * contribute no entries for their ports - getPortAnchors returns [] for them
+ * by design - which is what lets buildRenderedConnections below skip a
+ * connection to such a port instead of guessing at a location for it.
+ */
+export function buildPortAnchorMap(
+  devices: PlacedDevice[],
+  deviceTypesBySlug: Map<string, DeviceType>,
+  rackView: RackView,
+  rackDims: RackDimensions,
+): Map<string, ResolvedPortAnchor> {
+  const map = new Map<string, ResolvedPortAnchor>();
+
+  for (const placedDevice of devices) {
+    const deviceType = deviceTypesBySlug.get(placedDevice.device_type);
+    if (!deviceType?.interfaces?.length) continue;
+
+    const ports = placedDevice.ports ?? [];
+    const offset = computeDeviceOffset({
+      position: placedDevice.position,
+      deviceUHeight: deviceType.u_height,
+      rackHeight: rackDims.rackHeight,
+      uHeight: rackDims.uHeight,
+      railWidth: rackDims.railWidth,
+      rackPadding: rackDims.rackPadding,
+    });
+
+    const anchors = getPortAnchors({
+      interfaces: deviceType.interfaces,
+      ports,
+      rackView,
+      deviceWidth: rackDims.interiorWidth,
+      deviceHeight: deviceType.u_height * rackDims.uHeight,
+      offset,
+    });
+
+    for (const anchor of anchors) {
+      const port = ports.find((p) => p.id === anchor.portId);
+      const iface = port
+        ? deviceType.interfaces[port.template_index]
+        : undefined;
+      map.set(anchor.portId, {
+        anchor,
+        direction: resolveConnectionPortDirection(port, iface),
+      });
+    }
+  }
+
+  return map;
+}
+
+export interface RenderedConnection {
+  connection: Connection;
+  geometry: ConnectionGeometry;
+}
+
+/**
+ * Resolve every connection to its renderable geometry, skipping any
+ * connection where either endpoint has no anchor.
+ *
+ * Grouped-mode fallback decision (#1931 AC, #3089): a port with no anchor -
+ * because its device is over the high-density threshold, the port is on the
+ * other rack face, or the layout predates PlacedPort identity - is skipped
+ * entirely rather than approximated (e.g. anchored to the device's edge
+ * centre). An edge-centre fallback would draw a specific, plausible-looking
+ * line to a location that is not actually where the port is, misleading the
+ * viewer about what is connected to what. Silently omitting the connection
+ * is the honest failure mode; the connection still exists in the data and
+ * reappears the moment its port becomes individually addressable (device
+ * drops under the threshold, or the layout gains PlacedPort ids).
+ */
+export function buildRenderedConnections(
+  connections: Connection[],
+  portAnchors: Map<string, ResolvedPortAnchor>,
+  rackBounds: RackBounds,
+  options: ConnectionGeometryOptions = {},
+): RenderedConnection[] {
+  const results: RenderedConnection[] = [];
+  let index = 0;
+
+  for (const connection of connections) {
+    const a = portAnchors.get(connection.a_port_id);
+    const b = portAnchors.get(connection.b_port_id);
+    if (!a || !b) continue;
+
+    const direction = resolveArrowDirection(a.direction, b.direction);
+    const geometry = computeConnectionGeometry(
+      a.anchor,
+      b.anchor,
+      rackBounds,
+      index,
+      direction,
+      options,
+    );
+
+    results.push({ connection, geometry });
+    index++;
+  }
+
+  return results;
+}

--- a/src/tests/connection-path.test.ts
+++ b/src/tests/connection-path.test.ts
@@ -10,14 +10,14 @@
  * are out of unit scope per the issue's Testing Notes; they are verified
  * manually / via E2E, not here.
  *
- * Connection test objects use a small local helper (not
- * src/tests/factories.ts's createTestConnection): PR #3115 is adding that
- * factory concurrently, so a local helper here avoids colliding with it.
+ * Connection test objects use src/tests/factories.ts's createTestConnection
+ * (added by #3090's PR #3115).
  */
 import { describe, it, expect } from "vitest";
-import type { Connection, PortDirection } from "$lib/types";
+import type { PortDirection } from "$lib/types";
 import { toInternalUnits } from "$lib/utils/position";
 import {
+  createTestConnection,
   createTestDevice,
   createTestDeviceType,
   createTestInterfaceTemplate,
@@ -41,16 +41,6 @@ import {
   type ResolvedPortAnchor,
 } from "$lib/utils/connection-path";
 import { HIGH_DENSITY_THRESHOLD } from "$lib/utils/port-geometry";
-
-/** Local Connection factory - see file header for why this isn't in factories.ts. */
-function makeTestConnection(overrides: Partial<Connection> = {}): Connection {
-  return {
-    id: "test-connection",
-    a_port_id: "port-a",
-    b_port_id: "port-b",
-    ...overrides,
-  };
-}
 
 function makeResolvedAnchor(
   portId: string,
@@ -465,7 +455,7 @@ describe("buildRenderedConnections", () => {
       ["port-a", makeResolvedAnchor("port-a", 10, 50, "output")],
       ["port-b", makeResolvedAnchor("port-b", 190, 300, "input")],
     ]);
-    const connection = makeTestConnection();
+    const connection = createTestConnection();
 
     const rendered = buildRenderedConnections(
       [connection],
@@ -485,7 +475,7 @@ describe("buildRenderedConnections", () => {
       // port-b intentionally missing: high-density device, wrong face, or
       // legacy data with no PlacedPort match.
     ]);
-    const connection = makeTestConnection();
+    const connection = createTestConnection();
 
     const rendered = buildRenderedConnections(
       [connection],
@@ -504,19 +494,19 @@ describe("buildRenderedConnections", () => {
       ["port-d", makeResolvedAnchor("port-d", 190, 400)],
     ]);
     const connections = [
-      makeTestConnection({
+      createTestConnection({
         id: "conn-1",
         a_port_id: "port-a",
         b_port_id: "port-b",
       }),
       // conn-2 references a port with no anchor and is skipped; it must not
       // consume a channel-side slot.
-      makeTestConnection({
+      createTestConnection({
         id: "conn-2",
         a_port_id: "port-a",
         b_port_id: "missing",
       }),
-      makeTestConnection({
+      createTestConnection({
         id: "conn-3",
         a_port_id: "port-c",
         b_port_id: "port-d",

--- a/src/tests/connection-path.test.ts
+++ b/src/tests/connection-path.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Tests for the connection path geometry helpers (#1931): pure, DOM-free
+ * functions covering the external-channel cubic bezier routing (spike #262),
+ * channel-side assignment, direction-arrow placement/orientation and gating,
+ * the device-offset formula that mirrors RackDevice.svelte, and the
+ * grouped-mode fallback that skips a connection when either endpoint has no
+ * per-port anchor (#3089).
+ *
+ * Rendered-DOM assertions (hover highlight, on-screen tooltip, frame-rate)
+ * are out of unit scope per the issue's Testing Notes; they are verified
+ * manually / via E2E, not here.
+ *
+ * Connection test objects use a small local helper (not
+ * src/tests/factories.ts's createTestConnection): PR #3115 is adding that
+ * factory concurrently, so a local helper here avoids colliding with it.
+ */
+import { describe, it, expect } from "vitest";
+import type { Connection, PortDirection } from "$lib/types";
+import { toInternalUnits } from "$lib/utils/position";
+import {
+  createTestDevice,
+  createTestDeviceType,
+  createTestInterfaceTemplate,
+  createTestPlacedPort,
+} from "./factories";
+import {
+  DEFAULT_GUTTER_OFFSET,
+  arrowPointsAttr,
+  assignChannelSide,
+  buildCubicBezierPath,
+  buildPortAnchorMap,
+  buildRenderedConnections,
+  computeArrowTriangle,
+  computeChannelControlPoints,
+  computeConnectionGeometry,
+  computeDeviceOffset,
+  cubicBezierPointAt,
+  cubicBezierTangentAt,
+  resolveArrowDirection,
+  resolveConnectionPortDirection,
+  type ResolvedPortAnchor,
+} from "$lib/utils/connection-path";
+import { HIGH_DENSITY_THRESHOLD } from "$lib/utils/port-geometry";
+
+/** Local Connection factory - see file header for why this isn't in factories.ts. */
+function makeTestConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: "test-connection",
+    a_port_id: "port-a",
+    b_port_id: "port-b",
+    ...overrides,
+  };
+}
+
+function makeResolvedAnchor(
+  portId: string,
+  x: number,
+  y: number,
+  direction?: PortDirection,
+): ResolvedPortAnchor {
+  return { anchor: { portId, x, y }, direction };
+}
+
+describe("assignChannelSide", () => {
+  it("alternates right/left starting with right at index 0", () => {
+    expect(assignChannelSide(0)).toBe("right");
+    expect(assignChannelSide(1)).toBe("left");
+    expect(assignChannelSide(2)).toBe("right");
+    expect(assignChannelSide(3)).toBe("left");
+  });
+});
+
+describe("computeChannelControlPoints", () => {
+  const rackBounds = { x: 0, y: 0, width: 200, height: 900 };
+  const source = { x: 10, y: 50 };
+  const target = { x: 190, y: 300 };
+
+  it("routes the right-side gutter outside the rack's right edge", () => {
+    const control = computeChannelControlPoints(
+      source,
+      target,
+      rackBounds,
+      "right",
+      30,
+    );
+    expect(control).toEqual({ c1: { x: 230, y: 50 }, c2: { x: 230, y: 300 } });
+  });
+
+  it("routes the left-side gutter outside the rack's left edge", () => {
+    const control = computeChannelControlPoints(
+      source,
+      target,
+      rackBounds,
+      "left",
+      30,
+    );
+    expect(control).toEqual({ c1: { x: -30, y: 50 }, c2: { x: -30, y: 300 } });
+  });
+
+  it("defaults the gutter offset when none is supplied", () => {
+    const control = computeChannelControlPoints(
+      source,
+      target,
+      rackBounds,
+      "right",
+    );
+    expect(control.c1.x).toBe(
+      rackBounds.x + rackBounds.width + DEFAULT_GUTTER_OFFSET,
+    );
+  });
+});
+
+describe("buildCubicBezierPath", () => {
+  it("formats an SVG cubic bezier path from source through both control points to target", () => {
+    const path = buildCubicBezierPath(
+      { x: 10, y: 50 },
+      { c1: { x: 230, y: 50 }, c2: { x: 230, y: 300 } },
+      { x: 190, y: 300 },
+    );
+    expect(path).toBe("M 10,50 C 230,50 230,300 190,300");
+  });
+});
+
+describe("cubicBezierPointAt", () => {
+  // Evenly-spaced, collinear control points reduce the cubic bezier to a
+  // straight line: P1 = P0 + d, P2 = P0 + 2d, P3 = P0 + 3d. Lets every
+  // t produce an exactly-checkable point without a curve-fitting library.
+  const source = { x: 0, y: 0 };
+  const control = { c1: { x: 10, y: 20 }, c2: { x: 20, y: 40 } };
+  const target = { x: 30, y: 60 };
+
+  it("returns the source point at t=0", () => {
+    expect(cubicBezierPointAt(source, control, target, 0)).toEqual(source);
+  });
+
+  it("returns the target point at t=1", () => {
+    expect(cubicBezierPointAt(source, control, target, 1)).toEqual(target);
+  });
+
+  it("returns the straight-line midpoint at t=0.5 for evenly-spaced collinear controls", () => {
+    expect(cubicBezierPointAt(source, control, target, 0.5)).toEqual({
+      x: 15,
+      y: 30,
+    });
+  });
+});
+
+describe("cubicBezierTangentAt", () => {
+  it("is constant and equal to (target - source) for evenly-spaced collinear controls", () => {
+    const source = { x: 0, y: 0 };
+    const control = { c1: { x: 10, y: 20 }, c2: { x: 20, y: 40 } };
+    const target = { x: 30, y: 60 };
+
+    for (const t of [0, 0.25, 0.5, 0.75, 1]) {
+      expect(cubicBezierTangentAt(source, control, target, t)).toEqual({
+        x: 30,
+        y: 60,
+      });
+    }
+  });
+});
+
+describe("resolveArrowDirection", () => {
+  it("points a-to-b when a is output and b is input", () => {
+    expect(resolveArrowDirection("output", "input")).toBe("a-to-b");
+  });
+
+  it("points b-to-a when a is input and b is output", () => {
+    expect(resolveArrowDirection("input", "output")).toBe("b-to-a");
+  });
+
+  it("renders no arrow when either side is bidirectional", () => {
+    expect(resolveArrowDirection("bidirectional", "input")).toBeNull();
+    expect(resolveArrowDirection("output", "bidirectional")).toBeNull();
+  });
+
+  it("renders no arrow when either side is unspecified", () => {
+    expect(resolveArrowDirection(undefined, "input")).toBeNull();
+    expect(resolveArrowDirection("output", undefined)).toBeNull();
+    expect(resolveArrowDirection(undefined, undefined)).toBeNull();
+  });
+
+  it("renders no arrow when both sides share the same role", () => {
+    expect(resolveArrowDirection("output", "output")).toBeNull();
+    expect(resolveArrowDirection("input", "input")).toBeNull();
+  });
+});
+
+describe("computeArrowTriangle", () => {
+  const source = { x: 0, y: 0 };
+  const control = { c1: { x: 10, y: 20 }, c2: { x: 20, y: 40 } };
+  const target = { x: 30, y: 60 };
+
+  it("returns null when direction is null (no arrow to draw)", () => {
+    expect(computeArrowTriangle(source, control, target, null)).toBeNull();
+  });
+
+  it("returns null for a degenerate (zero-length) tangent", () => {
+    const point = { x: 5, y: 5 };
+    const flatControl = { c1: point, c2: point };
+    expect(
+      computeArrowTriangle(point, flatControl, point, "a-to-b"),
+    ).toBeNull();
+  });
+
+  it("centres a triangle on the midpoint, tip pointing toward the target for a-to-b", () => {
+    const triangle = computeArrowTriangle(source, control, target, "a-to-b");
+    expect(triangle).not.toBeNull();
+    // Hand-computed: midpoint (15,30), unit tangent (1/sqrt5, 2/sqrt5),
+    // half-length 3.5 (ARROW_LENGTH/2), half-width 2.5 (ARROW_WIDTH/2).
+    expect(triangle!.tip.x).toBeCloseTo(16.56525, 4);
+    expect(triangle!.tip.y).toBeCloseTo(33.1305, 4);
+    expect(triangle!.base1.x).toBeCloseTo(11.19868, 4);
+    expect(triangle!.base1.y).toBeCloseTo(27.98754, 4);
+    expect(triangle!.base2.x).toBeCloseTo(15.67082, 4);
+    expect(triangle!.base2.y).toBeCloseTo(25.75147, 4);
+  });
+
+  it("flips the tip toward the source for b-to-a (opposite orientation of a-to-b)", () => {
+    const aToB = computeArrowTriangle(source, control, target, "a-to-b")!;
+    const bToA = computeArrowTriangle(source, control, target, "b-to-a")!;
+    const midpoint = cubicBezierPointAt(source, control, target, 0.5);
+
+    // a-to-b's tip sits past the midpoint toward the target (larger x/y);
+    // b-to-a's tip sits past the midpoint toward the source (smaller x/y).
+    expect(aToB.tip.x).toBeGreaterThan(midpoint.x);
+    expect(bToA.tip.x).toBeLessThan(midpoint.x);
+    expect(aToB.tip.y).toBeGreaterThan(midpoint.y);
+    expect(bToA.tip.y).toBeLessThan(midpoint.y);
+  });
+
+  it("uses the supplied arrow size instead of the module defaults", () => {
+    const small = computeArrowTriangle(source, control, target, "a-to-b", {
+      length: 2,
+      width: 2,
+    });
+    const dflt = computeArrowTriangle(source, control, target, "a-to-b");
+    expect(small).not.toBeNull();
+    expect(dflt).not.toBeNull();
+    const midpoint = cubicBezierPointAt(source, control, target, 0.5);
+    const smallDist = Math.hypot(
+      small!.tip.x - midpoint.x,
+      small!.tip.y - midpoint.y,
+    );
+    const dfltDist = Math.hypot(
+      dflt!.tip.x - midpoint.x,
+      dflt!.tip.y - midpoint.y,
+    );
+    expect(smallDist).toBeLessThan(dfltDist);
+  });
+});
+
+describe("arrowPointsAttr", () => {
+  it("formats a triangle as an SVG polygon points attribute", () => {
+    const points = arrowPointsAttr({
+      tip: { x: 1, y: 2 },
+      base1: { x: 3, y: 4 },
+      base2: { x: 5, y: 6 },
+    });
+    expect(points).toBe("1,2 3,4 5,6");
+  });
+});
+
+describe("computeConnectionGeometry", () => {
+  const rackBounds = { x: 0, y: 0, width: 200, height: 900 };
+  const source = { x: 10, y: 50 };
+  const target = { x: 190, y: 300 };
+
+  it("routes through the right gutter at index 0 and produces no arrow with no direction", () => {
+    const geometry = computeConnectionGeometry(
+      source,
+      target,
+      rackBounds,
+      0,
+      null,
+    );
+    expect(geometry.side).toBe("right");
+    expect(geometry.arrow).toBeNull();
+    expect(geometry.path.startsWith("M 10,50 C 230,50 230,300")).toBe(true);
+  });
+
+  it("routes through the left gutter at index 1 and produces an arrow when direction is set", () => {
+    const geometry = computeConnectionGeometry(
+      source,
+      target,
+      rackBounds,
+      1,
+      "a-to-b",
+    );
+    expect(geometry.side).toBe("left");
+    expect(geometry.arrow).not.toBeNull();
+  });
+
+  it("computes the midpoint from the same control points used in the path", () => {
+    const geometry = computeConnectionGeometry(
+      source,
+      target,
+      rackBounds,
+      0,
+      null,
+    );
+    const control = computeChannelControlPoints(
+      source,
+      target,
+      rackBounds,
+      "right",
+    );
+    expect(geometry.midpoint).toEqual(
+      cubicBezierPointAt(source, control, target, 0.5),
+    );
+  });
+});
+
+describe("resolveConnectionPortDirection", () => {
+  it("prefers an explicit PlacedPort.direction override over everything else", () => {
+    const port = createTestPlacedPort({ direction: "output" });
+    const iface = createTestInterfaceTemplate({ direction: "input" });
+    expect(resolveConnectionPortDirection(port, iface)).toBe("output");
+  });
+
+  it("falls back to the InterfaceTemplate default when the port has no override", () => {
+    const port = createTestPlacedPort();
+    const iface = createTestInterfaceTemplate({ direction: "input" });
+    expect(resolveConnectionPortDirection(port, iface)).toBe("input");
+  });
+
+  it("falls back to inferDirection() using the interface type when neither is explicit", () => {
+    const port = createTestPlacedPort({ type: "1000base-t" });
+    const iface = createTestInterfaceTemplate({ type: "1000base-t" });
+    expect(resolveConnectionPortDirection(port, iface)).toBe("bidirectional");
+  });
+
+  it("infers input for console/management interfaces with no explicit direction", () => {
+    const port = createTestPlacedPort({ type: "console" });
+    const iface = createTestInterfaceTemplate({ type: "console" });
+    expect(resolveConnectionPortDirection(port, iface)).toBe("input");
+  });
+
+  it("has no inferred direction for an AV type with no explicit direction", () => {
+    const port = createTestPlacedPort({ type: "hdmi" });
+    const iface = createTestInterfaceTemplate({ type: "hdmi" });
+    expect(resolveConnectionPortDirection(port, iface)).toBeUndefined();
+  });
+
+  it("falls back to the PlacedPort's cached type when no InterfaceTemplate is available", () => {
+    const port = createTestPlacedPort({ type: "console" });
+    expect(resolveConnectionPortDirection(port, undefined)).toBe("input");
+  });
+
+  it("returns undefined when neither a port nor an interface is available", () => {
+    expect(
+      resolveConnectionPortDirection(undefined, undefined),
+    ).toBeUndefined();
+  });
+});
+
+describe("computeDeviceOffset", () => {
+  it("matches RackDevice.svelte's transform formula for a mid-rack device", () => {
+    const offset = computeDeviceOffset({
+      position: toInternalUnits(10),
+      deviceUHeight: 2,
+      rackHeight: 42,
+      uHeight: 22,
+      railWidth: 17,
+      rackPadding: 18,
+    });
+    // yPosition = (42 - 10 - 2 + 1) * 22 = 682; y = rackPadding + railWidth + yPosition
+    expect(offset).toEqual({ x: 17, y: 717 });
+  });
+
+  it("matches the formula for a device at the bottom of a short rack", () => {
+    const offset = computeDeviceOffset({
+      position: toInternalUnits(1),
+      deviceUHeight: 1,
+      rackHeight: 10,
+      uHeight: 22,
+      railWidth: 17,
+      rackPadding: 18,
+    });
+    // yPosition = (10 - 1 - 1 + 1) * 22 = 198; y = 18 + 17 + 198
+    expect(offset).toEqual({ x: 17, y: 233 });
+  });
+});
+
+describe("buildPortAnchorMap", () => {
+  const rackDims = {
+    rackHeight: 42,
+    rackWidth: 220,
+    interiorWidth: 186,
+    uHeight: 22,
+    rackPadding: 18,
+    railWidth: 17,
+  };
+
+  it("anchors every individually-rendered port, keyed by PlacedPort.id", () => {
+    const deviceType = {
+      ...createTestDeviceType({ slug: "switch-1", u_height: 1 }),
+      interfaces: [
+        createTestInterfaceTemplate({ name: "eth0", direction: "output" }),
+        createTestInterfaceTemplate({ name: "eth1", direction: "input" }),
+      ],
+    };
+    const device = createTestDevice({
+      device_type: "switch-1",
+      position: 10,
+      ports: [
+        createTestPlacedPort({ id: "port-eth0", template_index: 0 }),
+        createTestPlacedPort({ id: "port-eth1", template_index: 1 }),
+      ],
+    });
+    const bySlug = new Map([[deviceType.slug, deviceType]]);
+
+    const anchors = buildPortAnchorMap([device], bySlug, "front", rackDims);
+
+    expect(anchors.size).toBe(2);
+    expect(anchors.get("port-eth0")?.direction).toBe("output");
+    expect(anchors.get("port-eth1")?.direction).toBe("input");
+  });
+
+  it("anchors no ports for a device in grouped/high-density mode (#3089 fallback)", () => {
+    const interfaces = Array.from(
+      { length: HIGH_DENSITY_THRESHOLD + 1 },
+      (_, i) => createTestInterfaceTemplate({ name: `eth${i}` }),
+    );
+    const ports = interfaces.map((_, i) =>
+      createTestPlacedPort({ id: `port-${i}`, template_index: i }),
+    );
+    const deviceType = {
+      ...createTestDeviceType({ slug: "patch-panel", u_height: 1 }),
+      interfaces,
+    };
+    const device = createTestDevice({ device_type: "patch-panel", ports });
+    const bySlug = new Map([[deviceType.slug, deviceType]]);
+
+    const anchors = buildPortAnchorMap([device], bySlug, "front", rackDims);
+
+    expect(anchors.size).toBe(0);
+  });
+
+  it("skips a device whose type is missing from the library without throwing", () => {
+    const device = createTestDevice({ device_type: "unknown-slug" });
+    expect(() =>
+      buildPortAnchorMap([device], new Map(), "front", rackDims),
+    ).not.toThrow();
+    expect(
+      buildPortAnchorMap([device], new Map(), "front", rackDims).size,
+    ).toBe(0);
+  });
+
+  it("skips a device type with no interfaces", () => {
+    const deviceType = createTestDeviceType({ slug: "blank-1u", u_height: 1 });
+    const device = createTestDevice({ device_type: "blank-1u" });
+    const bySlug = new Map([[deviceType.slug, deviceType]]);
+    expect(buildPortAnchorMap([device], bySlug, "front", rackDims).size).toBe(
+      0,
+    );
+  });
+});
+
+describe("buildRenderedConnections", () => {
+  const rackBounds = { x: 0, y: 0, width: 220, height: 900 };
+
+  it("resolves a connection whose both ports are anchored, with a gated arrow", () => {
+    const portAnchors = new Map<string, ResolvedPortAnchor>([
+      ["port-a", makeResolvedAnchor("port-a", 10, 50, "output")],
+      ["port-b", makeResolvedAnchor("port-b", 190, 300, "input")],
+    ]);
+    const connection = makeTestConnection();
+
+    const rendered = buildRenderedConnections(
+      [connection],
+      portAnchors,
+      rackBounds,
+    );
+
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: exactly one fully-anchored connection renders
+    expect(rendered).toHaveLength(1);
+    expect(rendered[0].connection).toBe(connection);
+    expect(rendered[0].geometry.arrow).not.toBeNull();
+  });
+
+  it("skips a connection when either endpoint has no anchor (grouped-mode fallback)", () => {
+    const portAnchors = new Map<string, ResolvedPortAnchor>([
+      ["port-a", makeResolvedAnchor("port-a", 10, 50, "output")],
+      // port-b intentionally missing: high-density device, wrong face, or
+      // legacy data with no PlacedPort match.
+    ]);
+    const connection = makeTestConnection();
+
+    const rendered = buildRenderedConnections(
+      [connection],
+      portAnchors,
+      rackBounds,
+    );
+
+    expect(rendered).toEqual([]);
+  });
+
+  it("only advances the channel-side index for connections that actually render", () => {
+    const portAnchors = new Map<string, ResolvedPortAnchor>([
+      ["port-a", makeResolvedAnchor("port-a", 10, 50)],
+      ["port-b", makeResolvedAnchor("port-b", 190, 300)],
+      ["port-c", makeResolvedAnchor("port-c", 10, 100)],
+      ["port-d", makeResolvedAnchor("port-d", 190, 400)],
+    ]);
+    const connections = [
+      makeTestConnection({
+        id: "conn-1",
+        a_port_id: "port-a",
+        b_port_id: "port-b",
+      }),
+      // conn-2 references a port with no anchor and is skipped; it must not
+      // consume a channel-side slot.
+      makeTestConnection({
+        id: "conn-2",
+        a_port_id: "port-a",
+        b_port_id: "missing",
+      }),
+      makeTestConnection({
+        id: "conn-3",
+        a_port_id: "port-c",
+        b_port_id: "port-d",
+      }),
+    ];
+
+    const rendered = buildRenderedConnections(
+      connections,
+      portAnchors,
+      rackBounds,
+    );
+
+    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: the skipped connection must not render or consume a channel-side slot
+    expect(rendered).toHaveLength(2);
+    expect(rendered[0].geometry.side).toBe("right");
+    expect(rendered[1].geometry.side).toBe("left");
+  });
+});

--- a/src/tests/connection-path.test.ts
+++ b/src/tests/connection-path.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./factories";
 import {
   DEFAULT_GUTTER_OFFSET,
+  HIT_PATH_TRIM,
   arrowPointsAttr,
   assignChannelSide,
   buildCubicBezierPath,
@@ -38,6 +39,7 @@ import {
   cubicBezierTangentAt,
   resolveArrowDirection,
   resolveConnectionPortDirection,
+  trimCubicBezier,
   type ResolvedPortAnchor,
 } from "$lib/utils/connection-path";
 import { HIGH_DENSITY_THRESHOLD } from "$lib/utils/port-geometry";
@@ -147,6 +149,48 @@ describe("cubicBezierTangentAt", () => {
         y: 60,
       });
     }
+  });
+});
+
+describe("trimCubicBezier", () => {
+  // A genuinely curved (non-collinear) fixture, so the subdivision test
+  // below is not trivially satisfied by a degenerate straight-line case.
+  const source = { x: 0, y: 0 };
+  const control = { c1: { x: 0, y: 100 }, c2: { x: 100, y: 100 } };
+  const target = { x: 100, y: 0 };
+
+  it("leaves the curve unchanged when trimming the full [0, 1] range", () => {
+    const trimmed = trimCubicBezier(source, control, target, 0, 1);
+    expect(trimmed).toEqual({ source, control, target });
+  });
+
+  it("reproduces the exact original curve over the trimmed sub-range (De Casteljau exactness)", () => {
+    const t0 = 0.15;
+    const t1 = 0.85;
+    const trimmed = trimCubicBezier(source, control, target, t0, t1);
+
+    for (const s of [0, 0.25, 0.5, 0.75, 1]) {
+      const originalT = t0 + s * (t1 - t0);
+      const expected = cubicBezierPointAt(source, control, target, originalT);
+      const actual = cubicBezierPointAt(
+        trimmed.source,
+        trimmed.control,
+        trimmed.target,
+        s,
+      );
+      expect(actual.x).toBeCloseTo(expected.x, 6);
+      expect(actual.y).toBeCloseTo(expected.y, 6);
+    }
+  });
+
+  it("collapses to a single point when t1 does not exceed t0", () => {
+    const point = cubicBezierPointAt(source, control, target, 0.4);
+    const trimmed = trimCubicBezier(source, control, target, 0.4, 0.4);
+    expect(trimmed).toEqual({
+      source: point,
+      control: { c1: point, c2: point },
+      target: point,
+    });
   });
 });
 
@@ -298,6 +342,37 @@ describe("computeConnectionGeometry", () => {
     expect(geometry.midpoint).toEqual(
       cubicBezierPointAt(source, control, target, 0.5),
     );
+  });
+
+  it("trims the hit-stroke path away from both endpoints, unlike the full visible path", () => {
+    const geometry = computeConnectionGeometry(
+      source,
+      target,
+      rackBounds,
+      0,
+      null,
+    );
+    const control = computeChannelControlPoints(
+      source,
+      target,
+      rackBounds,
+      "right",
+    );
+    const trimmedStart = cubicBezierPointAt(
+      source,
+      control,
+      target,
+      HIT_PATH_TRIM,
+    );
+
+    // The full path still starts at the true source (the port anchor).
+    expect(geometry.path.startsWith(`M ${source.x},${source.y}`)).toBe(true);
+
+    expect(geometry.hitPath).not.toBe(geometry.path);
+    const hitStartMatch = geometry.hitPath.match(/^M ([\d.-]+),([\d.-]+)/);
+    expect(hitStartMatch).not.toBeNull();
+    expect(Number(hitStartMatch![1])).toBeCloseTo(trimmedStart.x, 6);
+    expect(Number(hitStartMatch![2])).toBeCloseTo(trimmedStart.y, 6);
   });
 });
 
@@ -463,8 +538,7 @@ describe("buildRenderedConnections", () => {
       rackBounds,
     );
 
-    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: exactly one fully-anchored connection renders
-    expect(rendered).toHaveLength(1);
+    expect(rendered.map((r) => r.connection.id)).toEqual([connection.id]);
     expect(rendered[0].connection).toBe(connection);
     expect(rendered[0].geometry.arrow).not.toBeNull();
   });
@@ -519,8 +593,7 @@ describe("buildRenderedConnections", () => {
       rackBounds,
     );
 
-    // eslint-disable-next-line no-restricted-syntax -- behavioral invariant: the skipped connection must not render or consume a channel-side slot
-    expect(rendered).toHaveLength(2);
+    expect(rendered.map((r) => r.connection.id)).toEqual(["conn-1", "conn-3"]);
     expect(rendered[0].geometry.side).toBe("right");
     expect(rendered[1].geometry.side).toBe("left");
   });


### PR DESCRIPTION
## **User description**
## Summary

Renders port-to-port connections as SVG cubic bezier curves in the rack view: `ConnectionLayer.svelte` (the SVG container) and `ConnectionPath.svelte` (one connection). This is the core visual feature that lets users see signal flow between devices.

Closes #1931

## Layer architecture: why rack level

`ConnectionLayer` is rendered by `Rack.svelte` as a sibling layer immediately after the device each-block, so it draws above every device body. It is not rendered inside `RackDevice`: `PortIndicators` already renders mid-stack inside `RackDevice`, and a per-device layer cannot draw a line that starts on one device and ends on another; only a rack-level layer can see both endpoints and paint above the whole stack.

`Rack.svelte` passes it the same visible-device set `RackDevice` renders from (`connectionDevices`, derived from `visibleDevices`), the device library, the current rack view, and the existing `rackDims` object it already builds for the drag/drop pipeline, so no new prop plumbing was needed there.

## Channel algorithm and spike #262 lineage

`src/lib/utils/connection-path.ts` is the production implementation of the "external channel" algorithm spike #262 recommended (`docs/research/connection-routing.ts`, scored 5/5: never crosses devices, clean visual hierarchy, natural bundling). The reference file is read-only prior art, not imported from; the routing math is reproduced and split into independently testable steps:

- `assignChannelSide(index)`: alternates connections between the right and left gutter for visual load balancing.
- `computeChannelControlPoints`: control points that exit both endpoints horizontally toward a shared gutter line outside the rack body.
- `buildCubicBezierPath` / `cubicBezierPointAt` / `cubicBezierTangentAt`: the SVG path string, a point on the curve at parameter t, and its tangent there.
- `computeConnectionGeometry`: composes the above into one connection's renderable geometry (path, side, midpoint, arrow).

The gutter routes outside the rack's `x` bounds; `Rack.svelte`'s SVG already sets `overflow: visible`, so the curve renders correctly there.

## Anchor sourcing (#3089)

Port anchors come exclusively from `port-geometry.ts`'s `getPortAnchors` (#3089), never recomputed. `buildPortAnchorMap` in `connection-path.ts` is a thin per-device loop: for each visible device it computes the device's SVG-space offset (`computeDeviceOffset`, reproducing the `RAIL_WIDTH` / `RACK_PADDING + RAIL_WIDTH + yPosition` transform `RackDevice.svelte` and `Rack.svelte` apply together) and calls `getPortAnchors` with that offset, exactly as documented in `port-geometry.ts`'s own module comment anticipating this issue.

Because anchors are derived reactively from `rack.devices` via `$derived`, a device move (drag-drop, undo/redo, keyboard nudge) that changes `PlacedDevice.position` flows straight through to new anchor coordinates and the connection follows.

## Direction arrow gating

A small triangle renders at the path midpoint only when the two ports resolve to unambiguous, opposite roles: one "output", the other "input" (`resolveArrowDirection`). Bidirectional, unspecified, or same-role pairs (input/input, output/output) render as a plain line, no arrow.

Each port's effective direction (`resolveConnectionPortDirection`) follows the same precedence `PortIndicators` already uses for a port's own direction glyph: an explicit `PlacedPort.direction` override, then the `InterfaceTemplate.direction` default, then `inferDirection()`. This keeps the connection arrow consistent with whatever direction indicator the port itself already shows. It falls back to `PlacedPort.type` (documented as cached "to avoid lookups for cable routing") when no `InterfaceTemplate` is available.

## Colour and label handling

`Connection.color` is a user-chosen hex literal per the schema comment ("hex, e.g. `#FF5500`"), used as-is when set. The fallback is a design token (`var(--colour-port-default)`), not a hardcoded hex, matching the project's token-based-defaults convention.

Hover and label follow the `PortIndicators` hit-target idiom rather than a new global tooltip store: a wide invisible stroke (`pointer-events: stroke`) owns the hover/click target and carries the connection's `label` as a native SVG `<title>` (a lightweight tooltip, one of the two options the issue explicitly allows), while a sibling CSS `:hover` rule on the shared group brightens the visible line and arrow. This avoids introducing new global state or touching `App.svelte` for a feature the issue treats as out of unit-test scope anyway.

## Grouped-mode fallback decision (#3089 caveat)

A connection whose port has no anchor, because its device is over the high-density threshold (`getPortAnchors` returns `[]` for >24 visible ports), the port is on the other rack face, it is a cross-rack endpoint, or the layout predates `PlacedPort` identity, is skipped entirely by `buildRenderedConnections`. It is not approximated with a device-edge-centre anchor.

Reasoning, documented in code alongside the function: an edge-centre fallback would draw a specific, plausible-looking line to a location that is not actually where the port is, misleading the viewer about what is connected to what. Silently omitting the connection is the honest failure mode. The connection still exists in the data and reappears the moment its port becomes individually addressable again (device drops under the threshold, or the layout gains `PlacedPort` ids via #3090's serialization).

## Performance argument (50+ connections)

No benchmark; the algorithmic case:

- Anchor lookup is O(devices x ports-per-device); connection resolution is O(connections). Total per-recompute work is O(D + C), not O(D x C) or worse.
- `resolvedPorts` and `renderedConnections` are plain `$derived` values, so Svelte only recomputes them when `rack.devices` or the connections array actually change reference, not on pan/zoom, selection, or unrelated store updates. Idle steady-state cost is zero.
- Each connection's geometry is closed-form arithmetic (a handful of multiplications for the bezier control points, plus a De Casteljau evaluation for the midpoint/arrow), not a search or a layout pass. Fifty-plus of those per relevant state change is comfortably sub-millisecond, far under a 16ms frame budget.
- Moving one device does invalidate and recompute anchors for every device in the rack, not just the moved one (Svelte's `$derived.by` reruns as one unit on any tracked dependency change). True per-device incremental memoization would require `RackDevice` to publish its own anchors into a shared reactive map, which is a larger architectural change out of scope for this issue. Given the O(D + C) cost above, full recomputation on every move is not perceptible at realistic rack/connection counts, so this was deliberately not built.

## What is unit-tested vs deferred to E2E

Per the issue's Testing Notes, rendered-DOM assertions are blocked by the project's ESLint testing rules, so hover highlight and frame-rate acceptance are verified manually / via E2E, not unit tests.

Unit-tested (`src/tests/connection-path.test.ts`, 39 tests, all pure functions in `connection-path.ts`):

- Channel side assignment and control-point/gutter placement (both sides, default and explicit gutter offset).
- Cubic bezier path string formatting, point-at-t, and tangent-at-t (verified against hand-computed straight-line-reduction cases).
- Direction gating (`resolveArrowDirection`) for every role combination.
- Arrow triangle placement, orientation (a-to-b vs b-to-a), degenerate (zero-length tangent) handling, and custom sizing.
- Effective port direction resolution precedence (`resolveConnectionPortDirection`), including the `PlacedPort.type` fallback.
- The device-offset formula (`computeDeviceOffset`) against hand-computed values matching `RackDevice.svelte`'s transform.
- `buildPortAnchorMap`: anchors ports correctly, returns no anchors for a grouped/high-density device, and skips unknown/interface-less device types without throwing.
- `buildRenderedConnections`: renders a fully-anchored connection with a gated arrow, skips a connection with a missing anchor (the grouped-mode fallback, asserted directly), and confirms a skipped connection does not consume a channel-side slot.

Connection test objects use `src/tests/factories.ts`'s `createTestConnection`, added by #3115 while this branch was in flight; the branch was rebased onto `origin/main` after that PR merged and switched from a local placeholder helper to the shared factory.

## Testing

- [x] Unit tests pass (`VITEST_MAX_WORKERS=2 npm run test:run`): 252 files, 3736 tests, all green.
- [x] `npm run check`: 0 errors, 0 warnings.
- [x] `npx eslint` on all touched/new files: no issues.
- [x] Svelte MCP `svelte-autofixer` on `ConnectionLayer.svelte`, `ConnectionPath.svelte`, and `Rack.svelte`: no issues (Rack.svelte surfaced only pre-existing, unrelated suggestions about code this PR did not touch).
- [ ] E2E tests: not run for this PR; hover highlight and frame-rate acceptance are manual/E2E per the issue's Testing Notes.
- [ ] Manual testing: not yet performed in a running app.

## Accessibility

Connections are decorative SVG paths layered above devices; they carry no new interactive controls beyond the existing hover/title affordance (matching `PortIndicators`' established pattern) and respect `prefers-reduced-motion` (hover transitions are disabled under that media query, same as the rest of the rack rendering).

- [x] `prefers-reduced-motion` is respected for the hover transition
- [ ] Other items not applicable: no new interactive controls, keyboard focus targets, or panels/dialogs were added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Show rack connections as routed lines with optional direction arrows**

### What Changed
- Rack connections now appear as SVG curves drawn above the device stack, so links between ports stay visible across the whole rack
- Connections route around the outside of the rack instead of crossing through devices, and they alternate between left and right sides
- A direction arrow is shown only when the two ports clearly go from output to input; otherwise the connection is shown as a plain line
- Hovering a connection highlights it, and labeled connections show a native tooltip
- Connections with no exact port anchor are skipped instead of being guessed at, which avoids drawing misleading lines for grouped or high-density ports

### Impact
`✅ Clearer rack signal flow`
`✅ Fewer misleading connection lines`
`✅ Easier-to-read port direction`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
