### PR TITLE
docs: record the release-unblock work and dependency updates in the v26.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Calendar Versioning](https://calver.org/).
 
-## [26.8.0] - 2026-08-23
+## [26.8.0] - 2026-08-25
 
 Rackula can now model how your gear is actually wired. Ports carry direction, signal type and connector gender, connections are drawn between them on the canvas, and the device library understands pro audio and AV connectors. This release also moves production hosting to Cloudflare, retiring the server that took count.racku.la offline in August.
 
@@ -46,6 +46,10 @@ Rackula can now model how your gear is actually wired. Ports carry direction, si
 - Release pipeline is idempotent on re-run (#2709, PR #3082)
 - Trivy gates fixable HIGH and CRITICAL findings (#2720, PR #3084)
 - Cable model retired, with a cables-to-connections migration (PR #3119)
+- Upgrade-corpus fixtures allow the migration version stamp, so bumping the app version no longer fails the corpus test (PR #3228)
+- postcss pinned above CVE-2026-73646 in the api image, which also clears the nanoid advisories it pulled in (PR #3228)
+- community-scripts helpers are sourced from ProxmoxVE, after ProxmoxVED moved its engine to community-scripts/core and dropped misc/ (PR #3228)
+- Dependency updates across svelte, hono, wrangler, better-auth, jose, dompurify, eslint and vitest tooling, GitHub Actions, and the production/development-dependency groups, spanning PR #3123 through PR #3225 (~63 PRs)
 
 ## [26.7.0] - 2026-07-18
 


### PR DESCRIPTION
## **User description**
Last piece before re-tagging v26.8.0.

The `[26.8.0]` entry was written before the first release attempt on 2026-08-23, so it predates everything that went into actually getting the release out. Adds four lines under `### Technical`:

- the upgrade-corpus allow-list fix, which is what had `validate` red on main and every open PR
- the postcss pin that cleared the Trivy `scan-images` gate
- the community-scripts URL flip that cleared the LXC smoke gate
- a consolidated dependency line

That last one closes a real gap: 26.7.0 carries a `Dependency updates across ...` line, but 26.8.0 had none, despite 61 Dependabot PRs merging between the v26.7.0 tag and now (#3123 through #3225).

The date moves from 2026-08-23 to 2026-08-25, since the original tag was unstaged and the release is being re-cut.

CHANGELOG.md is the source of truth for the GitHub release body (`stage-release` generates it from here), so this is the only place that needs editing.

## Context

The v26.8.0 tag and its stuck prerelease were deleted; `main` stays at version 26.8.0, and August keeps the CalVer number the same. `scripts/check-corpus-freshness.sh` was dry-run against the new baseline and passes (`comparing v26.7.0..HEAD ... 6 new corpus fixture(s) added`).

Not included: #3221 (better-auth 1.7.1) is held, tracked in #3229. #3217 ships in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9E2kotAGPQEYYGgtLRr7


___

## **CodeAnt-AI Description**
Document the release-unblock fixes and dependency updates in v26.8.0

### What Changed
- Updates the v26.8.0 release date to August 25, 2026
- Records fixes that allow version upgrades to pass corpus validation, clear container security checks, and restore Proxmox helper sourcing
- Adds the dependency updates included since v26.7.0

### Impact
`✅ Release validation passes after version bumps`
`✅ Container security gates clear`
`✅ Proxmox helper-based workflows continue working`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
