### PR TITLE
chore(ci): validate autoformat patch before privileged apply

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -13,6 +13,22 @@ name: Autoformat PRs
 #     branch only to apply the patch and push. It does not use actions/checkout
 #     to lay down PR code in the privileged job.
 #
+# Artifact poisoning and patch validation (CodeQL actions/untrusted-checkout):
+# the artifact still crosses from the untrusted job into the privileged one, so
+# the push job treats format.patch as untrusted input and validates it before
+# applying, failing closed on anything it cannot check:
+#   - a 2 MB byte cap on format.patch;
+#   - a path allowlist built from `git apply --numstat -z`, so the patch may
+#     only touch extensions prettier actually formats;
+#   - `git apply --check` before the real apply.
+# The format job also skips the setup-node npm cache. GitHub already scopes
+# Actions caches so a PR branch cannot write into the default branch's cache
+# scope, so that is defence in depth, not the closure of a live path.
+# Residual risk, stated honestly: the allowlist blocks a patch that introduces
+# a new file type, but it does NOT block a malicious edit to an existing .ts
+# file. What carries that remainder is the fork gate below plus the fact that
+# same-repo PR authors already have write access to this repository.
+#
 # Setup required (one-time, by a maintainer): a fine-grained PAT stored under
 # the name AUTOFORMAT_PAT in BOTH secret stores:
 #   - Settings > Secrets and variables > Actions   (for human in-repo PRs)
@@ -52,10 +68,14 @@ jobs:
           ref: ${{ github.head_ref }}
           persist-credentials: false
 
+      # No `cache: "npm"` on purpose. This job runs PR-controlled code, and
+      # keeping it out of the Actions cache is defence in depth: GitHub already
+      # scopes caches so a PR branch cannot write into the default branch's
+      # cache scope, so this closes no live path, it just removes the shared
+      # mutable surface from the untrusted job.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: "22"
-          cache: "npm"
 
       - run: npm ci --ignore-scripts
 
@@ -108,10 +128,69 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+
+          PATCH="$GITHUB_WORKSPACE/format.patch"
+
+          # format.patch is untrusted: it was produced by the job that ran
+          # PR-controlled code. Validate it before this privileged job applies
+          # it with a PAT that can write workflows. Fail closed throughout.
+
+          # 1. Byte cap. 2 MB (2097152 bytes) is far above any real prettier
+          # reformat of this tree and bounds the parsing work below.
+          MAX_PATCH_BYTES=2097152
+          PATCH_BYTES=$(wc -c < "$PATCH")
+          if [ "$PATCH_BYTES" -gt "$MAX_PATCH_BYTES" ]; then
+            echo "::error::format.patch is $PATCH_BYTES bytes, over the $MAX_PATCH_BYTES byte cap."
+            exit 1
+          fi
+
           git clone --depth=1 --branch "$HEAD_REF" \
             "https://x-access-token:${PAT}@github.com/${REPO}.git" work
           cd work
