### PR TITLE
feat: add signal_type field (optional, inferred) to InterfaceTemplate and PlacedPort

### DIFF
--- a/src/lib/components/PortTooltip.svelte
+++ b/src/lib/components/PortTooltip.svelte
@@ -6,7 +6,11 @@
 <script lang="ts">
   import type { InterfaceTemplate, InterfaceType } from "$lib/types";
   import { getPortTooltipState } from "$lib/stores/portTooltip.svelte";
-  import { inferDirection } from "$lib/utils/port-utils";
+  import {
+    inferDirection,
+    inferSignalType,
+    getSignalLabel,
+  } from "$lib/utils/port-utils";
 
   // Get reactive tooltip state from store
   const tooltipState = $derived(getPortTooltipState());
@@ -68,6 +72,15 @@
     return direction ? DIRECTION_LABELS[direction] : null;
   }
 
+  // Signal label: explicit signal_type wins; otherwise inferred from the
+  // connector type plus the (explicit or inferred) direction. Null hides the row.
+  function getSignalTypeLabel(port: InterfaceTemplate): string | null {
+    const direction =
+      port.direction ?? inferDirection(port.type, port.mgmt_only);
+    const signal = port.signal_type ?? inferSignalType(port.type, direction);
+    return signal ? getSignalLabel(signal) : null;
+  }
+
   // Get PoE label
   function getPoELabel(
     poeMode?: "pd" | "pse",
@@ -93,6 +106,9 @@
     <div class="port-tooltip-type">{getTypeLabel(port.type)}</div>
     {#if getDirectionLabel(port)}
       <div class="port-tooltip-direction">{getDirectionLabel(port)}</div>
+    {/if}
+    {#if getSignalTypeLabel(port)}
+      <div class="port-tooltip-signal">{getSignalTypeLabel(port)}</div>
     {/if}
     {#if port.mgmt_only}
       <div class="port-tooltip-badge mgmt">Management Only</div>
@@ -149,7 +165,8 @@
     font-size: var(--font-size-xs);
   }
 
-  .port-tooltip-direction {
+  .port-tooltip-direction,
+  .port-tooltip-signal {
     color: var(--colour-text-muted-inverse, rgba(255, 255, 255, 0.7));
     font-size: var(--font-size-xs);
   }

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -222,6 +222,25 @@ export const InterfacePositionSchema = z.enum(["front", "rear"]);
  */
 export const PortDirectionSchema = z.enum(["input", "output", "bidirectional"]);
 
+/**
+ * Signal type enum - what a port carries, independent of the connector
+ * (spike #1927; #1935). The connector (InterfaceType) describes the plug;
+ * the signal type describes what flows through it (an XLR can carry mic,
+ * line, or AES3). Deliberately starts small; the taxonomy can grow.
+ */
+export const SignalTypeSchema = z.enum([
+  "analog-audio-mic",
+  "analog-audio-line",
+  "analog-audio-speaker",
+  "digital-audio-aes3",
+  "digital-audio-dante",
+  "digital-audio-avb",
+  "digital-video-hdmi",
+  "digital-video-sdi",
+  "clock-word",
+  "control-midi",
+]);
+
 // ============================================================================
 // Container Slot Schemas (v0.6.0)
 // ============================================================================
@@ -302,6 +321,7 @@ export const InterfaceTemplateSchema = z
     poe_mode: PoEModeSchema.optional(),
     poe_type: PoETypeSchema.optional(),
     direction: PortDirectionSchema.optional(),
+    signal_type: SignalTypeSchema.optional(),
   })
   .passthrough();
 
@@ -381,6 +401,7 @@ export const PlacedPortSchema = z
     type: InterfaceTypeSchema,
     label: z.string().max(64).optional(),
     direction: PortDirectionSchema.optional(),
+    signal_type: SignalTypeSchema.optional(),
   })
   .passthrough();
 
@@ -1110,6 +1131,7 @@ export type PoEType = z.infer<typeof PoETypeSchema>;
 export type PoEMode = z.infer<typeof PoEModeSchema>;
 export type InterfacePosition = z.infer<typeof InterfacePositionSchema>;
 export type PortDirection = z.infer<typeof PortDirectionSchema>;
+export type SignalType = z.infer<typeof SignalTypeSchema>;
 export type InterfaceTemplate = z.infer<typeof InterfaceTemplateSchema>;
 export type PowerPort = z.infer<typeof PowerPortSchema>;
 export type PowerOutlet = z.infer<typeof PowerOutletSchema>;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -214,6 +214,23 @@ export type InterfacePosition = "front" | "rear";
  */
 export type PortDirection = "input" | "output" | "bidirectional";
 
