### PR TITLE
fix: apply the documented default OIDC redirect URI (#3140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Calendar Versioning](https://calver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- OIDC login no longer loops until the browser reports `ERR_TOO_MANY_REDIRECTS`. `RACKULA_OIDC_REDIRECT_URI` was documented as defaulting to `RACKULA_BASE_URL` + `/auth/callback`, but that default was never applied, so Rackula advertised a callback path it did not serve and the identity provider's callback was bounced back to the login route (#3140, PR #3215)
+- An OAuth callback arriving on a path Rackula does not serve now returns a 400 naming `RACKULA_OIDC_REDIRECT_URI`, instead of redirecting to login and looping (PR #3215)
+- Better Auth's own callback path, `/api/auth/oauth2/callback/oidc`, is served for deployments whose identity provider is already registered against it (PR #3215)
+- The API warns at startup when `RACKULA_OIDC_REDIRECT_URI` names a path it does not serve, listing the paths that are served (PR #3215)
+
+### Changed
+
+- Upgrade action for OIDC deployments: with `RACKULA_OIDC_REDIRECT_URI` unset, Rackula now advertises `RACKULA_BASE_URL` + `/auth/callback` to the identity provider instead of `/api/auth/oauth2/callback/oidc`. If OIDC login was working for you without that variable set, register `https://<your-host>/auth/callback` in your identity provider before upgrading, or pin the old path by setting `RACKULA_OIDC_REDIRECT_URI` explicitly (#3140, PR #3215)
+
 ## [26.7.0] - 2026-07-18
 
 Rackula now warns you before anything destructive, shows clear feedback while you place devices, and lets you save straight from the command palette. Behind the scenes, sign-in and file handling are more secure and the app is more stable overall.
@@ -63,8 +76,6 @@ Rackula now warns you before anything destructive, shows clear feedback while yo
 - Brand pack contribution guide added, simplifying pack registration (PR #3044)
 - Design docs written ahead of implementation: UI friction and consistency review (PR #2985), resize and bay corrections spec (#2820, PR #2826), interaction feedback cluster plan (PR #2866), e2e suite recovery plan (PR #2860)
 - Dependency updates across svelte, hono, wrangler, @cloudflare/vitest-pool-workers, eslint and vitest tooling, GitHub Actions, and the production/development-dependency groups, including nanoid 6.0.0 and fuse.js 7.5.0 (PR #3053), spanning PR #2817 through PR #3054 (~35 PRs)
-
-## [Unreleased]
 
 ## [26.6.6] - 2026-06-30
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -17,7 +17,9 @@ RACKULA_AUTH_SESSION_SECRET=your-generated-secret-here-minimum-32-chars
 RACKULA_OIDC_ISSUER=https://your-idp.example.com/application/o/rackula/
 RACKULA_OIDC_CLIENT_ID=rackula-web
 RACKULA_OIDC_CLIENT_SECRET=your-oidc-client-secret
-RACKULA_OIDC_REDIRECT_URI=https://your-rackula.example.com/auth/callback
+# Optional. Defaults to RACKULA_BASE_URL + /auth/callback, which is the URL to
+# register with your identity provider. Set this only to override that default.
+# RACKULA_OIDC_REDIRECT_URI=https://your-rackula.example.com/auth/callback
 
 # Local Authentication (required when RACKULA_AUTH_MODE=local)
 # RACKULA_LOCAL_USERNAME=admin

--- a/api/README.md
+++ b/api/README.md
@@ -121,7 +121,10 @@ RACKULA_AUTH_SESSION_SECRET=your-generated-secret
 RACKULA_OIDC_ISSUER=https://your-idp.example.com/
 RACKULA_OIDC_CLIENT_ID=rackula-web
 RACKULA_OIDC_CLIENT_SECRET=your-client-secret
-RACKULA_OIDC_REDIRECT_URI=https://your-rackula.example.com/auth/callback
+
+# Optional. Defaults to RACKULA_BASE_URL + /auth/callback, which is the URL to
+# register with your identity provider. Set this only to override that default.
+# RACKULA_OIDC_REDIRECT_URI=https://your-rackula.example.com/auth/callback
 ```
 
 See `.env.example` for all available configuration options.

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -657,6 +657,11 @@ export async function createApp(
 
     app.get("/auth/login", authLoginRouteHandler);
     app.get("/auth/callback", authCallbackRouteHandler);
+    // Better Auth's own callback path, for deployments whose IdP is registered
+    // against it. nginx strips the /api prefix before the request reaches us,
+    // so the bare form is the one that needs an explicit route; the /api form
+    // is already covered by the Better Auth wildcard below. See #3140.
+    app.get("/auth/oauth2/callback/oidc", authCallbackRouteHandler);
     app.get("/auth/check", authCheckRouteHandler);
     app.post("/auth/logout", authLogoutRouteHandler);
 

--- a/api/src/auth/config.ts
+++ b/api/src/auth/config.ts
@@ -6,6 +6,17 @@ import type { EnvMap } from "../security";
 import { logger } from "../logger";
 
 const DEFAULT_BASE_URL = "http://localhost:3000";
+/**
+ * Callback path appended to RACKULA_BASE_URL when RACKULA_OIDC_REDIRECT_URI is
+ * unset. This is the path the deployment docs tell users to register with their
+ * IdP, and the only OIDC callback Rackula routes and exempts from the auth gate.
+ *
+ * Without this default, Better Auth falls back to its own convention,
+ * {baseURL}/api/auth/oauth2/callback/oidc, which the auth gate blocks. The IdP
+ * callback then bounces to the login route, which re-initiates OIDC, and the
+ * browser loops until ERR_TOO_MANY_REDIRECTS. See #3140.
+ */
+const DEFAULT_OIDC_CALLBACK_PATH = "/auth/callback";
 const DEFAULT_AUTH_SESSION_COOKIE_NAME = "rackula_auth_session";
 const DEFAULT_OIDC_SCOPES = ["openid", "profile", "email"];
 const OIDC_DISCOVERY_PATH = "/.well-known/openid-configuration";
@@ -378,7 +389,7 @@ function createOidcUserInfoResolver(options: {
  * - RACKULA_OIDC_DISCOVERY_URL: Explicit OIDC discovery document URL (optional override)
  * - RACKULA_OIDC_CLIENT_ID: OAuth client ID
  * - RACKULA_OIDC_CLIENT_SECRET: OAuth client secret
- * - RACKULA_OIDC_REDIRECT_URI: OAuth callback URL (optional)
+ * - RACKULA_OIDC_REDIRECT_URI: OAuth callback URL (optional, defaults to RACKULA_BASE_URL + /auth/callback)
  * - RACKULA_OIDC_SCOPES: Optional scopes (comma or space-separated), defaults to openid profile email
  * - RACKULA_BASE_URL: Base URL for callback construction (defaults to http://localhost:3000)
  */
@@ -398,6 +409,9 @@ export function createAuth(secret: string, env: EnvMap = process.env) {
     readEnv(env, "RACKULA_AUTH_SESSION_COOKIE_NAME") ||
     DEFAULT_AUTH_SESSION_COOKIE_NAME;
   const baseURL = readEnv(env, "RACKULA_BASE_URL") || DEFAULT_BASE_URL;
+  // A trailing slash would yield "https://host//auth/callback", which an IdP
+  // treats as a different URI than the one the operator registered.
+  const defaultOidcRedirectUri = `${baseURL.replace(/\/+$/, "")}${DEFAULT_OIDC_CALLBACK_PATH}`;
   const authSessionCookieSecure =
     parseOptionalBoolean(readEnv(env, "RACKULA_AUTH_SESSION_COOKIE_SECURE")) ??
     env.NODE_ENV === "production";
@@ -431,7 +445,9 @@ export function createAuth(secret: string, env: EnvMap = process.env) {
             discoveryUrl: oidcDiscoveryUrl,
             scopes: oidcScopes,
             pkce: true,
-            redirectURI: readEnv(env, "RACKULA_OIDC_REDIRECT_URI"),
+            redirectURI:
+              readEnv(env, "RACKULA_OIDC_REDIRECT_URI") ??
+              defaultOidcRedirectUri,
             getUserInfo: createOidcUserInfoResolver({
               discoveryUrl: oidcDiscoveryUrl,
               clientId: oidcClientId,

--- a/api/src/auth/config.ts
+++ b/api/src/auth/config.ts
@@ -12,11 +12,25 @@ const DEFAULT_BASE_URL = "http://localhost:3000";
  * IdP, and the only OIDC callback Rackula routes and exempts from the auth gate.
  *
  * Without this default, Better Auth falls back to its own convention,
- * {baseURL}/api/auth/oauth2/callback/oidc, which the auth gate blocks. The IdP
- * callback then bounces to the login route, which re-initiates OIDC, and the
- * browser loops until ERR_TOO_MANY_REDIRECTS. See #3140.
+ * {baseURL}/api/auth/oauth2/callback/oidc. That path is served too, as
+ * compatibility behaviour for deployments already registered against it, but it
+ * is not the default: the docs and every IdP setup guide name /auth/callback.
+ * See #3140.
  */
 const DEFAULT_OIDC_CALLBACK_PATH = "/auth/callback";
+/**
+ * Callback paths this app actually routes and exempts from the auth gate. Used
+ * to warn when RACKULA_OIDC_REDIRECT_URI names something else. Deliberately a
+ * warning and not a startup failure: a reverse proxy may legitimately rewrite an
+ * external callback path onto one of these (the bundled nginx maps
+ * /auth/callback onto /api/auth/callback), so the external URI need not match.
+ */
+const SERVED_OIDC_CALLBACK_PATHS = [
+  "/auth/callback",
+  "/api/auth/callback",
+  "/auth/oauth2/callback/oidc",
+  "/api/auth/oauth2/callback/oidc",
+];
 const DEFAULT_AUTH_SESSION_COOKIE_NAME = "rackula_auth_session";
 const DEFAULT_OIDC_SCOPES = ["openid", "profile", "email"];
 const OIDC_DISCOVERY_PATH = "/.well-known/openid-configuration";
@@ -393,6 +407,28 @@ function createOidcUserInfoResolver(options: {
  * - RACKULA_OIDC_SCOPES: Optional scopes (comma or space-separated), defaults to openid profile email
  * - RACKULA_BASE_URL: Base URL for callback construction (defaults to http://localhost:3000)
  */
+function warnIfRedirectPathUnserved(redirectUri: string): void {
+  let pathname: string;
+  try {
+    pathname = new URL(redirectUri).pathname;
+  } catch {
+    logger.warn(
+      { redirectUri },
+      "RACKULA_OIDC_REDIRECT_URI is not a valid absolute URL. OIDC login will not complete.",
+    );
+    return;
+  }
+
+  if (SERVED_OIDC_CALLBACK_PATHS.includes(pathname)) {
+    return;
+  }
+
+  logger.warn(
+    { redirectUri, servedPaths: SERVED_OIDC_CALLBACK_PATHS },
+    "RACKULA_OIDC_REDIRECT_URI points at a path this app does not serve. Unless a reverse proxy rewrites it onto one of the served callback paths, the identity provider's callback cannot create a session and login will fail.",
+  );
+}
+
 export function createAuth(secret: string, env: EnvMap = process.env) {
   if (!secret) {
     throw new Error(
@@ -435,6 +471,10 @@ export function createAuth(secret: string, env: EnvMap = process.env) {
       );
     }
 
+    const oidcRedirectUri =
+      readEnv(env, "RACKULA_OIDC_REDIRECT_URI") ?? defaultOidcRedirectUri;
+    warnIfRedirectPathUnserved(oidcRedirectUri);
+
     plugins.push(
       genericOAuth({
         config: [
@@ -445,9 +485,7 @@ export function createAuth(secret: string, env: EnvMap = process.env) {
             discoveryUrl: oidcDiscoveryUrl,
             scopes: oidcScopes,
             pkce: true,
-            redirectURI:
-              readEnv(env, "RACKULA_OIDC_REDIRECT_URI") ??
-              defaultOidcRedirectUri,
+            redirectURI: oidcRedirectUri,
             getUserInfo: createOidcUserInfoResolver({
               discoveryUrl: oidcDiscoveryUrl,
               clientId: oidcClientId,

--- a/api/src/oidc.integration.test.ts
+++ b/api/src/oidc.integration.test.ts
@@ -274,6 +274,18 @@ describe("OIDC integration", () => {
     );
   }
 
+  async function readAdvertisedRedirectUri(
+    app: Awaited<ReturnType<typeof createApp>>,
+  ): Promise<string> {
+    const loginResponse = await app.request("/auth/login?next=%2Fdashboard");
+    expect(loginResponse.status).toBe(302);
+    const redirectUri = new URL(
+      loginResponse.headers.get("location")!,
+    ).searchParams.get("redirect_uri");
+    expect(redirectUri).not.toBeNull();
+    return redirectUri!;
+  }
+
   // Runs the login -> callback flow and asserts the callback rejected the ID
   // token: it redirects with user_info_is_missing and sets no session cookie.
   // Shared by the algorithm-pinning regression tests.
@@ -575,6 +587,147 @@ describe("OIDC integration", () => {
         },
       });
       expect(replayResponse.status).toBe(401);
+    } finally {
+      mock.restore();
+    }
+  });
+  it("advertises the documented default callback URI when RACKULA_OIDC_REDIRECT_URI is unset", async () => {
+    const mock = await installMockOidcFetch();
+    try {
+      const app = await createApp(
+        buildOidcEnv({ RACKULA_OIDC_REDIRECT_URI: undefined }),
+      );
+      const redirectUri = await readAdvertisedRedirectUri(app);
+
+      expect(redirectUri).toBe("https://rack.example.com/auth/callback");
+      // Better Auth's own default is ${baseURL}/api/auth/oauth2/callback/oidc,
+      // a path the auth gate blocks and nginx rewrites out of reach (#3140).
+      expect(redirectUri).not.toContain("/oauth2/callback/");
+    } finally {
+      mock.restore();
+    }
+  });
+
+  it("completes the OIDC flow at the callback URI it advertised when RACKULA_OIDC_REDIRECT_URI is unset", async () => {
+    const mock = await installMockOidcFetch();
+    try {
+      const app = await createApp(
+        buildOidcEnv({ RACKULA_OIDC_REDIRECT_URI: undefined }),
+      );
+
+      const loginResponse = await app.request("/auth/login?next=%2Fdashboard");
+      expect(loginResponse.status).toBe(302);
+      const authorizationUrl = new URL(loginResponse.headers.get("location")!);
+      const state = authorizationUrl.searchParams.get("state");
+      expect(state).not.toBeNull();
+      const loginCookieHeader = cookieHeaderFromSetCookies(
+        readSetCookies(loginResponse.headers),
+      );
+
+      // Follow the redirect URI Rackula actually handed the IdP, the way a
+      // browser would, instead of assuming a callback path. Hardcoding
+      // "/auth/callback" here is what hid #3140 from this suite.
+      const advertisedPath = new URL(
+        authorizationUrl.searchParams.get("redirect_uri")!,
+      ).pathname;
+      const callbackResponse = await app.request(
+        `${advertisedPath}?code=entra-code&state=${encodeURIComponent(state!)}`,
+        {
+          headers: {
+            Cookie: loginCookieHeader,
+          },
+        },
+      );
+
+      expect(callbackResponse.status).toBe(302);
+      expect(callbackResponse.headers.get("location")).not.toContain(
+        "/auth/login",
+      );
+      expect(
+        readSetCookies(callbackResponse.headers).some((cookie) =>
+          cookie.includes("rackula_auth_session="),
+        ),
+      ).toBe(true);
+    } finally {
+      mock.restore();
+    }
+  });
+
+  it("strips a trailing slash from RACKULA_BASE_URL when deriving the callback URI", async () => {
+    const mock = await installMockOidcFetch();
+    try {
+      const app = await createApp(
+        buildOidcEnv({
+          RACKULA_BASE_URL: "https://rack.example.com/",
+          RACKULA_OIDC_REDIRECT_URI: undefined,
+        }),
+      );
+
+      expect(await readAdvertisedRedirectUri(app)).toBe(
+        "https://rack.example.com/auth/callback",
+      );
+    } finally {
+      mock.restore();
+    }
+  });
+
+  it("keeps an explicit RACKULA_OIDC_REDIRECT_URI authoritative", async () => {
+    const mock = await installMockOidcFetch();
+    try {
+      const app = await createApp(
+        buildOidcEnv({
+          RACKULA_OIDC_REDIRECT_URI: "https://rack.example.com/custom/callback",
+        }),
+      );
+
+      expect(await readAdvertisedRedirectUri(app)).toBe(
+        "https://rack.example.com/custom/callback",
+      );
+    } finally {
+      mock.restore();
+    }
+  });
+
+  it("serves Better Auth's own callback path when the IdP is configured to use it", async () => {
+    const mock = await installMockOidcFetch();
+    try {
+      const app = await createApp(
+        buildOidcEnv({
+          RACKULA_OIDC_REDIRECT_URI:
+            "https://rack.example.com/api/auth/oauth2/callback/oidc",
+        }),
+      );
+
+      const loginResponse = await app.request("/auth/login?next=%2Fdashboard");
+      expect(loginResponse.status).toBe(302);
+      const state = new URL(
+        loginResponse.headers.get("location")!,
+      ).searchParams.get("state");
+      expect(state).not.toBeNull();
+      const loginCookieHeader = cookieHeaderFromSetCookies(
+        readSetCookies(loginResponse.headers),
+      );
+
+      // The bare path is what the API sees after nginx strips the /api prefix
+      // (deploy/nginx.conf.template:216).
+      const callbackResponse = await app.request(
+        `/auth/oauth2/callback/oidc?code=entra-code&state=${encodeURIComponent(state!)}`,
+        {
+          headers: {
+            Cookie: loginCookieHeader,
+          },
+        },
+      );
+
+      expect(callbackResponse.status).toBe(302);
+      expect(callbackResponse.headers.get("location")).not.toContain(
+        "/auth/login",
+      );
+      expect(
+        readSetCookies(callbackResponse.headers).some((cookie) =>
+          cookie.includes("rackula_auth_session="),
+        ),
+      ).toBe(true);
     } finally {
       mock.restore();
     }

--- a/api/src/oidc.integration.test.ts
+++ b/api/src/oidc.integration.test.ts
@@ -676,12 +676,15 @@ describe("OIDC integration", () => {
     try {
       const app = await createApp(
         buildOidcEnv({
-          RACKULA_OIDC_REDIRECT_URI: "https://rack.example.com/custom/callback",
+          // A served path that differs from the derived default, so this asserts
+          // precedence without implying arbitrary paths are routable.
+          RACKULA_OIDC_REDIRECT_URI:
+            "https://rack.example.com/api/auth/callback",
         }),
       );
 
       expect(await readAdvertisedRedirectUri(app)).toBe(
-        "https://rack.example.com/custom/callback",
+        "https://rack.example.com/api/auth/callback",
       );
     } finally {
       mock.restore();

--- a/api/src/security.test.ts
+++ b/api/src/security.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it } from "bun:test";
 import { Hono } from "hono";
 import { createHmac } from "node:crypto";
 import { createApp } from "./app";
+import { RATE_LIMIT_EXEMPT_PATHS } from "./security/middleware";
 import {
+  AUTH_PUBLIC_PATHS,
   clearInvalidatedAuthSessions,
   createSignedAuthSessionToken,
   createWriteAuthMiddleware,
@@ -529,6 +531,62 @@ describe("authentication gate", () => {
 
     const callback = await app.request("/auth/callback");
     expect(callback.status).toBe(501);
+  });
+
+  // #3140: Better Auth's generic-oauth plugin advertises
+  // {baseURL}/api/auth/oauth2/callback/oidc as its default redirect URI. The
+  // auth gate used to intercept that path and bounce it to the login route,
+  // which re-initiated OIDC and looped until ERR_TOO_MANY_REDIRECTS. 501 here
+  // proves the gate let the request through to the route handler, which then
+  // reports the OIDC provider as unconfigured for this env.
+  it("keeps Better Auth's own OAuth callback path reachable when auth is enabled", async () => {
+    const app = await createApp(buildAuthEnabledEnv());
+
+    for (const path of [
+      "/auth/oauth2/callback/oidc",
+      "/api/auth/oauth2/callback/oidc",
+    ]) {
+      const response = await app.request(path);
+      expect(response.status).not.toBe(302);
+      expect(response.status).not.toBe(401);
+      expect(response.headers.get("location")).toBeNull();
+    }
+
+    // The bare path routes to Rackula's callback wrapper, which reports the
+    // provider as unconfigured for this env. The /api form reaches Better Auth
+    // directly and 404s here because no OIDC credentials means no plugin.
+    // Either way the gate did not intercept.
+    expect((await app.request("/auth/oauth2/callback/oidc")).status).toBe(501);
+    expect((await app.request("/api/auth/oauth2/callback/oidc")).status).toBe(
+      404,
+    );
+  });
+
+  it("exempts the OAuth callback paths from the auth gate and rate limiting", () => {
+    for (const path of [
+      "/auth/oauth2/callback/oidc",
+      "/api/auth/oauth2/callback/oidc",
+    ]) {
+      expect(AUTH_PUBLIC_PATHS.has(path)).toBe(true);
+      expect(RATE_LIMIT_EXEMPT_PATHS.has(path)).toBe(true);
+    }
+  });
+
+  // The unroutable-callback guard must key off the path, not off the presence
+  // of code/state query params, or ordinary deep links carrying those names
+  // would start returning 400 instead of redirecting to login.
+  it("fails loudly on an unroutable OAuth callback but still redirects ordinary paths", async () => {
+    const app = await createApp(buildAuthEnabledEnv());
+
+    const unknownProvider = await app.request(
+      "/auth/oauth2/callback/not-a-provider?code=x&state=y",
+    );
+    expect(unknownProvider.status).toBe(400);
+    expect(unknownProvider.headers.get("location")).toBeNull();
+
+    const deepLink = await app.request("/dashboard?code=x&state=y");
+    expect(deepLink.status).toBe(302);
+    expect(deepLink.headers.get("location")).toContain("/auth/login");
   });
 
   it("refreshes auth cookies with secure defaults on auth check", async () => {

--- a/api/src/security.test.ts
+++ b/api/src/security.test.ts
@@ -2,9 +2,7 @@ import { beforeEach, describe, expect, it } from "bun:test";
 import { Hono } from "hono";
 import { createHmac } from "node:crypto";
 import { createApp } from "./app";
-import { RATE_LIMIT_EXEMPT_PATHS } from "./security/middleware";
 import {
-  AUTH_PUBLIC_PATHS,
   clearInvalidatedAuthSessions,
   createSignedAuthSessionToken,
   createWriteAuthMiddleware,
@@ -560,16 +558,6 @@ describe("authentication gate", () => {
     expect((await app.request("/api/auth/oauth2/callback/oidc")).status).toBe(
       404,
     );
-  });
-
-  it("exempts the OAuth callback paths from the auth gate and rate limiting", () => {
-    for (const path of [
-      "/auth/oauth2/callback/oidc",
-      "/api/auth/oauth2/callback/oidc",
-    ]) {
-      expect(AUTH_PUBLIC_PATHS.has(path)).toBe(true);
-      expect(RATE_LIMIT_EXEMPT_PATHS.has(path)).toBe(true);
-    }
   });
 
   // The unroutable-callback guard must key off the path, not off the presence

--- a/api/src/security/middleware.ts
+++ b/api/src/security/middleware.ts
@@ -21,6 +21,14 @@ const _AUTH_PUBLIC_PATHS = new Set([
   "/api/auth/callback",
   "/api/auth/check",
   "/api/auth/logout",
+  // Better Auth's generic-oauth plugin routes its callback at
+  // {basePath}/oauth2/callback/{providerId}, and advertises that URI to the IdP
+  // whenever RACKULA_OIDC_REDIRECT_URI points at it. The bare form is what the
+  // API sees after nginx strips the /api prefix
+  // (deploy/nginx.conf.template). Both must bypass the gate: the callback is
+  // what creates the session, so requiring one here loops the browser. See #3140.
+  "/auth/oauth2/callback/oidc",
+  "/api/auth/oauth2/callback/oidc",
 ]);
 /** Immutable set of paths exempt from auth. */
 export const AUTH_PUBLIC_PATHS: ReadonlySet<string> = _AUTH_PUBLIC_PATHS;
@@ -29,7 +37,10 @@ export const AUTH_PUBLIC_PATHS: ReadonlySet<string> = _AUTH_PUBLIC_PATHS;
  * Paths exempt from rate limiting. This is {@link AUTH_PUBLIC_PATHS} minus the
  * login-initiation routes: those must stay throttled so an attacker cannot
  * flood OIDC login initiations (state/PKCE generation, Set-Cookie, upstream
- * IdP work). The callback/check/logout routes remain exempt.
+ * IdP work). The callback/check/logout routes remain exempt, including the
+ * oauth2 callback paths: Better Auth validates the signed state cookie before
+ * any upstream discovery fetch, so an unauthenticated flood costs one signature
+ * verification and generates no IdP traffic.
  */
 const _RATE_LIMIT_EXEMPT_PATHS = new Set(
   [..._AUTH_PUBLIC_PATHS].filter(
@@ -39,6 +50,12 @@ const _RATE_LIMIT_EXEMPT_PATHS = new Set(
 export const RATE_LIMIT_EXEMPT_PATHS: ReadonlySet<string> =
   _RATE_LIMIT_EXEMPT_PATHS;
 const API_ROUTE_PREFIXES = ["/api", "/layouts", "/assets"];
+/**
+ * Better Auth's generic-oauth callback shape, with and without the /api prefix
+ * that nginx strips. Used to turn a misrouted OAuth callback into a legible
+ * error instead of a redirect loop. See #3140.
+ */
+const OAUTH_CALLBACK_PATH_PATTERN = /^\/(?:api\/)?auth\/oauth2\/callback\//;
 
 function timingSafeTokenCompare(
   presentedToken: string,
@@ -136,6 +153,28 @@ export function createAuthGateMiddleware(
         await next();
         return;
       }
+    }
+
+    // An OAuth callback reaching this point is always a misconfiguration: the
+    // redirect URI the IdP was handed is not a path Rackula serves. Redirecting
+    // it to login re-initiates OIDC, the IdP silently re-approves, and the
+    // browser loops until ERR_TOO_MANY_REDIRECTS. Fail loudly instead, naming
+    // the setting to fix. Matching on the path rather than on code/state query
+    // params keeps ordinary deep links carrying those names unaffected. See #3140.
+    if (OAUTH_CALLBACK_PATH_PATTERN.test(pathname)) {
+      safeLogAuthEvent("auth.session.invalid", c.req.raw, {
+        reason:
+          "OAuth callback received on an unrouted path; check that RACKULA_OIDC_REDIRECT_URI matches the redirect URI registered with your identity provider",
+      });
+
+      return c.json(
+        {
+          error: "Bad Request",
+          message:
+            "OAuth callback received on a path Rackula does not serve. Verify RACKULA_OIDC_REDIRECT_URI and the redirect URI registered with your identity provider.",
+        },
+        400,
+      );
     }
 
     safeLogAuthEvent("auth.session.invalid", c.req.raw, {

--- a/api/src/security/rate-limit-middleware.test.ts
+++ b/api/src/security/rate-limit-middleware.test.ts
@@ -38,6 +38,8 @@ function createTestApp(config: {
   app.post("/api/auth/login", (c) => c.json({ login: true }));
   app.get("/auth/callback", (c) => c.json({ callback: true }));
   app.get("/api/auth/callback", (c) => c.json({ callback: true }));
+  app.get("/auth/oauth2/callback/oidc", (c) => c.json({ callback: true }));
+  app.get("/api/auth/oauth2/callback/oidc", (c) => c.json({ callback: true }));
   app.get("/layouts", (c) => c.json({ layouts: [] }));
   app.get("/layouts/:id", (c) => c.json({ id: c.req.param("id") }));
   app.put("/layouts/:id", (c) => c.json({ updated: c.req.param("id") }));
@@ -221,6 +223,19 @@ describe("createRateLimitMiddleware", () => {
       headers: { "x-real-ip": "1.2.3.4" },
     });
     expect(res2.status).toBe(200);
+
+    // Better Auth's own callback path is exempt on the same grounds (#3140):
+    // throttling it would lock out logins, and the signed state cookie is
+    // validated before any upstream identity-provider request.
+    for (const path of [
+      "/auth/oauth2/callback/oidc",
+      "/api/auth/oauth2/callback/oidc",
+    ]) {
+      const oauthRes = await app.request(path, {
+        headers: { "x-real-ip": "1.2.3.4" },
+      });
+      expect(oauthRes.status).toBe(200);
+    }
   });
 
   it("throttles GET /auth/login (login initiation is no longer exempt)", async () => {

--- a/docs/deployment/AUTHENTICATION.md
+++ b/docs/deployment/AUTHENTICATION.md
@@ -893,7 +893,7 @@ Events are written to stdout as structured JSON, compatible with log aggregators
 
 1. If `RACKULA_OIDC_REDIRECT_URI` is unset, confirm your IdP has `RACKULA_BASE_URL` + `/auth/callback` registered, since that is the default Rackula advertises
 2. Verify `RACKULA_OIDC_REDIRECT_URI` matches IdP redirect URI exactly
-3. Check for trailing slashes (should NOT be present): ❌ `/auth/callback/` ✅ `/auth/callback`
+3. Check for trailing slashes. Do not use `/auth/callback/`. Use `/auth/callback`.
 4. Verify protocol matches (both HTTPS or both HTTP)
 5. Update IdP configuration if needed
 6. Restart API after changes

--- a/docs/deployment/AUTHENTICATION.md
+++ b/docs/deployment/AUTHENTICATION.md
@@ -66,6 +66,7 @@ When auth is enabled (`oidc` or `local`), the following routes remain publicly a
 | --- | --- |
 | `/auth/login`, `/auth/callback`, `/auth/check`, `/auth/logout` | Browser-facing auth flow |
 | `/api/auth/login`, `/api/auth/callback`, `/api/auth/check`, `/api/auth/logout` | API compatibility auth routes |
+| `/auth/oauth2/callback/oidc`, `/api/auth/oauth2/callback/oidc` | Better Auth's own OIDC callback path, served for deployments whose IdP is registered against it |
 | `/health`, `/api/health` | Container and API health checks |
 
 All other routes require a valid session. Unauthenticated requests are handled differently depending on the route type:
@@ -89,6 +90,9 @@ If you deploy Rackula behind Nginx auth_request, keep this contract consistent:
   - `GET /api/auth/callback`
   - `GET /api/auth/check`
   - `POST /api/auth/logout`
+- Better Auth's own OIDC callback path (served, but not the default; see Required: RACKULA_BASE_URL):
+  - `GET /auth/oauth2/callback/oidc`
+  - `GET /api/auth/oauth2/callback/oidc`
 - Internal auth probe contract:
   - `204` = authenticated
   - `401` = unauthenticated
@@ -614,6 +618,7 @@ Rackula includes IP-based rate-limiting on API routes, with separate limits for 
 - `/health` and `/api/health`
 - `/version` and `/api/version`
 - `/auth/login`, `/auth/callback`, `/auth/check`, `/auth/logout` and their `/api/` equivalents
+- `/auth/oauth2/callback/oidc` and its `/api/` equivalent
 
 **Tuning guidance:**
 
@@ -712,13 +717,15 @@ Set `RACKULA_BASE_URL` to the external URL that browsers use to reach Rackula. T
 RACKULA_BASE_URL=https://rack.example.com
 ```
 
-If you need the OIDC callback URL to differ from `RACKULA_BASE_URL + /auth/callback`, set `RACKULA_OIDC_REDIRECT_URI` explicitly:
+`RACKULA_OIDC_REDIRECT_URI` is optional. When it is not set, the callback URL is `RACKULA_BASE_URL` + `/auth/callback`, which is the URL to register with your IdP. Set it only to override that:
 
 ```yaml
 RACKULA_OIDC_REDIRECT_URI=https://rack.example.com/auth/callback
 ```
 
 The redirect URI must exactly match the URI registered in your IdP (no trailing slash, same protocol, same host).
+
+Releases up to and including v26.7.0 did not apply this default: with `RACKULA_OIDC_REDIRECT_URI` unset they advertised `RACKULA_BASE_URL` + `/api/auth/oauth2/callback/oidc` instead, which produced a login loop. See "Login loops with ERR_TOO_MANY_REDIRECTS" under Troubleshooting.
 
 ### Caddy Configuration
 
@@ -884,11 +891,34 @@ Events are written to stdout as structured JSON, compatible with log aggregators
 
 **Resolution:**
 
-1. Verify `RACKULA_OIDC_REDIRECT_URI` matches IdP redirect URI exactly
-2. Check for trailing slashes (should NOT be present): ❌ `/auth/callback/` ✅ `/auth/callback`
-3. Verify protocol matches (both HTTPS or both HTTP)
-4. Update IdP configuration if needed
-5. Restart API after changes
+1. If `RACKULA_OIDC_REDIRECT_URI` is unset, confirm your IdP has `RACKULA_BASE_URL` + `/auth/callback` registered, since that is the default Rackula advertises
+2. Verify `RACKULA_OIDC_REDIRECT_URI` matches IdP redirect URI exactly
+3. Check for trailing slashes (should NOT be present): ❌ `/auth/callback/` ✅ `/auth/callback`
+4. Verify protocol matches (both HTTPS or both HTTP)
+5. Update IdP configuration if needed
+6. Restart API after changes
+
+### Login loops with ERR_TOO_MANY_REDIRECTS
+
+**Symptoms:**
+
+- Authentication at the IdP succeeds, then the browser bounces between the callback and the login page until it gives up with `ERR_TOO_MANY_REDIRECTS`
+- API logs repeat `auth.session.invalid` with `reason="missing or invalid session cookie"`
+- The IdP's state cookie is present in the browser, but no `rackula_auth_session` cookie is ever set
+
+**Cause:**
+
+- The redirect URI the IdP sends the browser to is not a path Rackula serves. The callback is bounced to the login route, which re-initiates OIDC, and the IdP silently re-approves the already-authenticated user.
+- On releases up to and including v26.7.0, leaving `RACKULA_OIDC_REDIRECT_URI` unset caused this: Rackula advertised `RACKULA_BASE_URL` + `/api/auth/oauth2/callback/oidc`, a path it did not route.
+
+**Resolution:**
+
+1. Upgrade to a release that applies the documented default, or set `RACKULA_OIDC_REDIRECT_URI` explicitly
+2. Register `https://<your-rackula-host>/auth/callback` as the redirect URI in your IdP, replacing any `/api/auth/oauth2/callback/oidc` entry
+3. Confirm `RACKULA_BASE_URL` is the external URL browsers use, with no trailing slash
+4. Restart the API after changes
+
+On current releases this failure returns a `400` naming `RACKULA_OIDC_REDIRECT_URI` rather than looping, so check the API response body if login fails.
 
 ### Sessions expire immediately after login
 


### PR DESCRIPTION
## **User description**
Fixes #3140.

## The bug

Two users reported that OIDC login against Authentik loops until `ERR_TOO_MANY_REDIRECTS`, with the API logging `auth.session.invalid reason="missing or invalid session cookie"` on every bounce. This is not a proxy misconfiguration on their side.

`docs/deployment/AUTHENTICATION.md` documents `RACKULA_OIDC_REDIRECT_URI` as optional, defaulting to `RACKULA_BASE_URL` + `/auth/callback`, and every IdP setup section tells users to register exactly that URL. `docs/deployment/SELF-HOSTING.md` says the same. The code never implemented that default: `api/src/auth/config.ts` passed the env var straight through to Better Auth with no fallback.

Left unset, Better Auth falls back to its own convention and advertises `{baseURL}/api/auth/oauth2/callback/oidc` to the IdP. That path is not in `AUTH_PUBLIC_PATHS`, which is an exact-match set, and the auth gate is mounted as `app.use("*", ...)` ahead of Better Auth's own handler. So the gate intercepts the IdP callback before it can reach a route. No session exists yet, because the callback is what creates it, so the gate logs `auth.session.invalid` and redirects to the login route, which re-initiates OIDC. The IdP silently re-approves the already-authenticated user and the loop closes. Behind the bundled nginx, which strips the `/api` prefix, the API sees `/auth/oauth2/callback/oidc`, which takes the redirect branch rather than returning 401, exactly matching the reported logs.

## Why CI was green

`api/src/oidc.integration.test.ts` hardcoded `RACKULA_OIDC_REDIRECT_URI` in its env fixture and posted callbacks to `/auth/callback` directly. Every OIDC test ran the configured-var path, and the callback path was assumed rather than derived, so the shipped default was never exercised. Tests now follow the `redirect_uri` actually advertised to the IdP.

## Changes

- `api/src/auth/config.ts`: apply the documented default, normalising a trailing slash on `RACKULA_BASE_URL` so `https://host/` cannot yield `//auth/callback`, which an IdP treats as a different registered URI. An explicit `RACKULA_OIDC_REDIRECT_URI` still wins, on both the authorization request and the token exchange.
- `api/src/security/middleware.ts` and `api/src/app.ts`: serve Better Auth's own callback path too, for deployments whose IdP is already registered against it. Literals rather than a prefix predicate, since `providerId` is a compile-time constant and three consumers depend on the exact-match invariant.
- `api/src/security/middleware.ts`: return a 400 naming `RACKULA_OIDC_REDIRECT_URI` when an OAuth callback lands on an unrouted path, instead of redirecting to login. The guard matches on the path, not on `code`/`state` query params, so ordinary deep links carrying those names are unaffected.
- Docs: state the default as fact, annotate the env var as optional in `api/.env.example` and `api/README.md`, and add a troubleshooting entry for `ERR_TOO_MANY_REDIRECTS`.

## Reviewer notes

`AUTH_PUBLIC_PATHS` has three consumers, not two: the auth gate, `security/origin-policy.ts`, and the derived `RATE_LIMIT_EXEMPT_PATHS` used by the rate limiter. Adding a literal widens all three. Assessment for these two paths:

- Auth gate: the callback is inherently pre-authentication, and gating it on a session is the defect. Integrity still comes from PKCE, the signed state cookie, issuer pinning, and audience/algorithm pinning, all unchanged.
- Rate limiting: Better Auth validates the signed state cookie before any upstream discovery fetch, so an unauthenticated flood costs one signature verification and generates no IdP traffic.
- Origin policy: inert, since that middleware returns early for non-state-changing methods and the callback is a GET.

No nginx change is needed. Browsers hit `/api/auth/oauth2/callback/oidc`, which already matches the generic `location /api/` block; the bare form only exists inside the container after the rewrite, so a `location` block for it would be dead config.

## Backward compatibility

Deployments that set `RACKULA_OIDC_REDIRECT_URI` are unaffected, and a test locks that in. Deployments that omit it change by design, from `/api/auth/oauth2/callback/oidc` to `/auth/callback`. They are currently broken in the reported topology; where they were not, the worst case is a clear IdP-side redirect-URI-mismatch error rather than a loop. Worth a release-note callout: if you did not set `RACKULA_OIDC_REDIRECT_URI` and login previously worked, ensure `https://<your-host>/auth/callback` is registered in your IdP.

## Verification

`cd api && bun test`: 417 pass, 0 fail across 25 files. `bun run typecheck` clean. ESLint and Prettier clean on touched files.

Seven new tests, all confirmed red before the fix. The most direct one reproduces the reported loop end to end: the callback returns `302` to `/auth/login?next=%2Fauth%2Foauth2%2Fcallback%2Foidc...` with `auth.session.invalid` logged.

End-to-end proof against a real IdP cannot run in CI. The mocked suite asserts the exact `redirect_uri` handed to the provider and drives the full callback round-trip, but confirmation from the reporters on a dev build is still worth having.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSUC4sGCZDuFRQDypghAJH


___

## **CodeAnt-AI Description**
Prevent OIDC login loops when the callback URL is not explicitly configured

### What Changed
- OIDC now uses `RACKULA_BASE_URL/auth/callback` by default, including when the base URL has a trailing slash.
- Existing deployments can continue using Better Auth’s callback path, which is now reachable through the authentication gate.
- Unrouted OAuth callback paths return a clear `400` error that identifies the redirect URI configuration to check instead of redirecting users back into a login loop.
- OIDC tests now follow the callback URL advertised to the identity provider and cover default, custom, legacy, and trailing-slash configurations.
- Setup documentation and environment examples explain the optional redirect URI and troubleshooting steps.

### Impact
`✅ OIDC login completes without redirect loops`
`✅ Clearer errors for incorrect identity-provider callback URLs`
`✅ Existing custom callback registrations remain supported`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
