### PR TITLE
fix: unblock the v26.8.0 release (corpus, Trivy gate, LXC gate)

### DIFF
--- a/api/bun.lock
+++ b/api/bun.lock
@@ -28,6 +28,7 @@
     "@hono/node-server": "^1.19.10",
     "defu": "^6.1.5",
     "hono": "^4.12.27",
+    "postcss": "^8.5.18",
   },
   "packages": {
     "@better-auth/core": ["@better-auth/core@1.6.29", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.4.0", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-hkUxePo548G0Y247had36TcfsH7E+cofcTc2UivMAbjkdLPKn1ZUk6Pjkc/kvk9xTbWYCUDX6JA9emJc0Gnufg=="],
@@ -458,7 +459,7 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 

--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,8 @@
   "overrides": {
     "hono": "^4.12.27",
     "@hono/node-server": "^1.19.10",
-    "defu": "^6.1.5"
+    "defu": "^6.1.5",
+    "postcss": "^8.5.18"
   },
   "dependencies": {
     "@node-rs/argon2": "^2.1.0",

--- a/deploy/lxc/community-scripts/README.md
+++ b/deploy/lxc/community-scripts/README.md
@@ -32,4 +32,6 @@ In short: canonical = upstream + dev override. When syncing, carry every other c
 
 ## URL note: ProxmoxVE vs ProxmoxVED
 
-The `build.func` source line and the License URL point at `ProxmoxVED` (the dev/testing repo), matching the re-submission target. When a script is promoted from ProxmoxVED to the production `ProxmoxVE` repo, those two URLs flip to `ProxmoxVE`.
+The `build.func` source line and the License URL point at `ProxmoxVE`. Rackula was promoted from the `ProxmoxVED` dev/testing repo to the production `ProxmoxVE` repo, and those two URLs flipped with it. New scripts still start life in ProxmoxVED and flip on promotion.
+
+ProxmoxVED has since moved its engine out into `community-scripts/core` and dropped `misc/` entirely, so `ProxmoxVED/main/misc/build.func` and `misc/install.func` now 404. ProxmoxVE still serves both. Anything here that fetches framework helpers must target ProxmoxVE, including `scripts/lxc-smoke-test.sh`, whose release gate broke on the old URL.

--- a/deploy/lxc/community-scripts/ct/rackula.sh
+++ b/deploy/lxc/community-scripts/ct/rackula.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main/misc/build.func)
-# build.func is sourced unpinned from ProxmoxVED@main by convention (every
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+# build.func is sourced unpinned from ProxmoxVE@main by convention (every
 # community-scripts app does this; the branch is community-scripts-controlled).
 # An upstream compromise would run as root during CT creation. Accepted as a
 # residual supply-chain risk rather than pinned, to stay aligned with the
 # ecosystem norm. See issue #2943.
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: gVNS (ggfevans)
-# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://github.com/RackulaLives/Rackula
 
 APP="Rackula"

--- a/deploy/lxc/community-scripts/install/rackula-install.sh
+++ b/deploy/lxc/community-scripts/install/rackula-install.sh
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: gVNS (ggfevans)
-# License: MIT | https://github.com/community-scripts/ProxmoxVED/raw/main/LICENSE
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://github.com/RackulaLives/Rackula
 
 source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"

--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -38,7 +38,11 @@ BRIDGE="vmbr0"
 TEMPLATE=""
 KEEP=0
 SENTINEL_PREFIX="rackula-smoke-"
-COMMUNITY_SCRIPTS_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVED/main"
+# Rackula was promoted from the ProxmoxVED dev repo to the production ProxmoxVE
+# repo, so the framework helpers come from ProxmoxVE now. ProxmoxVED has since
+# moved its engine out to community-scripts/core and dropped misc/ entirely, so
+# the old URL 404s.
+COMMUNITY_SCRIPTS_URL="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -399,8 +403,9 @@ stage_ct() {
     echo "DRY-RUN curl $COMMUNITY_SCRIPTS_URL/misc/install.func -> $TMPD/install.func" >&2
     : >"$TMPD/install.func"
   else
-    curl -fsSL "$COMMUNITY_SCRIPTS_URL/misc/install.func" -o "$TMPD/install.func" ||
-      die "failed to fetch install.func"
+    curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+      "$COMMUNITY_SCRIPTS_URL/misc/install.func" -o "$TMPD/install.func" ||
+      die "failed to fetch install.func from $COMMUNITY_SCRIPTS_URL/misc/install.func"
   fi
   ct_exec "$id" 'apt-get update -qq && apt-get install -y -qq curl ca-certificates tar >/dev/null' ||
     die "failed to install base tools in CT $id"

--- a/src/tests/fixtures/upgrade-corpus/v26.7.0-port-direction.expected.json
+++ b/src/tests/fixtures/upgrade-corpus/v26.7.0-port-direction.expected.json
@@ -3,6 +3,10 @@
     {
       "pathPattern": "\\.position$",
       "reason": "rail position 3 is converted to internal 1/6U units on load; no coincidental duplicate elsewhere in this fixture unlike the sibling AV fixtures"
+    },
+    {
+      "pathPattern": "\\.version$",
+      "reason": "position 3 falls in the pre-0.7.0 heuristic band, so needsPositionMigration stamps the current app version over the declared 26.7.0"
     }
   ]
 }

