### PR TITLE
fix: give the LXC smoke gate the framework vars build.func exports

### DIFF
--- a/scripts/lxc-smoke-test.sh
+++ b/scripts/lxc-smoke-test.sh
@@ -431,10 +431,27 @@ run_install() {
   # No errexit/nounset: the framework runs install.sh without them and install.sh
   # self-manages via catch_errors. app/APPLICATION are framework vars its motd/cleanup
   # tail references; provide them so the tail does not trip on an unset value.
+  #
+  # SSH_ROOT/PASSWORD/SSH_AUTHORIZED_KEY are the same deal, for the motd_ssh and
+  # customize calls at the end of rackula-install.sh. build.func exports them for
+  # real installs; we source install.func directly, so nothing sets them here.
+  # They are only unset-fatal because core.func's silent-command wrapper restores
+  # error handling with `set -Eeuo pipefail`, switching on nounset that
+  # catch_errors deliberately left off (STRICT_UNSET defaults to 0).
+  #
+  # Values are chosen so the framework tail cannot sabotage the smoke run:
+  #   SSH_ROOT=no             skips the sshd_config edit + `systemctl restart sshd`,
+  #                           which would drop the SSH session driving this test.
+  #   SSH_AUTHORIZED_KEY=""   upstream's own default; a value here would overwrite
+  #                           /root/.ssh/authorized_keys and lock us out mid-run.
+  #   PASSWORD=smoke          non-empty, so customize() skips the getty autologin
+  #                           override. That block is framework console setup, not
+  #                           Rackula behaviour, and is not what this gate tests.
   body="
     set -o pipefail
     export FUNCTIONS_FILE_PATH=\"\$(cat /root/install.func)\"
     export app=rackula APPLICATION=Rackula tz=\"\${tz:-Etc/UTC}\"
+    export SSH_ROOT=no PASSWORD=smoke SSH_AUTHORIZED_KEY=
     ${pre}
     bash /root/rackula-install.sh
   "


### PR DESCRIPTION
## **User description**
Second and, I think, last blocker on the v26.8.0 LXC smoke gate. The first fix (#3228) was right and got us much further.

## What happened

The release run got past the `install.func` 404 and ran the real `rackula-install.sh` end to end inside the CT:

```
[+] CT 2000 up at 10.0.0.53 with network + sshd
[*] installing dev payload (rackula-lxc-v26.8.0.tar.gz) via real rackula-install.sh
  ✔️  Deployed dev prebuild
  ✔️  Installed Rackula
  ✔️  Generated API write token
  ✔️  Configured nginx
  ✔️  Created Services
  ✔️  Service running successfully
/dev/stdin: line 508: SSH_ROOT: unbound variable
```

So the install itself is healthy. It died in the framework tail.

## Why

`rackula-install.sh` ends with `motd_ssh` / `customize` / `cleanup_lxc`. Those read `SSH_ROOT` (install.func:508), `PASSWORD` (:529) and `SSH_AUTHORIZED_KEY` (:545). `build.func` exports all three for real installs, but the smoke test pushes `install.func` into the CT and sources it directly, so nothing sets them.

They are unset-fatal only by accident. `catch_errors` deliberately leaves nounset off:

```bash
catch_errors() {
  set -Ee -o pipefail
  if [ "${STRICT_UNSET:-0}" = "1" ]; then
    set -u
  fi
```

but `core.func`'s silent-command wrapper restores error handling with `set -Eeuo pipefail`, switching `-u` back on. Arguably an upstream bug: the restore is stricter than the state it replaced.

This only surfaced now because #3228 moved the URL to ProxmoxVE, whose `install.func` carries a `motd_ssh` that ProxmoxVED's did not.

## The fix

Export the three vars next to the `app`/`APPLICATION`/`tz` ones already provided for exactly this reason. Values are chosen so the framework tail cannot sabotage the run:

| Var | Value | Why |
| --- | --- | --- |
| `SSH_ROOT` | `no` | Skips the sshd_config edit and `systemctl restart sshd`, which would drop the SSH session driving the test |
| `SSH_AUTHORIZED_KEY` | empty | Upstream's own default. A value here overwrites `/root/.ssh/authorized_keys` and locks the test out mid-run |
| `PASSWORD` | `smoke` | Non-empty, so `customize()` skips the getty autologin override. Framework console setup, not Rackula behaviour, and not what this gate tests |

I checked every var `install.func` reads but never assigns; the rest come from `core.func` (colours, `msg_*`, `cleanup_lxc`) which it bootstraps itself. These three are the complete set.

## Verification

`bash -n` and `shellcheck -S warning` clean. Full verification is the gate itself, which needs the Proxmox runner.

Note the tag has to move: `gate-lxc` checks out at `ref: needs.validate.outputs.tag`, so a `workflow_dispatch` re-run of v26.8.0 would use the old script. I will delete and re-cut the tag once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9E2kotAGPQEYYGgtLRr7


___

## **CodeAnt-AI Description**
Keep the LXC smoke test running through framework cleanup

### What Changed
- The LXC smoke test now supplies the SSH and console settings expected by the installer’s final setup steps
- The test avoids restarting SSH, overwriting its authorized keys, or changing console autologin while the test session is active
- Installer runs now complete instead of failing on missing framework variables after Rackula installation succeeds

### Impact
`✅ Fewer LXC smoke gate failures`
`✅ Preserved SSH access during smoke tests`
`✅ Successful end-to-end installer validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
