### PR TITLE
feat: desktop connection creation workflow

### DIFF
--- a/src/lib/components/DialogOrchestrator.svelte
+++ b/src/lib/components/DialogOrchestrator.svelte
@@ -37,6 +37,7 @@
   import type { ImageStoreMap } from "$lib/types/images";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
+  import { getConnectionCreationStore } from "$lib/stores/connection-creation.svelte";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
 
   import {
@@ -92,6 +93,7 @@
   const imageStore = getImageStore();
   const viewportStore = getViewportStore();
   const placementStore = getPlacementStore();
+  const connectionCreationStore = getConnectionCreationStore();
 
   // Dialog state — derived from dialogStore
   let addDeviceFormOpen = $derived(dialogStore.isOpen("addDevice"));
@@ -1021,4 +1023,18 @@
   data-testid="placement-sr-announcer"
 >
   {placementStore.placementAnnouncement ?? ""}
+</div>
+
+<!--
+  Connection-creation outcome SR announcer (#1932).
+  Assertive live region announces mode transitions (started, cancelled,
+  created), mirroring the placement announcer above.
+-->
+<div
+  aria-live="assertive"
+  aria-atomic="true"
+  class="sr-only"
+  data-testid="connection-creation-sr-announcer"
+>
+  {connectionCreationStore.connectionAnnouncement ?? ""}
 </div>

--- a/src/lib/components/KeyboardHandler.svelte
+++ b/src/lib/components/KeyboardHandler.svelte
@@ -13,6 +13,7 @@
   import { dialogStore } from "$lib/stores/dialogs.svelte";
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
+  import { getConnectionCreationStore } from "$lib/stores/connection-creation.svelte";
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
   import { getToastStore } from "$lib/stores/toast.svelte";
   import {
@@ -25,6 +26,7 @@
 
   const layoutStore = getLayoutStore();
   const placementStore = getPlacementStore();
+  const connectionCreationStore = getConnectionCreationStore();
   const canvasStore = getCanvasStore();
   const toastStore = getToastStore();
 
@@ -83,6 +85,19 @@
     return true;
   }
 
+  /**
+   * Right-click cancels connection-creation mode (#1932) anywhere it is not
+   * already handled by a more specific target. RackDevice's own context menu
+   * handler covers a right-click on a device body or a port (it stops
+   * propagation before this window listener would see it); this covers
+   * right-clicking empty rack space or canvas chrome instead.
+   */
+  function handleContextMenu(event: MouseEvent) {
+    if (!connectionCreationStore.isCreating) return;
+    event.preventDefault();
+    connectionCreationStore.cancelConnection();
+  }
+
   function handleKeyDown(event: KeyboardEvent) {
     // Palette shortcut fires even from a text field, and before any other
     // handling. It is the first special-case to run before shouldIgnoreKeyboard.
@@ -106,6 +121,13 @@
     // Ignore if in input field
     if (shouldIgnoreKeyboard(event)) return;
 
+    // Escape cancels connection-creation mode (#1932), mirroring right-click.
+    if (connectionCreationStore.isCreating && event.key === "Escape") {
+      event.preventDefault();
+      connectionCreationStore.cancelConnection();
+      return;
+    }
+
     // Keyboard placement (#106) owns arrow / Tab / Enter / Escape while a device
     // is armed, so it runs before the action registry (which binds arrows to
     // move-device and Escape to clear-selection). It only consumes keys while
@@ -127,4 +149,4 @@
   }
 </script>
 
-<svelte:window onkeydown={handleKeyDown} />
+<svelte:window onkeydown={handleKeyDown} oncontextmenu={handleContextMenu} />

--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -189,7 +189,7 @@
     iface: InterfaceTemplate,
     port: PlacedPort | undefined,
   ) {
-    onPortClick?.({ portId: port?.id, iface });
+    onPortClick?.({ portId: port?.id, iface, port });
   }
 
   function handlePortMouseEnter(event: MouseEvent, iface: InterfaceTemplate) {
@@ -229,7 +229,8 @@
           class="port-circle"
           class:port-connection-source={port?.id === connectionSourcePortId}
           class:port-connection-target={isConnectionCreationMode &&
-            port?.id !== connectionSourcePortId}
+            port?.id != null &&
+            port.id !== connectionSourcePortId}
           cx={x}
           cy={y}
           r={PORT_RADIUS}
@@ -283,7 +284,8 @@
           class="port-hit-target"
           class:port-connection-source={port?.id === connectionSourcePortId}
           class:port-connection-target={isConnectionCreationMode &&
-            port?.id !== connectionSourcePortId}
+            port?.id != null &&
+            port.id !== connectionSourcePortId}
           cx={x}
           cy={y}
           r={6}
@@ -293,7 +295,9 @@
           aria-label="{iface.label ?? iface.name} ({iface.type}){port?.id ===
           connectionSourcePortId
             ? ', connection source'
-            : isConnectionCreationMode && port?.id !== connectionSourcePortId
+            : isConnectionCreationMode &&
+                port?.id != null &&
+                port.id !== connectionSourcePortId
               ? ', potential connection target'
               : ''}"
           onclick={() => handlePortClick(iface, port)}

--- a/src/lib/components/PortIndicators.svelte
+++ b/src/lib/components/PortIndicators.svelte
@@ -24,6 +24,7 @@
     showPortTooltip,
     hidePortTooltip,
   } from "$lib/stores/portTooltip.svelte";