--- a/src/tests/fixtures/upgrade-corpus/v26.7.0-signal-type.expected.json
+++ b/src/tests/fixtures/upgrade-corpus/v26.7.0-signal-type.expected.json
@@ -3,6 +3,10 @@
     {
       "pathPattern": "\\.position$",
       "reason": "rail position 3 is converted to internal 1/6U units on load; no coincidental duplicate elsewhere in this fixture unlike the sibling AV fixtures"
+    },
+    {
+      "pathPattern": "\\.version$",
+      "reason": "position 3 falls in the pre-0.7.0 heuristic band, so needsPositionMigration stamps the current app version over the declared 26.7.0"
     }
   ]
 }


### PR DESCRIPTION
## **User description**
Three independent breakages, all of which had to clear before v26.8.0 could ship. The staged v26.8.0 release and tag have been removed; the release gets re-cut once this and the open dependency PRs land.

## 1. `validate` red on main and every open PR

`v26.7.0-port-direction` and `v26.7.0-signal-type` both place a rack-level device at `position: 3`. That falls inside the `1 <= position < UNITS_PER_U` band `needsPositionMigration` treats as a pre-0.7.0 layout, so the schema transform stamps the current app version over the fixture's declared `26.7.0`.

Their sidecars allow-listed `.position$` but not `.version$`, so the test only ever passed because `package.json` happened to read `26.7.0` too. The bump to 26.8.0 broke that coincidence, turning `main` red and failing `validate` on all four open PRs. The scheduled Full E2E was failing the same way, with all four E2E shards green and only `lint-unit` red.

Allow-listing `.version$` matches the precedent already set by `v0.6.0-single-rack.expected.json`. The entry is path-based, so it holds across future bumps rather than needing another fix each release.

## 2. Release `scan-images (-api)` gate

CVE-2026-73646, `postcss` 8.5.16, HIGH, fixed in 8.5.18. postcss reaches the api image via better-auth's optional peer on vitest -> vite, which survives `bun install --production`.

Overriding to `^8.5.18` resolves 8.5.26, which also pulls `nanoid ^3.3.17` and clears the two open nanoid alerts (CVE-2026-67213, CVE-2026-67214).

Deliberately not a `.trivyignore` entry: that file's policy reserves the escape hatch for findings unfixable upstream, and a fix exists. The alert was already dismissed as a false positive on GitHub (alert #97), but Trivy's `exit-code` only reads `.trivyignore`, never GitHub dismissals, so the gate fails again on re-run regardless.

## 3. Release `Gate: LXC smoke test`

Failed on `curl: (22) 404` fetching `install.func`. community-scripts moved the ProxmoxVED engine out into a new `community-scripts/core` repo and dropped `misc/` entirely, so both `ProxmoxVED/main/misc/install.func` and `misc/build.func` now 404. Verified live, not transient.

Rackula was promoted from ProxmoxVED to production ProxmoxVE, which still serves both helpers. The live upstream `ProxmoxVE/main/ct/rackula.sh` already sources ProxmoxVE, so **users are unaffected** - only our in-repo copies never got the flip the README documents. The install.func fetch also gets retries; a single unretried curl against a CDN is what turned an upstream reshuffle into a hard gate failure.

## Verification

- `npx vitest run src/tests/upgrade-corpus.test.ts` - 19 passed
- `npm run test:run` - 255 files, 3794 tests passed
- `npm run lint` - clean
- `cd api && bun run typecheck` - clean; `bun test` - 416 passed
- `bash -n` on all three modified shell scripts - clean
- `curl -sI` on both ProxmoxVE helper URLs - 200

## Follow-ups worth filing (not in this PR)

- `main` has no required status checks. Its only active ruleset enforces `deletion` and `non_fast_forward`, which is how a red main took five more merges, and why `gh pr merge --auto` is permanently broken with `enablePullRequestAutoMerge`.
- Security Triage dismissals do not feed `.trivyignore`, so triaged-but-unfixable findings will keep ambushing release gates.
- The api image ships dev-only transitives; `bun install --production` does not exclude better-auth's optional peer on vitest -> vite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9E2kotAGPQEYYGgtLRr7


___

## **CodeAnt-AI Description**
Unblock the v26.8.0 release and restore Rackula container installation

### What Changed
- Rackula’s LXC installer and smoke test now use the production community-scripts repository, restoring access to required installation helpers
- API dependencies now use a postcss version that addresses the release-blocking security findings
- Upgrade-corpus validation accepts the expected version update for fixtures affected by migration

### Impact
`✅ Working Rackula LXC installations`
`✅ Passing release security scans`
`✅ Passing upgrade-corpus validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
