### PR TITLE
feat: cut prod over to Cloudflare Workers Static Assets (#2029)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,8 +2,9 @@ name: Build Images
 
 # Reusable workflow: build and push ONLY immutable Docker tags (:vX.Y.Z).
 # No :latest and no :year_month tags are pushed here. Those are applied later
-# by the promote stage, by digest. Mirrors the build/scan jobs from
-# deploy-prod.yml, changed only for the immutable-tag policy plus digest outputs.
+# by the promote stage, by digest. This workflow owns the release-time image
+# build and Trivy scan outright; deploy-prod.yml no longer touches Docker at all
+# now that prod is a Cloudflare Worker serving static assets (#2029).
 #
 # Each image (frontend, persist, api) builds linux/amd64 and linux/arm64 as
 # separate per-arch jobs, amd64 on ubuntu-latest and arm64 on the native

--- a/.github/workflows/compose-parity.yml
+++ b/.github/workflows/compose-parity.yml
@@ -7,7 +7,6 @@ on:
       - "deploy/docker-compose.persist.yml"
       - "scripts/check-compose-persist-parity.sh"
       - ".github/workflows/deploy-dev.yml"
-      - ".github/workflows/deploy-prod.yml"
       - ".github/workflows/test.yml"
       - "README.md"
       - ".env.example"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,9 +1,25 @@
 name: Deploy Prod
 
-# Reusable workflow: deploys an already-built, already-scanned release to the
-# prod VPS and runs a post-deploy smoke test. Called by the release orchestrator
-# during the promote stage. The orchestrator validates the tag and passes the
-# tag/version inputs; this workflow no longer triggers independently on tag push.
+# Reusable workflow: builds the released tag and publishes count.racku.la to
+# Cloudflare Workers Static Assets. Called by the release orchestrator during
+# the promote stage; the orchestrator validates the tag and passes tag/version.
+#
+# Prod is an ASSETS-ONLY Worker (see wrangler.jsonc): no `main`, no bindings, no
+# API. The frontend runs in browser-storage mode and keeps nothing server-side.
+#
+# Deploy order every release (#2029):
+#   1. build the tag, generate the CF-only artifacts
+#   2. `wrangler versions upload`   -> a per-version preview URL, no traffic
+#   3. FULL fail-closed smoke against that preview URL
+#   4. `wrangler versions deploy`   -> shifts 100% of traffic
+#   5. light re-check of the live host
+# A bad build therefore never takes traffic. No percentage rollouts: Cloudflare
+# documents a mixed-version hazard where HTML from one version references hashed
+# assets that only exist in another, and version affinity needs a request header
+# browsers do not send.
+#
+# Rollback: .github/workflows/rollback-prod.yml (`wrangler versions deploy <id>`),
+# which does not traverse this workflow's approval gate.
 
 on:
   workflow_call:
@@ -14,115 +30,124 @@ on:
       version:
         required: true
         type: string
+    # Reusable workflows do NOT inherit secrets from the caller. Without this
+    # block (and `secrets: inherit` on the caller in release.yml) the Cloudflare
+    # credentials resolve to empty strings and every wrangler call fails.
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
 
 concurrency:
   group: deploy-prod-${{ inputs.tag }}
   cancel-in-progress: false
 
+env:
+  # Pinned rather than added to root devDependencies: every other job would pay
+  # the install cost, and this workflow runs a handful of times a month.
+  WRANGLER_VERSION: "4.124.0"
+
 jobs:
   deploy:
-    runs-on: [self-hosted, vps-rackula]
-    timeout-minutes: 20
+    name: "Deploy to Cloudflare Workers"
+    # No `environment:` here. promote-gate in release.yml already binds the
+    # protected `prod` environment; binding it again would prompt the same
+    # reviewer twice in one run.
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: read
 
     steps:
+      # .git must be present (fetch-depth 0) so vite's getGitInfo() populates
+      # version.json.commit. The Docker build ships commit="" because
+      # .dockerignore strips .git; the CF build deliberately does not.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag }}
-          sparse-checkout: |
-            docker-compose.yml
-          sparse-checkout-cone-mode: false
-
-      - name: Sync docker-compose.yml to prod
-        run: |
-          cp docker-compose.yml /opt/rackula/rackula-app/docker-compose.yml
-          # Ensure RACKULA_PORT is set (localhost only - Caddy handles external traffic)
-          # Uses grep+echo pattern to avoid overwriting other env vars
-          ENV_FILE=/opt/rackula/rackula-app/.env
-          touch "$ENV_FILE"
-          grep -q '^RACKULA_PORT=' "$ENV_FILE" || echo "RACKULA_PORT=127.0.0.1:8080" >> "$ENV_FILE"
-
-      - name: Deploy to prod
-        run: |
-          cd /opt/rackula/rackula-app
-          # Stop old container if exists (name changed from rackula-app to rackula)
-          docker stop rackula-app 2>/dev/null && docker rm rackula-app 2>/dev/null || true
-          docker compose pull
-          docker compose up -d --remove-orphans
-          # Prune the image the new pull just superseded (now dangling);
-          # running containers keep their tagged images. Prevents disk fill.
-          docker image prune -f
-
-  smoke-test:
-    needs: [deploy]
-    runs-on: [self-hosted, vps-rackula]
-    timeout-minutes: 10
-    permissions:
-      contents: read
-
-    steps:
-      # Fast curl gate: fails immediately if the server is unreachable, before we
-      # spend time spinning up a browser.
-      - name: Verify deployment responds
-        run: |
-          sleep 5
-          curl -sf --retry 5 --retry-delay 3 https://count.racku.la
-
-      - name: Verify live frontend version
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          # Public prod (count.racku.la) serves the static frontend only — it has
-          # no API/persistence backend by design (no user-data storage), so
-          # /api/version intentionally returns 503 "Persistence API unavailable".
-          # We therefore verify the live FRONTEND version here. The published API
-          # image version is validated separately by the verify-version-alignment
-          # job, which runs the image in an ephemeral container.
-          #
-          # The browser smoke test below checks version.json is well-formed; this
-          # step additionally asserts it matches the released tag.
-          #
-          # Extract .version from JSON without depending on jq being installed
-          # on the self-hosted runner.
-          extract_version() {
-            grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' \
-              | head -n1 \
-              | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/'
-          }
-          fe="$(curl -sf --retry 5 --retry-delay 3 https://count.racku.la/version.json | extract_version)"
-          echo "frontend=${fe} expected=${VERSION}"
-          [ "$fe" = "$VERSION" ] || { echo "::error::Live frontend version '${fe}' != '${VERSION}'"; exit 1; }
-          echo "✓ Live frontend reports ${VERSION}"
-
-      # The deploy job runs a sparse checkout on this same self-hosted runner and
-      # leaves the shared workspace in sparse mode. actions/checkout does not clear
-      # an existing sparse cone when the sparse-checkout input is omitted, so the
-      # full tree (package-lock.json, e2e specs) would be missing here. Wipe the
-      # workspace before checkout so the full tree is restored cleanly (mirrors
-      # deploy-dev's root fix for #2327).
-      - name: Clean stale workspace from the deploy job
-        run: |
-          if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then
-            find "$GITHUB_WORKSPACE" -mindepth 1 -delete
-          fi
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.tag }}
+          fetch-depth: 0
           persist-credentials: false
 
-      # No cache: "npm" here. The npm cache lookup runs before checkout settles
-      # and hard-errors ("Dependencies lock file is not found", #2327) if a stale
-      # workspace ever slips through. The clean-workspace step above is the root
-      # fix; dropping the cache removes the fragile lockfile-hash dependency.
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: "22"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Resolve expected commit
+        id: expected
+        # Short format, matching what vite writes into version.json.
+        run: echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build production bundle
+        # VITE_ENV pinned explicitly to match the gated Docker build. #2032
+        # guards this env against drift.
+        env:
+          VITE_ENV: production
+        run: npm run build
+
+      - name: Generate Cloudflare-only artifacts
+        # _headers and .assetsignore are emitted into dist/ here and never
+        # committed to static/: publicDir copies static/ verbatim into EVERY
+        # dist, which would leak them into the Docker/LXC self-host images.
+        run: |
+          node scripts/gen-headers.mjs prod --out dist/_headers
+          node scripts/gen-headers.mjs --assetsignore dist/.assetsignore
+          echo "--- dist/_headers ---"
+          cat dist/_headers
+
+      - name: Strip login.html from the prod artifact
+        # Removed here, NOT by branching vite's rollupOptions.input, which would
+        # fork the gated artifact and risk stripping login.html from the
+        # self-host builds where it is required. Prod has no auth backend, and
+        # Workers' default html_handling would otherwise serve the form at
+        # /login. Afterwards /login resolves to the SPA shell.
+        run: |
+          test -f dist/login.html || { echo "::error::dist/login.html missing - the self-host artifact would be broken"; exit 1; }
+          rm -f dist/login.html
+
+      - name: Assert artifact integrity before upload
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+          EXPECTED_COMMIT: ${{ steps.expected.outputs.commit }}
+        run: |
+          set -euo pipefail
+          # config.js ships from publicDir in every dist. A regression here would
+          # surface only as a blocked-script console error under SPA fallback
+          # plus nosniff, so assert it before it can reach traffic.
+          grep -q 'storage: *"browser"' dist/config.js \
+            || { echo "::error::dist/config.js is not in browser storage mode"; exit 1; }
+          grep -q "\"version\": *\"${EXPECTED_VERSION}\"" dist/version.json \
+            || { echo "::error::version.json != ${EXPECTED_VERSION}"; cat dist/version.json; exit 1; }
+          grep -q "\"commit\": *\"${EXPECTED_COMMIT}\"" dist/version.json \
+            || { echo "::error::version.json commit != ${EXPECTED_COMMIT}"; cat dist/version.json; exit 1; }
+          echo "artifact OK: ${EXPECTED_VERSION} @ ${EXPECTED_COMMIT}"
+
+      - name: Upload version (no traffic)
+        id: upload
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --yes "wrangler@${WRANGLER_VERSION}" versions upload 2>&1 | tee upload.log
+          version_id="$(grep -oE 'Worker Version ID: [0-9a-f-]+' upload.log | tail -1 | awk '{print $NF}')"
+          preview_url="$(grep -oE 'Version Preview URL: https://[^[:space:]]+' upload.log | tail -1 | awk '{print $NF}')"
+          [ -n "$version_id" ] || { echo "::error::could not parse Worker Version ID"; exit 1; }
+          [ -n "$preview_url" ] || { echo "::error::could not parse Version Preview URL (is preview_urls enabled?)"; exit 1; }
+          echo "version_id=$version_id" >> "$GITHUB_OUTPUT"
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+          echo "uploaded $version_id -> $preview_url"
+
+      - name: Smoke headers and content types against the preview URL
+        run: |
+          scripts/smoke-headers.sh "${{ steps.upload.outputs.preview_url }}" \
+            --expect-version "${{ inputs.version }}" \
+            --expect-commit "${{ steps.expected.outputs.commit }}"
 
       - name: Cache Playwright browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -132,11 +157,37 @@ jobs:
           restore-keys: playwright-${{ runner.os }}-chromium-
 
       - name: Install Playwright chromium
-        # --with-deps installs OS libraries via apt and needs root; fall back to a
-        # plain browser install when the self-hosted runner already has them.
-        run: npx playwright install --with-deps chromium || npx playwright install chromium
+        run: npx playwright install --with-deps chromium
 
-      - name: Browser smoke test against deployed app
+      - name: Browser smoke against the preview URL
+        env:
+          SMOKE_TEST_URL: ${{ steps.upload.outputs.preview_url }}
+        run: npm run test:e2e:smoke
+
+      # Everything above is fail-closed. Only now does traffic move.
+      - name: Promote version to 100% of traffic
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes "wrangler@${WRANGLER_VERSION}" versions deploy \
+            "${{ steps.upload.outputs.version_id }}@100%" --yes
+
+      # `versions deploy` does not apply trigger changes. If wrangler.jsonc's
+      # routes ever change, this is what lands them.
+      - name: Apply triggers (routes)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx --yes "wrangler@${WRANGLER_VERSION}" triggers deploy
+
+      - name: Verify the live host
+        run: |
+          scripts/smoke-headers.sh https://count.racku.la --live \
+            --expect-version "${{ inputs.version }}" \
+            --expect-commit "${{ steps.expected.outputs.commit }}"
+
+      - name: Browser smoke against the live host
         env:
           SMOKE_TEST_URL: https://count.racku.la
         run: npm run test:e2e:smoke
@@ -148,3 +199,17 @@ jobs:
           name: deploy-prod-smoke-report
           path: playwright-report/
           retention-days: 7
