### PR TITLE
docs: move the RACKULA LIVES banner into the v26.8.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Calendar Versioning](https://calver.org/).
 
-## RACKULA LIVES
+## [26.8.0] - 2026-08-25
+
+### RACKULA LIVES
 
 For three weeks in August count.racku.la was unreachable. That was not an outage. That was a dormancy. Vampires do this. It is extremely well documented and I am not going to argue about it here.
 
 It came back on Cloudflare, with no origin server left to die. The old one is gone. I do not want to talk about the old one.
 
-## [26.8.0] - 2026-08-25
+### This release
 
 Rackula can now model how your gear is actually wired. Ports carry direction, signal type and connector gender, connections are drawn between them on the canvas, and the device library understands pro audio and AV connectors. This release also moves production hosting to Cloudflare, retiring the server that took count.racku.la offline in August.
 


### PR DESCRIPTION
## **User description**
Follow-up to #3234. The banner was above the first version heading, which is exactly the position that keeps it out of GitHub release notes, so it was only visible to people reading CHANGELOG.md directly. It should be on the v26.8.0 release.

`stage-release` extracts with:

```bash
awk "/^## \[$VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md
```

which only reads between `## [VERSION]` and the next `## [`. Anything above the first version heading is invisible to it.

## Change

Moves the banner inside the 26.8.0 section as a `###`, so it is a sibling of Added/Changed/Fixed and leads the release notes. The existing release summary gets its own `### This release` heading so the two paragraphs are not run together under one banner.

Extraction verified, the notes now open with:

```
### RACKULA LIVES

For three weeks in August count.racku.la was unreachable. That was not an outage. ...

It came back on Cloudflare, with no origin server left to die. ...

### This release

Rackula can now model how your gear is actually wired. ...
```

## The published release also needs updating

The v26.8.0 release body was generated when the release was staged and does not regenerate when CHANGELOG.md changes. Merging this alone will not alter the published release. I will update it from this same source once this lands, so the changelog stays the single source of truth.

`prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc9E2kotAGPQEYYGgtLRr7


___

## **CodeAnt-AI Description**
Place the RACKULA LIVES announcement in the v26.8.0 release notes

### What Changed
- The RACKULA LIVES announcement now appears at the start of the v26.8.0 changelog section
- The existing release summary is separated under a dedicated “This release” heading
- The announcement is included when v26.8.0 notes are extracted for published release information

### Impact
`✅ RACKULA LIVES appears in published v26.8.0 release notes`
`✅ Clear separation between the announcement and release summary`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
