### PR TITLE
fix: restore dropped connector-gender row in PortTooltip

### DIFF
--- a/src/lib/components/PortTooltip.svelte
+++ b/src/lib/components/PortTooltip.svelte
@@ -10,6 +10,7 @@
     inferDirection,
     inferSignalType,
     getSignalLabel,
+    deriveGender,
   } from "$lib/utils/port-utils";
 
   // Get reactive tooltip state from store
@@ -81,6 +82,21 @@
     return signal ? getSignalLabel(signal) : null;
   }
 
+  const GENDER_LABELS = {
+    male: "Male",
+    female: "Female",
+  } as const;
+
+  // Connector gender is computed, never stored (spike #1927). Undefined for
+  // connectors whose convention is ambiguous or whose direction is unresolved;
+  // null hides the row.
+  function getGenderLabel(port: InterfaceTemplate): string | null {
+    const direction =
+      port.direction ?? inferDirection(port.type, port.mgmt_only);
+    const gender = deriveGender(port.type, direction);
+    return gender ? GENDER_LABELS[gender] : null;
+  }
+
   // Get PoE label
   function getPoELabel(
     poeMode?: "pd" | "pse",
@@ -110,6 +126,9 @@
     {/if}
     {#if getSignalTypeLabel(port)}
       <div class="port-tooltip-signal">{getSignalTypeLabel(port)}</div>
+    {/if}
+    {#if genderLabel}
+      <div class="port-tooltip-gender">{genderLabel}</div>
     {/if}
     {#if port.mgmt_only}
       <div class="port-tooltip-badge mgmt">Management Only</div>
@@ -167,7 +186,8 @@
   }
 
   .port-tooltip-direction,
-  .port-tooltip-signal {
+  .port-tooltip-signal,
+  .port-tooltip-gender {
     color: var(--colour-text-muted-inverse, rgba(255, 255, 255, 0.7));
     font-size: var(--font-size-xs);
   }


### PR DESCRIPTION
## **User description**
## Problem

`main` is red. `npm run lint` fails, which fails the `validate` gate on **every open PR**:

```
src/lib/components/PortTooltip.svelte
  104:11  error  'genderLabel' is assigned a value but never used
```

Root cause is the #3120 / #3121 merge. #3121's own description called it out in advance:

> Heads-up: PR #3120 (signal_type) also touches PortTooltip.svelte (adds a signal row in the same spot) and the same port-utils import line - whichever merges second has a trivial both-sides conflict.

The conflict resolution kept one line and dropped three. `git show 8a2b2220 --stat` shows `PortTooltip.svelte | 1 +` -- the only line that survived was the orphan `{@const genderLabel = getGenderLabel(port)}`. Lost were the `deriveGender` import, the `getGenderLabel` helper, and the row that renders it.

So there are two bugs, not one:

1. **CI**: the unused `genderLabel` fails lint, blocking every PR.
2. **Runtime**: `getGenderLabel` is called but never defined or imported. Hovering any port throws `ReferenceError: getGenderLabel is not defined`. `deriveGender` and its tests landed fine in `port-utils.ts`, so the feature was dead on arrival at the only surface that consumes it.

## Fix

Restores the three dropped pieces so gender displays as #3121 intended:

- `deriveGender` added to the existing `$lib/utils/port-utils` import.
- `getGenderLabel` helper, mirroring the shape of the adjacent `getSignalTypeLabel` (explicit `direction` wins, else `inferDirection`; null hides the row).
- The `{#if genderLabel}` row, rendered next to the signal row, sharing the muted-label styling.

No change to `deriveGender` or its tests -- the conventions from #3121 (XLR per AES14, Speakon always male, dmx-xlr deliberately underived) are untouched.

## Verification

```
npm run lint                                    # pass (was failing on main)
npx svelte-check --threshold error               # 0 errors, 0 warnings
npx prettier --check src/lib/components/PortTooltip.svelte   # clean
npx vitest run src/tests/derive-gender.test.ts   # 5 passed
```

Refs #3121, #3120, #1944


___

## **CodeAnt-AI Description**
Restore connector gender details in port tooltips

### What Changed
- Port tooltips now show “Male” or “Female” when connector gender can be determined
- Gender is inferred from the connector type and direction, while ambiguous connectors hide the row
- Restores tooltip behavior without leaving unused or missing gender logic that can break linting and hover interactions

### Impact
`✅ Clearer connector information`
`✅ Fewer port tooltip errors`
`✅ Passing lint validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
