### PR TITLE
chore(api): bump nanoid to 3.3.18

### DIFF
--- a/api/bun.lock
+++ b/api/bun.lock
@@ -434,7 +434,7 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "nanostores": ["nanostores@1.3.0", "", {}, "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA=="],
 


### PR DESCRIPTION
## What

Bumps the transitive `nanoid` pin in `api/bun.lock` from 3.3.15 to 3.3.18. One line changed, nothing else.

## Why

Clears two Trivy code-scanning alerts against `ghcr.io/rackulalives/rackula-api:latest`, both reporting `app/node_modules/nanoid` at 3.3.15:

| Alert | CVE | Fixed in |
| --- | --- | --- |
| #95 | CVE-2026-67213 | 3.3.18 |
| #96 | CVE-2026-67214 | 3.3.16 |

3.3.18 covers both.

## Scope

`nanoid` is a dev-scope transitive: `vite@8.1.0` -> `postcss@8.5.16` -> `nanoid` (`^3.3.12`). It is not a runtime dependency of the API, but it lands in `node_modules` inside the published API image, so Trivy flags it there.

`postcss` already declares `^3.3.12`, so 3.3.18 satisfies the existing range. No `package.json` change and no override are needed. The lockfile entry was retargeted in place: same `bin`, no dependencies, only the version and integrity hash differ between 3.3.15 and 3.3.18.

Note: `bun update nanoid` is the wrong tool here. It resolves the `latest` dist-tag (nanoid 6.0.1) and adds it as a direct dependency while leaving the vulnerable `postcss/nanoid` at 3.3.15. This PR does the minimal correct thing instead.

## Verification

Run from `api/`:

- `bun install --frozen-lockfile` succeeds with no drift, installs `nanoid@3.3.18` (integrity hash validated on download)
- `bun run typecheck` passes
- `bun test` passes: 409 pass, 0 fail across 25 files
- `npx vitest run --config vitest.workers.config.ts` passes: 10 pass

## Merging this will NOT close alerts #95 and #96

`rebuild-images.yml` checks out the latest RELEASE tag, not `main`:

```yaml
- uses: actions/checkout@...
  with:
    ref: ${{ needs.resolve.outputs.tag }}
```

The latest release is v26.7.0 (2026-07-18), so `rackula-api:latest` will keep building from that tag and will keep shipping nanoid 3.3.15 until the next release is cut. After that release, dispatching `trivy.yml` re-uploads SARIF under the same category, and alerts #95 and #96 auto-close then.
