### PR TITLE
fix(ci): make self-hosted e2e tier opt-in via E2E_SELF_HOSTED

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,11 +165,20 @@ jobs:
   # Org PRs use the e2e-trusted environment (auto-runs); fork PRs use
   # e2e-approval, which requires ggfevans to review and approve before any
   # untrusted code executes on the homelab runner.
+  #
+  # Opt-in: this tier runs only when the repository variable E2E_SELF_HOSTED is
+  # set to 'true'. An unset variable evaluates to false, so the default is to
+  # skip. Set it to 'true' once a runner carrying the e2e label is registered.
+  # Reason: with no such runner online the job is never picked up, so it queues
+  # until the 24 hour dispatch timeout and then reports a false red on every
+  # open PR. That is not merge-blocking (continue-on-error below), but it leaves
+  # each PR at mergeStateStatus UNSTABLE, which blocks --auto merge.
   e2e-self-hosted:
     name: e2e (self-hosted full suite)
     needs: [validate, detect]
-    # Fail open on detect; still gate on validate succeeding and PR context.
-    if: ${{ !cancelled() && needs.validate.result == 'success' && github.event_name == 'pull_request' && !(needs.detect.result == 'success' && needs.detect.outputs.autoformat == 'true') }}
+    # Fail open on detect; still gate on validate succeeding, PR context, and
+    # the E2E_SELF_HOSTED opt-in described above.
+    if: ${{ !cancelled() && needs.validate.result == 'success' && github.event_name == 'pull_request' && !(needs.detect.result == 'success' && needs.detect.outputs.autoformat == 'true') && vars.E2E_SELF_HOSTED == 'true' }}
     # Advisory, not merge-blocking. Per spike #1994 the self-hosted tier is
     # *additive* to the GH-hosted chromium smoke (the validate job), which stays
     # the hard gate. This job runs on a single homelab VM (one runner, one host)

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -293,10 +293,19 @@ E2E coverage in CI has three layers (spike #1994):
 | Tier | Runner | Browsers | When | Approval |
 | --- | --- | --- | --- | --- |
 | Baseline | `ubuntu-latest` | chromium smoke | Every PR (`validate` job) | None |
-| Trusted | `ci-runner` | full suite | Main-repo PRs (auto) | None |
-| Approval | `ci-runner` | full suite | Fork PRs | `ggfevans` gate |
+| Trusted | `self-hosted, e2e` | full suite | Main-repo PRs, only while `E2E_SELF_HOSTED` is `true` | None |
+| Approval | `self-hosted, e2e` | full suite | Fork PRs, only while `E2E_SELF_HOSTED` is `true` | `ggfevans` gate |
 
-The baseline chromium smoke runs on GitHub-hosted runners for all PRs. The `e2e-self-hosted` job runs the full browser suite on the self-hosted `ci-runner` only after the baseline passes (`needs: validate`). The job selects its environment from the PR source:
+The baseline chromium smoke runs on GitHub-hosted runners for all PRs. The `e2e-self-hosted` job runs the full browser suite on the self-hosted e2e runner only after the baseline passes (`needs: validate`).
+
+The self-hosted tier is opt-in. The job carries `&& vars.E2E_SELF_HOSTED == 'true'` in its `if:`, so it is skipped whenever that repository variable is unset or not `true`. An unlabelled or absent runner previously left the job queued until it hit a 24 hour timeout, which showed as a failing check on every PR even though the tier is advisory. Skipping is the safe default.
+
+To turn the tier back on:
+
+1. Register a self-hosted runner that advertises both the `self-hosted` and `e2e` labels. The job declares `runs-on: [self-hosted, e2e]`, so a runner missing the `e2e` label will never pick it up.
+2. Set the repository variable `E2E_SELF_HOSTED` to `true` under Settings > Secrets and variables > Actions > Variables.
+
+To turn it off again, unset the variable or set it to anything other than `true`. The job selects its environment from the PR source:
 
 ```yaml
 environment: ${{ github.event.pull_request.head.repo.full_name == 'RackulaLives/Rackula' && 'e2e-trusted' || 'e2e-approval' }}
@@ -308,7 +317,8 @@ Maintainer prerequisites (one-time, in repo settings):
 
 - GitHub Environment `e2e-trusted`: no required reviewers and no deployment branch policy. Org PRs run from feature branches (and `pull_request` refs are not branch names), so restricting this environment to `main` would block the trusted tier for every PR.
 - GitHub Environment `e2e-approval`: `ggfevans` as the required reviewer, no branch restriction (fork PRs run from arbitrary branches).
-- Self-hosted runner online advertising the `ci-runner` label.
+- Self-hosted runner online advertising both the `self-hosted` and `e2e` labels, matching the job's `runs-on: [self-hosted, e2e]`.
+- Repository variable `E2E_SELF_HOSTED` set to `true`. Without it the tier stays skipped.
 
 ### iOS Safari Testing
 


### PR DESCRIPTION
## **User description**
## Problem

The `e2e (self-hosted full suite)` job fails on every open PR, and it is a phantom failure: the suite never runs.

Root cause is a runner label mismatch. The job declares:

```yaml
runs-on: [self-hosted, e2e]
```

The only online self-hosted runners are:

- `vps-web-rackula`: labels `self-hosted, Linux, X64, vps-rackula`
- `lxc-gate` (org level): labels `self-hosted, Linux, X64, lxc-gate, pve-prod`

Neither carries the `e2e` label, so no runner can ever match. The job queues until it hits the 24 hour dispatch timeout and then reports failure. `actionlint` corroborates the label is unknown to the repo config.

The job is `continue-on-error: true`, so it is not merge-blocking, but the red result still leaves every PR at `mergeStateStatus: UNSTABLE`, which blocks `gh pr merge --auto` and burns 24 hours of queue time per PR.

## Fix

Gate the job on a repository variable so it skips cleanly instead of queueing into a timeout:

```yaml
if: ${{ !cancelled() && needs.validate.result == 'success' && github.event_name == 'pull_request' && !(needs.detect.result == 'success' && needs.detect.outputs.autoformat == 'true') && vars.E2E_SELF_HOSTED == 'true' }}
```

An unset variable evaluates to false, so the default is skip, which matches current reality: there is no e2e runner. Every pre-existing condition is preserved unchanged. The comment block above the job now documents the opt-in and why it exists; the spike #1994 two-tier explanation is untouched.

The variable is intentionally not created in this PR.

## Downstream job

`notify-e2e-self-hosted` has `needs: e2e-self-hosted` and `if: ${{ !cancelled() && needs.e2e-self-hosted.outputs.e2e_result == 'failure' }}`. It does not misfire when the upstream job skips:

- The `!cancelled()` status check function removes the implicit `success()` requirement, so the `if` is still evaluated rather than the job being auto-skipped.
- A skipped job exposes no outputs, so `needs.e2e-self-hosted.outputs.e2e_result` resolves to the empty string.
- `'' == 'failure'` is false, so notify skips too. No spurious tracking issue is filed.

No other job in `test.yml` has `needs:` on `e2e-self-hosted`, so nothing else changes behaviour. The repo rulesets declare no required status checks, so a skipped job cannot leave a PR waiting on a pending required check.

## Verification

- `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/test.yml'))"` passes.
- `actionlint .github/workflows/test.yml` reports only the pre-existing unknown-label warning on `runs-on: [self-hosted, e2e]`, which is the root cause being worked around, not a regression from this change.
- Formatted with prettier 3.9.5 (no changes needed).

## How to re-enable

1. Register a self-hosted runner that carries the `e2e` label.
2. Set the repository variable: `gh variable set E2E_SELF_HOSTED --body true --repo RackulaLives/Rackula`

Unsetting the variable, or setting it to anything other than `true`, turns the tier back off.


___

## **CodeAnt-AI Description**
Prevent unavailable self-hosted E2E checks from creating false PR failures

### What Changed
- The self-hosted full browser suite now runs only when `E2E_SELF_HOSTED` is set to `true`
- PRs skip this check by default when the required labeled runner is unavailable
- The workflow documents how to enable the suite once a suitable runner is registered

### Impact
`✅ No 24-hour self-hosted runner timeouts`
`✅ Fewer false red PR checks`
`✅ Automatic merging is no longer blocked by the unavailable E2E tier`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
