### PR TITLE
docs: add a RACKULA LIVES banner to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Calendar Versioning](https://calver.org/).
 
+## RACKULA LIVES
+
+For three weeks in August count.racku.la was unreachable. That was not an outage. That was a dormancy. Vampires do this. It is extremely well documented and I am not going to argue about it here.
+
+It came back on Cloudflare, with no origin server left to die. The old one is gone. I do not want to talk about the old one.
+
 ## [26.8.0] - 2026-08-25
 
 Rackula can now model how your gear is actually wired. Ports carry direction, signal type and connector gender, connections are drawn between them on the canvas, and the device library understands pro audio and AV connectors. This release also moves production hosting to Cloudflare, retiring the server that took count.racku.la offline in August.


### PR DESCRIPTION
## **User description**
Marks the return of count.racku.la at the top of the changelog, now that v26.8.0 has actually shipped and prod is off v26.7.0 for the first time since the outage.

```markdown
## RACKULA LIVES

For three weeks in August count.racku.la was unreachable. That was not an outage. That was a dormancy. Vampires do this. It is extremely well documented and I am not going to argue about it here.

It came back on Cloudflare, with no origin server left to die. The old one is gone. I do not want to talk about the old one.
```

## Placement

Above the first version heading, so it is a permanent file-level banner rather than something that scrolls away with August.

That position also keeps it out of GitHub release notes. `stage-release` extracts with:

```bash
awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md
```

which only reads between `## [VERSION]` and the next `## [`. Verified the 26.8.0 extraction is byte-identical to before this change, and that the banner does not appear in it.

## Notes

- Plain punctuation only, no em dashes or smart quotes, per the repo writing style.
- `prettier --check` clean.
- The claim about no origin server is accurate: prod is an assets-only Worker with no `main` and no bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9E2kotAGPQEYYGgtLRr7


___

## **CodeAnt-AI Description**
Add a permanent “RACKULA LIVES” banner to the changelog

### What Changed
- Adds a file-level banner above the first release heading describing count.racku.la’s return on Cloudflare
- Keeps the banner outside version-specific release notes

### Impact
`✅ Clearer changelog context for the service’s return`
`✅ Release notes remain unchanged`
`✅ Banner stays visible at the top of the changelog`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