+  import { getConnectionCreationStore } from "$lib/stores/connection-creation.svelte";
   import { getPortCategory, inferDirection } from "$lib/utils/port-utils";
   import {
     computeVisiblePortLayout,
@@ -55,6 +56,19 @@
   // Tooltip delay timer (reactive state for proper cleanup)
   let hoverTimeoutId = $state<ReturnType<typeof setTimeout> | null>(null);
   const TOOLTIP_DELAY_MS = 300;
+
+  // Connection-creation mode (#1932): while armed, the source port shows as
+  // active and every other rendered port shows as a potential target. Read
+  // directly from the store (like placementStore elsewhere) rather than
+  // threaded as a prop, since every PortIndicators instance needs the same
+  // global mode state.
+  const connectionCreationStore = getConnectionCreationStore();
+  const connectionSourcePortId = $derived(
+    connectionCreationStore.isCreating
+      ? connectionCreationStore.sourcePortId
+      : null,
+  );
+  const isConnectionCreationMode = $derived(connectionCreationStore.isCreating);
 
   // Cleanup timeout on component unmount to prevent dangling timers
   $effect(() => {
@@ -213,6 +227,9 @@
       {#each portPositions as { iface, port, x, y, color }, i (port?.id ?? i)}
         <circle
           class="port-circle"
+          class:port-connection-source={port?.id === connectionSourcePortId}
+          class:port-connection-target={isConnectionCreationMode &&
+            port?.id !== connectionSourcePortId}
           cx={x}
           cy={y}
           r={PORT_RADIUS}
@@ -264,13 +281,21 @@
       {#each portPositions as { iface, port, x, y }, i (port?.id ?? i)}
         <circle
           class="port-hit-target"
+          class:port-connection-source={port?.id === connectionSourcePortId}
+          class:port-connection-target={isConnectionCreationMode &&
+            port?.id !== connectionSourcePortId}
           cx={x}
           cy={y}
           r={6}
           fill="transparent"
           role="button"
           tabindex="0"
-          aria-label="{iface.label ?? iface.name} ({iface.type})"
+          aria-label="{iface.label ?? iface.name} ({iface.type}){port?.id ===
+          connectionSourcePortId
+            ? ', connection source'
+            : isConnectionCreationMode && port?.id !== connectionSourcePortId
+              ? ', potential connection target'
+              : ''}"
           onclick={() => handlePortClick(iface, port)}
           onmouseenter={(e) => handlePortMouseEnter(e, iface)}
           onmouseleave={handlePortMouseLeave}
@@ -355,6 +380,21 @@
     font-weight: 600;
     font-family: var(--font-mono, monospace);
     text-shadow: var(--shadow-port-text);
+  }
+
+  /* Connection-creation mode (#1932): the source port shows as active... */
+  .port-connection-source {
+    stroke: var(--colour-selection, var(--dracula-pink, #ff79c6));
+    stroke-width: 1.5;
+  }
+
+  /* ...every other port shows as a potential target while the mode is armed.
+     Stroke-only: the hit-target's fill stays transparent (or its existing
+     hover tint) so this layers with, rather than replaces, hover feedback. */
+  .port-connection-target {
+    stroke: var(--colour-selection, var(--dracula-pink, #ff79c6));
+    stroke-width: 1;
+    stroke-dasharray: 1.5 1;
   }
 
   .port-group-badge rect {

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -42,6 +42,10 @@
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
   import { validStartPositions } from "$lib/utils/placement-keyboard";
+  import { getConnectionCreationStore } from "$lib/stores/connection-creation.svelte";
+  import { getConnectionStore } from "$lib/stores/connection.svelte";
+  import { handleConnectionPortClick } from "$lib/utils/connection-creation";
+  import type { PortClickInfo } from "$lib/types";
   import { SvelteSet, SvelteMap } from "svelte/reactivity";
   import { fade } from "svelte/transition";
   import { prefersReducedMotion } from "svelte/motion";
@@ -81,6 +85,8 @@
   const toastStore = getToastStore();
   const layoutStore = getLayoutStore();
   const selectionStore = getSelectionStore();
+  const connectionCreationStore = getConnectionCreationStore();
+  const connectionStore = getConnectionStore();
 
   const showChristmasHats = isChristmas();
   const DRAG_CLICK_DEBOUNCE_MS = 100;
@@ -473,6 +479,22 @@
       onselect?.(new CustomEvent("select", { detail: { rackId: rack.id } }));
     }
   }
+
+  /**
+   * Route a port click through connection-creation mode (#1932): the first
+   * click on a port arms the mode with it as source, the second click on a
+   * different port validates and creates the connection. Delegates to the
+   * pure handler in connection-creation.ts so the state machine and
+   * validation/warning surfacing are unit-testable without mounting Rack.
+   */
+  function handlePortClick(info: PortClickInfo) {
+    handleConnectionPortClick(info, {
+      connectionCreation: connectionCreationStore,
+      validateConnection: connectionStore.validateConnection,
+      addConnection: connectionStore.addConnection,
+      showToast: (message, type) => toastStore.showToast(message, type, 4000),
+    });
+  }
 </script>
 
 <!-- The rack is a list item that holds interactive devices, so it is a
@@ -585,6 +607,7 @@
               isDragTargetValid={isHoveredContainer &&
                 (containerHoverInfo?.isValidTarget ?? false)}
               onselect={ondeviceselect}
+              onPortClick={handlePortClick}
               ondragend={() => setDragFinished()}
               onduplicate={(e) =>
                 contextActions.handleDuplicate(rack, {

--- a/src/lib/components/Rack.svelte
+++ b/src/lib/components/Rack.svelte
@@ -486,10 +486,14 @@
    * different port validates and creates the connection. Delegates to the
    * pure handler in connection-creation.ts so the state machine and
    * validation/warning surfacing are unit-testable without mounting Rack.
+   * Placement mode owns the click gesture while armed (isPlacementActive),
+   * so a port click is a no-op there rather than also arming connection
+   * creation on top of an active placement.
    */
   function handlePortClick(info: PortClickInfo) {
     handleConnectionPortClick(info, {
       connectionCreation: connectionCreationStore,
+      isPlacementActive: placementStore.isPlacing,
       validateConnection: connectionStore.validateConnection,
       addConnection: connectionStore.addConnection,
       showToast: (message, type) => toastStore.showToast(message, type, 4000),

--- a/src/lib/components/RackDevice.svelte
+++ b/src/lib/components/RackDevice.svelte
@@ -29,6 +29,7 @@
   import { getLayoutStore } from "$lib/stores/layout.svelte";
   import { getCanvasStore } from "$lib/stores/canvas.svelte";
   import { getPlacementStore } from "$lib/stores/placement.svelte";
+  import { getConnectionCreationStore } from "$lib/stores/connection-creation.svelte";
   import { placementKey } from "$lib/utils/placement-key";
   import { getViewportStore } from "$lib/utils/viewport.svelte";
   import { useLongPress } from "$lib/utils/gestures";
@@ -154,6 +155,7 @@
   const imageStore = getImageStore();
   const layoutStore = getLayoutStore();
   const placementStore = getPlacementStore();
+  const connectionCreationStore = getConnectionCreationStore();
 
   // Check if display mode shows images (either 'image' or 'image-label')
   const isImageMode = $derived(
@@ -632,10 +634,17 @@
     }
   }
 
-  // Context menu handler (right-click) - opens device context menu
+  // Context menu handler (right-click) - opens device context menu, unless
+  // connection-creation mode is armed (#1932), in which case right-click
+  // cancels the mode instead (mirrors Escape). Ports render inside this
+  // device's own <g>, so a right-click on a port also reaches this handler.
   function handleContextMenu(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();
+    if (connectionCreationStore.isCreating) {
+      connectionCreationStore.cancelConnection();
+      return;
+    }
     // Use element bounds as fallback when clientX/Y are outside the device
     // (panzoom transforms can distort coordinates for half-width devices)
     let x = event.clientX;

--- a/src/lib/stores/connection-creation.svelte.ts
+++ b/src/lib/stores/connection-creation.svelte.ts
@@ -1,0 +1,108 @@
+/**
+ * Connection Creation Store
+ * Manages the desktop click-to-click connection creation workflow (#1932):
+ * click a source port to arm the mode, then click a target port to create
+ * the connection. Mirrors the tap-to-place pattern (placement.svelte.ts): a
+ * mode flag plus the minimal state needed to resume the interaction, reset
+ * on cancel/complete rather than accumulated across attempts.
+ */
+
+import type { InterfaceTemplate } from "$lib/types";
+
+// State
+let isCreating = $state(false);
+let sourcePortId = $state<string | null>(null);
+let sourceIface = $state<InterfaceTemplate | null>(null);
+
+/**
+ * Screen-reader announcement for connection-creation state transitions. Set
+ * on start, cancel, and complete so assistive technologies can announce the
+ * mode without a visible toast for every step (mirrors placementAnnouncement).
+ */
+let connectionAnnouncement = $state<string | null>(null);
+
+/**
+ * Arm connection creation with a source port. Clicking a second port while
+ * armed targets it (see the handler in connection-creation.ts); clicking a
+ * port while idle calls this to start.
+ *
+ * Unlike placement mode (which has a persistent "Placing" banner covering
+ * the armed state), connection creation has no equivalent banner, so this
+ * sets an announcement rather than clearing it: it is the only screen-reader
+ * signal that the mode was entered.
+ */
+function startConnection(portId: string, iface: InterfaceTemplate): void {
+  connectionAnnouncement = `${iface.label ?? iface.name} selected, click a target port to connect`;
+  isCreating = true;
+  sourcePortId = portId;
+  sourceIface = iface;
+}
+
+/**
+ * Internal helper to reset connection-creation state.
+ * Used by cancel and complete.
+ */
+function resetState(): void {
+  isCreating = false;
+  sourcePortId = null;
+  sourceIface = null;
+}
+
+/**
+ * Cancel connection creation without creating a connection.
+ * Used by Escape, right-click, clicking the source port again, and a
+ * validation error on the target port.
+ */
+function cancelConnection(): void {
+  if (isCreating) {
+    connectionAnnouncement = "Connection creation cancelled";
+  }
+  resetState();
+}
+
+/**
+ * Complete connection creation after a connection was successfully added.
+ * `summary` overrides the default announcement.
+ */
+function completeConnection(summary?: string): void {
+  if (isCreating) {
+    connectionAnnouncement = summary ?? "Connection created";
+  }
+  resetState();
+}
+
+/**
+ * Reset connection-creation store state (for testing).
+ */
+export function resetConnectionCreationStore(): void {
+  connectionAnnouncement = null;
+  resetState();
+}
+
+/**
+ * Get the connection-creation store with reactive state and actions.
+ * @returns Store object with getters and actions
+ */
+export function getConnectionCreationStore() {
+  return {
+    get isCreating() {
+      return isCreating;
+    },
+    get sourcePortId() {
+      return sourcePortId;
+    },
+    get sourceIface() {
+      return sourceIface;
+    },
+    /**
+     * Screen-reader announcement text for the most recent connection-creation
+     * state transition (started, cancelled, or created). Null while idle.
+     */
+    get connectionAnnouncement() {
+      return connectionAnnouncement;
+    },
+    startConnection,
+    cancelConnection,
+    completeConnection,
+  };
+}

--- a/src/lib/stores/connection-creation.svelte.ts
+++ b/src/lib/stores/connection-creation.svelte.ts
@@ -7,12 +7,20 @@
  * on cancel/complete rather than accumulated across attempts.
  */
 
-import type { InterfaceTemplate } from "$lib/types";
+import type { InterfaceTemplate, PlacedPort } from "$lib/types";
 
 // State
 let isCreating = $state(false);
 let sourcePortId = $state<string | null>(null);
 let sourceIface = $state<InterfaceTemplate | null>(null);
+/**
+ * The source PlacedPort itself, when the click that armed the source had
+ * one (it always does in practice, since a click with no id is a no-op
+ * before startConnection is ever called). Carries any per-port direction
+ * override (#1930) so the handler can resolve effective direction the same
+ * way connection rendering does, not just from the InterfaceTemplate default.
+ */
+let sourcePort = $state<PlacedPort | null>(null);
 
 /**
  * Screen-reader announcement for connection-creation state transitions. Set
@@ -31,11 +39,16 @@ let connectionAnnouncement = $state<string | null>(null);
  * sets an announcement rather than clearing it: it is the only screen-reader
  * signal that the mode was entered.
  */
-function startConnection(portId: string, iface: InterfaceTemplate): void {
+function startConnection(
+  portId: string,
+  iface: InterfaceTemplate,
+  port: PlacedPort | null,
+): void {
   connectionAnnouncement = `${iface.label ?? iface.name} selected, click a target port to connect`;
   isCreating = true;
   sourcePortId = portId;
   sourceIface = iface;
+  sourcePort = port;
 }
 
 /**
@@ -46,6 +59,7 @@ function resetState(): void {
   isCreating = false;
   sourcePortId = null;
   sourceIface = null;
+  sourcePort = null;
 }
 
 /**
@@ -93,6 +107,9 @@ export function getConnectionCreationStore() {
     },
     get sourceIface() {
       return sourceIface;
+    },
+    get sourcePort() {
+      return sourcePort;
     },
     /**
      * Screen-reader announcement text for the most recent connection-creation

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -380,6 +380,14 @@ export interface PortClickInfo {
   portId: string | undefined;
   /** The interface template this port renders from. */
   iface: InterfaceTemplate;
+  /**
+   * The instantiated PlacedPort itself, when one exists (same presence rule
+   * as portId - they always agree). Carries any per-port direction override
+   * (#1930) so a consumer can resolve the effective direction the same way
+   * connection rendering does (resolveConnectionPortDirection in
+   * connection-path.ts), not just from the InterfaceTemplate default.
+   */
+  port: PlacedPort | undefined;
 }
 
 // =============================================================================

--- a/src/lib/utils/connection-creation.ts
+++ b/src/lib/utils/connection-creation.ts
@@ -12,35 +12,46 @@
  *   the connection store's own validateConnection() (#369) - not
  *   reimplemented here.
  * - Direction mismatch (e.g. output to output) has no store-side check: the
- *   store's Connection model does not carry direction, only the
- *   InterfaceTemplate does, and PortClickInfo already gives this handler both
- *   endpoints' templates. Computed here instead.
+ *   store's Connection model does not carry direction, only PlacedPort and
+ *   InterfaceTemplate do, and PortClickInfo already gives this handler both
+ *   endpoints' PlacedPort/InterfaceTemplate pairs. Computed here instead,
+ *   using the same override-then-template-then-inferred resolution
+ *   connection rendering uses (resolveConnectionPortDirection).
  */
 
-import type {
-  InterfaceTemplate,
-  PortClickInfo,
-  PortDirection,
-} from "$lib/types";
+import type { InterfaceTemplate, PlacedPort, PortClickInfo } from "$lib/types";
 import type {
   ConnectionValidationResult,
   CreateConnectionInput,
 } from "$lib/stores/connection.svelte";
 import type { Connection } from "$lib/types";
-import { inferDirection } from "$lib/utils/port-utils";
+import { resolveConnectionPortDirection } from "$lib/utils/connection-path";
 
 /** The subset of the connection-creation store's API the handler needs. */
 export interface ConnectionCreationStoreLike {
   readonly isCreating: boolean;
   readonly sourcePortId: string | null;
   readonly sourceIface: InterfaceTemplate | null;
-  startConnection: (portId: string, iface: InterfaceTemplate) => void;
+  readonly sourcePort: PlacedPort | null;
+  startConnection: (
+    portId: string,
+    iface: InterfaceTemplate,
+    port: PlacedPort | null,
+  ) => void;
   cancelConnection: () => void;
   completeConnection: (summary?: string) => void;
 }
 
 export interface ConnectionCreationHandlerContext {
   connectionCreation: ConnectionCreationStoreLike;
+  /**
+   * Whether tap-to-place is currently armed (placementStore.isPlacing).
+   * Placement owns the click gesture while armed (it already suppresses
+   * device selection the same way, see RackDevice.svelte's handlePointerUp),
+   * so a port click is a no-op here rather than also arming connection
+   * creation and leaving both modes active at once.
+   */
+  isPlacementActive: boolean;
   validateConnection: (
     input: CreateConnectionInput,
   ) => ConnectionValidationResult;
@@ -51,30 +62,24 @@ export interface ConnectionCreationHandlerContext {
 }
 
 /**
- * Resolve the direction PortIndicators would display for this template:
- * its own override, or the type-inferred default. Matches
- * PortIndicators.svelte's getPortDirection() exactly, so a direction warning
- * here always agrees with what the user sees rendered as an arrow.
- */
-function effectiveDirection(
-  iface: InterfaceTemplate,
-): PortDirection | undefined {
-  return iface.direction ?? inferDirection(iface.type, iface.mgmt_only);
-}
-
-/**
  * Warn when both endpoints resolve to the same non-bidirectional direction
- * (output-to-output, or input-to-input). Undirected AV types (no default,
- * e.g. an XLR port with no explicit direction set) and bidirectional ports
- * never trigger this: there is nothing to mismatch.
+ * (output-to-output, or input-to-input). Direction is resolved the same way
+ * connection rendering resolves it for its arrows
+ * (resolveConnectionPortDirection: PlacedPort.direction override, then
+ * InterfaceTemplate.direction, then the type-inferred default), so a warning
+ * here always agrees with what the user sees drawn. Undirected AV types (no
+ * default, e.g. an XLR port with no explicit direction set anywhere) and
+ * bidirectional ports never trigger this: there is nothing to mismatch.
  * @returns A warning message, or null when directions are compatible.
  */
 export function getDirectionMismatchWarning(
-  a: InterfaceTemplate,
-  b: InterfaceTemplate,
+  aPort: PlacedPort | undefined,
+  aIface: InterfaceTemplate,
+  bPort: PlacedPort | undefined,
+  bIface: InterfaceTemplate,
 ): string | null {
-  const aDirection = effectiveDirection(a);
-  const bDirection = effectiveDirection(b);
+  const aDirection = resolveConnectionPortDirection(aPort, aIface);
+  const bDirection = resolveConnectionPortDirection(bPort, bIface);
   if (!aDirection || !bDirection) return null;
   if (aDirection === "bidirectional" || bDirection === "bidirectional") {
     return null;
@@ -89,6 +94,9 @@ export function getDirectionMismatchWarning(
  * Route a port click through connection-creation mode.
  *
  * State machine (mirrors tap-to-place's arm/complete/cancel shape):
+ * - Placement mode armed -> no-op. Placement owns the click gesture until
+ *   it is placed or cancelled; arming connection creation on top of it would
+ *   leave two global modes active at once with conflicting cancel paths.
  * - Idle + click a port with an id -> arm the mode with that port as source.
  * - Armed + click any port (including the source port again) -> validate,
  *   then create. Clicking the same port twice reaches the store's own
@@ -108,13 +116,15 @@ export function handleConnectionPortClick(
   info: PortClickInfo,
   ctx: ConnectionCreationHandlerContext,
 ): void {
-  const { portId, iface } = info;
+  if (ctx.isPlacementActive) return;
+
+  const { portId, iface, port } = info;
   if (!portId) return;
 
   const { connectionCreation } = ctx;
 
   if (!connectionCreation.isCreating) {
-    connectionCreation.startConnection(portId, iface);
+    connectionCreation.startConnection(portId, iface, port ?? null);
     return;
   }
 
@@ -123,9 +133,10 @@ export function handleConnectionPortClick(
   if (!sourcePortId || !sourceIface) {
     // Defensive: armed with no recorded source (should not happen); start
     // clean from this click rather than attempt an invalid connection.
-    connectionCreation.startConnection(portId, iface);
+    connectionCreation.startConnection(portId, iface, port ?? null);
     return;
   }
+  const sourcePort = connectionCreation.sourcePort;
 
   const input: CreateConnectionInput = {
     a_port_id: sourcePortId,
@@ -139,7 +150,12 @@ export function handleConnectionPortClick(
     return;
   }
 
-  const directionWarning = getDirectionMismatchWarning(sourceIface, iface);
+  const directionWarning = getDirectionMismatchWarning(
+    sourcePort ?? undefined,
+    sourceIface,
+    port,
+    iface,
+  );
   const warnings = directionWarning
     ? [...validation.warnings, directionWarning]
     : validation.warnings;

--- a/src/lib/utils/connection-creation.ts
+++ b/src/lib/utils/connection-creation.ts
@@ -1,0 +1,161 @@
+/**
+ * Connection Creation Handler (#1932)
+ * Pure routing logic for the desktop click-to-click connection creation
+ * workflow: click a source port, then click a target port to create a
+ * connection. Mirrors rack-interaction-handlers.ts's placement handlers -
+ * dependencies are injected via a context object so this is testable without
+ * mounting any component.
+ *
+ * Validation split:
+ * - Self-connection, port-not-found, port-already-in-use, duplicate
+ *   connection, and category/type mismatch (e.g. XLR to HDMI) all come from
+ *   the connection store's own validateConnection() (#369) - not
+ *   reimplemented here.
+ * - Direction mismatch (e.g. output to output) has no store-side check: the
+ *   store's Connection model does not carry direction, only the
+ *   InterfaceTemplate does, and PortClickInfo already gives this handler both
+ *   endpoints' templates. Computed here instead.
+ */
+
+import type {
+  InterfaceTemplate,
+  PortClickInfo,
+  PortDirection,
+} from "$lib/types";
+import type {
+  ConnectionValidationResult,
+  CreateConnectionInput,
+} from "$lib/stores/connection.svelte";
+import type { Connection } from "$lib/types";
+import { inferDirection } from "$lib/utils/port-utils";
+
+/** The subset of the connection-creation store's API the handler needs. */
+export interface ConnectionCreationStoreLike {
+  readonly isCreating: boolean;
+  readonly sourcePortId: string | null;
+  readonly sourceIface: InterfaceTemplate | null;
+  startConnection: (portId: string, iface: InterfaceTemplate) => void;
+  cancelConnection: () => void;
+  completeConnection: (summary?: string) => void;
+}
+
+export interface ConnectionCreationHandlerContext {
+  connectionCreation: ConnectionCreationStoreLike;
+  validateConnection: (
+    input: CreateConnectionInput,
+  ) => ConnectionValidationResult;
+  addConnection: (
+    input: CreateConnectionInput,
+  ) => { connection: Connection } | { errors: string[] };
+  showToast: (message: string, type: "error" | "warning") => void;
+}
+
+/**
+ * Resolve the direction PortIndicators would display for this template:
+ * its own override, or the type-inferred default. Matches
+ * PortIndicators.svelte's getPortDirection() exactly, so a direction warning
+ * here always agrees with what the user sees rendered as an arrow.
+ */
+function effectiveDirection(
+  iface: InterfaceTemplate,
+): PortDirection | undefined {
+  return iface.direction ?? inferDirection(iface.type, iface.mgmt_only);
+}
+
+/**
+ * Warn when both endpoints resolve to the same non-bidirectional direction
+ * (output-to-output, or input-to-input). Undirected AV types (no default,
+ * e.g. an XLR port with no explicit direction set) and bidirectional ports
+ * never trigger this: there is nothing to mismatch.
+ * @returns A warning message, or null when directions are compatible.
+ */
+export function getDirectionMismatchWarning(
+  a: InterfaceTemplate,
+  b: InterfaceTemplate,
+): string | null {
+  const aDirection = effectiveDirection(a);
+  const bDirection = effectiveDirection(b);
+  if (!aDirection || !bDirection) return null;
+  if (aDirection === "bidirectional" || bDirection === "bidirectional") {
+    return null;
+  }
+  if (aDirection === bDirection) {
+    return `Both ports are ${aDirection}s: signal direction mismatch`;
+  }
+  return null;
+}
+
+/**
+ * Route a port click through connection-creation mode.
+ *
+ * State machine (mirrors tap-to-place's arm/complete/cancel shape):
+ * - Idle + click a port with an id -> arm the mode with that port as source.
+ * - Armed + click any port (including the source port again) -> validate,
+ *   then create. Clicking the same port twice reaches the store's own
+ *   self-connection check (ConnectionSchema refine, #369) rather than a
+ *   bespoke short-circuit here, so its "Cannot connect a port to itself"
+ *   message surfaces as the cancellation's feedback instead of a silent
+ *   no-op.
+ * - A validation error surfaces as a toast and exits the mode (the target the
+ *   user just clicked was invalid; staying armed on it would repeat the same
+ *   error). A non-blocking warning (category/type/direction mismatch) still
+ *   creates the connection and surfaces as its own toast.
+ * - A port with no id (grouped/high-density device, or a legacy port with no
+ *   PlacedPort match, #3089) has no click target to begin with in practice;
+ *   this is a defensive no-op, not a UI state.
+ */
+export function handleConnectionPortClick(
+  info: PortClickInfo,
+  ctx: ConnectionCreationHandlerContext,
+): void {
+  const { portId, iface } = info;
+  if (!portId) return;
+
+  const { connectionCreation } = ctx;
+
+  if (!connectionCreation.isCreating) {
+    connectionCreation.startConnection(portId, iface);
+    return;
+  }
+
+  const sourcePortId = connectionCreation.sourcePortId;
+  const sourceIface = connectionCreation.sourceIface;
+  if (!sourcePortId || !sourceIface) {
+    // Defensive: armed with no recorded source (should not happen); start
+    // clean from this click rather than attempt an invalid connection.
+    connectionCreation.startConnection(portId, iface);
+    return;
+  }
+
+  const input: CreateConnectionInput = {
+    a_port_id: sourcePortId,
+    b_port_id: portId,
+  };
+
+  const validation = ctx.validateConnection(input);
+  if (!validation.valid) {
+    ctx.showToast(validation.errors.join("; "), "error");
+    connectionCreation.cancelConnection();
+    return;
+  }
+
+  const directionWarning = getDirectionMismatchWarning(sourceIface, iface);
+  const warnings = directionWarning
+    ? [...validation.warnings, directionWarning]
+    : validation.warnings;
+
+  const result = ctx.addConnection(input);
+  if ("errors" in result) {
+    // TOCTOU guard: validateConnection() passed but addConnection() still
+    // failed. Not expected in the synchronous store, but never leave the UI
+    // stuck armed on a target that a failed attempt already consumed.
+    ctx.showToast(result.errors.join("; "), "error");
+    connectionCreation.cancelConnection();
+    return;
+  }
+
+  if (warnings.length > 0) {
+    ctx.showToast(warnings.join("; "), "warning");
+  }
+  connectionCreation.completeConnection();
+}

--- a/src/tests/connection-creation-store.test.ts
+++ b/src/tests/connection-creation-store.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Connection Creation Store Tests (#1932)
+ * Tests for the desktop click-to-click connection creation mode state
+ * machine. Mirrors placement-store.test.ts's structure for the tap-to-place
+ * mode this feature is modeled after.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getConnectionCreationStore,
+  resetConnectionCreationStore,
+} from "$lib/stores/connection-creation.svelte";
+import { createTestInterfaceTemplate } from "./factories";
+
+describe("connection creation store", () => {
+  const sourceIface = createTestInterfaceTemplate({ name: "eth0" });
+
+  beforeEach(() => {
+    resetConnectionCreationStore();
+  });
+
+  describe("initial state", () => {
+    it("has isCreating as false by default", () => {
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+    });
+
+    it("has sourcePortId as null by default", () => {
+      expect(getConnectionCreationStore().sourcePortId).toBeNull();
+    });
+
+    it("has sourceIface as null by default", () => {
+      expect(getConnectionCreationStore().sourceIface).toBeNull();
+    });
+
+    it("has connectionAnnouncement as null by default", () => {
+      expect(getConnectionCreationStore().connectionAnnouncement).toBeNull();
+    });
+  });
+
+  describe("startConnection()", () => {
+    it("sets isCreating to true", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      expect(store.isCreating).toBe(true);
+    });
+
+    it("records the source port id and interface", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      expect(store.sourcePortId).toBe("port-a");
+      expect(store.sourceIface).toEqual(sourceIface);
+    });
+
+    it("sets a screen-reader announcement", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      expect(store.connectionAnnouncement).toBeTruthy();
+    });
+
+    it("replaces a previous source when called again while already armed", () => {
+      const store = getConnectionCreationStore();
+      const otherIface = createTestInterfaceTemplate({ name: "eth1" });
+      store.startConnection("port-a", sourceIface);
+      store.startConnection("port-b", otherIface);
+      expect(store.sourcePortId).toBe("port-b");
+      expect(store.sourceIface).toEqual(otherIface);
+    });
+  });
+
+  describe("cancelConnection()", () => {
+    it("sets isCreating to false", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      store.cancelConnection();
+      expect(store.isCreating).toBe(false);
+    });
+
+    it("clears the source port and interface", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      store.cancelConnection();
+      expect(store.sourcePortId).toBeNull();
+      expect(store.sourceIface).toBeNull();
+    });
+
+    it("sets a cancellation announcement", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      store.cancelConnection();
+      expect(store.connectionAnnouncement).toBe(
+        "Connection creation cancelled",
+      );
+    });
+
+    it("is safe to call when not creating", () => {
+      const store = getConnectionCreationStore();
+      expect(() => store.cancelConnection()).not.toThrow();
+      expect(store.isCreating).toBe(false);
+      // No active connection-creation means nothing to announce.
+      expect(store.connectionAnnouncement).toBeNull();
+    });
+  });
+
+  describe("completeConnection()", () => {
+    it("sets isCreating to false", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      store.completeConnection();
+      expect(store.isCreating).toBe(false);
+    });
+
+    it("clears the source port and interface", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      store.completeConnection();
+      expect(store.sourcePortId).toBeNull();
+      expect(store.sourceIface).toBeNull();
+    });
+
+    it("sets a default completion announcement", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      store.completeConnection();
+      expect(store.connectionAnnouncement).toBe("Connection created");
+    });
+
+    it("accepts a custom summary announcement", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+      store.completeConnection("Connected eth0 to eth1");
+      expect(store.connectionAnnouncement).toBe("Connected eth0 to eth1");
+    });
+
+    it("is safe to call when not creating", () => {
+      const store = getConnectionCreationStore();
+      expect(() => store.completeConnection()).not.toThrow();
+      expect(store.isCreating).toBe(false);
+      expect(store.connectionAnnouncement).toBeNull();
+    });
+  });
+
+  describe("resetConnectionCreationStore()", () => {
+    it("resets all state to defaults", () => {
+      const store = getConnectionCreationStore();
+      store.startConnection("port-a", sourceIface);
+
+      resetConnectionCreationStore();
+
+      expect(store.isCreating).toBe(false);
+      expect(store.sourcePortId).toBeNull();
+      expect(store.sourceIface).toBeNull();
+      expect(store.connectionAnnouncement).toBeNull();
+    });
+  });
+});

--- a/src/tests/connection-creation.test.ts
+++ b/src/tests/connection-creation.test.ts
@@ -439,3 +439,39 @@ describe("getDirectionMismatchWarning", () => {
     });
   });
 });
+
+describe("placeDeviceWithPorts test factory (#1932 CodeRabbit review)", () => {
+  let layoutStore: ReturnType<typeof getLayoutStore>;
+  let rackId: string;
+
+  beforeEach(() => {
+    layoutStore = createTestLayoutStore();
+    const rack = layoutStore.addRack("Test Rack", 42)!;
+    rackId = rack.id;
+  });
+
+  it("resolves the newly placed instance's ports, not an earlier instance with the same slug", () => {
+    const first = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+      "1000base-t",
+    ]);
+    const second = placeDeviceWithPorts(layoutStore, rackId, "device-a", 10, [
+      "1000base-t",
+    ]);
+
+    // Both placements share slug "device-a"; the second call must resolve to
+    // the PlacedDevice it just placed, not fall back to the first instance
+    // via a global first-match on slug (they are distinct placements with
+    // distinct ids and distinct instantiated port ids, even though both
+    // share the same device type and interface list).
+    expect(second.deviceId).not.toBe(first.deviceId);
+    expect(second.ports[0]!.id).not.toBe(first.ports[0]!.id);
+
+    // Both instances persist as separate devices in the rack; the second
+    // call did not silently replace or alias the first.
+    const rackDeviceIds = layoutStore.racks
+      .find((r) => r.id === rackId)!
+      .devices.map((d) => d.id);
+    expect(rackDeviceIds).toContain(first.deviceId);
+    expect(rackDeviceIds).toContain(second.deviceId);
+  });
+});

--- a/src/tests/connection-creation.test.ts
+++ b/src/tests/connection-creation.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Connection Creation Handler Tests (#1932)
+ * Behavioral tests for the desktop click-to-click connection creation state
+ * machine: enter, target, cancel (same-port click, which now surfaces the
+ * store's own self-connection error), the already-connected error path, and
+ * the category/type/direction warning path. Uses the real connection store
+ * and layout store (like connection-store.test.ts) so validation is
+ * exercised for real, not mocked, plus a real connection-creation store
+ * reset between tests and a spy for the toast side effect.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  handleConnectionPortClick,
+  getDirectionMismatchWarning,
+  type ConnectionCreationHandlerContext,
+} from "$lib/utils/connection-creation";
+import {
+  getConnectionCreationStore,
+  resetConnectionCreationStore,
+} from "$lib/stores/connection-creation.svelte";
+import { getConnectionStore } from "$lib/stores/connection.svelte";
+import { getLayoutStore } from "$lib/stores/layout.svelte";
+import type { InterfaceType, PlacedPort } from "$lib/types";
+import {
+  createTestLayoutStore,
+  createTestDeviceType,
+  createTestInterfaceTemplate,
+} from "./factories";
+
+/**
+ * Place a device with the given interface templates in a rack and return its
+ * PlacedPort instances (real, store-generated ids), mirroring
+ * connection-store.test.ts's helper.
+ */
+function placeDeviceWithPorts(
+  store: ReturnType<typeof getLayoutStore>,
+  rackId: string,
+  slug: string,
+  position: number,
+  interfaces: Array<{ type: InterfaceType; direction?: "input" | "output" }>,
+): PlacedPort[] {
+  const deviceType = createTestDeviceType({ slug });
+  deviceType.interfaces = interfaces.map((i, index) =>
+    createTestInterfaceTemplate({
+      name: `port-${index}`,
+      type: i.type,
+      direction: i.direction,
+    }),
+  );
+  store.addDeviceTypeRaw(deviceType);
+  store.placeDevice(rackId, slug, position);
+  const device = store.racks
+    .flatMap((r) => r.devices)
+    .find((d) => d.device_type === slug)!;
+  return device.ports ?? [];
+}
+
+describe("handleConnectionPortClick", () => {
+  let layoutStore: ReturnType<typeof getLayoutStore>;
+  let rackId: string;
+  let showToast: ReturnType<typeof vi.fn>;
+
+  function buildContext(): ConnectionCreationHandlerContext {
+    const connectionStore = getConnectionStore();
+    return {
+      connectionCreation: getConnectionCreationStore(),
+      validateConnection: connectionStore.validateConnection,
+      addConnection: connectionStore.addConnection,
+      showToast,
+    };
+  }
+
+  beforeEach(() => {
+    layoutStore = createTestLayoutStore();
+    const rack = layoutStore.addRack("Test Rack", 42)!;
+    rackId = rack.id;
+    resetConnectionCreationStore();
+    showToast = vi.fn();
+  });
+
+  describe("entering the mode", () => {
+    it("arms the mode with the clicked port as source", () => {
+      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        { type: "1000base-t" },
+      ]);
+      const ctx = buildContext();
+
+      handleConnectionPortClick(
+        { portId: portA!.id, iface: createTestInterfaceTemplate() },
+        ctx,
+      );
+
+      expect(getConnectionCreationStore().isCreating).toBe(true);
+      expect(getConnectionCreationStore().sourcePortId).toBe(portA!.id);
+      expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it("is a defensive no-op for a port with no id (grouped/high-density device)", () => {
+      const ctx = buildContext();
+
+      handleConnectionPortClick(
+        { portId: undefined, iface: createTestInterfaceTemplate() },
+        ctx,
+      );
+
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+      expect(showToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("targeting a valid port", () => {
+    it("creates the connection and exits the mode", () => {
+      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        { type: "1000base-t" },
+      ]);
+      const [portB] = placeDeviceWithPorts(
+        layoutStore,
+        rackId,
+        "device-b",
+        10,
+        [{ type: "1000base-t" }],
+      );
+      const ctx = buildContext();
+      const ifaceA = createTestInterfaceTemplate({ type: "1000base-t" });
+      const ifaceB = createTestInterfaceTemplate({ type: "1000base-t" });
+
+      handleConnectionPortClick({ portId: portA!.id, iface: ifaceA }, ctx);
+      handleConnectionPortClick({ portId: portB!.id, iface: ifaceB }, ctx);
+
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+      expect(getConnectionStore().connections).toContainEqual(
+        expect.objectContaining({
+          a_port_id: portA!.id,
+          b_port_id: portB!.id,
+        }),
+      );
+      expect(showToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("clicking the same port twice", () => {
+    it("surfaces the store's self-connection error and exits the mode", () => {
+      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        { type: "1000base-t" },
+      ]);
+      const ctx = buildContext();
+      const iface = createTestInterfaceTemplate({ type: "1000base-t" });
+
+      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining("itself"),
+        "error",
+      );
+      expect(getConnectionStore().connections).toEqual([]);
+    });
+  });
+
+  describe("targeting an already-connected port", () => {
+    it("shows an error toast, creates no connection, and exits the mode", () => {
+      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        { type: "1000base-t" },
+      ]);
+      const [portB] = placeDeviceWithPorts(
+        layoutStore,
+        rackId,
+        "device-b",
+        10,
+        [{ type: "1000base-t" }],
+      );
+      const [portC] = placeDeviceWithPorts(
+        layoutStore,
+        rackId,
+        "device-c",
+        15,
+        [{ type: "1000base-t" }],
+      );
+      getConnectionStore().addConnection({
+        a_port_id: portA!.id,
+        b_port_id: portB!.id,
+      });
+      const ctx = buildContext();
+      const iface = createTestInterfaceTemplate({ type: "1000base-t" });
+
+      // Arm from device-c, then target device-a's port, which is already
+      // connected to device-b.
+      handleConnectionPortClick({ portId: portC!.id, iface }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining("already has a connection"),
+        "error",
+      );
+      // Only the original connection exists; the failed attempt added nothing.
+      expect(getConnectionStore().connections).toContainEqual(
+        expect.objectContaining({ a_port_id: portA!.id, b_port_id: portB!.id }),
+      );
+      expect(
+        getConnectionStore().connections.some(
+          (c) => c.a_port_id === portC!.id || c.b_port_id === portC!.id,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("warning path: category/type and direction mismatches", () => {
+    it("creates the connection and shows a warning toast on a type mismatch (XLR to HDMI)", () => {
+      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        { type: "xlr-3" },
+      ]);
+      const [portB] = placeDeviceWithPorts(
+        layoutStore,
+        rackId,
+        "device-b",
+        10,
+        [{ type: "hdmi" }],
+      );
+      const ctx = buildContext();
+      const ifaceA = createTestInterfaceTemplate({ type: "xlr-3" });
+      const ifaceB = createTestInterfaceTemplate({ type: "hdmi" });
+
+      handleConnectionPortClick({ portId: portA!.id, iface: ifaceA }, ctx);
+      handleConnectionPortClick({ portId: portB!.id, iface: ifaceB }, ctx);
+
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+      expect(getConnectionStore().connections).toContainEqual(
+        expect.objectContaining({
+          a_port_id: portA!.id,
+          b_port_id: portB!.id,
+        }),
+      );
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining("types do not match"),
+        "warning",
+      );
+    });
+
+    it("creates the connection and shows a warning toast on a direction mismatch (output to output)", () => {
+      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        { type: "1000base-t", direction: "output" },
+      ]);
+      const [portB] = placeDeviceWithPorts(
+        layoutStore,
+        rackId,
+        "device-b",
+        10,
+        [{ type: "1000base-t", direction: "output" }],
+      );
+      const ctx = buildContext();
+      const ifaceA = createTestInterfaceTemplate({
+        type: "1000base-t",
+        direction: "output",
+      });
+      const ifaceB = createTestInterfaceTemplate({
+        type: "1000base-t",
+        direction: "output",
+      });
+
+      handleConnectionPortClick({ portId: portA!.id, iface: ifaceA }, ctx);
+      handleConnectionPortClick({ portId: portB!.id, iface: ifaceB }, ctx);
+
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+      expect(getConnectionStore().connections).toContainEqual(
+        expect.objectContaining({
+          a_port_id: portA!.id,
+          b_port_id: portB!.id,
+        }),
+      );
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining("outputs"),
+        "warning",
+      );
+    });
+  });
+
+  describe("cancellation resets state for the next attempt", () => {
+    it("allows starting a fresh connection after a validation error cancelled the mode", () => {
+      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        { type: "1000base-t" },
+      ]);
+      const [portB] = placeDeviceWithPorts(
+        layoutStore,
+        rackId,
+        "device-b",
+        10,
+        [{ type: "1000base-t" }],
+      );
+      const ctx = buildContext();
+      const iface = createTestInterfaceTemplate({ type: "1000base-t" });
+
+      // Self-click cancels with an error.
+      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+
+      // A fresh click starts a new attempt rather than staying stuck.
+      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+      expect(getConnectionCreationStore().isCreating).toBe(true);
+      expect(getConnectionCreationStore().sourcePortId).toBe(portA!.id);
+
+      handleConnectionPortClick({ portId: portB!.id, iface }, ctx);
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+      expect(getConnectionStore().connections).toContainEqual(
+        expect.objectContaining({
+          a_port_id: portA!.id,
+          b_port_id: portB!.id,
+        }),
+      );
+    });
+  });
+});
+
+describe("getDirectionMismatchWarning", () => {
+  it("warns when both ports are output", () => {
+    const a = createTestInterfaceTemplate({ direction: "output" });
+    const b = createTestInterfaceTemplate({ direction: "output" });
+    expect(getDirectionMismatchWarning(a, b)).toContain("outputs");
+  });
+
+  it("warns when both ports are input", () => {
+    const a = createTestInterfaceTemplate({ direction: "input" });
+    const b = createTestInterfaceTemplate({ direction: "input" });
+    expect(getDirectionMismatchWarning(a, b)).toContain("inputs");
+  });
+
+  it("does not warn when directions are complementary", () => {
+    const a = createTestInterfaceTemplate({ direction: "output" });
+    const b = createTestInterfaceTemplate({ direction: "input" });
+    expect(getDirectionMismatchWarning(a, b)).toBeNull();
+  });
+
+  it("does not warn when either side is bidirectional", () => {
+    const a = createTestInterfaceTemplate({ direction: "output" });
+    const b = createTestInterfaceTemplate({ direction: "bidirectional" });
+    expect(getDirectionMismatchWarning(a, b)).toBeNull();
+  });
+
+  it("does not warn for an undirected AV type with no explicit direction", () => {
+    // xlr-3 has no inferDirection default (spike #1927): direction must be
+    // set explicitly, so two undirected XLR ports compare as "nothing to
+    // mismatch" rather than a false-positive warning.
+    const a = createTestInterfaceTemplate({ type: "xlr-3" });
+    const b = createTestInterfaceTemplate({ type: "xlr-3" });
+    expect(getDirectionMismatchWarning(a, b)).toBeNull();
+  });
+});

--- a/src/tests/connection-creation.test.ts
+++ b/src/tests/connection-creation.test.ts
@@ -2,11 +2,12 @@
  * Connection Creation Handler Tests (#1932)
  * Behavioral tests for the desktop click-to-click connection creation state
  * machine: enter, target, cancel (same-port click, which now surfaces the
- * store's own self-connection error), the already-connected error path, and
- * the category/type/direction warning path. Uses the real connection store
- * and layout store (like connection-store.test.ts) so validation is
- * exercised for real, not mocked, plus a real connection-creation store
- * reset between tests and a spy for the toast side effect.
+ * store's own self-connection error), the already-connected error path, the
+ * category/type/direction warning path, and the placement-mode collision
+ * guard. Uses the real connection store and layout store (like
+ * connection-store.test.ts) so validation is exercised for real, not mocked,
+ * plus a real connection-creation store reset between tests and a spy for
+ * the toast side effect.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -21,53 +22,29 @@ import {
 } from "$lib/stores/connection-creation.svelte";
 import { getConnectionStore } from "$lib/stores/connection.svelte";
 import { getLayoutStore } from "$lib/stores/layout.svelte";
-import type { InterfaceType, PlacedPort } from "$lib/types";
 import {
   createTestLayoutStore,
-  createTestDeviceType,
   createTestInterfaceTemplate,
+  createTestPlacedPort,
+  placeDeviceWithPorts,
 } from "./factories";
-
-/**
- * Place a device with the given interface templates in a rack and return its
- * PlacedPort instances (real, store-generated ids), mirroring
- * connection-store.test.ts's helper.
- */
-function placeDeviceWithPorts(
-  store: ReturnType<typeof getLayoutStore>,
-  rackId: string,
-  slug: string,
-  position: number,
-  interfaces: Array<{ type: InterfaceType; direction?: "input" | "output" }>,
-): PlacedPort[] {
-  const deviceType = createTestDeviceType({ slug });
-  deviceType.interfaces = interfaces.map((i, index) =>
-    createTestInterfaceTemplate({
-      name: `port-${index}`,
-      type: i.type,
-      direction: i.direction,
-    }),
-  );
-  store.addDeviceTypeRaw(deviceType);
-  store.placeDevice(rackId, slug, position);
-  const device = store.racks
-    .flatMap((r) => r.devices)
-    .find((d) => d.device_type === slug)!;
-  return device.ports ?? [];
-}
 
 describe("handleConnectionPortClick", () => {
   let layoutStore: ReturnType<typeof getLayoutStore>;
   let rackId: string;
   let showToast: ReturnType<typeof vi.fn>;
 
-  function buildContext(): ConnectionCreationHandlerContext {
+  function buildContext(
+    overrides: Partial<ConnectionCreationHandlerContext> = {},
+  ): ConnectionCreationHandlerContext {
     const connectionStore = getConnectionStore();
     return {
       connectionCreation: getConnectionCreationStore(),
+      isPlacementActive: false,
       validateConnection: connectionStore.validateConnection,
       addConnection: connectionStore.addConnection,
       showToast,
+      ...overrides,
     };
   }
 
@@ -81,13 +58,19 @@ describe("handleConnectionPortClick", () => {
 
   describe("entering the mode", () => {
     it("arms the mode with the clicked port as source", () => {
-      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
-        { type: "1000base-t" },
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
       ]);
       const ctx = buildContext();
 
       handleConnectionPortClick(
-        { portId: portA!.id, iface: createTestInterfaceTemplate() },
+        {
+          portId: portA!.id,
+          iface: createTestInterfaceTemplate(),
+          port: portA,
+        },
         ctx,
       );
 
@@ -100,7 +83,11 @@ describe("handleConnectionPortClick", () => {
       const ctx = buildContext();
 
       handleConnectionPortClick(
-        { portId: undefined, iface: createTestInterfaceTemplate() },
+        {
+          portId: undefined,
+          iface: createTestInterfaceTemplate(),
+          port: undefined,
+        },
         ctx,
       );
 
@@ -109,24 +96,86 @@ describe("handleConnectionPortClick", () => {
     });
   });
 
+  describe("mode collision: placement mode active (#1932 CodeAnt review)", () => {
+    it("does not arm connection creation while placement mode is active", () => {
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const ctx = buildContext({ isPlacementActive: true });
+
+      handleConnectionPortClick(
+        {
+          portId: portA!.id,
+          iface: createTestInterfaceTemplate(),
+          port: portA,
+        },
+        ctx,
+      );
+
+      expect(getConnectionCreationStore().isCreating).toBe(false);
+      expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it("ignores a target click on an already-armed connection while placement mode is active", () => {
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
+      ]);
+      const {
+        ports: [portB],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const iface = createTestInterfaceTemplate({ type: "1000base-t" });
+
+      // Arm while placement is inactive.
+      handleConnectionPortClick(
+        { portId: portA!.id, iface, port: portA },
+        buildContext({ isPlacementActive: false }),
+      );
+      expect(getConnectionCreationStore().isCreating).toBe(true);
+
+      // Placement becomes active before the target click lands (e.g. armed
+      // via the command palette mid-flow); the click must not complete or
+      // cancel the already-armed connection, just no-op.
+      handleConnectionPortClick(
+        { portId: portB!.id, iface, port: portB },
+        buildContext({ isPlacementActive: true }),
+      );
+
+      expect(getConnectionCreationStore().isCreating).toBe(true);
+      expect(getConnectionCreationStore().sourcePortId).toBe(portA!.id);
+      expect(getConnectionStore().connections).toEqual([]);
+    });
+  });
+
   describe("targeting a valid port", () => {
     it("creates the connection and exits the mode", () => {
-      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
-        { type: "1000base-t" },
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
       ]);
-      const [portB] = placeDeviceWithPorts(
-        layoutStore,
-        rackId,
-        "device-b",
-        10,
-        [{ type: "1000base-t" }],
-      );
+      const {
+        ports: [portB],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
       const ctx = buildContext();
       const ifaceA = createTestInterfaceTemplate({ type: "1000base-t" });
       const ifaceB = createTestInterfaceTemplate({ type: "1000base-t" });
 
-      handleConnectionPortClick({ portId: portA!.id, iface: ifaceA }, ctx);
-      handleConnectionPortClick({ portId: portB!.id, iface: ifaceB }, ctx);
+      handleConnectionPortClick(
+        { portId: portA!.id, iface: ifaceA, port: portA },
+        ctx,
+      );
+      handleConnectionPortClick(
+        { portId: portB!.id, iface: ifaceB, port: portB },
+        ctx,
+      );
 
       expect(getConnectionCreationStore().isCreating).toBe(false);
       expect(getConnectionStore().connections).toContainEqual(
@@ -141,14 +190,16 @@ describe("handleConnectionPortClick", () => {
 
   describe("clicking the same port twice", () => {
     it("surfaces the store's self-connection error and exits the mode", () => {
-      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
-        { type: "1000base-t" },
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
       ]);
       const ctx = buildContext();
       const iface = createTestInterfaceTemplate({ type: "1000base-t" });
 
-      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
-      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface, port: portA }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface, port: portA }, ctx);
 
       expect(getConnectionCreationStore().isCreating).toBe(false);
       expect(showToast).toHaveBeenCalledWith(
@@ -161,23 +212,21 @@ describe("handleConnectionPortClick", () => {
 
   describe("targeting an already-connected port", () => {
     it("shows an error toast, creates no connection, and exits the mode", () => {
-      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
-        { type: "1000base-t" },
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
       ]);
-      const [portB] = placeDeviceWithPorts(
-        layoutStore,
-        rackId,
-        "device-b",
-        10,
-        [{ type: "1000base-t" }],
-      );
-      const [portC] = placeDeviceWithPorts(
-        layoutStore,
-        rackId,
-        "device-c",
-        15,
-        [{ type: "1000base-t" }],
-      );
+      const {
+        ports: [portB],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
+      const {
+        ports: [portC],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-c", 15, [
+        "1000base-t",
+      ]);
       getConnectionStore().addConnection({
         a_port_id: portA!.id,
         b_port_id: portB!.id,
@@ -187,8 +236,8 @@ describe("handleConnectionPortClick", () => {
 
       // Arm from device-c, then target device-a's port, which is already
       // connected to device-b.
-      handleConnectionPortClick({ portId: portC!.id, iface }, ctx);
-      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+      handleConnectionPortClick({ portId: portC!.id, iface, port: portC }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface, port: portA }, ctx);
 
       expect(getConnectionCreationStore().isCreating).toBe(false);
       expect(showToast).toHaveBeenCalledWith(
@@ -209,22 +258,24 @@ describe("handleConnectionPortClick", () => {
 
   describe("warning path: category/type and direction mismatches", () => {
     it("creates the connection and shows a warning toast on a type mismatch (XLR to HDMI)", () => {
-      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
-        { type: "xlr-3" },
-      ]);
-      const [portB] = placeDeviceWithPorts(
-        layoutStore,
-        rackId,
-        "device-b",
-        10,
-        [{ type: "hdmi" }],
-      );
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, ["xlr-3"]);
+      const {
+        ports: [portB],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, ["hdmi"]);
       const ctx = buildContext();
       const ifaceA = createTestInterfaceTemplate({ type: "xlr-3" });
       const ifaceB = createTestInterfaceTemplate({ type: "hdmi" });
 
-      handleConnectionPortClick({ portId: portA!.id, iface: ifaceA }, ctx);
-      handleConnectionPortClick({ portId: portB!.id, iface: ifaceB }, ctx);
+      handleConnectionPortClick(
+        { portId: portA!.id, iface: ifaceA, port: portA },
+        ctx,
+      );
+      handleConnectionPortClick(
+        { portId: portB!.id, iface: ifaceB, port: portB },
+        ctx,
+      );
 
       expect(getConnectionCreationStore().isCreating).toBe(false);
       expect(getConnectionStore().connections).toContainEqual(
@@ -240,16 +291,16 @@ describe("handleConnectionPortClick", () => {
     });
 
     it("creates the connection and shows a warning toast on a direction mismatch (output to output)", () => {
-      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
         { type: "1000base-t", direction: "output" },
       ]);
-      const [portB] = placeDeviceWithPorts(
-        layoutStore,
-        rackId,
-        "device-b",
-        10,
-        [{ type: "1000base-t", direction: "output" }],
-      );
+      const {
+        ports: [portB],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        { type: "1000base-t", direction: "output" },
+      ]);
       const ctx = buildContext();
       const ifaceA = createTestInterfaceTemplate({
         type: "1000base-t",
@@ -260,8 +311,14 @@ describe("handleConnectionPortClick", () => {
         direction: "output",
       });
 
-      handleConnectionPortClick({ portId: portA!.id, iface: ifaceA }, ctx);
-      handleConnectionPortClick({ portId: portB!.id, iface: ifaceB }, ctx);
+      handleConnectionPortClick(
+        { portId: portA!.id, iface: ifaceA, port: portA },
+        ctx,
+      );
+      handleConnectionPortClick(
+        { portId: portB!.id, iface: ifaceB, port: portB },
+        ctx,
+      );
 
       expect(getConnectionCreationStore().isCreating).toBe(false);
       expect(getConnectionStore().connections).toContainEqual(
@@ -279,30 +336,30 @@ describe("handleConnectionPortClick", () => {
 
   describe("cancellation resets state for the next attempt", () => {
     it("allows starting a fresh connection after a validation error cancelled the mode", () => {
-      const [portA] = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
-        { type: "1000base-t" },
+      const {
+        ports: [portA],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-a", 5, [
+        "1000base-t",
       ]);
-      const [portB] = placeDeviceWithPorts(
-        layoutStore,
-        rackId,
-        "device-b",
-        10,
-        [{ type: "1000base-t" }],
-      );
+      const {
+        ports: [portB],
+      } = placeDeviceWithPorts(layoutStore, rackId, "device-b", 10, [
+        "1000base-t",
+      ]);
       const ctx = buildContext();
       const iface = createTestInterfaceTemplate({ type: "1000base-t" });
 
       // Self-click cancels with an error.
-      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
-      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface, port: portA }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface, port: portA }, ctx);
       expect(getConnectionCreationStore().isCreating).toBe(false);
 
       // A fresh click starts a new attempt rather than staying stuck.
-      handleConnectionPortClick({ portId: portA!.id, iface }, ctx);
+      handleConnectionPortClick({ portId: portA!.id, iface, port: portA }, ctx);
       expect(getConnectionCreationStore().isCreating).toBe(true);
       expect(getConnectionCreationStore().sourcePortId).toBe(portA!.id);
 
-      handleConnectionPortClick({ portId: portB!.id, iface }, ctx);
+      handleConnectionPortClick({ portId: portB!.id, iface, port: portB }, ctx);
       expect(getConnectionCreationStore().isCreating).toBe(false);
       expect(getConnectionStore().connections).toContainEqual(
         expect.objectContaining({
@@ -315,28 +372,32 @@ describe("handleConnectionPortClick", () => {
 });
 
 describe("getDirectionMismatchWarning", () => {
-  it("warns when both ports are output", () => {
+  it("warns when both ports are output (no PlacedPort override on either side)", () => {
     const a = createTestInterfaceTemplate({ direction: "output" });
     const b = createTestInterfaceTemplate({ direction: "output" });
-    expect(getDirectionMismatchWarning(a, b)).toContain("outputs");
+    expect(getDirectionMismatchWarning(undefined, a, undefined, b)).toContain(
+      "outputs",
+    );
   });
 
-  it("warns when both ports are input", () => {
+  it("warns when both ports are input (no PlacedPort override on either side)", () => {
     const a = createTestInterfaceTemplate({ direction: "input" });
     const b = createTestInterfaceTemplate({ direction: "input" });
-    expect(getDirectionMismatchWarning(a, b)).toContain("inputs");
+    expect(getDirectionMismatchWarning(undefined, a, undefined, b)).toContain(
+      "inputs",
+    );
   });
 
   it("does not warn when directions are complementary", () => {
     const a = createTestInterfaceTemplate({ direction: "output" });
     const b = createTestInterfaceTemplate({ direction: "input" });
-    expect(getDirectionMismatchWarning(a, b)).toBeNull();
+    expect(getDirectionMismatchWarning(undefined, a, undefined, b)).toBeNull();
   });
 
   it("does not warn when either side is bidirectional", () => {
     const a = createTestInterfaceTemplate({ direction: "output" });
     const b = createTestInterfaceTemplate({ direction: "bidirectional" });
-    expect(getDirectionMismatchWarning(a, b)).toBeNull();
+    expect(getDirectionMismatchWarning(undefined, a, undefined, b)).toBeNull();
   });
 
   it("does not warn for an undirected AV type with no explicit direction", () => {
@@ -345,6 +406,36 @@ describe("getDirectionMismatchWarning", () => {
     // mismatch" rather than a false-positive warning.
     const a = createTestInterfaceTemplate({ type: "xlr-3" });
     const b = createTestInterfaceTemplate({ type: "xlr-3" });
-    expect(getDirectionMismatchWarning(a, b)).toBeNull();
+    expect(getDirectionMismatchWarning(undefined, a, undefined, b)).toBeNull();
+  });
+
+  describe("PlacedPort.direction override precedence (#1932 CodeAnt review)", () => {
+    it("resolves from the PlacedPort override, not the InterfaceTemplate default: an override can clear a template-level mismatch", () => {
+      // Both templates say "output" (would warn on their own), but each
+      // port's own override makes them complementary input/output. The
+      // override must win, matching resolveConnectionPortDirection's
+      // precedence (the same one connection rendering uses for its arrows).
+      const aIface = createTestInterfaceTemplate({ direction: "output" });
+      const bIface = createTestInterfaceTemplate({ direction: "output" });
+      const aPort = createTestPlacedPort({ direction: "output" });
+      const bPort = createTestPlacedPort({ direction: "input" });
+
+      expect(
+        getDirectionMismatchWarning(aPort, aIface, bPort, bIface),
+      ).toBeNull();
+    });
+
+    it("resolves from the PlacedPort override, not the InterfaceTemplate default: an override can introduce a mismatch the templates alone would not have", () => {
+      // Templates are complementary output/input (would not warn on their
+      // own), but both ports' own overrides make them both "input".
+      const aIface = createTestInterfaceTemplate({ direction: "output" });
+      const bIface = createTestInterfaceTemplate({ direction: "input" });
+      const aPort = createTestPlacedPort({ direction: "input" });
+      const bPort = createTestPlacedPort({ direction: "input" });
+
+      expect(
+        getDirectionMismatchWarning(aPort, aIface, bPort, bIface),
+      ).toContain("inputs");
+    });
   });
 });

--- a/src/tests/connection-store.test.ts
+++ b/src/tests/connection-store.test.ts
@@ -13,35 +13,8 @@ import {
   validateConnection,
 } from "$lib/stores/connection.svelte";
 import { getLayoutStore } from "$lib/stores/layout.svelte";
-import type { Connection, InterfaceType, PlacedPort } from "$lib/types";
-import {
-  createTestLayoutStore,
-  createTestDeviceType,
-  createTestInterfaceTemplate,
-} from "./factories";
-
-/**
- * Place a device with the given interface types in a rack and return its id
- * plus the resulting PlacedPort instances (real, store-generated ids).
- */
-function placeDeviceWithPorts(
-  store: ReturnType<typeof getLayoutStore>,
-  rackId: string,
-  slug: string,
-  position: number,
-  interfaceTypes: InterfaceType[],
-): { deviceId: string; ports: PlacedPort[] } {
-  const deviceType = createTestDeviceType({ slug });
-  deviceType.interfaces = interfaceTypes.map((type, i) =>
-    createTestInterfaceTemplate({ name: `port-${i}`, type }),
-  );
-  store.addDeviceTypeRaw(deviceType);
-  store.placeDevice(rackId, slug, position);
-  const device = store.racks
-    .flatMap((r) => r.devices)
-    .find((d) => d.device_type === slug)!;
-  return { deviceId: device.id, ports: device.ports ?? [] };
-}
+import type { Connection } from "$lib/types";
+import { createTestLayoutStore, placeDeviceWithPorts } from "./factories";
 
 /**
  * Narrow an addConnection-style result to its success case, throwing with

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -275,6 +275,17 @@ export function createTestConnection(
  * Each entry is either a bare InterfaceType (uses the InterfaceTemplate
  * default direction) or an object with a `direction` override, for tests
  * that need to set the interface template's direction explicitly.
+ *
+ * Resolves the placed device by scoping to `rackId` and taking the last
+ * device with a matching slug in that rack's devices array (placeDeviceRaw
+ * always appends, so the most recently placed instance is always last),
+ * rather than by slug alone: a global first-match would return the wrong
+ * instance across racks, or an earlier instance within the same rack, when a
+ * test places more than one device of the same type. Deliberately not
+ * matching on `position` instead: PlacedDevice.position is stored in
+ * internal units (position.ts's toInternalUnits, U x 6), not the human-unit
+ * `position` argument this function takes, so a naive `d.position ===
+ * position` comparison would never match.
  */
 export function placeDeviceWithPorts(
   store: ReturnType<typeof getLayoutStore>,
@@ -292,9 +303,9 @@ export function placeDeviceWithPorts(
   });
   store.addDeviceTypeRaw(deviceType);
   store.placeDevice(rackId, slug, position);
-  const device = store.racks
-    .flatMap((r) => r.devices)
-    .find((d) => d.device_type === slug)!;
+  const rack = store.racks.find((r) => r.id === rackId)!;
+  const matches = rack.devices.filter((d) => d.device_type === slug);
+  const device = matches[matches.length - 1]!;
   return { deviceId: device.id, ports: device.ports ?? [] };
 }
 

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -27,7 +27,9 @@ import type {
   SlotWidth,
   Connection,
   InterfaceTemplate,
+  InterfaceType,
   PlacedPort,
+  PortDirection,
 } from "$lib/types";
 import type { CreateDeviceTypeInput } from "$lib/stores/layout-helpers";
 import type { NetBoxDeviceType } from "$lib/utils/netbox-import";
@@ -261,6 +263,39 @@ export function createTestConnection(
     b_port_id: "port-b",
     ...overrides,
   };
+}
+
+/**
+ * Places a device with the given interfaces in a rack via the real placement
+ * pipeline (store.placeDevice -> instantiatePorts) and returns its id and
+ * resulting PlacedPort instances, with real store-generated ids. Shared by
+ * connection-store.test.ts and connection-creation.test.ts so both exercise
+ * the same setup instead of duplicating it.
+ *
+ * Each entry is either a bare InterfaceType (uses the InterfaceTemplate
+ * default direction) or an object with a `direction` override, for tests
+ * that need to set the interface template's direction explicitly.
+ */
+export function placeDeviceWithPorts(
+  store: ReturnType<typeof getLayoutStore>,
+  rackId: string,
+  slug: string,
+  position: number,
+  interfaces: Array<
+    InterfaceType | { type: InterfaceType; direction?: PortDirection }
+  >,
+): { deviceId: string; ports: PlacedPort[] } {
+  const deviceType = createTestDeviceType({ slug });
+  deviceType.interfaces = interfaces.map((entry, index) => {
+    const spec = typeof entry === "string" ? { type: entry } : entry;
+    return createTestInterfaceTemplate({ name: `port-${index}`, ...spec });
+  });
+  store.addDeviceTypeRaw(deviceType);
+  store.placeDevice(rackId, slug, position);
+  const device = store.racks
+    .flatMap((r) => r.devices)
+    .find((d) => d.device_type === slug)!;
+  return { deviceId: device.id, ports: device.ports ?? [] };
 }
 
 // =============================================================================


### PR DESCRIPTION
## **User description**
## Summary

Implements the desktop connection creation workflow: click a source port to arm connection-creation mode, then click a target port to create a connection. Escape or right-click cancels. Closes #1932.

## Mode design and drag-to-place lineage

The mode is a small global-singleton store, `src/lib/stores/connection-creation.svelte.ts`, modeled directly on `placement.svelte.ts` (the tap-to-place store):

- `isCreating`, `sourcePortId`, `sourceIface` track the armed state, reset together on cancel/complete.
- `startConnection`, `cancelConnection`, `completeConnection` mirror `startPlacement`, `cancelPlacement`, `completePlacement`.
- A `connectionAnnouncement` field mirrors `placementAnnouncement`, rendered in a new assertive live region in `DialogOrchestrator.svelte` alongside the existing placement announcer. Unlike placement mode (which has a persistent "Placing" banner covering the armed state), connection creation has no equivalent banner, so `startConnection` sets an announcement rather than clearing it: it is the only screen-reader signal that the mode was entered.

The actual routing logic lives in a separate pure module, `src/lib/utils/connection-creation.ts` (`handleConnectionPortClick`), which takes an injected context (the store, `connectionStore.validateConnection`, `connectionStore.addConnection`, a `showToast` callback) so it is unit-testable without mounting any component, the same shape as `rack-interaction-handlers.ts`'s placement handlers.

`Rack.svelte` wires `onPortClick` on every `RackDevice` to a thin wrapper that calls the handler with the real stores, the same way it already reads `placementStore` directly rather than having mode state threaded down as props.

## Click-to-click flow

1. Click a port with an id: arms the mode, that port becomes the source.
2. Click a second port: builds `{ a_port_id: source, b_port_id: target }` and calls `connectionStore.validateConnection()`.
3. A validation error (including self-connection, already-connected, duplicate) shows an error toast and exits the mode.
4. A pass with warnings still creates the connection via `connectionStore.addConnection()`, then shows a warning toast.
5. A clean pass creates the connection silently and exits the mode.

The created connection appears immediately because `ConnectionLayer` (#1931) already renders reactively from `connectionStore.connections`, and persists because `addConnection` goes through the layout store's recorded/raw command pattern (undo/dirty tracking from #369) and serialization landed in #3090.

## Validation surfacing: blocked vs warn-and-allow

Self-connection, port-not-found, port-already-in-use, duplicate-connection, and category/type mismatch (e.g. XLR to HDMI, since both are category "av" with different exact types) are **not reimplemented**: they all come from `connectionStore.validateConnection()` (#369), which the handler calls and surfaces via toast. XLR-to-HDMI in particular is already covered generically by the store's existing category-match/type-mismatch warning, no AV-specific code needed.

Direction mismatch (output to output) has no store-side check: `Connection` carries no direction field, only `InterfaceTemplate.direction` does, and the store's `CreateConnectionInput` only takes port ids. `PortClickInfo` (#3089) already gives the handler both endpoints' `InterfaceTemplate`s, so `getDirectionMismatchWarning()` computes this warning locally in the new handler, using the same `iface.direction ?? inferDirection(...)` resolution `PortIndicators.svelte` already uses to draw its direction arrows, so a warning always agrees with what's rendered. It warns on output-output and input-input (symmetric extension of the AC's output-output example); bidirectional and undirected AV ports (no explicit direction set) never trigger it.

Both warning classes are non-blocking: the connection is created either way.

## Grouped-mode and edge cases

- **Grouped/high-density devices** (over 24 visible ports, #3089's documented limitation): `PortIndicators` renders count badges with no per-port click target, so `onPortClick` is never invoked from one in practice. The handler still defensively no-ops on `portId: undefined` rather than assuming this.
- **Clicking the same port twice**: routes through the normal validate-then-act path rather than a bespoke short-circuit, so it hits the store's own self-connection check (`ConnectionSchema` refine) and its "Cannot connect a port to itself" message surfaces as the cancellation's toast feedback, instead of a silent no-op.
- **Clicking a non-port area while armed**: no handler is attached to non-port targets, so the mode simply stays armed, matching drag-to-place's "stay armed on an invalid target" convention with no extra code needed.
- **Targeting an already-connected port**: surfaces the store's "Port already has a connection" error and exits the mode.
- **Escape**: added to `KeyboardHandler.svelte`, checked before the keyboard-placement controller and the action registry.
- **Right-click**: `RackDevice.svelte`'s existing `handleContextMenu` (ports render inside the device's own `<g>`, so a right-click on a port reaches it too) now cancels connection-creation mode instead of opening the device context menu when the mode is armed. A window-level `oncontextmenu` listener in `KeyboardHandler.svelte` covers right-clicking empty rack space or canvas chrome, where nothing else intercepts the event first.
- **Front/rear view**: unaffected: `PortIndicators` already filters ports by `rackView`, so only the visible face's ports render a click target at all.

## Visual feedback

`PortIndicators.svelte` reads the connection-creation store directly (same global-singleton pattern as the mode-state checks elsewhere) and adds `port-connection-source` (solid ring) and `port-connection-target` (dashed ring) classes to the source port and every other rendered port respectively, stroke-only so they layer with the existing hover fill tint rather than replacing it. Existing per-port hover highlighting is untouched.

## What's unit-tested vs deferred

Unit-tested (`src/tests/connection-creation-store.test.ts`, `src/tests/connection-creation.test.ts`), all logic/store-level per repo policy, no DOM assertions:

- The store's state transitions (start, cancel, complete, reset).
- The handler's state machine: entering the mode, the grouped-mode no-op, targeting a valid port, the same-port-twice self-connection error path, the already-connected error path, the category/type warning path (XLR to HDMI), the direction warning path (output to output), and re-arming after a cancelled attempt.
- `getDirectionMismatchWarning()` as a pure function across output/output, input/input, complementary, bidirectional, and undirected-AV-type cases.

Deferred to E2E/manual: the actual DOM event wiring (Escape/right-click interception order, bits-ui context menu interaction on an empty-rack right-click, the CSS highlight rendering itself), since these are DOM-routing and visual-only concerns the repo's testing policy explicitly excludes from unit tests.

## Verification

- `VITEST_MAX_WORKERS=2 npm run test:run`: 254 test files, 3778 tests, all passing.
- `npm run check`: 0 errors, 0 warnings.
- `npx eslint` on all touched/new files: no issues.
- Svelte MCP `svelte-autofixer` on all modified `.svelte` files and the new `.svelte.ts` store: no issues (only pre-existing, unrelated `$effect` suggestions surfaced for files with prior `$effect` usage).
- `prettier --check` (pinned 3.9.5 vs local 3.8.4 drift noted in repo conventions): two new files needed `--write`, reformatted and reverified clean.

## Deviations

None from the assigned surface. No changes to `src/lib/schemas/index.ts`, `yaml-field-order.ts`, `adapt-legacy-layout.ts`, cable-named files, or `static/schemas/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AadzUkj8Q4YcAjXGeoG9b2


___

## **CodeAnt-AI Description**
**Create rack connections by clicking ports, with clear feedback and cancel support**

### What Changed
- You can now start a connection by clicking one port and finish it by clicking a second port.
- The selected source port is highlighted, and other ports are marked as possible targets while the mode is active.
- Escape, right-click, or clicking an invalid target cancels the mode and clears the armed state.
- Invalid connections show a toast message; valid but mismatched connections still create the connection and show a warning.
- Screen readers now announce when connection creation starts, is cancelled, or completes.

### Impact
`✅ Faster cable linking`
`✅ Clearer connection target feedback`
`✅ Fewer stuck connection attempts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
