### PR TITLE
chore(deps): bump nanoid to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5130,9 +5130,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## **User description**
Resolves Dependabot alert [#98](https://github.com/RackulaLives/Rackula/security/dependabot/98) (GHSA-2v37-7h3g-55p8: custom generators can loop indefinitely when size is zero).

## Change

Bumps the nested `nanoid` from 3.3.17 to 3.3.18 in the root `package-lock.json`. This is the only change: 3 lines, 1 file.

## Scope

Dev-scope transitive dependency, not shipped to users: `eslint-plugin-svelte` -> `postcss` 8.5.25 -> `nanoid`, resolved at `node_modules/postcss/node_modules/nanoid`.

No `overrides` entry was needed. postcss 8.5.25 declares `nanoid: ^3.3.16`, and that range already admits 3.3.18, so a plain `npm update nanoid` picks it up.

## Versions after the change

| Path | Version | Scope |
| --- | --- | --- |
| `node_modules/nanoid` | 6.0.1 | prod |
| `node_modules/postcss/node_modules/nanoid` | 3.3.18 | dev |

The root `nanoid` is a direct prod dependency pinned at `^6.0.1` and 6.0.1 is the latest published release, so it is unmoved. No other package in the lockfile changed.

## Verification

- `npm run test:run`: 255 files, 3794 tests passed
- `npm run lint`: one pre-existing error in `src/lib/components/PortTooltip.svelte` (unused `genderLabel`), present on `main` and unrelated to this change


___

## **CodeAnt-AI Description**
Resolve a security issue in the development dependency tree

### What Changed
- Updates the nested Nano ID package from 3.3.17 to 3.3.18
- Prevents custom generators configured with a zero size from looping indefinitely

### Impact
`✅ Resolved dependency security alert`
`✅ Prevented indefinite development-tool loops`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