-          git apply "$GITHUB_WORKSPACE/format.patch"
+
+          # 2. Path allowlist. `git apply --numstat -z` enumerates every path
+          # the patch touches without applying it. -z emits raw NUL-terminated
+          # records (`added<TAB>deleted<TAB>path`), so there is no C-style
+          # quoting to unpick; renames arrive as a separate delete record and
+          # add record rather than the `a/x => b/y` arrow form, so both sides
+          # get checked. Any record that does not match that shape is rejected.
+          #
+          # The allowlist is the set of extensions `npm run format`
+          # (`prettier --write .`) actually formats in this tree: the
+          # lint-staged globs in package.json (js, ts, svelte, json, md, css,
+          # html) plus the extra parsers a whole-tree run claims (mjs, jsonc)
+          # and workflow YAML (yml, yaml), which is why the PAT needs Workflows
+          # write. Adding a newly formattable extension to the repo means
+          # adding it here too; until then the workflow fails rather than
+          # applying a patch it cannot vouch for.
+          git apply --numstat -z "$PATCH" > "$RUNNER_TEMP/numstat.z"
+          while IFS= read -r -d '' entry; do
+            if [[ ! "$entry" =~ ^([0-9]+|-)$'\t'([0-9]+|-)$'\t'(.+)$ ]]; then
+              echo "::error::Refusing patch: unparseable git apply --numstat record: $entry"
+              exit 1
+            fi
+            path="${BASH_REMATCH[3]}"
+            case "$path" in
+              /* | ../* | */../* | *$'\n'*)
+                echo "::error::Refusing patch: suspicious path: $path"
+                exit 1
+                ;;
+            esac
+            case "$path" in
+              *.js | *.mjs | *.ts | *.svelte | *.json | *.jsonc | *.md | *.css | *.html | *.yml | *.yaml) ;;
+              *)
+                echo "::error::Refusing patch: touches $path, outside the prettier extension allowlist."
+                exit 1
+                ;;
+            esac
+            echo "Allowed: $path"
+          done < "$RUNNER_TEMP/numstat.z"
+
+          # 3. Dry run before the real apply.
+          git apply --check "$PATCH"
+
+          git apply "$PATCH"
           if git diff --quiet; then
             echo "Patch applied to no effect; nothing to commit."
             exit 0


### PR DESCRIPTION
## **User description**
Addresses CodeQL alert #92 (`actions/untrusted-checkout`, medium) on `.github/workflows/autoformat.yml`.

## Context

`autoformat.yml` already uses a two-job split: the `format` job runs PR-controlled code (`npm ci`, prettier plus its plugins) with no token and `persist-credentials: false`, gated to same-repo PRs; the `push` job holds `AUTOFORMAT_PAT` (Contents write, Workflows write) and runs no PR-controlled code. The residual risk CodeQL names is artifact poisoning: the untrusted job's `format.patch` artifact is consumed by the privileged job. Same-repo Dependabot PRs pass the fork gate, so a compromised prettier plugin arriving in a dev-dep bump could emit an arbitrary patch that the privileged job applies and pushes with a token that can write workflows.

## Changes

1. Drop `cache: "npm"` from `actions/setup-node` in the untrusted `format` job. This is defence in depth, not the closure of a live path: GitHub already scopes Actions caches so a PR branch cannot write into the default branch's cache scope. It just removes a shared mutable surface from the job that runs PR-controlled code.

2. Validate `format.patch` in the privileged `push` job before applying it, failing closed at every step:
   - byte cap of 2 MB (2097152 bytes) on the patch file, checked before the clone;
   - path allowlist built from `git apply --numstat -z`, which enumerates the touched paths without applying. `-z` emits raw NUL-terminated `added<TAB>deleted<TAB>path` records, so there is no C-style quoting to unpick, and renames arrive as a separate delete record plus add record rather than the `a/x => b/y` arrow form, so both sides get checked. Any record that does not match that shape is rejected, as are absolute paths, `..` segments, and embedded newlines;
   - `git apply --check` as a dry run before the real `git apply`.

The allowlist is the set of extensions `npm run format` (`prettier --write .`) actually formats in this tree: the lint-staged globs in `package.json` (js, ts, svelte, json, md, css, html) plus the extra parsers a whole-tree run claims (`mjs` for `scripts/gen-headers.mjs`, `jsonc` for `api/wrangler.jsonc` and `.markdownlint-cli2.jsonc`, both confirmed via `prettier --file-info`) and workflow YAML (yml, yaml), which is why the PAT needs Workflows write. Adding a newly formattable extension to the repo means adding it here too; until then the workflow fails rather than applying a patch it cannot vouch for.

The workflow header comment is extended to document all of this.

## Residual risk

This does not eliminate the alert's risk. The path allowlist blocks a patch that introduces a new file type, but it does not block a malicious edit to an existing `.ts` file. What carries that remainder is the fork gate plus the fact that same-repo PR authors already have write access to this repository. That is stated in the header comment rather than papered over.

## Verification

- `python3 -c "import yaml;yaml.safe_load(...)"` passes.
- `actionlint` passes (shellcheck 0.11.0 installed, so the `run` blocks were shell-linted).
- Allowlist logic exercised locally against crafted `git apply --numstat -z` output: accepts a clean record set (ts, workflow yml, md with spaces in the path, jsonc, mjs, svelte, css, json, html, js, yaml); rejects `Dockerfile`, `scripts/evil.sh`, `.npmrc`, a binary `.png` record, `../../.ssh/x.ts`, `/etc/cron.d/x.yml`, `src/../../x.ts`, a newline-smuggled path, and an unparseable record.
- End-to-end against a real throwaway git repo using the run block extracted verbatim from this YAML (clone and push stubbed): a legitimate `.ts` plus workflow `.yml` patch applies and commits; a patch that also touches `Dockerfile` and `scripts/build.sh` is refused before any apply, leaving the clone clean with no commit; a 2.55 MB patch touching only an allowlisted `.ts` is refused by the byte cap.

Do not dismiss alert #92 until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxjPYXAQVUe9LE2NQo68tf


___

## **CodeAnt-AI Description**
Validate autoformat patches before privileged commits

### What Changed
- Autoformat patches are rejected if they exceed 2 MB, contain unsafe paths, or touch file types outside the formatting allowlist
- Patches are checked for applicability before they are applied and pushed
- The untrusted formatting job no longer uses the npm cache

### Impact
`✅ Safer privileged autoformat commits`
`✅ Prevented workflow and unrelated-file changes from autoformat patches`
`✅ Bounded patch processing size`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