+/**
+ * Signal type carried by a port, independent of the physical connector.
+ * The connector (InterfaceType) describes the plug; the signal type describes
+ * what flows through it (e.g. an XLR can carry mic, line, or AES3).
+ */
+export type SignalType =
+  | "analog-audio-mic"
+  | "analog-audio-line"
+  | "analog-audio-speaker"
+  | "digital-audio-aes3"
+  | "digital-audio-dante"
+  | "digital-audio-avb"
+  | "digital-video-hdmi"
+  | "digital-video-sdi"
+  | "clock-word"
+  | "control-midi";
+
 // =============================================================================
 // Component Types (NetBox-compatible, schema-only)
 // =============================================================================
@@ -243,6 +260,8 @@ export interface InterfaceTemplate {
   poe_type?: PoEType;
   /** Signal direction. Provides the default used when the placed port omits its own. */
   direction?: PortDirection;
+  /** Signal carried by this port (explicit; inferred from type and direction when unset) */
+  signal_type?: SignalType;
 }
 
 /**
@@ -364,6 +383,8 @@ export interface PlacedPort {
   label?: string;
   /** Signal direction override; falls back to the InterfaceTemplate default when unset */
   direction?: PortDirection;
+  /** Signal override; falls back to the template value, then inference, when unset */
+  signal_type?: SignalType;
 }
 
 /**

--- a/src/lib/utils/port-utils.ts
+++ b/src/lib/utils/port-utils.ts
@@ -3,7 +3,13 @@
  * Functions for port instantiation when devices are placed
  */
 
-import type { DeviceType, PlacedPort, PortDirection } from "$lib/types";
+import type {
+  DeviceType,
+  InterfaceType,
+  PlacedPort,
+  PortDirection,
+  SignalType,
+} from "$lib/types";
 import { generateId } from "$lib/utils/device";
 
 export type PortCategory = "network" | "power" | "console" | "av";
@@ -104,6 +110,73 @@ export function inferDirection(
     return undefined;
   }
   return "bidirectional";