+
+      - name: Record the deployed version
+        if: always()
+        run: |
+          {
+            echo "### Prod deploy"
+            echo ""
+            echo "- tag: \`${{ inputs.tag }}\`"
+            echo "- version: \`${{ inputs.version }}\` @ \`${{ steps.expected.outputs.commit }}\`"
+            echo "- Worker version id: \`${{ steps.upload.outputs.version_id }}\`"
+            echo "- preview: ${{ steps.upload.outputs.preview_url }}"
+            echo ""
+            echo "Rollback: run the \`Rollback Prod\` workflow with the previous version id."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -148,7 +148,12 @@ jobs:
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
           echo "uploaded $version_id -> $preview_url"
 
+      # The preview URL is on workers.dev, outside the racku.la zone, so it is
+      # not challenged. The token is passed anyway so the same invocation works
+      # against both surfaces.
       - name: Smoke headers and content types against the preview URL
+        env:
+          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: |
           scripts/smoke-headers.sh "${{ steps.upload.outputs.preview_url }}" \
             --expect-version "${{ inputs.version }}" \
@@ -167,6 +172,7 @@ jobs:
       - name: Browser smoke against the preview URL
         env:
           SMOKE_TEST_URL: ${{ steps.upload.outputs.preview_url }}
+          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: npm run test:e2e:smoke
 
       # Everything above is fail-closed. Only now does traffic move.
@@ -186,7 +192,11 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx --yes "wrangler@${WRANGLER_VERSION}" triggers deploy
 
+      # count.racku.la IS inside the zone, so without the token this step is
+      # challenged and would fail every release.
       - name: Verify the live host
+        env:
+          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: |
           scripts/smoke-headers.sh https://count.racku.la --live \
             --expect-version "${{ inputs.version }}" \
@@ -195,6 +205,7 @@ jobs:
       - name: Browser smoke against the live host
         env:
           SMOKE_TEST_URL: https://count.racku.la
+          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: npm run test:e2e:smoke
 
       - name: Upload Playwright report

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -39,8 +39,13 @@ on:
       CLOUDFLARE_ACCOUNT_ID:
         required: true
 
+# Shared with rollback-prod.yml: both mutate which version serves 100% of prod
+# traffic, so they must serialize. Not keyed on the tag - two different tags
+# promoting concurrently is exactly the race worth preventing. If a rollback is
+# needed while a deploy is running, cancel the deploy run first; the deploy is
+# fail-closed and promotes only after its smoke passes, so cancelling it is safe.
 concurrency:
-  group: deploy-prod-${{ inputs.tag }}
+  group: prod-traffic
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -148,12 +148,12 @@ jobs:
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
           echo "uploaded $version_id -> $preview_url"
 
-      # The preview URL is on workers.dev, outside the racku.la zone, so it is
-      # not challenged. The token is passed anyway so the same invocation works
-      # against both surfaces.
+      # Runs against the preview URL specifically: it is on workers.dev, outside
+      # the racku.la zone, so it is not subject to the zone's bot challenge.
+      # curl cannot solve a JS challenge, and Bot Fight Mode cannot be skipped by
+      # a WAF rule on the Free plan, so the live origin is verified by the
+      # browser smoke instead (deploy-smoke.spec.ts).
       - name: Smoke headers and content types against the preview URL
-        env:
-          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: |
           scripts/smoke-headers.sh "${{ steps.upload.outputs.preview_url }}" \
             --expect-version "${{ inputs.version }}" \
@@ -172,7 +172,6 @@ jobs:
       - name: Browser smoke against the preview URL
         env:
           SMOKE_TEST_URL: ${{ steps.upload.outputs.preview_url }}
-          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: npm run test:e2e:smoke
 
       # Everything above is fail-closed. Only now does traffic move.
@@ -192,20 +191,17 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx --yes "wrangler@${WRANGLER_VERSION}" triggers deploy
 
-      # count.racku.la IS inside the zone, so without the token this step is
-      # challenged and would fail every release.
-      - name: Verify the live host
-        env:
-          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
-        run: |
-          scripts/smoke-headers.sh https://count.racku.la --live \
-            --expect-version "${{ inputs.version }}" \
-            --expect-commit "${{ steps.expected.outputs.commit }}"
-
-      - name: Browser smoke against the live host
+      # count.racku.la IS inside the zone and IS challenged from CI, so the
+      # live verification runs through the browser: Chromium solves the
+      # challenge, and deploy-smoke.spec.ts then asserts version, commit and the
+      # security headers by value through `page.request`, which inherits the
+      # clearance cookie. This is the step that can see zone-level header
+      # interference; the preview URL cannot (#3214).
+      - name: Verify the live host in a browser
         env:
           SMOKE_TEST_URL: https://count.racku.la
-          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
+          EXPECT_VERSION: ${{ inputs.version }}
+          EXPECT_COMMIT: ${{ steps.expected.outputs.commit }}
         run: npm run test:e2e:smoke
 
       - name: Upload Playwright report

--- a/.github/workflows/rebuild-images.yml
+++ b/.github/workflows/rebuild-images.yml
@@ -3,8 +3,9 @@ name: Rebuild Images (OS patch)
 # Proactively refresh OS packages in the published rolling image tags between
 # releases. Rebuilds the latest release's source with a busted apk-upgrade layer
 # cache (APK_CACHEBUST), republishes only the rolling tags (latest / persist /
-# api latest), and rescans. Complements deploy-prod.yml, which only patches at
-# release time. Does NOT deploy to prod.
+# api latest), and rescans. Complements build-images.yml, which only builds at
+# release time. Does NOT deploy to prod (and could not: prod is a Cloudflare
+# Worker serving static assets and pulls no images, #2029).
 
 on:
   workflow_dispatch:
@@ -106,7 +107,7 @@ jobs:
           # Full no-cache rebuild: guarantees apk upgrade re-fetches current Alpine
           # secfixes regardless of whether the resolved release tag's Dockerfile
           # carries the APK_CACHEBUST arg, and avoids sharing (and racing on)
-          # deploy-prod's release buildcache.
+          # build-images' release buildcache.
           no-cache: true
           build-args: |
             VITE_ENV=production
@@ -256,6 +257,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: trivy-results.sarif
-          # Match deploy-prod/trivy categories so a rebuild refreshes the same
+          # Match build-images/trivy categories so a rebuild refreshes the same
           # alert set instead of creating duplicates.
           category: trivy-${{ env.IMAGE_CATEGORY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -470,17 +470,27 @@ jobs:
         run: |
           gh release edit "$TAG" --prerelease=false --latest=true
 
-  # PROMOTE: deploy the promoted release to the prod VPS and smoke-test it. Needs
-  # promote-docker so prod pulls the freshly promoted :latest digests.
+  # PROMOTE: publish the released tag to Cloudflare Workers Static Assets and
+  # smoke-test it (#2029). Prod no longer pulls Docker images, so the dependency
+  # is promote-github rather than promote-docker: prod must not go live until the
+  # GitHub release is marked latest, otherwise a failed promotion leaves prod
+  # serving a build the release still calls a prerelease.
+  #
+  # This keeps the Docker coupling transitively and deliberately: promote-github
+  # itself needs promote-docker, so a release whose images failed to promote
+  # still cannot go live.
   promote-prod:
     name: "Promote to prod"
-    needs: [validate, promote-gate, promote-docker]
+    needs: [validate, promote-gate, promote-github]
     permissions:
       contents: read
     uses: ./.github/workflows/deploy-prod.yml
     with:
       tag: ${{ needs.validate.outputs.tag }}
       version: ${{ needs.validate.outputs.version }}
+    # Reusable workflows do not inherit secrets. Without this the Cloudflare
+    # credentials arrive empty and every wrangler call fails.
+    secrets: inherit
 
   # On any failure or cancellation, summarise the failed jobs and open/update a
   # `CI Alert` issue. Read-only except for issues:write.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,13 +450,35 @@ jobs:
             --tag "ghcr.io/${REPO_LC}:persist" \
             "ghcr.io/${REPO_LC}@${digest}"
 
-  # PROMOTE: mark the GitHub release as latest (no longer a prerelease).
-  # Needs promote-docker so the release is only advertised as latest once its
-  # docker images are promoted; a failed promote-docker leaves the release a
-  # prerelease (fail closed) rather than a half-promoted split-brain state.
+  # PROMOTE: publish the released tag to Cloudflare Workers Static Assets and
+  # smoke-test it (#2029). Prod no longer pulls Docker images, but it still needs
+  # promote-docker: a release whose images failed to promote must not go live.
+  #
+  # Deliberately ordered BEFORE promote-github. The GitHub release stays a
+  # prerelease until prod is actually serving the build, so a failed Cloudflare
+  # upload or a failed post-deploy smoke leaves the release marked prerelease
+  # rather than advertising as latest a build nobody can reach.
+  promote-prod:
+    name: "Promote to prod"
+    needs: [validate, promote-gate, promote-docker]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/deploy-prod.yml
+    with:
+      tag: ${{ needs.validate.outputs.tag }}
+      version: ${{ needs.validate.outputs.version }}
+    # Reusable workflows do not inherit secrets. Without this the Cloudflare
+    # credentials arrive empty and every wrangler call fails.
+    secrets: inherit
+
+  # PROMOTE: mark the GitHub release as latest (no longer a prerelease). Last in
+  # the promote chain, so "latest" means the docker tags are promoted AND prod is
+  # live on that build. Any earlier failure leaves the release a prerelease (fail
+  # closed) rather than a half-promoted split-brain state. promote-docker is
+  # reached transitively through promote-prod.
   promote-github:
     name: "Promote GitHub release"
-    needs: [validate, promote-gate, promote-docker]
+    needs: [validate, promote-gate, promote-prod]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -469,28 +491,6 @@ jobs:
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           gh release edit "$TAG" --prerelease=false --latest=true
-
-  # PROMOTE: publish the released tag to Cloudflare Workers Static Assets and
-  # smoke-test it (#2029). Prod no longer pulls Docker images, so the dependency
-  # is promote-github rather than promote-docker: prod must not go live until the
-  # GitHub release is marked latest, otherwise a failed promotion leaves prod
-  # serving a build the release still calls a prerelease.
-  #
-  # This keeps the Docker coupling transitively and deliberately: promote-github
-  # itself needs promote-docker, so a release whose images failed to promote
-  # still cannot go live.
-  promote-prod:
-    name: "Promote to prod"
-    needs: [validate, promote-gate, promote-github]
-    permissions:
-      contents: read
-    uses: ./.github/workflows/deploy-prod.yml
-    with:
-      tag: ${{ needs.validate.outputs.tag }}
-      version: ${{ needs.validate.outputs.version }}
-    # Reusable workflows do not inherit secrets. Without this the Cloudflare
-    # credentials arrive empty and every wrangler call fails.
-    secrets: inherit
 
   # On any failure or cancellation, summarise the failed jobs and open/update a
   # `CI Alert` issue. Read-only except for issues:write.
@@ -507,8 +507,8 @@ jobs:
         gate-lxc,
         promote-gate,
         promote-docker,
-        promote-github,
         promote-prod,
+        promote-github,
       ]
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -4,6 +4,15 @@ name: Rollback Prod
 # through release.yml, whose promote-gate waits on a human approval that may sit
 # unanswered for hours. During an incident the whole point is not to queue.
 #
+# This rolls back the WORKER VERSION only. Routes are trigger state, not version
+# state, so `versions deploy` leaves count.racku.la attached and serving - just an
+# older build. That is the intended behaviour for a bad release.
+#
+# It is NOT the way to undo the cutover itself. Detaching the hostname means
+# removing the `routes` entry from wrangler.jsonc and running
+# `wrangler triggers deploy`, which hands count.racku.la back to whatever the
+# origin DNS record points at. See docs/deployment/cloudflare-prod-runbook.md.
+#
 # Cloudflare retains the last 100 versions, so any recent release is reachable.
 # List candidates with:
 #   npx wrangler@4.124.0 versions list --name rackula-prod
@@ -25,10 +34,12 @@ on:
         required: false
         type: string
 
-# Its own group: a rollback must never queue behind an in-flight deploy of the
-# build it is rolling back.
+# Shared with deploy-prod.yml: both mutate which version serves 100% of prod
+# traffic. Without a shared group a rollback and an in-flight deploy race, and
+# the deploy can re-promote the very build being rolled back. To roll back
+# during a deploy, cancel the deploy run first.
 concurrency:
-  group: rollback-prod
+  group: prod-traffic
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -78,13 +78,16 @@ jobs:
           npx --yes "wrangler@${WRANGLER_VERSION}" versions deploy \
             "${{ inputs.version_id }}@100%" --yes
 
-      - name: Verify the live host
-        # Version/commit are intentionally not asserted: we are deliberately
-        # serving something other than the newest release. The header, content
-        # type and SPA-fallback checks still have to hold.
+      - name: Verify the live host in a browser
+        # Through the browser, because count.racku.la is challenged from CI and
+        # curl cannot solve a JS challenge (see deploy-prod.yml).
+        #
+        # Version/commit are intentionally not asserted here: we are deliberately
+        # serving something other than the newest release. The boot, render and
+        # header checks still have to hold.
         env:
-          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
-        run: scripts/smoke-headers.sh https://count.racku.la --live
+          SMOKE_TEST_URL: https://count.racku.la
+        run: npm run test:e2e:smoke
 
       - name: Summary
         if: always()

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -82,6 +82,8 @@ jobs:
         # Version/commit are intentionally not asserted: we are deliberately
         # serving something other than the newest release. The header, content
         # type and SPA-fallback checks still have to hold.
+        env:
+          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: scripts/smoke-headers.sh https://count.racku.la --live
 
       - name: Summary

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -1,0 +1,87 @@
+name: Rollback Prod
+
+# Manual rollback for count.racku.la. Deliberately standalone: it does NOT go
+# through release.yml, whose promote-gate waits on a human approval that may sit
+# unanswered for hours. During an incident the whole point is not to queue.
+#
+# Cloudflare retains the last 100 versions, so any recent release is reachable.
+# List candidates with:
+#   npx wrangler@4.124.0 versions list --name rackula-prod
+# or read the "Worker version id" line in a previous Deploy Prod run summary.
+#
+# This is the ONLY rollback path. The old VPS-DNS fallback documented in the
+# epic design is dead: that origin stopped answering in August 2026 (issue
+# #3167), which is what forced the Cloudflare cutover in the first place.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_id:
+        description: "Worker version id to roll back to (uuid from `wrangler versions list`)"
+        required: true
+        type: string
+      reason:
+        description: "Why (recorded in the run summary)"
+        required: false
+        type: string
+
+# Its own group: a rollback must never queue behind an in-flight deploy of the
+# build it is rolling back.
+concurrency:
+  group: rollback-prod
+  cancel-in-progress: false
+
+env:
+  WRANGLER_VERSION: "4.124.0"
+
+jobs:
+  rollback:
+    name: "Roll back count.racku.la"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate the version id
+        env:
+          VERSION_ID: ${{ inputs.version_id }}
+        run: |
+          echo "$VERSION_ID" | grep -qE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' \
+            || { echo "::error::'$VERSION_ID' is not a version uuid"; exit 1; }
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: "22"
+
+      - name: Deploy the target version
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes "wrangler@${WRANGLER_VERSION}" versions deploy \
+            "${{ inputs.version_id }}@100%" --yes
+
+      - name: Verify the live host
+        # Version/commit are intentionally not asserted: we are deliberately
+        # serving something other than the newest release. The header, content
+        # type and SPA-fallback checks still have to hold.
+        run: scripts/smoke-headers.sh https://count.racku.la --live
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Prod rollback"
+            echo ""
+            echo "- rolled back to: \`${{ inputs.version_id }}\`"
+            echo "- reason: ${{ inputs.reason || '(none given)' }}"
+            echo ""
+            echo "count.racku.la now serves that version. The next tagged release"
+            echo "will move it forward again, so land a fix or revert the tag."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: "22"
+          cache: "npm"
 
       - name: Deploy the target version
         env:
@@ -78,9 +79,30 @@ jobs:
           npx --yes "wrangler@${WRANGLER_VERSION}" versions deploy \
             "${{ inputs.version_id }}@100%" --yes
 
+      # The verification toolchain is installed AFTER the traffic mutation, on
+      # purpose. A registry or Playwright-download outage during an incident must
+      # not be able to block the rollback itself; it can only leave the rollback
+      # unverified and the run red, which is the failure mode you want at 3am.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-chromium-
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Verify the live host in a browser
         # Through the browser, because count.racku.la is challenged from CI and
-        # curl cannot solve a JS challenge (see deploy-prod.yml).
+        # curl cannot solve a JS challenge (see deploy-prod.yml). That also rules
+        # out scripts/smoke-headers.sh here: it is curl-based and only ever runs
+        # against the workers.dev preview URL, which a rollback does not create.
+        # deploy-smoke.spec.ts carries the same security-header assertions by
+        # value, so the rollback keeps that guarantee.
         #
         # Version/commit are intentionally not asserted here: we are deliberately
         # serving something other than the newest release. The boot, render and
@@ -88,6 +110,14 @@ jobs:
         env:
           SMOKE_TEST_URL: https://count.racku.la
         run: npm run test:e2e:smoke
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: rollback-prod-smoke-report
+          path: playwright-report/
+          retention-days: 7
 
       - name: Summary
         if: always()

--- a/.github/workflows/soak-smoke.yml
+++ b/.github/workflows/soak-smoke.yml
@@ -83,16 +83,17 @@ jobs:
       - name: Install Playwright chromium
         run: npx playwright install --with-deps chromium
 
-      # d.racku.la sits behind Cloudflare Access. The CF_ACCESS_* env vars are
-      # inherited by the smoke config (playwright.smoke.config.ts) and applied
-      # as headers on every request; without them the dev leg would hit the
-      # login wall instead of the app (#2346). count.racku.la is public today
-      # (#3094 tracks the pending Access decision), so the secrets are simply
-      # unused on the prod leg.
+      # No CF_ACCESS_* here: count.racku.la is public (#3094, decided), and the
+      # only target in the matrix today is prod. Handing Access service-token
+      # credentials to a public target would put them in the environment of a
+      # job that has no use for them.
+      #
+      # TODO(#2134): when the dev leg is restored, scope these to that target
+      # only - e.g. a per-target matrix flag gating the env, not a job-wide
+      # export. d.racku.la sits behind Access and the smoke config
+      # (playwright.smoke.config.ts) applies them as request headers; without
+      # them the dev leg hits the login wall instead of the app (#2346).
       - name: Browser smoke test against deployed app
-        env:
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: npm run test:e2e:smoke
 
       - name: Upload Playwright report

--- a/.github/workflows/soak-smoke.yml
+++ b/.github/workflows/soak-smoke.yml
@@ -13,10 +13,12 @@ name: Soak Smoke
 # whole run failed), so the streak query above is a straightforward read of
 # the "conclusion" column with no per-job digging required. See issue #2676.
 #
-# count.racku.la is public today (no CF Access token needed); d.racku.la sits
-# behind Cloudflare Access and authenticates via the same service-token
-# secrets deploy-dev.yml uses (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET,
-# added by #2346).
+# count.racku.la is public (confirmed by #3094: prod stays public; M017 brings
+# its own OAuth later) and is served from Cloudflare Workers Static Assets as of
+# #2029, so it needs no CF Access token. d.racku.la sits behind Cloudflare Access
+# and authenticates via the same service-token secrets deploy-dev.yml uses
+# (CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET, added by #2346); its leg is
+# commented out until #2134 moves dev onto Workers.
 
 on:
   schedule:
@@ -45,8 +47,16 @@ jobs:
         target:
           - name: prod
             url: https://count.racku.la
-          - name: dev
-            url: https://d.racku.la
+          # TODO(#2134): restore the dev leg when d.racku.la moves to Workers.
+          # It is removed, not left failing, on purpose. A run's conclusion spans
+          # both legs (fail-fast is off, but either leg failing fails the run),
+          # so while d.racku.la is down every run would be red. That destroys the
+          # two things this workflow exists for: the 7-day green streak that
+          # gates #1986, and an alert anyone still trusts. A permanently-red
+          # check is what got this workflow muted during the August 2026 outage
+          # (#3167) - it failed correctly for three days and was then disabled.
+          # - name: dev
+          #   url: https://d.racku.la
     env:
       SMOKE_TEST_URL: ${{ matrix.target.url }}
     steps:

--- a/.github/workflows/soak-smoke.yml
+++ b/.github/workflows/soak-smoke.yml
@@ -93,24 +93,15 @@ jobs:
       # export. d.racku.la sits behind Access and the smoke config
       # (playwright.smoke.config.ts) applies them as request headers; without
       # them the dev leg hits the login wall instead of the app (#2346).
-      # TEMPORARY (#2029 investigation): the prod leg fails on the version.json
-      # assertion while the same request succeeds from a developer machine.
-      # Print what the runner actually receives before the browser suite runs.
-      # Remove once the cause is known.
-      - name: Diagnose version.json from the runner
-        run: |
-          echo "--- runner egress IP ---"
-          curl -sS -m 15 https://api.ipify.org || true; echo
-          echo "--- GET ${SMOKE_TEST_URL}/version.json ---"
-          curl -sS -m 20 -i "${SMOKE_TEST_URL}/version.json" | head -30 || true
-          echo "--- status only, 3 attempts ---"
-          for i in 1 2 3; do
-            curl -sS -m 20 -o /dev/null -w "  attempt $i: %{http_code}\n" "${SMOKE_TEST_URL}/version.json" || true
-          done
-          echo "--- root for comparison ---"
-          curl -sS -m 20 -o /dev/null -w "  GET /: %{http_code}\n" "${SMOKE_TEST_URL}/" || true
-
+      # RACKULA_SMOKE_TOKEN is required, not optional: Cloudflare serves a
+      # Managed Challenge to datacenter IPs across the zone, and Playwright's
+      # `request` fixture runs no JS so it cannot solve one. Without the token
+      # the version.json assertion sees a 403 challenge page. This is why every
+      # run of this workflow failed from 2026-07-20 until #2029 -- 79 runs, zero
+      # successes, predating the August outage entirely.
       - name: Browser smoke test against deployed app
+        env:
+          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: npm run test:e2e:smoke
 
       - name: Upload Playwright report

--- a/.github/workflows/soak-smoke.yml
+++ b/.github/workflows/soak-smoke.yml
@@ -93,15 +93,13 @@ jobs:
       # export. d.racku.la sits behind Access and the smoke config
       # (playwright.smoke.config.ts) applies them as request headers; without
       # them the dev leg hits the login wall instead of the app (#2346).
-      # RACKULA_SMOKE_TOKEN is required, not optional: Cloudflare serves a
-      # Managed Challenge to datacenter IPs across the zone, and Playwright's
-      # `request` fixture runs no JS so it cannot solve one. Without the token
-      # the version.json assertion sees a 403 challenge page. This is why every
-      # run of this workflow failed from 2026-07-20 until #2029 -- 79 runs, zero
-      # successes, predating the August outage entirely.
+      # Cloudflare serves a Managed Challenge to datacenter IPs across the zone.
+      # The specs navigate first so Chromium solves it, then use `page.request`,
+      # which inherits the clearance cookie. Before that fix a bare API request
+      # saw a 403 challenge page, which is why every run of this workflow failed
+      # from 2026-07-20 until #2029 -- 79 runs, zero successes, predating the
+      # August outage entirely.
       - name: Browser smoke test against deployed app
-        env:
-          RACKULA_SMOKE_TOKEN: ${{ secrets.RACKULA_SMOKE_TOKEN }}
         run: npm run test:e2e:smoke
 
       - name: Upload Playwright report

--- a/.github/workflows/soak-smoke.yml
+++ b/.github/workflows/soak-smoke.yml
@@ -93,6 +93,23 @@ jobs:
       # export. d.racku.la sits behind Access and the smoke config
       # (playwright.smoke.config.ts) applies them as request headers; without
       # them the dev leg hits the login wall instead of the app (#2346).
+      # TEMPORARY (#2029 investigation): the prod leg fails on the version.json
+      # assertion while the same request succeeds from a developer machine.
+      # Print what the runner actually receives before the browser suite runs.
+      # Remove once the cause is known.
+      - name: Diagnose version.json from the runner
+        run: |
+          echo "--- runner egress IP ---"
+          curl -sS -m 15 https://api.ipify.org || true; echo
+          echo "--- GET ${SMOKE_TEST_URL}/version.json ---"
+          curl -sS -m 20 -i "${SMOKE_TEST_URL}/version.json" | head -30 || true
+          echo "--- status only, 3 attempts ---"
+          for i in 1 2 3; do
+            curl -sS -m 20 -o /dev/null -w "  attempt $i: %{http_code}\n" "${SMOKE_TEST_URL}/version.json" || true
+          done
+          echo "--- root for comparison ---"
+          curl -sS -m 20 -o /dev/null -w "  GET /: %{http_code}\n" "${SMOKE_TEST_URL}/" || true
+
       - name: Browser smoke test against deployed app
         run: npm run test:e2e:smoke
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The CF `_headers` generator must not drift from the nginx source of
+      # truth it transcribes. `--check` diffs it against
+      # deploy/security-headers.conf in both directions. It shipped in #3092
+      # with no callers; this is the caller.
+      - name: Check Cloudflare header generator parity
+        run: node scripts/gen-headers.mjs --check
+
       - name: Run linter
         run: npm run lint
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,9 +1,12 @@
 name: Trivy Security Scan
 
 # On-demand Trivy vulnerability scan that complements the release-time scan
-# in deploy-prod.yml. Lets us re-scan published images and the current repo
-# state without cutting a release. Image categories match deploy-prod's scan
+# in build-images.yml. Lets us re-scan published images and the current repo
+# state without cutting a release. Image categories match build-images' scan
 # so findings refresh the same alert set instead of stacking duplicates.
+#
+# deploy-prod.yml no longer builds or scans images: prod is a Cloudflare Worker
+# serving static assets (#2029). Docker images are a self-host artifact only.
 
 on:
   workflow_dispatch:
@@ -132,6 +135,6 @@ jobs:
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: trivy-results.sarif
-          # Match deploy-prod's category so on-demand runs refresh the
+          # Match build-images' category so on-demand runs refresh the
           # release-time alert set rather than creating duplicates.
           category: trivy-${{ env.IMAGE_CATEGORY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -558,7 +558,7 @@ Deploys when a version tag is pushed:
 /release              # Auto-computes next CalVer version, tags, and pushes
 ```
 
-Prod is an assets-only Cloudflare Worker (`wrangler.jsonc` at the repo root): no `main`, no bindings, no API. It serves the static bundle in browser-storage mode and holds no user data. Static-asset requests are unmetered only while there is no Worker script on the hot path, so **do not add a `main` to `rackula-prod`**.
+Prod is an assets-only Cloudflare Worker (`wrangler.jsonc` at the repo root): no `main`, no bindings, no API. It serves the static bundle in browser-storage mode and holds no user data. Static-asset requests are unmetered only while there is no Worker script on the hot path, so do not add a `main` to `rackula-prod`.
 
 Each release: `wrangler versions upload` -> full fail-closed smoke against the per-version preview URL (`scripts/smoke-headers.sh` plus the Playwright deploy smoke) -> `wrangler versions deploy` -> re-check the live host. A bad build never takes traffic. Rollback is the `Rollback Prod` workflow, which takes a Worker version id and bypasses the release approval gate.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,7 +560,7 @@ Deploys when a version tag is pushed:
 
 Prod is an assets-only Cloudflare Worker (`wrangler.jsonc` at the repo root): no `main`, no bindings, no API. It serves the static bundle in browser-storage mode and holds no user data. Static-asset requests are unmetered only while there is no Worker script on the hot path, so do not add a `main` to `rackula-prod`.
 
-Each release: `wrangler versions upload` -> full fail-closed smoke against the per-version preview URL (`scripts/smoke-headers.sh` plus the Playwright deploy smoke) -> `wrangler versions deploy` -> re-check the live host. A bad build never takes traffic. Rollback is the `Rollback Prod` workflow, which takes a Worker version id and bypasses the release approval gate.
+Each release: `wrangler versions upload` -> full fail-closed smoke against the per-version preview URL (`scripts/smoke-headers.sh` plus the Playwright deploy smoke) -> `wrangler versions deploy` -> `wrangler triggers deploy` -> re-check the live host. A bad build never takes traffic. `versions deploy` shifts traffic but does not apply route changes, so `triggers deploy` is the step that lands any edit to `wrangler.jsonc`'s `routes`. Rollback is the `Rollback Prod` workflow, which takes a Worker version id and bypasses the release approval gate; it runs `versions deploy` only, so it never touches routes.
 
 Security headers come from `scripts/gen-headers.mjs`, which transcribes `deploy/security-headers.conf` by value and is parity-checked in CI. They are generated into `dist/` at deploy time and never committed to `static/`, which would leak them into the self-host images.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ The `/release` skill will:
 - `M002 -- LXC Release & Stability` (in progress)
 - `M003 -- Data Format & Interop` (next)
 - `M004 -- Type Safety, Decomposition & Stability` (planned)
+- `M018 - cloudflare migration` (in progress: prod is on Workers; dev cutover and VPS decommission remain)
 
 ---
 
@@ -532,10 +533,10 @@ Core rule: if there is even a small chance a skill applies, invoke it via the Sk
 
 Two environments with different deployment triggers:
 
-| Environment | URL            | Trigger        | Infrastructure |
-| ----------- | -------------- | -------------- | -------------- |
-| **Dev**     | d.racku.la     | Push to `main` | VPS (Docker)   |
-| **Prod**    | count.racku.la | Git tag `v*`   | VPS (Docker)   |
+| Environment | URL | Trigger | Infrastructure |
+| --- | --- | --- | --- |
+| **Dev** | d.racku.la | Push to `main` | VPS (Docker) |
+| **Prod** | count.racku.la | Git tag `v*` | Cloudflare Workers Static Assets |
 
 ### Dev Deployment
 
@@ -557,9 +558,15 @@ Deploys when a version tag is pushed:
 /release              # Auto-computes next CalVer version, tags, and pushes
 ```
 
+Prod is an assets-only Cloudflare Worker (`wrangler.jsonc` at the repo root): no `main`, no bindings, no API. It serves the static bundle in browser-storage mode and holds no user data. Static-asset requests are unmetered only while there is no Worker script on the hot path, so **do not add a `main` to `rackula-prod`**.
+
+Each release: `wrangler versions upload` -> full fail-closed smoke against the per-version preview URL (`scripts/smoke-headers.sh` plus the Playwright deploy smoke) -> `wrangler versions deploy` -> re-check the live host. A bad build never takes traffic. Rollback is the `Rollback Prod` workflow, which takes a Worker version id and bypasses the release approval gate.
+
+Security headers come from `scripts/gen-headers.mjs`, which transcribes `deploy/security-headers.conf` by value and is parity-checked in CI. They are generated into `dist/` at deploy time and never committed to `static/`, which would leak them into the self-host images.
+
 ### Workflow
 
 1. Develop locally (`npm run dev`)
 2. Push to `main` → auto-deploys to d.racku.la
 3. Test on dev environment
-4. Tag release → auto-deploys to count.racku.la
+4. Tag release → approve the promote gate → deploys to count.racku.la (Cloudflare Workers)

--- a/docs/deployment/RELEASE-PIPELINE.md
+++ b/docs/deployment/RELEASE-PIPELINE.md
@@ -21,7 +21,7 @@ Previously a tag push published `latest` everywhere (Docker `:latest`, GitHub la
    - A maintainer approves the `prod` Environment (single approval choke point).
    - Docker: retag the gated digest to `:latest` and `:YY.M` (by digest, never a rebuild).
    - GitHub: `gh release edit <tag> --prerelease=false --latest=true`.
-   - Prod: deploy the VPS and run the post-deploy smoke test.
+   - Prod: upload the build as a new Cloudflare Worker version, smoke it on the per-version preview URL, and only then shift traffic to it.
 
 ## Operator actions
 
@@ -77,7 +77,7 @@ Do not add an entry to unblock a release without that discussion first. If a fix
 
 `smoke-test` in `deploy-dev.yml` runs the deployed app through Playwright once the dev deploy completes. It needs a Cloudflare Access service token (`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`) because d.racku.la sits behind Cloudflare Access; without it every request only reaches the login wall (#2346). Rather than let those requests fail (or silently no-op inside a job that still reports success), a preceding `check-cf-access` job checks secret availability and publishes it as an output. `smoke-test` has a job-level `if:` on that output, so when the token is unavailable the job's conclusion is `skipped`, visibly distinct from a passed run in the Actions summary, and the gate step also emits an `::notice::` and a `$GITHUB_STEP_SUMMARY` line explaining why. This does not change when the smoke test is skipped, only how the skip is reported.
 
-`smoke-test` in `deploy-prod.yml` has no equivalent skip: it runs on the trusted self-hosted path during promote, count.racku.la is not behind Cloudflare Access, and the required secrets are always present there.
+`deploy-prod.yml` needs no equivalent skip: count.racku.la is public (#3094) and the Cloudflare credentials are always present during promote. Its smoke is fail-closed and runs twice, first against the per-version preview URL before any traffic moves, then against the live host. It runs on `ubuntu-latest`; prod left the self-hosted runner with #2029.
 
 ## Upgrade-gate baseline
 

--- a/docs/deployment/cloudflare-prod-runbook.md
+++ b/docs/deployment/cloudflare-prod-runbook.md
@@ -1,0 +1,90 @@
+# Cloudflare prod runbook (count.racku.la)
+
+Production is an **assets-only** Cloudflare Worker: `wrangler.jsonc` at the repo root, no `main`, no bindings, no API. The frontend runs in browser-storage mode and stores nothing server-side, so there is no prod database, no volume, and nothing to back up.
+
+Related: [`cloudflare-token-rotation.md`](cloudflare-token-rotation.md), [`RELEASE-PIPELINE.md`](RELEASE-PIPELINE.md), [`soak-smoke.md`](soak-smoke.md).
+
+## Standing invariants
+
+- **Never add a `main` to `rackula-prod`.** Static-asset requests are unmetered only while no Worker script sits on the hot path. Adding one meters every request against the Workers free-tier limit. This constrains the analytics beacon (#2030) and preview deploys (#2031); both must stay assets-only.
+- **Never commit `_headers` or `.assetsignore` to `static/`.** Vite's `publicDir` copies `static/` verbatim into every `dist/`, including the Docker and LXC self-host images. Both files are generated into `dist/` in the deploy step instead.
+- **Never hand-edit header values.** `deploy/security-headers.conf` is the source of truth; `scripts/gen-headers.mjs` transcribes it and CI runs `--check` in both directions.
+- **`login.html` is stripped from the prod artifact only**, in the deploy step, never by branching `vite.config.ts`. The self-host builds need it.
+
+## Steady state: a normal release
+
+Nothing manual. `/release` tags, `release.yml` gates, a maintainer approves the `prod` environment once at `promote-gate`, and `deploy-prod.yml` does:
+
+1. Build the tag with `.git` present, so `version.json.commit` is populated.
+2. Generate `_headers` and `.assetsignore`; strip `login.html`; assert `config.js`, version and commit.
+3. `wrangler versions upload` -> a per-version preview URL. **No traffic yet.**
+4. Fail-closed smoke against that preview URL: `scripts/smoke-headers.sh` plus the Playwright deploy smoke.
+5. `wrangler versions deploy <id>@100%`, then `wrangler triggers deploy`.
+6. Re-run both smokes against `https://count.racku.la`.
+
+No percentage rollouts. Cloudflare documents a mixed-version hazard where HTML served by one version references hashed assets that exist only in another, and version affinity needs a request header browsers do not send.
+
+`wrangler versions deploy` does **not** apply trigger changes. If `wrangler.jsonc`'s `routes` change, `wrangler triggers deploy` is what lands them (the workflow runs it every time).
+
+## Rollback
+
+Run the **Rollback Prod** workflow with a Worker version id. It has its own concurrency group and does not traverse `release.yml`'s approval gate, so it does not queue behind the deploy it is undoing.
+
+```bash
+npx wrangler@4.124.0 versions list --name rackula-prod   # find the id
+gh workflow run rollback-prod.yml -f version_id=<uuid> -f reason="..."
+```
+
+Cloudflare retains the last 100 versions. The previous version id is also in every Deploy Prod run summary.
+
+There is **no VPS fallback.** The epic design spec assumed the old prod container would stay running as a DNS-level rollback; that origin stopped answering in August 2026 (#3167), which is what forced this cutover. Rolling back means deploying an earlier Worker version.
+
+## How the hostname is attached
+
+`count.racku.la` is bound with a **Workers route**, not a Custom Domain:
+
+```jsonc
+"routes": [{ "pattern": "count.racku.la/*", "zone_name": "racku.la" }]
+```
+
+At cutover the hostname already had a healthy proxied DNS record and edge certificate, and the origin was returning 522. A route intercepts ahead of the origin, so the cutover needed no DNS change, no certificate wait, and no delete-then-attach window (a Custom Domain cannot be created over an existing record, and the zone's SOA minimum is 1800s, so that path risked up to 30 minutes of NXDOMAIN). Rollback is removing the route entry and redeploying.
+
+The original Custom Domain approach remains valid and is documented in the epic design spec if the route ever needs replacing.
+
+## Bootstrap, as executed (2026-08-22)
+
+One-time, out-of-band, not through `release.yml`. Recorded because the next surface (#2134, dev) will repeat it.
+
+1. Built **v26.7.0**, the release that was live before the outage, from a clean `git worktree` of the tag. Not `main`, which was 91 commits ahead.
+2. `wrangler versions upload` **fails on a Worker that does not exist yet** ("You cannot upload a new version of a Worker that does not yet exist"). Bootstrap with a plain `wrangler deploy`. This is safe precisely because no hostname is attached: a deployed-but-unrouted Worker takes zero traffic. The upload-then-promote ordering only matters once a hostname is bound.
+3. Smoked the workers.dev URL, then added the route and redeployed.
+4. Turned `workers_dev` back off, leaving one public surface.
+
+### Build from a clean checkout, always
+
+`publicDir` copies `static/` verbatim, and gitignored files are still copied. At the time of the cutover the working tree's `dist/` contained `.claude/settings.local.json` (ignored via the _user-global_ ignore file, so invisible to `git status`) and two `.DS_Store` files. Deploying from that tree would have published a local editor config to a public origin.
+
+CI is unaffected, because a fresh checkout has neither. Hand-run deploys are the exposure. Two defences, both in place: build from a clean worktree, and `.assetsignore` lists `.DS_Store` and `.claude/**`. `scripts/smoke-headers.sh` asserts all four paths are unreachable.
+
+## Zone-level HSTS (resolved, #3214)
+
+`scripts/gen-headers.mjs` emits `Strict-Transport-Security: max-age=31536000; includeSubDomains`, matching nginx.
+
+At cutover the live host returned `max-age=0` instead. The cause was zone-scoped, not this Worker: every `racku.la` hostname returned `max-age=0` while the same Worker on `*.workers.dev` returned the correct value, which isolated it to a zone-level control. Disabling zone HSTS in the Cloudflare dashboard let each Worker's own `_headers` value through, and `count.racku.la` now serves the expected value.
+
+`smoke-headers.sh` asserts the value strictly as part of the by-value header diff, and separately asserts there is exactly **one** `Strict-Transport-Security` header. That second check is deliberate: re-enabling zone HSTS would either replace the Worker's value again or emit a duplicate, and both should fail the next deploy loudly rather than drift.
+
+Do not enable zone HSTS with `includeSubDomains`: it applies to every proxied hostname in the zone, including `d.racku.la` and any future host, which is the cross-subdomain blast radius the epic design spec warns against. Per-host HSTS via `_headers` is the mechanism this repo uses.
+
+## Verifying prod by hand
+
+```bash
+scripts/smoke-headers.sh https://count.racku.la --live \
+  --expect-version 26.7.0 --expect-commit 792a7d17
+
+SMOKE_TEST_URL=https://count.racku.la npm run test:e2e:smoke
+```
+
+`scripts/smoke-headers.sh` exists because `e2e/deploy-smoke.spec.ts` does not cover this ground: it proves the bundle boots in a real browser, but asserts nothing about headers, content types, SPA-fallback behaviour, or version/commit matching, and it tolerates an empty commit. Both are needed.
+
+The content-type assertions matter more here than on nginx. `not_found_handling: "single-page-application"` turns every unmatched path into `200` + `index.html`, so a missing asset returns a cheerful HTML page rather than a 404, and `nosniff` then stops the browser executing it. A smoke test that only checks for `200` cannot see that failure.

--- a/docs/deployment/cloudflare-prod-runbook.md
+++ b/docs/deployment/cloudflare-prod-runbook.md
@@ -37,10 +37,16 @@ gh workflow run rollback-prod.yml -f version_id=<uuid> -f reason="..."
 
 If a deploy is currently running, cancel it first. Both workflows share the `prod-traffic` concurrency group with `cancel-in-progress: false`, so a rollback started mid-deploy sits queued rather than running -- exactly when you least want to wait. That grouping is deliberate: without it the two race, and a deploy that finishes after your rollback re-promotes the build you just rolled back.
 
+The deploy runs as the `promote-prod` job inside a Release run: `deploy-prod.yml` is `workflow_call`-only, so it has no run of its own and `gh run list --workflow=deploy-prod.yml` only ever shows pre-cutover history. Query `release.yml` instead, and confirm the run before killing it.
+
 ```bash
-gh run list --workflow=deploy-prod.yml --limit 1     # is one in flight?
-gh run cancel <run-id>
+RUN_ID="$(gh run list --workflow=release.yml --status=in_progress \
+  --json databaseId --jq '.[0].databaseId // empty')"
+[ -n "$RUN_ID" ] && gh run view "$RUN_ID"     # confirm this is the one
+[ -n "$RUN_ID" ] && gh run cancel "$RUN_ID"
 ```
+
+An empty `RUN_ID` means nothing is deploying and both lines no-op, so this is safe to paste blind. A release parked at the `promote-gate` approval reports `waiting`, not `in_progress`; it is harmless until someone approves it, so it is deliberately not matched here.
 
 Cancelling a deploy is safe. It promotes traffic only after its smoke passes, so a cancelled run either had not shifted traffic yet, or had already finished doing so and the rollback supersedes it either way.
 

--- a/docs/deployment/cloudflare-prod-runbook.md
+++ b/docs/deployment/cloudflare-prod-runbook.md
@@ -1,15 +1,15 @@
 # Cloudflare prod runbook (count.racku.la)
 
-Production is an **assets-only** Cloudflare Worker: `wrangler.jsonc` at the repo root, no `main`, no bindings, no API. The frontend runs in browser-storage mode and stores nothing server-side, so there is no prod database, no volume, and nothing to back up.
+Production is an assets-only Cloudflare Worker: `wrangler.jsonc` at the repo root, no `main`, no bindings, no API. The frontend runs in browser-storage mode and stores nothing server-side, so there is no prod database, no volume, and nothing to back up.
 
 Related: [`cloudflare-token-rotation.md`](cloudflare-token-rotation.md), [`RELEASE-PIPELINE.md`](RELEASE-PIPELINE.md), [`soak-smoke.md`](soak-smoke.md).
 
 ## Standing invariants
 
-- **Never add a `main` to `rackula-prod`.** Static-asset requests are unmetered only while no Worker script sits on the hot path. Adding one meters every request against the Workers free-tier limit. This constrains the analytics beacon (#2030) and preview deploys (#2031); both must stay assets-only.
-- **Never commit `_headers` or `.assetsignore` to `static/`.** Vite's `publicDir` copies `static/` verbatim into every `dist/`, including the Docker and LXC self-host images. Both files are generated into `dist/` in the deploy step instead.
-- **Never hand-edit header values.** `deploy/security-headers.conf` is the source of truth; `scripts/gen-headers.mjs` transcribes it and CI runs `--check` in both directions.
-- **`login.html` is stripped from the prod artifact only**, in the deploy step, never by branching `vite.config.ts`. The self-host builds need it.
+- Never add a `main` to `rackula-prod`. Static-asset requests are unmetered only while no Worker script sits on the hot path. Adding one meters every request against the Workers free-tier limit. This constrains the analytics beacon (#2030) and preview deploys (#2031); both must stay assets-only.
+- Never commit `_headers` or `.assetsignore` to `static/`. Vite's `publicDir` copies `static/` verbatim into every `dist/`, including the Docker and LXC self-host images. Both files are generated into `dist/` in the deploy step instead.
+- Never hand-edit header values. `deploy/security-headers.conf` is the source of truth; `scripts/gen-headers.mjs` transcribes it and CI runs `--check` in both directions.
+- `login.html` is stripped from the prod artifact only, in the deploy step, never by branching `vite.config.ts`. The self-host builds need it.
 
 ## Steady state: a normal release
 
@@ -17,25 +17,25 @@ Nothing manual. `/release` tags, `release.yml` gates, a maintainer approves the 
 
 1. Build the tag with `.git` present, so `version.json.commit` is populated.
 2. Generate `_headers` and `.assetsignore`; strip `login.html`; assert `config.js`, version and commit.
-3. `wrangler versions upload` -> a per-version preview URL. **No traffic yet.**
+3. `wrangler versions upload` -> a per-version preview URL. No traffic yet.
 4. Fail-closed smoke against that preview URL: `scripts/smoke-headers.sh` plus the Playwright deploy smoke.
 5. `wrangler versions deploy <id>@100%`, then `wrangler triggers deploy`.
 6. Re-run both smokes against `https://count.racku.la`.
 
 No percentage rollouts. Cloudflare documents a mixed-version hazard where HTML served by one version references hashed assets that exist only in another, and version affinity needs a request header browsers do not send.
 
-`wrangler versions deploy` does **not** apply trigger changes. If `wrangler.jsonc`'s `routes` change, `wrangler triggers deploy` is what lands them (the workflow runs it every time).
+`wrangler versions deploy` does not apply trigger changes. If `wrangler.jsonc`'s `routes` change, `wrangler triggers deploy` is what lands them (the workflow runs it every time).
 
 ## Rollback
 
-Run the **Rollback Prod** workflow with a Worker version id. It has its own concurrency group and does not traverse `release.yml`'s approval gate, so it does not queue behind the deploy it is undoing.
+Run the Rollback Prod workflow with a Worker version id. It does not traverse `release.yml`'s approval gate, so it never waits on a human to approve the `prod` environment. It does share a concurrency group with the deploy workflow, so see the note below if a deploy is in flight.
 
 ```bash
 npx wrangler@4.124.0 versions list --name rackula-prod   # find the id
 gh workflow run rollback-prod.yml -f version_id=<uuid> -f reason="..."
 ```
 
-**If a deploy is currently running, cancel it first.** Both workflows share the `prod-traffic` concurrency group with `cancel-in-progress: false`, so a rollback started mid-deploy sits queued rather than running -- exactly when you least want to wait. That grouping is deliberate: without it the two race, and a deploy that finishes after your rollback re-promotes the build you just rolled back.
+If a deploy is currently running, cancel it first. Both workflows share the `prod-traffic` concurrency group with `cancel-in-progress: false`, so a rollback started mid-deploy sits queued rather than running -- exactly when you least want to wait. That grouping is deliberate: without it the two race, and a deploy that finishes after your rollback re-promotes the build you just rolled back.
 
 ```bash
 gh run list --workflow=deploy-prod.yml --limit 1     # is one in flight?
@@ -46,7 +46,7 @@ Cancelling a deploy is safe. It promotes traffic only after its smoke passes, so
 
 Cloudflare retains the last 100 versions. The previous version id is also in every Deploy Prod run summary.
 
-There is **no VPS fallback.** The epic design spec assumed the old prod container would stay running as a DNS-level rollback; that origin stopped answering in August 2026 (#3167), which is what forced this cutover. Rolling back means deploying an earlier Worker version.
+There is no VPS fallback. The epic design spec assumed the old prod container would stay running as a DNS-level rollback; that origin stopped answering in August 2026 (#3167), which is what forced this cutover. Rolling back means deploying an earlier Worker version.
 
 ### Rolling back a release vs undoing the cutover
 
@@ -65,7 +65,7 @@ Detaching only helps if the origin behind that DNS record is healthy. At cutover
 
 ## How the hostname is attached
 
-`count.racku.la` is bound with a **Workers route**, not a Custom Domain:
+`count.racku.la` is bound with a Workers route, not a Custom Domain:
 
 ```jsonc
 "routes": [{ "pattern": "count.racku.la/*", "zone_name": "racku.la" }]
@@ -79,8 +79,8 @@ The original Custom Domain approach remains valid and is documented in the epic 
 
 One-time, out-of-band, not through `release.yml`. Recorded because the next surface (#2134, dev) will repeat it.
 
-1. Built **v26.7.0**, the release that was live before the outage, from a clean `git worktree` of the tag. Not `main`, which was 91 commits ahead.
-2. `wrangler versions upload` **fails on a Worker that does not exist yet** ("You cannot upload a new version of a Worker that does not yet exist"). Bootstrap with a plain `wrangler deploy`. This is safe precisely because no hostname is attached: a deployed-but-unrouted Worker takes zero traffic. The upload-then-promote ordering only matters once a hostname is bound.
+1. Built v26.7.0, the release that was live before the outage, from a clean `git worktree` of the tag. Not `main`, which was 91 commits ahead.
+2. `wrangler versions upload` fails on a Worker that does not exist yet ("You cannot upload a new version of a Worker that does not yet exist"). Bootstrap with a plain `wrangler deploy`. This is safe precisely because no hostname is attached: a deployed-but-unrouted Worker takes zero traffic. The upload-then-promote ordering only matters once a hostname is bound.
 3. Smoked the workers.dev URL, then added the route and redeployed.
 4. Turned `workers_dev` back off, leaving one public surface.
 
@@ -96,7 +96,7 @@ CI is unaffected, because a fresh checkout has neither. Hand-run deploys are the
 
 At cutover the live host returned `max-age=0` instead. The cause was zone-scoped, not this Worker: every `racku.la` hostname returned `max-age=0` while the same Worker on `*.workers.dev` returned the correct value, which isolated it to a zone-level control. Disabling zone HSTS in the Cloudflare dashboard let each Worker's own `_headers` value through, and `count.racku.la` now serves the expected value.
 
-`smoke-headers.sh` asserts the value strictly as part of the by-value header diff, and separately asserts there is exactly **one** `Strict-Transport-Security` header. That second check is deliberate: re-enabling zone HSTS would either replace the Worker's value again or emit a duplicate, and both should fail the next deploy loudly rather than drift.
+`smoke-headers.sh` asserts the value strictly as part of the by-value header diff, and separately asserts there is exactly one `Strict-Transport-Security` header. That second check is deliberate: re-enabling zone HSTS would either replace the Worker's value again or emit a duplicate, and both should fail the next deploy loudly rather than drift.
 
 Do not enable zone HSTS with `includeSubDomains`: it applies to every proxied hostname in the zone, including `d.racku.la` and any future host, which is the cross-subdomain blast radius the epic design spec warns against. Per-host HSTS via `_headers` is the mechanism this repo uses.
 

--- a/docs/deployment/cloudflare-prod-runbook.md
+++ b/docs/deployment/cloudflare-prod-runbook.md
@@ -35,6 +35,15 @@ npx wrangler@4.124.0 versions list --name rackula-prod   # find the id
 gh workflow run rollback-prod.yml -f version_id=<uuid> -f reason="..."
 ```
 
+**If a deploy is currently running, cancel it first.** Both workflows share the `prod-traffic` concurrency group with `cancel-in-progress: false`, so a rollback started mid-deploy sits queued rather than running -- exactly when you least want to wait. That grouping is deliberate: without it the two race, and a deploy that finishes after your rollback re-promotes the build you just rolled back.
+
+```bash
+gh run list --workflow=deploy-prod.yml --limit 1     # is one in flight?
+gh run cancel <run-id>
+```
+
+Cancelling a deploy is safe. It promotes traffic only after its smoke passes, so a cancelled run either had not shifted traffic yet, or had already finished doing so and the rollback supersedes it either way.
+
 Cloudflare retains the last 100 versions. The previous version id is also in every Deploy Prod run summary.
 
 There is **no VPS fallback.** The epic design spec assumed the old prod container would stay running as a DNS-level rollback; that origin stopped answering in August 2026 (#3167), which is what forced this cutover. Rolling back means deploying an earlier Worker version.

--- a/docs/deployment/cloudflare-prod-runbook.md
+++ b/docs/deployment/cloudflare-prod-runbook.md
@@ -39,6 +39,21 @@ Cloudflare retains the last 100 versions. The previous version id is also in eve
 
 There is **no VPS fallback.** The epic design spec assumed the old prod container would stay running as a DNS-level rollback; that origin stopped answering in August 2026 (#3167), which is what forced this cutover. Rolling back means deploying an earlier Worker version.
 
+### Rolling back a release vs undoing the cutover
+
+Two different operations, easy to conflate:
+
+|  | Bad release | Bad cutover |
+| --- | --- | --- |
+| Symptom | count.racku.la serves a broken build | Workers hosting itself is wrong for prod |
+| Action | `Rollback Prod` workflow with a version id | Remove the `routes` entry from `wrangler.jsonc`, then `wrangler triggers deploy` |
+| Effect | Hostname stays attached, serves an older build | Hostname detaches; requests fall back to whatever the `count.racku.la` DNS record points at |
+| Automated | Yes | No, deliberately |
+
+Routes are _trigger_ state, not _version_ state, so `wrangler versions deploy` never touches them. That is why the rollback workflow leaves the site attached and simply serving an older build, which is what you want for a bad release.
+
+Detaching only helps if the origin behind that DNS record is healthy. At cutover it was not -- it had been returning 522 for three weeks -- so detaching would have restored the outage, not fixed anything.
+
 ## How the hostname is attached
 
 `count.racku.la` is bound with a **Workers route**, not a Custom Domain:

--- a/docs/deployment/cloudflare-token-rotation.md
+++ b/docs/deployment/cloudflare-token-rotation.md
@@ -16,7 +16,7 @@ Cloudflare API tokens scoped to Workers Scripts edit cannot be restricted to a s
 
 ## Token class 1: Cloudflare API deploy tokens
 
-Used by the deploy workflows to publish the Worker (`wrangler versions upload`, `versions deploy`, `triggers deploy` in `deploy-prod.yml` and `rollback-prod.yml`; `wrangler deploy` in #2134 once dev lands).
+Used by the deploy workflows to publish the Worker. `deploy-prod.yml` runs `wrangler versions upload`, `versions deploy` and `triggers deploy`. `rollback-prod.yml` runs `versions deploy` only, so the Workers Routes scope in the table below is exercised by `deploy-prod.yml` alone. #2134 adds `wrangler deploy` once dev lands.
 
 ### Storage
 

--- a/docs/deployment/cloudflare-token-rotation.md
+++ b/docs/deployment/cloudflare-token-rotation.md
@@ -6,7 +6,7 @@ This is the operational runbook for rotating and revoking the two classes of Clo
 
 The prod surface is live (#2029). Account: `GarethLand`, id `f8606884a913456ec07bf4ccbf136abc`. Zone `racku.la`, id `ecc485cd0dd1c5fe05e803f83632d721`. Worker `rackula-prod`, `workers.dev` subdomain `gvns`.
 
-The **dev** half of #2675 is still outstanding: no `rackula-dev` Worker and no R2 bucket yet. When it lands, extend the inventory below rather than rewriting it, and record whether dev gets its own token copy or shares the prod one (Cloudflare cannot scope a Workers Scripts token to a single Worker, so both carry the same blast radius either way; see the account-wide risk note below).
+The dev half of #2675 is still outstanding: no `rackula-dev` Worker and no R2 bucket yet. When it lands, extend the inventory below rather than rewriting it, and record whether dev gets its own token copy or shares the prod one (Cloudflare cannot scope a Workers Scripts token to a single Worker, so both carry the same blast radius either way; see the account-wide risk note below).
 
 The Cloudflare Access service token pair (`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`) already exists; its section below is accurate today.
 
@@ -22,7 +22,7 @@ Used by the deploy workflows to publish the Worker (`wrangler versions upload`, 
 
 - Secret names: `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, following the Wrangler convention so no extra env plumbing is needed. `deploy-prod.yml` and `rollback-prod.yml` read both.
 - Storage tier: repository-level GitHub Actions secrets, matching how `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` are stored. Environment-scoped secrets were considered and not used: `deploy-prod.yml` deliberately carries no `environment:` binding, because `promote-gate` in `release.yml` already binds the protected `prod` environment and a second binding would prompt the same reviewer twice in one run. The approval gate is therefore upstream of the token, not around it.
-- **Minimum scope for the prod token** (three permissions, verified against the deploy path):
+- Minimum scope for the prod token (three permissions, verified against the deploy path):
 
   | Scope | Permission | Needed for |
   | --- | --- | --- |
@@ -30,9 +30,9 @@ Used by the deploy workflows to publish the Worker (`wrangler versions upload`, 
   | Zone (`racku.la` only) | Workers Routes: **Edit** | `triggers deploy` maintaining the `count.racku.la/*` route |
   | Zone (`racku.la` only) | Zone: **Read** | resolving `zone_name: "racku.la"` to a zone id |
 
-  Deliberately **not** granted, versus the set Cloudflare's Workers Builds template auto-generates: R2 Storage and KV Storage (prod is assets-only with zero bindings -- the dev Worker will need R2, mint that separately rather than widening this token), Account Settings: Read (only needed to resolve the account when it is not supplied, and `CLOUDFLARE_ACCOUNT_ID` is passed explicitly), and User Details / Memberships: Read (used by `wrangler whoami`, not by deploys).
+  Deliberately not granted, versus the set Cloudflare's Workers Builds template auto-generates: R2 Storage and KV Storage (prod is assets-only with zero bindings -- the dev Worker will need R2, mint that separately rather than widening this token), Account Settings: Read (only needed to resolve the account when it is not supplied, and `CLOUDFLARE_ACCOUNT_ID` is passed explicitly), and User Details / Memberships: Read (used by `wrangler whoami`, not by deploys).
 
-  No DNS permission is required. The Custom Domain attach path would have needed DNS: Edit, but `count.racku.la` is bound with a Workers **route** instead, so the token never touches DNS records.
+  No DNS permission is required. The Custom Domain attach path would have needed DNS: Edit, but `count.racku.la` is bound with a Workers route instead, so the token never touches DNS records.
 
 ### Who can rotate
 

--- a/docs/deployment/cloudflare-token-rotation.md
+++ b/docs/deployment/cloudflare-token-rotation.md
@@ -2,17 +2,13 @@
 
 This is the operational runbook for rotating and revoking the two classes of Cloudflare credentials the Cloudflare migration (epic #1984, milestone M018) uses: Cloudflare API deploy tokens and Cloudflare Access service tokens. Follow it as-is during a scheduled rotation or a suspected compromise. It does not explain how the migration works; see `docs/plans/2026-06-29-cloudflare-migration-plan.md` for that.
 
-## Status: placeholders pending #2675
+## Status
 
-Issue #2675 has not run yet. No Cloudflare API deploy token exists, and `CLOUDFLARE_ACCOUNT_ID` is not set anywhere. This runbook documents the rotation procedure against the planned inventory so the procedure exists before the tokens do. Wherever a name below is not yet fixed, it is written as an angle-bracket placeholder, for example `<CF_API_TOKEN_NAME_TBD>`.
+The prod surface is live (#2029). Account: `GarethLand`, id `f8606884a913456ec07bf4ccbf136abc`. Zone `racku.la`, id `ecc485cd0dd1c5fe05e803f83632d721`. Worker `rackula-prod`, `workers.dev` subdomain `gvns`.
 
-When #2675 mints the real tokens, it must:
+The **dev** half of #2675 is still outstanding: no `rackula-dev` Worker and no R2 bucket yet. When it lands, extend the inventory below rather than rewriting it, and record whether dev gets its own token copy or shares the prod one (Cloudflare cannot scope a Workers Scripts token to a single Worker, so both carry the same blast radius either way; see the account-wide risk note below).
 
-- Replace every `<..._TBD>` placeholder below with the actual GitHub secret name it used.
-- Confirm or correct the token scope, storage environment, and whether dev and prod share one account-wide token or hold separate copies of an identically-scoped token (Cloudflare cannot scope a Workers Scripts token to a single Worker, so the two copies would carry the same blast radius either way; see the account-wide risk note below).
-- Link this file from the deploy docs #2675 produces.
-
-The Cloudflare Access service token pair (`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`) already exists and is not a placeholder; its section below is accurate today.
+The Cloudflare Access service token pair (`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`) already exists; its section below is accurate today.
 
 ## Account-wide risk: read this before rotating anything
 
@@ -20,13 +16,23 @@ Cloudflare API tokens scoped to Workers Scripts edit cannot be restricted to a s
 
 ## Token class 1: Cloudflare API deploy tokens
 
-Used by the deploy workflows to publish the Worker and manage R2 bindings (`wrangler deploy` / `wrangler versions upload` in #2134 and #2029).
+Used by the deploy workflows to publish the Worker (`wrangler versions upload`, `versions deploy`, `triggers deploy` in `deploy-prod.yml` and `rollback-prod.yml`; `wrangler deploy` in #2134 once dev lands).
 
 ### Storage
 
-- Secret names (planned, per the migration plan and #2675's acceptance criteria): `<CF_API_TOKEN_NAME_TBD>` (expected to follow the Wrangler convention `CLOUDFLARE_API_TOKEN`) and `<CF_ACCOUNT_ID_NAME_TBD>` (expected `CLOUDFLARE_ACCOUNT_ID`).
-- Storage tier is not yet fixed: #2675 must decide between repository-level GitHub Actions secrets (visible to every workflow, matching how `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` are stored today) and GitHub Environment secrets scoped to `dev` and/or `prod` (both environments already exist in repo settings, alongside `e2e-approval` and `e2e-trusted`, which are not deploy-token holders). Environment scoping buys GitHub-side protection rules (required reviewers) even though Cloudflare itself cannot scope the token below account-wide; #2675 should record which tier it chose and this file should be updated to match.
-- Scope (per #2675 AC): Workers Scripts edit, R2 read/write, account-wide. No narrower scope is available from Cloudflare for this permission set.
+- Secret names: `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`, following the Wrangler convention so no extra env plumbing is needed. `deploy-prod.yml` and `rollback-prod.yml` read both.
+- Storage tier: repository-level GitHub Actions secrets, matching how `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` are stored. Environment-scoped secrets were considered and not used: `deploy-prod.yml` deliberately carries no `environment:` binding, because `promote-gate` in `release.yml` already binds the protected `prod` environment and a second binding would prompt the same reviewer twice in one run. The approval gate is therefore upstream of the token, not around it.
+- **Minimum scope for the prod token** (three permissions, verified against the deploy path):
+
+  | Scope | Permission | Needed for |
+  | --- | --- | --- |
+  | Account | Workers Scripts: **Edit** | `versions upload` / `versions deploy`, including static-asset upload |
+  | Zone (`racku.la` only) | Workers Routes: **Edit** | `triggers deploy` maintaining the `count.racku.la/*` route |
+  | Zone (`racku.la` only) | Zone: **Read** | resolving `zone_name: "racku.la"` to a zone id |
+
+  Deliberately **not** granted, versus the set Cloudflare's Workers Builds template auto-generates: R2 Storage and KV Storage (prod is assets-only with zero bindings -- the dev Worker will need R2, mint that separately rather than widening this token), Account Settings: Read (only needed to resolve the account when it is not supplied, and `CLOUDFLARE_ACCOUNT_ID` is passed explicitly), and User Details / Memberships: Read (used by `wrangler whoami`, not by deploys).
+
+  No DNS permission is required. The Custom Domain attach path would have needed DNS: Edit, but `count.racku.la` is bound with a Workers **route** instead, so the token never touches DNS records.
 
 ### Who can rotate
 
@@ -38,9 +44,9 @@ Every 90 days, or immediately on suspected compromise. Cloudflare account API to
 
 ### Rotation procedure
 
-1. In the Cloudflare dashboard, go to My Profile > API Tokens > Create Token. Recreate the same scope as the token being replaced (Workers Scripts edit, R2 read/write, account-wide). Do not reuse the old token's name; append a date suffix so the audit log distinguishes them.
+1. In the Cloudflare dashboard, go to My Profile > API Tokens > Create Token. Recreate the same scope as the token being replaced (see the scope table above; for prod that is Workers Scripts: Edit, plus Workers Routes: Edit and Zone: Read on `racku.la`). Do not reuse the old token's name; append a date suffix so the audit log distinguishes them.
 2. Copy the new token value immediately; Cloudflare shows it once.
-3. Update `<CF_API_TOKEN_NAME_TBD>` with the new value everywhere it is stored: check Settings > Secrets and variables > Actions for a repository secret, and check Settings > Environments > `dev` and > `prod` for environment secrets, and update every copy you find. Do not stop at the first one; a copy left on the old value is a copy still trusting a token you are about to revoke. Confirm `<CF_ACCOUNT_ID_NAME_TBD>` is still correct in each location; it does not usually need to change.
+3. Update `CLOUDFLARE_API_TOKEN` with the new value everywhere it is stored: check Settings > Secrets and variables > Actions for a repository secret, and check Settings > Environments > `dev` and > `prod` for environment secrets, and update every copy you find. Do not stop at the first one; a copy left on the old value is a copy still trusting a token you are about to revoke. Confirm `CLOUDFLARE_ACCOUNT_ID` is still correct in each location; it does not usually need to change.
 4. Trigger a `workflow_dispatch` run of `Deploy Dev` (Actions > Deploy Dev > Run workflow) and confirm the `deploy` job succeeds against d.racku.la. For a prod-side rotation, trigger the equivalent verification path once #2029 lands (`deploy-prod.yml` is currently a `workflow_call`-only reusable workflow invoked by the release orchestrator; confirm with a real release promote or with whatever manual dispatch path #2029 adds).
 5. Once the new token has verified deploy success, return to the Cloudflare dashboard and revoke the old token (API Tokens > find the old entry > Roll or Delete).
 6. Note the rotation date and who performed it somewhere durable (a comment on the tracking issue is sufficient); there is no in-repo rotation log to update.

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -93,7 +93,7 @@ We deleted **78 low-value test files** (57% reduction) that tested implementatio
 The dev environment auto-deploys on every push to `main`:
 
 ```
-Push to main → Lint → Test → Build → Deploy to GitHub Pages
+Push to main → Build images → Deploy to d.racku.la (VPS/Docker)
 ```
 
 Use it to:

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -85,8 +85,8 @@ We deleted **78 low-value test files** (57% reduction) that tested implementatio
 | Environment | URL | Purpose |
 | --- | --- | --- |
 | **Local** | `localhost:5173` | Development with HMR (`npm run dev`) |
-| **Dev** | https://dev.racku.la | Preview production builds before release |
-| **Prod** | https://app.racku.la | Live production environment |
+| **Dev** | https://d.racku.la | Preview production builds before release (behind Cloudflare Access) |
+| **Prod** | https://count.racku.la | Live production environment (Cloudflare Workers Static Assets) |
 
 ### Dev Environment
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -163,15 +163,17 @@ No legacy support or migration code. Features are implemented as if they're the 
 │         │                                                    │
 │         ▼                                                    │
 │   ┌─────────────┐     ┌─────────────┐     ┌─────────────┐   │
-│   │Docker Build │────▶│  Push to    │────▶│  VPS Pull   │   │
-│   │             │     │   ghcr.io   │     │  & Deploy   │   │
+│   │   Build     │────▶│  Upload     │────▶│ Smoke the   │   │
+│   │   the tag   │     │  version    │     │ preview URL │   │
 │   └─────────────┘     └─────────────┘     └─────────────┘   │
 │                                                  │           │
 │                                                  ▼           │
 │                                        ┌─────────────────┐   │
-│                                        │   VPS (Docker)  │   │
-│                                        │  app.racku.la   │   │
+│                                        │ CF Workers      │   │
+│                                        │ count.racku.la  │   │
 │                                        └─────────────────┘   │
+│                                                              │
+│   (Docker images still build for self-host, via ghcr.io.)    │
 └─────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -155,8 +155,8 @@ No legacy support or migration code. Features are implemented as if they're the 
 │                                                  │           │
 │                                                  ▼           │
 │                                        ┌─────────────────┐   │
-│                                        │  GitHub Pages   │   │
-│                                        │  dev.racku.la   │   │
+│                                        │   VPS (Docker)  │   │
+│                                        │   d.racku.la    │   │
 │                                        └─────────────────┘   │
 │                                                              │
 │   Git tag v* ───────────────────────────────────────────────│

--- a/docs/reference/SPEC.md
+++ b/docs/reference/SPEC.md
@@ -41,10 +41,10 @@ Homelabbers planning rack layouts. Desktop browser users for creation/editing, m
 
 Rackula supports two deployment modes:
 
-| Mode        | Backend  | Persistence            | Use Case                   |
-| ----------- | -------- | ---------------------- | -------------------------- |
-| **Static**  | None     | File download/upload   | GitHub Pages, simple hosts |
-| **Persist** | Hono/Bun | API server (save/load) | Self-hosted Docker         |
+| Mode | Backend | Persistence | Use Case |
+| --- | --- | --- | --- |
+| **Static** | None | File download/upload | Cloudflare Workers, static hosts |
+| **Persist** | Hono/Bun | API server (save/load) | Self-hosted Docker |
 
 In static mode, Rackula is a pure client-side SPA with no network dependencies. In persist mode, an optional API server provides layout storage, authentication, and multi-device sync.
 

--- a/e2e/deploy-smoke.spec.ts
+++ b/e2e/deploy-smoke.spec.ts
@@ -85,10 +85,24 @@ test.describe("Post-deploy smoke", () => {
     ).toHaveLength(0);
   });
 
-  test("version endpoint reports a well-formed build", async ({ request }) => {
+  test("version endpoint reports a well-formed build", async ({ page }) => {
     // version.json is emitted at build time and served statically, so it proves
     // the deployed bundle is the one we expect without executing any JS.
-    const response = await request.get("/version.json");
+    //
+    // Fetched through `page.request`, not the standalone `request` fixture, and
+    // only AFTER a navigation. Cloudflare serves a Managed Challenge to
+    // datacenter IPs across the racku.la zone, and Bot Fight Mode cannot be
+    // skipped by a WAF rule on the Free plan. A bare API request runs no JS, so
+    // it cannot solve the challenge and receives a 403 challenge page --
+    // `response.ok()` is then false and the check reports a healthy deploy as
+    // broken. That is exactly what happened: this workflow failed 79 out of 79
+    // runs from 2026-07-20 onward, including before the August outage.
+    //
+    // Navigating first lets Chromium solve the challenge and earn a clearance
+    // cookie; `page.request` shares the browser context's cookie jar, so the
+    // request that follows carries that clearance and is not challenged.
+    await page.goto("/");
+    const response = await page.request.get("/version.json");
     expect(response.ok()).toBe(true);
 
     const body = (await response.json()) as {
@@ -107,5 +121,56 @@ test.describe("Post-deploy smoke", () => {
     // buildTime is an ISO timestamp; a valid parse guards against truncated or
     // placeholder values slipping through.
     expect(Date.parse(body.buildTime as string)).not.toBeNaN();
+
+    // When the deploy workflow tells us which build it just promoted, assert
+    // that this is the one actually being served. Without this the check only
+    // proves *a* build is live, not the right one -- a deploy that silently
+    // failed to promote would still pass. The commit is the real discriminator:
+    // a re-deploy of the same tag shares its version but not its commit.
+    // Absent for the scheduled soak, which has no expectation to compare to.
+    const expectedVersion = process.env.EXPECT_VERSION;
+    if (expectedVersion) {
+      expect(body.version).toBe(expectedVersion);
+    }
+    const expectedCommit = process.env.EXPECT_COMMIT;
+    if (expectedCommit) {
+      expect(body.commit).toBe(expectedCommit);
+    }
+  });
+
+  test("security headers are present by value on the deployed origin", async ({
+    page,
+  }) => {
+    // Verifies headers on the LIVE origin, which a curl-based check cannot do
+    // from CI (see the challenge note above). This is not redundant with the
+    // curl smoke that runs against the preview URL: that surface is on
+    // workers.dev and cannot observe zone-level interference. Exactly that bit
+    // mattered once already -- a zone setting was rewriting HSTS to max-age=0
+    // on every racku.la hostname while the same Worker served the correct value
+    // on workers.dev (#3214).
+    await page.goto("/");
+    const response = await page.request.get("/");
+    expect(response.ok()).toBe(true);
+    const headers = response.headers();
+
+    const csp = headers["content-security-policy"] ?? "";
+    expect(csp).toContain("script-src 'self'");
+    // The whole point of the policy: no inline script execution. Asserted on
+    // the script-src directive specifically, since style-src legitimately
+    // carries 'unsafe-inline' for Svelte's scoped styles.
+    const scriptSrc = csp
+      .split(";")
+      .find((d) => d.trim().startsWith("script-src"));
+    expect(scriptSrc ?? "").not.toContain("unsafe-inline");
+
+    expect(headers["x-content-type-options"]).toBe("nosniff");
+    expect(headers["x-frame-options"]).toBe("SAMEORIGIN");
+    expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+
+    // Deployed surfaces are HTTPS, so HSTS must be both present and non-zero.
+    // `max-age=0` is what a zone-level override looked like in #3214.
+    const hsts = headers["strict-transport-security"] ?? "";
+    expect(hsts).toMatch(/max-age=\d+/);
+    expect(hsts).not.toMatch(/max-age=0\b/);
   });
 });

--- a/e2e/deploy-smoke.spec.ts
+++ b/e2e/deploy-smoke.spec.ts
@@ -89,23 +89,30 @@ test.describe("Post-deploy smoke", () => {
     // version.json is emitted at build time and served statically, so it proves
     // the deployed bundle is the one we expect without executing any JS.
     //
-    // Fetched through `page.request`, not the standalone `request` fixture, and
-    // only AFTER a navigation. Cloudflare serves a Managed Challenge to
-    // datacenter IPs across the racku.la zone, and Bot Fight Mode cannot be
-    // skipped by a WAF rule on the Free plan. A bare API request runs no JS, so
-    // it cannot solve the challenge and receives a 403 challenge page --
-    // `response.ok()` is then false and the check reports a healthy deploy as
-    // broken. That is exactly what happened: this workflow failed 79 out of 79
-    // runs from 2026-07-20 onward, including before the August outage.
+    // Fetched from INSIDE the page, not via the `request` fixture or
+    // `page.request`. Cloudflare serves a Managed Challenge to datacenter IPs
+    // across the racku.la zone, and Bot Fight Mode cannot be skipped by a WAF
+    // rule on the Free plan (it does not run on the Ruleset Engine).
     //
-    // Navigating first lets Chromium solve the challenge and earn a clearance
-    // cookie; `page.request` shares the browser context's cookie jar, so the
-    // request that follows carries that clearance and is not challenged.
+    // A bare API request runs no JS, cannot solve the challenge, and receives a
+    // 403 challenge page, so `response.ok()` is false and a healthy deploy is
+    // reported as broken. This workflow failed 79 out of 79 runs from
+    // 2026-07-20 onward for exactly that reason, including before the August
+    // outage.
+    //
+    // `page.request` does not help either, despite sharing the context's cookie
+    // jar: it uses Playwright's own HTTP stack, so its TLS fingerprint differs
+    // from the browser's and Cloudflare rejects the clearance. Verified on CI,
+    // not assumed. Only a fetch issued by the page itself reuses the browser's
+    // network stack, fingerprint and clearance cookie together.
     await page.goto("/");
-    const response = await page.request.get("/version.json");
-    expect(response.ok()).toBe(true);
+    const result = await page.evaluate(async () => {
+      const r = await fetch("/version.json", { cache: "no-store" });
+      return { ok: r.ok, status: r.status, text: await r.text() };
+    });
+    expect(result.ok, `GET /version.json returned ${result.status}`).toBe(true);
 
-    const body = (await response.json()) as {
+    const body = JSON.parse(result.text) as {
       version?: unknown;
       commit?: unknown;
       buildTime?: unknown;
@@ -149,9 +156,17 @@ test.describe("Post-deploy smoke", () => {
     // on every racku.la hostname while the same Worker served the correct value
     // on workers.dev (#3214).
     await page.goto("/");
-    const response = await page.request.get("/");
-    expect(response.ok()).toBe(true);
-    const headers = response.headers();
+    const probe = await page.evaluate(async () => {
+      const r = await fetch("/", { cache: "no-store" });
+      const h: Record<string, string> = {};
+      // Same-origin, so every response header is readable.
+      r.headers.forEach((value, key) => {
+        h[key.toLowerCase()] = value;
+      });
+      return { ok: r.ok, status: r.status, headers: h };
+    });
+    expect(probe.ok, `GET / returned ${probe.status}`).toBe(true);
+    const headers = probe.headers;
 
     const csp = headers["content-security-policy"] ?? "";
     expect(csp).toContain("script-src 'self'");

--- a/e2e/playwright.smoke.config.ts
+++ b/e2e/playwright.smoke.config.ts
@@ -18,22 +18,13 @@ const cfAccessHeaders =
       }
     : undefined;
 
-// Cloudflare serves a Managed Challenge to datacenter IPs, including GitHub
-// runners, across the racku.la zone. A browser navigation survives it because
-// Chromium executes the challenge and earns clearance, but the `request`
-// fixture runs no JS, so API assertions saw a 403 challenge page instead of the
-// app. That is why the prod soak leg failed 79 out of 79 runs from 2026-07-20
-// onwards, including before the August outage.
-//
-// A WAF custom rule skips the challenge for requests carrying this token.
-// Absent locally (residential IPs are not challenged) and absent in forks.
-const smokeToken = process.env.RACKULA_SMOKE_TOKEN;
-const smokeHeaders = smokeToken ? { "X-Rackula-Smoke": smokeToken } : undefined;
-
-const extraHTTPHeaders =
-  cfAccessHeaders || smokeHeaders
-    ? { ...(cfAccessHeaders ?? {}), ...(smokeHeaders ?? {}) }
-    : undefined;
+// On Cloudflare's bot challenge: datacenter IPs, GitHub runners included, are
+// served a Managed Challenge across the racku.la zone, and Bot Fight Mode
+// cannot be skipped by a WAF rule on the Free plan (it does not run on the
+// Ruleset Engine, so Skip has no effect). There is deliberately no bypass
+// header here. Deploy-mode specs navigate first, so Chromium solves the
+// challenge, then use `page.request`, which shares the browser context's
+// clearance cookie. See the comments in deploy-smoke.spec.ts.
 
 /**
  * Playwright configuration for smoke tests.
@@ -85,7 +76,7 @@ export default defineConfig({
     baseURL: smokeTestUrl || "http://localhost:4173",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
-    ...(extraHTTPHeaders ? { extraHTTPHeaders } : {}),
+    ...(cfAccessHeaders ? { extraHTTPHeaders: cfAccessHeaders } : {}),
   },
   projects: [
     {

--- a/e2e/playwright.smoke.config.ts
+++ b/e2e/playwright.smoke.config.ts
@@ -18,6 +18,23 @@ const cfAccessHeaders =
       }
     : undefined;
 
+// Cloudflare serves a Managed Challenge to datacenter IPs, including GitHub
+// runners, across the racku.la zone. A browser navigation survives it because
+// Chromium executes the challenge and earns clearance, but the `request`
+// fixture runs no JS, so API assertions saw a 403 challenge page instead of the
+// app. That is why the prod soak leg failed 79 out of 79 runs from 2026-07-20
+// onwards, including before the August outage.
+//
+// A WAF custom rule skips the challenge for requests carrying this token.
+// Absent locally (residential IPs are not challenged) and absent in forks.
+const smokeToken = process.env.RACKULA_SMOKE_TOKEN;
+const smokeHeaders = smokeToken ? { "X-Rackula-Smoke": smokeToken } : undefined;
+
+const extraHTTPHeaders =
+  cfAccessHeaders || smokeHeaders
+    ? { ...(cfAccessHeaders ?? {}), ...(smokeHeaders ?? {}) }
+    : undefined;
+
 /**
  * Playwright configuration for smoke tests.
  *
@@ -68,7 +85,7 @@ export default defineConfig({
     baseURL: smokeTestUrl || "http://localhost:4173",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
-    ...(cfAccessHeaders ? { extraHTTPHeaders: cfAccessHeaders } : {}),
+    ...(extraHTTPHeaders ? { extraHTTPHeaders } : {}),
   },
   projects: [
     {

--- a/scripts/gen-headers.mjs
+++ b/scripts/gen-headers.mjs
@@ -9,13 +9,15 @@
 // Usage:
 //   node scripts/gen-headers.mjs <prod|dev>              print _headers to stdout
 //   node scripts/gen-headers.mjs <prod|dev> --out <file>  write _headers to a file
+//   node scripts/gen-headers.mjs --assetsignore <file>    write the .assetsignore
 //   node scripts/gen-headers.mjs --check                  verify values against
 //                                                          deploy/security-headers.conf
 //
-// Consumers: the future #2029 (prod) and #2134 (dev) wrangler deploy steps call
-// this generator to produce the CF `_headers` artifact; the future CF half of
-// scripts/check-header-parity.sh (#2032) diffs its output. Neither consumer
-// exists yet, so this script has no callers wired in.
+// Consumers: the prod wrangler deploy step (.github/workflows/deploy-prod.yml,
+// #2029) calls this to produce the CF `_headers` and `.assetsignore` artifacts;
+// the dev cutover (#2134) will call it with the `dev` surface. `--check` runs in
+// the validate job (.github/workflows/test.yml) so the generator cannot silently
+// drift from deploy/security-headers.conf.
 //
 // Carved out of #2029 by #3092. No credentials required; independent of #2675.
 
@@ -54,6 +56,42 @@ const SURFACES = {
   },
 };
 
+// Cache split, transcribed from deploy/nginx.conf.template (`location /assets/`
+// sets `expires 1y` + `Cache-Control "public, immutable"`). These live OUTSIDE
+// buildHeaders() on purpose: runCheck() diffs buildHeaders() against the
+// add_header directives in deploy/security-headers.conf, and Cache-Control is
+// not one of them. Putting cache rules in buildHeaders() would break that parity
+// check in both directions.
+//
+// There is deliberately no Cache-Control on `/*`. Cloudflare's default for static
+// assets is `public, max-age=0, must-revalidate` plus an ETag, which is already
+// revalidate-on-every-request and therefore safe for the SPA shell and
+// version.json. Emitting our own `/*` value would raise a precedence question
+// against the `/assets/*` rule below (an open item in
+// docs/research/spike-2620-static-assets.md) for no benefit.
+const CACHE_RULES = [
+  ["/assets/*", [["Cache-Control", "public, max-age=31536000, immutable"]]],
+];
+
+// Files that must exist in the assets directory so Workers parses them, but must
+// never be fetchable. `_headers` and `.assetsignore` are Workers metadata.
+// `.DS_Store` and `.claude/` are belt-and-braces: publicDir copies static/
+// verbatim, and both are gitignored (`.claude/settings.local.json` via the
+// user-global ignore file), so they are invisible to `git status` yet still reach
+// dist/ in a hand-run build from a working tree.
+const ASSETSIGNORE_ENTRIES = [
+  "_headers",
+  ".assetsignore",
+  ".DS_Store",
+  "**/.DS_Store",
+  ".claude",
+  ".claude/**",
+];
+
+function renderAssetsIgnore() {
+  return ASSETSIGNORE_ENTRIES.join("\n") + "\n";
+}
+
 function buildHeaders(surfaceName) {
   const surface = SURFACES[surfaceName];
   if (!surface) {
@@ -77,6 +115,12 @@ function renderHeadersFile(surfaceName) {
   const lines = ["/*"];
   for (const [name, value] of buildHeaders(surfaceName)) {
     lines.push(`  ${name}: ${value}`);
+  }
+  for (const [pattern, headers] of CACHE_RULES) {
+    lines.push("", pattern);
+    for (const [name, value] of headers) {
+      lines.push(`  ${name}: ${value}`);
+    }
   }
   return lines.join("\n") + "\n";
 }
@@ -169,6 +213,7 @@ function printUsage() {
   console.error(
     "usage: node scripts/gen-headers.mjs <prod|dev> [--out <file>]",
   );
+  console.error("       node scripts/gen-headers.mjs --assetsignore <file>");
   console.error("       node scripts/gen-headers.mjs --check");
 }
 
@@ -177,6 +222,17 @@ function main() {
 
   if (args[0] === "--check") {
     process.exit(runCheck());
+  }
+
+  if (args[0] === "--assetsignore") {
+    const target = args[1];
+    if (!target) {
+      console.error("error: --assetsignore requires a file path");
+      printUsage();
+      process.exit(2);
+    }
+    writeFileSync(target, renderAssetsIgnore());
+    return;
   }
 
   const surfaceName = args[0];

--- a/scripts/gen-headers.mjs
+++ b/scripts/gen-headers.mjs
@@ -71,6 +71,19 @@ const SURFACES = {
 // docs/research/spike-2620-static-assets.md) for no benefit.
 const CACHE_RULES = [
   ["/assets/*", [["Cache-Control", "public, max-age=31536000, immutable"]]],
+  // version.json is the deploy oracle: the post-deploy smoke reads it to prove
+  // which build is live, so a stale copy defeats the check. It is 93 bytes and
+  // read a handful of times a day, so there is nothing to gain by caching it.
+  //
+  // Caveat, verified rather than assumed: this does NOT stop conditional
+  // requests. Workers Static Assets still emits an ETag and still answers
+  // If-None-Match with a 304 regardless of the Cache-Control value in
+  // `_headers` -- that handling sits in the asset server, ahead of these
+  // headers. A client that sends If-None-Match therefore still gets a bodiless
+  // 304, which would fail Playwright's `response.ok()` (true only for 200-299).
+  // If a smoke ever needs to defeat that, it must cache-bust the URL; the
+  // header alone cannot.
+  ["/version.json", [["Cache-Control", "no-store"]]],
 ];
 
 // Files that must exist in the assets directory so Workers parses them, but must

--- a/scripts/smoke-headers.sh
+++ b/scripts/smoke-headers.sh
@@ -66,9 +66,43 @@ FAILS=0
 fail() { echo "FAIL: $*" >&2; FAILS=$((FAILS + 1)); }
 pass() { echo "ok: $*"; }
 
+# Cloudflare serves a Managed Challenge to datacenter IPs, including GitHub
+# runners, on every path of the racku.la zone. A JS challenge cannot be solved
+# by curl, so without this header every assertion below sees a 403 challenge
+# page instead of the app. A WAF custom rule skips the challenge for requests
+# carrying RACKULA_SMOKE_TOKEN; CI supplies it from a GitHub secret.
+#
+# Absent locally (a residential IP is not challenged) and absent in forks, where
+# the secret does not exist. In both cases the header is simply not sent.
+SMOKE_HEADER=()
+if [ -n "${RACKULA_SMOKE_TOKEN:-}" ]; then
+  SMOKE_HEADER=(-H "X-Rackula-Smoke: ${RACKULA_SMOKE_TOKEN}")
+fi
+
 # Retry the whole request: a freshly promoted version can 5xx for a beat.
-fetch() { curl -sS --max-time 30 --retry 3 --retry-delay 2 "$@"; }
+#
+# The ${arr[@]+"${arr[@]}"} form is required, not stylistic: under `set -u`,
+# bash 3.2 (which macOS still ships) treats "${arr[@]}" on an EMPTY array as an
+# unbound variable and aborts. Plain "${SMOKE_HEADER[@]}" therefore works in CI
+# on bash 5 and breaks every local run without the token.
+fetch() {
+  curl -sS --max-time 30 --retry 3 --retry-delay 2 \
+    ${SMOKE_HEADER[@]+"${SMOKE_HEADER[@]}"} "$@"
+}
 headers_of() { fetch -I "$1" | tr -d '\r'; }
+
+# Fail loudly rather than silently reporting a challenge page as a broken deploy.
+challenge_guard() {
+  local mitigated
+  mitigated="$(headers_of "$BASE_URL/" | grep -i '^cf-mitigated:' || true)"
+  if [ -n "$mitigated" ]; then
+    echo "FAIL: Cloudflare is challenging this client ($mitigated)." >&2
+    echo "      Every assertion below would report a challenge page as a broken deploy." >&2
+    echo "      Set RACKULA_SMOKE_TOKEN to a value the WAF skip rule accepts." >&2
+    exit 1
+  fi
+}
+challenge_guard
 
 # --- 1. shell ------------------------------------------------------------
 code="$(fetch -o /dev/null -w '%{http_code}' "$BASE_URL/")"

--- a/scripts/smoke-headers.sh
+++ b/scripts/smoke-headers.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# smoke-headers.sh - fail-closed post-deploy smoke for the Cloudflare prod surface.
+#
+# Part of issue #2029. Complements e2e/deploy-smoke.spec.ts rather than
+# duplicating it: that suite proves the bundle BOOTS in a real browser (shell
+# renders, a share link paints, version.json is well-formed). It deliberately
+# asserts nothing about headers, content types, SPA-fallback behaviour, or
+# version/commit matching, and it tolerates an empty commit for Docker builds.
+# Those are exactly the checks that catch a broken Workers deploy, so they live
+# here.
+#
+# Why they matter on Workers specifically: not_found_handling
+# "single-page-application" turns EVERY unmatched path into 200 + index.html.
+# A missing or misnamed asset therefore returns a cheerful HTML page instead of
+# a 404, and under nosniff the browser refuses to execute it. A smoke test that
+# only checks "did / return 200" cannot see that. Every content-type assertion
+# below exists to make that failure mode loud.
+#
+# Expected header values are read from scripts/gen-headers.mjs, which is itself
+# parity-checked against deploy/security-headers.conf by `--check`. There is no
+# second copy of the values here to drift.
+#
+# Usage:
+#   scripts/smoke-headers.sh <base-url> [--live] [--expect-version X] [--expect-commit Y]
+#
+#   --live   additionally assert exactly one Strict-Transport-Security header.
+#            Only meaningful on a hostname inside the racku.la zone; see #3214
+#            (a zone-level control currently rewrites HSTS to max-age=0).
+#
+# Exits non-zero on the first category of failure, after running every check, so
+# CI reports all problems in one pass.
+
+set -uo pipefail
+
+BASE_URL="${1:-}"
+if [ -z "$BASE_URL" ]; then
+  echo "usage: scripts/smoke-headers.sh <base-url> [--live] [--expect-version X] [--expect-commit Y]" >&2
+  exit 2
+fi
+shift
+
+LIVE=0
+EXPECT_VERSION=""
+EXPECT_COMMIT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --live) LIVE=1; shift ;;
+    --expect-version) EXPECT_VERSION="${2:-}"; shift 2 ;;
+    --expect-commit) EXPECT_COMMIT="${2:-}"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+BASE_URL="${BASE_URL%/}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+FAILS=0
+fail() { echo "FAIL: $*" >&2; FAILS=$((FAILS + 1)); }
+pass() { echo "ok: $*"; }
+
+# Retry the whole request: a freshly promoted version can 5xx for a beat.
+fetch() { curl -sS --max-time 30 --retry 3 --retry-delay 2 "$@"; }
+headers_of() { fetch -I "$1" | tr -d '\r'; }
+
+# --- 1. shell ------------------------------------------------------------
+code="$(fetch -o /dev/null -w '%{http_code}' "$BASE_URL/")"
+[ "$code" = "200" ] && pass "GET / -> 200" || fail "GET / -> $code (expected 200)"
+
+if headers_of "$BASE_URL/" | grep -qi '^content-type: *text/html'; then
+  pass "/ is text/html"
+else
+  fail "/ content-type is not text/html"
+fi
+
+# --- 2. version.json: version AND commit, cache-busted -------------------
+version_json="$(fetch "$BASE_URL/version.json?cb=$$")"
+if headers_of "$BASE_URL/version.json" | grep -qi '^content-type: *application/json'; then
+  pass "version.json is application/json"
+else
+  fail "version.json is not application/json (SPA fallback would return HTML)"
+fi
+
+if [ -n "$EXPECT_VERSION" ]; then
+  if printf '%s' "$version_json" | tr -d ' \n' | grep -q "\"version\":\"$EXPECT_VERSION\""; then
+    pass "version.json version = $EXPECT_VERSION"
+  else
+    fail "version.json version != $EXPECT_VERSION (got: $(printf '%s' "$version_json" | tr -d '\n'))"
+  fi
+fi
+
+# The commit assertion is the real cache-buster: version alone cannot tell a
+# re-deploy of the same tag from the new build.
+if [ -n "$EXPECT_COMMIT" ]; then
+  if printf '%s' "$version_json" | tr -d ' \n' | grep -q "\"commit\":\"$EXPECT_COMMIT\""; then
+    pass "version.json commit = $EXPECT_COMMIT"
+  else
+    fail "version.json commit != $EXPECT_COMMIT (got: $(printf '%s' "$version_json" | tr -d '\n'))"
+  fi
+fi
+
+# --- 3. config.js must be JS, not the SPA shell --------------------------
+# If publicDir ever regressed, config.js would fall through to index.html and,
+# under nosniff, be blocked - the app would boot into an undefined storage mode.
+if headers_of "$BASE_URL/config.js" | grep -qiE '^content-type: *(application|text)/javascript'; then
+  pass "config.js is JavaScript"
+else
+  fail "config.js is not JavaScript (SPA fallback; nosniff would block it)"
+fi
+if fetch "$BASE_URL/config.js" | grep -q 'storage: *"browser"'; then
+  pass "config.js declares browser storage"
+else
+  fail "config.js does not declare browser storage"
+fi
+
+# --- 4. hashed entry point resolves to real JS with immutable caching -----
+entry="$(fetch "$BASE_URL/" | grep -oE '/assets/main-[A-Za-z0-9_-]+\.js' | head -1)"
+if [ -z "$entry" ]; then
+  fail "could not find a hashed entry-point script in /"
+else
+  pass "entry point: $entry"
+  if headers_of "$BASE_URL$entry" | grep -qiE '^content-type: *(application|text)/javascript'; then
+    pass "entry point is JavaScript"
+  else
+    fail "entry point is not JavaScript (SPA fallback returned HTML)"
+  fi
+  if headers_of "$BASE_URL$entry" | grep -qi '^cache-control: *public, max-age=31536000, immutable'; then
+    pass "/assets/* is immutable"
+  else
+    fail "/assets/* missing immutable Cache-Control"
+  fi
+fi
+
+# --- 5. security headers, BY VALUE, diffed against the generator ---------
+# Compare only the /* security block. The generator also emits an /assets/*
+# Cache-Control rule, which is asserted separately in check 4.
+#
+# All six are strict, including Strict-Transport-Security. Check 6 additionally
+# asserts it is not duplicated. (Until #3214 was fixed, a zone-level control
+# rewrote HSTS to max-age=0 on every racku.la hostname; disabling zone HSTS let
+# each Worker's own _headers value through.)
+SECURITY_HEADERS='^(content-security-policy|x-frame-options|x-content-type-options|referrer-policy|permissions-policy|strict-transport-security):'
+expected="$(node "$SCRIPT_DIR/gen-headers.mjs" prod \
+  | sed -n '/^\/\*/,/^$/p' | sed -n 's/^  //p' \
+  | tr 'A-Z' 'a-z' | grep -E "$SECURITY_HEADERS" | sort)"
+actual="$(headers_of "$BASE_URL/" | tr 'A-Z' 'a-z' \
+  | grep -E "$SECURITY_HEADERS" | sort)"
+if [ "$expected" = "$actual" ]; then
+  pass "security headers match scripts/gen-headers.mjs by value"
+else
+  fail "security header drift from the generator:"
+  diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") >&2 || true
+fi
+
+# --- 6. exactly one Strict-Transport-Security header ---------------------
+# The value itself is covered by the strict diff in check 5. This catches the
+# duplicate-header case, which happens when a zone-level control emits HSTS
+# alongside the Worker's own _headers. #3214 was that failure in its
+# single-header form: the zone replaced the value with max-age=0. Guarding the
+# count keeps the zone setting from silently coming back.
+if [ "$LIVE" = "1" ]; then
+  n="$(headers_of "$BASE_URL/" | grep -ci '^strict-transport-security:')"
+  if [ "$n" = "1" ]; then
+    pass "exactly one Strict-Transport-Security header"
+  else
+    fail "expected exactly 1 Strict-Transport-Security header, found $n (a zone-level HSTS setting is likely competing with _headers; see #3214)"
+  fi
+fi
+
+# --- 7. SPA fallback, with headers still applied -------------------------
+if fetch "$BASE_URL/no-such-path-$$" | grep -q 'id="app"'; then
+  pass "absent path returns the SPA shell"
+else
+  fail "absent path does not return the SPA shell"
+fi
+if headers_of "$BASE_URL/no-such-path-$$" | grep -qi '^content-security-policy:'; then
+  pass "CSP applied on an absent path"
+else
+  fail "CSP missing on an absent path"
+fi
+
+# --- 8. login.html is stripped from the prod artifact --------------------
+if fetch "$BASE_URL/login.html" | grep -q 'id="app"'; then
+  pass "/login.html returns the SPA shell (login form not published)"
+else
+  fail "/login.html still serves the login form - prod has no auth backend"
+fi
+
+# --- 9. Workers metadata and stray publicDir files are not fetchable -----
+# .claude/settings.local.json and .DS_Store are gitignored (the former via the
+# user-global ignore file), so they are invisible to `git status` yet can reach
+# dist/ in a hand-run build. .assetsignore is the guard; this asserts it holds.
+check_not_served() {
+  if fetch "$BASE_URL$1" | grep -q 'id="app"'; then
+    pass "$1 is not served"
+  else
+    fail "$1 IS SERVED - expected the SPA shell"
+  fi
+}
+check_not_served "/_headers"
+check_not_served "/.assetsignore"
+check_not_served "/.claude/settings.local.json"
+check_not_served "/.DS_Store"
+
+echo
+if [ "$FAILS" -eq 0 ]; then
+  echo "Smoke passed against $BASE_URL"
+  exit 0
+fi
+echo "Smoke FAILED against $BASE_URL: $FAILS check(s) failed" >&2
+exit 1

--- a/scripts/smoke-headers.sh
+++ b/scripts/smoke-headers.sh
@@ -66,39 +66,30 @@ FAILS=0
 fail() { echo "FAIL: $*" >&2; FAILS=$((FAILS + 1)); }
 pass() { echo "ok: $*"; }
 
-# Cloudflare serves a Managed Challenge to datacenter IPs, including GitHub
-# runners, on every path of the racku.la zone. A JS challenge cannot be solved
-# by curl, so without this header every assertion below sees a 403 challenge
-# page instead of the app. A WAF custom rule skips the challenge for requests
-# carrying RACKULA_SMOKE_TOKEN; CI supplies it from a GitHub secret.
-#
-# Absent locally (a residential IP is not challenged) and absent in forks, where
-# the secret does not exist. In both cases the header is simply not sent.
-SMOKE_HEADER=()
-if [ -n "${RACKULA_SMOKE_TOKEN:-}" ]; then
-  SMOKE_HEADER=(-H "X-Rackula-Smoke: ${RACKULA_SMOKE_TOKEN}")
-fi
-
 # Retry the whole request: a freshly promoted version can 5xx for a beat.
-#
-# The ${arr[@]+"${arr[@]}"} form is required, not stylistic: under `set -u`,
-# bash 3.2 (which macOS still ships) treats "${arr[@]}" on an EMPTY array as an
-# unbound variable and aborts. Plain "${SMOKE_HEADER[@]}" therefore works in CI
-# on bash 5 and breaks every local run without the token.
-fetch() {
-  curl -sS --max-time 30 --retry 3 --retry-delay 2 \
-    ${SMOKE_HEADER[@]+"${SMOKE_HEADER[@]}"} "$@"
-}
+fetch() { curl -sS --max-time 30 --retry 3 --retry-delay 2 "$@"; }
 headers_of() { fetch -I "$1" | tr -d '\r'; }
 
 # Fail loudly rather than silently reporting a challenge page as a broken deploy.
+#
+# This script cannot solve a JS challenge, and on the Free plan Bot Fight Mode
+# cannot be skipped by a WAF rule (it does not run on the Ruleset Engine). So on
+# a challenged surface the only correct behaviour is to stop with a message that
+# names the cause, instead of emitting seventeen phantom deploy failures -- which
+# is how this presented before it was diagnosed.
+#
+# In CI this script therefore runs against the workers.dev preview URL, which is
+# outside the racku.la zone and not challenged. Live-origin header verification
+# is done by the browser instead, in e2e/deploy-smoke.spec.ts.
 challenge_guard() {
   local mitigated
   mitigated="$(headers_of "$BASE_URL/" | grep -i '^cf-mitigated:' || true)"
   if [ -n "$mitigated" ]; then
     echo "FAIL: Cloudflare is challenging this client ($mitigated)." >&2
-    echo "      Every assertion below would report a challenge page as a broken deploy." >&2
-    echo "      Set RACKULA_SMOKE_TOKEN to a value the WAF skip rule accepts." >&2
+    echo "      curl cannot solve a JS challenge, so every assertion below would" >&2
+    echo "      report a challenge page as a broken deploy." >&2
+    echo "      Run this against the workers.dev preview URL, or verify this" >&2
+    echo "      surface through the browser smoke instead." >&2
     exit 1
   fi
 }

--- a/scripts/smoke-headers.sh
+++ b/scripts/smoke-headers.sh
@@ -46,8 +46,15 @@ EXPECT_COMMIT=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --live) LIVE=1; shift ;;
-    --expect-version) EXPECT_VERSION="${2:-}"; shift 2 ;;
-    --expect-commit) EXPECT_COMMIT="${2:-}"; shift 2 ;;
+    --expect-version|--expect-commit)
+      # `shift 2` with only one argument left fails under `set -u`-less bash and
+      # loops forever; reject explicitly so a malformed CI invocation is loud.
+      [ $# -ge 2 ] || { echo "error: $1 requires a value" >&2; exit 2; }
+      case "$1" in
+        --expect-version) EXPECT_VERSION="$2" ;;
+        --expect-commit)  EXPECT_COMMIT="$2" ;;
+      esac
+      shift 2 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,9 +138,10 @@ function emitVersionJson(info: {
 }
 
 export default defineConfig(() => ({
-  // VITE_BASE_PATH env var allows different base paths per deployment:
-  // - GitHub Pages: /Rackula/ (set in workflow)
-  // - Docker/local: / (default)
+  // VITE_BASE_PATH env var allows different base paths per deployment.
+  // Every current target serves from the root: Cloudflare Workers Static
+  // Assets (count.racku.la), Docker/LXC self-host, and local dev. The override
+  // exists for sub-path hosting; nothing sets it today.
   base: process.env.VITE_BASE_PATH || "/",
   publicDir: "static",
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,10 +138,17 @@ function emitVersionJson(info: {
 }
 
 export default defineConfig(() => ({
-  // VITE_BASE_PATH env var allows different base paths per deployment.
-  // Every current target serves from the root: Cloudflare Workers Static
-  // Assets (count.racku.la), Docker/LXC self-host, and local dev. The override
-  // exists for sub-path hosting; nothing sets it today.
+  // Every deployment target serves from the root: Cloudflare Workers Static
+  // Assets (count.racku.la), Docker/LXC self-host, and local dev. Nothing sets
+  // VITE_BASE_PATH today.
+  //
+  // Sub-path hosting is NOT supported, despite this override existing. Vite
+  // rewrites the URLs it generates, but index.html and login.html also carry
+  // root-absolute references it leaves alone -- /config.js and the favicons --
+  // so under a non-root base the bundle would load from the sub-path while the
+  // runtime config was still fetched from the domain root, and the app would
+  // boot without its storage mode. Making those base-aware is a prerequisite
+  // for ever using this.
   base: process.env.VITE_BASE_PATH || "/",
   publicDir: "static",
   plugins: [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,7 +29,15 @@
   // record and edge certificate (the dead VPS origin returned 522), so a route
   // intercepts ahead of the origin with no DNS change, no delete-then-attach
   // NXDOMAIN window (the zone SOA minimum is 1800s), and no certificate wait.
-  // Rollback is removing this entry and redeploying.
+  //
+  // Two distinct rollbacks, do not conflate them:
+  //   - Bad RELEASE -> roll the Worker version back (rollback-prod.yml). The
+  //     route is untouched; count.racku.la keeps serving, just an older build.
+  //   - Bad CUTOVER -> remove this entry and `wrangler triggers deploy`, which
+  //     detaches the hostname and returns it to the origin DNS record. Only
+  //     meaningful if that origin is healthy, which it was not at cutover.
+  // rollback-prod.yml implements the first. The second is a manual step in
+  // docs/deployment/cloudflare-prod-runbook.md.
   "routes": [{ "pattern": "count.racku.la/*", "zone_name": "racku.la" }],
 
   // One public surface. preview_urls stays on so `wrangler versions upload`

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,41 @@
+{
+  // Cloudflare Workers Static Assets config for production (count.racku.la).
+  //
+  // ASSETS-ONLY: there is deliberately NO `main`. Prod serves a no-API static
+  // bundle (config.js pins `storage: "browser"`), and static-asset requests are
+  // unmetered ONLY while no Worker script sits on the hot path. Adding `main`
+  // would meter every request against the Workers free-tier limit. This is a
+  // standing invariant, not a bootstrap detail: it constrains #2030 (analytics)
+  // and #2031 (preview deploys). See docs/research/spike-2620-static-assets.md.
+  //
+  // The dev surface is a SEPARATE Worker with its own config (api/wrangler.jsonc,
+  // #2626/#2134): it does have a `main`, an R2 binding and Cloudflare Access.
+  // Do not merge the two.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "rackula-prod",
+
+  // Pinned workerd baseline. Bump deliberately.
+  "compatibility_date": "2026-08-01",
+
+  // `_headers` and `.assetsignore` are generated into dist/ by the deploy step
+  // (scripts/gen-headers.mjs), never committed to static/ -- publicDir copies
+  // static/ verbatim into EVERY dist, including the Docker/LXC self-host builds.
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+  },
+
+  // A route, not a custom_domain. count.racku.la already had a healthy proxied
+  // record and edge certificate (the dead VPS origin returned 522), so a route
+  // intercepts ahead of the origin with no DNS change, no delete-then-attach
+  // NXDOMAIN window (the zone SOA minimum is 1800s), and no certificate wait.
+  // Rollback is removing this entry and redeploying.
+  "routes": [{ "pattern": "count.racku.la/*", "zone_name": "racku.la" }],
+
+  // One public surface. preview_urls stays on so `wrangler versions upload`
+  // yields a per-version URL for the pre-promotion smoke in deploy-prod.yml.
+  "workers_dev": false,
+  "preview_urls": true,
+
+  "observability": { "enabled": true },
+}


### PR DESCRIPTION
## **User description**
Closes #2029. Part of epic #1984.

## Context

`count.racku.la` was down for roughly three weeks (#3167, five user reports). The VPS origin died after a VM host move; Cloudflare kept proxying to it and returned 522. **The cutover has already been executed out-of-band** to end the outage. Prod is live on Cloudflare Workers now, serving v26.7.0.

This PR lands the config that was deployed, plus the pipeline needed to keep deploying it.

Prod was already a no-API static bundle (`docker-compose.yml` runs frontend-only, `RACKULA_STORAGE_MODE` defaults to `browser`, share links are client-side lz-string in a `?l=` param), so this is an origin swap, not a rewrite. There was no server-side user data to migrate, which is why #2029's user-data-disposition AC does not apply.

## Hosting

- `wrangler.jsonc`: assets-only, **no `main`**. Static-asset requests are unmetered only while no Worker script sits on the hot path; adding one meters every request against the free tier. Recorded as a standing invariant because it also constrains #2030 (analytics) and #2031 (previews).
- `count.racku.la` is bound with a **Workers route**, not a Custom Domain. The hostname already had a healthy proxied record and edge certificate (the dead origin returned 522, which proves the edge was fine), so a route intercepts ahead of the origin: no DNS change, no certificate wait, and no delete-then-attach window. The zone's SOA minimum is 1800s, so the Custom Domain path risked up to 30 minutes of NXDOMAIN. Rollback is removing the route entry.

## Pipeline

- **`deploy-prod.yml` fully rewritten** onto `ubuntu-latest`. Zero `self-hosted` references remain. Order every release: `versions upload` -> full fail-closed smoke against the per-version preview URL -> `versions deploy` -> re-verify the live host. A bad build never takes traffic. No percentage rollouts (documented mixed-version asset hazard).
- **`release.yml`**: `promote-prod` now needs `promote-github` instead of `promote-docker` (prod pulls no images; the Docker coupling survives transitively because `promote-github` needs `promote-docker`), and gains **`secrets: inherit`**.

  That second change is a latent bug fix, not bookkeeping. `deploy-prod.yml` is a `workflow_call` reusable workflow, and **reusable workflows do not inherit secrets**. Without it, `CLOUDFLARE_API_TOKEN` resolves to an empty string and the first release after cutover fails at the first wrangler call. Not mentioned in #2029, the epic design spec, or the June migration plan.
- **New `rollback-prod.yml`**: dispatch-triggered `wrangler versions deploy <id>`, own concurrency group, so a rollback never queues behind the deploy it is undoing or behind the release approval gate.
- `versions deploy` does **not** apply trigger changes; the workflow runs `wrangler triggers deploy` too, so a future `routes` edit actually lands.

## Verification

**New `scripts/smoke-headers.sh`.** #2029's AC10 and the spike both assume `e2e/deploy-smoke.spec.ts` is a fail-closed smoke. It is not: it asserts the shell boots, a share link renders, and `version.json` is well-formed, and it explicitly tolerates an empty `commit`. Nothing about headers, content types, SPA fallback, or version/commit matching. This script covers that ground and sources expected values from `gen-headers.mjs`, so there is no second copy to drift.

This matters more on Workers than it did on nginx: `not_found_handling: "single-page-application"` turns every unmatched path into `200` + `index.html`, so a missing asset returns a cheerful HTML page instead of a 404, and `nosniff` then stops the browser executing it. A smoke that only checks for `200` cannot see that.

Proven to fail closed: wrong commit -> exit 1; pointed at an unrelated site -> exit 1 with 14 failures; unreachable host -> exit 1.

**`gen-headers.mjs`** now emits the `/assets/*` immutable rule and the `.assetsignore`, and its `--check` mode is wired into the `validate` job. It shipped in #3092 with **zero callers**, so it could silently drift from `deploy/security-headers.conf`. Cache rules live outside `buildHeaders()` so `--check` parity is unaffected in both directions. Generator output is byte-identical to what is deployed.

**Near-miss caught during the bootstrap:** `static/.claude/settings.local.json` is ignored via the *user-global* ignore file and `static/.DS_Store` via `.gitignore`, so neither appears in `git status` — but `publicDir` copies `static/` verbatim, and both were sitting in the working tree's `dist/`. A hand-run deploy would have published a local editor config to a public origin. CI is unaffected (a fresh checkout has neither); hand-run deploys are the exposure. `.assetsignore` now covers them and the smoke asserts all four paths are unreachable.

Live results against `count.racku.la` and the version preview URL:

```
ok: GET / -> 200
ok: version.json version = 26.7.0 / commit = 792a7d17
ok: config.js is JavaScript, declares browser storage
ok: entry point is JavaScript, /assets/* immutable
ok: security headers match scripts/gen-headers.mjs by value
ok: exactly one Strict-Transport-Security header
ok: absent path returns the SPA shell, CSP applied
ok: /login.html returns the SPA shell
ok: /_headers, /.assetsignore, /.claude/..., /.DS_Store not served
3 passed  (Playwright deploy smoke)
```

Zone-level HSTS was rewriting the value to `max-age=0` on **every** `racku.la` hostname while the same Worker on `*.workers.dev` served the correct value (#3214). That has been disabled and the expected value now serves, so the check is strict rather than advisory.

## Also

- **`soak-smoke.yml`**: dev leg commented out until #2134. A run's conclusion spans both legs, so while `d.racku.la` is down every run would be red — destroying both the 7-day green streak that gates #1986 and the alert's credibility. A permanently-red check is exactly what got this workflow muted during the outage; it failed correctly for three days and was then disabled.
- `compose-parity.yml` drops `deploy-prod.yml` (prod no longer pulls compose).
- Stale "dev = GitHub Pages" claims fixed at the live targets: `docs/reference/ARCHITECTURE.md`, `docs/guides/TESTING.md`, `docs/reference/SPEC.md`, `vite.config.ts`.
- `deploy-prod` cross-references in `trivy.yml`, `build-images.yml`, `rebuild-images.yml` repointed at `build-images.yml`, which owns the image build and scan.
- New `docs/deployment/cloudflare-prod-runbook.md`; `CLAUDE.md` and `RELEASE-PIPELINE.md` updated.
- #3094 answered: prod stays public.

## Test plan

```
npm run lint                            # pass
npm run format:check                    # pass
npx svelte-check --threshold error      # 0 errors, 0 warnings
npm run test:run                        # 255 files, 3794 tests pass
node scripts/gen-headers.mjs --check    # parity holds
bash scripts/check-header-parity.sh     # pass
bash scripts/check-compose-persist-parity.sh  # pass
actionlint                              # no new findings
```

The steady-state pipeline itself is exercised by the next tagged release. Cutting **v26.8.0** is the immediate follow-up: it proves the rewritten path end-to-end, ships the 91 commits currently unreleased on `main`, and discharges #1986's "one green steady-state release" gate early.


___

## **CodeAnt-AI Description**
Move production hosting to Cloudflare Workers with fail-closed releases and fast rollback

### What Changed
- Production now serves the browser-only app from Cloudflare Workers Static Assets instead of the VPS.
- Releases are built, uploaded to a private preview, and checked for version, content type, security headers, SPA behavior, and browser startup before any traffic is moved.
- Live traffic switches to the verified version at 100%, followed by checks against the production hostname.
- Added a manual rollback workflow that can restore a recent Worker version without waiting for the normal release approval flow.
- Production artifacts omit the unused login page and block accidental publication of deployment metadata or local files.
- Scheduled production smoke tests no longer fail because the unavailable dev host is included.

### Impact
`✅ Production remains available after VPS failures`
`✅ Fewer broken releases reach users`
`✅ Faster production rollback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