+}
+
+/**
+ * Human-readable signal names, one per SignalType value. Shared source for
+ * every surface that labels signals, so a label change lands everywhere.
+ */
+export const SIGNAL_LABELS: Record<SignalType, string> = {
+  "analog-audio-mic": "Mic level",
+  "analog-audio-line": "Line level",
+  "analog-audio-speaker": "Speaker level",
+  "digital-audio-aes3": "AES3",
+  "digital-audio-dante": "Dante",
+  "digital-audio-avb": "AVB",
+  "digital-video-hdmi": "HDMI",
+  "digital-video-sdi": "SDI",
+  "clock-word": "Word clock",
+  "control-midi": "MIDI",
+};
+
+/**
+ * Label for a signal type, falling back to the raw slug for forward
+ * compatibility if a new value is not yet in SIGNAL_LABELS.
+ */
+export function getSignalLabel(signal: SignalType): string {
+  return SIGNAL_LABELS[signal] ?? signal;
+}
+
+/**
+ * Infer the signal a connector carries from its type (and, for XLR, its
+ * direction: mic level into an input, line level out of anything else).
+ * Returns undefined when the connector implies no distinct signal to label:
+ * network types (ethernet is the connector, not a separate signal), connectors
+ * whose signal has no SignalTypeSchema value yet (DMX, ADAT), and genuinely
+ * ambiguous ones. Device authors set signal_type explicitly for those.
+ */
+export function inferSignalType(
+  type: InterfaceType,
+  direction?: PortDirection,
+): SignalType | undefined {
+  switch (type) {
+    case "xlr-3":
+      return direction === "input" ? "analog-audio-mic" : "analog-audio-line";
+    case "trs-1-4":
+    case "ts-1-4":
+    case "rca":
+    case "db25-audio":
+    case "phoenix":
+      return "analog-audio-line";
+    case "speakon":
+      return "analog-audio-speaker";
+    case "aes3":
+      return "digital-audio-aes3";
+    case "dante":
+      return "digital-audio-dante";
+    case "avb":
+      return "digital-audio-avb";
+    case "hdmi":
+      return "digital-video-hdmi";
+    case "sdi-bnc":
+      return "digital-video-sdi";
+    case "bnc":
+      return "clock-word";
+    case "midi-din":
+      return "control-midi";
+    default:
+      return undefined;
+  }
 }
 
 /**

--- a/src/tests/fixtures/upgrade-corpus/v26.7.0-signal-type.expected.json
+++ b/src/tests/fixtures/upgrade-corpus/v26.7.0-signal-type.expected.json
@@ -1,0 +1,8 @@
+{
+  "allowList": [
+    {
+      "pathPattern": "\\.position$",
+      "reason": "rail position 3 is converted to internal 1/6U units on load; no coincidental duplicate elsewhere in this fixture unlike the sibling AV fixtures"
+    }
+  ]
+}

--- a/src/tests/fixtures/upgrade-corpus/v26.7.0-signal-type.rackula.yaml
+++ b/src/tests/fixtures/upgrade-corpus/v26.7.0-signal-type.rackula.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://count.racku.la/schemas/rackula-layout.schema.json
+metadata:
+  id: 3f8a1c2d-9e4b-4c7a-8d1f-6b2e9a5c3d71
+  name: Signal Type Demo Rack
+  schema_version: "1.1"
+version: "26.7.0"
+name: Signal Type Demo Rack
+racks:
+  - id: rack-signal
+    name: Signal Demo Rack
+    height: 8
+    width: 19
+    desc_units: false
+    show_rear: true
+    form_factor: 4-post-cabinet
+    starting_unit: 1
+    position: 0
+    devices:
+      - id: dev-signal-demo
+        device_type: signal-demo-device
+        position: 3
+        face: front
+        ports:
+          - id: port-mic-in
+            template_name: Mic In
+            template_index: 0
+            type: xlr-3
+            direction: input
+          - id: port-aes-out
+            template_name: AES Out
+            template_index: 1
+            type: xlr-3
+            direction: output
+            signal_type: digital-audio-aes3
+device_types:
+  - slug: signal-demo-device
+    manufacturer: Acme Audio
+    model: Signal Demo 1U
+    u_height: 1
+    colour: "#8BE9FD"
+    category: av-media
+    interfaces:
+      - name: Mic In
+        type: xlr-3
+        direction: input
+        signal_type: analog-audio-mic
+      - name: AES Out
+        type: xlr-3
+        direction: output
+        signal_type: digital-audio-aes3
+settings:
+  display_mode: label
+  show_labels_on_images: false

--- a/src/tests/signal-type.test.ts
+++ b/src/tests/signal-type.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  InterfaceTemplateSchema,
+  PlacedPortSchema,
+  SignalTypeSchema,
+} from "$lib/schemas";
+import { getSignalLabel, inferSignalType } from "$lib/utils/port-utils";
+import { createTestInterfaceTemplate, createTestPlacedPort } from "./factories";
+import type { SignalType } from "$lib/types";
+
+describe("inferSignalType", () => {
+  it("infers mic level for XLR inputs and line level otherwise", () => {
+    expect(inferSignalType("xlr-3", "input")).toBe("analog-audio-mic");
+    expect(inferSignalType("xlr-3", "output")).toBe("analog-audio-line");
+    expect(inferSignalType("xlr-3")).toBe("analog-audio-line");
+  });
+
+  it("maps analog connectors to line level and speakon to speaker level", () => {
+    expect(inferSignalType("trs-1-4")).toBe("analog-audio-line");
+    expect(inferSignalType("ts-1-4")).toBe("analog-audio-line");
+    expect(inferSignalType("rca")).toBe("analog-audio-line");
+    expect(inferSignalType("db25-audio")).toBe("analog-audio-line");
+    expect(inferSignalType("phoenix")).toBe("analog-audio-line");
+    expect(inferSignalType("speakon")).toBe("analog-audio-speaker");
+  });
+
+  it("maps digital audio, video, clock, and control connectors", () => {
+    expect(inferSignalType("aes3")).toBe("digital-audio-aes3");
+    expect(inferSignalType("dante")).toBe("digital-audio-dante");
+    expect(inferSignalType("avb")).toBe("digital-audio-avb");
+    expect(inferSignalType("hdmi")).toBe("digital-video-hdmi");
+    expect(inferSignalType("sdi-bnc")).toBe("digital-video-sdi");
+    expect(inferSignalType("bnc")).toBe("clock-word");
+    expect(inferSignalType("midi-din")).toBe("control-midi");
+  });
+
+  it("returns undefined when the connector implies no distinct signal", () => {
+    expect(inferSignalType("1000base-t")).toBeUndefined();
+    expect(inferSignalType("console")).toBeUndefined();
+    expect(inferSignalType("dmx-xlr")).toBeUndefined();
+    expect(inferSignalType("adat-optical")).toBeUndefined();
+    expect(inferSignalType("usb-c")).toBeUndefined();
+  });
+});
+
+describe("getSignalLabel", () => {
+  it("labels known signals and falls back to the raw slug", () => {
+    expect(getSignalLabel("analog-audio-mic")).toBe("Mic level");
+    expect(getSignalLabel("clock-word")).toBe("Word clock");
+    expect(getSignalLabel("future-signal" as SignalType)).toBe("future-signal");
+  });
+});
+
+describe("signal_type schema fields", () => {
+  it("accepts signal_type on interface templates and placed ports", () => {
+    const template = InterfaceTemplateSchema.parse(
+      createTestInterfaceTemplate({
+        type: "xlr-3",
+        signal_type: "digital-audio-aes3",
+      }),
+    );
+    expect(template.signal_type).toBe("digital-audio-aes3");
+
+    const port = PlacedPortSchema.parse(
+      createTestPlacedPort({ type: "xlr-3", signal_type: "analog-audio-mic" }),
+    );
+    expect(port.signal_type).toBe("analog-audio-mic");
+  });
+
+  it("rejects unknown signal_type values", () => {
+    expect(SignalTypeSchema.safeParse("laser-show").success).toBe(false);
+    expect(
+      InterfaceTemplateSchema.safeParse({
+        ...createTestInterfaceTemplate(),
+        signal_type: "laser-show",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/static/schemas/rackula-layout.schema.json
+++ b/static/schemas/rackula-layout.schema.json
@@ -161,6 +161,21 @@
                   ],
                   "type": "string"
                 },
+                "signal_type": {
+                  "enum": [
+                    "analog-audio-mic",
+                    "analog-audio-line",
+                    "analog-audio-speaker",
+                    "digital-audio-aes3",
+                    "digital-audio-dante",
+                    "digital-audio-avb",
+                    "digital-video-hdmi",
+                    "digital-video-sdi",
+                    "clock-word",
+                    "control-midi"
+                  ],
+                  "type": "string"
+                },
                 "type": {
                   "enum": [
                     "100base-tx",
@@ -641,6 +656,21 @@
                       "maxLength": 64,
                       "type": "string"
                     },
+                    "signal_type": {
+                      "enum": [
+                        "analog-audio-mic",
+                        "analog-audio-line",
+                        "analog-audio-speaker",
+                        "digital-audio-aes3",
+                        "digital-audio-dante",
+                        "digital-audio-avb",
+                        "digital-video-hdmi",
+                        "digital-video-sdi",
+                        "clock-word",
+                        "control-midi"
+                      ],
+                      "type": "string"
+                    },
                     "template_index": {
                       "maximum": 9007199254740991,
                       "minimum": 0,
@@ -936,6 +966,21 @@
                       },
                       "label": {
                         "maxLength": 64,
+                        "type": "string"
+                      },
+                      "signal_type": {
+                        "enum": [
+                          "analog-audio-mic",
+                          "analog-audio-line",
+                          "analog-audio-speaker",
+                          "digital-audio-aes3",
+                          "digital-audio-dante",
+                          "digital-audio-avb",
+                          "digital-video-hdmi",
+                          "digital-video-sdi",
+                          "clock-word",
+                          "control-midi"
+                        ],
                         "type": "string"
                       },
                       "template_index": {


### PR DESCRIPTION
## **User description**
Closes #1935.

Adds the 10-value SignalTypeSchema from the issue AC, optional signal_type on
InterfaceTemplate and PlacedPort (a placed port's value overrides its template;
both are resolved at read time, mirroring how direction works), an
inferSignalType(type, direction) utility beside inferDirection, and a signal
row in PortTooltip.

Inference covers the connectors whose signal is unambiguous (XLR resolves
mic-vs-line via direction); DMX, ADAT, and other connectors without a taxonomy
value yet return undefined rather than guessing.

Schema changes are additive and backward compatible. SCHEMA_VERSION is left at
1.1: it was introduced earlier this release cycle and has not shipped yet (the
latest tag is still on 1.0), so per the same-release convention this optional,
additive field rides on 1.1 rather than triggering a second bump. A
current-format upgrade-corpus fixture (v26.7.0-signal-type, schema_version 1.1)
exercises the new fields, including an explicit AES3-over-XLR override beating
inference; its sidecar allowlists only the pre-existing rail-position
conversion. The published JSON schema is regenerated.

Not in scope, per the epic split: signal_type on Connection, compatibility
warnings (#1936), and CSV export (#1940).


___

## **CodeAnt-AI Description**
**Show signal type on ports and support explicit signal values**

### What Changed
- Ports can now store a signal type in addition to their connector type and direction.
- Signal type is shown in the port tooltip, using the saved value when present or a sensible inferred value when it is not.
- Common connectors now infer a signal type automatically, while unclear cases leave the field blank instead of guessing.
- The app now accepts and validates signal type values in saved layouts and device templates.

### Impact
`✅ Clearer port details`
`✅ Less manual signal labeling`
`✅ Fewer wrong signal assumptions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
